### PR TITLE
fix(ItemTransfer): 尝试使用 TM_CCORR_NORMED 方法以规避粉末等形状相同物品导致的识别错误

### DIFF
--- a/assets/tasks/ItemTransfer.json
+++ b/assets/tasks/ItemTransfer.json
@@ -31,13 +31,16 @@
                             "template": "ItemTransfer/矿物.png"
                         },
                         "FindItemInRepo": {
-                            "template": "ItemTransfer/蓝铁矿.png"
+                            "template": "ItemTransfer/蓝铁矿.png",
+                            "method": 3
                         },
                         "FindItemInBag": {
-                            "template": "ItemTransfer/蓝铁矿.png"
+                            "template": "ItemTransfer/蓝铁矿.png",
+                            "method": 3
                         },
                         "FindItemInBagReturn": {
-                            "template": "ItemTransfer/蓝铁矿.png"
+                            "template": "ItemTransfer/蓝铁矿.png",
+                            "method": 3
                         }
                     }
                 },
@@ -49,13 +52,16 @@
                             "template": "ItemTransfer/矿物.png"
                         },
                         "FindItemInRepo": {
-                            "template": "ItemTransfer/源矿.png"
+                            "template": "ItemTransfer/源矿.png",
+                            "method": 3
                         },
                         "FindItemInBag": {
-                            "template": "ItemTransfer/源矿.png"
+                            "template": "ItemTransfer/源矿.png",
+                            "method": 3
                         },
                         "FindItemInBagReturn": {
-                            "template": "ItemTransfer/源矿.png"
+                            "template": "ItemTransfer/源矿.png",
+                            "method": 3
                         }
                     }
                 },
@@ -301,13 +307,16 @@
                             "template": "ItemTransfer/产物.png"
                         },
                         "FindItemInRepo": {
-                            "template": "ItemTransfer/致密源石粉末.png"
+                            "template": "ItemTransfer/致密源石粉末.png",
+                            "method": 3
                         },
                         "FindItemInBag": {
-                            "template": "ItemTransfer/致密源石粉末.png"
+                            "template": "ItemTransfer/致密源石粉末.png",
+                            "method": 3
                         },
                         "FindItemInBagReturn": {
-                            "template": "ItemTransfer/致密源石粉末.png"
+                            "template": "ItemTransfer/致密源石粉末.png",
+                            "method": 3
                         }
                     }
                 },
@@ -319,13 +328,16 @@
                             "template": "ItemTransfer/产物.png"
                         },
                         "FindItemInRepo": {
-                            "template": "ItemTransfer/致密碳粉末.png"
+                            "template": "ItemTransfer/致密碳粉末.png",
+                            "method": 3
                         },
                         "FindItemInBag": {
-                            "template": "ItemTransfer/致密碳粉末.png"
+                            "template": "ItemTransfer/致密碳粉末.png",
+                            "method": 3
                         },
                         "FindItemInBagReturn": {
-                            "template": "ItemTransfer/致密碳粉末.png"
+                            "template": "ItemTransfer/致密碳粉末.png",
+                            "method": 3
                         }
                     }
                 },
@@ -355,13 +367,16 @@
                             "template": "ItemTransfer/产物.png"
                         },
                         "FindItemInRepo": {
-                            "template": "ItemTransfer/致密晶体粉末.png"
+                            "template": "ItemTransfer/致密晶体粉末.png",
+                            "method": 3
                         },
                         "FindItemInBag": {
-                            "template": "ItemTransfer/致密晶体粉末.png"
+                            "template": "ItemTransfer/致密晶体粉末.png",
+                            "method": 3
                         },
                         "FindItemInBagReturn": {
-                            "template": "ItemTransfer/致密晶体粉末.png"
+                            "template": "ItemTransfer/致密晶体粉末.png",
+                            "method": 3
                         }
                     }
                 },
@@ -391,13 +406,16 @@
                             "template": "ItemTransfer/产物.png"
                         },
                         "FindItemInRepo": {
-                            "template": "ItemTransfer/细磨柑实粉末.png"
+                            "template": "ItemTransfer/细磨柑实粉末.png",
+                            "method": 3
                         },
                         "FindItemInBag": {
-                            "template": "ItemTransfer/细磨柑实粉末.png"
+                            "template": "ItemTransfer/细磨柑实粉末.png",
+                            "method": 3
                         },
                         "FindItemInBagReturn": {
-                            "template": "ItemTransfer/细磨柑实粉末.png"
+                            "template": "ItemTransfer/细磨柑实粉末.png",
+                            "method": 3
                         }
                     }
                 },
@@ -409,13 +427,16 @@
                             "template": "ItemTransfer/产物.png"
                         },
                         "FindItemInRepo": {
-                            "template": "ItemTransfer/细磨荞花粉末.png"
+                            "template": "ItemTransfer/细磨荞花粉末.png",
+                            "method": 3
                         },
                         "FindItemInBag": {
-                            "template": "ItemTransfer/细磨荞花粉末.png"
+                            "template": "ItemTransfer/细磨荞花粉末.png",
+                            "method": 3
                         },
                         "FindItemInBagReturn": {
-                            "template": "ItemTransfer/细磨荞花粉末.png"
+                            "template": "ItemTransfer/细磨荞花粉末.png",
+                            "method": 3
                         }
                     }
                 },
@@ -427,13 +448,16 @@
                             "template": "ItemTransfer/可用道具.png"
                         },
                         "FindItemInRepo": {
-                            "template": "ItemTransfer/芽针粉末.png"
+                            "template": "ItemTransfer/芽针粉末.png",
+                            "method": 3
                         },
                         "FindItemInBag": {
-                            "template": "ItemTransfer/芽针粉末.png"
+                            "template": "ItemTransfer/芽针粉末.png",
+                            "method": 3
                         },
                         "FindItemInBagReturn": {
-                            "template": "ItemTransfer/芽针粉末.png"
+                            "template": "ItemTransfer/芽针粉末.png",
+                            "method": 3
                         }
                     }
                 },
@@ -445,13 +469,16 @@
                             "template": "ItemTransfer/可用道具.png"
                         },
                         "FindItemInRepo": {
-                            "template": "ItemTransfer/锦草粉末.png"
+                            "template": "ItemTransfer/锦草粉末.png",
+                            "method": 3
                         },
                         "FindItemInBag": {
-                            "template": "ItemTransfer/锦草粉末.png"
+                            "template": "ItemTransfer/锦草粉末.png",
+                            "method": 3
                         },
                         "FindItemInBagReturn": {
-                            "template": "ItemTransfer/锦草粉末.png"
+                            "template": "ItemTransfer/锦草粉末.png",
+                            "method": 3
                         }
                     }
                 }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 调整 ItemTransfer 任务匹配配置，在使用 TM_CCOEFF_NORMED 处理如粉末等形状相似的物品时，减少误识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust ItemTransfer task matching configuration to reduce misrecognition when using TM_CCOEFF_NORMED with similarly shaped items such as powders.

</details>