### PR TITLE
feat:协议空间增加队伍选择

### DIFF
--- a/assets/misc/locales/en_us.json
+++ b/assets/misc/locales/en_us.json
@@ -180,6 +180,8 @@
     "option.ProtocolSpaceSuccessCount.label": "Max action success count",
     "option.ProtocolSpaceFailedCount.label": "Max action failure count",
     "option.ProtocolSpaceCountUnlimited.label": "Unlimited",
+    "option.ProtocolSpaceTeamChoose.label": "Select Team",
+    "option.ProtocolSpaceTeamChoose.case.ProtocolSpaceTeamChooseDefault.label": "Default",
     "option.RewardsSetOption.label": "Optional Reward Set",
     "option.OperatorProgression.label": "Operator Progression",
     "option.OperatorProgression.OperatorEXP.label": "Operator Experience",

--- a/assets/misc/locales/ja_jp.json
+++ b/assets/misc/locales/ja_jp.json
@@ -302,6 +302,8 @@
     "option.ProtocolSpaceSuccessCount.label": "行動成功回数上限",
     "option.ProtocolSpaceFailedCount.label": "行動失敗回数上限",
     "option.ProtocolSpaceCountUnlimited.label": "無制限",
+    "option.ProtocolSpaceTeamChoose.label": "チーム選択",
+    "option.ProtocolSpaceTeamChoose.case.ProtocolSpaceTeamChooseDefault.label": "デフォルト",
     "option.RewardsSetOption.label": "選択可能報酬セット",
     "option.OperatorProgression.label": "オペレーター育成",
     "option.OperatorProgression.OperatorEXP.label": "オペレーター経験",

--- a/assets/misc/locales/ko_kr.json
+++ b/assets/misc/locales/ko_kr.json
@@ -406,6 +406,8 @@
     "option.ProtocolSpaceSuccessCount.label": "행동 성공 횟수 상한",
     "option.ProtocolSpaceFailedCount.label": "행동 실패 횟수 상한",
     "option.ProtocolSpaceCountUnlimited.label": "무제한",
+    "option.ProtocolSpaceTeamChoose.label": "팀 선택",
+    "option.ProtocolSpaceTeamChoose.case.ProtocolSpaceTeamChooseDefault.label": "기본값",
     "option.RewardsSetOption.label": "선택 보상 세트",
     "option.OperatorProgression.label": "오퍼레이터 육성",
     "option.OperatorProgression.OperatorEXP.label": "오퍼레이터 경험",

--- a/assets/misc/locales/zh_cn.json
+++ b/assets/misc/locales/zh_cn.json
@@ -406,6 +406,8 @@
     "option.ProtocolSpaceSuccessCount.label": "行动成功次数上限",
     "option.ProtocolSpaceFailedCount.label": "行动失败次数上限",
     "option.ProtocolSpaceCountUnlimited.label": "无限制",
+    "option.ProtocolSpaceTeamChoose.label": "选择队伍",
+    "option.ProtocolSpaceTeamChoose.case.ProtocolSpaceTeamChooseDefault.label": "默认",
     "option.RewardsSetOption.label": "可选奖励组",
     "option.OperatorProgression.label": "干员养成",
     "option.OperatorProgression.OperatorEXP.label": "干员经验",

--- a/assets/misc/locales/zh_tw.json
+++ b/assets/misc/locales/zh_tw.json
@@ -434,6 +434,8 @@
     "option.ProtocolSpaceSuccessCount.label": "行動成功次數上限",
     "option.ProtocolSpaceFailedCount.label": "行動失敗次數上限",
     "option.ProtocolSpaceCountUnlimited.label": "無限制",
+    "option.ProtocolSpaceTeamChoose.label": "選擇隊伍",
+    "option.ProtocolSpaceTeamChoose.case.ProtocolSpaceTeamChooseDefault.label": "預設",
     "option.RewardsSetOption.label": "可選獎勵組",
     "option.OperatorProgression.label": "幹員養成",
     "option.OperatorProgression.OperatorEXP.label": "幹員經驗",

