### PR TITLE
refactor: 提供 Key 相关操作的抽象封装

### DIFF
--- a/agent/go-service/keymap/actions.go
+++ b/agent/go-service/keymap/actions.go
@@ -1,0 +1,144 @@
+package keymap
+
+import (
+	"encoding/json"
+	"time"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	unsupportedKey = -1
+	invalidKey     = -2
+)
+
+var keymap map[string]int32 = Win32Keymap
+
+// Transfer key string to key code.
+//
+// Params:
+//   - key: The key string, e.g. "Move_W", "Jump", "Attack", etc.
+//
+// Returns:
+//   - KeyCode(int32): The corresponding key code for the given key string if the key is supported.
+//   - -1: If the key string is unsupported.
+//   - -2: If the key string is invalid.
+func GetKeyCode(key string) int32 {
+
+	var keyCode, ok = keymap[key]
+	if !ok {
+		log.Error().Msgf("Invalid key: %s", key)
+		return invalidKey
+	}
+	if keyCode == unsupportedKey {
+		log.Error().Msgf("Unsupported key: %s", key)
+	}
+
+	return keyCode
+}
+
+type KM_Init struct{}
+
+func (a *KM_Init) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	var params map[string]int32
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
+		return false
+	}
+
+	keymap = params
+
+	log.Info().Msg("Keymap initialized successfully!")
+	log.Info().Interface("keymap", keymap).Msg("Current keymap")
+
+	return true
+}
+
+type KM_ClickKey struct{}
+
+func (a *KM_ClickKey) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	var params struct {
+		Key string `json:"key"`
+	}
+
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
+		return false
+	}
+
+	key := GetKeyCode(params.Key)
+	if key < 0 {
+		return false
+	}
+
+	return ctx.GetTasker().GetController().PostClickKey(key).Wait().Done()
+}
+
+type KM_LongPressKey struct{}
+
+func (a *KM_LongPressKey) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	var params struct {
+		Key      string `json:"key"`
+		Duration int32  `json:"duration"`
+	}
+
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
+		return false
+	}
+
+	key := GetKeyCode(params.Key)
+	if key < 0 {
+		return false
+	}
+
+	var ctrl = ctx.GetTasker().GetController()
+	if !ctrl.PostKeyDown(key).Wait().Done() {
+		return false
+	}
+
+	time.Sleep(time.Duration(params.Duration) * time.Millisecond)
+
+	return ctrl.PostKeyUp(key).Wait().Done()
+}
+
+type KM_KeyDown struct{}
+
+func (a *KM_KeyDown) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	var params struct {
+		Key string `json:"key"`
+	}
+
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
+		return false
+	}
+
+	key := GetKeyCode(params.Key)
+	if key < 0 {
+		return false
+	}
+
+	return ctx.GetTasker().GetController().PostKeyDown(key).Wait().Done()
+}
+
+type KM_KeyUp struct{}
+
+func (a *KM_KeyUp) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	var params struct {
+		Key string `json:"key"`
+	}
+
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
+		return false
+	}
+
+	key := GetKeyCode(params.Key)
+	if key < 0 {
+		return false
+	}
+
+	return ctx.GetTasker().GetController().PostKeyUp(key).Wait().Done()
+}

--- a/agent/go-service/keymap/keymap.go
+++ b/agent/go-service/keymap/keymap.go
@@ -64,6 +64,30 @@ var Win32KeyEnum = map[string]int32{
 	"Show/HideProductIcons": 0x73, // F4
 }
 
+// GetKeyCode Transfer key string to key code.
+//
+// Params:
+//   - key: The key string, e.g. "Move_W", "Jump", "Attack", etc.
+//
+// Returns:
+//   - KeyCode(int32): The corresponding key code for the given key string if the key is supported.
+//   - -1: If the key string is unsupported.
+//   - -2: If the key string is invalid.
+func GetKeyCode(key string) int32 {
+	var keyCode, ok = Win32KeyEnum[key]
+	if !ok {
+		log.Error().Msgf("Invalid key: %s", key)
+		return -2
+	}
+	if keyCode == -1 {
+		log.Error().Msgf("Unsupported key: %s", key)
+	}
+
+	//log.Debug().Msgf("Posting KeyDown: %s (%d | 0x%X)", key, keyCode, keyCode)
+
+	return keyCode
+}
+
 // In order to avoid conflict with maafw, add _ for struct names.
 type _ClickKey struct{}
 
