### PR TITLE
ci: 只在主仓库执行 format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   format:
+    if: ${{ github.repository_owner == 'MaaEnd' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 将格式化的 GitHub Actions 任务设置为仅在仓库所有者为 `MaaEnd` 时运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Gate the format GitHub Actions job so it only runs when the repository owner is 'MaaEnd'.

</details>