### PR TITLE
chore: 更新JSON Schema引用

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,24 +7,25 @@
                 "/assets/resource/**/*.jsonc",
                 "/install/resource/**/*.jsonc"
             ],
-            "url": "/maafw/tools/pipeline.schema.json"
+            "url": "https://github.com/MaaXYZ/MaaFramework/raw/refs/heads/main/tools/pipeline.schema.json"
         },
         {
             "fileMatch": [
                 "/assets/interface.json",
                 "/install/interface.json"
             ],
-            "url": "/maafw/tools/interface.schema.json"
+            "url": "https://github.com/MaaXYZ/MaaFramework/raw/refs/heads/main/tools/interface.schema.json"
         },
         {
             "fileMatch": [
                 "/install/config/maa_pi_config.json"
             ],
-            "url": "/maafw/tools/interface_config.schema.json"
+            "url": "https://github.com/MaaXYZ/MaaFramework/raw/refs/heads/main/tools/interface_config.schema.json"
         }
     ],
     "files.associations": {
-        "**/assets/**/*.json": "jsonc"
+        "**/assets/**/*.json": "jsonc",
+        "**/install/**/*.json": "jsonc"
     },
     "[json][jsonc]": {
         "editor.formatOnSave": true,
@@ -33,6 +34,7 @@
         "editor.indentSize": "tabSize"
     },
     "[python]": {
+        "editor.formatOnSave": true,
         "editor.defaultFormatter": "ms-python.black-formatter"
     },
     "[markdown]": {


### PR DESCRIPTION
## 概要

此 PR 修正了 Pipeline 和 Interface 两种 JSON Schema 的资源路径，使其指向远程仓库资源。

此更改需要开发者在 VS Code 中开启 `JSON > Schema Download > Enable` 设置（默认已开启）才能生效。

## Summary by Sourcery

增强功能：
- 将编辑器配置中的 JSON Schema 引用与远程仓库中 Pipeline 和 Interface 模式(schema)的位置对齐。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Align JSON Schema references in editor configuration with remote repository locations for Pipeline and Interface schemas.

</details>