@@ -83,13 +107,10 @@ func (a *_ClickKey) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		return false
 	}
 
-	var key, ok = Win32KeyEnum[params.Key]
-	if !ok {
-		log.Error().Msgf("Invalid key: %s", params.Key)
+	key := GetKeyCode(params.Key)
+	if key < 0 {
 		return false
 	}
-
-	log.Debug().Msgf("Posting ClickKey: %s (%d | 0x%X)", params.Key, key, key)
 
 	return ctx.GetTasker().GetController().PostClickKey(key).Wait().Done()
 }
@@ -105,13 +126,10 @@ func (a *_LongPressKey) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		return false
 	}
 
-	var key, ok = Win32KeyEnum[params.Key]
-	if !ok {
-		log.Error().Msgf("Invalid key: %s", params.Key)
+	key := GetKeyCode(params.Key)
+	if key < 0 {
 		return false
 	}
-
-	log.Debug().Msgf("Posting LongPressKey: %s (%d | 0x%X) for %d ms", params.Key, key, key, params.Duration)
 
 	var ctrl = ctx.GetTasker().GetController()
 	if !ctrl.PostKeyDown(key).Wait().Done() {
@@ -133,13 +151,10 @@ func (a *_KeyDown) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		return false
 	}
 
-	var key, ok = Win32KeyEnum[params.Key]
-	if !ok {
-		log.Error().Msgf("Invalid key: %s", params.Key)
+	key := GetKeyCode(params.Key)
+	if key < 0 {
 		return false
 	}
-
-	log.Debug().Msgf("Posting KeyDown: %s (%d | 0x%X)", params.Key, key, key)
 
 	return ctx.GetTasker().GetController().PostKeyDown(key).Wait().Done()
 }
@@ -154,13 +169,10 @@ func (a *_KeyUp) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		return false
 	}
 
-	var key, ok = Win32KeyEnum[params.Key]
-	if !ok {
-		log.Error().Msgf("Invalid key: %s", params.Key)
+	key := GetKeyCode(params.Key)
+	if key < 0 {
 		return false
 	}
-
-	log.Debug().Msgf("Posting KeyUp: %s (%d | 0x%X)", params.Key, key, key)
 
 	return ctx.GetTasker().GetController().PostKeyUp(key).Wait().Done()
 }

