### PR TITLE
fix: 修复adb抢单时滑动到底部不会再上滑的问题，移除AndroidSeizeEntrustTaskInUpSwipeDown配置复用PC端

### DIFF
--- a/assets/resource/pipeline/SeizeEntrustTask.json
+++ b/assets/resource/pipeline/SeizeEntrustTask.json
@@ -354,6 +354,5 @@
             },
             "type": "OCR"
         }
-    },
-    "AndroidSeizeEntrustTaskInUpSwipeDown": {}
+    }
 }

--- a/assets/resource_adb/pipeline/SeizeEntrustTask.json
+++ b/assets/resource_adb/pipeline/SeizeEntrustTask.json
@@ -150,7 +150,7 @@
                 ],
                 "end": [
                     776,
-                    448
+                    348
                 ]
             },
             "type": "Swipe"
@@ -164,39 +164,7 @@
                     1246,
                     388,
                     23,
-                    40
-                ],
-                "template": [
-                    "SeizeEntrustTask/InMiddle.png"
-                ]
-            },
-            "type": "TemplateMatch"
-        }
-    },
-    "AndroidSeizeEntrustTaskInUpSwipeDown": {
-        "action": {
-            "param": {
-                "begin": [
-                    776,
-                    208
-                ],
-                "end": [
-                    776,
-                    448
-                ]
-            },
-            "type": "Swipe"
-        },
-        "doc": "没找到武陵城就往上翻一页",
-        "enabled": false,
-        "inverse": true,
-        "recognition": {
-            "param": {
-                "roi": [
-                    1246,
-                    388,
-                    23,
-                    40
+                    60
                 ],
                 "template": [
                     "SeizeEntrustTask/InMiddle.png"
@@ -285,7 +253,7 @@
         "next": [
             "[JumpBack]SeizeEntrustTaskFound7.31wMoneyF1",
             "[JumpBack]SeizeEntrustTaskErrorTaskStop",
-            "[JumpBack]AndroidSeizeEntrustTaskInUpSwipeDown",
+            "[JumpBack]SeizeEntrustTaskInUpSwipeDown",
             "[JumpBack]SeizeEntrustTaskNews2"
         ],
         "recognition": {

--- a/assets/tasks/SeizeEntrustTask.json
+++ b/assets/tasks/SeizeEntrustTask.json
@@ -73,17 +73,6 @@
                         },
                         "SeizeEntrustTaskInDownSwipeMiddle": {
                             "enabled": true
-                        },
-                        "AndroidSeizeEntrustTaskInUpSwipeDown": {
-                            "param": {
-                                "roi": [
-                                    1245,
-                                    173,
-                                    24,
-                                    37
-                                ],
-                                "template": "SeizeEntrustTask/InUp.png"
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary by Sourcery

在标准流水线和 ADB 流水线之间对 seize-entrust 任务配置进行对齐，以复用 PC 端行为，并在通过 ADB 抢单时调整列表底部的滚动行为。

Bug 修复：
- 确保 ADB seize-entrust 流程在滚动到列表底部后能够向上滚回，而不是直接停止。
- 通过复用现有的 PC 配置，消除对 `AndroidSeizeEntrustTaskInUpSwipeDown` 专用配置的依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align seize-entrust task configuration between standard and ADB pipelines to reuse the PC behavior and adjust scrolling behavior at the bottom of the list when seizing orders via ADB.

Bug Fixes:
- Ensure ADB seize-entrust flow scrolls back up after reaching the bottom of the list instead of stopping.
- Eliminate reliance on the AndroidSeizeEntrustTaskInUpSwipeDown-specific configuration by reusing the existing PC configuration.

</details>