### PR TITLE
fix: 抢 7.31w 识别阈值

### DIFF
--- a/assets/resource/pipeline/GetWuling731.json
+++ b/assets/resource/pipeline/GetWuling731.json
@@ -18,6 +18,7 @@
     "FindWuling731": {
         "recognition": "TemplateMatch",
         "template": "GetWuling731/731.png",
+        "threshold": 0.9,
         "next": [
             "ClickWuling731"
         ]


### PR DESCRIPTION
@MistEO 先把这个合了发出去吧，0.7太低了，会抢其它价格的

## Summary by Sourcery

Bug Fixes:
- 提高“抢 7.31w”识别阈值，避免错误匹配到其他价格点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Increase the抢 7.31w recognition threshold so it no longer incorrectly matches other price points.

</details>