--- a/agent/go-service/keymap/keymap.go
+++ b/agent/go-service/keymap/keymap.go
@@ -1,0 +1,166 @@
+package keymap
+
+import (
+	"encoding/json"
+	"time"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+// Default settings
+var Win32KeyEnum = map[string]int32{
+	// General
+	"Move_W":           0x57, // W (Locked)
+	"Move_A":           0x41, // A (Locked)
+	"Move_S":           0x53, // S (Locked)
+	"Move_D":           0x44, // D (Locked)
+	"Dash":             0x10, // Shift
+	"Jump":             0x20, // Space
+	"Interact":         0x46, // F
+	"Walk":             0x11, // Ctrl (Locked)
+	"Menu":             0x1B, // Esc (Locked)
+	"Backpack":         0x42, // B
+	"Valuables":        0x4E, // N
+	"Team":             0x55, // U
+	"Operator":         0x43, // C
+	"Mission":          0x4A, // J
+	"TrackMission":     0x56, // V
+	"Map":              0x4D, // M
+	"BackerChat":       0x48, // H
+	"Mail":             0x4B, // K
+	"Operational":      0x77, // F8
+	"Headhunt":         0x78, // F9
+	"SwitchModes":      0x09, // Tab (Locked)
+	"UseTools":         0x52, // R
+	"ExpandToolsWheel": 0x52, // R (LongPress Key) (Followed "UseTools")
+	// Combat
+	"Attack":              0x01, // Left Mouse Button (Locked)
+	"LockToTarget":        0x04, // Middle Mouse Button (Locked)
+	"SwitchTarget":        -1,   // Please Use "Scroll" Action. (Locked)
+	"CastCombo":           0x45, // E
+	"OperatorSkill_1":     0x31, // 1
+	"OperatorSkill_2":     0x32, // 2
+	"OperatorSkill_3":     0x33, // 3
+	"OperatorSkill_4":     0x34, // 4
+	"OperatorUltimate_1":  0x31, // 4 (LongPress Key) (Followed "OperatorSkill_1")
+	"OperatorUltimate_2":  0x32, // 4 (LongPress Key) (Followed "OperatorSkill_2")
+	"OperatorUltimate_3":  0x33, // 4 (LongPress Key) (Followed "OperatorSkill_3")
+	"OperatorUltimate_4":  0x34, // 4 (LongPress Key) (Followed "OperatorSkill_4")
+	"SwitchOperator_1":    0x70, // F1
+	"SwitchOperator_2":    0x71, // F2
+	"SwitchOperator_3":    0x72, // F3
+	"SwitchOperator_4":    0x73, // F4
+	"SwitchOperator_Next": 0x51, // Q
+	// AIC Factory
+	"AICFactoryPlan":        0x4C, // T
+	"TransportBelt":         0x45, // E
+	"Pipeline":              0x51, // Q
+	"FacilityList":          0x5A, // Z
+	"TopViewMode":           0x14, // CapsLock
+	"StashMode":             0x58, // X
+	"RegionalDeployment":    0x59, // Y
+	"Blueprints":            0x70, // F1
+	"Show/HideProductIcons": 0x73, // F4
+}
+
+// In order to avoid conflict with maafw, add _ for struct names.
+type _ClickKey struct{}
+
+type _LongPressKey struct{}
+
+type _KeyDown struct{}
+
+type _KeyUp struct{}
+
+func (a *_ClickKey) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	var params struct {
+		Key string `json:"key"`
+	}
+
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
+		return false
+	}
+
+	var key, ok = Win32KeyEnum[params.Key]
+	if !ok {
+		log.Error().Msgf("Invalid key: %s", params.Key)
+		return false
+	}
+
+	log.Debug().Msgf("Posting ClickKey: %s (%d | 0x%X)", params.Key, key, key)
+
+	return ctx.GetTasker().GetController().PostClickKey(key).Wait().Done()
+}
+
+func (a *_LongPressKey) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	var params struct {
+		Key      string `json:"key"`
+		Duration int32  `json:"duration"`
+	}
+
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
+		return false
+	}
+
+	var key, ok = Win32KeyEnum[params.Key]
+	if !ok {
+		log.Error().Msgf("Invalid key: %s", params.Key)
+		return false
+	}
+
+	log.Debug().Msgf("Posting LongPressKey: %s (%d | 0x%X) for %d ms", params.Key, key, key, params.Duration)
+
+	var ctrl = ctx.GetTasker().GetController()
+	if !ctrl.PostKeyDown(key).Wait().Done() {
+		return false
+	}
+
+	time.Sleep(time.Duration(params.Duration) * time.Millisecond)
+
+	return ctrl.PostKeyUp(key).Wait().Done()
+}
+
+func (a *_KeyDown) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	var params struct {
+		Key string `json:"key"`
+	}
+
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
+		return false
+	}
+
+	var key, ok = Win32KeyEnum[params.Key]
+	if !ok {
+		log.Error().Msgf("Invalid key: %s", params.Key)
+		return false
+	}
+
+	log.Debug().Msgf("Posting KeyDown: %s (%d | 0x%X)", params.Key, key, key)
+
+	return ctx.GetTasker().GetController().PostKeyDown(key).Wait().Done()
+}
+
+func (a *_KeyUp) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	var params struct {
+		Key string `json:"key"`
+	}
+
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
+		return false
+	}
+
+	var key, ok = Win32KeyEnum[params.Key]
+	if !ok {
+		log.Error().Msgf("Invalid key: %s", params.Key)
+		return false
+	}
+
+	log.Debug().Msgf("Posting KeyUp: %s (%d | 0x%X)", params.Key, key, key)
+
+	return ctx.GetTasker().GetController().PostKeyUp(key).Wait().Done()
+}

--- a/agent/go-service/keymap/keymap.go
+++ b/agent/go-service/keymap/keymap.go
@@ -8,8 +8,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	unsupported = -1
+	invalid     = -2
+)
+
 // Default settings
