### PR TITLE
perf：优化倒卖商店库存识别

### DIFF
--- a/assets/resource/pipeline/Resell.json
+++ b/assets/resource/pipeline/Resell.json
@@ -158,8 +158,56 @@
         "threshold": 0.8,
         "action": "DoNothing",
         "next": [
+            "ResellCheckSoldoutInHeader",
             "ResellinUnstableStore",
             "ResellWaitForUnstableStore"
+        ]
+    },
+    "ResellCheckSoldoutInHeader": {
+        "desc": "在商店顶部，识别库存是否售罄，售罄则切换区域",
+        "recognition": "OCR",
+        "roi": [
+            70,
+            125,
+            160,
+            50
+        ],
+        "expected": [
+            "剩余可购买数量\\s*0",
+            "剩餘可購買數量\\s*0",
+            "Can\\s*purchase\\s*0",
+            "購入可能\\s*0",
+            "남은\\s*구매\\s*가능\\s*수량\\s*0"
+        ],
+        "order_by": "Expected",
+        "action": "DoNothing",
+        "next": [
+            "ChangeNextRegionPrepare"
+        ],
+        "focus": {
+            "Node.Action.Starting": "当前地区已售罄，切换下个地区"
+        }
+    },
+    "ResellCheckStockRemainInHeader": {
+        "desc": "在商店顶部，识别库存未售罄，开始选择倒卖商品",
+        "recognition": "OCR",
+        "roi": [
+            70,
+            125,
+            160,
+            50
+        ],
+        "expected": [
+            "剩余可购买数量\\s*[1-9]+",
+            "剩餘可購買數量\\s*[1-9]+",
+            "Can\\s*purchase\\s*[1-9]+",
+            "購入可能\\s*[1-9]+",
+            "남은\\s*구매\\s*가능\\s*수량\\s*[1-9]+"
+        ],
+        "order_by": "Expected",
+        "action": "DoNothing",
+        "next": [
+            "ResellStart"
         ]
     },
     "ResellinUnstableStore": {
@@ -173,6 +221,7 @@
         "dy": -240,
         "post_wait_freezes": 600,
         "next": [
+            "ResellCheckStockRemainInHeader",
             "ResellStartCheckStock",
             "ResellStart"
         ]


### PR DESCRIPTION
perf：优化倒卖商店库存识别
OCR识别倒卖商店顶部的剩余可购买数量为0时，直接跳转下一区域；识别不到也不影响原有逻辑。
<img width="1399" height="650" alt="图片" src="https://github.com/user-attachments/assets/aefa7487-35a6-4f38-8ce6-9a28f47e640a" />
<img width="346" height="153" alt="图片" src="https://github.com/user-attachments/assets/e46e0840-84b9-4bcc-8f5c-83586a5c9ffa" />
剩余可购买数量>0也从倒卖商店顶部识别，识别成功则不必点击商品从弹窗识别剩余可购买数量。


## Summary by Sourcery

Enhancements:
- 当 OCR 检测到剩余可购买数量为零时，对转售流水线进行短路处理，直接跳到下一个区域，同时在 OCR 失败时不影响现有逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Short-circuit the resell pipeline to skip to the next area when OCR detects zero remaining purchasable quantity without impacting existing logic when OCR fails.

</details>