### PR TITLE
fix:修复基建奖励任务

### DIFF
--- a/assets/resource/pipeline/DijiangRewards/GrowthChamber.json
+++ b/assets/resource/pipeline/DijiangRewards/GrowthChamber.json
@@ -260,7 +260,8 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "ExitGrowthChamber"
+            "ExitGrowthChamber",
+            "InDijiangControlNexus"
         ]
     },
     "ExitGrow": {

--- a/assets/resource/pipeline/DijiangRewards/GrowthChamber.json
+++ b/assets/resource/pipeline/DijiangRewards/GrowthChamber.json
@@ -106,7 +106,8 @@
         "rate_limit": 0,
         "next": [
             "Grow",
-            "ExitGrowthChamber"
+            "ExitGrowthChamber",
+            "ClaimAllGrowRewardClose"
         ]
     },
     "Grow": {

--- a/assets/resource/pipeline/DijiangRewards/Manufacturing.json
+++ b/assets/resource/pipeline/DijiangRewards/Manufacturing.json
@@ -1,7 +1,6 @@
 {
     "MFG_ReceiveRewards": {
         "desc": "[控制中枢·制造舱] 识别制造舱界面，领取奖励和补货",
-        "max_hit": 2,
         "recognition": {
             "type": "OCR",
             "param": {

--- a/assets/resource/pipeline/DijiangRewards/NeedCredit.json
+++ b/assets/resource/pipeline/DijiangRewards/NeedCredit.json
@@ -49,6 +49,7 @@
             }
         },
         "next": [
+            "[JumpBack]ReceptionRoomSetClues",
             "InControlNexus_NeedCredit",
             "WhiteConfirmButtonType1",
             "[JumpBack]StartExchange"

--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -92,7 +92,6 @@
         "next": [
             "ReceptionRoomNeedCollectClues",
             "ReceptionRoomNeedReceiveClues",
-            "[JumpBack]ReceptionRoomSetClues",
             "StartExchange",
             "ExitClueLibrary",
             "ExitReceptionRoom",
@@ -136,6 +135,7 @@
             "type": "Click"
         },
         "next": [
+            "[JumpBack]ReceptionRoomSetClues",
             "ExitClueLibrary",
             "ExitReceptionRoom"
         ]

--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -92,6 +92,7 @@
         "next": [
             "ReceptionRoomNeedCollectClues",
             "ReceptionRoomNeedReceiveClues",
+            "[JumpBack]ReceptionRoomSetClues",
             "StartExchange",
             "ExitClueLibrary",
             "ExitReceptionRoom",


### PR DESCRIPTION
## 由 Sourcery 提供的总结

修复基础设施奖励任务定义，使 Dijiang 设施房间能够授予其预期奖励。

错误修复：
- 更正 `GrowthChamber` 的奖励任务配置，使其能够授予预期的基础设施奖励。
- 更正 `Manufacturing` 的奖励任务配置，使其能够授予预期的基础设施奖励。
- 更正 `NeedCredit` 的奖励任务配置，使其能够授予预期的基础设施奖励。
- 更正 `ReceptionRoom` 的奖励任务配置，使其能够授予预期的基础设施奖励。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix infrastructure reward task definitions so Dijiang facility rooms grant their intended rewards.

Bug Fixes:
- Correct reward task configurations for GrowthChamber so it grants the intended infrastructure rewards.
- Correct reward task configurations for Manufacturing so it grants the intended infrastructure rewards.
- Correct reward task configurations for NeedCredit so it grants the intended infrastructure rewards.
- Correct reward task configurations for ReceptionRoom so it grants the intended infrastructure rewards.

</details>
- 修复 GrowthChamber、Manufacturing、NeedCredit 和 ReceptionRoom 的奖励任务定义，使其能够授予预期的基础设施奖励。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

修复基础设施奖励任务定义，使 Dijiang 设施房间能够授予其预期奖励。

错误修复：
- 更正 `GrowthChamber` 的奖励任务配置，使其能够授予预期的基础设施奖励。
- 更正 `Manufacturing` 的奖励任务配置，使其能够授予预期的基础设施奖励。
- 更正 `NeedCredit` 的奖励任务配置，使其能够授予预期的基础设施奖励。
- 更正 `ReceptionRoom` 的奖励任务配置，使其能够授予预期的基础设施奖励。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix infrastructure reward task definitions so Dijiang facility rooms grant their intended rewards.

Bug Fixes:
- Correct reward task configurations for GrowthChamber so it grants the intended infrastructure rewards.
- Correct reward task configurations for Manufacturing so it grants the intended infrastructure rewards.
- Correct reward task configurations for NeedCredit so it grants the intended infrastructure rewards.
- Correct reward task configurations for ReceptionRoom so it grants the intended infrastructure rewards.

</details>

</details>