### PR TITLE
fix: 好友拜访逻辑问题

### DIFF
--- a/assets/resource/pipeline/VisitFriends.json
+++ b/assets/resource/pipeline/VisitFriends.json
@@ -172,19 +172,9 @@
         ]
     },
     "VisitorTerminalAssist": {
-        "recognition": "Or",
-        "any_of": [
-            {
-              "recognition": "TemplateMatch",
-              "template": "VisitFriends/ProductionAssist.png",
-              "threshold": 0.8
-            },
-            {
-              "recognition": "TemplateMatch",
-              "template": "VisitFriends/ClueExchange.png",
-              "threshold": 0.8
-            }
-        ],
+        "recognition": "TemplateMatch",
+        "template": ["VisitFriends/ProductionAssist.png", "VisitFriends/ClueExchange.png"]
+        "threshold": 0.8,
         "action": {
             "type": "Click",
             "param": {}
@@ -347,19 +337,9 @@
         ]
     },
     "VisitorTerminalExchange": {
-        "recognition": "Or",
-        "any_of": [
-            {
-              "recognition": "TemplateMatch",
-              "template": "VisitFriends/ProductionAssist.png",
-              "threshold": 0.8
-            },
-            {
-              "recognition": "TemplateMatch",
-              "template": "VisitFriends/ClueExchange.png",
-              "threshold": 0.8
-            }
-        ],
+        "recognition": "TemplateMatch",
+        "template": ["VisitFriends/ProductionAssist.png", "VisitFriends/ClueExchange.png"]
+        "threshold": 0.8,
         "action": {
             "type": "Click",
             "param": {}


### PR DESCRIPTION
https://github.com/MaaEnd/MaaEnd/issues/316

之前的好友拜访逻辑为先进行助力，助力结束后再进行线索交流，因此在助力的最后一个好友同时可以进行线索交流的时候，会导致访问按钮点击失败：
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/eab9d71d-7cc3-4dcb-a0d8-a1276bc9ac6d" />

修改：在进行助力的时候，如果好友可以进行线索交流，那么也进行线索交流，这样就不会出现识别的可线索交流好友为当前好友，无法点击进入的情况

## Summary by Sourcery

Bug Fixes:
- 修复好友访问流程中的问题：由于协助和线索交换按顺序处理，导致无法进入最后一位仍有可用线索交换的已协助好友。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix friend visit flow where the last assisted friend with available clue exchange could not be entered due to sequential handling of assistance and clue exchange.

</details>