### PR TITLE
feat(DeliveryJobs): 武陵支持填入砂叶粉末等货物

### DIFF
--- a/assets/tasks/DeliveryJobs.json
+++ b/assets/tasks/DeliveryJobs.json
@@ -249,6 +249,42 @@
                             "template": "DeliveryJobs/Jincao.png"
                         }
                     }
+                },
+                {
+                    "name": "砂叶粉末",
+                    "label": "$item.SandleafPowder",
+                    "pipeline_override": {
+                        "DeliveryJobsSelectItemToFillWuling": {
+                            "template": "DeliveryJobs/SandleafPowder.png"
+                        }
+                    }
+                },
+                {
+                    "name": "荞花粉末",
+                    "label": "$item.BuckflowerPowder",
+                    "pipeline_override": {
+                        "DeliveryJobsSelectItemToFillWuling": {
+                            "template": "DeliveryJobs/BuckflowerPowder.png"
+                        }
+                    }
+                },
+                {
+                    "name": "柑实粉末",
+                    "label": "$item.CitromePowder",
+                    "pipeline_override": {
+                        "DeliveryJobsSelectItemToFillWuling": {
+                            "template": "DeliveryJobs/CitromePowder.png"
+                        }
+                    }
+                },
+                {
+                    "name": "酮化灌木粉末",
+                    "label": "$item.AketinePowder",
+                    "pipeline_override": {
+                        "DeliveryJobsSelectItemToFillWuling": {
+                            "template": "DeliveryJobs/AketinePowder.png"
+                        }
+                    }
                 }
             ],
             "default_case": "芽针"


### PR DESCRIPTION
close #1241

## Summary by Sourcery

新功能：
- 允许在配置中将五菱配送任务中包含砂叶粉等类似货物。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Allow Wuling delivery jobs to include cargo items such as sand leaf powder and similar goods in the configuration.

</details>