### PR TITLE
fix(Resell):售卖物品时点击位置偏上；售罄切换地区失败的问题

### DIFF
--- a/assets/resource/pipeline/Resell.json
+++ b/assets/resource/pipeline/Resell.json
@@ -188,7 +188,7 @@
             128,
             126
         ],
-        "post_wait_freezes": 1000,
+        "post_wait_freezes": 600,
         "action": "Scroll",
         "target": [
             640,
@@ -210,6 +210,7 @@
             1151,
             254
         ],
+        "repeat": 2, //有时候不知道为什么会在鼠标原本的位置先按下点击再去目标点位置，就重复一下
         "expected": "[0-9]+",
         "action": "Click",
         "next": [
@@ -231,7 +232,8 @@
         "action": "ClickKey",
         "key": 27,
         "repeat": 2,
-        "repeat_wait_freezes": 1000,
+        "repeat_wait_freezes": 200,
+        "post_wait_freezes": 200,
         "focus": {
             "Node.Action.Starting": "当前地区已售罄，切换下个地区"
         },

--- a/assets/resource/pipeline/Resell/ChangeRegion.json
+++ b/assets/resource/pipeline/Resell/ChangeRegion.json
@@ -48,7 +48,7 @@
             121
         ],
         "pre_delay": 0,
-        "post_wait_freezes": 500,
+        "post_wait_freezes": 200,
         "action": "Click",
         "next": [
             "ResellStageEnterStore",

--- a/assets/resource/pipeline/Resell/GotoSell.json
+++ b/assets/resource/pipeline/Resell/GotoSell.json
@@ -12,15 +12,9 @@
         ],
         "pre_delay": 0,
         "post_delay": 500,
-        "action": "Click",
-        "target": [
-            90,
-            200,
-            100,
-            80
-        ],
+        "action": "DoNothing",
         "next": [
-            "ResellListFriends",
+            "ResellClickStock",
             "ResellStageEnterStore"
         ]
     },
@@ -30,11 +24,12 @@
         "order_by": "Expected",
         "threshold": 0.8,
         "roi": [
-            73,
+            80,
             241,
             139,
             142
         ],
+        "repeat": 2, //有时候不知道为什么会在鼠标原本的位置先按下点击再去目标点位置，就重复一下
         "expected": "[0-9]+",
         "action": "Click",
         "next": [

--- a/assets/resource/pipeline/Resell/SelectProduct.json
+++ b/assets/resource/pipeline/Resell/SelectProduct.json
@@ -596,7 +596,7 @@
     "ResellScrollToTop": {
         "doc": "滚动到顶部，准备去飞船",
         "recognition": "DirectHit",
-        "post_wait_freezes": 1000,
+        "post_wait_freezes": 300,
         "action": "Scroll",
         "target": [
             640,


### PR DESCRIPTION
1. 售卖物品时点击位置偏上：改用OCR识别数字的方式确定点击位置
2. 切换地区失败：回地区管理的界面动画有点长，加一个静止200ms后再检测
3. 降低部分延迟

## Summary by Sourcery

修复转售（Resell）流程中的交互问题，以提升点击准确性和区域切换的可靠性，同时减少不必要的延迟。

Bug 修复：
- 通过基于 OCR 识别出的数字来确定点击区域，修正转售流程中商品出售点击位置不准确的问题。
- 通过适配从区域管理界面返回时更长的动画时间，提高转售流程中区域切换的稳定性和可靠性。

增强：
- 减少转售自动化流水线中的部分等待与延迟，以加快执行速度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Resell pipeline interactions to improve click accuracy and region switching reliability while reducing unnecessary delays.

Bug Fixes:
- Correct item sell click targeting in the Resell flow by basing the tap area on OCR-recognized numbers.
- Increase robustness of region switching in the Resell flow by accommodating the longer return animation from the region management screen.

Enhancements:
- Reduce some waits and delays in the Resell automation pipeline to speed up execution.

</details>