### PR TITLE
fix(AutoEssence): fix infinite click loop on ChooseScaling1 when claiming rewards

### DIFF
--- a/assets/resource/pipeline/AutoEssence/AutoEssence.json
+++ b/assets/resource/pipeline/AutoEssence/AutoEssence.json
@@ -265,9 +265,7 @@
     "AutoEssenceChooseScaling": {
         "post_delay": 1000,
         "next": [
-            "[JumpBack]AutoEssenceChooseScaling1",
-            "[JumpBack]AutoEssenceChooseOverrideOff",
-            "[JumpBack]AutoEssenceChooseOverrideOn",
+            "AutoEssenceChooseScaling1",
             "AutoEssenceConfirmObtain"
         ]
     },
@@ -288,6 +286,12 @@
         "action": {
             "type": "Click"
         },
+        "post_delay": 1000,
+        "next": [
+            "[JumpBack]AutoEssenceChooseOverrideOff",
+            "[JumpBack]AutoEssenceChooseOverrideOn",
+            "AutoEssenceConfirmObtain"
+        ],
         "focus": {
             "Node.Action.Starting": "👆点击单倍领取按钮"
         }


### PR DESCRIPTION
## 问题

修复 #1042

`AutoEssenceChooseScaling` 节点的 `next` 列表中，`AutoEssenceChooseScaling1` 使用了 `[JumpBack]` 前缀。由于点击单倍领取按钮后，游戏 UI 不会发生足够的变化，模板 `EssenceScaling1.png` 仍然以 ~0.997 的高置信度持续匹配，导致 `[JumpBack]` 机制不断回跳重新点击同一按钮，形成无限循环，永远无法到达 `AutoEssenceConfirmObtain`。

## 修复方案

将 `AutoEssenceChooseScaling1` 从 `[JumpBack]` 节点改为**普通节点**，并为其添加独立的 `next` 列表来衔接后续流程：

**`AutoEssenceChooseScaling`（父节点）：**
- `[JumpBack]AutoEssenceChooseScaling1` → `AutoEssenceChooseScaling1`（移除 JumpBack）
- Override 检查移至 ChooseScaling1 的 next 中
- 保留 `AutoEssenceConfirmObtain` 作为兜底

**`AutoEssenceChooseScaling1`：**
- 添加 `post_delay: 1000`（点击后等待 UI 刷新）
- 添加 `next` 列表：`[JumpBack]ChooseOverrideOff` → `[JumpBack]ChooseOverrideOn` → `AutoEssenceConfirmObtain`

这样每轮评估只点击一次缩放按钮，然后自然进入 Override 检查和确认领取流程，不依赖 `max_hit`，每轮循环都能正常执行。

## 测试

已在本地 v1.18.1 环境下验证，配置 `max_hit: 10` 循环刷取时不再卡死。

## Summary by Sourcery

调整 AutoEssence 的倍率选择流程，以防止在选择单倍倍率奖励时发生无限重试。

Bug 修复：
- 解决一个由 `AutoEssenceChooseScaling1` 节点引起的无限循环问题，该节点会反复点击单倍倍率按钮，而不是继续推进到奖励确认步骤。

增强内容：
- 优化 AutoEssence 流程，将 `AutoEssenceChooseScaling1` 拆分为一个普通节点，并赋予其独立的跳转序列，以确保在覆盖检查和奖励确认过程中的稳定推进。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust AutoEssence scaling selection flow to prevent infinite retries when choosing single scaling rewards.

Bug Fixes:
- Resolve an infinite loop caused by the AutoEssenceChooseScaling1 node repeatedly re-clicking the single scaling button instead of progressing to reward confirmation.

Enhancements:
- Refine the AutoEssence pipeline by separating AutoEssenceChooseScaling1 into a normal node with its own transition sequence to ensure stable progression through override checks and reward confirmation.

</details>