### PR TITLE
fix:修复在俯瞰模式下无法进入蓝图界面问题

### DIFF
--- a/assets/resource/pipeline/SceneManager/Region.json
+++ b/assets/resource/pipeline/SceneManager/Region.json
@@ -176,5 +176,44 @@
                 "threshold": 0.9
             }
         }
+    },
+    "InWorldFactory": {
+        "desc": "在大世界工厂模式界面",
+        "recognition": "Or",
+        "any_of": [
+            {
+                "recognition": "TemplateMatch",
+                "roi": [
+                    0,
+                    0,
+                    60,
+                    60
+                ],
+                "template": [
+                    "SceneManager/WorldFactoryActive.png"
+                ]
+            },
+            {
+                "recognition": "OCR",
+                "roi": [
+                    500,
+                    0,
+                    300,
+                    100
+                ],
+                "expected": [
+                    "进入俯瞰",
+                    "進入俯瞰",
+                    "見下ろし視点ON",
+                    "탑뷰 모드로 전환",
+                    "Enter Top View",
+                    "退出俯瞰",
+                    "關閉俯瞰",
+                    "見下ろし視点OFF",
+                    "탑뷰 모드 나가기",
+                    "Exit Top View"
+                ]
+            }
+        ]
     }
 }

--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -857,20 +857,10 @@
     },
     "__ScenePrivateWorldFactoryEnterMenuBluePrint": {
         "desc": "从大世界工厂模式进入蓝图菜单",
-        "recognition": {
-            "type": "TemplateMatch",
-            "param": {
-                "roi": [
-                    0,
-                    0,
-                    60,
-                    60
-                ],
-                "template": [
-                    "SceneManager/WorldFactoryActive.png"
-                ]
-            }
-        },
+        "recognition": "And",
+        "all_of": [
+            "InWorldFactory"
+        ],
         "action": {
             "type": "ClickKey",
             "param": {
@@ -892,20 +882,10 @@
     },
     "__ScenePrivateWorldFactoryEnterMenuGearAssembly": {
         "desc": "从大世界工厂模式进入装备加工界面",
-        "recognition": {
-            "type": "TemplateMatch",
-            "param": {
-                "roi": [
-                    0,
-                    0,
-                    60,
-                    60
-                ],
-                "template": [
-                    "SceneManager/WorldFactoryActive.png"
-                ]
-            }
-        },
+        "recognition": "And",
+        "all_of": [
+            "InWorldFactory"
+        ],
         "action": {
             "type": "ClickKey",
             "param": {

--- a/assets/resource/pipeline/SceneManager/SceneWorld.json
+++ b/assets/resource/pipeline/SceneManager/SceneWorld.json
@@ -197,20 +197,10 @@
     },
     "__ScenePrivateAnyEnterWorldFactorySuccess": {
         "desc": "从任意界面进入大世界工厂模式成功",
-        "recognition": {
-            "type": "TemplateMatch",
-            "param": {
-                "roi": [
-                    0,
-                    0,
-                    60,
-                    60
-                ],
-                "template": [
-                    "SceneManager/WorldFactoryActive.png"
-                ]
-            }
-        },
+        "recognition": "And",
+        "all_of": [
+            "InWorldFactory"
+        ],
         "pre_delay": 0,
         "post_delay": 0
     }


### PR DESCRIPTION
fix #1398

## Summary by Sourcery

Bug Fixes:
- 通过调整与场景相关的配置文件，解决了在游戏处于俯视模式时无法打开蓝图界面的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve inability to open the blueprint interface when the game is in overlook mode by adjusting scene-related configuration files.

</details>