### PR TITLE
fix: 修复尾扫和跳过冲突的问题

### DIFF
--- a/agent/go-service/essencefilter/actions.go
+++ b/agent/go-service/essencefilter/actions.go
@@ -564,6 +564,7 @@ func (a *EssenceFilterRowCollectAction) Run(ctx *maa.Context, arg *maa.CustomAct
 	}
 
 	isFallbackScan := arg.CurrentTaskName == "EssenceDetectFinal"
+	st.InFinalScan = isFallbackScan
 	if isFallbackScan && !st.FinalLargeScanUsed {
 		st.FinalLargeScanUsed = true
 		ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: "EssenceDetectFinal"}})
@@ -593,13 +594,16 @@ func (a *EssenceFilterRowNextItemAction) Run(ctx *maa.Context, arg *maa.CustomAc
 	}
 	if st.PendingFinalScan {
 		st.PendingFinalScan = false
+		// 尾扫后直接基于已收集的 RowBoxes 逐个处理，不再尝试 TryLastFirst/回 EssenceRowDetect
+		st.InFinalScan = true
+		st.TryLastFirst = false
 		log.Info().Str("component", "EssenceFilter").Str("action", "RowNextItem").Msg("补 swipe 完成，进入尾扫")
 		LogMXUSimpleHTML(ctx, "补 swipe 完成，进入尾扫")
 		ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: "EssenceDetectFinal"}})
 		return true
 	}
 	// Try-last-first: only when row is full (9). If total known and remaining this row < 9, skip and use normal logic.
-	if st.RowIndex == 0 && st.TryLastFirst && len(st.RowBoxes) > 0 {
+	if st.RowIndex == 0 && st.TryLastFirst && !st.InFinalScan && len(st.RowBoxes) > 0 {
 		remaining := st.TotalCount - st.MaxItemsPerRow*(st.CurrentRow-1)
 		if st.TotalCount > 0 && remaining < st.MaxItemsPerRow {
 			// partial row, do not try last first
@@ -650,12 +654,20 @@ func (a *EssenceFilterRowNextItemAction) Run(ctx *maa.Context, arg *maa.CustomAc
 				st.PendingFinalScan = true
 				LogMXUSimpleHTML(ctx, fmt.Sprintf("剩余 %d 个 ≤ %d，先补一次滑动再尾扫（总 %d，已 %d 行）", remaining, maxRemainingForFinalScan, st.TotalCount, rowsDone))
 			}
+			nextNode := "EssenceFilterSwipeNext"
 			if !st.FirstRowSwipeDone {
 				st.FirstRowSwipeDone = true
-				ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: "EssenceFilterSwipeFirst"}})
-			} else {
-				ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: "EssenceFilterSwipeNext"}})
+				nextNode = "EssenceFilterSwipeFirst"
 			}
+			// 最后一次补滑（remaining <= 45）不走校准：避免 SwipeCalibrate 识别失败导致流程中断
+			if st.PendingFinalScan {
+				if nextNode == "EssenceFilterSwipeFirst" {
+					nextNode = "EssenceFilterSwipeFirstNoCalibrate"
+				} else {
+					nextNode = "EssenceFilterSwipeNextNoCalibrate"
+				}
+			}
+			ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: nextNode}})
 			LogMXUSimpleHTML(ctx, fmt.Sprintf("滑动到第 %d 行", st.CurrentRow+1))
 			st.CurrentRow++
 			return true

--- a/agent/go-service/essencefilter/state.go
+++ b/agent/go-service/essencefilter/state.go
@@ -29,6 +29,7 @@ type RunState struct {
 	TotalCount          int // OCR 得到的库存总数，0 表示未知；用于计算剩余是否 <= 45 以决定是否尾扫
 	FirstRowSwipeDone   bool
 	FinalLargeScanUsed  bool
+	InFinalScan         bool // 当前 RowBoxes 来自 EssenceDetectFinal；尾扫后禁用 TryLastFirst 等“回头重扫行”逻辑
 	PendingFinalScan    bool // 剩余 ≤ 45 时先补一次 swipe，下次进 RowNextItem 再进尾扫
 	SwipeCalibrateRetry int
 
@@ -68,6 +69,7 @@ func (s *RunState) Reset() {
 	s.TotalCount = 0
 	s.FirstRowSwipeDone = false
 	s.FinalLargeScanUsed = false
+	s.InFinalScan = false
 	s.PendingFinalScan = false
 	s.SwipeCalibrateRetry = 0
 	s.CurrentSkills = [3]string{}

--- a/assets/resource/pipeline/EssenceFilter/Swipe.json
+++ b/assets/resource/pipeline/EssenceFilter/Swipe.json
@@ -45,6 +45,54 @@
             "EssenceFilterSwipeCalibrate"
         ]
     },
+    "EssenceFilterSwipeFirstNoCalibrate": {
+        "desc": "首行滑动（不校准，用于尾扫前最后一次补滑）",
+        "pre_delay": 0,
+        "action": {
+            "type": "Swipe",
+            "param": {
+                "begin": [
+                    135,
+                    191
+                ],
+                "end": [
+                    135,
+                    75
+                ],
+                "end_hold": 700,
+                "duration": 100
+            }
+        },
+        "post_delay": 200,
+        "next": [
+            "EssenceRowDetect",
+            "EssenceDetectFinal"
+        ]
+    },
+    "EssenceFilterSwipeNextNoCalibrate": {
+        "desc": "后续滑动（不校准，用于尾扫前最后一次补滑）",
+        "pre_delay": 0,
+        "action": {
+            "type": "Swipe",
+            "param": {
+                "begin": [
+                    135,
+                    191
+                ],
+                "end": [
+                    135,
+                    76
+                ],
+                "end_hold": 700,
+                "duration": 101
+            }
+        },
+        "post_delay": 200,
+        "next": [
+            "EssenceRowDetect",
+            "EssenceDetectFinal"
+        ]
+    },
     "EssenceFilterSwipeCalibrateCorrect": {
         "desc": "校准微滑（由 SwipeCalibrateAction 通过 RunTask override begin/end 调用）",
         "pre_delay": 0,


### PR DESCRIPTION
## Summary by Sourcery

调整 essence 过滤尾部扫描流程，以避免最终扫描与 skip/try-last-first 逻辑之间的冲突。

Bug 修复：
- 防止在最终（尾部）扫描期间运行 TryLastFirst 逻辑，避免重复处理行及由此产生的冲突。
- 确保状态能够正确跟踪管线处于最终扫描阶段，从而使后续的行导航行为保持一致。
- 在尾部扫描前的最后一次补偿滑动中避免进行滑动校准，以防止可能中断流程的失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust essence filtering tail-scan flow to avoid conflicts between final scans and skip/try-last-first logic.

Bug Fixes:
- Prevent TryLastFirst logic from running during final (tail) scans to avoid reprocessing rows and conflicts.
- Ensure state correctly tracks when the pipeline is in a final scan so subsequent row navigation behaves consistently.
- Avoid swipe calibration on the last compensating swipe before the tail scan to prevent failures that could interrupt the flow.

</details>