### PR TITLE
Fix/essence substring matching

### DIFF
--- a/agent/go-service/essencefilter/matcher.go
+++ b/agent/go-service/essencefilter/matcher.go
@@ -1,7 +1,6 @@
 package essencefilter
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 	"unicode"
@@ -389,37 +388,11 @@ func attemptMatch(phase matchPhase, slot int, cleaned, core string, idx slotInde
 			return ids[0], true
 		}
 	}
-	// // 6) 编辑距兜底（保守：长度<4 允许 1，否则 2）
-	// maxEd := 1
-	// if cLen >= 4 {
-	// 	maxEd = 2
-	// }
-	// bestID, bestDist := 0, maxEd+1
-	// for _, e := range idx.entries {
-	// 	tFull := e.RawFull
-	// 	if useNorm {
-	// 		tFull = e.NormFull
-	// 	}
-	// 	dist := editDistance(cleaned, tFull, maxEd)
-	// 	if dist <= maxEd && dist < bestDist {
-	// 		bestID, bestDist = e.ID, dist
-	// 	}
-	// }
-	// if bestID != 0 {
-	// 	log.Info().Int("slot", slot).Str("phase", string(phase)).Str("step", "edit_distance").
-	// 		Str("cleaned", cleaned).Int("distance", bestDist).
-	// 		Int("skill_id", bestID).Str("skill_name", idToName[bestID]).
-	// 		Msg("[EssenceFilter] match hit")
-	// 	return bestID, true
-	// }
-	// return 0, false
 
 	// 6) 编辑距兜底（保守：长度<4 允许 1，否则 2）
 	// 6a) 若命中停用后缀（core != cleaned），优先用 core 做编辑距：忽略低信息量后缀，显著降低 "XX提升" 之类的误命中。
 	//     注意：当 core-ed 不命中时，这里直接返回 miss（不再回退到 full-ed），避免用后缀把错误候选“拉近”。
-	fmt.Println("entering  step 6")
 	if core != "" && core != cleaned {
-		fmt.Println("core is different from cleaned, trying edit distance on core")
 		maxEdCore := 1
 		if coreLen >= 4 {
 			maxEdCore = 2


### PR DESCRIPTION
修复字串的mismatch问题 #802，现在字串的距离计算仅在core string内进行

## Summary by Sourcery

Bug Fixes:
- 通过在存在停用词后缀时仅针对核心字符串计算编辑距离，修复了由“提升”等低信息量后缀导致的错误匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect matches caused by low-information suffixes like "提升" by computing edit distance on the core string only when a stopword suffix is present.

</details>