### PR TITLE
ci: treat mpe config as error

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Run maa-checker
         run: |
+          # Always use latests @nekosu/maa-checker
           npx @nekosu/maa-checker@latest ./assets/interface.json --github=. --error=mpe-config
 
       # pip install maafw


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

CI：
- 更新 GitHub Actions 中的 `maa-checker` 调用方式，当检测到 MPE 配置问题时使工作流程失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update maa-checker invocation in GitHub Actions to fail the workflow when MPE configuration problems are detected.

</details>
- 在 GitHub Actions 工作流中配置 maa-checker，使其在出现 MPE 配置问题时任务失败。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

CI：
- 更新 GitHub Actions 中的 `maa-checker` 调用方式，当检测到 MPE 配置问题时使工作流程失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update maa-checker invocation in GitHub Actions to fail the workflow when MPE configuration problems are detected.

</details>

</details>