### PR TITLE
fix: 修复 go-service 进程残留

### DIFF
--- a/agent/go-service/aspectratio/checker.go
+++ b/agent/go-service/aspectratio/checker.go
@@ -28,7 +28,13 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 	if event != maa.EventStatusStarting {
 		return
 	}
-
+	
+	if detail.Entry == "MaaTaskerPostStop" {
+		// Ignore post-stop events to avoid redundant checks
+		log.Debug().Msg("Received PostStop event, skipping aspect ratio check")
+		return
+	}
+	
 	log.Debug().
 		Uint64("task_id", detail.TaskID).
 		Str("entry", detail.Entry).


### PR DESCRIPTION
修复 #422 
在checker接受到MaaTaskerPostStop事件时，agent已经进入停止的流程，maafw中agentServer的msg loop也将关闭，此时若继续获取controller并继续获取image则会陷入无限等待
checker.go不应进行后续检查，避免agent在关闭流程中仍旧请求controller.CacheImage()

## Summary by Sourcery

错误修复：
- 防止纵横比检查器在 `MaaTaskerPostStop` 事件中执行与图像相关的检查，以避免代理在关闭过程中可能出现卡死。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent aspect ratio checker from performing image-related checks on MaaTaskerPostStop events that could cause the agent to hang during shutdown.

</details>