### PR TITLE
fix: 修复自动点击传送按钮识别了标记追踪按钮

### DIFF
--- a/assets/resource/pipeline/RealTimeTask/QuickTeleport.json
+++ b/assets/resource/pipeline/RealTimeTask/QuickTeleport.json
@@ -25,7 +25,7 @@
         "doc": "直接点击传送按钮",
         "recognition": "TemplateMatch",
         "template": "RealTimeTask/Teleport.png",
-        "threshold": 0.7,
+        "threshold": 0.8,
         "roi": [
             1210,
             648,


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修正 QuickTeleport 中的按钮识别，使自动点击逻辑目标为传送按钮而不是标记追踪按钮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct button identification in QuickTeleport so the auto-click logic targets the teleport button instead of the marker tracking button.

</details>