### PR TITLE
fix: ItemTransfer 仓库切换 不再使用 post_wait_freezes

### DIFF
--- a/assets/resource/pipeline/ItemTransfer.json
+++ b/assets/resource/pipeline/ItemTransfer.json
@@ -45,7 +45,20 @@
         ],
         "expected": "ORIGIN_REGION",
         "action": "Click",
-        "post_wait_freezes": 400,
+        "post_delay": 400,
+        "next": [
+            "ItemTransferClickOriginClicked"
+        ]
+    },
+    "ItemTransferClickOriginClicked": {
+        "recognition": "OCR",
+        "roi": [
+            596,
+            346,
+            213,
+            23
+        ],
+        "expected": "ORIGIN_REGION",
         "next": [
             "ItemTransferClickConfirmOrigin",
             "ItemTransferAtOrigin"
@@ -255,7 +268,20 @@
         ],
         "expected": "DESTINATION_REGION",
         "action": "Click",
-        "post_wait_freezes": 400,
+        "post_delay": 400,
+        "next": [
+            "ItemTransferClickDestinationClicked"
+        ]
+    },
+    "ItemTransferClickDestinationClicked": {
+        "recognition": "OCR",
+        "roi": [
+            596,
+            346,
+            213,
+            23
+        ],
+        "expected": "DESTINATION_REGION",
         "next": [
             "ItemTransferClickConfirmDestination",
             "ItemTransferAtDestination"
@@ -420,7 +446,20 @@
         ],
         "expected": "ORIGIN_REGION",
         "action": "Click",
-        "post_wait_freezes": 400,
+        "post_delay": 400,
+        "next": [
+            "ItemTransferClickOriginReturnClicked"
+        ]
+    },
+    "ItemTransferClickOriginReturnClicked": {
+        "recognition": "OCR",
+        "roi": [
+            596,
+            346,
+            213,
+            23
+        ],
+        "expected": "ORIGIN_REGION",
         "next": [
             "ItemTransferClickConfirmOriginReturn",
             "ItemTransferAtOriginReturn"

--- a/assets/tasks/ItemTransfer.json
+++ b/assets/tasks/ItemTransfer.json
@@ -1670,20 +1670,16 @@
                     "label": "$global.region.ValleyIV",
                     "pipeline_override": {
                         "ItemTransferClickOrigin": {
-                            "expected": [
-                                "四号谷地",
-                                "四號谷地",
-                                "Valley IV",
-                                "Valley"
-                            ]
+                            "expected": "四号谷地"
+                        },
+                        "ItemTransferClickOriginClicked": {
+                            "expected": "四号谷地"
                         },
                         "ItemTransferClickOriginReturn": {
-                            "expected": [
-                                "四号谷地",
-                                "四號谷地",
-                                "Valley IV",
-                                "Valley"
-                            ]
+                            "expected": "四号谷地"
+                        },
+                        "ItemTransferClickOriginReturnClicked": {
+                            "expected": "四号谷地"
                         }
                     }
                 },
@@ -1692,16 +1688,16 @@
                     "label": "$global.region.Wuling",
                     "pipeline_override": {
                         "ItemTransferClickOrigin": {
-                            "expected": [
-                                "武陵",
-                                "Wuling"
-                            ]
+                            "expected": "武陵"
+                        },
+                        "ItemTransferClickOriginClicked": {
+                            "expected": "武陵"
                         },
                         "ItemTransferClickOriginReturn": {
-                            "expected": [
-                                "武陵",
-                                "Wuling"
-                            ]
+                            "expected": "武陵"
+                        },
+                        "ItemTransferClickOriginReturnClicked": {
+                            "expected": "武陵"
                         }
                     }
                 }
@@ -1718,12 +1714,10 @@
                     "label": "$global.region.ValleyIV",
                     "pipeline_override": {
                         "ItemTransferClickDestination": {
-                            "expected": [
-                                "四号谷地",
-                                "四號谷地",
-                                "Valley IV",
-                                "Valley"
-                            ]
+                            "expected": "四号谷地"
+                        },
+                        "ItemTransferClickDestinationClicked": {
+                            "expected": "四号谷地"
                         }
                     }
                 },
@@ -1732,10 +1726,10 @@
                     "label": "$global.region.Wuling",
                     "pipeline_override": {
                         "ItemTransferClickDestination": {
-                            "expected": [
-                                "武陵",
-                                "Wuling"
-                            ]
+                            "expected": "武陵"
+                        },
+                        "ItemTransferClickDestinationClicked": {
+                            "expected": "武陵"
                         }
                     }
                 }


### PR DESCRIPTION
Fix #924 
Fix #721 

由 post_wait_freezes 改为 OCR 识别对应仓库的文字，是否已经移至目标位置

cc @MistEO 
在两个 issue 中的 wait_freezes 均出现大量连续 0 分，可能确实是 maafw 哪里出了问题

## Summary by Sourcery

将 ItemTransfer 仓库切换逻辑由依赖 `post_wait_freezes` 判断完成状态，改为通过 OCR 识别仓库文本来判定完成，以解决传输不稳定的问题。

Bug Fixes:
- 解决由于 `post_wait_freezes` 定时检查不可靠而导致的 ItemTransfer 仓库切换失败问题。

Enhancements:
- 通过使用基于 OCR 的状态检测来判断仓库传输是否完成，提升 ItemTransfer 流水线和任务配置的健壮性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace ItemTransfer warehouse switching logic to determine completion via OCR-based warehouse text recognition instead of post_wait_freezes to address unreliable transfers.

Bug Fixes:
- Resolve ItemTransfer warehouse switching failures caused by unreliable post_wait_freezes timing checks.

Enhancements:
- Improve robustness of ItemTransfer pipeline and task configuration by using OCR-driven state detection for warehouse transfer completion.

</details>