### PR TITLE
feat(map): 添加大地图定位节点MapTrackerBigMapInfer

### DIFF
--- a/agent/go-service/map-tracker/big_map_infer.go
+++ b/agent/go-service/map-tracker/big_map_infer.go
@@ -63,7 +63,7 @@ func (r *MapTrackerBigMapInfer) Run(ctx *maa.Context, arg *maa.CustomRecognition
 	}
 
 	screenImg := minicv.ImageConvertRGBA(arg.Img)
-	template, cropLeft, cropTop, ok := cropBigMapTemplate(screenImg)
+	template, _, _, ok := cropBigMapTemplate(screenImg)
 	if !ok {
 		log.Warn().Msg("Big-map crop area is invalid")
 		return nil, false
@@ -81,6 +81,7 @@ func (r *MapTrackerBigMapInfer) Run(ctx *maa.Context, arg *maa.CustomRecognition
 	coarseBestMap := MapCache{}
 	hasCoarseBestMap := false
 	triedMaps := 0
+	coarseMatchingSteps := []int{8, 4}
 	coarseTplScaleMin := 1.0 / GAME_MAP_SCALE_MAX
 	coarseTplScaleMax := 1.0 / GAME_MAP_SCALE_MIN
 
@@ -106,7 +107,7 @@ func (r *MapTrackerBigMapInfer) Run(ctx *maa.Context, arg *maa.CustomRecognition
 			fastTpl,
 			coarseTplScaleMin,
 			coarseTplScaleMax,
-			[]int{8, 8},
+			coarseMatchingSteps,
 		)
 		coarseBestScore = score
 		coarseBestTplScale = tplScale
@@ -126,7 +127,7 @@ func (r *MapTrackerBigMapInfer) Run(ctx *maa.Context, arg *maa.CustomRecognition
 					fastTpl,
 					coarseTplScaleMin,
 					coarseTplScaleMax,
-					[]int{8, 8},
+					coarseMatchingSteps,
 				)
 				resChan <- coarseResult{score: score, tplScale: tplScale, m: m}
 			}(mapData)
@@ -157,8 +158,10 @@ func (r *MapTrackerBigMapInfer) Run(ctx *maa.Context, arg *maa.CustomRecognition
 		return nil, false
 	}
 
-	fineMinScale := max(coarseTplScaleMin, coarseBestTplScale-0.1)
-	fineMaxScale := min(coarseTplScaleMax, coarseBestTplScale+0.1)
+	fineMatchingSteps := []int{8, 4}
+	fineMatchingScaleOffset := (coarseTplScaleMax - coarseTplScaleMin) / 32.0
+	fineMinScale := max(coarseTplScaleMin, coarseBestTplScale-fineMatchingScaleOffset)
+	fineMaxScale := min(coarseTplScaleMax, coarseBestTplScale-fineMatchingScaleOffset)
 
 	matchX, matchY, fineScore, fineTplScale := minicv.MatchTemplateAnyScaleInArea(
 		coarseBestMap.Img,
@@ -166,7 +169,7 @@ func (r *MapTrackerBigMapInfer) Run(ctx *maa.Context, arg *maa.CustomRecognition
 		fastTpl,
 		fineMinScale,
 		fineMaxScale,
-		[]int{4, 4},
+		fineMatchingSteps,
 	)
 
 	if fineScore < param.Threshold {
@@ -182,8 +185,8 @@ func (r *MapTrackerBigMapInfer) Run(ctx *maa.Context, arg *maa.CustomRecognition
 
 	result := MapTrackerBigMapInferResult{
 		MapName:     coarseBestMap.Name,
-		X:           roundTo1Decimal(matchX/float64(WIRE_MATCH_PRECISION) + float64(coarseBestMap.OffsetX) + float64(cropLeft)),
-		Y:           roundTo1Decimal(matchY/float64(WIRE_MATCH_PRECISION) + float64(coarseBestMap.OffsetY) + float64(cropTop)),
+		X:           roundTo1Decimal(matchX/float64(WIRE_MATCH_PRECISION) + float64(coarseBestMap.OffsetX)),
+		Y:           roundTo1Decimal(matchY/float64(WIRE_MATCH_PRECISION) + float64(coarseBestMap.OffsetY)),
 		Scale:       1.0 / fineTplScale,
 		InferTimeMs: time.Since(t0).Milliseconds(),
 	}

--- a/agent/go-service/map-tracker/big_map_infer.go
+++ b/agent/go-service/map-tracker/big_map_infer.go
@@ -1,0 +1,282 @@
+// Copyright (c) 2026 Harry Huang
+package maptracker
+
+import (
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/draw"
+	"math"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv"
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+// MapTrackerBigMapInferResult represents the output of big map inference.
+type MapTrackerBigMapInferResult struct {
+	MapName     string  `json:"mapName"`
+	X           float64 `json:"x"`
+	Y           float64 `json:"y"`
+	Scale       float64 `json:"scale"`
+	InferTimeMs int64   `json:"inferTimeMs"`
+}
+
+// MapTrackerBigMapInferParam represents the custom_recognition_param for MapTrackerBigMapInfer.
+type MapTrackerBigMapInferParam struct {
+	MapNameRegex string  `json:"map_name_regex,omitempty"`
+	Threshold    float64 `json:"threshold,omitempty"`
+}
+
+// MapTrackerBigMapInfer is the custom recognition component for big-map location inference.
+type MapTrackerBigMapInfer struct {
+	mapsOnce sync.Once
+	maps     []MapCache
+	mapsErr  error
+}
+
+var _ maa.CustomRecognitionRunner = &MapTrackerBigMapInfer{}
+
+// Run implements maa.CustomRecognitionRunner.
+func (r *MapTrackerBigMapInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa.CustomRecognitionResult, bool) {
+	t0 := time.Now()
+
+	param, err := r.parseParam(arg.CustomRecognitionParam)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to parse parameters for MapTrackerBigMapInfer")
+		return nil, false
+	}
+
+	mapNameRegex, err := regexp.Compile(param.MapNameRegex)
+	if err != nil {
+		log.Error().Err(err).Str("regex", param.MapNameRegex).Msg("Invalid map_name_regex")
+		return nil, false
+	}
+
+	r.initMaps(ctx)
+	if r.mapsErr != nil {
+		log.Error().Err(r.mapsErr).Msg("Failed to initialize maps for MapTrackerBigMapInfer")
+		return nil, false
+	}
+
+	screenImg := minicv.ImageConvertRGBA(arg.Img)
+	template, cropLeft, cropTop, ok := cropBigMapTemplate(screenImg)
+	if !ok {
+		log.Warn().Msg("Big-map crop area is invalid")
+		return nil, false
+	}
+
+	fastTpl := minicv.ImageScale(template, WIRE_MATCH_PRECISION)
+	fastTplStats := minicv.GetImageStats(fastTpl)
+	if fastTplStats.Std < 1e-6 {
+		log.Warn().Msg("Big-map template standard deviation is too small")
+		return nil, false
+	}
+
+	coarseBestScore := -1.0
+	coarseBestTplScale := 0.0
+	coarseBestMap := MapCache{}
+	hasCoarseBestMap := false
+	triedMaps := 0
+	coarseTplScaleMin := 1.0 / GAME_MAP_SCALE_MAX
+	coarseTplScaleMax := 1.0 / GAME_MAP_SCALE_MIN
+
+	candidateMaps := make([]MapCache, 0, len(r.maps))
+	for _, m := range r.maps {
+		if mapNameRegex.MatchString(m.Name) {
+			candidateMaps = append(candidateMaps, m)
+		}
+	}
+	triedMaps = len(candidateMaps)
+
+	type coarseResult struct {
+		score    float64
+		tplScale float64
+		m        MapCache
+	}
+
+	if triedMaps == 1 {
+		single := candidateMaps[0]
+		_, _, score, tplScale := minicv.MatchTemplateAnyScaleInArea(
+			single.Img,
+			single.Integral,
+			fastTpl,
+			coarseTplScaleMin,
+			coarseTplScaleMax,
+			[]int{8, 8},
+		)
+		coarseBestScore = score
+		coarseBestTplScale = tplScale
+		coarseBestMap = single
+		hasCoarseBestMap = true
+	} else if triedMaps > 1 {
+		resChan := make(chan coarseResult, triedMaps)
+		var wg sync.WaitGroup
+
+		for _, mapData := range candidateMaps {
+			wg.Add(1)
+			go func(m MapCache) {
+				defer wg.Done()
+				_, _, score, tplScale := minicv.MatchTemplateAnyScaleInArea(
+					m.Img,
+					m.Integral,
+					fastTpl,
+					coarseTplScaleMin,
+					coarseTplScaleMax,
+					[]int{8, 8},
+				)
+				resChan <- coarseResult{score: score, tplScale: tplScale, m: m}
+			}(mapData)
+		}
+
+		go func() {
+			wg.Wait()
+			close(resChan)
+		}()
+
+		for res := range resChan {
+			if res.score > coarseBestScore {
+				coarseBestScore = res.score
+				coarseBestTplScale = res.tplScale
+				coarseBestMap = res.m
+				hasCoarseBestMap = true
+			}
+		}
+	}
+
+	if triedMaps == 0 {
+		log.Warn().Str("regex", mapNameRegex.String()).Msg("No maps matched regex for big-map inference")
+		return nil, false
+	}
+
+	if !hasCoarseBestMap {
+		log.Warn().Msg("Big-map coarse matching did not produce a candidate")
+		return nil, false
+	}
+
+	fineMinScale := max(coarseTplScaleMin, coarseBestTplScale-0.1)
+	fineMaxScale := min(coarseTplScaleMax, coarseBestTplScale+0.1)
+
+	matchX, matchY, fineScore, fineTplScale := minicv.MatchTemplateAnyScaleInArea(
+		coarseBestMap.Img,
+		coarseBestMap.Integral,
+		fastTpl,
+		fineMinScale,
+		fineMaxScale,
+		[]int{4, 4},
+	)
+
+	if fineScore < param.Threshold {
+		log.Info().
+			Int("triedMaps", triedMaps).
+			Str("map", coarseBestMap.Name).
+			Float64("coarseScore", coarseBestScore).
+			Float64("fineScore", fineScore).
+			Float64("threshold", param.Threshold).
+			Msg("Big-map inference confidence below threshold")
+		return nil, false
+	}
+
+	result := MapTrackerBigMapInferResult{
+		MapName:     coarseBestMap.Name,
+		X:           roundTo1Decimal(matchX/float64(WIRE_MATCH_PRECISION) + float64(coarseBestMap.OffsetX) + float64(cropLeft)),
+		Y:           roundTo1Decimal(matchY/float64(WIRE_MATCH_PRECISION) + float64(coarseBestMap.OffsetY) + float64(cropTop)),
+		Scale:       1.0 / fineTplScale,
+		InferTimeMs: time.Since(t0).Milliseconds(),
+	}
+
+	detailJSON, err := json.Marshal(result)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to marshal MapTrackerBigMapInfer result")
+		return nil, false
+	}
+
+	log.Info().
+		Int("triedMaps", triedMaps).
+		Str("map", result.MapName).
+		Float64("coarseScore", coarseBestScore).
+		Float64("fineScore", fineScore).
+		Float64("x", result.X).
+		Float64("y", result.Y).
+		Float64("scale", result.Scale).
+		Int64("inferTimeMs", result.InferTimeMs).
+		Msg("Big-map inference completed")
+
+	return &maa.CustomRecognitionResult{
+		Box:    arg.Roi,
+		Detail: string(detailJSON),
+	}, true
+}
+
+func (r *MapTrackerBigMapInfer) parseParam(paramStr string) (*MapTrackerBigMapInferParam, error) {
+	if paramStr == "" {
+		return &DEFAULT_BIG_MAP_INFERENCE_PARAM, nil
+	}
+
+	var param MapTrackerBigMapInferParam
+	if err := json.Unmarshal([]byte(paramStr), &param); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal parameters: %w", err)
+	}
+
+	if param.MapNameRegex == "" {
+		param.MapNameRegex = DEFAULT_BIG_MAP_INFERENCE_PARAM.MapNameRegex
+	}
+	if param.Threshold == 0.0 {
+		param.Threshold = DEFAULT_BIG_MAP_INFERENCE_PARAM.Threshold
+	} else if param.Threshold < 0.0 || param.Threshold > 1.0 {
+		return nil, fmt.Errorf("invalid threshold value: %f", param.Threshold)
+	}
+
+	return &param, nil
+}
+
+// initMaps initializes map cache for big-map inference only.
+func (r *MapTrackerBigMapInfer) initMaps(ctx *maa.Context) {
+	r.mapsOnce.Do(func() {
+		loader := &MapTrackerInfer{}
+		maps, err := loader.loadMaps(ctx)
+		if err != nil {
+			r.mapsErr = err
+			return
+		}
+
+		fastMaps := make([]MapCache, 0, len(maps))
+		for _, m := range maps {
+			fastImg := minicv.ImageScale(m.Img, WIRE_MATCH_PRECISION)
+			fastMaps = append(fastMaps, MapCache{
+				Name:     m.Name,
+				Img:      fastImg,
+				Integral: minicv.GetIntegralArray(fastImg),
+				OffsetX:  m.OffsetX,
+				OffsetY:  m.OffsetY,
+			})
+		}
+
+		r.maps = fastMaps
+		log.Info().Int("mapsCount", len(r.maps)).Msg("Big-map maps cache initialized")
+	})
+}
+
+func cropBigMapTemplate(screen *image.RGBA) (*image.RGBA, int, int, bool) {
+	w, h := screen.Rect.Dx(), screen.Rect.Dy()
+	padLR := int(math.Round(PADDING_LR))
+	padTB := int(math.Round(PADDING_TB))
+
+	left := max(0, min(w, padLR))
+	right := max(0, min(w, w-padLR))
+	top := max(0, min(h, padTB))
+	bottom := max(0, min(h, h-padTB))
+
+	if right <= left || bottom <= top {
+		return nil, 0, 0, false
+	}
+
+	region := image.Rect(left, top, right, bottom)
+	dst := image.NewRGBA(image.Rect(0, 0, region.Dx(), region.Dy()))
+	draw.Draw(dst, dst.Bounds(), screen, region.Min, draw.Src)
+
+	return dst, left, top, true
+}

--- a/agent/go-service/map-tracker/const.go
+++ b/agent/go-service/map-tracker/const.go
@@ -22,6 +22,15 @@ const (
 	ROT_RADIUS   = 12
 )
 
+// Big map scanning configuration
+const (
+	PADDING_LR           = 0.1328 * WORK_W
+	PADDING_TB           = 0.2083 * WORK_H
+	WIRE_MATCH_PRECISION = 0.25
+	GAME_MAP_SCALE_MIN   = 1.0
+	GAME_MAP_SCALE_MAX   = 7.0
+)
+
 // Time-series empirical optimization configuration
 const (
 	PENDING_TAKEOVER_TIME_MS         = 1000
@@ -56,6 +65,12 @@ var DEFAULT_INFERENCE_PARAM = MapTrackerInferParam{
 var DEFAULT_INFERENCE_PARAM_FOR_MOVE = MapTrackerInferParam{
 	Precision: 0.7,
 	Threshold: 0.3,
+}
+
+// MapTrackerBigMapInfer parameters default values
+var DEFAULT_BIG_MAP_INFERENCE_PARAM = MapTrackerBigMapInferParam{
+	MapNameRegex: "^map\\d+_lv\\d+$",
+	Threshold:    0.5,
 }
 
 // MapTrackerMove parameters default values

--- a/agent/go-service/map-tracker/register.go
+++ b/agent/go-service/map-tracker/register.go
@@ -8,6 +8,7 @@ func Register() {
 	ensureResourcePathSink()
 
 	maa.AgentServerRegisterCustomRecognition("MapTrackerInfer", &MapTrackerInfer{})
+	maa.AgentServerRegisterCustomRecognition("MapTrackerBigMapInfer", &MapTrackerBigMapInfer{})
 	maa.AgentServerRegisterCustomRecognition("MapTrackerAssertLocation", &MapTrackerAssertLocation{})
 	maa.AgentServerRegisterCustomAction("MapTrackerMove", &MapTrackerMove{})
 }

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -151,3 +151,106 @@ func MatchTemplateInArea(
 
 	return subX, subY, fm
 }
+
+// MatchTemplateAnyScaleInArea performs iterative template matching over a scale range.
+// The number of iterations is defined by len(steps), and each element controls the
+// sampling count for that iteration.
+// Returns (x, y, score, scale) for the best match found across all iterations.
+func MatchTemplateAnyScaleInArea(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	minScale, maxScale float64,
+	steps []int,
+) (float64, float64, float64, float64) {
+	if minScale > maxScale {
+		minScale, maxScale = maxScale, minScale
+	}
+	if maxScale <= 0 {
+		return 0, 0, 0, 0
+	}
+	if minScale <= 0 {
+		minScale = 1e-6
+	}
+	if len(steps) == 0 {
+		steps = []int{1}
+	}
+
+	bestX, bestY, bestScore, bestScale := 0.0, 0.0, -1.0, minScale
+
+	for _, stepCount := range steps {
+		if minScale > maxScale {
+			break
+		}
+		if stepCount < 1 {
+			stepCount = 1
+		}
+
+		stepSize := 0.0
+		if stepCount > 1 {
+			stepSize = (maxScale - minScale) / float64(stepCount-1)
+		}
+
+		iterBestIdx := 0
+		iterBestScale := minScale
+		iterBestX, iterBestY, iterBestScore := 0.0, 0.0, -1.0
+
+		for idx := range stepCount {
+			scale := minScale
+			if stepCount == 1 {
+				scale = (minScale + maxScale) * 0.5
+			} else {
+				scale = minScale + float64(idx)*stepSize
+			}
+			if scale <= 0 {
+				continue
+			}
+
+			scaledTpl := ImageScale(tpl, scale)
+			scaledStats := GetImageStats(scaledTpl)
+			if scaledStats.Std < 1e-12 {
+				continue
+			}
+
+			x, y, score := MatchTemplate(img, imgIntArr, scaledTpl, scaledStats)
+			if score > iterBestScore {
+				iterBestScore = score
+				iterBestX = x
+				iterBestY = y
+				iterBestScale = scale
+				iterBestIdx = idx
+			}
+		}
+
+		if iterBestScore > bestScore {
+			bestScore = iterBestScore
+			bestX = iterBestX
+			bestY = iterBestY
+			bestScale = iterBestScale
+		}
+
+		if stepSize <= 0 {
+			break
+		}
+
+		if iterBestIdx == 0 {
+			minScale = iterBestScale
+			maxScale = iterBestScale + stepSize
+			continue
+		}
+		if iterBestIdx == stepCount-1 {
+			minScale = iterBestScale - stepSize
+			maxScale = iterBestScale
+			continue
+		}
+
+		minScale = iterBestScale - stepSize
+		maxScale = iterBestScale + stepSize
+	}
+
+	if bestScore < 0 {
+		return 0, 0, 0, 0
+	}
+
+	return bestX, bestY, bestScore, bestScale
+}

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -172,6 +172,7 @@ func MatchTemplateAnyScaleInArea(
 	if minScale <= 0 {
 		minScale = 1e-6
 	}
+	minScale0, maxScale0 := minScale, maxScale
 	if len(steps) == 0 {
 		steps = []int{1}
 	}
@@ -236,16 +237,21 @@ func MatchTemplateAnyScaleInArea(
 		if iterBestIdx == 0 {
 			minScale = iterBestScale
 			maxScale = iterBestScale + stepSize
-			continue
-		}
-		if iterBestIdx == stepCount-1 {
+		} else if iterBestIdx == stepCount-1 {
 			minScale = iterBestScale - stepSize
 			maxScale = iterBestScale
-			continue
+		} else {
+			minScale = iterBestScale - stepSize
+			maxScale = iterBestScale + stepSize
 		}
 
-		minScale = iterBestScale - stepSize
-		maxScale = iterBestScale + stepSize
+		minScale = max(minScale0, minScale)
+		maxScale = min(maxScale0, maxScale)
+		if minScale > maxScale {
+			clamped := min(max(iterBestScale, minScale0), maxScale0)
+			minScale = clamped
+			maxScale = clamped
+		}
 	}
 
 	if bestScore < 0 {

--- a/docs/en_us/developers/map-tracker.md
+++ b/docs/en_us/developers/map-tracker.md
@@ -170,7 +170,7 @@ Optional parameters:
 
 > [!WARNING]
 >
-> This node is designed for advanced programming, so it is not suitable for low-code development in the pipeline. If you need to judge whether the player's current position meets conditions, please use the [MapTrackerAssertLocation](#recognition-maptrackerassertlocation) node.
+> This node is designed for advanced programming, so it is not suitable for low-code development in the pipeline. If you need to judge whether the player's current position meets the conditions, please use the [MapTrackerAssertLocation](#recognition-maptrackerassertlocation) node.
 
 ### Recognition: MapTrackerBigMapInfer
 
@@ -178,7 +178,7 @@ Optional parameters:
 
 > [!WARNING]
 >
-> This node is designed for advanced programming, so it is not suitable for low-code development in the pipeline. For the exact crop rule of the "current viewport region", refer to the implementation details in code.
+> This node is designed for advanced programming, so it is not suitable for low-code development in the pipeline. For the exact cropping rule of the "current viewport region", refer to the implementation details in code.
 
 #### Node Parameters
 

--- a/docs/en_us/developers/map-tracker.md
+++ b/docs/en_us/developers/map-tracker.md
@@ -86,57 +86,6 @@ Optional parameters:
 >
 > During the execution of this node, ensure that the player is **always in** the specified map, and adjacent waypoints **can be reached in a straight line**.
 
-### Recognition: MapTrackerInfer
-
-📍Gets the player's current map name, position coordinates, and orientation.
-
-#### Node Parameters
-
-Required parameters: None
-
-Optional parameters:
-
-- `map_name_regex`: A [regular expression](https://regexr.com/) used to filter map names. Only maps matching this regular expression will participate in recognition. For example:
-
-    - `^map\\d+_lv\\d+$`: Default value. Matches all regular maps.
-    - `^map\\d+_lv\\d+(_tier_\\d+)?$`: Matches all regular maps and tiered maps (Tier).
-    - `^map001_lv001$`: Only matches "map001_lv001" (Fourth Valley - Hub Area).
-    - `^map001_lv\\d+$`: Matches all sub-regions of "map001" (Fourth Valley).
-
-- `print`: Boolean value, default `false` . Whether to enable UI message printing of recognition results.
-
-<details>
-<summary>Advanced Optional Parameters (Expand)</summary>
-
-- `precision`: Real number between $(0, 1]$, default `0.5`. Controls the accuracy of matching. A larger value will match map features more strictly but may result in slow matching speed; a smaller value will greatly improve matching speed but may lead to incorrect results. When the number of maps to be matched is small (e.g., only one map), it is recommended to use a larger value to obtain more accurate results.
-
-- `threshold`: Real number between $(0, 1]$, default `0.4` Controls the confidence threshold for matching. Matching results below this value will not hit the recognition.
-
-</details>
-
-#### Example Usage
-
-```json
-{
-    "MyNodeName": {
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerInfer",
-        "custom_recognition_param": {
-            "map_name_regex": "^map\\d+_lv\\d+$"
-        },
-        "action": "DoNothing"
-    }
-}
-```
-
-> [!TIP]
->
-> MapTracker uses an integer between $[0, 360)$ to represent the player's **orientation**, in degrees. 0° indicates facing due north, with clockwise rotation as the increasing direction.
-
-> [!WARNING]
->
-> This node is not suitable for low-code development in the pipeline. If you need to judge whether the player's current position meets the conditions, please use the [MapTrackerAssertLocation](#recognition-maptrackerassertlocation) node.
-
 ### Recognition: MapTrackerAssertLocation
 
 ✅Judges whether the player's current map name and position coordinates meet any of the expected conditions.
@@ -184,6 +133,56 @@ Required parameters:
     }
 }
 ```
+
+### Recognition: MapTrackerInfer
+
+📍Gets the player's current map name, position coordinates, and orientation.
+
+#### Node Parameters
+
+Required parameters: None
+
+Optional parameters:
+
+- `map_name_regex`: A [regular expression](https://regexr.com/) used to filter map names. Only maps matching this regular expression will participate in recognition. For example:
+
+    - `^map\\d+_lv\\d+$`: Default value. Matches all regular maps.
+    - `^map\\d+_lv\\d+(_tier_\\d+)?$`: Matches all regular maps and tiered maps (Tier).
+    - `^map001_lv001$`: Only matches "map001_lv001" (Fourth Valley - Hub Area).
+    - `^map001_lv\\d+$`: Matches all sub-regions of "map001" (Fourth Valley).
+
+- `print`: Boolean value, default `false`. Whether to enable UI message printing of recognition results.
+
+<details>
+<summary>Advanced Optional Parameters (Expand)</summary>
+
+- `precision`: Real number between $(0, 1]$, default `0.5`. Controls the accuracy of matching. A larger value will match map features more strictly but may result in slow matching speed; a smaller value will greatly improve matching speed but may lead to incorrect results. When the number of maps to be matched is small (e.g., only one map), it is recommended to use a larger value to obtain more accurate results.
+
+- `threshold`: Real number between $(0, 1]$, default `0.4`. Controls the confidence threshold for matching. Matching results below this value will not hit the recognition.
+
+</details>
+
+<br>
+
+> [!TIP]
+>
+> MapTracker uses an integer between $[0, 360)$ to represent the player's **orientation**, in degrees. 0° indicates facing due north, with clockwise rotation as the increasing direction.
+
+> [!WARNING]
+>
+> This node is designed for advanced programming, so it is not suitable for low-code development in the pipeline. If you need to judge whether the player's current position meets conditions, please use the [MapTrackerAssertLocation](#recognition-maptrackerassertlocation) node.
+
+### Recognition: MapTrackerBigMapInfer
+
+🗺️ Infers the top-left map coordinate of the current viewport region on the big map and the current map scale.
+
+> [!WARNING]
+>
+> This node is designed for advanced programming, so it is not suitable for low-code development in the pipeline. For the exact crop rule of the "current viewport region", refer to the implementation details in code.
+
+#### Node Parameters
+
+Please refer to the `MapTrackerBigMapInferParam` type definition in code.
 
 ## Tool Instructions
 

--- a/docs/zh_cn/developers/map-tracker.md
+++ b/docs/zh_cn/developers/map-tracker.md
@@ -93,57 +93,6 @@
 >
 > 执行此节点期间，请确保玩家**始终处于**指定的地图中，并且相邻的路径点之间**可以直线抵达**。
 
-### Recognition: MapTrackerInfer
-
-📍获取玩家当前所处的地图名称、位置坐标和朝向。
-
-#### 节点参数
-
-必填参数：无
-
-可选参数：
-
-- `map_name_regex`: 用于筛选地图名称的[正则表达式](https://regexr.com/)。仅匹配该正则表达式的地图会参与识别。例如：
-
-    - `^map\\d+_lv\\d+$`: 默认值。匹配所有常规地图。
-    - `^map\\d+_lv\\d+(_tier_\\d+)?$`: 匹配所有常规地图和分层地图（Tier）。
-    - `^map001_lv001$`: 仅匹配 "map001_lv001"（四号谷地-枢纽区）。
-    - `^map001_lv\\d+$`: 匹配 "map001"（四号谷地）的所有子区域。
-
-- `print`: 真假值，默认 `false`。是否开启识别结果的 UI 消息打印。
-
-<details>
-<summary>高级可选参数（展开）</summary>
-
-- `precision`: 介于 $(0, 1]$ 的实数，默认 `0.5`。控制匹配的精确度。较大的值会更严格地匹配地图特征，但可能导致匹配速度缓慢；较小的值会极大提升匹配速度，但可能导致结果错误。在需要匹配的地图数量较少时（例如只匹配一张地图），推荐使用较大的值以获得更准确的结果。
-
-- `threshold`: 介于 $(0, 1]$ 的实数，默认 `0.4`。控制匹配的置信度阈值。低于此值的匹配结果将不命中识别。
-
-</details>
-
-#### 示例用法
-
-```json
-{
-    "MyNodeName": {
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerInfer",
-        "custom_recognition_param": {
-            "map_name_regex": "^map\\d+_lv\\d+$"
-        },
-        "action": "DoNothing"
-    }
-}
-```
-
-> [!TIP]
->
-> MapTracker 使用一个介于 $[0, 360)$ 的整数来表示玩家的**朝向**，单位是度。0° 表示朝向正北方向，以顺时针旋转为递增方向。
-
-> [!WARNING]
->
-> 该节点不适合放在 pipeline 中进行低代码开发。如需判断玩家所处的位置是否符合条件，请使用 [MapTrackerAssertLocation](#recognition-maptrackerassertlocation) 节点。
-
 ### Recognition: MapTrackerAssertLocation
 
 ✅判断玩家当前所处的地图名称和位置坐标是否满足任一预期条件。
@@ -191,6 +140,56 @@
     }
 }
 ```
+
+### Recognition: MapTrackerInfer
+
+📍获取玩家当前所处的地图名称、位置坐标和朝向。
+
+#### 节点参数
+
+必填参数：无
+
+可选参数：
+
+- `map_name_regex`: 用于筛选地图名称的[正则表达式](https://regexr.com/)。仅匹配该正则表达式的地图会参与识别。例如：
+
+    - `^map\\d+_lv\\d+$`: 默认值。匹配所有常规地图。
+    - `^map\\d+_lv\\d+(_tier_\\d+)?$`: 匹配所有常规地图和分层地图（Tier）。
+    - `^map001_lv001$`: 仅匹配 "map001_lv001"（四号谷地-枢纽区）。
+    - `^map001_lv\\d+$`: 匹配 "map001"（四号谷地）的所有子区域。
+
+- `print`: 真假值，默认 `false`。是否开启识别结果的 UI 消息打印。
+
+<details>
+<summary>高级可选参数（展开）</summary>
+
+- `precision`: 介于 $(0, 1]$ 的实数，默认 `0.5`。控制匹配的精确度。较大的值会更严格地匹配地图特征，但可能导致匹配速度缓慢；较小的值会极大提升匹配速度，但可能导致结果错误。在需要匹配的地图数量较少时（例如只匹配一张地图），推荐使用较大的值以获得更准确的结果。
+
+- `threshold`: 介于 $(0, 1]$ 的实数，默认 `0.4`。控制匹配的置信度阈值。低于此值的匹配结果将不命中识别。
+
+</details>
+
+<br>
+
+> [!TIP]
+>
+> MapTracker 使用一个介于 $[0, 360)$ 的整数来表示玩家的**朝向**，单位是度。0° 表示朝向正北方向，以顺时针旋转为递增方向。
+
+> [!WARNING]
+>
+> 该节点是为高级编程而设计的，因此不适合放在 pipeline 中进行低代码开发。如需判断玩家所处的位置是否符合条件，请使用 [MapTrackerAssertLocation](#recognition-maptrackerassertlocation) 节点。
+
+### Recognition: MapTrackerBigMapInfer
+
+🗺️ 在大地图界面中推断当前视野区域在地图中的左上角坐标与地图缩放。
+
+> [!WARNING]
+>
+> 该节点是为高级编程而设计的，因此不适合放在 pipeline 中进行低代码开发。“当前视野区域”的裁切规则请参见具体代码中的定义。
+
+#### 节点参数
+
+请参见具体代码中 `MapTrackerBigMapInferParam` 的类型定义。
 
 ## 工具说明
 


### PR DESCRIPTION
## 概述

此 PR 添加了 MapTrackerBigMapInfer 识别节点，用于识别当前大地图界面的位置。采用**分步迭代多尺度模板匹配**方法进行识别。

## Summary by Sourcery

为 MapTracker 新增大地图位置推断支持和多尺度模板匹配工具，并在英文和中文开发者指南中记录这些新功能。

New Features:
- 引入 `MapTrackerBigMapInfer` 自定义识别节点，用于推断大地图视口左上角坐标以及当前地图缩放比例。
- 新增迭代式多尺度模板匹配辅助工具，以支持在指定区域内进行尺度不变的识别。

Enhancements:
- 初始化并缓存缩放后（下采样）的地图数据，以加速大地图推断并复用现有地图资源。

Documentation:
- 在英文和中文地图追踪器开发者指南中记录 `MapTrackerBigMapInfer` 的用法与行为，包括其参数和使用限制。
- 改进 `MapTrackerInfer` 文档格式，并澄清其更适合高级编程场景，而非低代码流水线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add big-map location inference support and multi-scale template matching utilities for MapTracker, and document the new capabilities in both English and Chinese developer guides.

New Features:
- Introduce MapTrackerBigMapInfer custom recognition node to infer the big map viewport’s top-left coordinate and current map scale.
- Add an iterative multi-scale template matching helper to support scale-invariant recognition within a specified region.

Enhancements:
- Initialize and cache downscaled map data for faster big-map inference and reuse of existing map resources.

Documentation:
- Document MapTrackerBigMapInfer usage and behavior in English and Chinese map tracker developer guides, including its parameters and limitations.
- Improve MapTrackerInfer documentation formatting and clarify its suitability for advanced programming rather than low-code pipelines.

</details>