### PR TITLE
refactor(ci): simplify optimize-img workflow

### DIFF
--- a/.github/workflows/optimize-img.yml
+++ b/.github/workflows/optimize-img.yml
@@ -19,7 +19,8 @@ jobs:
     # Only run on main repo, skip bot commits to prevent infinite loops
     if: >-
       ${{ github.repository_owner == 'MaaEnd' &&
-          (github.event_name != 'push' || github.event.head_commit.author.email != '41898282+github-actions[bot]@users.noreply.github.com') }}
+          github.actor != 'github-actions[bot]' &&
+          github.triggering_actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
PR merges already trigger push events, making the API check unnecessary.

## Summary by Sourcery

简化 PNG 优化工作流，使其依赖 push 事件运行，同时仍能避免由机器人提交引发的无限循环。

CI：
- 从 `optimize-img` 工作流中移除 `pull_request` 触发器和基于 API 的 PR 合并检测，仅在直接 push 和手动触发时运行。
- 精简作业步骤条件，使得在主仓库上执行工作流时，只要不是由 GitHub Actions 机器人发起的提交，就会运行优化和 push 步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the PNG optimization workflow to rely on push events while still avoiding infinite loops from bot commits.

CI:
- Remove the pull_request trigger and API-based PR-merge detection from the optimize-img workflow, running it only on direct pushes and manual dispatch.
- Streamline job step conditions so the optimization and push steps run whenever the workflow executes on the main repository, excluding commits from the GitHub Actions bot.

</details>