### PR TITLE
fix: 信用购物无信用领取状态改用OCR识别

### DIFF
--- a/assets/resource/pipeline/CreditShopping/ClaimCredit.json
+++ b/assets/resource/pipeline/CreditShopping/ClaimCredit.json
@@ -16,24 +16,14 @@
     },
     "CreditShoppingNoCreditClaim": {
         "doc": "没有信用点可领取",
-        "recognition": "ColorMatch",
-        "lower": [
-            111,
-            109,
-            111
-        ],
-        "upper": [
-            111,
-            109,
-            111
-        ],
-        "count": 500,
+        "recognition": "OCR",
         "roi": [
-            81,
-            664,
-            100,
-            19
+            26,
+            583,
+            254,
+            137
         ],
+        "expected": "无待领取信用",
         "action": "DoNothing",
         "next": [
             "CreditShoppingShopping"


### PR DESCRIPTION
-移除颜色匹配 [111, 109, 111]，改用文字识别

## Summary by Sourcery

Bug Fixes:
- 通过依赖 OCR 而不是脆弱的颜色匹配，在信用购物中正确检测无额度可用的申领状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correctly detect the no-credit claim status in credit shopping by relying on OCR instead of fragile color matching.

</details>