### PR TITLE
perf(MapLocator): 引入 YOLO ROI 约束与全链路异步流水线 重构全局检索与双轨验证体系 修复相关工具

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
@@ -1,16 +1,17 @@
-#include "MapLocateAction.h"
-#include "MapLocator.h"
+#include <filesystem>
+#include <thread>
+
+#include <MaaFramework/MaaAPI.h>
 #include <MaaUtils/Logger.h>
-
-#include "MaaFramework/MaaAPI.h"
-
-#include "../utils.h"
 #include <MaaUtils/NoWarningCV.hpp>
 #include <MaaUtils/Platform.h>
-#include <filesystem>
 #ifdef _WIN32
 #include <MaaUtils/SafeWindows.hpp>
 #endif
+#include "../utils.h"
+
+#include "MapLocateAction.h"
+#include "MapLocator.h"
 
 #ifndef MAA_TRUE
 #define MAA_TRUE 1
@@ -51,7 +52,8 @@ std::shared_ptr<MapLocator> getOrInitLocator()
         MapLocatorConfig cfg;
         cfg.mapResourceDir = mapRootStr;
         cfg.yoloModelPath = yoloModelStr;
-        cfg.yoloThreads = 1;
+        const unsigned hardwareThreads = std::thread::hardware_concurrency();
+        cfg.yoloThreads = (hardwareThreads >= 8) ? 4 : ((hardwareThreads >= 4) ? 2 : 1);
 
         auto loc = std::make_shared<MapLocator>();
         bool ok = loc->initialize(cfg);

--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -40,7 +40,8 @@ bool MatchesExpectedZoneSelector(const std::string& expected_zone_selector, cons
     if (expected_zone_selector.empty()) {
         return true;
     }
-    if (coarse.zone_id == expected_zone_selector || coarse.base_class == expected_zone_selector || coarse.raw_class == expected_zone_selector) {
+    if (coarse.zone_id == expected_zone_selector || coarse.base_class == expected_zone_selector
+        || coarse.raw_class == expected_zone_selector) {
         return true;
     }
     return coarse.raw_class.starts_with(expected_zone_selector);
@@ -66,6 +67,18 @@ struct GlobalSearchAttempt
 {
     std::optional<MapPosition> result;
     MapPosition rawPos {};
+};
+
+using TimePoint = std::chrono::steady_clock::time_point;
+
+struct SearchExecutionContext
+{
+    const MatchFeature& tmplFeat;
+    IMatchStrategy* strategy = nullptr;
+    const cv::Mat& bigMap;
+    cv::Rect constrainedRect {};
+    const std::string& targetZoneId;
+    MapPosition* outRawPos = nullptr;
 };
 
 } // namespace
@@ -95,7 +108,7 @@ private:
     std::optional<MapPosition> tryTracking(
         const MatchFeature& tmplFeat,
         IMatchStrategy* strategy,
-        std::chrono::steady_clock::time_point now,
+        TimePoint now,
         const LocateOptions& options,
         MapPosition* outRawPos = nullptr);
 
@@ -112,36 +125,19 @@ private:
         const cv::Mat& templ,
         IMatchStrategy* strategy,
         const std::string& targetZoneId);
-    std::optional<MapPosition> tryConstrainedFineSearch(
-        const MatchFeature& tmplFeat,
-        IMatchStrategy* strategy,
-        const cv::Mat& bigMap,
-        const cv::Rect& constrainedRect,
-        const std::string& targetZoneId,
-        MapPosition* outRawPos);
-    std::optional<MapPosition> tryLegacyCoarseSearch(
-        const MatchFeature& tmplFeat,
-        IMatchStrategy* strategy,
-        const cv::Mat& bigMap,
-        const cv::Rect& constrainedRect,
-        const std::string& targetZoneId,
-        MapPosition* outRawPos);
+    std::optional<MapPosition> tryConstrainedFineSearch(const SearchExecutionContext& ctx);
+    std::optional<MapPosition> tryLegacyCoarseSearch(const SearchExecutionContext& ctx);
 
     YoloCoarseResult predictCoarse(const cv::Mat& minimap) const;
-    void refreshAsyncYoloState(const cv::Mat& minimap, std::chrono::steady_clock::time_point now);
-    std::optional<LocateResult> tryTrackingLocate(
-        const cv::Mat& minimap,
-        const LocateOptions& options,
-        const std::string& expectedZoneId,
-        std::chrono::steady_clock::time_point now);
+    void refreshAsyncYoloState(const cv::Mat& minimap, TimePoint now);
+    std::optional<LocateResult>
+        tryTrackingLocate(const cv::Mat& minimap, const LocateOptions& options, const std::string& expectedZoneId, TimePoint now);
     SearchConstraint buildSearchConstraint(
         const std::string& expectedZoneSelector,
         const std::string& targetZoneId,
         const YoloCoarseResult& coarse) const;
-    std::optional<MapPosition> tryGlobalSearchWithFallback(
-        const cv::Mat& minimap,
-        const std::string& targetZoneId,
-        const SearchConstraint& constraint);
+    std::optional<MapPosition>
+        tryGlobalSearchWithFallback(const cv::Mat& minimap, const std::string& targetZoneId, const SearchConstraint& constraint);
     void drainBackgroundGlobalSearchTasks();
 
     void loadAvailableZones(const std::string& root);
