### PR TITLE
feat:自动战斗普攻支持改键0

### DIFF
--- a/assets/misc/locales/en_us.json
+++ b/assets/misc/locales/en_us.json
@@ -17,6 +17,8 @@
     "option.AutoFight.label": "Combat Assist",
     "option.AutoFight.description": "Semi-automatic combat.",
     "option.AutoFightAttack.label": "Auto Basic Attack",
+    "option.AutoFightAttackKey.label": "Remap Basic Attack Key",
+    "option.AutoFightAttackKey.description": "Requires in-game setting: Basic Attack - Key 2 set to 0",
     "option.AutoFightSkill.label": "Auto Use Skills",
     "option.AutoFightEndSkill.label": "Auto Use Ultimate",
     "option.AutoFightCombo.label": "Auto Trigger Link Skills",

--- a/assets/misc/locales/ja_jp.json
+++ b/assets/misc/locales/ja_jp.json
@@ -17,6 +17,8 @@
     "option.AutoFight.label": "戦闘支援",
     "option.AutoFight.description": "半自動戦闘です。",
     "option.AutoFightAttack.label": "通常攻撃を自動",
+    "option.AutoFightAttackKey.label": "通常攻撃キー変更",
+    "option.AutoFightAttackKey.description": "ゲーム内設定が必要：通常攻撃-キー2を0に設定",
     "option.AutoFightSkill.label": "スキル自動使用",
     "option.AutoFightEndSkill.label": "必殺技自動使用",
     "option.AutoFightCombo.label": "連携スキル自動発動",

--- a/assets/misc/locales/ko_kr.json
+++ b/assets/misc/locales/ko_kr.json
@@ -17,6 +17,8 @@
     "option.AutoFight.label": "전투 보조",
     "option.AutoFight.description": "반자동 전투입니다.",
     "option.AutoFightAttack.label": "기본 공격 자동",
+    "option.AutoFightAttackKey.label": "기본 공격 키 변경",
+    "option.AutoFightAttackKey.description": "게임 내 설정 필요: 기본 공격 - 키 2를 0으로 설정",
     "option.AutoFightSkill.label": "스킬 자동 사용",
     "option.AutoFightEndSkill.label": "궁극기 자동 사용",
     "option.AutoFightCombo.label": "연계 스킬 자동 발동",

--- a/assets/misc/locales/zh_cn.json
+++ b/assets/misc/locales/zh_cn.json
@@ -17,6 +17,8 @@
     "option.AutoFight.label": "辅助战斗",
     "option.AutoFight.description": "半自动战斗",
     "option.AutoFightAttack.label": "自动普攻",
+    "option.AutoFightAttackKey.label": "普攻改键",
+    "option.AutoFightAttackKey.description": "需在游戏中设置:普通攻击-按键2改为0",
     "option.AutoFightSkill.label": "自动释放技能",
     "option.AutoFightEndSkill.label": "自动释放终结技",
     "option.AutoFightCombo.label": "自动触发连携技能",

--- a/assets/misc/locales/zh_tw.json
+++ b/assets/misc/locales/zh_tw.json
@@ -17,6 +17,8 @@
     "option.AutoFight.label": "輔助戰鬥",
     "option.AutoFight.description": "半自動戰鬥",
     "option.AutoFightAttack.label": "自動普攻",
+    "option.AutoFightAttackKey.label": "普攻改鍵",
+    "option.AutoFightAttackKey.description": "需在遊戲中設定:普通攻擊-按鍵2改為0",
     "option.AutoFightSkill.label": "自動釋放技能",
     "option.AutoFightEndSkill.label": "自動釋放終結技",
     "option.AutoFightCombo.label": "自動觸發連攜技能",

--- a/assets/resource/pipeline/RealTimeTask/AutoFight.json
+++ b/assets/resource/pipeline/RealTimeTask/AutoFight.json
@@ -75,15 +75,44 @@
     "RealTimeAutoFightAttack": {
         "doc": "自动普攻",
         "recognition": "DirectHit",
-        "action": "Click",
         "pre_delay": 0,
         "post_delay": 0,
-        "target": [
-            600,
-            320,
-            80,
-            80
-        ],
+        "next": [
+            "RealTimeAutoFightAttackMousePress",
+            "RealTimeAutoFightAttackKeyPress"
+        ]
+    },
+    "RealTimeAutoFightAttackMousePress": {
+        "doc": "自动普攻点击鼠标",
+        "recognition": "DirectHit",
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    600,
+                    320,
+                    80,
+                    80
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "RealTimeAutoFightEntry"
+        ]
+    },
+    "RealTimeAutoFightAttackKeyPress": {
+        "doc": "自动普攻键盘按键",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "action": {
+            "type": "ClickKey",
+            "param": {
+                "key": 48 // 0键
+            }
+        },
         "next": [
             "RealTimeAutoFightEntry"
         ]

--- a/assets/tasks/RealTimeTask.json
+++ b/assets/tasks/RealTimeTask.json
@@ -328,12 +328,45 @@
                         "RealTimeAutoFightAttack": {
                             "enabled": true
                         }
-                    }
+                    },
+                    "option": [
+                        "AutoFightAttackKey"
+                    ]
                 },
                 {
                     "name": "No",
                     "pipeline_override": {
                         "RealTimeAutoFightAttack": {
+                            "enabled": false
+                        }
+                    }
+                }
+            ]
+        },
+        "AutoFightAttackKey": {
+            "label": "$option.AutoFightAttackKey.label",
+            "type": "switch",
+            "description": "$option.AutoFightAttackKey.description",
+            "default": "No",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "RealTimeAutoFightAttackMousePress": {
+                            "enabled": false
+                        },
+                        "RealTimeAutoFightAttackKeyPress": {
+                            "enabled": true
+                        }
+                    }
+                },
+                {
+                    "name": "No",
+                    "pipeline_override": {
+                        "RealTimeAutoFightAttackMousePress": {
+                            "enabled": true
+                        },
+                        "RealTimeAutoFightAttackKeyPress": {
                             "enabled": false
                         }
                     }


### PR DESCRIPTION
自动战斗普攻支持改键0

## Summary by Sourcery

添加对将自动战斗普通攻击重映射到按键 0 的支持，并更新相关的实时任务配置。

新功能：
- 允许通过按键重映射设置，将自动战斗的普通攻击绑定到按键 0 触发。

增强：
- 调整实时自动战斗任务配置，以识别新的普通攻击按键映射选项。
- 更新本地化资源，使其在所有受支持语言中体现新的自动战斗按键映射功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for remapping the auto-battle normal attack to the 0 key and update related real-time task configuration.

New Features:
- Allow auto-battle normal attacks to be triggered using the 0 key via key remapping settings.

Enhancements:
- Adjust real-time auto-fight task configuration to recognize the new key-mapping option for normal attacks.
- Update localization resources to reflect the new auto-battle key-mapping capability across supported languages.

</details>