### PR TITLE
feat:一键售卖产品，增加某个据点售卖多种商品的选项

### DIFF
--- a/assets/resource/pipeline/SellProduct.json
+++ b/assets/resource/pipeline/SellProduct.json
@@ -423,7 +423,7 @@
         "focus": {
             "Node.Action.Succeeded": "成功完成一次交易"
         },
-        "doc": "交易后确认",
+        "doc": "交易后确认，仅zeromoney时切区域，否则先尝试切货品",
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -442,8 +442,10 @@
             "type": "Click",
             "param": {}
         },
+        "post_wait_freezes": 10,
         "next": [
-            "SellProductNext",
+            "SellProductZeroMoney",
+            "SellProductCanSell",
             "SellProductSellCheck"
         ]
     },
@@ -461,10 +463,142 @@
     "SellProductZeroProduct": {
         "pre_delay": 0,
         "post_delay": 0,
+        "doc": "货物数量是0，先尝试更换货品，失败则换据点",
+        "recognition": {
+            "type": "ColorMatch",
+            "param": {
+                "lower": [
+                    [
+                        255,
+                        110,
+                        110
+                    ]
+                ],
+                "upper": [
+                    [
+                        255,
+                        130,
+                        130
+                    ]
+                ],
+                "roi": [
+                    1118,
+                    286,
+                    75,
+                    86
+                ],
+                "count": 10
+            }
+        },
+        "next": [
+            "SellProductChangeProduct",
+            "SellProductNext"
+        ]
+    },
+    "SellProductChangeProduct": {
+        "pre_delay": 0,
+        "doc": "识别更换货品并点击，进入更换UI",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    // 更换货品
+                    "更换货品",
+                    "更換貨品",
+                    "Switch Goods",
+                    "商品変更",
+                    "상품 교체"
+                ],
+                "roi": [
+                    1115,
+                    410,
+                    172,
+                    83
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "SellProductSelectNewProduct"
+        ]
+    },
+    "SellProductSelectNewProduct": {
+        "pre_delay": 0,
+        "doc": "在更换UI中识别新货物并点击",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    // 货品/商品相关
+                    "本地仓储",
+                    "本地區倉儲",
+                    "Local Depot",
+                    "地域在庫",
+                    "지역 저장고"
+                ],
+                "roi": [
+                    511,
+                    180,
+                    274,
+                    83
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "SellProductSelectNewProductComfirm",
+            "SellProductSelectNewProduct"
+        ]
+    },
+    "SellProductSelectNewProductComfirm": {
+        "pre_delay": 0,
+        "doc": "点击确认",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "template": [
+                    "Common/Button/WhiteConfirmButtonType2.png"
+                ],
+                "roi": [
+                    945,
+                    557,
+                    172,
+                    45
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "SellProductCanSellAfterChange"
+        ]
+    },
+    "SellProductCanSellAfterChange": {
+        "pre_delay": 0,
+        "post_delay": 200,
+        "doc": "更换货品后重新判断能否售卖",
+        "next": [
+            "SellProductZeroProductRetry",
+            "SellProductZeroMoney",
+            "SellProductClickBarRight",
+            "SellProductDragBar"
+        ]
+    },
+    "SellProductZeroProductRetry": {
+        "pre_delay": 0,
+        "post_delay": 0,
+        "doc": "更换货品后仍为0，进入换据点流程",
         "focus": {
             "Node.Action.Succeeded": "当前选择产品缺货，请制造或更换"
         },
-        "doc": "货物数量是0",
         "recognition": {
             "type": "ColorMatch",
             "param": {


### PR DESCRIPTION
fix #627

## Summary by Sourcery

在 SellProduct 流水线中引入一键售卖产品功能，并支持在单一地点销售多种产品类型。

新功能：
- 在 SellProduct 流水线中新增一键售卖产品流程。
- 允许在 SellProduct 流水线中配置单一网点/地点，以销售多种不同产品。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce one-click product selling and support selling multiple product types from a single location in the SellProduct pipeline.

New Features:
- Add a one-click product selling flow to the SellProduct pipeline.
- Allow configuring a single outlet/location to sell multiple different products within the SellProduct pipeline.

</details>

新功能：
- 在 `SellProduct` 流程中引入一键产品售卖流程。
- 允许在 `SellProduct` 流程中配置单个网点/地点以售卖多种不同的产品。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 SellProduct 流水线中引入一键售卖产品功能，并支持在单一地点销售多种产品类型。

新功能：
- 在 SellProduct 流水线中新增一键售卖产品流程。
- 允许在 SellProduct 流水线中配置单一网点/地点，以销售多种不同产品。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce one-click product selling and support selling multiple product types from a single location in the SellProduct pipeline.

New Features:
- Add a one-click product selling flow to the SellProduct pipeline.
- Allow configuring a single outlet/location to sell multiple different products within the SellProduct pipeline.

</details>

</details>