### PR TITLE
fix(EssenceFilter): OCR 文本存入前预清洗

### DIFF
--- a/agent/go-service/essencefilter/actions.go
+++ b/agent/go-service/essencefilter/actions.go
@@ -266,14 +266,15 @@ func (a *EssenceFilterCheckItemAction) Run(ctx *maa.Context, arg *maa.CustomActi
 	}
 
 	ocr, _ := arg.RecognitionDetail.Results.Filtered[0].AsOCR()
-	text := ocr.Text
+	rawText := ocr.Text
+	text := cleanChinese(rawText)
 
 	if text == "" {
-		log.Error().Int("slot", params.Slot).Msg("<EssenceFilter> OCR empty")
+		log.Error().Int("slot", params.Slot).Str("raw", rawText).Msg("<EssenceFilter> OCR empty")
 		return false
 	}
-	currentSkills[params.Slot-1] = cleanChinese(text)
-	log.Info().Int("slot", params.Slot).Str("skill", text).Bool("is_last", params.IsLast).Msg("<EssenceFilter> OCR ok")
+	currentSkills[params.Slot-1] = text
+	log.Info().Int("slot", params.Slot).Str("skill", rawText).Bool("is_last", params.IsLast).Msg("<EssenceFilter> OCR ok")
 
 	if !params.IsLast {
 		// wait for next slot


### PR DESCRIPTION
## 问题
1. OCR 误识别：点击基质后，详情面板展开存在动画过渡，若截图时面板尚未完全加载，OCR 会识别到残缺/错误的词条文本（如 "做捷提升" 而非 "敏捷提升"）。<img width="803" height="331" src="https://github.com/user-attachments/assets/1f7cfbe7-5fa4-466c-89a4-792497ba1dc7" />

2. 日志混入杂字符：OCR 偶尔会将 UI 中的横线一并识别（如 智识提升_），导致输出给用户的日志包含杂字符。<img width="1187" height="601" src="https://github.com/user-attachments/assets/7ecf2b95-d798-48ac-b33c-1a362d7e2315" />

## 分析
匹配逻辑中已有 `cleanChinese()`，similarWordMap 映射、子串匹配及编辑距离等多层容错机制，匹配结果本身不受上述问题影响。但 `currentSkills[]` 中存储的仍是原始 OCR 文本，会在打印前台日志时输出，影响用户体验。

## 修复
OCR 识别后即调用 `cleanChinese()`，使下游所有代码（日志展示、技能匹配）统一使用清洗后的文本。
`matchSkillIDEnhanced()`仍会调用`cleanChinese()`，性能影响可以忽略，出于最小化改动的考虑，暂不处理该冗余~~相信后人的智慧~~。

## 后续
考虑重构上述机制，例如：等待画面静止再进行 OCR 识别，换用 TemplateMatch 方法匹配词条，但是需要长期维护模板库。

## Summary by Sourcery

错误修复：
- 在保存用于后续使用和展示之前，确保通过 OCR 识别的技能文本已清理掉无关或残缺的字符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure OCR-recognized skill text is cleaned of spurious or partial characters before being saved for later use and display.

</details>