@@ -266,7 +262,7 @@ void MapLocator::Impl::drainBackgroundGlobalSearchTasks()
 std::optional<MapPosition> MapLocator::Impl::tryTracking(
     const MatchFeature& tmplFeat,
     IMatchStrategy* strategy,
-    std::chrono::steady_clock::time_point now,
+    TimePoint now,
     const LocateOptions& options,
     MapPosition* outRawPos)
 {
@@ -306,15 +302,7 @@ std::optional<MapPosition> MapLocator::Impl::tryTracking(
         const int bottom = searchRect.y + searchRect.height - (validRoi.y + validRoi.height);
         const int left = validRoi.x - searchRect.x;
         const int right = searchRect.x + searchRect.width - (validRoi.x + validRoi.width);
-        cv::copyMakeBorder(
-            zoneMap(validRoi),
-            searchRoiWithPad,
-            top,
-            bottom,
-            left,
-            right,
-            cv::BORDER_CONSTANT,
-            cv::Scalar(0, 0, 0, 0));
+        cv::copyMakeBorder(zoneMap(validRoi), searchRoiWithPad, top, bottom, left, right, cv::BORDER_CONSTANT, cv::Scalar(0, 0, 0, 0));
     }
 
     auto searchFeature = strategy->extractSearchFeature(searchRoiWithPad);
@@ -465,16 +453,10 @@ std::optional<MapPosition> MapLocator::Impl::evaluateAndAcceptResult(
     return pos;
 }
 
-std::optional<MapPosition> MapLocator::Impl::tryConstrainedFineSearch(
-    const MatchFeature& tmplFeat,
-    IMatchStrategy* strategy,
-    const cv::Mat& bigMap,
-    const cv::Rect& constrainedRect,
-    const std::string& targetZoneId,
-    MapPosition* outRawPos)
+std::optional<MapPosition> MapLocator::Impl::tryConstrainedFineSearch(const SearchExecutionContext& ctx)
 {
-    cv::Mat fineMap = bigMap(constrainedRect);
-    auto fineSearchFeat = strategy->extractSearchFeature(fineMap);
+    cv::Mat fineMap = ctx.bigMap(ctx.constrainedRect);
+    auto fineSearchFeat = ctx.strategy->extractSearchFeature(fineMap);
     std::vector<double> scales;
     for (double s = 0.90; s <= 1.101; s += 0.02) {
         scales.push_back(s);
@@ -492,12 +474,12 @@ std::optional<MapPosition> MapLocator::Impl::tryConstrainedFineSearch(
 
             cv::Mat scaledTempl, scaledWeightMask;
             if (std::abs(s - 1.0) > 0.001) {
-                cv::resize(tmplFeat.image, scaledTempl, cv::Size(), s, s, cv::INTER_LINEAR);
-                cv::resize(tmplFeat.mask, scaledWeightMask, cv::Size(), s, s, cv::INTER_NEAREST);
+                cv::resize(ctx.tmplFeat.image, scaledTempl, cv::Size(), s, s, cv::INTER_LINEAR);
+                cv::resize(ctx.tmplFeat.mask, scaledWeightMask, cv::Size(), s, s, cv::INTER_NEAREST);
             }
             else {
-                scaledTempl = tmplFeat.image;
-                scaledWeightMask = tmplFeat.mask;
+                scaledTempl = ctx.tmplFeat.image;
+                scaledWeightMask = ctx.tmplFeat.mask;
             }
 
             if (scaledTempl.cols > fineSearchFeat.image.cols || scaledTempl.rows > fineSearchFeat.image.rows
@@ -563,7 +545,7 @@ std::optional<MapPosition> MapLocator::Impl::tryConstrainedFineSearch(
         }
 
         auto directResult =
-            evaluateAndAcceptResult(scaleResult.fineRes, constrainedRect, scaleResult.scaledTempl, strategy, targetZoneId);
+            evaluateAndAcceptResult(scaleResult.fineRes, ctx.constrainedRect, scaleResult.scaledTempl, ctx.strategy, ctx.targetZoneId);
         if (!directResult) {
             continue;
         }
@@ -576,12 +558,12 @@ std::optional<MapPosition> MapLocator::Impl::tryConstrainedFineSearch(
         }
     }
 
-    if (outRawPos && bestRawScore >= 0.0) {
-        outRawPos->zoneId = targetZoneId;
-        outRawPos->x = constrainedRect.x + bestFineRes.loc.x + bestScaledTempl.cols / 2.0;
-        outRawPos->y = constrainedRect.y + bestFineRes.loc.y + bestScaledTempl.rows / 2.0;
-        outRawPos->score = bestRawScore;
-        outRawPos->scale = bestScale;
+    if (ctx.outRawPos && bestRawScore >= 0.0) {
+        ctx.outRawPos->zoneId = ctx.targetZoneId;
+        ctx.outRawPos->x = ctx.constrainedRect.x + bestFineRes.loc.x + bestScaledTempl.cols / 2.0;
+        ctx.outRawPos->y = ctx.constrainedRect.y + bestFineRes.loc.y + bestScaledTempl.rows / 2.0;
+        ctx.outRawPos->score = bestRawScore;
+        ctx.outRawPos->scale = bestScale;
     }
 
     if (bestValidScore < 0.0) {
@@ -589,7 +571,7 @@ std::optional<MapPosition> MapLocator::Impl::tryConstrainedFineSearch(
         return std::nullopt;
     }
 
-    auto directResult = evaluateAndAcceptResult(bestFineRes, constrainedRect, bestScaledTempl, strategy, targetZoneId);
+    auto directResult = evaluateAndAcceptResult(bestFineRes, ctx.constrainedRect, bestScaledTempl, ctx.strategy, ctx.targetZoneId);
     if (!directResult) {
         LogInfo << "Global Search: constrained ROI direct fine failed, no coarse fallback will be used." << VAR(bestRawScore);
         return std::nullopt;
@@ -600,24 +582,18 @@ std::optional<MapPosition> MapLocator::Impl::tryConstrainedFineSearch(
     return directResult;
 }
 
-std::optional<MapPosition> MapLocator::Impl::tryLegacyCoarseSearch(
-    const MatchFeature& tmplFeat,
-    IMatchStrategy* strategy,
-    const cv::Mat& bigMap,
-    const cv::Rect& constrainedRect,
-    const std::string& targetZoneId,
-    MapPosition* outRawPos)
+std::optional<MapPosition> MapLocator::Impl::tryLegacyCoarseSearch(const SearchExecutionContext& ctx)
 {
-    const cv::Rect mapBounds(0, 0, bigMap.cols, bigMap.rows);
+    const cv::Rect mapBounds(0, 0, ctx.bigMap.cols, ctx.bigMap.rows);
 
     // 图像金字塔：全图匹配耗时极高，因此粗搜先固定在 coarseScale (约 0.2~0.3) 的降采样级别寻找可能的高分岛
     double coarseScale = matchCfg.coarseScale;
 
-    cv::Mat constrainedMap = bigMap(constrainedRect);
+    cv::Mat constrainedMap = ctx.bigMap(ctx.constrainedRect);
     cv::Mat smallMap;
     cv::resize(constrainedMap, smallMap, cv::Size(), coarseScale, coarseScale, cv::INTER_AREA);
 
-    auto coarseSearchFeat = strategy->extractSearchFeature(smallMap);
+    auto coarseSearchFeat = ctx.strategy->extractSearchFeature(smallMap);
     cv::Mat mapToUse;
     if (coarseSearchFeat.image.channels() == 3) {
         cv::cvtColor(coarseSearchFeat.image, mapToUse, cv::COLOR_BGR2GRAY);
@@ -629,19 +605,19 @@ std::optional<MapPosition> MapLocator::Impl::tryLegacyCoarseSearch(
         mapToUse = coarseSearchFeat.image.clone();
     }
 
-    if (matchCfg.blurSize > 0 && !strategy->needsChamferCompensation()) {
+    if (matchCfg.blurSize > 0 && !ctx.strategy->needsChamferCompensation()) {
         cv::GaussianBlur(mapToUse, mapToUse, cv::Size(matchCfg.blurSize, matchCfg.blurSize), 0);
     }
 
     cv::Mat tmplGrayToUse;
-    if (tmplFeat.image.channels() == 3) {
-        cv::cvtColor(tmplFeat.image, tmplGrayToUse, cv::COLOR_BGR2GRAY);
+    if (ctx.tmplFeat.image.channels() == 3) {
+        cv::cvtColor(ctx.tmplFeat.image, tmplGrayToUse, cv::COLOR_BGR2GRAY);
     }
-    else if (tmplFeat.image.channels() == 4) {
-        cv::cvtColor(tmplFeat.image, tmplGrayToUse, cv::COLOR_BGRA2GRAY);
+    else if (ctx.tmplFeat.image.channels() == 4) {
+        cv::cvtColor(ctx.tmplFeat.image, tmplGrayToUse, cv::COLOR_BGRA2GRAY);
     }
     else {
-        tmplGrayToUse = tmplFeat.image.clone();
+        tmplGrayToUse = ctx.tmplFeat.image.clone();
     }
 
     struct CoarseCand
@@ -660,7 +636,7 @@ std::optional<MapPosition> MapLocator::Impl::tryLegacyCoarseSearch(
         double currentScale = coarseScale * s;
         cv::Mat smallTempl, smallWeightMask;
         cv::resize(tmplGrayToUse, smallTempl, cv::Size(), currentScale, currentScale, cv::INTER_LINEAR);
-        cv::resize(tmplFeat.mask, smallWeightMask, cv::Size(), currentScale, currentScale, cv::INTER_NEAREST);
+        cv::resize(ctx.tmplFeat.mask, smallWeightMask, cv::Size(), currentScale, currentScale, cv::INTER_NEAREST);
 
         if (cv::countNonZero(smallWeightMask) < 5) {
             continue;
@@ -717,17 +693,17 @@ std::optional<MapPosition> MapLocator::Impl::tryLegacyCoarseSearch(
 
     for (auto& cand : cands) {
         double s = cand.s;
-        int coarseX = static_cast<int>(cand.loc.x / coarseScale) + constrainedRect.x;
-        int coarseY = static_cast<int>(cand.loc.y / coarseScale) + constrainedRect.y;
+        int coarseX = static_cast<int>(cand.loc.x / coarseScale) + ctx.constrainedRect.x;
+        int coarseY = static_cast<int>(cand.loc.y / coarseScale) + ctx.constrainedRect.y;
 
         cv::Mat scaledTempl, scaledWeightMask;
         if (std::abs(s - 1.0) > 0.001) {
-            cv::resize(tmplFeat.image, scaledTempl, cv::Size(), s, s, cv::INTER_LINEAR);
-            cv::resize(tmplFeat.mask, scaledWeightMask, cv::Size(), s, s, cv::INTER_NEAREST);
+            cv::resize(ctx.tmplFeat.image, scaledTempl, cv::Size(), s, s, cv::INTER_LINEAR);
+            cv::resize(ctx.tmplFeat.mask, scaledWeightMask, cv::Size(), s, s, cv::INTER_NEAREST);
         }
         else {
-            scaledTempl = tmplFeat.image;
-            scaledWeightMask = tmplFeat.mask;
+            scaledTempl = ctx.tmplFeat.image;
+            scaledWeightMask = ctx.tmplFeat.mask;
         }
 
         cv::Rect fineRect(
@@ -741,9 +717,9 @@ std::optional<MapPosition> MapLocator::Impl::tryLegacyCoarseSearch(
             continue;
         }
 
-        cv::Mat fineMap = bigMap(validFineRect);
+        cv::Mat fineMap = ctx.bigMap(validFineRect);
 
-        auto fineSearchFeat = strategy->extractSearchFeature(fineMap);
+        auto fineSearchFeat = ctx.strategy->extractSearchFeature(fineMap);
         auto fineRes = CoreMatch(fineSearchFeat.image, scaledTempl, scaledWeightMask, matchCfg.blurSize);
 
         if (!fineRes) {
@@ -760,14 +736,14 @@ std::optional<MapPosition> MapLocator::Impl::tryLegacyCoarseSearch(
         }
 
         bool ambiguous = false;
-        if (strategy->needsChamferCompensation()) { // i.e. PathHeatmap
+        if (ctx.strategy->needsChamferCompensation()) { // i.e. PathHeatmap
             ambiguous = (fineRes->psr < 6.0) || (fineRes->delta < 0.04);
             if (fineRes->score < 0.45 && ambiguous) {
                 continue;
             }
         }
         else {
-            double lowScoreCut = (targetZoneId.find("Base") != std::string::npos) ? 0.85 : 0.75;
+            double lowScoreCut = (ctx.targetZoneId.find("Base") != std::string::npos) ? 0.85 : 0.75;
             ambiguous = (fineRes->score < lowScoreCut) && (fineRes->psr < 6.0 || fineRes->delta < 0.02);
             if (ambiguous) {
                 continue;
@@ -797,15 +773,15 @@ std::optional<MapPosition> MapLocator::Impl::tryLegacyCoarseSearch(
         LogInfo << "Global Search: All candidates ambiguous, using fallback (score " << fallbackScore << ")";
     }
 
-    if (outRawPos && bestFine >= 0.0) {
-        outRawPos->zoneId = targetZoneId;
-        outRawPos->x = bestValidFineRect.x + bestFineRes.loc.x + bestScaledTempl.cols / 2.0;
-        outRawPos->y = bestValidFineRect.y + bestFineRes.loc.y + bestScaledTempl.rows / 2.0;
-        outRawPos->score = bestFine;
-        outRawPos->scale = bestScale;
+    if (ctx.outRawPos && bestFine >= 0.0) {
+        ctx.outRawPos->zoneId = ctx.targetZoneId;
+        ctx.outRawPos->x = bestValidFineRect.x + bestFineRes.loc.x + bestScaledTempl.cols / 2.0;
+        ctx.outRawPos->y = bestValidFineRect.y + bestFineRes.loc.y + bestScaledTempl.rows / 2.0;
+        ctx.outRawPos->score = bestFine;
+        ctx.outRawPos->scale = bestScale;
     }
 
-    auto res = evaluateAndAcceptResult(bestFineRes, bestValidFineRect, bestScaledTempl, strategy, targetZoneId);
+    auto res = evaluateAndAcceptResult(bestFineRes, bestValidFineRect, bestScaledTempl, ctx.strategy, ctx.targetZoneId);
     if (res) {
         res->scale = bestScale;
     }
@@ -838,14 +814,14 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearch(
             LogInfo << "Global Search Aborted: coarse ROI is outside of map bounds.";
             return std::nullopt;
         }
-        return tryConstrainedFineSearch(tmplFeat, strategy, bigMap, constrainedRect, targetZoneId, outRawPos);
+        return tryConstrainedFineSearch({ tmplFeat, strategy, bigMap, constrainedRect, targetZoneId, outRawPos });
     }
 
     if (constraint.mode == GlobalSearchMode::FullMapFine) {
-        return tryConstrainedFineSearch(tmplFeat, strategy, bigMap, mapBounds, targetZoneId, outRawPos);
+        return tryConstrainedFineSearch({ tmplFeat, strategy, bigMap, mapBounds, targetZoneId, outRawPos });
     }
 
-    return tryLegacyCoarseSearch(tmplFeat, strategy, bigMap, mapBounds, targetZoneId, outRawPos);
+    return tryLegacyCoarseSearch({ tmplFeat, strategy, bigMap, mapBounds, targetZoneId, outRawPos });
 }
 
 YoloCoarseResult MapLocator::Impl::predictCoarse(const cv::Mat& minimap) const
@@ -856,7 +832,7 @@ YoloCoarseResult MapLocator::Impl::predictCoarse(const cv::Mat& minimap) const
     return zoneClassifier->predictCoarseByYOLO(minimap);
 }
 
-void MapLocator::Impl::refreshAsyncYoloState(const cv::Mat& minimap, std::chrono::steady_clock::time_point now)
+void MapLocator::Impl::refreshAsyncYoloState(const cv::Mat& minimap, TimePoint now)
 {
     if (!zoneClassifier || !zoneClassifier->isLoaded()) {
         return;
@@ -895,7 +871,7 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
     const cv::Mat& minimap,
     const LocateOptions& options,
     const std::string& expectedZoneId,
-    std::chrono::steady_clock::time_point now)
+    TimePoint now)
 {
     if (options.force_global_search) {
         return std::nullopt;
@@ -1016,8 +992,7 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearchWithFallback(
 {
     const bool isNativePathHeatmap = targetZoneId.find("OMVBase") != std::string::npos;
     const unsigned hardwareThreads = std::max(1U, std::thread::hardware_concurrency());
-    const bool canSpeculateDualMode =
-        !isNativePathHeatmap && constraint.mode != GlobalSearchMode::LegacyCoarse && hardwareThreads >= 8;
+    const bool canSpeculateDualMode = !isNativePathHeatmap && constraint.mode != GlobalSearchMode::LegacyCoarse && hardwareThreads >= 8;
 
     auto runSearch = [this, &constraint, &targetZoneId](const cv::Mat& searchMinimap, MatchMode mode) -> GlobalSearchAttempt {
         GlobalSearchAttempt attempt;
@@ -1038,8 +1013,8 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearchWithFallback(
         std::string fallbackZoneId = targetZoneId;
         fallbackTask = std::async(std::launch::async, [this, fallbackMinimap, fallbackConstraint, fallbackZoneId]() {
             GlobalSearchAttempt attempt;
-            auto fallbackStrategy = MatchStrategyFactory::create(
-                fallbackZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg, MatchMode::ForcePathHeatmap);
+            auto fallbackStrategy =
+                MatchStrategyFactory::create(fallbackZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg, MatchMode::ForcePathHeatmap);
             if (!fallbackStrategy) {
                 return attempt;
             }
@@ -1163,16 +1138,12 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
 
     const SearchConstraint constraint = buildSearchConstraint(expectedZoneSelector, targetZoneId, coarse);
     if (coarse.valid && !coarse.is_none && !constraint.yolo_validated) {
-        return LocateResult {
-            .status = LocateStatus::YoloFailed,
-            .debugMessage = "YOLO is confident but zone validation failed. Aborting before broad search."
-        };
+        return LocateResult { .status = LocateStatus::YoloFailed,
+                              .debugMessage = "YOLO is confident but zone validation failed. Aborting before broad search." };
     }
     if (coarse.valid && !coarse.is_none && coarse.has_roi && constraint.mode != GlobalSearchMode::RoiFine) {
-        return LocateResult {
-            .status = LocateStatus::YoloFailed,
-            .debugMessage = "YOLO is confident but ROI constraint validation failed. Aborting to avoid broad search."
-        };
+        return LocateResult { .status = LocateStatus::YoloFailed,
+                              .debugMessage = "YOLO is confident but ROI constraint validation failed. Aborting to avoid broad search." };
     }
 
     int maxAllowedLost = (targetZoneId.find("OMVBase") != std::string::npos) ? 10 : options.max_lost_frames;

--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -1163,17 +1163,16 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
 
     const SearchConstraint constraint = buildSearchConstraint(expectedZoneSelector, targetZoneId, coarse);
     if (coarse.valid && !coarse.is_none && !constraint.yolo_validated) {
-        const std::string debugMessage = "YOLO is confident but zone validation failed. Aborting before broad search.";
-        LogWarn << debugMessage << VAR(expectedZoneSelector) << VAR(targetZoneId) << VAR(coarse.raw_class) << VAR(coarse.base_class)
-                << VAR(coarse.zone_id) << VAR(coarse.has_roi);
-        return LocateResult { .status = LocateStatus::YoloFailed, .debugMessage = debugMessage };
+        return LocateResult {
+            .status = LocateStatus::YoloFailed,
+            .debugMessage = "YOLO is confident but zone validation failed. Aborting before broad search."
+        };
     }
     if (coarse.valid && !coarse.is_none && coarse.has_roi && constraint.mode != GlobalSearchMode::RoiFine) {
-        const std::string debugMessage =
-            "YOLO is confident but ROI constraint validation failed. Aborting to avoid broad search.";
-        LogWarn << debugMessage << VAR(expectedZoneSelector) << VAR(targetZoneId) << VAR(coarse.raw_class) << VAR(coarse.base_class)
-                << VAR(coarse.zone_id) << VAR(coarse.has_roi);
-        return LocateResult { .status = LocateStatus::YoloFailed, .debugMessage = debugMessage };
+        return LocateResult {
+            .status = LocateStatus::YoloFailed,
+            .debugMessage = "YOLO is confident but ROI constraint validation failed. Aborting to avoid broad search."
+        };
     }
 
     int maxAllowedLost = (targetZoneId.find("OMVBase") != std::string::npos) ? 10 : options.max_lost_frames;

--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -1,8 +1,10 @@
 #include <algorithm>
+#include <exception>
 #include <filesystem>
 #include <format>
 #include <future>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 #include <MaaUtils/ImageIo.h>
@@ -24,6 +26,50 @@ namespace fs = std::filesystem;
 namespace maplocator
 {
 
+namespace
+{
+
+std::string TrimLeadingZeros(std::string value)
+{
+    value.erase(0, std::min(value.find_first_not_of('0'), value.size() - 1));
+    return value;
+}
+
+bool MatchesExpectedZoneSelector(const std::string& expected_zone_selector, const YoloCoarseResult& coarse)
+{
+    if (expected_zone_selector.empty()) {
+        return true;
+    }
+    if (coarse.zone_id == expected_zone_selector || coarse.base_class == expected_zone_selector || coarse.raw_class == expected_zone_selector) {
+        return true;
+    }
+    return coarse.raw_class.starts_with(expected_zone_selector);
+}
+
+std::string NormalizeExpectedZoneId(const std::string& expected_zone_selector, YoloPredictor* predictor)
+{
+    if (expected_zone_selector.empty() || predictor == nullptr) {
+        return expected_zone_selector;
+    }
+    return predictor->convertYoloNameToZoneId(expected_zone_selector);
+}
+
+struct FineScaleSearchResult
+{
+    double scale = 1.0;
+    bool hasRawResult = false;
+    MatchResultRaw fineRes;
+    cv::Mat scaledTempl;
+};
+
+struct GlobalSearchAttempt
+{
+    std::optional<MapPosition> result;
+    MapPosition rawPos {};
+};
+
+} // namespace
+
 class MapLocator::Impl
 {
 public:
@@ -34,6 +80,7 @@ public:
         if (asyncYoloTask.valid()) {
             asyncYoloTask.wait();
         }
+        drainBackgroundGlobalSearchTasks();
     }
 
     bool initialize(const MapLocatorConfig& cfg);
@@ -56,6 +103,7 @@ private:
         const MatchFeature& tmplFeat,
         IMatchStrategy* strategy,
         const std::string& targetZoneId,
+        const SearchConstraint& constraint = {},
         MapPosition* outRawPos = nullptr);
 
     std::optional<MapPosition> evaluateAndAcceptResult(
@@ -64,6 +112,37 @@ private:
         const cv::Mat& templ,
         IMatchStrategy* strategy,
         const std::string& targetZoneId);
+    std::optional<MapPosition> tryConstrainedFineSearch(
+        const MatchFeature& tmplFeat,
+        IMatchStrategy* strategy,
+        const cv::Mat& bigMap,
+        const cv::Rect& constrainedRect,
+        const std::string& targetZoneId,
+        MapPosition* outRawPos);
+    std::optional<MapPosition> tryLegacyCoarseSearch(
+        const MatchFeature& tmplFeat,
+        IMatchStrategy* strategy,
+        const cv::Mat& bigMap,
+        const cv::Rect& constrainedRect,
+        const std::string& targetZoneId,
+        MapPosition* outRawPos);
+
+    YoloCoarseResult predictCoarse(const cv::Mat& minimap) const;
+    void refreshAsyncYoloState(const cv::Mat& minimap, std::chrono::steady_clock::time_point now);
+    std::optional<LocateResult> tryTrackingLocate(
+        const cv::Mat& minimap,
+        const LocateOptions& options,
+        const std::string& expectedZoneId,
+        std::chrono::steady_clock::time_point now);
+    SearchConstraint buildSearchConstraint(
+        const std::string& expectedZoneSelector,
+        const std::string& targetZoneId,
+        const YoloCoarseResult& coarse) const;
+    std::optional<MapPosition> tryGlobalSearchWithFallback(
+        const cv::Mat& minimap,
+        const std::string& targetZoneId,
+        const SearchConstraint& constraint);
+    void drainBackgroundGlobalSearchTasks();
 
     void loadAvailableZones(const std::string& root);
 
@@ -76,7 +155,8 @@ private:
     std::unique_ptr<MotionTracker> motionTracker;
     std::unique_ptr<YoloPredictor> zoneClassifier;
     std::mutex taskMutex;
-    std::future<std::string> asyncYoloTask;
+    std::future<YoloCoarseResult> asyncYoloTask;
+    std::vector<std::future<GlobalSearchAttempt>> backgroundGlobalSearchTasks;
     std::chrono::steady_clock::time_point lastYoloCheckTime;
 
     TrackingConfig trackingCfg;
@@ -113,7 +193,7 @@ bool MapLocator::Impl::initialize(const MapLocatorConfig& cfg)
     loadAvailableZones(config.mapResourceDir);
 
     if (!config.yoloModelPath.empty()) {
-        zoneClassifier = std::make_unique<YoloPredictor>(config.yoloModelPath, matchCfg.yoloConfThreshold);
+        zoneClassifier = std::make_unique<YoloPredictor>(config.yoloModelPath, matchCfg.yoloConfThreshold, config.yoloThreads);
     }
 
     isInitialized = true;
@@ -132,11 +212,12 @@ void MapLocator::Impl::loadAvailableZones(const std::string& root)
         if (entry.is_directory()) {
             continue;
         }
-        std::string filename = MAA_NS::path_to_utf8_string(entry.path());
-        std::string parentName = MAA_NS::path_to_utf8_string(entry.path().parent_path().filename());
+        const auto& entryPath = entry.path();
+        const std::string filename = MAA_NS::path_to_utf8_string(entryPath);
+        const std::string parentName = MAA_NS::path_to_utf8_string(entryPath.parent_path().filename());
 
         std::string key;
-        std::string filenameLower = entry.path().filename().string();
+        std::string filenameLower = entryPath.filename().string();
         std::transform(filenameLower.begin(), filenameLower.end(), filenameLower.begin(), ::tolower);
 
         if (filenameLower == "base.png") {
@@ -145,20 +226,16 @@ void MapLocator::Impl::loadAvailableZones(const std::string& root)
         else {
             boost::smatch matches;
             if (boost::regex_search(filename, matches, layerFileRegex)) {
-                std::string lv = matches[1].str();
-                std::string tier = matches[2].str();
-                lv.erase(0, std::min(lv.find_first_not_of('0'), lv.size() - 1));
-                tier.erase(0, std::min(tier.find_first_not_of('0'), tier.size() - 1));
-                key = std::format("{}_L{}_{}", parentName, lv, tier);
+                key = std::format("{}_L{}_{}", parentName, TrimLeadingZeros(matches[1].str()), TrimLeadingZeros(matches[2].str()));
             }
             else {
-                key = MAA_NS::path_to_utf8_string(entry.path().stem());
+                key = MAA_NS::path_to_utf8_string(entryPath.stem());
             }
         }
 
-        cv::Mat img = MAA_NS::imread(entry.path(), cv::IMREAD_UNCHANGED);
+        cv::Mat img = MAA_NS::imread(entryPath, cv::IMREAD_UNCHANGED);
         if (img.empty()) {
-            LogError << "Failed to load map: " << MAA_NS::path_to_utf8_string(entry.path());
+            LogError << "Failed to load map: " << MAA_NS::path_to_utf8_string(entryPath);
             continue;
         }
         if (img.channels() == 3) {
@@ -167,6 +244,23 @@ void MapLocator::Impl::loadAvailableZones(const std::string& root)
         zones[key] = std::move(img);
         LogInfo << "Loaded Map: " << key;
     }
+}
+
+void MapLocator::Impl::drainBackgroundGlobalSearchTasks()
+{
+    for (auto& task : backgroundGlobalSearchTasks) {
+        if (!task.valid()) {
+            continue;
+        }
+        try {
+            task.wait();
+            task.get();
+        }
+        catch (const std::exception& e) {
+            LogError << "Background global search task failed: " << e.what();
+        }
+    }
+    backgroundGlobalSearchTasks.clear();
 }
 
 std::optional<MapPosition> MapLocator::Impl::tryTracking(
@@ -201,12 +295,26 @@ std::optional<MapPosition> MapLocator::Impl::tryTracking(
 
     cv::Rect searchRect = motionTracker->predictNextSearchRect(trackScale, tmplFeat.image.cols, tmplFeat.image.rows, now);
 
-    cv::Mat searchRoiWithPad(searchRect.size(), zoneMap.type(), cv::Scalar(0, 0, 0, 0));
     cv::Rect mapBounds(0, 0, zoneMap.cols, zoneMap.rows);
     cv::Rect validRoi = searchRect & mapBounds;
-    if (!validRoi.empty()) {
-        zoneMap(validRoi).copyTo(
-            searchRoiWithPad(cv::Rect(validRoi.x - searchRect.x, validRoi.y - searchRect.y, validRoi.width, validRoi.height)));
+    cv::Mat searchRoiWithPad;
+    if (validRoi.empty()) {
+        searchRoiWithPad = cv::Mat(searchRect.size(), zoneMap.type(), cv::Scalar(0, 0, 0, 0));
+    }
+    else {
+        const int top = validRoi.y - searchRect.y;
+        const int bottom = searchRect.y + searchRect.height - (validRoi.y + validRoi.height);
+        const int left = validRoi.x - searchRect.x;
+        const int right = searchRect.x + searchRect.width - (validRoi.x + validRoi.width);
+        cv::copyMakeBorder(
+            zoneMap(validRoi),
+            searchRoiWithPad,
+            top,
+            bottom,
+            left,
+            right,
+            cv::BORDER_CONSTANT,
+            cv::Scalar(0, 0, 0, 0));
     }
 
     auto searchFeature = strategy->extractSearchFeature(searchRoiWithPad);
@@ -357,30 +465,157 @@ std::optional<MapPosition> MapLocator::Impl::evaluateAndAcceptResult(
     return pos;
 }
 
-std::optional<MapPosition> MapLocator::Impl::tryGlobalSearch(
+std::optional<MapPosition> MapLocator::Impl::tryConstrainedFineSearch(
     const MatchFeature& tmplFeat,
     IMatchStrategy* strategy,
+    const cv::Mat& bigMap,
+    const cv::Rect& constrainedRect,
     const std::string& targetZoneId,
     MapPosition* outRawPos)
 {
-    if (!strategy || targetZoneId.empty()) {
-        LogInfo << "Global Search Aborted: YOLO returned no result.";
+    cv::Mat fineMap = bigMap(constrainedRect);
+    auto fineSearchFeat = strategy->extractSearchFeature(fineMap);
+    std::vector<double> scales;
+    for (double s = 0.90; s <= 1.101; s += 0.02) {
+        scales.push_back(s);
+    }
+
+    std::vector<FineScaleSearchResult> scaleResults(scales.size());
+    for (size_t i = 0; i < scales.size(); ++i) {
+        scaleResults[i].scale = scales[i];
+    }
+
+    auto processScaleRange = [&](size_t beginIndex, size_t endIndex) {
+        for (size_t i = beginIndex; i < endIndex; ++i) {
+            const double s = scales[i];
+            auto& scaleResult = scaleResults[i];
+
+            cv::Mat scaledTempl, scaledWeightMask;
+            if (std::abs(s - 1.0) > 0.001) {
+                cv::resize(tmplFeat.image, scaledTempl, cv::Size(), s, s, cv::INTER_LINEAR);
+                cv::resize(tmplFeat.mask, scaledWeightMask, cv::Size(), s, s, cv::INTER_NEAREST);
+            }
+            else {
+                scaledTempl = tmplFeat.image;
+                scaledWeightMask = tmplFeat.mask;
+            }
+
+            if (scaledTempl.cols > fineSearchFeat.image.cols || scaledTempl.rows > fineSearchFeat.image.rows
+                || cv::countNonZero(scaledWeightMask) < 5) {
+                continue;
+            }
+
+            auto fineRes = CoreMatch(fineSearchFeat.image, scaledTempl, scaledWeightMask, matchCfg.blurSize);
+            if (!fineRes) {
+                continue;
+            }
+
+            scaleResult.hasRawResult = true;
+            scaleResult.fineRes = *fineRes;
+            scaleResult.scaledTempl = scaledTempl;
+        }
+    };
+
+    const unsigned hardwareThreads = std::max(1U, std::thread::hardware_concurrency());
+    const size_t workerCount = std::min(scales.size(), static_cast<size_t>(hardwareThreads));
+    if (workerCount <= 1) {
+        processScaleRange(0, scales.size());
+    }
+    else {
+        const size_t chunkSize = (scales.size() + workerCount - 1) / workerCount;
+        std::vector<std::future<void>> workers;
+        workers.reserve(workerCount - 1);
+
+        size_t beginIndex = 0;
+        for (size_t workerIndex = 0; workerIndex < workerCount && beginIndex < scales.size(); ++workerIndex) {
+            const size_t endIndex = std::min(scales.size(), beginIndex + chunkSize);
+            if (workerIndex + 1 == workerCount) {
+                processScaleRange(beginIndex, endIndex);
+            }
+            else {
+                workers.emplace_back(std::async(std::launch::async, processScaleRange, beginIndex, endIndex));
+            }
+            beginIndex = endIndex;
+        }
+
+        for (auto& worker : workers) {
+            worker.get();
+        }
+    }
+
+    double bestValidScore = -1.0;
+    double bestRawScore = -1.0;
+    double bestScale = 1.0;
+    MatchResultRaw bestFineRes;
+    cv::Mat bestScaledTempl;
+
+    // Preserve the original scan order and tie-breaks while parallelizing the expensive CoreMatch calls.
+    for (const auto& scaleResult : scaleResults) {
+        if (!scaleResult.hasRawResult) {
+            continue;
+        }
+
+        if (scaleResult.fineRes.score > bestRawScore) {
+            bestRawScore = scaleResult.fineRes.score;
+            bestScale = scaleResult.scale;
+            bestFineRes = scaleResult.fineRes;
+            bestScaledTempl = scaleResult.scaledTempl;
+        }
+
+        auto directResult =
+            evaluateAndAcceptResult(scaleResult.fineRes, constrainedRect, scaleResult.scaledTempl, strategy, targetZoneId);
+        if (!directResult) {
+            continue;
+        }
+
+        if (directResult->score > bestValidScore) {
+            bestValidScore = directResult->score;
+            bestScale = scaleResult.scale;
+            bestFineRes = scaleResult.fineRes;
+            bestScaledTempl = scaleResult.scaledTempl;
+        }
+    }
+
+    if (outRawPos && bestRawScore >= 0.0) {
+        outRawPos->zoneId = targetZoneId;
+        outRawPos->x = constrainedRect.x + bestFineRes.loc.x + bestScaledTempl.cols / 2.0;
+        outRawPos->y = constrainedRect.y + bestFineRes.loc.y + bestScaledTempl.rows / 2.0;
+        outRawPos->score = bestRawScore;
+        outRawPos->scale = bestScale;
+    }
+
+    if (bestValidScore < 0.0) {
+        LogInfo << "Global Search: constrained ROI direct fine failed, no coarse fallback will be used." << VAR(bestRawScore);
         return std::nullopt;
     }
 
-    if (zones.find(targetZoneId) == zones.end()) {
-        std::string msg = "Global Search Aborted: YOLO predicted '" + targetZoneId + "', but this map is NOT loaded in 'zones'.";
-        LogInfo << msg;
+    auto directResult = evaluateAndAcceptResult(bestFineRes, constrainedRect, bestScaledTempl, strategy, targetZoneId);
+    if (!directResult) {
+        LogInfo << "Global Search: constrained ROI direct fine failed, no coarse fallback will be used." << VAR(bestRawScore);
         return std::nullopt;
     }
 
-    const cv::Mat& bigMap = zones.at(targetZoneId);
+    directResult->scale = bestScale;
+    LogInfo << "Global Search: direct fine search accepted inside constrained ROI." << VAR(bestScale) << VAR(bestValidScore);
+    return directResult;
+}
+
+std::optional<MapPosition> MapLocator::Impl::tryLegacyCoarseSearch(
+    const MatchFeature& tmplFeat,
+    IMatchStrategy* strategy,
+    const cv::Mat& bigMap,
+    const cv::Rect& constrainedRect,
+    const std::string& targetZoneId,
+    MapPosition* outRawPos)
+{
+    const cv::Rect mapBounds(0, 0, bigMap.cols, bigMap.rows);
 
     // 图像金字塔：全图匹配耗时极高，因此粗搜先固定在 coarseScale (约 0.2~0.3) 的降采样级别寻找可能的高分岛
     double coarseScale = matchCfg.coarseScale;
 
+    cv::Mat constrainedMap = bigMap(constrainedRect);
     cv::Mat smallMap;
-    cv::resize(bigMap, smallMap, cv::Size(), coarseScale, coarseScale, cv::INTER_AREA);
+    cv::resize(constrainedMap, smallMap, cv::Size(), coarseScale, coarseScale, cv::INTER_AREA);
 
     auto coarseSearchFeat = strategy->extractSearchFeature(smallMap);
     cv::Mat mapToUse;
@@ -482,8 +717,8 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearch(
 
     for (auto& cand : cands) {
         double s = cand.s;
-        int coarseX = static_cast<int>(cand.loc.x / coarseScale);
-        int coarseY = static_cast<int>(cand.loc.y / coarseScale);
+        int coarseX = static_cast<int>(cand.loc.x / coarseScale) + constrainedRect.x;
+        int coarseY = static_cast<int>(cand.loc.y / coarseScale) + constrainedRect.y;
 
         cv::Mat scaledTempl, scaledWeightMask;
         if (std::abs(s - 1.0) > 0.001) {
@@ -500,7 +735,6 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearch(
             coarseY - searchRadius,
             scaledTempl.cols + searchRadius * 2,
             scaledTempl.rows + searchRadius * 2);
-        cv::Rect mapBounds(0, 0, bigMap.cols, bigMap.rows);
         cv::Rect validFineRect = fineRect & mapBounds;
 
         if (validFineRect.empty()) {
@@ -578,106 +812,341 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearch(
     return res;
 }
 
+std::optional<MapPosition> MapLocator::Impl::tryGlobalSearch(
+    const MatchFeature& tmplFeat,
+    IMatchStrategy* strategy,
+    const std::string& targetZoneId,
+    const SearchConstraint& constraint,
+    MapPosition* outRawPos)
+{
+    if (!strategy || targetZoneId.empty()) {
+        LogInfo << "Global Search Aborted: YOLO returned no result.";
+        return std::nullopt;
+    }
+
+    if (zones.find(targetZoneId) == zones.end()) {
+        std::string msg = "Global Search Aborted: YOLO predicted '" + targetZoneId + "', but this map is NOT loaded in 'zones'.";
+        LogInfo << msg;
+        return std::nullopt;
+    }
+
+    const cv::Mat& bigMap = zones.at(targetZoneId);
+    const cv::Rect mapBounds(0, 0, bigMap.cols, bigMap.rows);
+    if (constraint.mode == GlobalSearchMode::RoiFine) {
+        const cv::Rect constrainedRect = constraint.roi & mapBounds;
+        if (constrainedRect.empty()) {
+            LogInfo << "Global Search Aborted: coarse ROI is outside of map bounds.";
+            return std::nullopt;
+        }
+        return tryConstrainedFineSearch(tmplFeat, strategy, bigMap, constrainedRect, targetZoneId, outRawPos);
+    }
+
+    if (constraint.mode == GlobalSearchMode::FullMapFine) {
+        return tryConstrainedFineSearch(tmplFeat, strategy, bigMap, mapBounds, targetZoneId, outRawPos);
+    }
+
+    return tryLegacyCoarseSearch(tmplFeat, strategy, bigMap, mapBounds, targetZoneId, outRawPos);
+}
+
+YoloCoarseResult MapLocator::Impl::predictCoarse(const cv::Mat& minimap) const
+{
+    if (!zoneClassifier || !zoneClassifier->isLoaded()) {
+        return {};
+    }
+    return zoneClassifier->predictCoarseByYOLO(minimap);
+}
+
+void MapLocator::Impl::refreshAsyncYoloState(const cv::Mat& minimap, std::chrono::steady_clock::time_point now)
+{
+    if (!zoneClassifier || !zoneClassifier->isLoaded()) {
+        return;
+    }
+
+    std::unique_lock<std::mutex> lock(taskMutex, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        return;
+    }
+
+    if (asyncYoloTask.valid() && asyncYoloTask.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+        YoloCoarseResult predicted = asyncYoloTask.get();
+        if (predicted.valid && !predicted.is_none && !predicted.zone_id.empty() && !currentZoneId.empty()
+            && predicted.zone_id != currentZoneId) {
+            LogInfo << "Async YOLO detected zone change: " << currentZoneId << " -> " << predicted.zone_id;
+            motionTracker->forceLost();
+        }
+    }
+
+    if (asyncYoloTask.valid()) {
+        return;
+    }
+
+    const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - lastYoloCheckTime).count();
+    if (elapsed < 3) {
+        return;
+    }
+
+    // 限制频次：YOLO CPU 推理存在开销，区域大范围切换并非瞬发，降低频率足以应对漂移容错并显著降低资源负担
+    lastYoloCheckTime = now;
+    cv::Mat yoloInput = minimap.clone();
+    asyncYoloTask = std::async(std::launch::async, [this, yoloInput]() { return zoneClassifier->predictCoarseByYOLO(yoloInput); });
+}
+
+std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
+    const cv::Mat& minimap,
+    const LocateOptions& options,
+    const std::string& expectedZoneId,
+    std::chrono::steady_clock::time_point now)
+{
+    if (options.force_global_search) {
+        return std::nullopt;
+    }
+
+    refreshAsyncYoloState(minimap, now);
+
+    if (currentZoneId.empty()) {
+        return std::nullopt;
+    }
+    if (!expectedZoneId.empty() && currentZoneId != expectedZoneId) {
+        return std::nullopt;
+    }
+
+    auto primaryStrategy = MatchStrategyFactory::create(currentZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg);
+    if (!primaryStrategy) {
+        return std::nullopt;
+    }
+
+    const bool isNativePathHeatmap = currentZoneId.find("OMVBase") != std::string::npos;
+    MapPosition rawPrimaryPos {};
+    auto trackingTmpl = primaryStrategy->extractTemplateFeature(minimap);
+    auto trackingResult = tryTracking(trackingTmpl, primaryStrategy.get(), now, options, &rawPrimaryPos);
+    const bool trackingHeld = trackingResult.has_value() && trackingResult->isHeld;
+
+    if (trackingResult && !trackingHeld) {
+        return LocateResult { .status = LocateStatus::Success, .position = trackingResult, .debugMessage = "Tracking Success" };
+    }
+
+    const bool shouldTryDualTracking = !isNativePathHeatmap && rawPrimaryPos.score > 0.1 && (!trackingResult || trackingHeld);
+    if (shouldTryDualTracking) {
+        auto fallbackStrategy =
+            MatchStrategyFactory::create(currentZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg, MatchMode::ForcePathHeatmap);
+        auto fallbackTmpl = fallbackStrategy->extractTemplateFeature(minimap);
+
+        MapPosition rawFallbackPos {};
+        auto fallbackResult = tryTracking(fallbackTmpl, fallbackStrategy.get(), now, options, &rawFallbackPos);
+        const bool fallbackHeld = fallbackResult.has_value() && fallbackResult->isHeld;
+        const double dist = std::hypot(rawPrimaryPos.x - rawFallbackPos.x, rawPrimaryPos.y - rawFallbackPos.y);
+
+        if (rawFallbackPos.score > 0.1 && dist <= 5.0) {
+            LogInfo << "Dual-Mode Tracking Verified! Coords matched. Dist: " << dist;
+
+            MapPosition verifiedPos = rawPrimaryPos;
+            verifiedPos.score = std::max(rawPrimaryPos.score, rawFallbackPos.score);
+            motionTracker->update(verifiedPos, now);
+
+            return LocateResult {
+                .status = LocateStatus::Success,
+                .position = verifiedPos,
+                .debugMessage = "Dual-Mode Tracking Success",
+            };
+        }
+
+        if (fallbackResult && !fallbackHeld) {
+            LogInfo << "Dual-Mode Tracking: accepted fallback strategy result independently. Dist was " << dist;
+            return LocateResult { .status = LocateStatus::Success, .position = fallbackResult, .debugMessage = "Tracking Success" };
+        }
+    }
+
+    if (!trackingHeld) {
+        return std::nullopt;
+    }
+
+    return LocateResult { .status = LocateStatus::Success, .position = trackingResult, .debugMessage = "Tracking Hold" };
+}
+
+SearchConstraint MapLocator::Impl::buildSearchConstraint(
+    const std::string& expectedZoneSelector,
+    const std::string& targetZoneId,
+    const YoloCoarseResult& coarse) const
+{
+    SearchConstraint constraint;
+    if (!coarse.valid) {
+        return constraint;
+    }
+
+    constraint.yolo_validated = coarse.zone_id == targetZoneId && MatchesExpectedZoneSelector(expectedZoneSelector, coarse);
+    if (!constraint.yolo_validated) {
+        return constraint;
+    }
+
+    if (!coarse.has_roi) {
+        constraint.mode = GlobalSearchMode::FullMapFine;
+        LogInfo << "YOLO validated zone without ROI mapping; using full-map direct fine search." << VAR(expectedZoneSelector)
+                << VAR(coarse.raw_class) << VAR(targetZoneId);
+        return constraint;
+    }
+
+    const auto zoneIt = zones.find(targetZoneId);
+    if (zoneIt == zones.end()) {
+        return constraint;
+    }
+
+    const cv::Mat& zoneMap = zoneIt->second;
+    const cv::Rect mapBounds(0, 0, zoneMap.cols, zoneMap.rows);
+    const cv::Rect expandedRoi(
+        coarse.roi_x - coarse.infer_margin,
+        coarse.roi_y - coarse.infer_margin,
+        coarse.roi_w + coarse.infer_margin * 2,
+        coarse.roi_h + coarse.infer_margin * 2);
+    const cv::Rect constrainedRoi = expandedRoi & mapBounds;
+    if (constrainedRoi.empty()) {
+        return constraint;
+    }
+
+    constraint.mode = GlobalSearchMode::RoiFine;
+    constraint.roi = constrainedRoi;
+    LogInfo << "YOLO constrained global search to ROI" << VAR(expectedZoneSelector) << VAR(coarse.raw_class) << VAR(targetZoneId)
+            << VAR(constraint.roi.x) << VAR(constraint.roi.y) << VAR(constraint.roi.width) << VAR(constraint.roi.height);
+    return constraint;
+}
+
+std::optional<MapPosition> MapLocator::Impl::tryGlobalSearchWithFallback(
+    const cv::Mat& minimap,
+    const std::string& targetZoneId,
+    const SearchConstraint& constraint)
+{
+    const bool isNativePathHeatmap = targetZoneId.find("OMVBase") != std::string::npos;
+    const unsigned hardwareThreads = std::max(1U, std::thread::hardware_concurrency());
+    const bool canSpeculateDualMode =
+        !isNativePathHeatmap && constraint.mode != GlobalSearchMode::LegacyCoarse && hardwareThreads >= 8;
+
+    auto runSearch = [this, &constraint, &targetZoneId](const cv::Mat& searchMinimap, MatchMode mode) -> GlobalSearchAttempt {
+        GlobalSearchAttempt attempt;
+        auto strategy = MatchStrategyFactory::create(targetZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg, mode);
+        if (!strategy) {
+            return attempt;
+        }
+
+        auto globalTmpl = strategy->extractTemplateFeature(searchMinimap);
+        attempt.result = tryGlobalSearch(globalTmpl, strategy.get(), targetZoneId, constraint, &attempt.rawPos);
+        return attempt;
+    };
+
+    std::future<GlobalSearchAttempt> fallbackTask;
+    if (canSpeculateDualMode) {
+        cv::Mat fallbackMinimap = minimap.clone();
+        SearchConstraint fallbackConstraint = constraint;
+        std::string fallbackZoneId = targetZoneId;
+        fallbackTask = std::async(std::launch::async, [this, fallbackMinimap, fallbackConstraint, fallbackZoneId]() {
+            GlobalSearchAttempt attempt;
+            auto fallbackStrategy = MatchStrategyFactory::create(
+                fallbackZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg, MatchMode::ForcePathHeatmap);
+            if (!fallbackStrategy) {
+                return attempt;
+            }
+
+            auto fallbackTmpl = fallbackStrategy->extractTemplateFeature(fallbackMinimap);
+            attempt.result = tryGlobalSearch(fallbackTmpl, fallbackStrategy.get(), fallbackZoneId, fallbackConstraint, &attempt.rawPos);
+            return attempt;
+        });
+    }
+
+    auto primaryAttempt = runSearch(minimap, MatchMode::Auto);
+    auto globalResult = primaryAttempt.result;
+    const MapPosition& rawGlobalPrimaryPos = primaryAttempt.rawPos;
+
+    const bool shouldTryDualMode =
+        !globalResult && !isNativePathHeatmap && (constraint.mode != GlobalSearchMode::LegacyCoarse || rawGlobalPrimaryPos.score > 0.1);
+    if (!shouldTryDualMode) {
+        if (fallbackTask.valid()) {
+            // Keep the future alive so its destructor cannot block the successful path.
+            backgroundGlobalSearchTasks.emplace_back(std::move(fallbackTask));
+        }
+        return globalResult;
+    }
+
+    GlobalSearchAttempt fallbackAttempt;
+    if (fallbackTask.valid()) {
+        fallbackAttempt = fallbackTask.get();
+    }
+    else {
+        fallbackAttempt = runSearch(minimap, MatchMode::ForcePathHeatmap);
+    }
+
+    auto fallbackResult = fallbackAttempt.result;
+    const MapPosition& rawGlobalFallbackPos = fallbackAttempt.rawPos;
+    const double dist = std::hypot(rawGlobalPrimaryPos.x - rawGlobalFallbackPos.x, rawGlobalPrimaryPos.y - rawGlobalFallbackPos.y);
+
+    // 双策略验证：正常图传和梯度图传独立得出的坐标若极度相近（误差<5像素），说明虽然个别策略信心不足，但互为佐证，此即确信坐标
+    if (rawGlobalPrimaryPos.score > 0.1 && rawGlobalFallbackPos.score > 0.1 && dist <= 5.0) {
+        LogInfo << "Dual-Mode Global Search Verified! Dist: " << dist;
+        globalResult = rawGlobalPrimaryPos;
+        globalResult->score = std::max(rawGlobalPrimaryPos.score, rawGlobalFallbackPos.score);
+        return globalResult;
+    }
+
+    if (!globalResult && fallbackResult) {
+        LogInfo << "Global Search: accepted fallback strategy result inside same ROI/path.";
+        return fallbackResult;
+    }
+
+    return globalResult;
+}
+
 LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOptions& options)
 {
-    auto now = std::chrono::steady_clock::now();
-    LocateResult result;
-    result.status = LocateStatus::TrackingLost;
+    const auto now = std::chrono::steady_clock::now();
 
     if (!isInitialized) {
-        result.status = LocateStatus::NotInitialized;
-        result.debugMessage = "MapLocator not initialized.";
-        return result;
+        return LocateResult { .status = LocateStatus::NotInitialized, .debugMessage = "MapLocator not initialized." };
     }
+
+    drainBackgroundGlobalSearchTasks();
 
     matchCfg.passThreshold = options.loc_threshold;
     matchCfg.yoloConfThreshold = options.yolo_threshold;
     if (zoneClassifier) {
         zoneClassifier->SetConfThreshold(options.yolo_threshold);
     }
-    const std::string expectedZoneId = options.expected_zone_id;
 
-    std::unique_ptr<IMatchStrategy> strategy;
-
-    if (!options.force_global_search) {
-        {
-            std::lock_guard<std::mutex> lock(taskMutex);
-            if (asyncYoloTask.valid() && asyncYoloTask.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-                std::string predictedZone = asyncYoloTask.get();
-                if (!predictedZone.empty() && !currentZoneId.empty() && predictedZone != currentZoneId) {
-                    LogInfo << "Async YOLO detected zone change: " << currentZoneId << " -> " << predictedZone;
-                    motionTracker->forceLost();
-                }
-            }
-            if (!asyncYoloTask.valid()) {
-                auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - lastYoloCheckTime).count();
-                // 限制频次：YOLO CPU 推理存在开销，区域大范围切换并非瞬发，降低频率足以应对漂移容错并显著降低资源负担
-                if (elapsed >= 3 && zoneClassifier && zoneClassifier->isLoaded()) {
-                    lastYoloCheckTime = now;
-                    cv::Mat yoloInput = minimap.clone();
-                    asyncYoloTask =
-                        std::async(std::launch::async, [this, yoloInput]() { return zoneClassifier->predictZoneByYOLO(yoloInput); });
-                }
-            }
+    std::future<double> angleFuture = std::async(std::launch::async, [&minimap]() { return InferYellowArrowRotation(minimap); });
+    std::optional<double> resolvedAngle;
+    auto resolveAngle = [&]() -> double {
+        if (!resolvedAngle.has_value()) {
+            resolvedAngle = angleFuture.get();
         }
+        return *resolvedAngle;
+    };
 
-        bool isNativePathHeatmap = (!currentZoneId.empty() && currentZoneId.find("OMVBase") != std::string::npos);
-
-        if (!currentZoneId.empty() && (expectedZoneId.empty() || currentZoneId == expectedZoneId)) {
-            strategy = MatchStrategyFactory::create(currentZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg);
+    std::optional<YoloCoarseResult> angleGuardCoarse;
+    const std::string expectedZoneSelector = options.expected_zone_id;
+    const std::string expectedZoneId = NormalizeExpectedZoneId(expectedZoneSelector, zoneClassifier.get());
+    if (auto trackingResult = tryTrackingLocate(minimap, options, expectedZoneId, now)) {
+        if (trackingResult->position.has_value()) {
+            trackingResult->position->angle = resolveAngle();
         }
+        return *trackingResult;
+    }
 
-        if (strategy) {
-            MapPosition rawPrimaryPos {};
-            auto trackingTmpl = strategy->extractTemplateFeature(minimap);
-            auto trackingResult = tryTracking(trackingTmpl, strategy.get(), now, options, &rawPrimaryPos);
-
-            if (trackingResult) {
-                trackingResult->angle = InferYellowArrowRotation(minimap);
-                result.position = trackingResult;
-                result.status = LocateStatus::Success;
-                result.debugMessage = "Tracking Success";
-                return result;
-            }
-            else if (!isNativePathHeatmap && rawPrimaryPos.score > 0.1) {
-                auto fallbackStrategy =
-                    MatchStrategyFactory::create(currentZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg, MatchMode::ForcePathHeatmap);
-                auto fallbackTmpl = fallbackStrategy->extractTemplateFeature(minimap);
-
-                MapPosition rawFallbackPos;
-                tryTracking(fallbackTmpl, fallbackStrategy.get(), now, options, &rawFallbackPos);
-
-                double dist = std::hypot(rawPrimaryPos.x - rawFallbackPos.x, rawPrimaryPos.y - rawFallbackPos.y);
-
-                if (rawFallbackPos.score > 0.1 && dist <= 2.0) {
-                    LogInfo << "Dual-Mode Tracking Verified! Coords matched. Dist: " << dist;
-                    MapPosition verifiedPos = rawPrimaryPos;
-                    verifiedPos.score = std::max(rawPrimaryPos.score, rawFallbackPos.score);
-
-                    motionTracker->update(verifiedPos, now);
-                    verifiedPos.angle = InferYellowArrowRotation(minimap);
-
-                    result.position = verifiedPos;
-                    result.status = LocateStatus::Success;
-                    result.debugMessage = "Dual-Mode Tracking Success";
-                    return result;
-                }
-            }
-        }
+    const double inferredAngle = resolveAngle();
+    if (inferredAngle < 0.0) {
+        angleGuardCoarse = predictCoarse(minimap);
+        LogInfo << "Angle inference failed; forcing synchronous YOLO refresh." << VAR(angleGuardCoarse->valid)
+                << VAR(angleGuardCoarse->is_none) << VAR(angleGuardCoarse->zone_id);
     }
 
     std::string targetZoneId = expectedZoneId;
-    if (targetZoneId.empty()) {
-        targetZoneId = zoneClassifier ? zoneClassifier->predictZoneByYOLO(minimap) : "";
+    const YoloCoarseResult coarse = angleGuardCoarse.value_or(predictCoarse(minimap));
+    if (targetZoneId.empty() && coarse.valid) {
+        targetZoneId = coarse.zone_id;
     }
 
     if (targetZoneId.empty()) {
-        result.status = LocateStatus::YoloFailed;
-        result.debugMessage =
+        const std::string debugMessage =
             expectedZoneId.empty() ? "YOLO inference failed or no result." : "Expected zone is empty and YOLO inference failed.";
-        return result;
+        return LocateResult { .status = LocateStatus::YoloFailed, .debugMessage = debugMessage };
     }
-    if (targetZoneId == "None") {
+
+    if ((expectedZoneId.empty() && coarse.valid && coarse.is_none) || targetZoneId == "None") {
         LogInfo << "YOLO explicitly identified 'None', assuming UI occlusion.";
 
         if (motionTracker->getLastPos()) {
@@ -689,47 +1158,32 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
         nonePos.x = 0;
         nonePos.y = 0;
         nonePos.score = 1.0;
-
-        result.status = LocateStatus::Success;
-        result.position = nonePos;
-        result.debugMessage = "Occluded by UI (None)";
-
-        return result;
+        return LocateResult { .status = LocateStatus::Success, .position = nonePos, .debugMessage = "Occluded by UI (None)" };
     }
 
-    bool isNativePathHeatmap = (targetZoneId.find("OMVBase") != std::string::npos);
-    auto nextStrategy = MatchStrategyFactory::create(targetZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg);
-    auto globalTmpl = nextStrategy->extractTemplateFeature(minimap);
-
-    MapPosition rawGlobalPrimaryPos {};
-    auto globalResult = tryGlobalSearch(globalTmpl, nextStrategy.get(), targetZoneId, &rawGlobalPrimaryPos);
-
-    if (!globalResult && !isNativePathHeatmap && rawGlobalPrimaryPos.score > 0.1) {
-        auto fallbackStrategy =
-            MatchStrategyFactory::create(targetZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg, MatchMode::ForcePathHeatmap);
-        auto fallbackTmpl = fallbackStrategy->extractTemplateFeature(minimap);
-
-        MapPosition rawGlobalFallbackPos;
-        tryGlobalSearch(fallbackTmpl, fallbackStrategy.get(), targetZoneId, &rawGlobalFallbackPos);
-
-        double dist = std::hypot(rawGlobalPrimaryPos.x - rawGlobalFallbackPos.x, rawGlobalPrimaryPos.y - rawGlobalFallbackPos.y);
-        // 双策略验证：正常图传和梯度图传独立得出的坐标若极度相近（误差<5像素），说明虽然个别策略信心不足，但互为佐证，此即确信坐标
-        if (rawGlobalFallbackPos.score > 0.1 && dist <= 5.0) {
-            LogInfo << "Dual-Mode Global Search Verified! Dist: " << dist;
-            globalResult = rawGlobalPrimaryPos;
-            globalResult->score = std::max(rawGlobalPrimaryPos.score, rawGlobalFallbackPos.score);
-        }
+    const SearchConstraint constraint = buildSearchConstraint(expectedZoneSelector, targetZoneId, coarse);
+    if (coarse.valid && !coarse.is_none && !constraint.yolo_validated) {
+        const std::string debugMessage = "YOLO is confident but zone validation failed. Aborting before broad search.";
+        LogWarn << debugMessage << VAR(expectedZoneSelector) << VAR(targetZoneId) << VAR(coarse.raw_class) << VAR(coarse.base_class)
+                << VAR(coarse.zone_id) << VAR(coarse.has_roi);
+        return LocateResult { .status = LocateStatus::YoloFailed, .debugMessage = debugMessage };
+    }
+    if (coarse.valid && !coarse.is_none && coarse.has_roi && constraint.mode != GlobalSearchMode::RoiFine) {
+        const std::string debugMessage =
+            "YOLO is confident but ROI constraint validation failed. Aborting to avoid broad search.";
+        LogWarn << debugMessage << VAR(expectedZoneSelector) << VAR(targetZoneId) << VAR(coarse.raw_class) << VAR(coarse.base_class)
+                << VAR(coarse.zone_id) << VAR(coarse.has_roi);
+        return LocateResult { .status = LocateStatus::YoloFailed, .debugMessage = debugMessage };
     }
 
     int maxAllowedLost = (targetZoneId.find("OMVBase") != std::string::npos) ? 10 : options.max_lost_frames;
+    auto globalResult = tryGlobalSearchWithFallback(minimap, targetZoneId, constraint);
     if (!globalResult) {
         motionTracker->markLost();
         if (motionTracker->getLostCount() > maxAllowedLost) {
             motionTracker->forceLost();
         }
-        result.status = LocateStatus::TrackingLost;
-        result.debugMessage = "Global search failed.";
-        return result;
+        return LocateResult { .status = LocateStatus::TrackingLost, .debugMessage = "Global search failed." };
     }
 
     if (currentZoneId != globalResult->zoneId) {
@@ -737,14 +1191,10 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
     }
 
     currentZoneId = globalResult->zoneId;
-    globalResult->angle = InferYellowArrowRotation(minimap);
+    globalResult->angle = inferredAngle;
 
     motionTracker->update(*globalResult, now);
-
-    result.status = LocateStatus::Success;
-    result.position = globalResult;
-    result.debugMessage = "Global Search Success";
-    return result;
+    return LocateResult { .status = LocateStatus::Success, .position = globalResult, .debugMessage = "Global Search Success" };
 }
 
 void MapLocator::Impl::resetTrackingState()

--- a/agent/cpp-algo/source/MapLocator/MapTypes.h
+++ b/agent/cpp-algo/source/MapLocator/MapTypes.h
@@ -4,6 +4,8 @@
 #include <optional>
 #include <string>
 
+#include <MaaUtils/NoWarningCV.hpp>
+
 namespace maplocator
 {
 
@@ -59,6 +61,38 @@ struct LocateResult
     LocateStatus status;
     std::optional<MapPosition> position;
     std::string debugMessage; // 用于向 Pipeline 输出日志
+};
+
+enum class GlobalSearchMode
+{
+    LegacyCoarse,
+    FullMapFine,
+    RoiFine,
+};
+
+struct SearchConstraint
+{
+    GlobalSearchMode mode = GlobalSearchMode::LegacyCoarse;
+    bool yolo_validated = false;
+    cv::Rect roi {};
+};
+
+struct YoloCoarseResult
+{
+    bool valid = false;
+    bool is_none = false;
+
+    std::string raw_class;
+    std::string base_class;
+    std::string zone_id;
+    float confidence = 0.0f;
+
+    bool has_roi = false;
+    int roi_x = 0;
+    int roi_y = 0;
+    int roi_w = 0;
+    int roi_h = 0;
+    int infer_margin = 0;
 };
 
 // roi及搜索相关常量

--- a/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
+++ b/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
@@ -1,7 +1,9 @@
+#include <filesystem>
+
+#include <MaaUtils/Logger.h>
+
 #include "MatchStrategy.h"
 #include "MapAlgorithm.h"
-#include <MaaUtils/Logger.h>
-#include <filesystem>
 
 namespace fs = std::filesystem;
 
@@ -120,17 +122,28 @@ std::optional<MatchResultRaw> CoreMatch(const cv::Mat& searchImgRaw, const cv::M
     cv::Rect peakRect(maxLoc.x - ex, maxLoc.y - ex, ex * 2 + 1, ex * 2 + 1);
     peakRect &= cv::Rect(0, 0, result.cols, result.rows);
 
-    cv::Mat tmp = result.clone();
+    thread_local cv::Mat peakBackupCache;
+    if (peakBackupCache.rows < peakRect.height || peakBackupCache.cols < peakRect.width || peakBackupCache.type() != result.type()) {
+        peakBackupCache.create(peakRect.size(), result.type());
+    }
+    cv::Mat peakBackup = peakBackupCache(cv::Rect(0, 0, peakRect.width, peakRect.height));
+    result(peakRect).copyTo(peakBackup);
+
     // 找次极大值：在最高分周围开辟“黑洞”区域屏蔽主峰，随后寻找全局次高分，用于计算 PSR 与 delta，判断周遭是否存在相似纹理导致匹配歧义
-    tmp(peakRect).setTo(-2.0f);
+    result(peakRect).setTo(-2.0f);
     double secondVal;
     cv::Point secondLoc;
-    cv::minMaxLoc(tmp, nullptr, &secondVal, nullptr, &secondLoc);
+    cv::minMaxLoc(result, nullptr, &secondVal, nullptr, &secondLoc);
+    peakBackup.copyTo(result(peakRect));
 
-    cv::Mat sideMask(result.size(), CV_8U, cv::Scalar(255));
-    sideMask(peakRect).setTo(0);
+    thread_local cv::Mat sideMaskCache;
+    if (sideMaskCache.size() != result.size() || sideMaskCache.type() != CV_8U) {
+        sideMaskCache.create(result.size(), CV_8U);
+    }
+    sideMaskCache.setTo(static_cast<uchar>(1));
+    sideMaskCache(peakRect).setTo(static_cast<uchar>(0));
     cv::Scalar mean, stddev;
-    cv::meanStdDev(result, mean, stddev, sideMask);
+    cv::meanStdDev(result, mean, stddev, sideMaskCache);
     // PSR (Peak to Sidelobe Ratio) 峰值旁瓣比：衡量最高分是否唯一。
     // 若匹配区域纹理单一或是重复铺装路面，旁瓣(周围区域)得分也会很高，导致 PSR 骤降，借此拒绝高分歧义解
     double psr = (maxVal - mean[0]) / (stddev[0] + 1e-6);

--- a/agent/cpp-algo/source/MapLocator/YoloPredictor.cpp
+++ b/agent/cpp-algo/source/MapLocator/YoloPredictor.cpp
@@ -261,13 +261,15 @@ YoloCoarseResult YoloPredictor::predictCoarseByYOLO(const cv::Mat& minimap)
             result.infer_margin = tileIt->second.infer_margin;
         }
 
-        std::string succMsg = "YOLO Success: " + predictedName + " -> ZoneId: " + result.zone_id + " (Conf: "
-            + std::to_string(maxConf * 100.0) + "%)";
+        LogInfo << "YOLO Success" << VAR(predictedName) << VAR(result.zone_id) << VAR(maxConf) << VAR(result.has_roi);
         if (result.has_roi) {
-            succMsg += " ROI=(" + std::to_string(result.roi_x) + "," + std::to_string(result.roi_y) + "," + std::to_string(result.roi_w)
-                + "," + std::to_string(result.roi_h) + ") margin=" + std::to_string(result.infer_margin);
+            LogInfo << "YOLO ROI"
+                    << VAR(result.roi_x)
+                    << VAR(result.roi_y)
+                    << VAR(result.roi_w)
+                    << VAR(result.roi_h)
+                    << VAR(result.infer_margin);
         }
-        LogInfo << succMsg;
         return result;
     }
     if (maxConf <= yoloConfThreshold) {

--- a/agent/cpp-algo/source/MapLocator/YoloPredictor.cpp
+++ b/agent/cpp-algo/source/MapLocator/YoloPredictor.cpp
@@ -1,6 +1,5 @@
 #include <algorithm>
 #include <filesystem>
-#include <string_view>
 
 #include <MaaUtils/Logger.h>
 #include <MaaUtils/Platform.h>
@@ -14,31 +13,6 @@ namespace fs = std::filesystem;
 
 namespace maplocator
 {
-
-namespace
-{
-
-int ReadIntField(const Json& value, std::string_view key, int default_value = 0)
-{
-    const std::string keyString(key);
-    const auto field = value.find(keyString);
-    if (!field) {
-        return default_value;
-    }
-    return field->as<int>();
-}
-
-std::string ReadStringField(const Json& value, std::string_view key, std::string default_value = {})
-{
-    const std::string keyString(key);
-    const auto field = value.find(keyString);
-    if (!field) {
-        return default_value;
-    }
-    return field->as<std::string>();
-}
-
-} // namespace
 
 YoloPredictor::YoloPredictor(const std::string& yoloModelPath, double confThreshold, int threads)
     : yoloConfThreshold(confThreshold)
@@ -88,16 +62,7 @@ YoloPredictor::YoloPredictor(const std::string& yoloModelPath, double confThresh
         if (tileMappingOpt) {
             const Json& tileMapping = *tileMappingOpt;
             for (auto& [key, val] : tileMapping.as_object()) {
-                tileRegions.emplace(
-                    key,
-                    TileRegion {
-                        .base_class = ReadStringField(val, "base_class"),
-                        .x = ReadIntField(val, "x"),
-                        .y = ReadIntField(val, "y"),
-                        .w = ReadIntField(val, "w"),
-                        .h = ReadIntField(val, "h"),
-                        .infer_margin = ReadIntField(val, "infer_margin"),
-                    });
+                tileRegions.emplace(key, val.as<TileRegion>());
             }
             const std::string tileMappingPathUtf8 = MAA_NS::path_to_utf8_string(tileMappingPath);
             LogInfo << "Loaded tile mapping" << VAR(tileMappingPathUtf8) << VAR(tileRegions.size());

--- a/agent/cpp-algo/source/MapLocator/YoloPredictor.cpp
+++ b/agent/cpp-algo/source/MapLocator/YoloPredictor.cpp
@@ -82,7 +82,8 @@ YoloPredictor::YoloPredictor(const std::string& yoloModelPath, double confThresh
             LogWarn << "Config file not found or invalid json: " << jsonPath;
         }
 
-        fs::path tileMappingPath = modelPath.parent_path() / "tile_mapping.json";
+        fs::path tileMappingPath = modelPath;
+        tileMappingPath.replace_filename(MAA_NS::path("tile_mapping.json"));
         auto tileMappingOpt = json::open(tileMappingPath);
         if (tileMappingOpt) {
             const Json& tileMapping = *tileMappingOpt;
@@ -98,10 +99,12 @@ YoloPredictor::YoloPredictor(const std::string& yoloModelPath, double confThresh
                         .infer_margin = ReadIntField(val, "infer_margin"),
                     });
             }
-            LogInfo << "Loaded tile mapping from: " << tileMappingPath << " count=" << tileRegions.size();
+            const std::string tileMappingPathUtf8 = MAA_NS::path_to_utf8_string(tileMappingPath);
+            LogInfo << "Loaded tile mapping" << VAR(tileMappingPathUtf8) << VAR(tileRegions.size());
         }
         else {
-            LogWarn << "Tile mapping file not found or invalid json: " << tileMappingPath;
+            const std::string tileMappingPathUtf8 = MAA_NS::path_to_utf8_string(tileMappingPath);
+            LogWarn << "Tile mapping file not found or invalid json" << VAR(tileMappingPathUtf8);
         }
 
         LogInfo << "YOLO Model loaded successfully.";

--- a/agent/cpp-algo/source/MapLocator/YoloPredictor.cpp
+++ b/agent/cpp-algo/source/MapLocator/YoloPredictor.cpp
@@ -1,29 +1,52 @@
-#include "YoloPredictor.h"
+#include <algorithm>
+#include <filesystem>
+#include <string_view>
+
 #include <MaaUtils/Logger.h>
 #include <MaaUtils/Platform.h>
-#include <atomic>
-#include <filesystem>
-#include <fstream>
-#include <iomanip>
+#include <boost/regex.hpp>
 #include <meojson/json.hpp>
-#include <regex>
-#include <sstream>
 
-#include <algorithm>
-#include <iostream>
+#include "YoloPredictor.h"
+
 using Json = json::value;
 namespace fs = std::filesystem;
 
 namespace maplocator
 {
 
-YoloPredictor::YoloPredictor(const std::string& yoloModelPath, double confThreshold)
+namespace
+{
+
+int ReadIntField(const Json& value, std::string_view key, int default_value = 0)
+{
+    const std::string keyString(key);
+    const auto field = value.find(keyString);
+    if (!field) {
+        return default_value;
+    }
+    return field->as<int>();
+}
+
+std::string ReadStringField(const Json& value, std::string_view key, std::string default_value = {})
+{
+    const std::string keyString(key);
+    const auto field = value.find(keyString);
+    if (!field) {
+        return default_value;
+    }
+    return field->as<std::string>();
+}
+
+} // namespace
+
+YoloPredictor::YoloPredictor(const std::string& yoloModelPath, double confThreshold, int threads)
     : yoloConfThreshold(confThreshold)
 {
     if (!yoloModelPath.empty()) {
         ortEnv = std::make_unique<Ort::Env>(ORT_LOGGING_LEVEL_WARNING, "MapLocatorYolo");
         Ort::SessionOptions sessionOptions;
-        sessionOptions.SetIntraOpNumThreads(1);
+        sessionOptions.SetIntraOpNumThreads(std::max(1, threads));
         sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_BASIC);
 
         auto osModelPath = MAA_NS::to_osstring(yoloModelPath);
@@ -59,23 +82,45 @@ YoloPredictor::YoloPredictor(const std::string& yoloModelPath, double confThresh
             LogWarn << "Config file not found or invalid json: " << jsonPath;
         }
 
+        fs::path tileMappingPath = modelPath.parent_path() / "tile_mapping.json";
+        auto tileMappingOpt = json::open(tileMappingPath);
+        if (tileMappingOpt) {
+            const Json& tileMapping = *tileMappingOpt;
+            for (auto& [key, val] : tileMapping.as_object()) {
+                tileRegions.emplace(
+                    key,
+                    TileRegion {
+                        .base_class = ReadStringField(val, "base_class"),
+                        .x = ReadIntField(val, "x"),
+                        .y = ReadIntField(val, "y"),
+                        .w = ReadIntField(val, "w"),
+                        .h = ReadIntField(val, "h"),
+                        .infer_margin = ReadIntField(val, "infer_margin"),
+                    });
+            }
+            LogInfo << "Loaded tile mapping from: " << tileMappingPath << " count=" << tileRegions.size();
+        }
+        else {
+            LogWarn << "Tile mapping file not found or invalid json: " << tileMappingPath;
+        }
+
         LogInfo << "YOLO Model loaded successfully.";
     }
 }
 
 std::string YoloPredictor::convertYoloNameToZoneId(const std::string& yoloName)
 {
-    std::string prefix = yoloName.length() >= 5 ? yoloName.substr(0, 5) : yoloName;
+    const std::string prefix = yoloName.length() >= 5 ? yoloName.substr(0, 5) : yoloName;
 
     auto it = regionMapping.find(prefix);
     if (it != regionMapping.end()) {
-        std::string regionName = it->second;
+        const std::string& regionName = it->second;
         if (yoloName.find("Base") != std::string::npos && yoloName.find("Map") != std::string::npos) {
             return regionName + "_Base";
         }
-        std::regex re(R"((Map\d+)Lv0*(\d+)Tier0*(\d+))");
-        std::smatch match;
-        if (std::regex_search(yoloName, match, re)) {
+        static const boost::regex kTierRegex(R"((Map\d+)Lv0*(\d+)Tier0*(\d+))");
+        boost::smatch match;
+        if (boost::regex_search(yoloName, match, kTierRegex)) {
             return regionName + "_L" + match[2].str() + "_" + match[3].str();
         }
     }
@@ -83,17 +128,18 @@ std::string YoloPredictor::convertYoloNameToZoneId(const std::string& yoloName)
     return yoloName;
 }
 
-std::string YoloPredictor::predictZoneByYOLO(const cv::Mat& minimap)
+YoloCoarseResult YoloPredictor::predictCoarseByYOLO(const cv::Mat& minimap)
 {
     std::lock_guard<std::mutex> lock(yoloMutex);
+    YoloCoarseResult result;
 
     if (!isYoloLoaded || !ortSession) {
         LogError << "YOLO Error: Model is NOT loaded.";
-        return "";
+        return result;
     }
     if (minimap.empty()) {
         LogError << "YOLO Error: Input minimap is empty.";
-        return "";
+        return result;
     }
 
     const int OUTPUT_SIZE = 128;
@@ -156,7 +202,7 @@ std::string YoloPredictor::predictZoneByYOLO(const cv::Mat& minimap)
 
     if (inputNodeNames.empty() || outputNodeNames.empty()) {
         LogError << "YOLO Error: input/output node names are not configured. Check model JSON sidecar.";
-        return "";
+        return result;
     }
 
     // Run Inference
@@ -165,7 +211,7 @@ std::string YoloPredictor::predictZoneByYOLO(const cv::Mat& minimap)
     auto outputTensors = ortSession->Run(Ort::RunOptions { nullptr }, &inName, &inputTensor, 1, &outName, 1);
 
     if (outputTensors.empty()) {
-        return "";
+        return result;
     }
 
     float* outputData = outputTensors.front().GetTensorMutableData<float>();
@@ -189,18 +235,40 @@ std::string YoloPredictor::predictZoneByYOLO(const cv::Mat& minimap)
     }
 
     LogInfo << "YOLO Raw:" << VAR(predictedName) << VAR(maxIdx) << VAR(maxConf);
+    result.raw_class = predictedName;
+    result.confidence = maxConf;
 
     if (predictedName == "None") {
         LogInfo << "YOLO Predicted 'None', skipping localization.";
-        return "None";
+        result.valid = true;
+        result.is_none = true;
+        result.zone_id = "None";
+        return result;
     }
 
     if (maxConf > yoloConfThreshold && maxIdx < (int)yoloClassNames.size()) {
-        std::string zoneId = convertYoloNameToZoneId(predictedName);
-        std::string succMsg =
-            "YOLO Success: " + predictedName + " -> ZoneId: " + zoneId + " (Conf: " + std::to_string(maxConf * 100.0) + "%)";
+        result.valid = true;
+        result.zone_id = convertYoloNameToZoneId(predictedName);
+
+        auto tileIt = tileRegions.find(predictedName);
+        if (tileIt != tileRegions.end()) {
+            result.base_class = tileIt->second.base_class;
+            result.has_roi = true;
+            result.roi_x = tileIt->second.x;
+            result.roi_y = tileIt->second.y;
+            result.roi_w = tileIt->second.w;
+            result.roi_h = tileIt->second.h;
+            result.infer_margin = tileIt->second.infer_margin;
+        }
+
+        std::string succMsg = "YOLO Success: " + predictedName + " -> ZoneId: " + result.zone_id + " (Conf: "
+            + std::to_string(maxConf * 100.0) + "%)";
+        if (result.has_roi) {
+            succMsg += " ROI=(" + std::to_string(result.roi_x) + "," + std::to_string(result.roi_y) + "," + std::to_string(result.roi_w)
+                + "," + std::to_string(result.roi_h) + ") margin=" + std::to_string(result.infer_margin);
+        }
         LogInfo << succMsg;
-        return zoneId;
+        return result;
     }
     if (maxConf <= yoloConfThreshold) {
         LogInfo << "YOLO Fail: Low Confidence" << VAR(maxConf) << VAR(yoloConfThreshold);
@@ -209,7 +277,7 @@ std::string YoloPredictor::predictZoneByYOLO(const cv::Mat& minimap)
         LogInfo << "YOLO Fail: Index Out of Bounds" << VAR(maxIdx) << VAR(yoloClassNames.size());
     }
 
-    return "";
+    return result;
 }
 
 } // namespace maplocator

--- a/agent/cpp-algo/source/MapLocator/YoloPredictor.h
+++ b/agent/cpp-algo/source/MapLocator/YoloPredictor.h
@@ -8,16 +8,18 @@
 #include <unordered_map>
 #include <vector>
 
+#include "MapTypes.h"
+
 namespace maplocator
 {
 
 class YoloPredictor
 {
 public:
-    explicit YoloPredictor(const std::string& yoloModelPath, double confThreshold = 0.60);
+    explicit YoloPredictor(const std::string& yoloModelPath, double confThreshold = 0.60, int threads = 1);
     ~YoloPredictor() = default;
 
-    std::string predictZoneByYOLO(const cv::Mat& minimap);
+    YoloCoarseResult predictCoarseByYOLO(const cv::Mat& minimap);
 
     bool isLoaded() const { return isYoloLoaded; }
 
@@ -27,6 +29,16 @@ public:
     std::string convertYoloNameToZoneId(const std::string& yoloName);
 
 private:
+    struct TileRegion
+    {
+        std::string base_class;
+        int x = 0;
+        int y = 0;
+        int w = 0;
+        int h = 0;
+        int infer_margin = 0;
+    };
+
     std::unique_ptr<Ort::Env> ortEnv;
     std::unique_ptr<Ort::Session> ortSession;
     std::vector<std::string> inputNodeNames;
@@ -35,6 +47,7 @@ private:
     bool isYoloLoaded = false;
     std::vector<std::string> yoloClassNames;
     std::unordered_map<std::string, std::string> regionMapping;
+    std::unordered_map<std::string, TileRegion> tileRegions;
 
     std::mutex yoloMutex;
     double yoloConfThreshold;

--- a/agent/cpp-algo/source/MapLocator/YoloPredictor.h
+++ b/agent/cpp-algo/source/MapLocator/YoloPredictor.h
@@ -37,6 +37,8 @@ private:
         int w = 0;
         int h = 0;
         int infer_margin = 0;
+
+        MEO_JSONIZATION(MEO_OPT(base_class), MEO_OPT(x), MEO_OPT(y), MEO_OPT(w), MEO_OPT(h), MEO_OPT(infer_margin))
     };
 
     std::unique_ptr<Ort::Env> ortEnv;

--- a/tools/MapNavigator/app_tk.py
+++ b/tools/MapNavigator/app_tk.py
@@ -14,13 +14,15 @@ from json_import import (
 )
 from model import (
     ACTION_COLORS,
+    ACTION_MENU_NAMES,
     ACTION_NAMES,
     ActionType,
     PathPoint,
     get_point_actions,
     normalize_path_points,
+    normalize_zone_id,
     resolve_zone_image,
-    set_point_actions,
+    set_manual_point_actions,
     simplify_path,
 )
 from point_editing import PointEditingService
@@ -48,6 +50,7 @@ class RouteEditorApp:
                 on_status=lambda text, color: self.root.after(0, lambda: self._set_status(text, color)),
                 on_finished=lambda raw_path: self.root.after(0, lambda: self._on_recording_finished(raw_path)),
                 on_error=lambda err: self.root.after(0, lambda: self._on_recording_error(err)),
+                on_locator_detail=lambda text: self.root.after(0, lambda: self._set_locator_debug(text)),
             )
 
         # 轨迹数据状态
@@ -56,6 +59,7 @@ class RouteEditorApp:
         self.density_val = tk.IntVar(value=50)
         self.strict_var = tk.BooleanVar(value=False)
         self.action_chain_var = tk.StringVar(value="Run")
+        self.locator_debug_var = tk.StringVar(value="Locator: --")
 
         # 领域服务
         self.zone_state = ZoneState()
@@ -84,10 +88,13 @@ class RouteEditorApp:
         self._refresh_zone_label()
 
     def _build_layout(self) -> None:
-        btn_frame = tk.Frame(self.root)
-        btn_frame.pack(fill=tk.X, pady=2, padx=8)
+        toolbar_frame = tk.Frame(self.root)
+        toolbar_frame.pack(fill=tk.X, pady=2, padx=8)
 
-        left_frame = tk.Frame(btn_frame)
+        primary_row = tk.Frame(toolbar_frame)
+        primary_row.pack(fill=tk.X)
+
+        left_frame = tk.Frame(primary_row)
         left_frame.pack(side=tk.LEFT, fill=tk.Y)
 
         self.btn_start = tk.Button(
@@ -121,70 +128,69 @@ class RouteEditorApp:
         self.btn_import = tk.Button(left_frame, text="📂 导入 JSON", command=self.import_json, padx=10)
         self.btn_import.pack(side=tk.LEFT, padx=3)
 
-        ttk.Separator(left_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
+        zone_frame = tk.Frame(primary_row)
+        zone_frame.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=12)
 
-        self.btn_prev = tk.Button(left_frame, text="◀", command=self.prev_zone, width=4)
-        self.btn_prev.pack(side=tk.LEFT, padx=2)
+        self.btn_prev = tk.Button(zone_frame, text="◀", command=self.prev_zone, width=4)
+        self.btn_prev.pack(side=tk.LEFT, padx=(0, 4))
 
         self.zone_label = tk.Label(
-            btn_frame,
+            zone_frame,
             text="— 无区域信息 —",
             font=("Consolas", 10, "bold"),
             fg="#1e293b",
             anchor="center",
-            width=28,
         )
-        self.zone_label.pack(side=tk.LEFT, expand=True, fill=tk.X, padx=10)
+        self.zone_label.pack(side=tk.LEFT, expand=True, fill=tk.X, padx=4)
 
-        right_frame = tk.Frame(btn_frame)
-        right_frame.pack(side=tk.RIGHT, fill=tk.Y)
+        self.btn_next = tk.Button(zone_frame, text="▶", command=self.next_zone, width=4)
+        self.btn_next.pack(side=tk.LEFT, padx=(4, 0))
 
-        self.btn_next = tk.Button(right_frame, text="▶", command=self.next_zone, width=4)
-        self.btn_next.pack(side=tk.LEFT, padx=2)
+        density_frame = tk.Frame(primary_row)
+        density_frame.pack(side=tk.RIGHT, fill=tk.Y)
 
-        ttk.Separator(right_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
-
-        tk.Label(right_frame, text="密度:", font=("Microsoft YaHei", 9)).pack(side=tk.LEFT, padx=(2, 0))
+        tk.Label(density_frame, text="密度:", font=("Microsoft YaHei", 9)).pack(side=tk.LEFT, padx=(2, 0))
         self.slider_density = tk.Scale(
-            right_frame,
+            density_frame,
             from_=0,
             to=100,
             orient=tk.HORIZONTAL,
             variable=self.density_val,
             showvalue=False,
             width=10,
-            length=70,
+            length=88,
             command=lambda _value: self.reprocess_points(),
         )
         self.slider_density.pack(side=tk.LEFT)
 
-        ttk.Separator(right_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
+        secondary_row = tk.Frame(toolbar_frame)
+        secondary_row.pack(fill=tk.X, pady=(4, 0))
 
-        self.action_menu = ttk.Combobox(right_frame, values=list(ACTION_NAMES.values()), width=10, state="readonly")
+        tk.Label(secondary_row, text="动作:", font=("Microsoft YaHei", 9)).pack(side=tk.LEFT, padx=(0, 4))
+        self.action_menu = ttk.Combobox(secondary_row, values=ACTION_MENU_NAMES, width=10, state="readonly")
         self.action_menu.set(ACTION_NAMES[ActionType.RUN])
         self.action_menu.pack(side=tk.LEFT, padx=2)
 
-        self.btn_apply_action = tk.Button(right_frame, text="设单", command=self.apply_action_to_selected)
+        self.btn_apply_action = tk.Button(secondary_row, text="设单", command=self.apply_action_to_selected)
         self.btn_apply_action.pack(side=tk.LEFT, padx=2)
 
-        self.btn_append_action = tk.Button(right_frame, text="追加", command=self.append_action_to_selected)
+        self.btn_append_action = tk.Button(secondary_row, text="追加", command=self.append_action_to_selected)
         self.btn_append_action.pack(side=tk.LEFT, padx=2)
 
-        self.btn_pop_action = tk.Button(right_frame, text="退一", command=self.pop_action_from_selected, width=4)
+        self.btn_pop_action = tk.Button(secondary_row, text="退一", command=self.pop_action_from_selected, width=4)
         self.btn_pop_action.pack(side=tk.LEFT, padx=2)
 
         self.action_chain_label = tk.Label(
-            right_frame,
+            secondary_row,
             textvariable=self.action_chain_var,
             font=("Consolas", 8),
             fg="#475569",
             anchor="w",
-            width=18,
         )
-        self.action_chain_label.pack(side=tk.LEFT, padx=(4, 6))
+        self.action_chain_label.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(8, 8))
 
         self.strict_check = tk.Checkbutton(
-            right_frame,
+            secondary_row,
             text="严格",
             variable=self.strict_var,
             onvalue=True,
@@ -194,7 +200,7 @@ class RouteEditorApp:
         self.strict_check.pack(side=tk.LEFT, padx=(4, 2))
 
         self.btn_del_point = tk.Button(
-            right_frame,
+            secondary_row,
             text="🗑",
             command=self.delete_selected_point,
             fg="#e74c3c",
@@ -210,6 +216,16 @@ class RouteEditorApp:
             font=("Microsoft YaHei", 9),
         )
         self.status_label.pack(fill=tk.X, padx=10, pady=2)
+
+        self.locator_debug_label = tk.Label(
+            self.root,
+            textvariable=self.locator_debug_var,
+            fg="#475569",
+            anchor="w",
+            justify=tk.LEFT,
+            font=("Consolas", 8),
+        )
+        self.locator_debug_label.pack(fill=tk.X, padx=10, pady=(0, 4))
 
         self.canvas = tk.Canvas(self.root, bg="#0f172a", highlightthickness=0)
         self.canvas.pack(fill=tk.BOTH, expand=True)
@@ -229,6 +245,9 @@ class RouteEditorApp:
 
     def _set_status(self, text: str, color: str) -> None:
         self.status_label.config(text=text, fg=color)
+
+    def _set_locator_debug(self, text: str) -> None:
+        self.locator_debug_var.set(text)
 
     def _refresh_zone_label(self) -> None:
         self.zone_label.config(text=self._compact_zone_label_text(self.zone_state.label_text()))
@@ -462,6 +481,7 @@ class RouteEditorApp:
         self.btn_start.config(state=tk.DISABLED)
         self.btn_stop.config(state=tk.NORMAL)
         self._set_status("● 正在启动识别引擎...", "#3b82f6")
+        self._set_locator_debug("Locator: waiting for first result...")
         try:
             self.recording_service.start()
         except Exception as exc:
@@ -583,7 +603,7 @@ class RouteEditorApp:
 
         self.push_undo()
         action_type = self.point_editor.action_name_to_type(self.action_menu.get())
-        set_point_actions(point, get_point_actions(point) + [action_type])
+        set_manual_point_actions(point, get_point_actions(point) + [action_type])
         self._sync_action_controls()
         self._on_points_structure_changed(redraw_fast=False)
 
@@ -596,9 +616,9 @@ class RouteEditorApp:
         self.push_undo()
         actions = get_point_actions(point)
         if len(actions) <= 1:
-            set_point_actions(point, [int(ActionType.RUN)])
+            set_manual_point_actions(point, [int(ActionType.RUN)])
         else:
-            set_point_actions(point, actions[:-1])
+            set_manual_point_actions(point, actions[:-1])
         self._sync_action_controls()
         self._on_points_structure_changed(redraw_fast=False)
 
@@ -767,7 +787,7 @@ class RouteEditorApp:
         return result["points"]
 
     def _validate_zone_assignments(self, points: list[PathPoint], title: str) -> bool:
-        zone_ids = sorted({str(point.get("zone", "") or "").strip() for point in points if str(point.get("zone", "") or "").strip()})
+        zone_ids = sorted({normalize_zone_id(point.get("zone", "")) for point in points if normalize_zone_id(point.get("zone", ""))})
         if not zone_ids:
             return True
 
@@ -785,7 +805,7 @@ class RouteEditorApp:
     def _dominant_zone(points: list[PathPoint]) -> str:
         counts: dict[str, int] = {}
         for point in points:
-            zone_name = str(point.get("zone", "") or "")
+            zone_name = normalize_zone_id(point.get("zone", ""))
             if not zone_name:
                 continue
             counts[zone_name] = counts.get(zone_name, 0) + 1

--- a/tools/MapNavigator/json_import.py
+++ b/tools/MapNavigator/json_import.py
@@ -20,6 +20,7 @@ from model import (
     get_display_action,
     get_point_actions,
     normalize_path_points,
+    normalize_zone_id,
     try_parse_action_type,
 )
 
@@ -48,7 +49,7 @@ def load_points_from_json_file(file_path: str | Path, apply_zone_inference: bool
         raise ValueError("未找到可识别的 path 数据")
 
     selected_route = max(routes, key=len)
-    source_has_zone_info = any(str(point.get("zone", "") or "") for point in selected_route)
+    source_has_zone_info = any(normalize_zone_id(point.get("zone", "")) for point in selected_route)
     if apply_zone_inference:
         selected_route = infer_missing_zones(selected_route)
     return ImportedRoute(
@@ -63,7 +64,7 @@ def export_path_nodes(points: list[PathPoint]) -> list[dict[str, Any] | list[int
     current_zone = ""
 
     for point in normalize_path_points(points):
-        zone_id = str(point.get("zone", "") or "")
+        zone_id = normalize_zone_id(point.get("zone", ""))
         if zone_id and zone_id != current_zone:
             exported_nodes.append({"action": "ZONE", "zone_id": zone_id})
             current_zone = zone_id
@@ -111,7 +112,7 @@ def infer_missing_zones(points: list[PathPoint]) -> list[PathPoint]:
     route_scores: dict[str, int] = {}
 
     for point in inferred:
-        explicit_zone = str(point.get("zone", "") or "")
+        explicit_zone = normalize_zone_id(point.get("zone", ""))
         if explicit_zone:
             route_scores[explicit_zone] = route_scores.get(explicit_zone, 0) + 100
             point_matches.append([explicit_zone])
@@ -157,8 +158,8 @@ def split_route_into_segments(points: list[PathPoint]) -> list[tuple[int, int]]:
     distances: list[float] = []
 
     for idx in range(1, len(points)):
-        prev_zone = str(points[idx - 1].get("zone", "") or "")
-        curr_zone = str(points[idx].get("zone", "") or "")
+        prev_zone = normalize_zone_id(points[idx - 1].get("zone", ""))
+        curr_zone = normalize_zone_id(points[idx].get("zone", ""))
         if prev_zone and curr_zone and prev_zone != curr_zone:
             break_indices.add(idx)
 
@@ -357,7 +358,7 @@ def _fill_unknown_zones(points: list[PathPoint], fallback_zone: str) -> None:
     if not points:
         return
 
-    known_indices = [idx for idx, point in enumerate(points) if point.get("zone")]
+    known_indices = [idx for idx, point in enumerate(points) if normalize_zone_id(point.get("zone", ""))]
     if not known_indices:
         if fallback_zone:
             for point in points:
@@ -365,20 +366,20 @@ def _fill_unknown_zones(points: list[PathPoint], fallback_zone: str) -> None:
         return
 
     for idx, point in enumerate(points):
-        if point.get("zone"):
+        if normalize_zone_id(point.get("zone", "")):
             continue
 
         prev_zone = ""
         next_zone = ""
 
         for prev_idx in range(idx - 1, -1, -1):
-            zone_name = str(points[prev_idx].get("zone", "") or "")
+            zone_name = normalize_zone_id(points[prev_idx].get("zone", ""))
             if zone_name:
                 prev_zone = zone_name
                 break
 
         for next_idx in range(idx + 1, len(points)):
-            zone_name = str(points[next_idx].get("zone", "") or "")
+            zone_name = normalize_zone_id(points[next_idx].get("zone", ""))
             if zone_name:
                 next_zone = zone_name
                 break
@@ -482,8 +483,10 @@ def _parse_point_list(node: list[Any], zone_hint: str) -> PathPoint | None:
             actions.append(parsed_action)
             continue
 
-        if isinstance(extra, str) and extra.strip():
-            zone = extra.strip()
+        if isinstance(extra, str):
+            parsed_zone = normalize_zone_id(extra)
+            if parsed_zone:
+                zone = parsed_zone
 
         if isinstance(extra, list):
             actions.extend(_parse_action_chain_value(extra))
@@ -503,8 +506,9 @@ def _parse_point_list(node: list[Any], zone_hint: str) -> PathPoint | None:
 def _resolve_zone_hint(node: dict[str, Any], fallback: str) -> str:
     for key in ZONE_HINT_KEYS:
         value = node.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
+        zone_id = normalize_zone_id(value)
+        if zone_id:
+            return zone_id
     return fallback
 
 

--- a/tools/MapNavigator/model.py
+++ b/tools/MapNavigator/model.py
@@ -5,7 +5,7 @@ import math
 import re
 from enum import IntEnum
 from pathlib import Path
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
 class PathPoint(TypedDict):
@@ -17,6 +17,8 @@ class PathPoint(TypedDict):
     actions: list[int]
     zone: str
     strict: bool
+    auto_portal: NotRequired[bool]
+    suppress_auto_portal: NotRequired[bool]
 
 
 class ActionType(IntEnum):
@@ -74,10 +76,21 @@ ACTION_NAME_LOOKUP: dict[str, int] = {
     "PORTAL": int(ActionType.PORTAL),
     "TRANSFER": int(ActionType.TRANSFER),
 }
+ACTION_MENU_TYPES: tuple[ActionType, ...] = (
+    ActionType.RUN,
+    ActionType.SPRINT,
+    ActionType.JUMP,
+    ActionType.FIGHT,
+    ActionType.INTERACT,
+    ActionType.PORTAL,
+    ActionType.TRANSFER,
+)
+ACTION_MENU_NAMES: tuple[str, ...] = tuple(ACTION_NAMES[action_type] for action_type in ACTION_MENU_TYPES)
+INVALID_ZONE_IDS = {"NONE", "NULL", "N/A"}
 
 
 def _normalize_action_chain(actions: list[int]) -> list[int]:
-    non_run_actions = [action for action in actions if action != int(ActionType.RUN)]
+    non_run_actions = [action for action in actions if action not in (int(ActionType.NONE), int(ActionType.RUN))]
     if non_run_actions:
         return non_run_actions
     return [int(ActionType.RUN)]
@@ -128,6 +141,18 @@ def coerce_action_chain(value: object, default: int = int(ActionType.RUN)) -> li
     return _normalize_action_chain([coerce_action_type(value, default=default)])
 
 
+def normalize_zone_id(value: object, default: str = "") -> str:
+    if not isinstance(value, str):
+        return default
+
+    zone_id = value.strip()
+    if not zone_id:
+        return default
+    if zone_id.upper() in INVALID_ZONE_IDS:
+        return default
+    return zone_id
+
+
 def get_point_actions(point: PathPoint) -> list[int]:
     fallback_action = coerce_action_type(point.get("action"), default=int(ActionType.RUN))
     return coerce_action_chain(point.get("actions"), default=fallback_action)
@@ -142,6 +167,15 @@ def set_point_actions(point: PathPoint, actions: list[int]) -> None:
     normalized_actions = coerce_action_chain(actions, default=int(ActionType.RUN))
     point["actions"] = normalized_actions
     point["action"] = get_display_action(normalized_actions)
+
+
+def set_manual_point_actions(point: PathPoint, actions: list[int]) -> None:
+    set_point_actions(point, actions)
+    point.pop("auto_portal", None)
+    if get_point_actions(point) == [int(ActionType.RUN)]:
+        point["suppress_auto_portal"] = True
+    else:
+        point.pop("suppress_auto_portal", None)
 
 
 def coerce_strict_arrival(value: object, default: bool = False) -> bool:
@@ -168,6 +202,18 @@ def export_action_token(value: object) -> str:
     return ACTION_TOKENS.get(coerce_action_type(value), "RUN")
 
 
+def _sync_portal_flags(point: PathPoint) -> None:
+    if bool(point.get("auto_portal")) and get_point_actions(point) == [int(ActionType.PORTAL)]:
+        point["auto_portal"] = True
+    else:
+        point.pop("auto_portal", None)
+
+    if bool(point.get("suppress_auto_portal")) and get_point_actions(point) == [int(ActionType.RUN)]:
+        point["suppress_auto_portal"] = True
+    else:
+        point.pop("suppress_auto_portal", None)
+
+
 def normalize_path_points(points: list[PathPoint]) -> list[PathPoint]:
     """
     统一清洗轨迹点，并自动在跨区域边界补 PORTAL 动作。
@@ -180,25 +226,51 @@ def normalize_path_points(points: list[PathPoint]) -> list[PathPoint]:
             point.get("actions"),
             default=coerce_action_type(point.get("action"), default=int(ActionType.RUN)),
         )
-        normalized.append(
-            {
-                "x": round(float(point["x"]), 2),
-                "y": round(float(point["y"]), 2),
-                "action": get_display_action(action_chain),
-                "actions": action_chain,
-                "zone": str(point.get("zone", "") or ""),
-                "strict": coerce_strict_arrival(point.get("strict"), default=False),
-            }
-        )
+        normalized_point: PathPoint = {
+            "x": round(float(point["x"]), 2),
+            "y": round(float(point["y"]), 2),
+            "action": get_display_action(action_chain),
+            "actions": action_chain,
+            "zone": normalize_zone_id(point.get("zone", "")),
+            "strict": coerce_strict_arrival(point.get("strict"), default=False),
+        }
+        if bool(point.get("auto_portal")):
+            normalized_point["auto_portal"] = True
+        if bool(point.get("suppress_auto_portal")):
+            normalized_point["suppress_auto_portal"] = True
+        _sync_portal_flags(normalized_point)
+        normalized.append(normalized_point)
 
+    boundary_indices: set[int] = set()
     for idx in range(len(normalized) - 1):
         current_zone = normalized[idx]["zone"]
         next_zone = normalized[idx + 1]["zone"]
         if current_zone and next_zone and current_zone != next_zone:
-            if get_point_actions(normalized[idx]) == [int(ActionType.RUN)]:
-                set_point_actions(normalized[idx], [int(ActionType.PORTAL)])
-            if get_point_actions(normalized[idx + 1]) == [int(ActionType.RUN)]:
-                set_point_actions(normalized[idx + 1], [int(ActionType.PORTAL)])
+            boundary_indices.add(idx)
+            boundary_indices.add(idx + 1)
+
+    for idx, point in enumerate(normalized):
+        actions = get_point_actions(point)
+        is_boundary_point = idx in boundary_indices
+
+        if is_boundary_point:
+            if bool(point.get("suppress_auto_portal")):
+                point.pop("auto_portal", None)
+                _sync_portal_flags(point)
+                continue
+
+            if actions == [int(ActionType.RUN)]:
+                set_point_actions(point, [int(ActionType.PORTAL)])
+                point["auto_portal"] = True
+            elif actions != [int(ActionType.PORTAL)]:
+                point.pop("auto_portal", None)
+            _sync_portal_flags(point)
+            continue
+
+        if bool(point.get("auto_portal")) and actions == [int(ActionType.PORTAL)]:
+            set_point_actions(point, [int(ActionType.RUN)])
+        point.pop("auto_portal", None)
+        point.pop("suppress_auto_portal", None)
 
     merged: list[PathPoint] = []
     for point in normalized:
@@ -209,7 +281,14 @@ def normalize_path_points(points: list[PathPoint]) -> list[PathPoint]:
             and merged[-1]["zone"] == point["zone"]
             and merged[-1]["strict"] == point["strict"]
         ):
+            merged_auto_portal = bool(merged[-1].get("auto_portal")) or bool(point.get("auto_portal"))
+            merged_suppressed = bool(merged[-1].get("suppress_auto_portal")) or bool(point.get("suppress_auto_portal"))
             set_point_actions(merged[-1], get_point_actions(merged[-1]) + get_point_actions(point))
+            if merged_auto_portal:
+                merged[-1]["auto_portal"] = True
+            if merged_suppressed:
+                merged[-1]["suppress_auto_portal"] = True
+            _sync_portal_flags(merged[-1])
             continue
         merged.append(point)
 
@@ -376,20 +455,27 @@ class PathRecorder:
         self.recorded_path: list[PathPoint] = []
 
     def add_waypoint(self, x: float, y: float, action: int, zone_id: str = "") -> None:
+        zone_name = normalize_zone_id(zone_id)
+        if not zone_name:
+            return
         self.recorded_path.append(
             {
                 "x": round(x, 2),
                 "y": round(y, 2),
                 "action": action,
                 "actions": [int(action)],
-                "zone": zone_id,
+                "zone": zone_name,
                 "strict": False,
             }
         )
 
     def update(self, current_x: float, current_y: float, current_action: int, zone_id: str = "") -> None:
+        zone_name = normalize_zone_id(zone_id)
+        if not zone_name:
+            return
+
         if not self.recorded_path:
-            self.add_waypoint(current_x, current_y, current_action, zone_id)
+            self.add_waypoint(current_x, current_y, current_action, zone_name)
             return
 
         last_wp = self.recorded_path[-1]
@@ -398,8 +484,8 @@ class PathRecorder:
         dist = math.hypot(dx, dy)
 
         # 保留尽量完整的原始轨迹，仅过滤亚像素级噪声。
-        if dist > 0.5 or current_action != last_wp["action"] or zone_id != last_wp["zone"]:
-            self.add_waypoint(current_x, current_y, current_action, zone_id)
+        if dist > 0.5 or current_action != last_wp["action"] or zone_name != last_wp["zone"]:
+            self.add_waypoint(current_x, current_y, current_action, zone_name)
 
 
 def resolve_zone_image(zone_id: str, map_image_dir: Path) -> Path | None:
@@ -412,7 +498,8 @@ def resolve_zone_image(zone_id: str, map_image_dir: Path) -> Path | None:
     - MapTracker: map01_lv001(_tier_114).png
     - 回退扫描：MapLocator 任意子目录下 `{zone_id}.png`
     """
-    if not zone_id or zone_id == "None":
+    normalized_zone_id = normalize_zone_id(zone_id)
+    if not normalized_zone_id:
         return None
     if not map_image_dir.exists():
         return None
@@ -427,18 +514,18 @@ def resolve_zone_image(zone_id: str, map_image_dir: Path) -> Path | None:
     else:
         map_tracker_dir = map_image_dir / "MapTracker" / "map"
 
-    tracker_candidate = map_tracker_dir / f"{zone_id}.png"
+    tracker_candidate = map_tracker_dir / f"{normalized_zone_id}.png"
     if tracker_candidate.exists():
         return tracker_candidate
 
-    level_match = re.match(r"^(\w+?)_L(\d+)_(\d+)$", zone_id)
+    level_match = re.match(r"^(\w+?)_L(\d+)_(\d+)$", normalized_zone_id)
     if level_match:
         region, level, tier = level_match.group(1), int(level_match.group(2)), level_match.group(3)
         candidate = map_locator_dir / region / f"Lv{level:03d}Tier{tier}.png"
         if candidate.exists():
             return candidate
 
-    base_match = re.match(r"^(\w+?)_Base$", zone_id)
+    base_match = re.match(r"^(\w+?)_Base$", normalized_zone_id)
     if base_match:
         region = base_match.group(1)
         candidate = map_locator_dir / region / "Base.png"
@@ -451,7 +538,7 @@ def resolve_zone_image(zone_id: str, map_image_dir: Path) -> Path | None:
     for sub_dir in map_locator_dir.iterdir():
         if not sub_dir.is_dir():
             continue
-        candidate = sub_dir / f"{zone_id}.png"
+        candidate = sub_dir / f"{normalized_zone_id}.png"
         if candidate.exists():
             return candidate
 

--- a/tools/MapNavigator/point_editing.py
+++ b/tools/MapNavigator/point_editing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from model import ACTION_NAMES, ActionType, PathPoint, set_point_actions
+from model import ACTION_NAMES, ActionType, PathPoint, get_point_actions, set_manual_point_actions, set_point_actions
 
 
 class CoordinateProjector(Protocol):
@@ -39,7 +39,7 @@ class PointEditingService:
         for action_type, display_name in ACTION_NAMES.items():
             if display_name == action_name:
                 return int(action_type)
-        return int(ActionType.NONE)
+        return int(ActionType.RUN)
 
     def insert_point(
         self,
@@ -103,7 +103,12 @@ class PointEditingService:
             return False
 
         global_idx = zone_indices[selected_idx]
-        set_point_actions(points[global_idx], [self.action_name_to_type(action_name)])
+        current_actions = get_point_actions(points[global_idx])
+        new_actions = [self.action_name_to_type(action_name)]
+        if current_actions == new_actions:
+            set_point_actions(points[global_idx], new_actions)
+        else:
+            set_manual_point_actions(points[global_idx], new_actions)
         points[global_idx]["strict"] = strict_arrival
         return True
 

--- a/tools/MapNavigator/recording_service.py
+++ b/tools/MapNavigator/recording_service.py
@@ -7,13 +7,14 @@ import threading
 import time
 from typing import Callable
 
-from model import ActionType, PathPoint, PathRecorder, is_key_pressed
+from model import ActionType, PathPoint, PathRecorder, is_key_pressed, normalize_zone_id
 from runtime import AGENT_DIR, CPP_AGENT_EXE, MAAFW_BIN_DIR, MaaRuntime, get_agent_env
 
 
 StatusCallback = Callable[[str, str], None]
 FinishedCallback = Callable[[list[PathPoint]], None]
 ErrorCallback = Callable[[str], None]
+LocatorDetailCallback = Callable[[str], None]
 
 
 class RecordingService:
@@ -32,16 +33,22 @@ class RecordingService:
         on_status: StatusCallback,
         on_finished: FinishedCallback,
         on_error: ErrorCallback,
+        on_locator_detail: LocatorDetailCallback | None = None,
     ) -> None:
         self._runtime = runtime
         self._on_status = on_status
         self._on_finished = on_finished
         self._on_error = on_error
+        self._on_locator_detail = on_locator_detail
 
         self._recorder = PathRecorder()
         self._agent_process: subprocess.Popen[str] | None = None
         self._worker_thread: threading.Thread | None = None
         self._running_event = threading.Event()
+        self._last_record_log_signature: tuple[object, ...] | None = None
+        self._last_record_log_at = 0.0
+        self._last_skip_log_signature: tuple[object, ...] | None = None
+        self._last_skip_log_at = 0.0
 
     @property
     def is_running(self) -> bool:
@@ -52,6 +59,10 @@ class RecordingService:
             return
 
         self._recorder = PathRecorder()
+        self._last_record_log_signature = None
+        self._last_record_log_at = 0.0
+        self._last_skip_log_signature = None
+        self._last_skip_log_at = 0.0
         self._running_event.set()
         self._worker_thread = threading.Thread(target=self._run, daemon=True)
         self._worker_thread.start()
@@ -145,7 +156,6 @@ class RecordingService:
         )
         get_window_text = ctypes.windll.user32.GetWindowTextW
         is_window_visible = ctypes.windll.user32.IsWindowVisible
-        get_class_name = ctypes.windll.user32.GetClassNameW
 
         result = [0]
 
@@ -157,20 +167,10 @@ class RecordingService:
             get_window_text(hwnd, title_buffer, 512)
             title = title_buffer.value
 
-            class_buffer = ctypes.create_unicode_buffer(512)
-            get_class_name(hwnd, class_buffer, 512)
-            class_name = class_buffer.value
-
             if not title:
                 return True
 
-            title_match = any(keyword in title for keyword in ("Endfield", "EndField", "终末地"))
-            class_match = (
-                "Unity" in class_name
-                or "Unreal" in class_name
-                or "Windows.UI.Core.CoreWindow" not in class_name
-            )
-            if title_match and class_match:
+            if title.strip() == "Endfield":
                 result[0] = hwnd
                 return False
             return True
@@ -189,6 +189,54 @@ class RecordingService:
             return ActionType.SPRINT
         return ActionType.RUN
 
+    def _emit_locator_detail(self, text: str) -> None:
+        timestamp = time.strftime("%H:%M:%S")
+        full_text = f"[{timestamp}] {text}"
+        print(full_text, flush=True)
+        if self._on_locator_detail:
+            self._on_locator_detail(full_text)
+
+    def _emit_skip_summary(self, detail: dict, reason: str) -> None:
+        now = time.monotonic()
+        signature = (
+            detail.get("status"),
+            detail.get("message", ""),
+            detail.get("mapName", ""),
+            reason,
+        )
+        if signature == self._last_skip_log_signature and now - self._last_skip_log_at < 1.5:
+            return
+
+        self._last_skip_log_signature = signature
+        self._last_skip_log_at = now
+        self._emit_locator_detail(
+            "Locator skip: "
+            f"reason={reason} "
+            f"status={detail.get('status')} "
+            f"map={detail.get('mapName', '')!r} "
+            f"msg={detail.get('message', '')!r} "
+            f"x={detail.get('x', '-')!r} "
+            f"y={detail.get('y', '-')!r}"
+        )
+
+    def _emit_record_summary(self, detail: dict, zone_id: str, action: ActionType) -> None:
+        now = time.monotonic()
+        signature = (zone_id, detail.get("status"))
+        if signature == self._last_record_log_signature and now - self._last_record_log_at < 0.5:
+            return
+
+        self._last_record_log_signature = signature
+        self._last_record_log_at = now
+        self._emit_locator_detail(
+            "Locator ok: "
+            f"zone={zone_id} "
+            f"x={detail.get('x', '-')!r} "
+            f"y={detail.get('y', '-')!r} "
+            f"conf={detail.get('locConf', '-')!r} "
+            f"latencyMs={detail.get('latencyMs', '-')!r} "
+            f"action={action.name}"
+        )
+
     def _consume_latest_result(self, tasker, action: ActionType) -> None:
         node = tasker.get_latest_node("MapLocateNode")
         if not node or not node.recognition or not node.recognition.best_result:
@@ -196,17 +244,28 @@ class RecordingService:
 
         detail = node.recognition.best_result.detail
         if isinstance(detail, str):
-            detail = json.loads(detail)
+            try:
+                detail = json.loads(detail)
+            except json.JSONDecodeError:
+                self._emit_locator_detail("Locator skip: reason=detail_parse_failed")
+                return
 
-        if not isinstance(detail, dict) or detail.get("status") != 0:
+        if not isinstance(detail, dict):
             return
 
-        self._recorder.update(
-            detail.get("x", 0),
-            detail.get("y", 0),
-            int(action),
-            detail.get("mapName", ""),
-        )
+        if detail.get("status") != 0:
+            self._emit_skip_summary(detail, reason="status")
+            return
+
+        zone_id = normalize_zone_id(detail.get("mapName", ""))
+        x = detail.get("x")
+        y = detail.get("y")
+        if not zone_id or not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
+            self._emit_skip_summary(detail, reason="invalid_zone_or_xy")
+            return
+
+        self._emit_record_summary(detail, zone_id=zone_id, action=action)
+        self._recorder.update(float(x), float(y), int(action), zone_id)
 
     def _shutdown_agent(self) -> None:
         if not self._agent_process:

--- a/tools/MapNavigator/zone_index.py
+++ b/tools/MapNavigator/zone_index.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from model import PathPoint
+from model import PathPoint, normalize_zone_id
 
 
 class ZoneState:
@@ -19,7 +19,7 @@ class ZoneState:
         zone_id = self.current_zone()
         if not zone_id:
             return list(range(len(points)))
-        return [index for index, point in enumerate(points) if point.get("zone") == zone_id]
+        return [index for index, point in enumerate(points) if normalize_zone_id(point.get("zone", "")) == zone_id]
 
     def current_points(self, points: list[PathPoint]) -> list[PathPoint]:
         return [points[index] for index in self.point_indices(points)]
@@ -28,7 +28,7 @@ class ZoneState:
         previous_zone = self.current_zone()
         discovered = []
         for point in points:
-            zone_id = point.get("zone", "")
+            zone_id = normalize_zone_id(point.get("zone", ""))
             if zone_id and zone_id not in discovered:
                 discovered.append(zone_id)
 


### PR DESCRIPTION
本 PR 围绕「YOLO 先验定界 + CV 局部精搜 + 运动学状态机」的异构 Pipeline 进行了底层执行拓扑的深度重构。我们彻底剥离了原有的“图像金字塔降采样粗搜”与“单线程串行阻塞”等历史包袱，全面演进至「YOLO ROI 约束 + 无阻塞异步双轨流水线」的全新并发架构。

凭借对现代多核算力的极致榨取与物理级的降维搜索策略，新引擎在超大地图的**检索准确率与抗错抓能力上实现了量级跃升**。在 20000+ 帧的真实 Benchmark 中，**全局冷启动与重搜延迟迎来了断崖式下跌**。

与此同时，进一步优化并修复MapNavigator所使用的配套编排工具，进一步提升了工具的稳定性。

### 核心技术特性
1. 空间降维与“零误判”级的 ROI 约束搜索

- **瓦片级精准映射**：通过引入YOLO映射配置`tile_mapping.json`，YOLO 推理已从“逻辑大区识别”细化为“子瓦片 ROI 及缓冲边界”的直接映射。

- **降采样粗搜的终结**：全局检索阶段正式告别高耗时且易诱发假阳性的“全局图像金字塔”。系统现在依赖 YOLO 下发的ROI定界，直接在极小范围内展开滑动窗口精确匹配。这不仅碾碎了冷启动的计算延迟，更在物理空间层面彻底斩断了降采样后导致“相似纹理”引发的错抓风险，使全局定位准确率逼近理论极限。

2. 算力压榨与无阻塞异步流水线

- **尺度池极进调度**：受限精搜模块现已接入动态线程池，根据宿主机情况对 Scale 遍历任务进行并行切割。多尺度 NCC 互相关运算的单核瓶颈被彻底击穿。

- **影子托底与抢占式返回**：重构了备用策略的执行逻辑，使其作为独立异步线程在后台运行。一旦主路径命中高置信度目标，后台备用任务将被直接流放至 `backgroundGlobalSearchTasks` 队列排干。这种“绝不阻塞主线程”的设计，确保了系统永远能跑出最佳延迟。

3. 异构特征的双轨交叉互证

- **空间坐标级豁免**：Tracking 与 Global Search 流程全面加强“标准NCC + 热度梯度拓扑”的双轨评估。当两套异构算法独立推演出的绝对坐标高度重合 (误差 <= 5.0 像素) 时，系统会判定为“强互补佐证”，进而无视单策略在复杂遮挡下遭遇的分数惩罚，采信该坐标。此机制为极端干扰下的置信度托底提供了完美保障。

4. 状态机前置拦截

- **异变前置熔断**：角度推演现与主逻辑并行运作。若解算因 UI 破缺而失败，系统会强制触发同步的 YOLO 推理以复核当前 ZoneId，防止后续意外输出错误坐标。

<img width="2182" height="951" alt="Fig1_Cold_Start_Recovery" src="https://github.com/user-attachments/assets/1053d7d1-cbe4-4bcc-ac2e-de6c3a8e2313" />
<img width="2182" height="1026" alt="FigB_Representative_Stability_Windows" src="https://github.com/user-attachments/assets/aafa5d87-7116-41cf-acec-764c94ea8978" />

所使用用于获取csv原始数据的Benchmark代码：
```Rust
use maa_framework::{
    agent_client::AgentClient,
    common::TaskDetail,
    controller::Controller,
    custom_controller::CustomControllerCallback,
    resource::Resource,
    tasker::Tasker,
};
use std::env;
use std::error::Error;
use std::fs;
use std::path::{Path, PathBuf};
use std::process::{Child, Command};
use std::sync::{Arc, Condvar, Mutex};
use std::time::{Duration, Instant};

const PROJECT_ROOT: &str = "F:/MaaEnd";
const CPP_AGENT_EXE: &str = "F:/MaaEnd/install/agent/cpp-algo.exe";
const MAAFW_BIN_DIR: &str = "F:/MaaEnd/install/maafw";
const CACHE_DIR: &str = "./.video_cache";

struct StreamState {
    image: Option<Vec<u8>>,
    frame_id: usize,
    finished: bool,
}

struct StreamController {
    agent_name: String,
    state: Arc<(Mutex<StreamState>, Condvar)>,
    last_processed_id: Mutex<usize>,
}

impl CustomControllerCallback for StreamController {
    fn connect(&self) -> bool {
        true
    }

    fn connected(&self) -> bool {
        true
    }

    fn request_uuid(&self) -> Option<String> {
        Some(format!("bench_ctrl_{}", self.agent_name))
    }

    fn screencap(&self) -> Option<Vec<u8>> {
        let (lock, cvar) = &*self.state;
        let mut state = lock.lock().unwrap();

        while !state.finished && state.frame_id == *self.last_processed_id.lock().unwrap() {
            state = cvar.wait(state).unwrap();
        }

        *self.last_processed_id.lock().unwrap() = state.frame_id;
        state.image.clone()
    }
}

struct AgentProcess(Child);

impl Drop for AgentProcess {
    fn drop(&mut self) {
        let _ = self.0.kill();
        let _ = self.0.wait();
        println!("[*] Agent 进程已安全回收");
    }
}

#[derive(Debug, Clone)]
struct RecoData {
    latency_ms: i64,
    map_name: String,
    x: i32,
    y: i32,
    rot: f64,
    loc_conf: f64,
    message: String,
    raw_json: String,
}

fn build_agent_path_env() -> String {
    let current = env::var_os("PATH").unwrap_or_default();
    let mut paths = vec![PathBuf::from(MAAFW_BIN_DIR)];
    paths.extend(env::split_paths(&current));
    env::join_paths(paths)
        .unwrap_or(current)
        .to_string_lossy()
        .into_owned()
}

fn load_cached_frames() -> Result<Vec<Vec<u8>>, Box<dyn Error>> {
    let cache_path = Path::new(CACHE_DIR);
    if !cache_path.exists() {
        return Err(format!("缓存目录不存在: {}", cache_path.display()).into());
    }

    let mut frame_files: Vec<_> = fs::read_dir(cache_path)?
        .filter_map(|entry| entry.ok())
        .map(|entry| entry.path())
        .filter(|path| {
            path.extension()
                .and_then(|ext| ext.to_str())
                .map(|ext| matches!(ext.to_ascii_lowercase().as_str(), "jpg" | "jpeg" | "png"))
                .unwrap_or(false)
        })
        .collect();
    frame_files.sort();

    if frame_files.is_empty() {
        return Err(format!("缓存目录为空: {}", cache_path.display()).into());
    }

    println!("[*] 直接读取缓存帧目录: {}", cache_path.display());
    println!("[*] 视频预处理完毕，共 {} 帧。", frame_files.len());

    let mut frames_data = Vec::with_capacity(frame_files.len());
    for path in frame_files {
        frames_data.push(fs::read(path)?);
    }

    Ok(frames_data)
}

fn extract_reco_info(detail: Option<TaskDetail>) -> Option<RecoData> {
    let mut task = detail?;
    let node = task.nodes.pop()??;
    let reco = node.recognition?;

    let raw_str = reco.detail.to_string();
    let mut val = serde_json::from_str::<serde_json::Value>(&raw_str).ok()?;
    let detail_node = val
        .get("best")
        .and_then(|best| best.get("detail"))
        .filter(|detail| detail.is_object())
        .unwrap_or(&val);

    if !detail_node.is_object() {
        return None;
    }

    let cpp_latency = detail_node
        .get("latencyMs")
        .and_then(|v| v.as_f64())
        .map(|v| v as i64);
    let go_loc_latency = detail_node
        .get("locTimeMs")
        .and_then(|v| v.as_f64())
        .map(|v| v as i64);
    let go_rot_latency = detail_node
        .get("rotTimeMs")
        .and_then(|v| v.as_f64())
        .map(|v| v as i64)
        .unwrap_or(0);

    let latency_ms = if let Some(ms) = cpp_latency {
        ms
    } else if let Some(ms) = go_loc_latency {
        ms + go_rot_latency
    } else {
        0
    };

    let map_name = detail_node
        .get("mapName")
        .and_then(|v| v.as_str())
        .unwrap_or("None")
        .to_string();
    let x = detail_node.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0) as i32;
    let y = detail_node.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0) as i32;
    let rot = detail_node.get("rot").and_then(|v| v.as_f64()).unwrap_or(0.0);
    let loc_conf = detail_node
        .get("locConf")
        .and_then(|v| v.as_f64())
        .unwrap_or(0.0);
    let message = detail_node
        .get("message")
        .and_then(|v| v.as_str())
        .unwrap_or(if reco.hit { "Hit" } else { "Miss" })
        .to_string();

    if let Some(obj) = val.as_object_mut() {
        obj.remove("all");
        obj.remove("filtered");
    }

    Some(RecoData {
        latency_ms,
        map_name,
        x,
        y,
        rot,
        loc_conf,
        message,
        raw_json: val.to_string(),
    })
}

fn run_benchmark(
    agent_name: &str,
    exe_path: &str,
    target_reco_name: &str,
    frames_data: &[Vec<u8>],
) -> Result<(f64, usize, usize, usize), Box<dyn Error>> {
    println!("\n==================================================");
    println!(
        "[*] 正在向 {} 推入 60FPS 视频流 (绑定算子: {})",
        agent_name, target_reco_name
    );
    println!("==================================================");

    let pipeline_def = serde_json::json!({
        "BenchmarkMapLocate": {
            "recognition": "Custom",
            "custom_recognition": target_reco_name,
            "custom_recognition_param": {
                "map_name_regex": ".*"
            },
            "timeout": 1,
            "rate_limit": 0,
            "pre_delay": 0,
            "post_delay": 0
        }
    });

    let test_pipeline_path = PathBuf::from(PROJECT_ROOT).join(format!("bench_{}.json", agent_name));
    fs::write(
        &test_pipeline_path,
        serde_json::to_string_pretty(&pipeline_def)?,
    )?;
    println!(
        "[bench:{}] 已生成测试 pipeline: {}",
        agent_name,
        test_pipeline_path.display()
    );

    let mut client = AgentClient::create_tcp(0)?;
    let addr = client.identifier().unwrap_or_default();
    println!("[bench:{}] AgentClient TCP 标识: {}", agent_name, addr);
    client.set_timeout(5000)?;

    println!("[bench:{}] 启动 agent: {}", agent_name, exe_path);
    let _proc = AgentProcess(
        Command::new(exe_path)
            .arg(&addr)
            .current_dir(Path::new(exe_path).parent().unwrap())
            .env("PATH", build_agent_path_env())
            .spawn()?,
    );
    std::thread::sleep(Duration::from_secs(3));
    println!("[bench:{}] agent 启动等待完成", agent_name);

    let stream_state = Arc::new((
        Mutex::new(StreamState {
            image: Some(frames_data[0].clone()),
            frame_id: 1,
            finished: false,
        }),
        Condvar::new(),
    ));

    let ctrl = Controller::new_custom(StreamController {
        agent_name: agent_name.to_string(),
        state: Arc::clone(&stream_state),
        last_processed_id: Mutex::new(0),
    })?;
    println!("[bench:{}] 自定义 Controller 已创建", agent_name);

    let res = Resource::new()?;
    println!("[bench:{}] 开始挂载测试 pipeline", agent_name);
    res.post_pipeline(test_pipeline_path.to_str().unwrap())?.wait();
    println!("[bench:{}] 测试 pipeline 挂载完成", agent_name);

    let tasker = Tasker::new()?;
    println!("[bench:{}] 开始 tasker.bind(resource, controller)", agent_name);
    tasker.bind(&res, &ctrl)?;
    println!("[bench:{}] tasker.bind 完成", agent_name);

    println!("[bench:{}] 开始 client.bind(resource)", agent_name);
    client.bind(res.clone())?;
    println!("[bench:{}] client.bind 完成", agent_name);

    println!("[bench:{}] 开始 client.register_sinks", agent_name);
    client.register_sinks(res.clone(), ctrl.clone(), tasker.clone())?;
    println!("[bench:{}] client.register_sinks 完成", agent_name);

    println!("[bench:{}] 开始 client.connect()", agent_name);
    client.connect()?;
    println!("[bench:{}] client.connect() 完成", agent_name);
    println!(
        "[bench:{}] connected={}, alive={}",
        agent_name,
        client.connected(),
        client.alive()
    );
    match client.custom_recognition_list() {
        Ok(list) => println!("[bench:{}] custom recognitions: {:?}", agent_name, list),
        Err(err) => println!("[bench:{}] 获取 custom recognition 列表失败: {}", agent_name, err),
    }

    let state_clone = Arc::clone(&stream_state);
    let frames_clone = frames_data[1..].to_vec();
    let camera_thread = std::thread::spawn(move || {
        let (lock, cvar) = &*state_clone;
        let frame_interval = Duration::from_secs_f64(1.0 / 60.0);
        let start_time = Instant::now();

        for (idx, img_bytes) in frames_clone.into_iter().enumerate() {
            let target_time = start_time + frame_interval.mul_f64((idx + 1) as f64);
            let now = Instant::now();
            if now < target_time {
                std::thread::sleep(target_time - now);
            }

            let mut st = lock.lock().unwrap();
            st.image = Some(img_bytes);
            st.frame_id = idx + 2;
            println!("[camera] 推送 frame_id={}", st.frame_id);
            cvar.notify_all();
        }

        let mut st = lock.lock().unwrap();
        st.finished = true;
        cvar.notify_all();
    });

    let mut times = Vec::new();
    let mut hits = 0;
    let mut tracking_hits = 0;
    let mut actual_processed_frames = 0;
    let mut csv_logs: Vec<(usize, RecoData)> = Vec::new();

    loop {
        let current_frame_id = {
            let (lock, _) = &*stream_state;
            let st = lock.lock().unwrap();
            if st.finished {
                break;
            }
            st.frame_id
        };

        println!("[bench:{}] post_task frame_id={}", agent_name, current_frame_id);
        let job = tasker.post_task("BenchmarkMapLocate", "{}")?;
        println!(
            "[bench:{}] job 已创建，等待结果 frame_id={}",
            agent_name, current_frame_id
        );
        let result = job.get(true)?;

        actual_processed_frames += 1;

        if let Some(data) = extract_reco_info(result) {
            times.push(data.latency_ms);
            hits += 1;

            if data.message.contains("Tracking") {
                tracking_hits += 1;
            }

            println!(
                "[物理帧: {:04}] 判定耗时: {:>4}ms | {} | {}",
                current_frame_id, data.latency_ms, data.message, data.raw_json
            );

            csv_logs.push((current_frame_id, data));
        } else {
            println!("[物理帧: {:04}] Missed / Failed", current_frame_id);
        }
    }

    let _ = camera_thread.join();
    let _ = fs::remove_file(test_pipeline_path);

    let csv_filename = format!("{}_benchmark_data.csv", agent_name);
    let mut csv_content = String::from("frame_id,map_name,x,y,rot,loc_conf,latency_ms,message\n");
    for (frame_id, data) in csv_logs {
        csv_content.push_str(&format!(
            "{},{},{},{},{:.2},{:.4},{},{}\n",
            frame_id,
            data.map_name,
            data.x,
            data.y,
            data.rot,
            data.loc_conf,
            data.latency_ms,
            data.message
        ));
    }
    fs::write(&csv_filename, csv_content)?;
    println!("[*] 已保存详细追踪数据至: {}", csv_filename);

    let avg = if times.is_empty() {
        0.0
    } else {
        times.iter().map(|&value| value as f64).sum::<f64>() / times.len() as f64
    };

    Ok((avg, hits, tracking_hits, actual_processed_frames))
}

fn main() -> Result<(), Box<dyn Error>> {
    let frames_data = load_cached_frames()?;

    unsafe {
        env::set_var("MAAFW_BINARY_PATH", MAAFW_BIN_DIR);
    }
    maa_framework::load_library(Path::new("F:/MaaEnd/install/maafw/MaaFramework.dll"))?;

    let (cpp_avg, cpp_hits, cpp_track, cpp_total) =
        run_benchmark("CPP", CPP_AGENT_EXE, "MapLocateRecognition", &frames_data)?;

    println!();
    println!("输入源视频总帧数: {}", frames_data.len());
    println!("(详细字段的判定记录已导出为 CSV 文件！)");
    println!();
    println!("【CPP Agent 表现】");
    println!("  实际捕获帧数 : {} (处理越慢，跳帧漏看的越多)", cpp_total);
    println!("  命中识别帧数 : {}", cpp_hits);
    println!("  内部判定均时 : {:.2} ms/帧", cpp_avg);
    println!(
        "  追踪维持率   : {:.1}% ({} 帧处于低延迟 Tracking)",
        if cpp_hits > 0 {
            (cpp_track as f64 / cpp_hits as f64) * 100.0
        } else {
            0.0
        },
        cpp_track
    );

    Ok(())
}
```

[CPP_benchmark_data_old.csv](https://github.com/user-attachments/files/26005586/CPP_benchmark_data_old.csv)

[CPP_benchmark_data.csv](https://github.com/user-attachments/files/26005581/CPP_benchmark_data.csv)

## Summary by Sourcery

重构 MapLocator 流水线，使用由 YOLO 驱动的 ROI 约束全局搜索，并采用异步双轨工作流，同时强化区域（zone）ID 处理以及 MapNavigator 工具中的传送门（portal）自动化。

New Features:
- 引入由 YOLO 粗略预测和瓦片映射元数据驱动的 ROI 约束和全地图精细全局搜索模式。
- 添加双模式全局搜索与跟踪校验，使用异构匹配策略以提升鲁棒性。
- 将详细的定位器状态流式暴露到 MapNavigator UI，用于路径录制过程中的实时调试。
- 在路径点上支持 auto-portal 和 suppress-auto-portal 标志，用于控制在区域边界处是否自动插入传送门。

Bug Fixes:
- 在全局搜索前，对 YOLO 粗略结果与已加载区域和预期区域选择器进行校验，防止因无效结果导致崩溃和错误的 ROI。
- 在 MapNavigator 中统一处理无效或占位的区域 ID，使得录制、导入/导出和区域解析会忽略不可用的值。
- 当搜索区域部分落在地图边界之外时，通过使用带填充的 ROI 修复跟踪和全局搜索中的边界情况问题。
- 通过规范化 NONE/RUN-only 动作链并改进键盘动作处理，避免产生虚假或噪声动作链。

Enhancements:
- 在 CoreMatch 中将精细尺度模板匹配并行化到多个 CPU 核心，并复用缓冲区，以更好地利用多核硬件。
- 基于硬件并发度，以可配置线程数运行 YOLO 推理，在性能与资源使用之间取得平衡。
- 将异步 YOLO 处理细化为具备后台区域变更检测的粗略预测器，并在角度推断失败时使用受保护的回退方案。
- 收紧 MapNavigator UI 布局，新增仅限可执行动作类型的动作菜单，并改进基于区域的点过滤与校验。
- 改进在代理和 MapNavigator 工具中对全局搜索尝试与路径录制决策的日志记录与摘要。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the MapLocator pipeline to use YOLO-driven ROI-constrained global search with asynchronous dual-track workflows, while tightening zone ID handling and portal automation in MapNavigator tools.

New Features:
- Introduce ROI-constrained and full-map fine global search modes driven by YOLO coarse predictions and tile mapping metadata.
- Add dual-mode global search and tracking verification using heterogeneous matching strategies for improved robustness.
- Expose detailed locator status streaming into the MapNavigator UI for live debugging during path recording.
- Support auto-portal and suppress-auto-portal flags on path points to control automatic portal insertion at zone boundaries.

Bug Fixes:
- Prevent crashes and incorrect ROIs by validating YOLO coarse results against loaded zones and expected zone selectors before global search.
- Handle invalid or placeholder zone IDs consistently in MapNavigator so that recording, import/export, and zone resolution ignore unusable values.
- Fix edge cases in tracking and global search when search regions fall partially outside map bounds by using padded ROIs.
- Avoid spurious or noisy action chains by normalizing NONE/RUN-only chains and improving keyboard action handling.

Enhancements:
- Parallelize fine-scale template matching across CPU cores and reuse buffers in CoreMatch to better exploit multi-core hardware.
- Run YOLO inference with configurable thread counts based on hardware concurrency to balance performance and resource usage.
- Refine async YOLO handling into a coarse predictor with background zone-change detection and guarded fallbacks when angle inference fails.
- Tighten the MapNavigator UI layout, add an action menu constrained to actionable types, and improve zone-based filtering and validation of points.
- Improve logging and summarization for global search attempts and path recording decisions in both the agent and MapNavigator tooling.

</details>