### PR TITLE
fix: 信用商店的点击仅执行一次（#396）

### DIFF
--- a/assets/resource/pipeline/CreditShopping/BuyItem.json
+++ b/assets/resource/pipeline/CreditShopping/BuyItem.json
@@ -1,13 +1,14 @@
 {
     // 在商店中购买物品的节点
-    "CreditShoppingBuyFistItem": {
+    "CreditShoppingBuyFirstItem": {
         "doc": "点击购买商品",
         "recognition": "DirectHit",
         "action": "Click",
         "target": "CreditShoppingBuyFirst",
         "next": [
             "CreditShoppingBuyFailed",
-            "CreditShoppingBuyConfirm"
+            "CreditShoppingBuyConfirm",
+            "CreditShoppingBuyFirstItem"
         ]
     },
     "CreditShoppingBuyNormalItem": {
@@ -17,7 +18,8 @@
         "target": "CreditShoppingBuyNormal",
         "next": [
             "CreditShoppingBuyFailed",
-            "CreditShoppingBuyConfirm"
+            "CreditShoppingBuyConfirm",
+            "CreditShoppingBuyNormalItem"
         ]
     },
     "CreditShoppingBuyBlacklistItem": {
@@ -27,7 +29,8 @@
         "target": "CreditShoppingBuyBlacklist",
         "next": [
             "CreditShoppingBuyFailed",
-            "CreditShoppingBuyConfirm"
+            "CreditShoppingBuyConfirm",
+            "CreditShoppingBuyBlacklistItem"
         ]
     },
     "CreditShoppingBuyFailed": {
@@ -64,7 +67,10 @@
             23,
             23
         ],
-        "action": "Click"
+        "action": "Click",
+        "next": [
+            "CreditShoppingCloseDialog"
+        ]
     },
     "CreditShoppingBuyConfirm": {
         "doc": "购买确认",
@@ -80,7 +86,8 @@
         "action": "Click",
         "next": [
             "CreditShoppingClaimConfirm",
-            "CreditShoppingBuyFailed"
+            "CreditShoppingBuyFailed",
+            "CreditShoppingBuyConfirm"
         ]
     }
 }

--- a/assets/resource/pipeline/CreditShopping/ClaimCredit.json
+++ b/assets/resource/pipeline/CreditShopping/ClaimCredit.json
@@ -11,7 +11,8 @@
         ],
         "action": "Click",
         "next": [
-            "CreditShoppingClaimConfirm"
+            "CreditShoppingClaimConfirm",
+            "CreditShoppingClaimCredit"
         ]
     },
     "CreditShoppingNoCreditClaim": {
@@ -41,7 +42,8 @@
         ],
         "action": "Click",
         "next": [
-            "CreditShoppingShopping"
+            "CreditShoppingShopping",
+            "CreditShoppingClaimConfirm"
         ]
     }
 }

--- a/assets/resource/pipeline/CreditShopping/Shopping.json
+++ b/assets/resource/pipeline/CreditShopping/Shopping.json
@@ -12,7 +12,9 @@
         ],
         "action": "Custom",
         "custom_action": "CreditShoppingParseParams",
-        "next": ["CreditShoppingScanItem"]
+        "next": [
+            "CreditShoppingScanItem"
+        ]
     },
     "CreditShoppingScanItem": {
         "recognition": "TemplateMatch",
@@ -49,7 +51,9 @@
     "CreditShoppingBuyFirst": {
         "doc": "优先购买",
         "recognition": "And",
-        "all_of": [{}],
+        "all_of": [
+            {}
+        ],
         "attach": {
             "all_of": [
                 {
@@ -125,13 +129,15 @@
             ]
         },
         "next": [
-            "CreditShoppingBuyFistItem"
+            "CreditShoppingBuyFirstItem"
         ]
     },
     "CreditShoppingBuyNormal": {
         "doc": "普通购买",
         "recognition": "And",
-        "all_of": [{}],
+        "all_of": [
+            {}
+        ],
         "attach": {
             "all_of": [
                 {


### PR DESCRIPTION
之前理解错了节点的执行逻辑，以为重试时会重新执行 Action，所以点击的部分写的都有点问题。
#396 修复了其中一个，这里尝试修复了剩下的。

## Summary by Sourcery

错误修复：
- 修正信用商店流水线配置，确保在重试执行时能够多次触发点击操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct credit shop pipeline configurations so retried executions do not trigger click actions multiple times.

</details>