### PR TITLE
feat: use vscode launch go service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -418,6 +418,7 @@ FodyWeavers.xsd
 # !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/mse_config.json
 *.code-workspace
 
 # Local History for Visual Studio Code

--- a/.vscode/mse_config.json
+++ b/.vscode/mse_config.json
@@ -1,0 +1,5 @@
+{
+    "agent.debug": {
+        "agent/go-service": "launch-agent"
+    }
+}

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -84,9 +84,7 @@
     ],
     "agent": {
         "child_exec": "agent/go-service",
-        "child_args": [],
-
-        "debug_session": "launch-agent"
+        "child_args": []
     },
     "task": [],
     "import": [


### PR DESCRIPTION
直接用vscode的调试能力来启动agent

@dongwlin 看看debug session的配置有没有要改的, 我xjb写的(

## Summary by Sourcery

添加编辑器调试配置，并调整相关项目文件，以便通过 VS Code 运行 agent。

Enhancements:
- 引入 VS Code 启动配置，以便在编辑器中运行 Go agent 服务。

Chores:
- 更新 `.gitignore` 和界面资源配置，以适配新的 VS Code 调试工作流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add editor debug configuration and adjust related project files for running the agent via VS Code.

Enhancements:
- Introduce a VS Code launch configuration to run the Go agent service from the editor.

Chores:
- Update .gitignore and interface asset configuration to align with the new VS Code debug workflow.

</details>