### PR TITLE
chore: 修复 json.schemas 无法匹配 pipeline 子文件夹内文件的问题

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,14 +2,14 @@
     "json.schemas": [
         {
             "fileMatch": [
-                "/assets/resource/pipeline/*.json",
-                "/assets/resource_*/pipeline/*.json",
-                "/install/resource/pipeline/*.json",
-                "/install/resource_*/pipeline/*.json",
-                "/assets/resource/pipeline/*.jsonc",
-                "/assets/resource_*/pipeline/*.jsonc",
-                "/install/resource/pipeline/*.jsonc",
-                "/install/resource_*/pipeline/*.jsonc"
+                "/assets/resource/pipeline/**/*.json",
+                "/assets/resource_*/pipeline/**/*.json",
+                "/install/resource/pipeline/**/*.json",
+                "/install/resource_*/pipeline/**/*.json",
+                "/assets/resource/pipeline/**/*.jsonc",
+                "/assets/resource_*/pipeline/**/*.jsonc",
+                "/install/resource/pipeline/**/*.jsonc",
+                "/install/resource_*/pipeline/**/*.jsonc"
             ],
             "url": "/tools/schema/pipeline.schema.json"
         },


### PR DESCRIPTION
## Summary by Sourcery

Build:
- 更新 VS Code JSON 架构配置，以便正确将管道子目录中的文件关联到对应的架构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update VS Code JSON schema configuration so pipeline subdirectory files are correctly associated with their schemas.

</details>