### PR TITLE
ci: use maa_checker.json

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run maa-checker
         run: |
           # Always use latests @nekosu/maa-checker
-          npx @nekosu/maa-checker@latest ./assets/interface.json --github=. --error=mpe-config
+          npx @nekosu/maa-checker@latest ./assets/interface.json --github=. --load-config=.vscode/maa_checker.json
 
       # pip install maafw
       - name: Install maafw

--- a/.gitignore
+++ b/.gitignore
@@ -420,6 +420,7 @@ FodyWeavers.xsd
 !.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/mse_config.json
+!.vscode/maa_checker.json
 *.code-workspace
 
 # Local History for Visual Studio Code

--- a/.vscode/maa_checker.json
+++ b/.vscode/maa_checker.json
@@ -1,0 +1,5 @@
+{
+    "errorTypes": [
+        "mpe-config"
+    ]
+}


### PR DESCRIPTION
主要是让vscode内部和流水线上的额外配置一致；目前只有将mpe-config视为错误。

## 由 Sourcery 提供的摘要

CI：
- 更新 GitHub Actions 工作流中的 maa-checker 调用方式，从 `.vscode/maa_checker.json` 加载配置，而不是使用硬编码的错误标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update maa-checker invocation in the GitHub Actions workflow to load configuration from .vscode/maa_checker.json instead of using a hardcoded error flag.

</details>