### PR TITLE
fix(resell): 通过OCR轮询修复稳定需求商店页面确认失败问题

### DIFF
--- a/assets/resource/pipeline/Resell.json
+++ b/assets/resource/pipeline/Resell.json
@@ -148,87 +148,72 @@
         "post_delay": 500,
         "action": "Click",
         "next": [
-            "ResellinStableStore",
-            "ResellinUnstableStore",
-            "ResellStageCheckArea"
+            "ResellWaitForStableStore"
         ]
     },
-    "ResellinStableStore": {
-        "doc": "在稳定需求物资商店，进入弹性需求物资商店",
-        "recognition": "Or",
-        "any_of": [
-            {
-                "recognition": "TemplateMatch",
-                "template": "Resell/inStableStore.png",
-                "threshold": 0.8,
-                "roi": [
-                    0,
-                    178,
-                    125,
-                    124
-                ]
-            },
-            {
-                "recognition": "OCR",
-                "order_by": "Expected",
-                "roi": [
-                    0,
-                    0,
-                    1280,
-                    160
-                ],
-                "expected": [
-                    "稳定需求",
-                    "Stable"
-                ],
-                "threshold": 0.6
-            }
+    "ResellWaitForStableStore": {
+        "doc": "轮询 OCR 识别稳定需求物资调度页面加载完成",
+        "recognition": "OCR",
+        "order_by": "Expected",
+        "roi": [
+            0,
+            0,
+            1280,
+            160
         ],
-        "pre_delay": 0,
-        "post_delay": 500,
+        "expected": [
+            "稳定需求",
+            "Stable"
+        ],
+        "threshold": 0.6,
+        "action": "DoNothing",
+        "next": [
+            "ResellClickToUnstableStore",
+            "ResellWaitForStableStore"
+        ]
+    },
+    "ResellClickToUnstableStore": {
+        "doc": "识别并点击弹性需求物资标签",
+        "recognition": "OCR",
+        "order_by": "Expected",
+        "roi": [
+            300,
+            50,
+            300,
+            80
+        ],
+        "expected": [
+            "弹性需求",
+            "Flexible"
+        ],
+        "threshold": 0.6,
         "action": "Click",
-        "target": [
-            389,
-            73,
-            185,
-            43
+        "post_delay": 500,
+        "next": [
+            "ResellWaitForUnstableStore",
+            "ResellClickToUnstableStore"
+        ]
+    },
+    "ResellWaitForUnstableStore": {
+        "doc": "轮询匹配左侧市场图标，确认切换到弹性需求物资页面",
+        "recognition": "TemplateMatch",
+        "template": "Resell/inUnstableStore.png",
+        "threshold": 0.8,
+        "roi": [
+            0,
+            209,
+            128,
+            126
         ],
+        "action": "DoNothing",
         "next": [
             "ResellinUnstableStore",
-            "ResellStageEnterStore"
+            "ResellWaitForUnstableStore"
         ]
     },
     "ResellinUnstableStore": {
-        "doc": "在弹性需求物资商店,滚动至最底端，开始识别价格",
-        "recognition": "Or",
-        "any_of": [
-            {
-                "recognition": "TemplateMatch",
-                "template": "Resell/inUnstableStore.png",
-                "threshold": 0.8,
-                "roi": [
-                    0,
-                    209,
-                    128,
-                    126
-                ]
-            },
-            {
-                "recognition": "OCR",
-                "order_by": "Expected",
-                "roi": [
-                    0,
-                    0,
-                    1280,
-                    160
-                ],
-                "expected": [
-                    "弹性需求",
-                    "Flexible"
-                ],
-                "threshold": 0.6
-            }
-        ],
+        "doc": "在弹性需求物资商店，滚动至最底端，开始识别价格",
+        "recognition": "DirectHit",
         "post_wait_freezes": 600,
         "action": "Scroll",
         "target": [


### PR DESCRIPTION
Fixes #413.

## 问题
Resell管线中，通过左侧的齿轮图标「工业物品」判断是否进入稳定需求商店页面，但该栏商品在被买空后图标会消失（~~竟然有人不留钱买刻写券~~），导致识别稳定需求商店页面失败，无法切换到弹性需求商店页面，继续下一步~~倒货~~。

## 改进
采用OCR 轮询机制替代原有的图标模板匹配，通过识别顶部标签文字来判断商店页面状态：

1. 等待稳定需求页面加载（ResellWaitForStableStore）
OCR 识别顶部"稳定需求"/"Stable"文字，轮询直到页面加载完成

2. 点击切换到弹性需求页面（ResellClickToUnstableStore）
OCR 识别并点击"弹性需求"/"Flexible"标签，进入弹性需求商店标签页

3. 验证弹性需求商店页面（ResellWaitForUnstableStore）
保留图标模板匹配作为切换成功的二次验证，轮询直到页面稳定

## 影响
- 覆盖稳定商店的商品在被买空后图标缺失和覆盖弹性需求商店图标可能在未来更新中缺失的边缘情况
- 最小化改动，不改变原有流程，仅增强页面识别鲁棒性

## Summary by Sourcery

通过改用基于 OCR 的轮询检测页面标题文本，并保留基于图标的检查作为二次验证，改进转售（Resell）流水线的商店页面检测。

Bug 修复：
- 修复当工业物品图标在物品售罄后消失时，无法检测到稳定需求商店页面的问题。

增强功能：
- 添加基于 OCR 的轮询步骤，通过页面标题文本检测稳定和弹性需求商店标签，并确认页面跳转是否成功。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Resell pipeline store-page detection by switching to OCR-based polling on page header text while retaining icon-based checks as secondary verification.

Bug Fixes:
- Fix failure to detect the stable demand store page when its industrial item icon disappears after items are sold out.

Enhancements:
- Add OCR-based polling steps to detect stable and flexible demand store tabs via header text and confirm successful page transitions.

</details>