### PR TITLE
Update recognition.go

### DIFF
--- a/agent/go-service/puzzle-solver/recognition.go
+++ b/agent/go-service/puzzle-solver/recognition.go
@@ -400,6 +400,7 @@ func doPreviewPuzzle(ctx *maa.Context, thumbX, thumbY int) *PuzzleDesc {
 
 	aw := NewActionWrapper(ctrl)
 	aw.TouchUpSync(100)
+
 	aw.TouchDownSync(0, startX, startY, 100)
 	aw.TouchMoveSync(0, endX, endY, 500)
 
@@ -409,6 +410,7 @@ func doPreviewPuzzle(ctx *maa.Context, thumbX, thumbY int) *PuzzleDesc {
 	if previewImg == nil {
 		log.Error().Msg("Failed to capture preview image")
 		aw.TouchUpSync(0)
+		time.Sleep(600 * time.Millisecond)
 		return nil
 	}
 


### PR DESCRIPTION
修复了拼图识别功能不正常，4块拼图的场合只拖动了两块就提示任务完成

## Summary by Sourcery

Bug Fixes:
- 确保在拼图预览中，触摸交互的顺序和时间不会在并非所有拼图块都被移动时导致提前完成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure touch interaction sequence and timing in puzzle preview do not cause early completion when not all pieces are moved.

</details>