### PR TITLE
ci: 允许 commit 中以 rft 作为 refactor的缩写

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -78,7 +78,7 @@ commit_parsers = [
     { message = "^fix", group = "<!-- 1 -->🐛 Bug修复" },
     { message = "^docs", group = "<!-- 4 -->📚 文档" },
     { message = "^perf", group = "<!-- 3 -->🚀 性能优化" },
-    { message = "^refactor", group = "<!-- 2 -->🚜 代码重构" },
+    { message = "^(refactor|rft)", group = "<!-- 2 -->🚜 代码重构" },
     { message = "^style", group = "<!-- 5 -->🎨 样式" },
     { message = "^test", group = "<!-- 6 -->🧪 测试" },
     { message = "^chore\\(deps\\)", group = "📦 依赖更新" },


### PR DESCRIPTION
## 由 Sourcery 提供的总结

CI：
- 更新提交解析配置，将 `refactor` 和 `rft` 前缀都视为代码重构提交。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update commit parsing config to treat both `refactor` and `rft` prefixes as code refactor commits.

</details>