### PR TITLE
fix: 修复基建会忽视培育仓的问题

### DIFF
--- a/assets/resource/pipeline/DijiangRewards.json
+++ b/assets/resource/pipeline/DijiangRewards.json
@@ -30,7 +30,6 @@
             "[JumpBack]Teleport",
             "[JumpBack]SelectDijiangTeleport",
             "[JumpBack]OpenMap"
-
         ]
     },
     "ControlNexus": {
@@ -109,7 +108,6 @@
             "[JumpBack]SelectDijiangTeleport",
             "[JumpBack]OpenMap",
             "[JumpBack]CancelExit"
-
         ]
     },
     "EntryReceptionRoom_NeedCredit": {
@@ -265,6 +263,7 @@
         "recognition": {
             "type": "TemplateMatch",
             "param": {
+                "threshold": 0.8,
                 "roi": [
                     895,
                     464,
@@ -427,7 +426,6 @@
                 ],
                 "expected": [
                     "线索" //#I18N
-
                 ],
                 "order_by": "Vertical"
             }
@@ -549,7 +547,6 @@
                                 ],
                                 "expected": [
                                     "线索已满" //#不确定
-
                                 ]
                             }
                         }
@@ -1217,7 +1214,7 @@
         "action": {
             "type": "Scroll",
             "param": {
-                "dx": 100,
+                "dx": 240,
                 "target_offset": [
                     600,
                     20,


### PR DESCRIPTION
- 增加识别阈值，防止错误识别培育仓icon
- 增加滑动力度，确保滑动到最后

## Summary by Sourcery

调整 Dijiang 奖励的流水线配置，以在基础设施运行中改进对繁殖室的识别与交互。

Bug Fixes:
- 通过收紧流水线配置中的识别阈值，防止将其他图标误识别为繁殖室图标。
- 确保滑动操作可以可靠地滚动至末尾，从而在处理过程中不再跳过繁殖室。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust pipeline configuration for Dijiang rewards to improve recognition and interaction with the breeding room in infrastructure runs.

Bug Fixes:
- Prevent misidentification of the breeding room icon by tightening recognition thresholds in the pipeline configuration.
- Ensure swipe actions reliably scroll to the end so the breeding room is no longer skipped during processing.

</details>