### PR TITLE
fix: 基建任务选项缺少“不使用总控中枢生产助力”

### DIFF
--- a/assets/tasks/DijiangRewards.json
+++ b/assets/tasks/DijiangRewards.json
@@ -6,7 +6,8 @@
             "entry": "DijiangRewards",
             "description": "$task.DijiangRewards.description",
             "option": [
-                "AutoStartExchange"
+                "AutoStartExchange",
+                "ProductionAssistanceWithoutTheControlNexus"
             ]
         }
     ],


### PR DESCRIPTION
#537 实现了该选项，但没有显示在 UI 上

## Summary by Sourcery

在狄江基础设施任务奖励配置中，公开先前已实现的用于禁用全球控制中心生产协助的选项。

New Features:
- 在 UI 中新增可见选项，用于在狄江任务中禁用使用全球控制中心进行生产协助。

Bug Fixes:
- 确保禁用全球控制中心生产协助的配置已正确接入，并能够在狄江任务的 UI 中正确显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose the previously implemented option for disabling global control center production assistance in the Dijiang infrastructure task rewards configuration.

New Features:
- Add a visible UI option to disable using the global control center for production assistance in Dijiang tasks.

Bug Fixes:
- Ensure the configuration for disabling global control center production assistance is correctly wired to appear in the Dijiang tasks UI.

</details>