### PR TITLE
Revert "perf(resell):去掉不需要的controller.PostScreencap().Wait()"

### DIFF
--- a/agent/go-service/resell/resell.go
+++ b/agent/go-service/resell/resell.go
@@ -91,7 +91,6 @@ func (a *ResellInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			log.Info().Msg("[Resell]第一步：识别商品价格")
 			ResellDelayFreezesTime(ctx, 200)
 			MoveMouseSafe(controller)
-			controller.PostScreencap().Wait()
 
 			// 构建Pipeline名称
 			pricePipelineName := fmt.Sprintf("ResellROIProductRow%dCol%dPrice", rowIdx+1, col)
@@ -99,7 +98,6 @@ func (a *ResellInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			if !success {
 				//失败就重试一遍
 				MoveMouseSafe(controller)
-				controller.PostScreencap().Wait()
 				costPrice, clickX, clickY, success = ocrExtractNumberWithCenter(ctx, controller, pricePipelineName)
 				if !success {
 					log.Info().Int("行", rowIdx+1).Int("列", col).Msg("[Resell]位置无数字，说明无商品，下一行")
@@ -114,7 +112,6 @@ func (a *ResellInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			log.Info().Msg("[Resell]第二步：查看好友价格")
 			ResellDelayFreezesTime(ctx, 200)
 			MoveMouseSafe(controller)
-			controller.PostScreencap().Wait()
 
 			_, friendBtnX, friendBtnY, success := ocrExtractTextWithCenter(ctx, controller, "ResellROIViewFriendPrice")
 			if !success {
@@ -123,14 +120,12 @@ func (a *ResellInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			}
 			//商品详情页右上角识别的成本价格为准
 			MoveMouseSafe(controller)
-			controller.PostScreencap().Wait()
 			ConfirmcostPrice, _, _, success := ocrExtractNumberWithCenter(ctx, controller, "ResellROIDetailCostPrice")
 			if success {
 				costPrice = ConfirmcostPrice
 			} else {
 				//失败就重试一遍
 				MoveMouseSafe(controller)
-				controller.PostScreencap().Wait()
 				ConfirmcostPrice, _, _, success := ocrExtractNumberWithCenter(ctx, controller, "ResellROIDetailCostPrice")
 				if success {
 					costPrice = ConfirmcostPrice
@@ -144,19 +139,17 @@ func (a *ResellInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 
 			// Step 3: 检查好友列表第一位的出售价，即最高价格
 			log.Info().Msg("[Resell]第三步：识别好友出售价")
-			//等加载好友价格：循环检测"加载中"字样消失
-			if !waitFriendLoading(ctx, controller) {
-				log.Info().Msg("[Resell]第三步：未能识别好友出售价，跳过该商品")
+			// 等加载好友价格：Pipeline next 轮询 ResellROIFriendSalePrice / ResellROIFriendLoading
+			if _, err := ctx.RunTask("ResellWaitFriendPrice", nil); err != nil {
+				log.Info().Err(err).Msg("[Resell]第三步：未能识别好友出售价，跳过该商品")
 				continue
 			}
 			MoveMouseSafe(controller)
-			controller.PostScreencap().Wait()
 
 			salePrice, _, _, success := ocrExtractNumberWithCenter(ctx, controller, "ResellROIFriendSalePrice")
 			if !success {
 				//失败就重试一遍
 				MoveMouseSafe(controller)
-				controller.PostScreencap().Wait()
 				salePrice, _, _, success = ocrExtractNumberWithCenter(ctx, controller, "ResellROIFriendSalePrice")
 				if !success {
 					log.Info().Msg("[Resell]第三步：未能识别好友出售价，跳过该商品")
@@ -186,7 +179,6 @@ func (a *ResellInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			log.Info().Msg("[Resell]第四步：返回商品详情页")
 			ResellDelayFreezesTime(ctx, 200)
 			MoveMouseSafe(controller)
-			controller.PostScreencap().Wait()
 
 			if _, err := ctx.RunTask("ResellROIReturnButton", nil); err != nil {
 				log.Warn().Err(err).Msg("[Resell]第四步：返回按钮点击失败")
@@ -198,7 +190,6 @@ func (a *ResellInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			log.Info().Msg("[Resell]第五步：关闭商品详情页")
 			ResellDelayFreezesTime(ctx, 200)
 			MoveMouseSafe(controller)
-			controller.PostScreencap().Wait()
 
 			if _, err := ctx.RunTask("CloseButtonType1", nil); err != nil {
 				log.Warn().Err(err).Msg("[Resell]第五步：关闭页面失败")

--- a/agent/go-service/resell/utils.go
+++ b/agent/go-service/resell/utils.go
@@ -36,6 +36,7 @@ func MoveMouseSafe(controller *maa.Controller) {
 
 // ocrExtractNumberWithCenter - OCR region using pipeline name and return number with center coordinates
 func ocrExtractNumberWithCenter(ctx *maa.Context, controller *maa.Controller, pipelineName string) (int, int, int, bool) {
+	controller.PostScreencap().Wait()
 	img, err := controller.CacheImage()
 	if err != nil {
 		log.Error().
@@ -82,6 +83,7 @@ func ocrExtractNumberWithCenter(ctx *maa.Context, controller *maa.Controller, pi
 // ocrExtractTextWithCenter - OCR region using pipeline name and check if pipeline filtered results exist, return center coordinates.
 // Keyword matching is delegated to the pipeline's "expected" field, so no redundant check is needed in Go.
 func ocrExtractTextWithCenter(ctx *maa.Context, controller *maa.Controller, pipelineName string) (bool, int, int, bool) {
+	controller.PostScreencap().Wait()
 	img, err := controller.CacheImage()
 	if err != nil {
 		log.Error().
@@ -261,30 +263,6 @@ func ocrAndParseQuota(ctx *maa.Context, controller *maa.Controller) (x int, y in
 	}
 
 	return x, y, hoursLater, b
-}
-
-func waitFriendLoading(ctx *maa.Context, controller *maa.Controller) bool {
-	notLoadingCount := 0
-	for attempt := 0; attempt < 10; attempt++ {
-		MoveMouseSafe(controller)
-		controller.PostScreencap().Wait()
-		img, err := controller.CacheImage()
-		if err != nil || img == nil {
-			return false
-		}
-		detail, err := ctx.RunRecognition("ResellROIFriendLoading", img, nil)
-		if err != nil || detail == nil || detail.Results == nil || (detail.Results.Best == nil && len(detail.Results.Filtered) == 0) {
-			notLoadingCount++
-			//连续两次未识别到“加载中”后，再确认加载已结束，防止过早判断已加载完成
-			if notLoadingCount >= 2 {
-				return true
-			}
-		} else {
-			notLoadingCount = 0
-		}
-		log.Info().Int("attempt", attempt+1).Int("notLoadingCount", notLoadingCount).Msg("[Resell]好友价格加载中，等待...")
-	}
-	return false
 }
 
 func processMaxRecord(record ProfitRecord) ProfitRecord {

--- a/assets/resource/pipeline/Resell.json
+++ b/assets/resource/pipeline/Resell.json
@@ -238,5 +238,14 @@
         "post_delay": 500,
         "action": "Custom",
         "custom_action": "ResellInitAction"
+    },
+    "ResellWaitFriendPrice": {
+        "doc": "轮询等待好友价格加载完成（加载中消失或售价可见）",
+        "recognition": "DirectHit",
+        "action": "DoNothing",
+        "next": [
+            "ResellROIFriendSalePrice",
+            "ResellROIFriendLoading"
+        ]
     }
 }

--- a/assets/resource/pipeline/Resell/ResellROI.json
+++ b/assets/resource/pipeline/Resell/ResellROI.json
@@ -379,7 +379,9 @@
             28
         ],
         "only_rec": true,
-        "color_filter": "ResellROITextColorGrey"
+        "color_filter": "ResellROITextColorGrey",
+        "action": "DoNothing",
+        "next": []
     },
     "ResellROIReturnButton": {
         "doc": "好友价格页返回按钮区域",
@@ -458,6 +460,11 @@
             376,
             145,
             95
+        ],
+        "action": "DoNothing",
+        "next": [
+            "ResellROIFriendSalePrice",
+            "ResellROIFriendLoading"
         ]
     },
     "ResellROITextColorGrey": {


### PR DESCRIPTION
This reverts commit df6ab3c2a1be397e1655ca6c542f1a8f7ae7184a.
去掉controller.PostScreencap()后运行有问题，先加回来后续再改成不需要这个

## Summary by Sourcery

在转售流程中恢复截屏步骤，以恢复稳定的基于 OCR 的价格检测和导航。

Bug 修复：
- 在转售初始化工作流中，在 OCR 步骤之前恢复基于 `PostScreencap` 的截屏，以修复移除这些步骤后引入的失败问题。
- 在好友加载检查过程中重新添加截屏，以防止图像缓存和识别不稳定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reinstate screen capture steps in the resell flow to restore stable OCR-based price detection and navigation.

Bug Fixes:
- Restore PostScreencap-based screenshots before OCR steps in the resell initialization workflow to fix failures introduced when they were removed.
- Re-add screen capture during friend loading checks to prevent unstable image caching and recognition.

</details>