### PR TITLE
chore: 更新 markdownlint 配置并为赞助图片添加 alt 属性

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,16 @@
+{
+    "MD033": {
+        "allowed_elements": [
+            "details",
+            "summary",
+            "br"
+        ]
+    },
+    "MD024": {
+        "siblings_only": true
+    },
+    "MD007": {
+        "indent": 4
+    },
+    "MD013": false
+}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,4 @@ Powered by [MaaFramework](https://github.com/MaaXYZ/MaaFramework) & [MXU](https:
 
 你的支持是我们持续更新的最大动力！💖
 
-<!-- markdownlint-disable MD045 -->
-
-[<img width="200" src="https://pic1.afdiancdn.com/static/img/welcome/button-sponsorme.png">](https://afdian.com/a/misteo)
+[<img width="200" alt="赞助我们" src="https://pic1.afdiancdn.com/static/img/welcome/button-sponsorme.png">](https://afdian.com/a/misteo)


### PR DESCRIPTION
- 在 .markdownlint.json 中允许 details、summary、br、img 等标签（MD033）
- 禁用 MD013 行长度规则
- 设置 MD024 为 siblings_only: true，允许不同层级标题重复
- 修改赞助按钮图片，添加 alt="赞助我们" 属性，修复 MD045 错误

## Summary by Sourcery

更新 markdownlint 配置，并修复 README 中赞助商图片的无障碍访问元数据。

文档（Documentation）：
- 为 README 中的赞助按钮图片添加替代文本（alt text），以满足 markdownlint 的无障碍访问规则。

杂项（Chores）：
- 引入一个 markdownlint 配置文件，自定义允许的 HTML 标签，并调整对行长度和标题重复的代码检查规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update markdownlint configuration and fix README sponsor image accessibility metadata.

Documentation:
- Add alt text to the sponsor button image in the README to satisfy markdownlint accessibility rules.

Chores:
- Introduce a markdownlint configuration file to customize allowed HTML tags and adjust linting rules for line length and heading duplication.

</details>