-var Win32KeyEnum = map[string]int32{
+var win32KeyEnum = map[string]int32{
 	// General
 	"Move_W":           0x57, // W (Locked)
 	"Move_A":           0x41, // A (Locked)
@@ -35,25 +40,25 @@ var Win32KeyEnum = map[string]int32{
 	"UseTools":         0x52, // R
 	"ExpandToolsWheel": 0x52, // R (LongPress Key) (Followed "UseTools")
 	// Combat
-	"Attack":              0x01, // Left Mouse Button (Locked)
-	"LockToTarget":        0x04, // Middle Mouse Button (Locked)
-	"SwitchTarget":        -1,   // Please Use "Scroll" Action. (Locked)
-	"CastCombo":           0x45, // E
-	"OperatorSkill_1":     0x31, // 1
-	"OperatorSkill_2":     0x32, // 2
-	"OperatorSkill_3":     0x33, // 3
-	"OperatorSkill_4":     0x34, // 4
-	"OperatorUltimate_1":  0x31, // 4 (LongPress Key) (Followed "OperatorSkill_1")
-	"OperatorUltimate_2":  0x32, // 4 (LongPress Key) (Followed "OperatorSkill_2")
-	"OperatorUltimate_3":  0x33, // 4 (LongPress Key) (Followed "OperatorSkill_3")
-	"OperatorUltimate_4":  0x34, // 4 (LongPress Key) (Followed "OperatorSkill_4")
-	"SwitchOperator_1":    0x70, // F1
-	"SwitchOperator_2":    0x71, // F2
-	"SwitchOperator_3":    0x72, // F3
-	"SwitchOperator_4":    0x73, // F4
-	"SwitchOperator_Next": 0x51, // Q
+	"Attack":              0x01,        // Left Mouse Button (Locked)
+	"LockToTarget":        0x04,        // Middle Mouse Button (Locked)
+	"SwitchTarget":        unsupported, // It's unsupported, please use the "Scroll" Action. (Locked)
+	"CastCombo":           0x45,        // E
+	"OperatorSkill_1":     0x31,        // 1
+	"OperatorSkill_2":     0x32,        // 2
+	"OperatorSkill_3":     0x33,        // 3
+	"OperatorSkill_4":     0x34,        // 4
+	"OperatorUltimate_1":  0x31,        // 1 (LongPress Key) (Followed "OperatorSkill_1")
+	"OperatorUltimate_2":  0x32,        // 2 (LongPress Key) (Followed "OperatorSkill_2")
+	"OperatorUltimate_3":  0x33,        // 3 (LongPress Key) (Followed "OperatorSkill_3")
+	"OperatorUltimate_4":  0x34,        // 4 (LongPress Key) (Followed "OperatorSkill_4")
+	"SwitchOperator_1":    0x70,        // F1
+	"SwitchOperator_2":    0x71,        // F2
+	"SwitchOperator_3":    0x72,        // F3
+	"SwitchOperator_4":    0x73,        // F4
+	"SwitchOperator_Next": 0x51,        // Q
 	// AIC Factory
-	"AICFactoryPlan":        0x4C, // T
+	"AICFactoryPlan":        0x54, // T
 	"TransportBelt":         0x45, // E
 	"Pipeline":              0x51, // Q
 	"FacilityList":          0x5A, // Z
@@ -74,12 +79,12 @@ var Win32KeyEnum = map[string]int32{
 //   - -1: If the key string is unsupported.
 //   - -2: If the key string is invalid.
 func GetKeyCode(key string) int32 {
-	var keyCode, ok = Win32KeyEnum[key]
+	var keyCode, ok = win32KeyEnum[key]
 	if !ok {
 		log.Error().Msgf("Invalid key: %s", key)
-		return -2
+		return invalid
 	}
-	if keyCode == -1 {
+	if keyCode == unsupported {
 		log.Error().Msgf("Unsupported key: %s", key)
 	}
 

--- a/agent/go-service/keymap/keymap.go
+++ b/agent/go-service/keymap/keymap.go
@@ -1,183 +1,57 @@
 package keymap
 
-import (
-	"encoding/json"
-	"time"
-
-	maa "github.com/MaaXYZ/maa-framework-go/v4"
-	"github.com/rs/zerolog/log"
-)
-
-const (
-	unsupported = -1
-	invalid     = -2
-)
-
-// Default settings
-var win32KeyEnum = map[string]int32{
+// Win32 Default settings
+var Win32Keymap = map[string]int32{
 	// General
-	"Move_W":           0x57, // W (Locked)
-	"Move_A":           0x41, // A (Locked)
-	"Move_S":           0x53, // S (Locked)
-	"Move_D":           0x44, // D (Locked)
-	"Dash":             0x10, // Shift
-	"Jump":             0x20, // Space
-	"Interact":         0x46, // F
-	"Walk":             0x11, // Ctrl (Locked)
-	"Menu":             0x1B, // Esc (Locked)
-	"Backpack":         0x42, // B
-	"Valuables":        0x4E, // N
-	"Team":             0x55, // U
-	"Operator":         0x43, // C
-	"Mission":          0x4A, // J
-	"TrackMission":     0x56, // V
-	"Map":              0x4D, // M
-	"BackerChat":       0x48, // H
-	"Mail":             0x4B, // K
-	"Operational":      0x77, // F8
-	"Headhunt":         0x78, // F9
-	"SwitchModes":      0x09, // Tab (Locked)
-	"UseTools":         0x52, // R
-	"ExpandToolsWheel": 0x52, // R (LongPress Key) (Followed "UseTools")
+	"Move_W":           87,  // W (Locked)
+	"Move_A":           65,  // A (Locked)
+	"Move_S":           83,  // S (Locked)
+	"Move_D":           68,  // D (Locked)
+	"Dash":             16,  // Shift
+	"Jump":             32,  // Space
+	"Interact":         70,  // F
+	"Walk":             17,  // Ctrl (Locked)
+	"Menu":             27,  // Esc (Locked)
+	"Backpack":         66,  // B
+	"Valuables":        78,  // N
+	"Team":             85,  // U
+	"Operator":         67,  // C
+	"Mission":          74,  // J
+	"TrackMission":     86,  // V
+	"Map":              77,  // M
+	"BackerChat":       72,  // H
+	"Mail":             75,  // K
+	"Operational":      119, // F8
+	"Headhunt":         120, // F9
+	"SwitchModes":      9,   // Tab (Locked)
+	"UseTools":         82,  // R
+	"ExpandToolsWheel": 82,  // R (LongPress Key) (Followed "UseTools")
 	// Combat
-	"Attack":              0x01,        // Left Mouse Button (Locked)
-	"LockToTarget":        0x04,        // Middle Mouse Button (Locked)
-	"SwitchTarget":        unsupported, // It's unsupported, please use the "Scroll" Action. (Locked)
-	"CastCombo":           0x45,        // E
-	"OperatorSkill_1":     0x31,        // 1
-	"OperatorSkill_2":     0x32,        // 2
-	"OperatorSkill_3":     0x33,        // 3
-	"OperatorSkill_4":     0x34,        // 4
-	"OperatorUltimate_1":  0x31,        // 1 (LongPress Key) (Followed "OperatorSkill_1")
-	"OperatorUltimate_2":  0x32,        // 2 (LongPress Key) (Followed "OperatorSkill_2")
-	"OperatorUltimate_3":  0x33,        // 3 (LongPress Key) (Followed "OperatorSkill_3")
-	"OperatorUltimate_4":  0x34,        // 4 (LongPress Key) (Followed "OperatorSkill_4")
-	"SwitchOperator_1":    0x70,        // F1
-	"SwitchOperator_2":    0x71,        // F2
-	"SwitchOperator_3":    0x72,        // F3
-	"SwitchOperator_4":    0x73,        // F4
-	"SwitchOperator_Next": 0x51,        // Q
+	"Attack":              1,              // Left Mouse Button (Locked)
+	"LockToTarget":        4,              // Middle Mouse Button (Locked)
+	"SwitchTarget":        unsupportedKey, // It's unsupported, please use the "Scroll" Action. (Locked)
+	"CastCombo":           69,             // E
+	"OperatorSkill_1":     49,             // 1
+	"OperatorSkill_2":     50,             // 2
+	"OperatorSkill_3":     51,             // 3
+	"OperatorSkill_4":     52,             // 4
+	"OperatorUltimate_1":  49,             // 1 (LongPress Key) (Followed "OperatorSkill_1")
+	"OperatorUltimate_2":  50,             // 2 (LongPress Key) (Followed "OperatorSkill_2")
+	"OperatorUltimate_3":  51,             // 3 (LongPress Key) (Followed "OperatorSkill_3")
+	"OperatorUltimate_4":  52,             // 4 (LongPress Key) (Followed "OperatorSkill_4")
+	"SwitchOperator_1":    112,            // F1
+	"SwitchOperator_2":    113,            // F2
+	"SwitchOperator_3":    114,            // F3
+	"SwitchOperator_4":    115,            // F4
+	"SwitchOperator_Next": 81,             // Q
 	// AIC Factory
-	"AICFactoryPlan":        0x54, // T
-	"TransportBelt":         0x45, // E
-	"Pipeline":              0x51, // Q
-	"FacilityList":          0x5A, // Z
-	"TopViewMode":           0x14, // CapsLock
-	"StashMode":             0x58, // X
-	"RegionalDeployment":    0x59, // Y
-	"Blueprints":            0x70, // F1
-	"Show/HideProductIcons": 0x73, // F4
-}
-
-// GetKeyCode Transfer key string to key code.
-//
-// Params:
-//   - key: The key string, e.g. "Move_W", "Jump", "Attack", etc.
-//
-// Returns:
-//   - KeyCode(int32): The corresponding key code for the given key string if the key is supported.
-//   - -1: If the key string is unsupported.
-//   - -2: If the key string is invalid.
-func GetKeyCode(key string) int32 {
-	var keyCode, ok = win32KeyEnum[key]
-	if !ok {
-		log.Error().Msgf("Invalid key: %s", key)
-		return invalid
-	}
-	if keyCode == unsupported {
-		log.Error().Msgf("Unsupported key: %s", key)
-	}
-
-	//log.Debug().Msgf("Posting KeyDown: %s (%d | 0x%X)", key, keyCode, keyCode)
-
-	return keyCode
-}
-
-// In order to avoid conflict with maafw, add _ for struct names.
-type _ClickKey struct{}
-
-type _LongPressKey struct{}
-
-type _KeyDown struct{}
-
-type _KeyUp struct{}
-
-func (a *_ClickKey) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
-	var params struct {
-		Key string `json:"key"`
-	}
-
-	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
-		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
-		return false
-	}
-
-	key := GetKeyCode(params.Key)
-	if key < 0 {
-		return false
-	}
-
-	return ctx.GetTasker().GetController().PostClickKey(key).Wait().Done()
-}
-
-func (a *_LongPressKey) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
-	var params struct {
-		Key      string `json:"key"`
-		Duration int32  `json:"duration"`
-	}
-
-	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
-		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
-		return false
-	}
-
-	key := GetKeyCode(params.Key)
-	if key < 0 {
-		return false
-	}
-
-	var ctrl = ctx.GetTasker().GetController()
-	if !ctrl.PostKeyDown(key).Wait().Done() {
-		return false
-	}
-
-	time.Sleep(time.Duration(params.Duration) * time.Millisecond)
-
-	return ctrl.PostKeyUp(key).Wait().Done()
-}
-
-func (a *_KeyDown) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
-	var params struct {
-		Key string `json:"key"`
-	}
-
-	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
-		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
-		return false
-	}
-
-	key := GetKeyCode(params.Key)
-	if key < 0 {
-		return false
-	}
-
-	return ctx.GetTasker().GetController().PostKeyDown(key).Wait().Done()
-}
-
-func (a *_KeyUp) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
-	var params struct {
-		Key string `json:"key"`
-	}
-
-	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
-		log.Error().Err(err).Msg("Failed to parse CustomActionParam")
-		return false
-	}
-
-	key := GetKeyCode(params.Key)
-	if key < 0 {
-		return false
-	}
-
-	return ctx.GetTasker().GetController().PostKeyUp(key).Wait().Done()
+	"AICFactoryPlan":        84,  // T
+	"TransportBelt":         69,  // E
+	"Pipeline":              81,  // Q
+	"FacilityList":          90,  // Z
+	"TopViewMode":           20,  // CapsLock
+	"StashMode":             88,  // X
+	"RegionalDeployment":    89,  // Y
+	"Blueprints":            112, // F1
+	"Show/HideProductIcons": 115, // F4
 }

