### PR TITLE
ci: 添加默认assign review

### DIFF
--- a/.github/workflows/i18n-sync.yml
+++ b/.github/workflows/i18n-sync.yml
@@ -6,7 +6,6 @@ on:
       reviewer:
         description: "自动请求评审的 GitHub 用户名（可留空）"
         required: false
-        default: "overflow65537"
   schedule:
     # 每天 UTC 03:00 自动运行（可按需调整）
     - cron: "0 3 * * *"

--- a/.github/workflows/i18n-sync.yml
+++ b/.github/workflows/i18n-sync.yml
@@ -2,6 +2,11 @@ name: i18n-sync
 
 on:
   workflow_dispatch:
+    inputs:
+      reviewer:
+        description: "自动请求评审的 GitHub 用户名（可留空）"
+        required: false
+        default: "overflow65537"
   schedule:
     # 每天 UTC 03:00 自动运行（可按需调整）
     - cron: "0 3 * * *"
@@ -13,6 +18,7 @@ permissions:
 env:
   I18N_SYNC_BRANCH: "chore/i18n-auto-sync"
   PR_TITLE: "chore: auto sync OCR i18n expected"
+  DEFAULT_PR_REVIEWER: "overflow65537"
 
 jobs:
   sync-ocr-expected:
@@ -73,10 +79,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_REVIEWER: ${{ github.event.inputs.reviewer || env.DEFAULT_PR_REVIEWER }}
         run: |
           pr_number="$(gh pr list --base "$BASE_BRANCH" --head "$I18N_SYNC_BRANCH" --state open --json number --jq '.[0].number')"
           if [ -n "$pr_number" ]; then
             echo "PR already exists: #$pr_number"
+            if [ -n "$PR_REVIEWER" ]; then
+              gh pr edit "$pr_number" --add-reviewer "$PR_REVIEWER" || echo "Skip add reviewer (maybe already requested)"
+            fi
             exit 0
           fi
           pr_body="$(cat <<'EOF'
@@ -89,11 +99,16 @@ jobs:
           - schedule (daily UTC)
           EOF
           )"
+          reviewer_args=()
+          if [ -n "$PR_REVIEWER" ]; then
+            reviewer_args=(--reviewer "$PR_REVIEWER")
+          fi
           gh pr create \
             --base "$BASE_BRANCH" \
             --head "$I18N_SYNC_BRANCH" \
             --title "$PR_TITLE" \
-            --body "$pr_body"
+            --body "$pr_body" \
+            "${reviewer_args[@]}"
 
       - name: Show changed files
         run: |

--- a/.github/workflows/i18n-sync.yml
+++ b/.github/workflows/i18n-sync.yml
@@ -84,7 +84,14 @@ jobs:
           if [ -n "$pr_number" ]; then
             echo "PR already exists: #$pr_number"
             if [ -n "$PR_REVIEWER" ]; then
-              gh pr edit "$pr_number" --add-reviewer "$PR_REVIEWER" || echo "Skip add reviewer (maybe already requested)"
+              if ! output="$(gh pr edit "$pr_number" --add-reviewer "$PR_REVIEWER" 2>&1)"; then
+                if echo "$output" | grep -qi "already requested"; then
+                  echo "Skip add reviewer (already requested)"
+                else
+                  echo "$output" >&2
+                  exit 1
+                fi
+              fi
             fi
             exit 0
           fi

