### PR TITLE
feat(ui): 添加提示用户关闭自动颜色管理的文案

### DIFF
--- a/agent/go-service/hdrcheck/warning_message.html
+++ b/agent/go-service/hdrcheck/warning_message.html
@@ -1,6 +1,7 @@
-<span style="color: #ff9800; font-size: 1.6em; font-weight: 900;">⚠️ 警告：检测到 HDR 已开启</span>
-<br/><span style="color: #faad14; font-size: 1.3em; font-weight: bold;">🖥️ HDR 可能导致截图颜色异常，影响图像识别准确性</span>
+<span style="color: #ff9800; font-size: 1.6em; font-weight: 900;">⚠️ 警告：检测到 HDR 或 自动管理应用的颜色 已开启</span>
+<br/><span style="color: #faad14; font-size: 1.3em; font-weight: bold;">🖥️ HDR 或 自动管理应用的颜色 可能导致截图颜色异常，影响图像识别准确性</span>
 <br/><span style="font-size: 1.2em; font-weight: bold;">💡 建议：</span>
-<br/><span style="color: #00bfff; font-size: 1.2em;">  • Windows 设置 → 显示 → 关闭 "使用 HDR"</span>
+<br/><span style="color: #00bfff; font-size: 1.2em;">  • Windows 设置 → 系统 → 屏幕 → 关闭 "HDR"</span>
+<br/><span style="color: #00bfff; font-size: 1.2em;">  • Windows 设置 → 系统 → 屏幕 → 颜色配置文件 → 关闭 "自动管理应用的颜色"</span>
 <br/><span style="color: #00bfff; font-size: 1.2em;">  • 或在图形驱动设置中关闭 HDR</span>
 <br/><br/><span style="font-size: 1.1em; color: #888;">ℹ️ 任务将继续执行，但可能出现识别问题</span>


### PR DESCRIPTION
- 效果图:
<img width="441" height="677" alt="QQ_1771475167710" src="https://github.com/user-attachments/assets/96b9f3d8-c4e4-42e1-ab2b-ec5cd95f25d9" />

## Summary by Sourcery

更新 HDR 检查警告对话框，使其同时涵盖 Windows 自动色彩管理，并优化建议的系统导航路径。

改进内容：
- 扩展 HDR 警告文案，将自动色彩管理作为截图颜色异常的潜在原因之一加以说明。
- 将 Windows 设置指引调整为当前的导航路径，并补充关闭自动色彩管理的具体步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the HDR check warning dialog to also cover Windows automatic color management and refine the suggested system navigation path.

Enhancements:
- Broaden the HDR warning text to mention automatic color management as a potential cause of screenshot color issues.
- Adjust the Windows settings instructions to the current navigation path and include steps to disable automatic color management.

</details>