### PR TITLE
fix: fix bug that scrolling to bottom may cause issue (fixes #423)

### DIFF
--- a/agent/go-service/essencefilter/types.go
+++ b/agent/go-service/essencefilter/types.go
@@ -69,10 +69,11 @@ var (
 	statsLogged             bool
 
 	// Grid traversal state
-	currentCol        int // 1~9
-	currentRow        int // row index
-	maxItemsPerRow    int
-	firstRowSwipeDone bool // true after first row swipe is used
+	currentCol         int // 1~9
+	currentRow         int // row index
+	maxItemsPerRow     int
+	firstRowSwipeDone  bool // true after first row swipe is used
+	finalLargeScanUsed bool // true if final large scan has been used
 
 	// Current item's three skills cache
 	currentSkills [3]string

--- a/assets/resource/pipeline/EssenceFilter.json
+++ b/assets/resource/pipeline/EssenceFilter.json
@@ -26,6 +26,7 @@
             "Node.Action.Succeeded": "确认在基质界面"
         }
     },
+
     "FirstSwipeToTop": {
         "doc": "初始化位置，滑动到顶端",
         "action": {
@@ -69,7 +70,11 @@
                 }
             }
         },
-        "next": ["EssenceRowDetect"],
+        "next": [
+            "EssenceRowDetect",
+            "EssenceDetectFinal",
+            "EssenceFilterFinish"
+        ],
         "focus": {
             "Node.Action.Succeeded": "初始化完成"
         }
@@ -97,7 +102,39 @@
                 "custom_action": "EssenceFilterRowCollectAction"
             }
         },
-        "next": ["EssenceFilterRowNextItem"]
+        "next": [
+            "EssenceFilterRowNextItem",
+            "EssenceDetectFinal"
+        ]
+    },
+    "EssenceDetectFinal": {
+        "doc": "尾扫：扩大 ROI 捕获底部剩余行",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "template": "EssenceFilter/EssenceGeneral.png",
+                "threshold": 0.55,
+                "roi": [
+                    18,
+                    72,
+                    956,
+                    570
+                ], // 高度放大，覆盖底部区域
+                "method": 5
+            }
+        },
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "EssenceFilterRowCollectAction"
+            }
+        },
+        "focus": {
+            "Node.Action.Succeeded": "尾扫完成，收集所有剩余基质格子"
+        },
+        "next": [
+            "EssenceFilterRowNextItem"
+        ]
     },
 
     "EssenceFilterCheckItemSlot1": {
@@ -313,7 +350,10 @@
             }
         },
         "post_delay": 200,
-        "next": ["EssenceRowDetect"]
+        "next": [
+            "EssenceRowDetect",
+            "EssenceDetectFinal"
+        ]
     },
     "EssenceFilterSwipeNext": {
         "doc": "后续滑动",
@@ -333,7 +373,10 @@
             }
         },
         "post_delay": 200,
-        "next": ["EssenceRowDetect"]
+        "next": [
+            "EssenceRowDetect",
+            "EssenceDetectFinal"
+        ]
     },
 
     "EssenceFilterFinish": {


### PR DESCRIPTION
### fix [【基质筛选锁定】基质行数可能会影响识别](https://github.com/MaaEnd/MaaEnd/issues/423)  
如果底部剩余行数不够，会导致滑动距离不足，第一行的roi无法覆盖到应当检测的位置。现在加入了在第一行roi无法命中时的大范围roi检测剩余所有格子。

## Summary by Sourcery

改进在列表底部附近的精华过滤网格检测可靠性，并调整最终报告输出。

Bug 修复：
- 在扫描精华盒子时，防止使用无效或零尺寸的检测区域，避免在底部较短行中遗漏物品。
- 当某一行未检测到任何盒子时，增加一次性的“大范围回退扫描”步骤；如果该步骤仍未发现任何内容，则优雅地终止流程。

改进：
- 为精华过滤完成的 HTML 汇总消息添加颜色，以突出显示成功完成状态。
- 在完成一次精华过滤运行后，重置更多遍历状态（包括大范围扫描使用标记和行缓冲区索引），以确保后续运行从干净状态开始。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve essence filter grid detection reliability near the bottom of the list and adjust final reporting output.

Bug Fixes:
- Prevent invalid or zero-sized detection regions from being used when scanning essence boxes, avoiding missed items on short bottom rows.
- Add a one-time fallback large-area scan step when no boxes are detected in a row, then terminate gracefully if that also finds nothing.

Enhancements:
- Colorize the essence filter completion HTML summary message to highlight successful completion.
- Reset additional traversal state (including large-scan usage and row buffer indices) when finishing an essence filter run to ensure clean subsequent runs.

</details>