### PR TITLE
refactor:将大部分万能跳转移动至从大世界跳转

### DIFF
--- a/assets/resource/pipeline/SceneInterface.json
+++ b/assets/resource/pipeline/SceneInterface.json
@@ -211,6 +211,15 @@
             "[JumpBack]SceneAnyEnterWorld"
         ]
     },
+    "SceneEnterMenuBackpack": {
+        "doc": "从任意界面进入背包界面，左侧不一定有仓库",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "ScenePrivateWorldEnterMenuBackpack",
+            "[JumpBack]SceneAnyEnterWorld"
+        ]
+    },
     "SceneEnterMenuBackpackWithDepot": {
         "doc": "从任意界面进入背包界面，左侧包含仓库",
         "pre_delay": 0,

--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -836,6 +836,42 @@
             }
         }
     },
+    "ScenePrivateWorldEnterMenuBackpack": {
+        "desc": "从任意大世界进入包含仓库的背包界面",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    -200,
+                    0,
+                    200,
+                    200
+                ],
+                "template": [
+                    "SceneManager/WorldMenu.png"
+                ],
+                "green_mask": true
+            }
+        },
+        "action": {
+            "type": "ClickKey",
+            "param": {
+                "key": 66 // B
+            }
+        },
+        "post_wait_freezes": {
+            "time": 400,
+            "target": [
+                900,
+                100,
+                250,
+                160
+            ]
+        },
+        "next": [
+            "ScenePrivateAnyEnterMenuBackpackSuccess"
+        ]
+    },
     "ScenePrivateWorldDijiangEnterMenuBackpackWithDepot": {
         "desc": "从帝江号大世界进入包含仓库的背包界面",
         "recognition": {
@@ -879,9 +915,23 @@
                 ]
             }
         },
+        "action": {
+            "type": "ClickKey",
+            "param": {
+                "key": 66 // B
+            }
+        },
+        "post_wait_freezes": {
+            "time": 400,
+            "target": [
+                900,
+                100,
+                250,
+                160
+            ]
+        },
         "next": [
-            "ScenePrivateMenuListEnterMenuBackpack",
-            "[JumpBack]ScenePrivateWorldEnterMenuList"
+            "ScenePrivateAnyEnterMenuBackpackSuccess"
         ]
     },
     "ScenePrivateMenuListEnterMenuBackpack": {


### PR DESCRIPTION
背景：
在后台运行，用户一直移动鼠标时，按esc出现的3D菜单列表会监听鼠标全局坐标，剧烈晃动，导致ocr识别的坐标不准
解决方案：
将大部分跳转从总菜单中移出，从大世界直接跳转

## Summary by Sourcery

增强功能：
- 调整场景接口和场景菜单配置，以支持直接进行主世界切换，而不再通过全局菜单进行跳转。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust scene interface and scene menu configurations to support direct overworld transitions instead of routing through the global menu.

</details>