### PR TITLE
fix: 更新更新的QQ群号的新的链接

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/MaaEnd/MaaEnd/blob/main/docs/users/troubleshooting.md
     about: 提交 Issue 前请先阅读此文档 / Please read this guide before submitting an issue
   - name: 🐧 用户 QQ 群 / User QQ Group (1082597011)
-    url: https://qm.qq.com/q/AmfJpePrI6
+    url: https://qm.qq.com/q/SMko3OzTWK
     about: 畅聊使用心得、提出建议等 / Chat about usage, share ideas, etc.
   - name: 🐧 开发 QQ 群 / Dev QQ Group (1072587329)
     url: https://qm.qq.com/q/etmHz614fm

--- a/.github/ISSUE_TEMPLATE/other_issue.yml
+++ b/.github/ISSUE_TEMPLATE/other_issue.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        简单的使用问题建议先在 [QQ 群 (1082597011)](https://qm.qq.com/q/EyirQpBiW4) 咨询。
+        简单的使用问题建议先在 [QQ 群 (1082597011)](https://qm.qq.com/q/SMko3OzTWK) 咨询。
 
   - type: textarea
     id: description

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Powered by [MaaFramework](https://github.com/MaaXYZ/MaaFramework) & [MXU](https:
 
 来和大家一起玩耍吧！
 
-- 💬 **用户 QQ 群**: [1082597011](https://qm.qq.com/q/9IMcuQ55ny)  
+- 💬 **用户 QQ 群**: [1082597011](https://qm.qq.com/q/SMko3OzTWK)  
   使用问题、功能建议、闲聊摸鱼，欢迎来撩~
   
 - 👨‍💻 **开发 QQ 群**: [1072587329](https://qm.qq.com/q/EyirQpBiW4)  

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -46,5 +46,5 @@
 ## 4. 交流反馈
 
 - **GitHub Issue**: [点击提交](https://github.com/MaaEnd/MaaEnd/issues)
-- **用户 QQ 群**: [1082597011](https://qm.qq.com/q/9IMcuQ55ny)
+- **用户 QQ 群**: [1082597011](https://qm.qq.com/q/SMko3OzTWK)
 - **开发 QQ 群**: [1072587329](https://qm.qq.com/q/EyirQpBiW4) （干活群，欢迎加入一起开发，但不受理用户问题）


### PR DESCRIPTION
## Summary by Sourcery

在各个模板和文档中更新用户 QQ 群联系方式链接，使其指向新的邀请 URL。

CI：
- 更新 GitHub issue 模板，在联系链接和说明文本中引用新的用户 QQ 群邀请 URL。

文档：
- 在 README 和故障排查指南中刷新用户 QQ 群链接，改为使用新的邀请 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update user QQ group contact links across templates and documentation to point to the new invitation URL.

CI:
- Update GitHub issue templates to reference the new user QQ group invitation URL in contact links and guidance text.

Documentation:
- Refresh user QQ group links in README and troubleshooting guide to use the new invitation URL.

</details>