--- a/agent/go-service/keymap/keymap.go
+++ b/agent/go-service/keymap/keymap.go
@@ -3,29 +3,29 @@ package keymap
 // Win32 Default settings
 var Win32Keymap = map[string]int32{
 	// General
-	"Move_W":           87,  // W (Locked)
-	"Move_A":           65,  // A (Locked)
-	"Move_S":           83,  // S (Locked)
-	"Move_D":           68,  // D (Locked)
-	"Dash":             16,  // Shift
-	"Jump":             32,  // Space
-	"Interact":         70,  // F
-	"Walk":             17,  // Ctrl (Locked)
-	"Menu":             27,  // Esc (Locked)
-	"Backpack":         66,  // B
-	"Valuables":        78,  // N
-	"Team":             85,  // U
-	"Operator":         67,  // C
-	"Mission":          74,  // J
-	"TrackMission":     86,  // V
-	"Map":              77,  // M
-	"BackerChat":       72,  // H
-	"Mail":             75,  // K
-	"Operational":      119, // F8
-	"Headhunt":         120, // F9
-	"SwitchModes":      9,   // Tab (Locked)
-	"UseTools":         82,  // R
-	"ExpandToolsWheel": 82,  // R (LongPress Key) (Followed "UseTools")
+	"Move_W":            87,  // W (Locked)
+	"Move_A":            65,  // A (Locked)
+	"Move_S":            83,  // S (Locked)
+	"Move_D":            68,  // D (Locked)
+	"Dash":              16,  // Shift
+	"Jump":              32,  // Space
+	"Interact":          70,  // F
+	"Walk":              17,  // Ctrl (Locked)
+	"Menu":              27,  // Esc (Locked)
+	"Backpack":          66,  // B
+	"Valuables":         78,  // N
+	"Team":              85,  // U
+	"Operator":          67,  // C
+	"Mission":           74,  // J
+	"TrackMission":      86,  // V
+	"Map":               77,  // M
+	"BackerChat":        72,  // H
+	"Mail":              75,  // K
+	"OperationalManual": 119, // F8
+	"Headhunt":          120, // F9
+	"SwitchModes":       9,   // Tab (Locked)
+	"UseTools":          82,  // R
+	"ExpandToolsWheel":  82,  // R (LongPress Key) (Followed "UseTools")
 	// Combat
 	"Attack":              1,              // Left Mouse Button (Locked)
 	"LockToTarget":        4,              // Middle Mouse Button (Locked)

--- a/agent/go-service/keymap/register.go
+++ b/agent/go-service/keymap/register.go
@@ -3,8 +3,8 @@ package keymap
 import maa "github.com/MaaXYZ/maa-framework-go/v4"
 
 func Register() {
-	maa.AgentServerRegisterCustomAction("_ClickKey", &_ClickKey{})
-	maa.AgentServerRegisterCustomAction("_LongPressKey", &_LongPressKey{})
-	maa.AgentServerRegisterCustomAction("_KeyDown", &_KeyDown{})
-	maa.AgentServerRegisterCustomAction("_KeyUp", &_KeyUp{})
+	maa.AgentServerRegisterCustomAction("km:ClickKey", &_ClickKey{})
+	maa.AgentServerRegisterCustomAction("km:LongPressKey", &_LongPressKey{})
+	maa.AgentServerRegisterCustomAction("km:KeyDown", &_KeyDown{})
+	maa.AgentServerRegisterCustomAction("km:KeyUp", &_KeyUp{})
 }

--- a/agent/go-service/keymap/register.go
+++ b/agent/go-service/keymap/register.go
@@ -1,0 +1,10 @@
+package keymap
+
+import maa "github.com/MaaXYZ/maa-framework-go/v4"
+
+func Register() {
+	maa.AgentServerRegisterCustomAction("_ClickKey", &_ClickKey{})
+	maa.AgentServerRegisterCustomAction("_LongPressKey", &_LongPressKey{})
+	maa.AgentServerRegisterCustomAction("_KeyDown", &_KeyDown{})
+	maa.AgentServerRegisterCustomAction("_KeyUp", &_KeyUp{})
+}

--- a/agent/go-service/keymap/register.go
+++ b/agent/go-service/keymap/register.go
@@ -3,8 +3,9 @@ package keymap
 import maa "github.com/MaaXYZ/maa-framework-go/v4"
 
 func Register() {
-	maa.AgentServerRegisterCustomAction("km:ClickKey", &_ClickKey{})
-	maa.AgentServerRegisterCustomAction("km:LongPressKey", &_LongPressKey{})
-	maa.AgentServerRegisterCustomAction("km:KeyDown", &_KeyDown{})
-	maa.AgentServerRegisterCustomAction("km:KeyUp", &_KeyUp{})
+	maa.AgentServerRegisterCustomAction("km:Init", &KM_Init{})
+	maa.AgentServerRegisterCustomAction("km:ClickKey", &KM_ClickKey{})
+	maa.AgentServerRegisterCustomAction("km:LongPressKey", &KM_LongPressKey{})
+	maa.AgentServerRegisterCustomAction("km:KeyDown", &KM_KeyDown{})
+	maa.AgentServerRegisterCustomAction("km:KeyUp", &KM_KeyUp{})
 }

--- a/agent/go-service/register.go
+++ b/agent/go-service/register.go
@@ -6,6 +6,7 @@ import (
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/essencefilter"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/hdrcheck"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/importtask"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/keymap"
 	puzzle "github.com/MaaXYZ/MaaEnd/agent/go-service/puzzle-solver"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/realtime"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/resell"
@@ -20,6 +21,7 @@ func registerAll() {
 	puzzle.Register()
 	essencefilter.Register()
 	creditshopping.Register()
+	keymap.Register()
 
 	// Register aspect ratio checker (uses TaskerSink, not custom action/recognition)
 	aspectratio.Register()


### PR DESCRIPTION
#457

~~命名好像有点丑 谁有什么其他想法吗（~~
暂定 `km:ClickKey` 这种风格

现在还没有实现获取用户键位配置的功能

合了之后我再去把现有的 pipeline 迁移过来

## Summary by Sourcery

引入一个按键映射模块，将游戏动作标准化为 Win32 按键码，并将其作为可复用的自定义按键动作暴露给各个流水线使用。

新功能：
- 添加默认的 Win32 按键映射，用于常见的游戏内与菜单操作。
- 通过控制器暴露用于点击、长按、按下和释放按键的自定义动作。
- 在 agent 服务中注册按键映射的自定义动作，以便现有和未来的流水线都能使用它们。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a key mapping module that standardizes game actions to Win32 key codes and exposes them as reusable custom key actions for pipelines.

New Features:
- Add a default Win32 keymap for common in-game and menu actions.
- Expose custom actions for clicking, long-pressing, pressing, and releasing keys via the controller.
- Register the keymap custom actions in the agent service so they can be used by existing and future pipelines.

</details>

增强点：
- 添加一个 keymap 模块，为常见的游戏内操作和菜单定义默认的 Win32 键位绑定。
- 通过代理控制器暴露用于点击、长按、按下和释放按键的自定义操作。
- 在代理服务中注册 keymap 自定义操作，使其可供各个 pipeline 使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个按键映射模块，将游戏动作标准化为 Win32 按键码，并将其作为可复用的自定义按键动作暴露给各个流水线使用。

新功能：
- 添加默认的 Win32 按键映射，用于常见的游戏内与菜单操作。
- 通过控制器暴露用于点击、长按、按下和释放按键的自定义动作。
- 在 agent 服务中注册按键映射的自定义动作，以便现有和未来的流水线都能使用它们。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a key mapping module that standardizes game actions to Win32 key codes and exposes them as reusable custom key actions for pipelines.

New Features:
- Add a default Win32 keymap for common in-game and menu actions.
- Expose custom actions for clicking, long-pressing, pressing, and releasing keys via the controller.
- Register the keymap custom actions in the agent service so they can be used by existing and future pipelines.

</details>

</details>