### PR TITLE
refactor: 提取MapTracker的CV逻辑为minicv程序包

### DIFF
--- a/agent/go-service/map-tracker/infer.go
+++ b/agent/go-service/map-tracker/infer.go
@@ -423,11 +423,10 @@ func (i *MapTrackerInfer) getScaledMaps(scale float64) []MapCache {
 	newScaled := make([]MapCache, 0, len(i.maps))
 	for _, m := range i.maps {
 		sImg := minicv.ImageScale(m.Img, scale)
-		sRGBA := minicv.ImageConvertRGBA(sImg)
 		newScaled = append(newScaled, MapCache{
 			Name:     m.Name,
-			Img:      sRGBA,
-			Integral: minicv.GetIntegralArray(sRGBA),
+			Img:      sImg,
+			Integral: minicv.GetIntegralArray(sImg),
 			OffsetX:  m.OffsetX,
 			OffsetY:  m.OffsetY,
 		})

--- a/agent/go-service/map-tracker/utils.go
+++ b/agent/go-service/map-tracker/utils.go
@@ -91,10 +91,11 @@ func computeNCCFast(hRGBA *image.RGBA, hInt minicv.IntegralArray, nRGBA *image.R
 	sh, ssh := hInt.GetAreaIntegral(ox, oy, nW, nH)
 	cnt := float64(nW * nH * 3)
 	mh := sh / cnt
-	dh := math.Sqrt(ssh - cnt*mh*mh)
-	if dh < 1e-6 {
+	vh := ssh - cnt*mh*mh
+	if vh < 1e-3 {
 		return 0.0
 	}
+	dh := math.Sqrt(vh)
 	return (shn - cnt*mh*nStats.Mean) / (dh * nStats.Std)
 }
 

--- a/agent/go-service/pkg/minicv/image_utils.go
+++ b/agent/go-service/pkg/minicv/image_utils.go
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2026 Harry Huang
+// Copyright (c) 2026 Harry Huang
 package minicv
 
 import (
@@ -11,8 +11,8 @@ import (
 
 // ImageCropSquareByRadius crops a square region from the image centered at (centerX, centerY) with the given radius
 func ImageCropSquareByRadius(img *image.RGBA, centerX, centerY, radius int) *image.RGBA {
-	x1, x2 := max(0, centerX-radius), min(img.Rect.Max.X, centerX+radius+1)
-	y1, y2 := max(0, centerY-radius), min(img.Rect.Max.Y, centerY+radius+1)
+	x1, x2 := max(img.Rect.Min.X, centerX-radius), min(img.Rect.Max.X, centerX+radius+1)
+	y1, y2 := max(img.Rect.Min.Y, centerY-radius), min(img.Rect.Max.Y, centerY+radius+1)
 
 	cropRect := image.Rect(x1, y1, x2, y2)
 	dst := image.NewRGBA(image.Rect(0, 0, cropRect.Dx(), cropRect.Dy()))
@@ -46,11 +46,20 @@ func ImageRotate(img *image.RGBA, angle float64) *image.RGBA {
 
 // ImageScale scales an image by the given factor using bilinear interpolation
 func ImageScale(img *image.RGBA, scale float64) *image.RGBA {
+	if scale <= 0 {
+		return img
+	}
 	if scale == 1.0 {
 		return img
 	}
 	w, h := img.Rect.Dx(), img.Rect.Dy()
 	newW, newH := int(float64(w)*scale), int(float64(h)*scale)
+	if newW < 1 {
+		newW = 1
+	}
+	if newH < 1 {
+		newH = 1
+	}
 	dst := image.NewRGBA(image.Rect(0, 0, newW, newH))
 	xdraw.BiLinear.Scale(dst, dst.Rect, img, img.Rect, xdraw.Over, nil)
 	return dst

--- a/agent/go-service/pkg/minicv/stats_utils.go
+++ b/agent/go-service/pkg/minicv/stats_utils.go
@@ -6,10 +6,10 @@ import (
 	"math"
 )
 
-// StatsResult holds the mean and standard deviation of pixel values in an image
+// StatsResult holds the mean and unnormalized standard deviation of pixel values in an image
 type StatsResult struct {
 	Mean float64 // Mean value
-	Std  float64 // Standard deviation value
+	Std  float64 // Standard deviation value (unnormalized)
 }
 
 // IntegralArray stores precomputed sums for O(1) area statistics
@@ -36,10 +36,14 @@ func GetImageStats(img *image.RGBA) StatsResult {
 			off += 4
 		}
 	}
+
 	count := float64(w * h * 3)
 	mean := sum / count
-	std := math.Sqrt(sumSq - count*(sum/count)*(sum/count))
-	return StatsResult{mean, std}
+	variance := sumSq - count*(mean*mean)
+	if variance < 0 {
+		return StatsResult{Mean: mean, Std: 0}
+	}
+	return StatsResult{mean, math.Sqrt(variance)}
 }
 
 // GetIntegralArray computes the integral array for an image


### PR DESCRIPTION
## 概要

此 PR 提取了 Go Agent 中的 MapTracker 相关代码中与计算机视觉相关的部分逻辑到 minicv 程序包，以分离逻辑并降低耦合性。

## Summary by Sourcery

将 MapTracker 的图像处理和统计逻辑提取到一个独立的 `minicv` 包中，并更新地图跟踪推理逻辑以使用新的抽象层。

Enhancements:
- 引入 `pkg/minicv`，提供可复用的辅助方法，用于 RGBA 转换、裁剪、缩放、旋转、图像统计以及积分图计算。
- 重构 MapTracker 推理逻辑，使其基于 `*image.RGBA` 输入运行，并依赖 `minicv` 类型来执行模板匹配和积分计算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract MapTracker image processing and statistics logic into a dedicated minicv package and update map tracking inference to consume the new abstractions.

Enhancements:
- Introduce pkg/minicv with reusable helpers for RGBA conversion, cropping, scaling, rotation, image statistics, and integral image computation.
- Refactor MapTracker inference to operate on *image.RGBA inputs and depend on minicv types for template matching and integral calculations.

</details>

增强内容：
- 将图像裁剪、缩放、旋转、格式转换、统计计算以及积分图相关的辅助函数，从 MapTracker 移动到新的 `pkg/minicv` 模块中。
- 重构 MapTracker 的推理代码，使其操作基于 `*image.RGBA` 输入，并依赖 minicv 中的类型来完成模板匹配和积分计算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 MapTracker 的图像处理和统计逻辑提取到一个独立的 `minicv` 包中，并更新地图跟踪推理逻辑以使用新的抽象层。

Enhancements:
- 引入 `pkg/minicv`，提供可复用的辅助方法，用于 RGBA 转换、裁剪、缩放、旋转、图像统计以及积分图计算。
- 重构 MapTracker 推理逻辑，使其基于 `*image.RGBA` 输入运行，并依赖 `minicv` 类型来执行模板匹配和积分计算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract MapTracker image processing and statistics logic into a dedicated minicv package and update map tracking inference to consume the new abstractions.

Enhancements:
- Introduce pkg/minicv with reusable helpers for RGBA conversion, cropping, scaling, rotation, image statistics, and integral image computation.
- Refactor MapTracker inference to operate on *image.RGBA inputs and depend on minicv types for template matching and integral calculations.

</details>

</details>