### PR TITLE
fix(Common): 尽量避免在中间状态单击 ChangeRegionButton

### DIFF
--- a/assets/resource_fast/pipeline/Common/ChangeRegion.json
+++ b/assets/resource_fast/pipeline/Common/ChangeRegion.json
@@ -1,28 +1,28 @@
 {
     "GoToValleyIV": {
-        "doc": "前往四号谷地",
-        "recognition": "Or",
-        "any_of": [
-            "IncomeReportButton"
+        "doc": "前往四号谷地地区建设界面",
+        "recognition": "And",
+        "all_of": [
+            "InRegionalDevelopment"
         ],
         "next": [
             "InValleyIVRegionalDevelopment",
             "[JumpBack]ConfirmChangeToValleyIV",
-            "[JumpBack]ChangeToValleyIV",
+            "[JumpBack]EnterChangeRegionMenu",
             "[JumpBack]ChangeRegionButton"
         ]
     },
     "GoToWuling": {
-        "doc": "前往武陵",
-        "recognition": "Or",
-        "any_of": [
-            "IncomeReportButton"
+        "doc": "前往武陵地区建设界面",
+        "recognition": "And",
+        "all_of": [
+            "InRegionalDevelopment"
         ],
         "next": [
             "InWulingRegionalDevelopment",
             "[JumpBack]ConfirmChangeToWuling",
             "[JumpBack]ChangeToWuling",
-            "[JumpBack]ChangeRegionButton",
+            "[JumpBack]EnterChangeRegionMenu",
             "[JumpBack]BackFromEnvironmentMonitoringTerminal" // 只有从其他地方切换到武陵双击时，才可能会意外进入环境监测终端
 
         ]
@@ -179,6 +179,25 @@
         "all_of": [
             "CloseButtonType1",
             "CheckOutskirtsMonitoringTerminal"
+        ],
+        "action": "Click",
+        "post_wait_freezes": {
+            "time": 80,
+            "target": [
+                0,
+                0,
+                0,
+                0
+            ]
+        }
+    },
+    "EnterChangeRegionMenu": {
+        "doc": "进入更改地区界面",
+        "recognition": "And",
+        "all_of": [
+            "ChangeRegionButton",
+            // 需要尽量避免在中间状态
+            "InRegionalDevelopment"
         ],
         "action": "Click",
         "post_wait_freezes": {


### PR DESCRIPTION
不过也不好说 InRegionalDevelopment 这个就一定很稳定。

fixed #660

## Summary by Sourcery

Bug Fixes:
- 调整区域更改行为，以在不稳定的中间状态期间尽量减少对 `ChangeRegionButton` 的点击次数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust region change behavior to minimize clicks on ChangeRegionButton during unstable intermediate states.

</details>