### PR TITLE
fix: 协议空间任务：不使用理智消耗许可时不再因为没有选择单倍消耗而卡死

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -256,7 +256,12 @@
             "理性消費許可証",
             "이성 소모 허가증"
         ],
-        "action": "Click",
+        "action":{ 
+            "type":"Click",
+            "param": {
+                "target_offset": [0,-120,0,0]
+            }
+        },
         "next": [
             "ProtocolSpaceRewardClaim"
         ],

--- a/assets/tasks/ProtocolSpace.json
+++ b/assets/tasks/ProtocolSpace.json
@@ -137,7 +137,12 @@
                     "name": "Yes",
                     "pipeline_override": {
                         "ProtocolSpaceRewardUsePermit": {
-                            "enabled": true
+                            "action":{ 
+                                "type":"Click",
+                                "param": {
+                                    "target_offset": [0,0,0,0]
+                                }
+                            }
                         }
                     }
                 },
@@ -145,7 +150,12 @@
                     "name": "No",
                     "pipeline_override": {
                         "ProtocolSpaceRewardUsePermit": {
-                            "enabled": false
+                            "action":{ 
+                                "type":"Click",
+                                "param": {
+                                    "target_offset": [0,-120,0,0]
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
 #1000  识别到理智消耗许可时，向上偏移120就是单倍消耗

## Summary by Sourcery

Bug Fixes:
- 修复在存在理智消耗许可但未选择单次消耗时导致游戏卡死的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the game from freezing when a sanity-consumption permit is present but single-consumption is not chosen.

</details>