### PR TITLE
Revert "perf: 优化帝江号上进入背包的逻辑"

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -1019,8 +1019,7 @@
             ]
         },
         "next": [
-            "__ScenePrivateAnyEnterMenuBackpackSuccess",
-            "__ScenePrivateWorldDijiangEnterMenuBackpackWithDepot"
+            "__ScenePrivateAnyEnterMenuBackpackSuccess"
         ]
     },
     "__ScenePrivateMenuListEnterMenuBackpack": {


### PR DESCRIPTION
Reverts MaaEnd/MaaEnd#1212

## Summary by Sourcery

错误修复：
- 通过回滚最近以性能为导向的改动，恢复帝江号上背包入口此前的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore the earlier backpack entry behavior on 帝江号 by reverting the recent performance-oriented change.

</details>