### PR TITLE
fix(VisitFriends): Issue #582 & #593

### DIFF
--- a/assets/resource/pipeline/VisitFriends.json
+++ b/assets/resource/pipeline/VisitFriends.json
@@ -35,40 +35,15 @@
             "OnFriendList"
         ]
     },
-    "OpenFriendListFromFriendShip": {
-        "doc": "在好友船上时按 Esc 会打开好友列表（而非暂停菜单），按下 Esc 后进入好友列表",
-        "recognition": {
-            "type": "TemplateMatch",
-            "param": {
-                "template": "VisitFriends/ArriveShip.png",
-                "roi": [
-                    1166,
-                    0,
-                    114,
-                    76
-                ],
-                "threshold": 0.8
-            }
-        },
-        "action": {
-            "type": "ClickKey",
-            "param": {
-                "key": 27
-            }
-        },
-        "post_delay": 400,
-        "next": [
-            "OnFriendList"
-        ]
-    },
     "EnterPauseMenu": {
-        "doc": "在己方世界按下 Esc 唤出暂停界面，等待「好友」按钮（仅在非好友船时有效）",
+        "doc": "在己方世界按下 Esc 唤出暂停界面，等待「好友」按钮（仅在非好友船、且不在好友列表时有效）",
         "max_hit": 1,
         "recognition": {
             "type": "And",
             "param": {
                 "all_of": [
-                    "InWorld"
+                    "InWorld",
+                    "NotOnFriendList"
                 ]
             }
         },
@@ -127,6 +102,28 @@
             "ClueExchangeOCR",
             "VisitEnd"
         ]
+    },
+    "NotOnFriendList": {
+        "doc": "识别当前不在好友列表界面（用于 EnterPauseMenu，避免在好友列表时误判为 InWorld 而按 Esc）",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "template": "VisitFriends/OnFriendList.png",
+                "roi": [
+                    12,
+                    44,
+                    80,
+                    64
+                ],
+                "threshold": 0.8
+            }
+        },
+        "inverse": true,
+        "action": {
+            "type": "DoNothing",
+            "param": {}
+        },
+        "next": []
     },
     "PriorStealGate": {
         "doc": "偷菜模式：助力生产 - 剩余次数大于0",
@@ -217,6 +214,7 @@
     },
     "ProductionAssistCheckPriorSteal": {
         "doc": "偷菜模式：找到可以线索交流也能助力生产的好友舰船",
+        "pre_wait_freezes": 200,
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -230,7 +228,29 @@
         },
         "next": [
             "GrowthChamberCheck",
-            "SkipConfirmBackToFriendList"
+            "SkipConfirmBackToFriendList",
+            "ProductionAssistCheckPriorStealRetry"
+        ]
+    },
+    "ProductionAssistCheckPriorStealRetry": {
+        "doc": "子菜单未打开时重试点击",
+        "max_hit": 5,
+        "pre_wait_freezes": 200,
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "template": "VisitFriends/PreStoleCheckAvailable.png",
+                "threshold": 0.95
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GrowthChamberCheck",
+            "SkipConfirmBackToFriendList",
+            "ProductionAssistCheckPriorStealRetry"
         ]
     },
     "ProductionAssistCheck": {
@@ -303,7 +323,6 @@
     "ProductionAssistSwipe": {
         "doc": "好友界面向下滑找更多好友",
         "recognition": "DirectHit",
-        "max_hit": 12,
         "action": {
             "type": "Swipe",
             "param": {
@@ -325,7 +344,6 @@
     "VisitorTerminalSwipeFacilityList": {
         "doc": "访客终端界面为了露出培养仓助力按钮而向左划。post_wait_freezes 用于等待滑动动画结束、界面回位后再识别下一节点，避免动画未结束时误判",
         "recognition": "DirectHit",
-        "max_hit": 12,
         "action": {
             "type": "Swipe",
             "param": {


### PR DESCRIPTION
## VisitFriends  (#582 & #593)

### EnterPauseMenu / NotOnFriendList
- **EnterPauseMenu** 现在还需要子识别项 **NotOnFriendList**（模板匹配 `OnFriendList.png` 且 `inverse: true`）。我们仅在处于 **InWorld** 且**不在**好友列表时，才将其视为“己方世界”并按下 Esc，从而避免在已处于好友列表时发生误触发。
- **NotOnFriendList**（新增）：匹配“不在好友列表”状态；仅用作 EnterPauseMenu 的子识别项。

### 优先偷菜子菜单重试
- **ProductionAssistCheckPriorSteal**：添加了 `pre_wait_freezes: 200` 以及新的后续步骤 **ProductionAssistCheckPriorStealRetry**，以便在子菜单未打开时进行重试，而不是直接跳转到 SkipConfirmBackToFriendList。
- **ProductionAssistCheckPriorStealRetry**（新增）：重试点击优先偷菜入口（使用相同模板，`max_hit: 5`，`pre_wait_freezes: 200`）；后续步骤：GrowthChamberCheck、SkipConfirmBackToFriendList 或自身。

## Summary by Sourcery

调整 VisitFriends 工作流程，以在未查看好友列表时更可靠地打开暂停菜单，并通过重试逻辑使“优先协助抢占”子菜单更加健壮，同时简化相关的导航步骤。

New Features:
- 添加 NotOnFriendList 子识别状态，用于区分玩家当前是否未在查看好友列表。
- 引入 ProductionAssistCheckPriorStealRetry，在“优先协助抢占”子菜单未成功出现时重试打开该子菜单。

Bug Fixes:
- 在 VisitFriends 期间，当已经处于好友列表界面时，防止误触 Esc。
- 当“优先协助抢占”子菜单未能成功打开时，增加重试路径，避免过早跳转到 SkipConfirmBackToFriendList。

Enhancements:
- 更新 EnterPauseMenu，使其依赖 InWorld 和 NotOnFriendList，从而只在玩家自己的世界且不在好友列表时发送 Esc。
- 移除 OpenFriendListFromFriendShip 入口点，改用更新后的 EnterPauseMenu + NotOnFriendList 逻辑。
- 从 ProductionAssistSwipe 和 VisitorTerminalSwipeFacilityList 中移除 max_hit 限制，以便在搜索好友或设施时允许不受限制的滑动操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust VisitFriends workflow to more reliably open the pause menu only when not viewing the friend list and to make the priority-steal submenu more robust with retry logic, while simplifying related navigation steps.

New Features:
- Add NotOnFriendList sub-recognition state to distinguish when the player is not viewing the friend list.
- Introduce ProductionAssistCheckPriorStealRetry to retry opening the priority-steal submenu when it fails to appear.

Bug Fixes:
- Prevent accidental Esc presses when already on the friend list screen during VisitFriends.
- Avoid prematurely skipping to SkipConfirmBackToFriendList by adding a retry path when the priority-steal submenu fails to open.

Enhancements:
- Update EnterPauseMenu to depend on InWorld and NotOnFriendList so Esc is only sent in the player’s own world outside the friend list.
- Remove the OpenFriendListFromFriendShip entry point in favor of the updated EnterPauseMenu + NotOnFriendList logic.
- Remove max_hit limits from ProductionAssistSwipe and VisitorTerminalSwipeFacilityList to allow unbounded swiping when searching for friends or facilities.

</details>