### PR TITLE
fix: :bug: 恢复之前删除 BakerTalkWith 节点的 threshold 参数，会导致部分识别模糊误点击

### DIFF
--- a/assets/resource/pipeline/BAKER.json
+++ b/assets/resource/pipeline/BAKER.json
@@ -229,6 +229,7 @@
             "Baker/TalkWith.png",
             "Baker/DialogWith.png" // 部分群组聊天框 TalkWith.png 检测不到
         ],
+        "threshold": 0.95,
         "roi": [
             31,
             61,


### PR DESCRIPTION
**恢复之前删除 BakerTalkWith 节点的 threshold 参数**

🐛 会导致在会话页面把对话结束图标视为可对话图标 

![9c1f932c38320be7c778c8fb8d398cad](https://github.com/user-attachments/assets/a7c98305-5f87-4c57-9ff7-985976a97ac6)

## Summary by Sourcery

错误修复：
- 重新引入 `BakerTalkWith` 节点的 `threshold` 参数，以防止将对话结束图标误识别为可交互对话图标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Reintroduce the threshold parameter for the BakerTalkWith node so end-of-conversation icons are no longer misidentified as interactive dialogue icons.

</details>