### PR TITLE
fix:  修复倒卖功能详情页OCR失败时成本价被覆盖为0的问题

### DIFF
--- a/agent/go-service/resell/resell.go
+++ b/agent/go-service/resell/resell.go
@@ -118,13 +118,14 @@ func (a *ResellInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 				currentROIX += 150
 				continue
 			}
-			//商品详情页右下角识别的成本价格为准
-			controller.PostScreencap().Wait()
-			ConfirmcostPrice, success := ocrExtractNumber(ctx, controller, 990, 490, 57, 27)
+		//商品详情页右下角识别的成本价格为准
+		controller.PostScreencap().Wait()
+		ConfirmcostPrice, success := ocrExtractNumber(ctx, controller, 990, 490, 57, 27)
+		if success {
 			costPrice = ConfirmcostPrice
-			if !success {
-				log.Info().Msg("[Resell]第二步：未能识别商品详情页成本价格，继续使用列表页识别的价格")
-			}
+		} else {
+			log.Info().Msg("[Resell]第二步：未能识别商品详情页成本价格，继续使用列表页识别的价格")
+		}
 			log.Info().Int("No.", stepCounter).Int("Cost", costPrice).Msg("[Resell]商品售价")
 			// 单击“查看好友价格”按钮
 			controller.PostClick(944+98/2, 446+26/2)


### PR DESCRIPTION
在详情页成本价ocr失败时，会把costPrice 覆盖成 0，导致利润计算出错。
改为ocr成功才覆盖，失败则继续使用列表页识别的价格

## Summary by Sourcery

错误修复：
- 防止在转售详情页进行 OCR 识别失败时，成本价被覆盖为 0，改为保留列表页中的价格。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent cost price from being overwritten to 0 when OCR on the resell detail page fails, preserving the list-page price instead.

</details>