### PR TITLE
fix: 协议空间低理智检测改为依赖弹窗, 以及进入协议空间等待动画完成

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -20,11 +20,42 @@
         ],
         "action": "Click",
         "next": [
+            "ProtocolSpacePopupSanityLow",
             "ProtocolSpaceEnterSpaceConfirm"
         ],
         "focus": {
             "Node.Action.Succeeded": "进入协议空间"
         }
+    },
+    "ProtocolSpacePopupSanityLow": {
+        "desc": "弹出理智不足，退出任务",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    279,
+                    295,
+                    310,
+                    40
+                ],
+                "expected": [
+                    "理智不足",
+                    "Insufficient Sanity"
+                ]
+            }
+        },
+        "next": ["ProtocolSpacePopupSanityLowCancel"],
+        "focus": {
+            "Node.ACtion.Succeeded": "理智不足，结束任务"
+        }
+    },
+    "ProtocolSpacePopupSanityLowCancel": {
+        "desc": "取消理智不足弹窗",
+        "recognition": "Or",
+        "any_of": [
+            "GrayCancelButton"
+        ],
+        "action": "Click"
     },
     "ProtocolSpaceEnterSpaceConfirm": {
         "desc": "确认进入协议空间",

--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -19,6 +19,7 @@
             }
         ],
         "action": "Click",
+        "post_wait_freezes": 500,
         "next": [
             "ProtocolSpacePopupSanityLow",
             "ProtocolSpaceEnterSpaceConfirm"

--- a/assets/resource/pipeline/ProtocolSpace/Prepare.json
+++ b/assets/resource/pipeline/ProtocolSpace/Prepare.json
@@ -35,7 +35,7 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "next": [
-            "ProtocolSpacePrepareSanityLow",
+            // "ProtocolSpacePrepareSanityLow",
             "ProtocolSpacePrepareLock",
             "ProtocolSpaceNormalPrepareChooseReward",
             "ProtocolSpaceEnterSpace"


### PR DESCRIPTION
#1064 之前使用的是识别右下角的理智红字，但是背景如果带一点红色就可能误判，改为识别理智不足弹窗
#1141 等待动画完成

## Summary by Sourcery

错误修复：
- 通过改用基于弹窗的检测方式，防止在屏幕背景包含红色元素时，低理智值检测出现误报。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent false positives in low-sanity detection when the screen background contains red elements by switching to popup-based detection.

</details>