--- a/tools/i18n/sync_ocr_expected.py
+++ b/tools/i18n/sync_ocr_expected.py
@@ -381,7 +381,9 @@ def get_object_members(parser: JsoncParser, member: Member) -> Optional[List[Mem
     return members
 
 
-def get_array_member_if_exists(parser: JsoncParser, members: Dict[str, Member], key: str) -> Optional[Member]:
+def get_array_member_if_exists(
+    parser: JsoncParser, members: Dict[str, Member], key: str
+) -> Optional[Member]:
     m = members.get(key)
     if not m:
         return None
@@ -399,7 +401,9 @@ def detect_line_indent(text: str, key_start: int) -> str:
     return text[line_start:i]
 
 
-def build_expected_array_text(values: Sequence[str], key_indent: str, newline: str) -> str:
+def build_expected_array_text(
+    values: Sequence[str], key_indent: str, newline: str
+) -> str:
     if not values:
         return "[]"
     inner = ("," + newline).join(
@@ -409,7 +413,9 @@ def build_expected_array_text(values: Sequence[str], key_indent: str, newline: s
 
 
 def resolve_lang_ids(
-    expected_values: Sequence[str], reverse_index: Dict[str, Set[str]]
+    expected_values: Sequence[str],
+    reverse_index: Dict[str, Set[str]],
+    tables: Dict[str, Dict[str, str]],
 ) -> Tuple[List[str], List[str]]:
     candidates_by_text: List[Tuple[str, Set[str]]] = []
     for text in expected_values:
@@ -434,18 +440,33 @@ def resolve_lang_ids(
     # 第二轮：如果歧义候选与已解析 ID 有交集，用交集兜底
     for text, candidates in candidates_by_text:
         if len(candidates) > 1:
-            intersection = [lang_id for lang_id in resolved_in_order if lang_id in candidates]
+            intersection = [
+                lang_id for lang_id in resolved_in_order if lang_id in candidates
+            ]
             if len(intersection) == 1:
                 # 这里表示“该歧义文本可复用一个已解析 ID”，无需重复加入列表
                 # 只把它视为已解析，不进入 unresolved_texts
                 pass
             else:
-                unresolved_texts.append(text)
+                # 安全兜底：若歧义候选在四语表中的文本完全一致，则稳定选择一个 ID。
+                candidate_rows = {
+                    tuple(tables[lang].get(lang_id, "") for lang in LANG_ORDER)
+                    for lang_id in candidates
+                }
+                if len(candidate_rows) == 1:
+                    chosen_lang_id = min(candidates)
+                    if chosen_lang_id not in resolved_set:
+                        resolved_in_order.append(chosen_lang_id)
+                        resolved_set.add(chosen_lang_id)
+                else:
+                    unresolved_texts.append(text)
 
     return resolved_in_order, unresolved_texts
 
 
-def expand_expected_from_ids(lang_ids: Sequence[str], tables: Dict[str, Dict[str, str]]) -> List[str]:
+def expand_expected_from_ids(
+    lang_ids: Sequence[str], tables: Dict[str, Dict[str, str]]
+) -> List[str]:
     expanded: List[str] = []
     for lang_id in lang_ids:
         row = [tables[lang].get(lang_id, "") for lang in LANG_ORDER]
@@ -455,7 +476,9 @@ def expand_expected_from_ids(lang_ids: Sequence[str], tables: Dict[str, Dict[str
     return expanded
 
 
-def append_unresolved_texts(base_expected: List[str], unresolved_texts: Sequence[str]) -> List[str]:
+def append_unresolved_texts(
+    base_expected: List[str], unresolved_texts: Sequence[str]
+) -> List[str]:
     """
     将未命中的原始 expected 追加到结果末尾，并避免重复追加。
     """
@@ -490,7 +513,11 @@ def safe_print(message: str) -> None:
         if hasattr(sys.stdout, "buffer"):
             sys.stdout.buffer.write((message + "\n").encode(encoding, errors="replace"))
         else:
-            print(message.encode(encoding, errors="replace").decode(encoding, errors="replace"))
+            print(
+                message.encode(encoding, errors="replace").decode(
+                    encoding, errors="replace"
+                )
+            )
 
 
 @dataclass
@@ -542,7 +569,9 @@ def process_pipeline_file(
                 if rec_members is not None:
                     rec_map = member_map(rec_members)
                     type_member = rec_map.get("type")
-                    rec_type = get_string_value(parser, type_member) if type_member else None
+                    rec_type = (
+                        get_string_value(parser, type_member) if type_member else None
+                    )
                     if rec_type == "OCR":
                         is_ocr = True
 
@@ -572,15 +601,21 @@ def process_pipeline_file(
 
         ocr_nodes_with_expected += 1
         old_expected, _ = parser.parse_array_string_values(expected_member.value_start)
-        lang_ids, unresolved_texts = resolve_lang_ids(old_expected, reverse_index)
+        lang_ids, unresolved_texts = resolve_lang_ids(
+            old_expected, reverse_index, tables
+        )
 
         if not lang_ids:
-            unresolved_nodes.append((str(path), node_name, unresolved_texts or old_expected))
+            unresolved_nodes.append(
+                (str(path), node_name, unresolved_texts or old_expected)
+            )
             continue
 
         new_expected = expand_expected_from_ids(lang_ids, tables)
         if not new_expected:
-            unresolved_nodes.append((str(path), node_name, unresolved_texts or old_expected))
+            unresolved_nodes.append(
+                (str(path), node_name, unresolved_texts or old_expected)
+            )
             continue
         new_expected = append_unresolved_texts(new_expected, unresolved_texts)
 
@@ -612,7 +647,13 @@ def process_pipeline_file(
             + change.replacement
             + new_text[change.value_end :]
         )
-    return new_text, changes, unresolved_nodes, ocr_nodes_with_expected, skipped_by_marker
+    return (
+        new_text,
+        changes,
+        unresolved_nodes,
+        ocr_nodes_with_expected,
+        skipped_by_marker,
+    )
 
 
 def iter_pipeline_files(base_dir: Path) -> List[Path]:
@@ -655,7 +696,9 @@ def main() -> int:
 
     base_dir = args.base_dir.resolve()
     tables, i18n_dir = load_i18n_tables(base_dir, args.i18n_dir)
-    hotfix_applied, hotfix_skipped, has_hotfix = apply_hotfix_to_tables(tables, i18n_dir)
+    hotfix_applied, hotfix_skipped, has_hotfix = apply_hotfix_to_tables(
+        tables, i18n_dir
+    )
     reverse_index = build_reverse_index(tables)
     pipeline_files = iter_pipeline_files(base_dir)
 
@@ -678,8 +721,8 @@ def main() -> int:
 
     for file_path in pipeline_files:
         try:
-            new_text, changes, unresolved_nodes, ocr_nodes, skipped_nodes = process_pipeline_file(
-                file_path, tables, reverse_index
+            new_text, changes, unresolved_nodes, ocr_nodes, skipped_nodes = (
+                process_pipeline_file(file_path, tables, reverse_index)
             )
         except Exception as exc:
             safe_print(f"[ERROR] {file_path}: {exc}")

--- a/tools/i18n/sync_ocr_expected.py
+++ b/tools/i18n/sync_ocr_expected.py
@@ -381,9 +381,7 @@ def get_object_members(parser: JsoncParser, member: Member) -> Optional[List[Mem
     return members
 
 
-def get_array_member_if_exists(
-    parser: JsoncParser, members: Dict[str, Member], key: str
-) -> Optional[Member]:
+def get_array_member_if_exists(parser: JsoncParser, members: Dict[str, Member], key: str) -> Optional[Member]:
     m = members.get(key)
     if not m:
         return None
@@ -401,9 +399,7 @@ def detect_line_indent(text: str, key_start: int) -> str:
     return text[line_start:i]
 
 
-def build_expected_array_text(
-    values: Sequence[str], key_indent: str, newline: str
-) -> str:
+def build_expected_array_text(values: Sequence[str], key_indent: str, newline: str) -> str:
     if not values:
         return "[]"
     inner = ("," + newline).join(
@@ -413,9 +409,7 @@ def build_expected_array_text(
 
 
 def resolve_lang_ids(
-    expected_values: Sequence[str],
-    reverse_index: Dict[str, Set[str]],
-    tables: Dict[str, Dict[str, str]],
+    expected_values: Sequence[str], reverse_index: Dict[str, Set[str]]
 ) -> Tuple[List[str], List[str]]:
     candidates_by_text: List[Tuple[str, Set[str]]] = []
     for text in expected_values:
@@ -440,33 +434,18 @@ def resolve_lang_ids(
     # 第二轮：如果歧义候选与已解析 ID 有交集，用交集兜底
     for text, candidates in candidates_by_text:
         if len(candidates) > 1:
-            intersection = [
-                lang_id for lang_id in resolved_in_order if lang_id in candidates
-            ]
+            intersection = [lang_id for lang_id in resolved_in_order if lang_id in candidates]
             if len(intersection) == 1:
                 # 这里表示“该歧义文本可复用一个已解析 ID”，无需重复加入列表
                 # 只把它视为已解析，不进入 unresolved_texts
                 pass
             else:
-                # 安全兜底：若歧义候选在四语表中的文本完全一致，则稳定选择一个 ID。
-                candidate_rows = {
-                    tuple(tables[lang].get(lang_id, "") for lang in LANG_ORDER)
-                    for lang_id in candidates
-                }
-                if len(candidate_rows) == 1:
-                    chosen_lang_id = min(candidates)
-                    if chosen_lang_id not in resolved_set:
-                        resolved_in_order.append(chosen_lang_id)
-                        resolved_set.add(chosen_lang_id)
-                else:
-                    unresolved_texts.append(text)
+                unresolved_texts.append(text)
 
     return resolved_in_order, unresolved_texts
 
 
-def expand_expected_from_ids(
-    lang_ids: Sequence[str], tables: Dict[str, Dict[str, str]]
-) -> List[str]:
+def expand_expected_from_ids(lang_ids: Sequence[str], tables: Dict[str, Dict[str, str]]) -> List[str]:
     expanded: List[str] = []
     for lang_id in lang_ids:
         row = [tables[lang].get(lang_id, "") for lang in LANG_ORDER]
@@ -476,9 +455,7 @@ def expand_expected_from_ids(
     return expanded
 
 
-def append_unresolved_texts(
-    base_expected: List[str], unresolved_texts: Sequence[str]
-) -> List[str]:
+def append_unresolved_texts(base_expected: List[str], unresolved_texts: Sequence[str]) -> List[str]:
     """
     将未命中的原始 expected 追加到结果末尾，并避免重复追加。
     """
@@ -513,11 +490,7 @@ def safe_print(message: str) -> None:
         if hasattr(sys.stdout, "buffer"):
             sys.stdout.buffer.write((message + "\n").encode(encoding, errors="replace"))
         else:
-            print(
-                message.encode(encoding, errors="replace").decode(
-                    encoding, errors="replace"
-                )
-            )
+            print(message.encode(encoding, errors="replace").decode(encoding, errors="replace"))
 
 
 @dataclass
@@ -569,9 +542,7 @@ def process_pipeline_file(
                 if rec_members is not None:
                     rec_map = member_map(rec_members)
                     type_member = rec_map.get("type")
-                    rec_type = (
-                        get_string_value(parser, type_member) if type_member else None
-                    )
+                    rec_type = get_string_value(parser, type_member) if type_member else None
                     if rec_type == "OCR":
                         is_ocr = True
 
@@ -601,21 +572,15 @@ def process_pipeline_file(
 
         ocr_nodes_with_expected += 1
         old_expected, _ = parser.parse_array_string_values(expected_member.value_start)
-        lang_ids, unresolved_texts = resolve_lang_ids(
-            old_expected, reverse_index, tables
-        )
+        lang_ids, unresolved_texts = resolve_lang_ids(old_expected, reverse_index)
 
         if not lang_ids:
-            unresolved_nodes.append(
-                (str(path), node_name, unresolved_texts or old_expected)
-            )
+            unresolved_nodes.append((str(path), node_name, unresolved_texts or old_expected))
             continue
 
         new_expected = expand_expected_from_ids(lang_ids, tables)
         if not new_expected:
-            unresolved_nodes.append(
-                (str(path), node_name, unresolved_texts or old_expected)
-            )
+            unresolved_nodes.append((str(path), node_name, unresolved_texts or old_expected))
             continue
         new_expected = append_unresolved_texts(new_expected, unresolved_texts)
 
@@ -647,13 +612,7 @@ def process_pipeline_file(
             + change.replacement
             + new_text[change.value_end :]
         )
-    return (
-        new_text,
-        changes,
-        unresolved_nodes,
-        ocr_nodes_with_expected,
-        skipped_by_marker,
-    )
+    return new_text, changes, unresolved_nodes, ocr_nodes_with_expected, skipped_by_marker
 
 
 def iter_pipeline_files(base_dir: Path) -> List[Path]:
@@ -696,9 +655,7 @@ def main() -> int:
 
     base_dir = args.base_dir.resolve()
     tables, i18n_dir = load_i18n_tables(base_dir, args.i18n_dir)
-    hotfix_applied, hotfix_skipped, has_hotfix = apply_hotfix_to_tables(
-        tables, i18n_dir
-    )
+    hotfix_applied, hotfix_skipped, has_hotfix = apply_hotfix_to_tables(tables, i18n_dir)
     reverse_index = build_reverse_index(tables)
     pipeline_files = iter_pipeline_files(base_dir)
 
@@ -721,8 +678,8 @@ def main() -> int:
 
     for file_path in pipeline_files:
         try:
-            new_text, changes, unresolved_nodes, ocr_nodes, skipped_nodes = (
-                process_pipeline_file(file_path, tables, reverse_index)
+            new_text, changes, unresolved_nodes, ocr_nodes, skipped_nodes = process_pipeline_file(
+                file_path, tables, reverse_index
             )
         except Exception as exc:
             safe_print(f"[ERROR] {file_path}: {exc}")


### PR DESCRIPTION
## Summary by Sourcery

为 i18n 同步工作流的拉取请求添加自动分配审阅者的支持。

增强功能：
- 在手动触发 i18n 同步工作流时，允许指定一个可选的审阅者用户名，并配置一个默认审阅者。
- 在创建或检测到已有的 i18n 同步拉取请求时，自动向配置的审阅者发出审阅请求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic reviewer assignment support to the i18n sync workflow pull requests.

Enhancements:
- Allow specifying an optional reviewer username when manually dispatching the i18n sync workflow, with a default reviewer configured.
- Automatically request a PR review from the configured reviewer when creating or detecting existing i18n sync pull requests.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 i18n 同步工作流的拉取请求添加自动分配审阅者的支持。

增强功能：
- 在手动触发 i18n 同步工作流时，允许指定一个可选的审阅者用户名，并配置一个默认审阅者。
- 在创建或检测到已有的 i18n 同步拉取请求时，自动向配置的审阅者发出审阅请求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic reviewer assignment support to the i18n sync workflow pull requests.

Enhancements:
- Allow specifying an optional reviewer username when manually dispatching the i18n sync workflow, with a default reviewer configured.
- Automatically request a PR review from the configured reviewer when creating or detecting existing i18n sync pull requests.

</details>

</details>