### PR TITLE
fix(DailyRewards): 修复自动领取委托无法的跳转到地区建设页面的问题

### DIFF
--- a/assets/resource/pipeline/DailyRewards/ClaimDeliveryJobs.json
+++ b/assets/resource/pipeline/DailyRewards/ClaimDeliveryJobs.json
@@ -3,14 +3,14 @@
         "doc": "开始自动领取委托",
         "next": [
             "DailyTaskClaimDeliveryJobsLoop",
-            "[JumpBack]RegionalDevelopmentButton"
+            "[JumpBack]SceneEnterMenuRegionalDevelopment"
         ]
     },
     "DailyTaskClaimDeliveryJobsLoop": {
         "doc": "主循环，确保在地区建设界面",
         "recognition": "And",
         "all_of": [
-            "IncomeReportButton"
+            "InRegionalDevelopment"
         ],
         "next": [
             "ClaimDeliveryJobsValleyIV",


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修复在 DailyRewards 中自动领取配送/佣金奖励后，前往地区建造页面的导航不正确或缺失的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect or missing navigation to the regional construction page after automatically claiming delivery/commission rewards in DailyRewards.

</details>