--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -22,11 +22,60 @@
         "action": "Click",
         "post_wait_freezes": 500,
         "next": [
+            "[JumpBack]ProtocolSpaceTeamChoose",
             "ProtocolSpacePopupSanityLow",
             "ProtocolSpaceEnterSpaceConfirm"
         ],
         "focus": {
             "Node.Action.Succeeded": "进入协议空间"
+        }
+    },
+    "ProtocolSpaceTeamChooseTextRecognition": {
+        "desc": "识别协议空间队伍",
+        "recognition": "OCR",
+        "roi": [
+            0,
+            -60,
+            500,
+            35
+        ],
+        "expected": [
+            "01"
+        ]
+    },
+    "ProtocolSpaceTeamChoose": {
+        "desc": "选择协议空间队伍",
+        "recognition": "And",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "all_of": [
+            "ProtocolSpaceTeamChooseTextRecognition",
+            {
+                "recognition": "ColorMatch",
+                "roi": "ProtocolSpaceTeamChooseTextRecognition",
+                "roi_offset": [
+                    -30,
+                    0,
+                    10,
+                    0
+                ],
+                "lower": [
+                    30,
+                    30,
+                    30
+                ],
+                "upper": [
+                    45,
+                    45,
+                    45
+                ],
+                "connected": true
+            }
+        ],
+        "action": "Click",
+        "post_wait_freezes": 200,
+        "focus": {
+            "Node.Action.Succeeded": "选择队伍"
         }
     },
     "ProtocolSpacePopupSanityLow": {

--- a/assets/tasks/ProtocolSpace.json
+++ b/assets/tasks/ProtocolSpace.json
@@ -83,7 +83,7 @@
                     "name": "ProtocolSpaceTeamChoose05",
                     "label": "05",
                     "pipeline_override": {
-                        "ProtocolSpaceTeamChoose": {
+                        "ProtocolSpaceTeamChooseTextRecognition": {
                             "expected": [
                                 "05"
                             ]

--- a/assets/tasks/ProtocolSpace.json
+++ b/assets/tasks/ProtocolSpace.json
@@ -6,6 +6,7 @@
             "entry": "ProtocolSpaceEntry",
             "description": "$task.ProtocolSpace.description",
             "option": [
+                "ProtocolSpaceTeamChoose",
                 "ProtocolSpaceSuccessCount",
                 "ProtocolSpaceFailedCount",
                 "ProtocolSpaceUsePermit",
@@ -14,10 +15,83 @@
             "controller": [
                 "Win32-Front"
             ],
-            "group": ["foreground"]
+            "group": [
+                "foreground"
+            ]
         }
     ],
     "option": {
+        "ProtocolSpaceTeamChoose": {
+            "type": "select",
+            "label": "$option.ProtocolSpaceTeamChoose.label",
+            "default_case": "ProtocolSpaceTeamChooseDefault",
+            "cases": [
+                {
+                    "name": "ProtocolSpaceTeamChooseDefault",
+                    "label": "$option.ProtocolSpaceTeamChoose.case.ProtocolSpaceTeamChooseDefault.label",
+                    "pipeline_override": {
+                        "ProtocolSpaceTeamChoose": {
+                            "disabled": true
+                        }
+                    }
+                },
+                {
+                    "name": "ProtocolSpaceTeamChoose01",
+                    "label": "01",
+                    "pipeline_override": {
+                        "ProtocolSpaceTeamChooseTextRecognition": {
+                            "expected": [
+                                "01"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "ProtocolSpaceTeamChoose02",
+                    "label": "02",
+                    "pipeline_override": {
+                        "ProtocolSpaceTeamChooseTextRecognition": {
+                            "expected": [
+                                "02"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "ProtocolSpaceTeamChoose03",
+                    "label": "03",
+                    "pipeline_override": {
+                        "ProtocolSpaceTeamChooseTextRecognition": {
+                            "expected": [
+                                "03"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "ProtocolSpaceTeamChoose04",
+                    "label": "04",
+                    "pipeline_override": {
+                        "ProtocolSpaceTeamChooseTextRecognition": {
+                            "expected": [
+                                "04"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "ProtocolSpaceTeamChoose05",
+                    "label": "05",
+                    "pipeline_override": {
+                        "ProtocolSpaceTeamChoose": {
+                            "expected": [
+                                "05"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
         "ProtocolSpaceSuccessCount": {
             "type": "select",
             "label": "$option.ProtocolSpaceSuccessCount.label",

--- a/assets/tasks/ProtocolSpace.json
+++ b/assets/tasks/ProtocolSpace.json
@@ -31,7 +31,7 @@
                     "label": "$option.ProtocolSpaceTeamChoose.case.ProtocolSpaceTeamChooseDefault.label",
                     "pipeline_override": {
                         "ProtocolSpaceTeamChoose": {
-                            "disabled": true
+                            "enabled": false
                         }
                     }
                 },


### PR DESCRIPTION
fix #1376

## Summary by Sourcery

为 ProtocolSpace 流程新增团队选择支持，并更新相关资源和本地化字符串。

新功能：
- 在 ProtocolSpace 场景中引入团队选择功能。

增强改进：
- 更新 ProtocolSpace 的流水线和任务配置以支持团队选择。
- 刷新 ProtocolSpace 的本地化资源，在所有支持的语言中加入与团队选择相关的字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add team selection support to the ProtocolSpace flow and update related resources and localization strings.

New Features:
- Introduce team selection capability within the ProtocolSpace scenario.

Enhancements:
- Update ProtocolSpace pipeline and task configuration to support team selection.
- Refresh localization resources for ProtocolSpace to include strings related to team selection across supported languages.

</details>