### PR TITLE
fix:基质锁定尾扫逻辑增强

### DIFF
--- a/agent/go-service/essencefilter/actions.go
+++ b/agent/go-service/essencefilter/actions.go
@@ -543,6 +543,13 @@ func (a *EssenceFilterRowNextItemAction) Run(ctx *maa.Context, arg *maa.CustomAc
 	if st == nil {
 		return false
 	}
+	if st.PendingFinalScan {
+		st.PendingFinalScan = false
+		log.Info().Str("component", "EssenceFilter").Str("action", "RowNextItem").Msg("补 swipe 完成，进入尾扫")
+		LogMXUSimpleHTML(ctx, "补 swipe 完成，进入尾扫")
+		ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: "EssenceDetectFinal"}})
+		return true
+	}
 	// Try-last-first: only when row is full (9). If total known and remaining this row < 9, skip and use normal logic.
 	if st.RowIndex == 0 && st.TryLastFirst && len(st.RowBoxes) > 0 {
 		remaining := st.TotalCount - st.MaxItemsPerRow*(st.CurrentRow-1)
@@ -588,14 +595,12 @@ func (a *EssenceFilterRowNextItemAction) Run(ctx *maa.Context, arg *maa.CustomAc
 	}
 	if st.RowIndex >= len(st.RowBoxes) {
 		if (len(st.RowBoxes) == st.MaxItemsPerRow) && !st.FinalLargeScanUsed {
-			// 已知总数时：若 剩余 = total - 9*已扫行数 <= 45，直接进入尾扫，避免到底后继续 swipe 卡死
 			const maxRemainingForFinalScan = 45
 			rowsDone := st.CurrentRow
 			remaining := st.TotalCount - st.MaxItemsPerRow*rowsDone
 			if st.TotalCount > 0 && remaining <= maxRemainingForFinalScan {
-				LogMXUSimpleHTML(ctx, fmt.Sprintf("剩余 %d 个 ≤ %d，进入尾扫（总 %d，已 %d 行）", remaining, maxRemainingForFinalScan, st.TotalCount, rowsDone))
-				ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: "EssenceDetectFinal"}})
-				return true
+				st.PendingFinalScan = true
+				LogMXUSimpleHTML(ctx, fmt.Sprintf("剩余 %d 个 ≤ %d，先补一次滑动再尾扫（总 %d，已 %d 行）", remaining, maxRemainingForFinalScan, st.TotalCount, rowsDone))
 			}
 			if !st.FirstRowSwipeDone {
 				st.FirstRowSwipeDone = true

--- a/agent/go-service/essencefilter/state.go
+++ b/agent/go-service/essencefilter/state.go
@@ -29,6 +29,7 @@ type RunState struct {
 	TotalCount          int // OCR 得到的库存总数，0 表示未知；用于计算剩余是否 <= 45 以决定是否尾扫
 	FirstRowSwipeDone   bool
 	FinalLargeScanUsed  bool
+	PendingFinalScan    bool // 剩余 ≤ 45 时先补一次 swipe，下次进 RowNextItem 再进尾扫
 	SwipeCalibrateRetry int
 
 	// Current item's three skills cache
@@ -64,6 +65,7 @@ func (s *RunState) Reset() {
 	s.TotalCount = 0
 	s.FirstRowSwipeDone = false
 	s.FinalLargeScanUsed = false
+	s.PendingFinalScan = false
 	s.SwipeCalibrateRetry = 0
 	s.CurrentSkills = [3]string{}
 	s.CurrentSkillLevels = [3]int{}


### PR DESCRIPTION
fix #1347

## Summary by Sourcery

增强 essence 筛选行的导航功能，在接近列表末尾时更稳健地处理最终扫描触发。

Bug 修复：
- 当剩余项数在最终扫描阈值范围内时，通过将最终扫描延后到补偿滑动之后执行，防止潜在的死锁或无限滑动问题。

增强内容：
- 引入 pending-final-scan 状态，在进入最终检测阶段前执行一次额外滑动，并增加相应日志以提高可追溯性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance essence filter row navigation to handle final scan triggering more robustly when approaching the end of the list.

Bug Fixes:
- Prevent potential deadlock or infinite swipe when remaining items are within the final-scan threshold by deferring final scan until after a compensating swipe.

Enhancements:
- Introduce a pending-final-scan state to perform an extra swipe before transitioning into the final detection phase, with corresponding logging for improved traceability.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

增强 essence 筛选行的导航功能，在接近列表末尾时更稳健地处理最终扫描触发。

Bug 修复：
- 当剩余项数在最终扫描阈值范围内时，通过将最终扫描延后到补偿滑动之后执行，防止潜在的死锁或无限滑动问题。

增强内容：
- 引入 pending-final-scan 状态，在进入最终检测阶段前执行一次额外滑动，并增加相应日志以提高可追溯性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance essence filter row navigation to handle final scan triggering more robustly when approaching the end of the list.

Bug Fixes:
- Prevent potential deadlock or infinite swipe when remaining items are within the final-scan threshold by deferring final scan until after a compensating swipe.

Enhancements:
- Introduce a pending-final-scan state to perform an extra swipe before transitioning into the final detection phase, with corresponding logging for improved traceability.

</details>

</details>