### PR TITLE
fix: 修复信用点识别问题

### DIFF
--- a/assets/resource/pipeline/CreditShopping/Shopping.json
+++ b/assets/resource/pipeline/CreditShopping/Shopping.json
@@ -37,7 +37,6 @@
     "CreditShoppingReserveCredit": {
         "doc": "信用点 < 300",
         "recognition": "OCR",
-        "only_rec": true,
         "roi": [
             1083,
             17,
@@ -130,7 +129,6 @@
             76,
             26
         ],
-        "only_rec": true,
         "expected": "^([3-9]\\d{2}|[1-9]\\d{3,})$"
     },
     "CreditShoppingNothingToBuy": {


### PR DESCRIPTION
识别1k+信用点有问题

## Summary by Sourcery

Bug Fixes:
- 修复了在 CreditShopping 流水线配置中对高于 1,000 的信用值处理不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct handling of credit values above 1,000 in the CreditShopping pipeline configuration.

</details>