### PR TITLE
fix: 已存在旧的运送委托、今天已满3单时结束抢单避免死循环

### DIFF
--- a/assets/resource/pipeline/SeizeEntrustTask.json
+++ b/assets/resource/pipeline/SeizeEntrustTask.json
@@ -477,6 +477,26 @@
             "Node.Recognition.Succeeded": "已存在旧的运送委托"
         }
     },
+    "isSeizeEntrustTaskExhausted": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    1030,
+                    650,
+                    45,
+                    40
+                ],
+                "expected": "3/3"
+            }
+        },
+        "next": [
+            "SeizeEntrustTaskStopTask"
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "今天的运送委托已满3单"
+        }
+    },
     "isSeizeEntrustTaskDestinationWulingCity": {
         "next": [
             "[JumpBack]SeizeEntrustTaskFound7.31wMoneyF1",
@@ -542,6 +562,7 @@
         "timeout": 3000,
         "next": [
             "isSeizeEntrustTaskExistOldTask",
+            "isSeizeEntrustTaskExhausted",
             "isSeizeEntrustTaskDestinationWulingCity"
         ],
         "on_error": [


### PR DESCRIPTION
<img width="493" height="649" alt="图片" src="https://github.com/user-attachments/assets/7eabf518-2edd-4375-98a0-6af3859221cb" />
<img width="296" height="211" alt="图片" src="https://github.com/user-attachments/assets/9a25fdad-30b7-416d-9329-73dc629c9994" />


## Summary by Sourcery

错误修复：
- 当已经存在之前的发货委托时，阻止“seize entrust”流水线反复尝试获取订单。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop the seize entrust pipeline from repeatedly attempting to grab orders when a previous shipping entrust is already present.

</details>