### PR TITLE
fix: 修复实时辅助截图过多的问题

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -276,8 +276,8 @@
                 }
             ],
             "pipeline_override": {
-                "RealTimeTaskMain": {
-                    "rate_limit": "{检测间隔}"
+                "RealTimeTaskMainDelay": {
+                    "post_delay": "{检测间隔}"
                 }
             }
         }

--- a/assets/resource/pipeline/RealTimeTask/AutoFight.json
+++ b/assets/resource/pipeline/RealTimeTask/AutoFight.json
@@ -12,10 +12,11 @@
         "threshold": 0.9,
         "pre_delay": 0,
         "post_delay": 0,
-        "timeout": 0,
         "template": "RealTimeTask/AutoFightBar.png",
         "next": [
-            "RealTimeAutoFightCombo"
+            "RealTimeAutoFightCombo",
+            "RealTimeAutoFight",
+            "RealTimeTaskMain"
         ]
     },
     "RealTimeAutoFightCombo": {
@@ -34,6 +35,11 @@
         "pre_delay": 0,
         "key": 69, // E键
         "repeat": 3, // 最大三个干员同时连携
-        "repeat_delay": 10
+        "repeat_delay": 10,
+        "next": [
+            "RealTimeAutoFightCombo",
+            "RealTimeAutoFight",
+            "RealTimeTaskMain"
+        ]
     }
 }

--- a/assets/resource/pipeline/RealTimeTask/AutoPick.json
+++ b/assets/resource/pipeline/RealTimeTask/AutoPick.json
@@ -63,6 +63,10 @@
                 "key": 70
             }
         },
-        "pre_delay": 0
+        "pre_delay": 0,
+        "next": [
+            "RealTimeAutoPick",
+            "RealTimeTaskMain"
+        ]
     }
 }

--- a/assets/resource/pipeline/RealTimeTask/AutoSkip.json
+++ b/assets/resource/pipeline/RealTimeTask/AutoSkip.json
@@ -47,11 +47,11 @@
         ],
         "pre_delay": 0,
         "post_delay": 0,
-        "timeout": 0,
         "next": [
             "RealTimeAutoSkipAll",
             "RealTimeAutoSkipChoose",
-            "RealTimeAutoSkipNext"
+            "RealTimeAutoSkipNext",
+            "RealTimeTaskMainDelay"
         ]
     },
     "RealTimeAutoSkipAll": {
@@ -93,7 +93,10 @@
             0
         ],
         "count": 200,
-        "action": "Click"
+        "action": "Click",
+        "next": [
+            "RealTimeTaskMain"
+        ]
     },
     "RealTimeAutoSkipChoose": {
         "doc": "自动跳过剧情中分支选择",
@@ -107,7 +110,11 @@
             300,
             300
         ],
-        "action": "Click"
+        "action": "Click",
+        "next": [
+            "RealTimeAutoSkip",
+            "RealTimeTaskMain"
+        ]
     },
     "RealTimeAutoSkipNext": {
         "doc": "自动点击剧情下一步",
@@ -137,6 +144,10 @@
                 ]
             }
         ],
-        "action": "Click"
+        "action": "Click",
+        "next": [
+            "RealTimeAutoSkip",
+            "RealTimeTaskMain"
+        ]
     }
 }

--- a/assets/resource/pipeline/RealtimeTask.json
+++ b/assets/resource/pipeline/RealtimeTask.json
@@ -3,12 +3,19 @@
         "doc": "实时任务主入口",
         "pre_delay": 0,
         "post_delay": 0,
-        "timeout": -1,
-        "rate_limit": 400,
         "next": [
-            "[JumpBack]RealTimeAutoSkip",
-            "[JumpBack]RealTimeAutoFight",
-            "[JumpBack]RealTimeAutoPick"
+            "RealTimeAutoSkip",
+            "RealTimeAutoFight",
+            "RealTimeAutoPick",
+            "RealTimeTaskMainDelay"
+        ]
+    },
+    "RealTimeTaskMainDelay": {
+        "doc": "实时任务主入口",
+        "pre_delay": 0,
+        "post_delay": 400,
+        "next": [
+            "RealTimeTaskMain"
         ]
     }
 }


### PR DESCRIPTION
不嘻嘻

## Summary by Sourcery

Bug Fixes:
- 限制或调整 AutoFight、AutoPick、AutoSkip 以及相关实时任务流水线中的实时辅助截图行为，避免捕获过多图像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Limit or tune real-time auxiliary screenshot behavior in AutoFight, AutoPick, AutoSkip, and related realtime task pipelines to avoid capturing too many images.

</details>