### PR TITLE
ci: 优化打包流程

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -182,7 +182,6 @@ jobs:
           find "$MAAFW_DIR" -maxdepth 1 -type f \( \
             -name "MaaDbgControlUnit*" \
             -o -name "MaaThriftControlUnit*" \
-            -o -name "MaaWin32ControlUnit*" \
             -o -name "MaaRpc*" \
             -o -name "MaaHttp*" \
             -o -name "MaaNode*" \
@@ -201,10 +200,19 @@ jobs:
             fi
           fi
 
-          # 将 MaaPiCli 重命名为 MaaEnd，清理其他关联文件（如 .pdb）
-          find "$MAAFW_DIR" -maxdepth 1 -type f -name "MaaPiCli" -exec sh -c 'mv "$1" "$(dirname "$1")/MaaEnd"' _ {} \;
-          find "$MAAFW_DIR" -maxdepth 1 -type f -name "MaaPiCli.exe" -exec sh -c 'mv "$1" "$(dirname "$1")/MaaEnd.exe"' _ {} \;
-          find "$MAAFW_DIR" -maxdepth 1 -type f -name "MaaPiCli*" -exec rm -f {} +
+          # 处理 MaaPiCli
+          if [[ "$MAAFW_DIR" == "install/maafw" ]]; then
+            # 有 maafw 目录说明使用 MXU，直接删除 MaaPiCli
+            find "$MAAFW_DIR" -maxdepth 1 -type f -name "MaaPiCli*" -exec rm -f {} +
+          else
+            # 没有 MXU（如 Linux ARM64），将 MaaPiCli 重命名为 MaaEnd
+            if [[ -f "$MAAFW_DIR/MaaPiCli" ]]; then
+              mv "$MAAFW_DIR/MaaPiCli" install/MaaEnd
+            elif [[ -f "$MAAFW_DIR/MaaPiCli.exe" ]]; then
+              mv "$MAAFW_DIR/MaaPiCli.exe" install/MaaEnd.exe
+            fi
+            find "$MAAFW_DIR" -maxdepth 1 -type f -name "MaaPiCli*" -exec rm -f {} +
+          fi
 
           # 更新 interface.json 中的版本号
           echo "Update interface version to ${{ needs.meta.outputs.tag }}"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -172,13 +172,23 @@ jobs:
           fi
 
           # 清理不必要的 MaaFramework 文件
+          # 根据平台确定 MaaFW 所在目录（Linux ARM64 在根目录，其他在 maafw/）
           echo "Clean unnecessary MaaFramework files"
-          find install/ -name "MaaDbgControlUnit*" -delete
-          find install/ -name "MaaThriftControlUnit*" -delete
-          find install/ -name "MaaRpc*" -delete
-          find install/ -name "MaaHttp*" -delete
-          find install/ \( -name "MaaNode*" -o -name "*.node" \) -delete
-          find install/ -name "MaaWin32ControlUnit*" -delete
+          if [[ "${{ matrix.os }}" == "linux" && "${{ matrix.arch }}" == "aarch64" ]]; then
+            MAAFW_DIR="install"
+          else
+            MAAFW_DIR="install/maafw"
+          fi
+          find "$MAAFW_DIR" -maxdepth 1 -type f \( \
+            -name "MaaDbgControlUnit*" \
+            -o -name "MaaThriftControlUnit*" \
+            -o -name "MaaWin32ControlUnit*" \
+            -o -name "MaaRpc*" \
+            -o -name "MaaHttp*" \
+            -o -name "MaaNode*" \
+            -o -name "maa_node*" \
+            -o -name "*.node" \
+          \) -exec rm -f {} +
 
           # 安装 MXU 并重命名为 MaaEnd
           echo "Install MXU"
@@ -191,11 +201,10 @@ jobs:
             fi
           fi
 
-          # 将 MaaPiCli 重命名为 MaaEnd
-          find install/ -name "MaaPiCli" -exec sh -c 'mv "$1" "$(dirname "$1")/MaaEnd"' _ {} \;
-          find install/ -name "MaaPiCli.exe" -exec sh -c 'mv "$1" "$(dirname "$1")/MaaEnd.exe"' _ {} \;
-          # 清理其他 MaaPiCli 相关文件（如 .pdb）
-          find install/ -name "MaaPiCli*" -delete
+          # 将 MaaPiCli 重命名为 MaaEnd，清理其他关联文件（如 .pdb）
+          find "$MAAFW_DIR" -maxdepth 1 -type f -name "MaaPiCli" -exec sh -c 'mv "$1" "$(dirname "$1")/MaaEnd"' _ {} \;
+          find "$MAAFW_DIR" -maxdepth 1 -type f -name "MaaPiCli.exe" -exec sh -c 'mv "$1" "$(dirname "$1")/MaaEnd.exe"' _ {} \;
+          find "$MAAFW_DIR" -maxdepth 1 -type f -name "MaaPiCli*" -exec rm -f {} +
 
           # 更新 interface.json 中的版本号
           echo "Update interface version to ${{ needs.meta.outputs.tag }}"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -161,9 +161,24 @@ jobs:
 
           # 安装 MaaFramework
           echo "Install MaaFramework"
-          cp -r deps/bin/* install/maafw/
-          cp -r deps/share/MaaAgentBinary install/maafw/
-          rm -rf install/maafw/MaaNode*
+          if [[ "${{ matrix.os }}" == "linux" && "${{ matrix.arch }}" == "aarch64" ]]; then
+            # Linux ARM64 没有 MXU，MaaFW 直接放到根目录
+            cp -r deps/bin/* install/
+            cp -r deps/share/MaaAgentBinary install/
+            rmdir install/maafw 2>/dev/null || true
+          else
+            cp -r deps/bin/* install/maafw/
+            cp -r deps/share/MaaAgentBinary install/maafw/
+          fi
+
+          # 清理不必要的 MaaFramework 文件
+          echo "Clean unnecessary MaaFramework files"
+          find install/ -name "MaaDbgControlUnit*" -delete
+          find install/ -name "MaaThriftControlUnit*" -delete
+          find install/ -name "MaaRpc*" -delete
+          find install/ -name "MaaHttp*" -delete
+          find install/ \( -name "MaaNode*" -o -name "*.node" \) -delete
+          find install/ -name "MaaWin32ControlUnit*" -delete
 
           # 安装 MXU 并重命名为 MaaEnd
           echo "Install MXU"
@@ -175,6 +190,12 @@ jobs:
               cp downloads/MXU/mxu install/MaaEnd
             fi
           fi
+
+          # 将 MaaPiCli 重命名为 MaaEnd
+          find install/ -name "MaaPiCli" -exec sh -c 'mv "$1" "$(dirname "$1")/MaaEnd"' _ {} \;
+          find install/ -name "MaaPiCli.exe" -exec sh -c 'mv "$1" "$(dirname "$1")/MaaEnd.exe"' _ {} \;
+          # 清理其他 MaaPiCli 相关文件（如 .pdb）
+          find install/ -name "MaaPiCli*" -delete
 
           # 更新 interface.json 中的版本号
           echo "Update interface version to ${{ needs.meta.outputs.tag }}"
@@ -216,8 +237,13 @@ jobs:
           if [[ -f install/agent/cpp-algo ]]; then
             chmod +x install/agent/cpp-algo
           fi
-          # 给 maafw 目录下的可执行文件添加权限
-          find install/maafw -type f -name "Maa*" ! -name "*.so" -exec chmod +x {} \;
+          # 给 MaaFramework 可执行文件添加权限
+          if [[ -d install/maafw ]]; then
+            find install/maafw -type f -name "Maa*" ! -name "*.so" -exec chmod +x {} \;
+          else
+            # Linux ARM64: MaaFW 文件在根目录
+            find install/ -maxdepth 1 -type f -name "Maa*" ! -name "*.so" -exec chmod +x {} \;
+          fi
 
           # 打包为 tar.gz
           cd install


### PR DESCRIPTION
## Summary by Sourcery

调整打包工作流程，以更好地处理各平台上的 MaaFramework 目录结构和二进制文件命名。

CI：
- 对 Linux ARM64 构建进行特殊处理，将 MaaFramework 文件安装到软件包根目录，而不是 `maafw` 目录。
- 在打包过程中移除不必要的 MaaFramework 二进制文件，以减小输出体积并精简内容。
- 在打包时将 `MaaPiCli` 二进制文件重命名为 `MaaEnd`，并清理剩余的与 `MaaPiCli` 相关的文件。
- 更新可执行权限设置逻辑，以同时支持 `maafw` 目录布局和根目录级的 MaaFramework 布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust packaging workflow to better handle MaaFramework layout and binary naming across platforms.

CI:
- Special-case Linux ARM64 builds to install MaaFramework files in the package root instead of the maafw directory.
- Remove unnecessary MaaFramework binaries during packaging to reduce output size and contents.
- Rename MaaPiCli binaries to MaaEnd during packaging and clean up remaining MaaPiCli-related files.
- Update executable permission setting logic to support both maafw-directory and root-level MaaFramework layouts.

</details>