### PR TITLE
fix: 添加跳转回收奖励和确认交换结束的节点来防止点击过快导致任务失败

### DIFF
--- a/assets/resource/pipeline/DijiangRewards.json
+++ b/assets/resource/pipeline/DijiangRewards.json
@@ -57,8 +57,9 @@
             "[JumpBack]MFG_ReceiveRewards",
             "[JumpBack]GrowthChamber",
             "InLastCarbin",
-            "[JumpBack]CarbinSwipe"
-
+            "[JumpBack]CarbinSwipe",
+            "[JumpBack]ConfirmExchangeEnd",
+            "[JumpBack]CloseDijiangRewards"
         ]
     },
     "InMainWindow_NeedCredit": {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 添加返回已回收奖励和确认兑换完成的导航步骤，防止用户点击过快时导致任务失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add navigation steps for returning to recycled rewards and confirming exchange completion to prevent task failures when users tap too quickly.

</details>