### PR TITLE
fix(SellProduct): 修复据点切换延迟过低引发的状态不一致问题

### DIFF
--- a/assets/resource/pipeline/SellProduct.json
+++ b/assets/resource/pipeline/SellProduct.json
@@ -612,6 +612,7 @@
                 ]
             }
         },
+        "post_wait_freezes": 80,
         "next": [
             "SellProductCheckLocalDone"
         ]


### PR DESCRIPTION
1. 因为延迟过低导致提前识别到了结束标志,即SellProductLocalDone节点的颜色识别,所以加点延迟修复

## Summary by Sourcery

错误修复：
- 增加对 `SellProductLocalDone` 检测的延迟，以避免由于延迟过低导致过早识别为结束状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Increase delay around SellProductLocalDone detection to avoid premature end-state recognition caused by overly low latency.

</details>