### PR TITLE
chore: exclude resource data from schema validation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Validate JSON Schema
         run: |
           python -m pip install jsonschema==4.26.0 referencing==0.37.0
-          python tools/validate_schema.py --resource-dirs assets/resource assets/resource_bilibili
+          python tools/validate_schema.py --resource-dirs assets/resource assets/resource_bilibili --exclude-dirs assets/resource/data

--- a/tools/validate_schema.py
+++ b/tools/validate_schema.py
@@ -228,8 +228,8 @@ def main():
         "--exclude-dirs",
         type=str,
         nargs="*",
-        default=["assets/resource/data"],
-        help="Directories to exclude from validation (default: assets/resource/data)",
+        default=[],
+        help="Directories to exclude from validation (default: none)",
     )
     parser.add_argument(
         "--interface-files",


### PR DESCRIPTION
## Summary
- exclude assets/resource/data from schema validation by default

## Test plan
- not run (CI change only)

## Summary by Sourcery

增强功能：
- 将 `assets/resource/data` 设置为默认在模式校验中被排除的目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Set assets/resource/data as the default directory to be excluded from schema validation.

</details>