### PR TITLE
fix:修复基建中有多次恢复低心情时,第二次恢复会选择第二排干员

### DIFF
--- a/assets/resource/pipeline/DijiangRewards.json
+++ b/assets/resource/pipeline/DijiangRewards.json
@@ -1816,7 +1816,7 @@
             }
         },
         "next": [
-            "EmotionFull",
+            "[JumpBack]EmotionFull",
             "[JumpBack]YellowConfirmButtonType1",
             "StartRecoveryEmotion",
             "CloseButtonType1"


### PR DESCRIPTION
## Summary by Sourcery

杂务：
- 调整 `DijiangRewards.json` 资源配置，以适配基础基础设施的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Adjust DijiangRewards.json resource configuration for base infrastructure behavior.

</details>