### PR TITLE
fix(autostockpile): 修复自动囤货无法运行

### DIFF
--- a/agent/go-service/autostockpile/recognition.go
+++ b/agent/go-service/autostockpile/recognition.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"image"
 	"math"
-	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -55,12 +53,6 @@ type ocrNameCandidate struct {
 	name string
 	tier string
 	box  maa.Rect
-}
-
-type goodsTemplate struct {
-	name         string
-	tier         string
-	templatePath string
 }
 
 // Run 执行 AutoStockpile 自定义识别，并返回包含商品与价格信息的结构化结果。
@@ -117,8 +109,21 @@ func (r *ItemValueChangeRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogn
 		Str("region", region).
 		Msg("goods region resolved")
 
+	itemMap := GetItemMap()
+	if err := validateItemMap(itemMap); err != nil {
+		nameCount, idCount := itemMapCounts(itemMap)
+		log.Error().
+			Err(err).
+			Str("component", autoStockpileComponent).
+			Str("step", "load_item_map").
+			Int("name_count", nameCount).
+			Int("id_count", idCount).
+			Msg("item_map is unavailable")
+		return nil, false
+	}
+
 	goodsROI := resolveGoodsRecognitionROI(ctx, arg.Img)
-	prices, ocrNames, err := runGoodsOCR(ctx, arg.Img, goodsROI)
+	prices, ocrNames, err := runGoodsOCR(ctx, arg.Img, goodsROI, itemMap)
 	if err != nil {
 		log.Warn().
 			Err(err).
@@ -180,36 +185,24 @@ func (r *ItemValueChangeRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogn
 		Int("bind_failed", pass1Failed).
 		Msg("goods-price binding finished")
 
-	templates, goodsDir, err := listGoodsTemplates(region)
-	if err != nil {
-		log.Error().
-			Err(err).
-			Str("component", autoStockpileComponent).
-			Str("region", region).
-			Msg("failed to read goods templates")
-		return nil, false
-	}
+	candidateIDs := listUnboundRegionItemIDs(itemMap, region, boundIDs)
 	log.Info().
 		Str("component", autoStockpileComponent).
 		Str("region", region).
-		Str("goods_dir", goodsDir).
-		Int("template_count", len(templates)).
-		Msg("goods templates loaded")
+		Str("template_source", "item_map").
+		Int("template_count", len(candidateIDs)).
+		Msg("goods template candidates loaded")
 
-	itemMap := GetItemMap()
-	goods := make([]goodsCandidate, 0, len(templates))
-	for _, tpl := range templates {
-		id := BuildIDFromTemplatePath(tpl.templatePath)
-		if boundIDs[id] {
-			continue
-		}
+	goods := make([]goodsCandidate, 0, len(candidateIDs))
+	for _, id := range candidateIDs {
+		templatePath := BuildTemplatePath(id)
 
-		detail, recErr := runGoodsTemplateMatch(ctx, arg.Img, tpl.templatePath, goodsROI)
+		detail, recErr := runGoodsTemplateMatch(ctx, arg.Img, templatePath, goodsROI)
 		if recErr != nil {
 			log.Warn().
 				Err(recErr).
 				Str("component", autoStockpileComponent).
-				Str("template", tpl.templatePath).
+				Str("template", templatePath).
 				Msg("template match failed")
 			continue
 		}
@@ -219,15 +212,8 @@ func (r *ItemValueChangeRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogn
 			continue
 		}
 
-		itemName := tpl.name
-		if name, ok := itemMap.IDToName[id]; ok {
-			itemName = name
-		}
-
+		itemName := itemMap.IDToName[id]
 		tier := ParseTierFromID(id)
-		if tier == "" {
-			tier = tpl.tier
-		}
 
 		goods = append(goods, goodsCandidate{
 			item: GoodsItem{
@@ -314,6 +300,47 @@ func (r *ItemValueChangeRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogn
 		Box:    arg.Roi,
 		Detail: string(resultDetail),
 	}, len(resultGoods) > 0
+}
+
+func validateItemMap(itemMap *ItemMap) error {
+	if itemMap == nil {
+		return fmt.Errorf("item_map is nil")
+	}
+	if len(itemMap.NameToID) == 0 {
+		return fmt.Errorf("item_map name_to_id is empty")
+	}
+	if len(itemMap.IDToName) == 0 {
+		return fmt.Errorf("item_map id_to_name is empty")
+	}
+	return nil
+}
+
+func itemMapCounts(itemMap *ItemMap) (nameCount int, idCount int) {
+	if itemMap == nil {
+		return 0, 0
+	}
+	return len(itemMap.NameToID), len(itemMap.IDToName)
+}
+
+func listUnboundRegionItemIDs(itemMap *ItemMap, region string, boundIDs map[string]bool) []string {
+	if itemMap == nil || len(itemMap.IDToName) == 0 {
+		return nil
+	}
+
+	prefix := region + "/"
+	ids := make([]string, 0, len(itemMap.IDToName))
+	for id := range itemMap.IDToName {
+		if !strings.HasPrefix(id, prefix) {
+			continue
+		}
+		if boundIDs[id] {
+			continue
+		}
+		ids = append(ids, id)
+	}
+
+	sort.Strings(ids)
+	return ids
 }
 
 // TODO: 当前 ColorMatch 溢出识别不够准确，需要改进。
@@ -480,78 +507,6 @@ func resolveGoodsRegion(ctx *maa.Context) (region string, anchor string) {
 			Msg("unexpected anchor value, fallback to Wuling")
 		return "Wuling", anchor
 	}
-}
-
-func listGoodsTemplates(region string) ([]goodsTemplate, string, error) {
-	baseParts := []string{"assets", "resource", "image", "AutoStockpile", "Goods", region}
-	pathCandidates := []string{
-		filepath.Join(baseParts...),
-		filepath.Join("..", "..", filepath.Join(baseParts...)),
-		filepath.Join("..", filepath.Join(baseParts...)),
-	}
-
-	var lastErr error
-	for _, goodsDir := range pathCandidates {
-		entries, err := os.ReadDir(goodsDir)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-
-		templates := make([]goodsTemplate, 0, len(entries))
-		for _, entry := range entries {
-			if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".png") {
-				continue
-			}
-
-			name, tier, ok := parseGoodsFileName(entry.Name(), region)
-			if !ok {
-				log.Warn().
-					Str("component", autoStockpileComponent).
-					Str("filename", entry.Name()).
-					Msg("invalid goods filename format, skip")
-				continue
-			}
-
-			templates = append(templates, goodsTemplate{
-				name:         name,
-				tier:         tier,
-				templatePath: filepath.ToSlash(filepath.Join("AutoStockpile", "Goods", region, entry.Name())),
-			})
-		}
-
-		sort.Slice(templates, func(i, j int) bool {
-			return templates[i].templatePath < templates[j].templatePath
-		})
-
-		return templates, goodsDir, nil
-	}
-
-	if lastErr == nil {
-		lastErr = fmt.Errorf("no valid goods directory found for region %s", region)
-	}
-	return nil, "", lastErr
-}
-
-func parseGoodsFileName(filename, region string) (name string, tier string, ok bool) {
-	parts := strings.Split(filename, ".")
-	if len(parts) < 3 {
-		return "", "", false
-	}
-
-	name = parts[0]
-	tierPart := parts[1]
-	tierLevel := strings.TrimPrefix(tierPart, "Tier")
-	if tierLevel == "" || tierLevel == tierPart {
-		return "", "", false
-	}
-
-	if _, err := strconv.Atoi(tierLevel); err != nil {
-		return "", "", false
-	}
-
-	tier = region + "Tier" + tierLevel
-	return name, tier, true
 }
 
 func runGoodsTemplateMatch(ctx *maa.Context, img image.Image, templatePath string, goodsROI []int) (*maa.RecognitionDetail, error) {
@@ -746,7 +701,7 @@ func recognitionParamROI(node *maa.Node) ([]int, error) {
 	return []int{rect[0], rect[1], rect[2], rect[3]}, nil
 }
 
-func runGoodsOCR(ctx *maa.Context, img image.Image, goodsROI []int) ([]priceCandidate, []ocrNameCandidate, error) {
+func runGoodsOCR(ctx *maa.Context, img image.Image, goodsROI []int, itemMap *ItemMap) ([]priceCandidate, []ocrNameCandidate, error) {
 	config := map[string]any{
 		goodsPriceNodeName: map[string]any{
 			"recognition": "OCR",
@@ -769,7 +724,6 @@ func runGoodsOCR(ctx *maa.Context, img image.Image, goodsROI []int) ([]priceCand
 	ocrNames := make([]ocrNameCandidate, 0, len(results))
 	seenPrice := make(map[string]struct{}, len(results))
 	seenName := make(map[string]struct{}, len(results))
-	itemMap := GetItemMap()
 	for _, result := range results {
 		ocrResult, ok := result.AsOCR()
 		if !ok {
@@ -933,13 +887,6 @@ func bindPriceToOCRGoods(goods ocrNameCandidate, prices []priceCandidate, used [
 		Msg("price bound to goods")
 
 	return prices[bestIdx].value, true
-}
-
-// BuildIDFromTemplatePath 根据模板路径构造商品 ID。
-func BuildIDFromTemplatePath(templatePath string) string {
-	trimmed := strings.TrimPrefix(templatePath, "AutoStockpile/Goods/")
-	trimmed = strings.TrimSuffix(trimmed, ".png")
-	return trimmed
 }
 
 func extractOCRTexts(detail *maa.RecognitionDetail) []string {

--- a/agent/go-service/autostockpile/recognition.go
+++ b/agent/go-service/autostockpile/recognition.go
@@ -299,7 +299,7 @@ func (r *ItemValueChangeRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogn
 	return &maa.CustomRecognitionResult{
 		Box:    arg.Roi,
 		Detail: string(resultDetail),
-	}, len(resultGoods) > 0
+	}, true
 }
 
 func validateItemMap(itemMap *ItemMap) error {

--- a/agent/go-service/autostockpile/selector.go
+++ b/agent/go-service/autostockpile/selector.go
@@ -10,7 +10,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const swipeMaxNodeName = "AutoStockpileSwipeMax"
+const (
+	swipeMaxNodeName    = "AutoStockpileSwipeMax"
+	noCandidateNodeName = "AutoStockpileNoCandidate"
+)
 
 type candidateGoods struct {
 	goods     GoodsItem
@@ -80,6 +83,23 @@ func (a *SelectItemAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			Str("reason", selection.Reason).
 			Msg("no qualifying product selected")
 		maafocus.NodeActionStarting(ctx, fmt.Sprintf("未找到符合条件的物资 (原因: %s)", selection.Reason))
+		if err := ctx.OverridePipeline(buildNoCandidateResetOverride()); err != nil {
+			log.Error().
+				Err(err).
+				Str("component", "autostockpile").
+				Str("node", selectedGoodsClickNodeName+","+swipeMaxNodeName+","+swipeSpecificQuantityNodeName).
+				Msg("failed to reset no-candidate pipeline state")
+			return false
+		}
+		if err := ctx.OverrideNext(arg.CurrentTaskName, buildNoCandidateNextItems()); err != nil {
+			log.Error().
+				Err(err).
+				Str("component", "autostockpile").
+				Str("node", arg.CurrentTaskName).
+				Str("next", noCandidateNodeName).
+				Msg("failed to override next for no-candidate branch")
+			return false
+		}
 		return true
 	}
 
@@ -206,6 +226,24 @@ func resolveSwipeEnable(selection SelectionResult, result RecognitionResult, cfg
 		return true, false, true
 	}
 	return true, true, false
+}
+
+func buildNoCandidateResetOverride() map[string]any {
+	return map[string]any{
+		selectedGoodsClickNodeName: map[string]any{
+			"enabled": false,
+		},
+		swipeMaxNodeName: map[string]any{
+			"enabled": false,
+		},
+		swipeSpecificQuantityNodeName: map[string]any{
+			"enabled": false,
+		},
+	}
+}
+
+func buildNoCandidateNextItems() []maa.NextItem {
+	return []maa.NextItem{{Name: noCandidateNodeName}}
 }
 
 func formatSelectionMode(selection SelectionResult, result RecognitionResult, cfg SelectionConfig) string {

--- a/agent/go-service/quantizedsliding/handlers.go
+++ b/agent/go-service/quantizedsliding/handlers.go
@@ -2,6 +2,7 @@ package quantizedsliding
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
@@ -183,7 +184,11 @@ func (a *QuantizedSlidingAction) handleFindStart(_ *maa.Context, arg *maa.Custom
 	return true
 }
 
-func (a *QuantizedSlidingAction) handleGetMaxQuantity(_ *maa.Context, arg *maa.CustomActionArg) bool {
+func (a *QuantizedSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	if ctx == nil {
+		a.logger.Error().Msg("context is nil")
+		return false
+	}
 	if arg == nil {
 		a.logger.Error().Msg("custom action arg is nil")
 		return false
@@ -196,12 +201,40 @@ func (a *QuantizedSlidingAction) handleGetMaxQuantity(_ *maa.Context, arg *maa.C
 	}
 
 	a.maxQuantity = maxQuantity
-	if a.maxQuantity < a.Target {
+	nextNode, err := resolveMaxQuantityNext(a.maxQuantity, a.Target)
+	if err != nil {
 		a.logger.Error().
 			Int("max_quantity", a.maxQuantity).
 			Int("target", a.Target).
 			Msg("max quantity lower than target")
 		return false
+	}
+	if nextNode != "" {
+		if err := ctx.OverridePipeline(buildCheckQuantityBranchOverride(nextNode, buttonTarget{}, 0)); err != nil {
+			a.logger.Error().
+				Err(err).
+				Int("max_quantity", a.maxQuantity).
+				Int("target", a.Target).
+				Str("next", nextNode).
+				Msg("failed to override direct-done branch")
+			return false
+		}
+		if err := ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: nextNode}}); err != nil {
+			a.logger.Error().
+				Err(err).
+				Int("max_quantity", a.maxQuantity).
+				Int("target", a.Target).
+				Str("next", nextNode).
+				Msg("failed to override next for direct-done branch")
+			return false
+		}
+
+		a.logger.Info().
+			Int("max_quantity", a.maxQuantity).
+			Int("target", a.Target).
+			Str("next", nextNode).
+			Msg("max quantity already satisfies target, branch to done")
+		return true
 	}
 
 	a.logger.Info().
@@ -220,7 +253,7 @@ func (a *QuantizedSlidingAction) handleFindEnd(ctx *maa.Context, arg *maa.Custom
 		a.logger.Error().Msg("recognition detail is nil")
 		return false
 	}
-	if a.maxQuantity <= 1 {
+	if a.maxQuantity < 1 {
 		a.logger.Error().
 			Int("max_quantity", a.maxQuantity).
 			Msg("invalid max quantity for precise click calculation")
@@ -448,4 +481,15 @@ func (a *QuantizedSlidingAction) resetState() {
 	a.startBox = nil
 	a.endBox = nil
 	a.maxQuantity = 0
+}
+
+func resolveMaxQuantityNext(maxQuantity int, target int) (string, error) {
+	if maxQuantity < target {
+		return "", fmt.Errorf("max quantity %d lower than target %d", maxQuantity, target)
+	}
+	if maxQuantity == 1 && target == 1 {
+		return "QuantizedSlidingDone", nil
+	}
+
+	return "", nil
 }

--- a/agent/go-service/quantizedsliding/ocr.go
+++ b/agent/go-service/quantizedsliding/ocr.go
@@ -3,6 +3,7 @@ package quantizedsliding
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -104,25 +105,13 @@ func extractOCRTextFromResults(results *maa.RecognitionResults) string {
 		return ""
 	}
 
-	for _, group := range [][]*maa.RecognitionResult{{results.Best}, results.Filtered, results.All} {
-		for _, result := range group {
-			if result == nil {
-				continue
-			}
-
-			ocrResult, ok := result.AsOCR()
-			if !ok {
-				continue
-			}
-
-			text := strings.TrimSpace(ocrResult.Text)
-			if text != "" {
-				return text
-			}
-		}
+	candidates := []ocrCandidate{
+		buildOCRCandidate([]*maa.RecognitionResult{results.Best}, 0),
+		buildOCRCandidate(results.Filtered, 1),
+		buildOCRCandidate(results.All, 2),
 	}
 
-	return ""
+	return selectOCRCandidate(candidates).text
 }
 
 func extractOCRTextFromDetailJSON(detailJSON string) string {
@@ -200,4 +189,134 @@ func extractOCRTextFromRawJSON(raw json.RawMessage) string {
 	}
 
 	return extractOCRTextFromDetailJSON(string(raw))
+}
+
+type ocrFragment struct {
+	text string
+	x    int
+	y    int
+	w    int
+	h    int
+}
+
+type ocrCandidate struct {
+	text          string
+	digitCount    int
+	fragmentCount int
+	priority      int
+}
+
+func buildOCRCandidate(results []*maa.RecognitionResult, priority int) ocrCandidate {
+	fragments := collectOCRFragments(results)
+	text := aggregateOCRFragments(fragments)
+
+	return ocrCandidate{
+		text:          text,
+		digitCount:    countDigits(text),
+		fragmentCount: len(fragments),
+		priority:      priority,
+	}
+}
+
+func collectOCRFragments(results []*maa.RecognitionResult) []ocrFragment {
+	fragments := make([]ocrFragment, 0, len(results))
+	for _, result := range results {
+		if result == nil {
+			continue
+		}
+
+		ocrResult, ok := result.AsOCR()
+		if !ok {
+			continue
+		}
+
+		text := strings.TrimSpace(ocrResult.Text)
+		if text == "" {
+			continue
+		}
+
+		fragments = append(fragments, ocrFragment{
+			text: text,
+			x:    ocrResult.Box.X(),
+			y:    ocrResult.Box.Y(),
+			w:    ocrResult.Box.Width(),
+			h:    ocrResult.Box.Height(),
+		})
+	}
+
+	return fragments
+}
+
+func selectOCRCandidate(candidates []ocrCandidate) ocrCandidate {
+	best := ocrCandidate{}
+	found := false
+	for _, candidate := range candidates {
+		if candidate.text == "" {
+			continue
+		}
+		if !found || betterOCRCandidate(candidate, best) {
+			best = candidate
+			found = true
+		}
+	}
+
+	return best
+}
+
+func betterOCRCandidate(candidate ocrCandidate, current ocrCandidate) bool {
+	if candidate.digitCount != current.digitCount {
+		return candidate.digitCount > current.digitCount
+	}
+	if candidate.fragmentCount != current.fragmentCount {
+		return candidate.fragmentCount < current.fragmentCount
+	}
+
+	return candidate.priority < current.priority
+}
+
+func countDigits(text string) int {
+	count := 0
+	for _, r := range text {
+		if r >= '0' && r <= '9' {
+			count++
+		}
+	}
+
+	return count
+}
+
+func aggregateOCRFragments(fragments []ocrFragment) string {
+	if len(fragments) == 0 {
+		return ""
+	}
+
+	unique := make([]ocrFragment, 0, len(fragments))
+	seen := make(map[string]struct{}, len(fragments))
+	for _, fragment := range fragments {
+		fragment.text = strings.TrimSpace(fragment.text)
+		if fragment.text == "" {
+			continue
+		}
+
+		key := fmt.Sprintf("%d:%d:%d:%d:%s", fragment.x, fragment.y, fragment.w, fragment.h, fragment.text)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, fragment)
+	}
+
+	sort.SliceStable(unique, func(i, j int) bool {
+		if unique[i].y != unique[j].y {
+			return unique[i].y < unique[j].y
+		}
+		return unique[i].x < unique[j].x
+	})
+
+	var builder strings.Builder
+	for _, fragment := range unique {
+		builder.WriteString(fragment.text)
+	}
+
+	return builder.String()
 }

--- a/agent/go-service/quantizedsliding/ocr.go
+++ b/agent/go-service/quantizedsliding/ocr.go
@@ -207,13 +207,17 @@ type ocrCandidate struct {
 }
 
 func buildOCRCandidate(results []*maa.RecognitionResult, priority int) ocrCandidate {
-	fragments := collectOCRFragments(results)
-	text := aggregateOCRFragments(fragments)
+	return buildOCRCandidateFromFragments(collectOCRFragments(results), priority)
+}
+
+func buildOCRCandidateFromFragments(fragments []ocrFragment, priority int) ocrCandidate {
+	uniqueFragments := uniqueOCRFragments(fragments)
+	text := joinOCRFragments(uniqueFragments)
 
 	return ocrCandidate{
 		text:          text,
 		digitCount:    countDigits(text),
-		fragmentCount: len(fragments),
+		fragmentCount: len(uniqueFragments),
 		priority:      priority,
 	}
 }
@@ -286,8 +290,12 @@ func countDigits(text string) int {
 }
 
 func aggregateOCRFragments(fragments []ocrFragment) string {
+	return joinOCRFragments(uniqueOCRFragments(fragments))
+}
+
+func uniqueOCRFragments(fragments []ocrFragment) []ocrFragment {
 	if len(fragments) == 0 {
-		return ""
+		return nil
 	}
 
 	unique := make([]ocrFragment, 0, len(fragments))
@@ -313,8 +321,16 @@ func aggregateOCRFragments(fragments []ocrFragment) string {
 		return unique[i].x < unique[j].x
 	})
 
+	return unique
+}
+
+func joinOCRFragments(fragments []ocrFragment) string {
+	if len(fragments) == 0 {
+		return ""
+	}
+
 	var builder strings.Builder
-	for _, fragment := range unique {
+	for _, fragment := range fragments {
 		builder.WriteString(fragment.text)
 	}
 

--- a/assets/resource/pipeline/AutoStockpile/Task.json
+++ b/assets/resource/pipeline/AutoStockpile/Task.json
@@ -96,7 +96,7 @@
         ]
     },
     "AutoStockpileGotoElasticGoods": {
-        "desc": "选择弹性物资调度",
+        "desc": "选择弹性物资调度，需要优化",
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -118,14 +118,7 @@
         "pre_delay": 0,
         "action": {
             "type": "Click",
-            "param": {
-                "target_offset": [
-                    20,
-                    0,
-                    -10,
-                    0
-                ]
-            }
+            "param": {}
         },
         "post_wait_freezes": 200,
         "post_delay": 0,

--- a/assets/tasks/AutoStockpile.json
+++ b/assets/tasks/AutoStockpile.json
@@ -5,6 +5,11 @@
             "label": "$task.AutoStockpile.label",
             "entry": "AutoStockpileMain",
             "description": "$task.AutoStockpile.description",
+            "controller": [
+                "Win32-Window",
+                "Win32-Window-Background",
+                "Win32-Front"
+            ],
             "group": ["daily"],
             "option": [
                 "AutoStockpileOverflowBuyLowPriceGoods",

--- a/docs/en_us/developers/quantized-sliding.md
+++ b/docs/en_us/developers/quantized-sliding.md
@@ -114,10 +114,13 @@ Pass `custom_action_param` as a JSON object directly.
 
 `QuantityFilter` is an **optional enhancement**. If omitted, `QuantizedSliding` behaves exactly like the current version. If provided, OCR for `QuantizedSlidingGetQuantity` first applies color filtering and then reads the digits.
 
+Important: the current implementation first concatenates OCR fragments from the same pass in positional order, then extracts **all digit characters** from the combined text and converts them to an integer. If `QuantityBox` includes unrelated numbers, those digits may also be merged into the final parsed value. One main purpose of `QuantityFilter` is to keep only the actual quantity visible before OCR runs.
+
 It is a good fit when:
 
 - the digit color itself is stable;
 - the background, outline, shadow, or nearby numbers introduce OCR noise;
+- `QuantityBox` is already hard to tighten further, but color still separates the target digits from the interference;
 - `QuantityBox` is already correct, but OCR needs one more preprocessing step.
 
 Minimal example:
@@ -135,6 +138,8 @@ Constraints and limits:
 - `lower` and `upper` must both be present and must have the same length;
 - use the common `ColorMatch` methods already used in this repo: `4` (RGB), `40` (HSV), or `6` (GRAY);
 - only a **single** color range is supported for now; `[[...], [...]]` multi-range input is not supported;
+- you can treat it as an approximate color-based binarization step for the quantity area before OCR;
+- if the interfering digits use exactly the same color as the target digits, `QuantityFilter` cannot fundamentally separate them, so tightening `QuantityBox` is still the first choice;
 - `QuantityFilter` improves OCR preprocessing, but it is not a substitute for an inaccurate `QuantityBox`.
 
 ### `IncreaseButton` / `DecreaseButton` formats
@@ -245,6 +250,7 @@ That means:
 - If OCR frequently misreads digits as letters, the whole action will fail.
 
 So `QuantityBox` must not only “read digits,” but should also avoid including unrelated numeric groups whenever possible.
+If screen constraints make `QuantityBox` difficult to shrink further, but the target digits have a stable color, combine it with `QuantityFilter` to suppress the background or nearby interfering digits before OCR.
 
 ### 4. Choose how to locate the buttons
 

--- a/docs/zh_cn/developers/quantized-sliding.md
+++ b/docs/zh_cn/developers/quantized-sliding.md
@@ -112,10 +112,13 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 `QuantityFilter` 是一个**可选增强项**。不传时，`QuantizedSliding` 的行为与旧版本一致；传入后，会先对 `QuantizedSlidingGetQuantity` 的 OCR 结果做颜色过滤，再识别数字。
 
+需要注意：当前实现会先按位置顺序拼接同一轮 OCR 命中的文本片段，再从中提取**全部数字字符**转成整数。因此，如果 `QuantityBox` 里混入了其他数字，它们也可能被一起拼进最终结果。`QuantityFilter` 的一个核心用途，就是在 OCR 前尽量只保留目标数量本身。
+
 它适合这类场景：
 
 - 数字本身颜色稳定；
 - 背景、描边、阴影或其他数字干扰较多；
+- `QuantityBox` 已经不太方便继续缩小，但还能通过颜色把目标数字和干扰数字拉开；
 - `QuantityBox` 本身已经框准，只是 OCR 前缺少一层颜色筛选。
 
 最小示例：
@@ -133,6 +136,8 @@ clickY = startY + (endY - startY) * numerator / denominator
 - `lower` / `upper` 必须同时存在，且长度一致；
 - 当前建议使用仓库内已有的常见 `ColorMatch` 模式：`4`（RGB）、`40`（HSV）或 `6`（GRAY）；
 - 当前仅支持**单组**颜色阈值，不支持 `[[...], [...]]` 这种多段范围；
+- 可以把它理解为对数量区域先做一次按颜色的“近似二值化”，尽量只留下目标数字再交给 OCR；
+- 如果干扰数字和目标数字颜色完全一致，`QuantityFilter` 也无法从根本上区分，这时仍应优先收紧 `QuantityBox`；
 - `QuantityFilter` 只是增强 OCR 预处理，不是 `QuantityBox` 选区不准时的替代品。
 
 ### `IncreaseButton` / `DecreaseButton` 的写法
@@ -235,6 +240,7 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 - 如果 OCR 容易把数字识别成字母，整个动作就会失败。
 
 所以 `QuantityBox` 不仅要“能读到数字”，还要尽量避免把其他数字组一起框进去。
+如果画面限制导致 `QuantityBox` 无法再继续缩小，但目标数字颜色足够稳定，可以再配合 `QuantityFilter` 做颜色过滤，先压掉背景或旁边的干扰数字。
 
 ### 4. 选择按钮定位方式
 


### PR DESCRIPTION
## 主要问题修复

 - 移除go侧扫描目录，改为从item_map中读取

close #1391

## 优化

 - 移除弹性物资调度点击偏移
 - 明确不支持ADB控制器
 - 使用QuantityFilter提高购买数量识别成功率

## Summary by Sourcery

将 AutoStockpile 的物品识别从基于文件系统的模板扫描切换为使用内存中的物品映射（item map），并改进量化滑动和自动存储（autostockpile）流水线中的数量 OCR 和控制流。

Bug Fixes（错误修复）:
- 确保 AutoStockpile 识别使用 `item_map` 元数据，而不是扫描货物图片目录，从而防止在模板不可读时发生失败。
- 修复量化滑动的最大数量处理逻辑，使在目标数量已满足时流程能够正确短路，并避免无效的精确点击计算。
- 阻止 AutoStockpile 在未找到符合条件的货物候选项时重用滑动/点击节点，避免造成流水线状态不一致。

Enhancements（增强改进）:
- 在 AutoStockpile 识别运行前，验证并记录 `item_map` 的可用性，并直接从中推导未绑定区域的物品 ID 用于模板匹配。
- 优化量化滑动中的 OCR 结果聚合方式，通过对片段分组进行排序并拼接位置片段，从而提高数字提取的可靠性。
- 扩展 QuantizedSliding 英文和中文文档，更清晰地说明 QuantityFilter 的行为、局限性，以及与 QuantityBox 结合使用的推荐方式。

Documentation（文档）:
- 在英文和中文开发者文档中进一步阐明 QuantityFilter 如何组合 OCR 片段、它与 QuantityBox 的分工以及在干扰数字与目标数字颜色相同时的局限性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch AutoStockpile item recognition from filesystem-based template scanning to the in-memory item map, and improve quantity OCR and control flow in the quantized sliding and autostockpile pipelines.

Bug Fixes:
- Ensure AutoStockpile recognition uses item_map metadata instead of scanning goods image directories, preventing failures when templates are not readable.
- Fix quantized sliding max-quantity handling so flows short-circuit correctly when target quantity is already satisfied and avoid invalid precise click calculations.
- Prevent AutoStockpile from reusing swipe/click nodes when no qualifying goods candidate is found, avoiding inconsistent pipeline state.

Enhancements:
- Validate and log item_map availability before AutoStockpile recognition runs, and derive unbound region item IDs directly from it for template matching.
- Refine OCR result aggregation in quantized sliding by ranking fragment groups and concatenating positional fragments, improving numeric extraction reliability.
- Extend QuantizedSliding documentation in both English and Chinese to clarify QuantityFilter behavior, limitations, and recommended usage with QuantityBox.

Documentation:
- Clarify in English and Chinese developer docs how QuantityFilter combines OCR fragments, its role alongside QuantityBox, and its limitations when interfering digits share the same color as target digits.

</details>