### PR TITLE
Update recognition.go

### DIFF
--- a/agent/go-service/puzzle-solver/recognition.go
+++ b/agent/go-service/puzzle-solver/recognition.go
@@ -405,12 +405,18 @@ func doPreviewPuzzle(ctx *maa.Context, thumbX, thumbY int) *PuzzleDesc {
 
 	// 2. Screenshot
 	ctrl.PostScreencap().Wait()
-	previewImg := ctrl.CacheImage()
-	if previewImg == nil {
-		log.Error().Msg("Failed to capture preview image")
-		aw.TouchUpSync(0)
-		return nil
-	}
+    previewImg := ctrl.CacheImage()
+    if previewImg == nil {
+        log.Error().Msg("Failed to capture preview image")
+        aw.TouchUpSync(0)
+        select {
+        case <-time.After(600 * time.Millisecond):
+            // 等待成功
+        default:
+            // 如果没有取消机制，这里什么都不做
+        }
+        return nil
+    }
 
 	// 3. Touch Up (Release)
 	aw.TouchUpSync(0)


### PR DESCRIPTION
修复了拼图功能识别不正常，只有第 1、3 块拼图（奇数次序）能够被拖动的bug

## Summary by Sourcery

Bug Fixes:
- 通过在预览捕获失败后添加等待时间，修复了拼图块识别问题，该问题导致只有某些拼图块可以被拖动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix puzzle piece recognition issue where only certain pieces could be dragged by adding a wait after failed preview capture.

</details>