### PR TITLE
fix: 修复 puzzle-solver 截图失败时的 nil panic

### DIFF
--- a/agent/go-service/puzzle-solver/recognition.go
+++ b/agent/go-service/puzzle-solver/recognition.go
@@ -499,6 +499,10 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 
 	// 2. Ensure tab state and determine board size (moved from step 4)
 	img = doEnsureTab(ctx, img)
+	if img == nil {
+		log.Error().Msg("Failed to ensure tab state: screenshot capture failed")
+		return nil, false
+	}
 
 	boardSize := getPossibleBoardSize(ctx, img)
 	if boardSize[0] == 0 || boardSize[1] == 0 {


### PR DESCRIPTION
## 由 Sourcery 提供的总结

错误修复：
- 防止从选项卡返回的 `nil` 图像，在确定棋盘大小时避免由于空值导致的崩溃。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Guard against nil images returned from tab ensuring to avoid panics when determining board size.

</details>