### PR TITLE
fix: 为 DailyRewards、ImportBluePrints、SellProduct 和 VisitFriends 任务添加控制器配置

### DIFF
--- a/assets/tasks/DailyRewards.json
+++ b/assets/tasks/DailyRewards.json
@@ -8,6 +8,11 @@
             "option": [
                 "DailyEmailRewards",
                 "DailyTaskRewards"
+            ],
+            "controller": [
+                "Win32",
+                "Win32-Front",
+                "Win32-Window"
             ]
         }
     ],

--- a/assets/tasks/ImportBluePrints.json
+++ b/assets/tasks/ImportBluePrints.json
@@ -7,6 +7,11 @@
             "description": "$task.ImportBluePrints.description",
             "option": [
                 "ImportBluePrints"
+            ],
+            "controller": [
+                "Win32",
+                "Win32-Front",
+                "Win32-Window"
             ]
         }
     ],

--- a/assets/tasks/SellProduct.json
+++ b/assets/tasks/SellProduct.json
@@ -4,7 +4,12 @@
             "name": "SellProduct",
             "label": "$task.SellProduct.label",
             "entry": "SellProductMain",
-            "description": "$task.SellProduct.description"
+            "description": "$task.SellProduct.description",
+            "controller": [
+                "Win32",
+                "Win32-Front",
+                "Win32-Window"
+            ]
         }
     ],
     "option": {}

--- a/assets/tasks/VisitFriends.json
+++ b/assets/tasks/VisitFriends.json
@@ -7,6 +7,11 @@
             "description": "$task.VisitFriends.description",
             "option": [
                 "PriorStealVegetables"
+            ],
+            "controller": [
+                "Win32",
+                "Win32-Front",
+                "Win32-Window"
             ]
         }
     ],


### PR DESCRIPTION
ReceiveProdManual
ReadAllWiki
ItemTransfer
BakerEntry
SimpleProductionBatchStart

我暂时没有条件进行测试。

## Summary by Sourcery

Bug Fixes:
- 确保 DailyRewards、ImportBluePrints、SellProduct 和 VisitFriends 任务正确连接到其控制器配置，以防止错误配置或运行时问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure DailyRewards, ImportBluePrints, SellProduct, and VisitFriends tasks are correctly wired to their controller configuration to prevent misconfiguration or runtime issues.

</details>