### PR TITLE
fix(Common): 使用 10001 来识别 CloseRewardsButton

### DIFF
--- a/assets/resource_fast/pipeline/Common/Button.json
+++ b/assets/resource_fast/pipeline/Common/Button.json
@@ -631,7 +631,8 @@
                     139,
                     126
                 ],
-                "threshold": 0.9
+                "threshold": 0.9,
+                "method": 10001
             }
         },
         "action": {

--- a/assets/resource_fast/pipeline/SellProduct/SellCore.json
+++ b/assets/resource_fast/pipeline/SellProduct/SellCore.json
@@ -200,8 +200,6 @@
             "param": {}
         },
         "next": [
-            // 交易后的弹窗第一次单击时跳过动画，第二次才能退出
-            "SellProductSellCheck",
             "SellProductSellCheckComplete"
         ]
     },


### PR DESCRIPTION
能够避免识别到动画中的中间状态

## Summary by Sourcery

错误修复：
- 通过在按钮配置中使用稳定标识符，防止在中间动画状态下误触发 CloseRewardsButton 的检测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent CloseRewardsButton detection from triggering on intermediate animation states by using a stable identifier in the button config.

</details>