### PR TITLE
fix(EnvironmentMonitoring): 判断是否需要传送前需要先回到大世界

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
@@ -164,7 +164,7 @@
         ]
     },
     "GoToAncientTreeStartPos": {
-        "desc": "在古树最近的传送点附近",
+        "desc": "在古树任务开始位置附近",
         "recognition": "Custom",
         "custom_recognition": "MapTrackerAssertLocation",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToAncientTree": {
-        "desc": "前往古树",
+        "desc": "前往古树，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToAncientTreeStartPos",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley7"
+            "GoToAncientTreeNotAtStartPos"
         ]
     },
     "GoToAncientTreeStartPos": {
@@ -178,6 +185,19 @@
                         15
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToAncientTreeMapTrackerMove"
+        ]
+    },
+    "GoToAncientTreeNotAtStartPos": {
+        "desc": "不在古树任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley7"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInBlightTide.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInBlightTide.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToBeaconDamagedInBlightTide": {
-        "desc": "前往侵蚀潮中损坏的信标",
+        "desc": "前往侵蚀潮中损坏的信标，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToBeaconDamagedInBlightTideStartPos",
-            "[JumpBack]SceneEnterWorldWulingWulingCity0"
+            "GoToBeaconDamagedInBlightTideNotAtStartPos"
         ]
     },
     "GoToBeaconDamagedInBlightTideStartPos": {
@@ -178,6 +185,19 @@
                         15
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToBeaconDamagedInBlightTideMapTrackerMove"
+        ]
+    },
+    "GoToBeaconDamagedInBlightTideNotAtStartPos": {
+        "desc": "不在侵蚀潮中损坏的信标任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity0"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToCisternOriginiumSlugs": {
-        "desc": "前往蓄水源石虫",
+        "desc": "前往蓄水源石虫，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToCisternOriginiumSlugsStartPos",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley7"
+            "GoToCisternOriginiumSlugsNotAtStartPos"
         ]
     },
     "GoToCisternOriginiumSlugsStartPos": {
@@ -178,6 +185,19 @@
                         15
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToCisternOriginiumSlugsMapTrackerMove"
+        ]
+    },
+    "GoToCisternOriginiumSlugsNotAtStartPos": {
+        "desc": "不在蓄水源石虫任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley7"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
@@ -164,7 +164,7 @@
         ]
     },
     "GoToCisternOriginiumSlugsStartPos": {
-        "desc": "在蓄水源石虫最近的传送点附近",
+        "desc": "在蓄水源石虫任务开始位置附近",
         "recognition": "Custom",
         "custom_recognition": "MapTrackerAssertLocation",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToCleansingJade": {
-        "desc": "前往漱玉",
+        "desc": "前往漱玉，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToCleansingJadeStartPos",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley4"
+            "GoToCleansingJadeNotAtStartPos"
         ]
     },
     "GoToCleansingJadeStartPos": {
@@ -178,6 +185,19 @@
                         15
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToCleansingJadeMapTrackerMove"
+        ]
+    },
+    "GoToCleansingJadeNotAtStartPos": {
+        "desc": "不在漱玉任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley4"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToCollapsedTianshiPillar": {
-        "desc": "前往倒塌的天师桩",
+        "desc": "前往倒塌的天师桩，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToCollapsedTianshiPillarStartPos",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley8"
+            "GoToCollapsedTianshiPillarNotAtStartPos"
         ]
     },
     "GoToCollapsedTianshiPillarStartPos": {
@@ -178,6 +185,19 @@
                         15
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToCollapsedTianshiPillarMapTrackerMove"
+        ]
+    },
+    "GoToCollapsedTianshiPillarNotAtStartPos": {
+        "desc": "不在倒塌的天师桩任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley8"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToEcologyNearTheFieldLogisticsDepot": {
-        "desc": "前往储备站周围的生态环境",
+        "desc": "前往储备站周围的生态环境，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToEcologyNearTheFieldLogisticsDepotStartPos",
-            "[JumpBack]SceneEnterWorldWulingWulingCity8"
+            "GoToEcologyNearTheFieldLogisticsDepotNotAtStartPos"
         ]
     },
     "GoToEcologyNearTheFieldLogisticsDepotStartPos": {
@@ -178,6 +185,19 @@
                         5.5
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove"
+        ]
+    },
+    "GoToEcologyNearTheFieldLogisticsDepotNotAtStartPos": {
+        "desc": "不在储备站周围的生态环境任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity8"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -164,7 +164,7 @@
         ]
     },
     "GoToEternalSunsetStartPos": {
-        "desc": "在栖霞驻影任务开始位置附近，聚宝窟外直接拍照",
+        "desc": "在栖霞驻影任务开始位置附近",
         "recognition": "Custom",
         "custom_recognition": "MapTrackerAssertLocation",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToEternalSunset": {
-        "desc": "前往栖霞驻影",
+        "desc": "前往栖霞驻影，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToEternalSunsetStartPos",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley2"
+            "GoToEternalSunsetNotAtStartPos"
         ]
     },
     "GoToEternalSunsetStartPos": {
@@ -178,6 +185,19 @@
                         15
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToEternalSunsetMapTrackerMove"
+        ]
+    },
+    "GoToEternalSunsetNotAtStartPos": {
+        "desc": "不在栖霞驻影任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley2"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToIndoorCrops": {
-        "desc": "前往室内作物",
+        "desc": "前往室内作物，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToIndoorCropsStartPos",
-            "[JumpBack]SceneEnterWorldWulingWulingCity4"
+            "GoToIndoorCropsNotAtStartPos"
         ]
     },
     "GoToIndoorCropsStartPos": {
@@ -178,6 +185,19 @@
                         15
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToIndoorCropsMapTrackerMove"
+        ]
+    },
+    "GoToIndoorCropsNotAtStartPos": {
+        "desc": "不在室内作物任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity4"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToInflatedAndGlowingBugspittingLankybeast": {
-        "desc": "前往肚子鼓气后发光的吐虫长股兽",
+        "desc": "前往肚子鼓气后发光的吐虫长股兽，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToInflatedAndGlowingBugspittingLankybeastStartPos",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley7"
+            "GoToInflatedAndGlowingBugspittingLankybeastNotAtStartPos"
         ]
     },
     "GoToInflatedAndGlowingBugspittingLankybeastStartPos": {
@@ -178,6 +185,19 @@
                         15
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove"
+        ]
+    },
+    "GoToInflatedAndGlowingBugspittingLankybeastNotAtStartPos": {
+        "desc": "不在肚子鼓气后发光的吐虫长股兽任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley7"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToObservantSableChestedFowlbeast": {
-        "desc": "前往东张西望的黑腹雉羽兽",
+        "desc": "前往东张西望的黑腹雉羽兽，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToObservantSableChestedFowlbeastStartPos",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley0"
+            "GoToObservantSableChestedFowlbeastNotAtStartPos"
         ]
     },
     "GoToObservantSableChestedFowlbeastStartPos": {
@@ -178,6 +185,19 @@
                         4
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToObservantSableChestedFowlbeastMapTrackerMove"
+        ]
+    },
+    "GoToObservantSableChestedFowlbeastNotAtStartPos": {
+        "desc": "不在东张西望的黑腹雉羽兽任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley0"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToRainbowFin": {
-        "desc": "前往七彩鳞",
+        "desc": "前往七彩鳞，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToRainbowFinStartPos",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley10"
+            "GoToRainbowFinNotAtStartPos"
         ]
     },
     "GoToRainbowFinStartPos": {
@@ -178,6 +185,19 @@
                         15
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToRainbowFinMapTrackerMove"
+        ]
+    },
+    "GoToRainbowFinNotAtStartPos": {
+        "desc": "不在七彩鳞任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley10"
             ]
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
@@ -157,10 +157,17 @@
         ]
     },
     "GoToVigorousCisternOriginiumSlug": {
-        "desc": "前往充满活力的蓄水源石虫",
+        "desc": "前往充满活力的蓄水源石虫，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoToVigorousCisternOriginiumSlugStartPos",
-            "[JumpBack]SceneEnterWorldWulingWulingCity3"
+            "GoToVigorousCisternOriginiumSlugNotAtStartPos"
         ]
     },
     "GoToVigorousCisternOriginiumSlugStartPos": {
@@ -178,6 +185,19 @@
                         4
                     ]
                 }
+            ]
+        },
+        "next": [
+            "GoToVigorousCisternOriginiumSlugMapTrackerMove"
+        ]
+    },
+    "GoToVigorousCisternOriginiumSlugNotAtStartPos": {
+        "desc": "不在充满活力的蓄水源石虫任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity3"
             ]
         },
         "next": [

--- a/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/README.md
+++ b/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/README.md
@@ -17,7 +17,7 @@ npx @joebao/maa-pipeline-generate \
 - `Name` — 任务中文名称（用于 desc 文本）
 - `ExpectedText` — 任务列表项 OCR 识别文本（多语言数组）
 - `InExpectedText` — 任务详情界面 OCR 识别文本（多数情况与 ExpectedText 相同）
-- `JumpBackNode` — 传送节点名称
+- `EnterMap` — 传送节点名称
 - `MapName` — 地图名称
 - `MapTarget` — 位置断言目标坐标 `[x, y, w, h]`
 - `MapPath` — 寻路路径点数组 `[[x, y], ...]`

--- a/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/README.md
+++ b/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/README.md
@@ -17,7 +17,6 @@ npx @joebao/maa-pipeline-generate \
 - `Name` — 任务中文名称（用于 desc 文本）
 - `ExpectedText` — 任务列表项 OCR 识别文本（多语言数组）
 - `InExpectedText` — 任务详情界面 OCR 识别文本（多数情况与 ExpectedText 相同）
-- `StartPosDesc` — `GoTo${Id}StartPos` 节点描述
 - `JumpBackNode` — 传送节点名称
 - `MapName` — 地图名称
 - `MapTarget` — 位置断言目标坐标 `[x, y, w, h]`

--- a/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/data.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/data.json
@@ -6,7 +6,6 @@
             "Name": "古树",
             "ExpectedText": ["古树", "古樹", "Ancient Tree", "古木", "고목"],
             "InExpectedText": ["古树", "古樹", "Ancient Tree", "古木", "고목"],
-            "StartPosDesc": "在古树最近的传送点附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley7",
             "MapName": "map02_lv001",
             "MapTarget": [280, 580, 15, 15],
@@ -48,7 +47,6 @@
                 "侵蝕潮で壊れたビーコン",
                 "침식 조류로 인해 훼손된 신호기"
             ],
-            "StartPosDesc": "在侵蚀潮中损坏的信标任务开始位置附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingWulingCity0",
             "MapName": "map02_lv002",
             "MapTarget": [640, 255, 15, 15],
@@ -72,7 +70,6 @@
             "Name": "蓄水源石虫",
             "ExpectedText": ["蓄水源石虫", "蓄水源石蟲", "Cistern Originium Slugs", "貯水オリジムシ", "저수 원석충"],
             "InExpectedText": ["蓄水源石虫", "蓄水源石蟲", "Cistern Originium Slugs", "貯水オリジムシ", "저수 원석충"],
-            "StartPosDesc": "在蓄水源石虫最近的传送点附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley7",
             "MapName": "map02_lv001",
             "MapTarget": [280, 580, 15, 15],
@@ -90,7 +87,6 @@
             "Name": "漱玉",
             "ExpectedText": ["漱玉", "漱玉", "Cleansing Jade", "漱玉", "수옥"],
             "InExpectedText": ["漱玉", "漱玉", "Cleansing Jade", "漱玉", "수옥"],
-            "StartPosDesc": "在漱玉任务开始位置附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley4",
             "MapName": "map02_lv001_tier_277",
             "MapTarget": [255, 395, 15, 15],
@@ -114,7 +110,6 @@
                 "倒れた天師杭",
                 "무너진 천사장"
             ],
-            "StartPosDesc": "在倒塌的天师桩任务开始位置附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley8",
             "MapName": "map02_lv001",
             "MapTarget": [210, 635, 15, 15],
@@ -143,7 +138,6 @@
                 "備蓄施設周辺の生態環境",
                 "보급소 주변의 생태 환경"
             ],
-            "StartPosDesc": "在储备站周围的生态环境任务开始位置附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingWulingCity8",
             "MapName": "map02_lv002",
             "MapTarget": [689.6, 917.3, 6.0, 5.5],
@@ -168,7 +162,6 @@
             "Name": "栖霞驻影",
             "ExpectedText": ["栖霞驻影", "棲霞駐影", "Eternal Sunset", "棲霞留影", "노을의 그림자"],
             "InExpectedText": ["栖霞驻影", "棲霞駐影", "Eternal Sunset", "棲霞留影", "노을의 그림자"],
-            "StartPosDesc": "在栖霞驻影任务开始位置附近，聚宝窟外直接拍照",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley2",
             "MapName": "map02_lv001",
             "MapTarget": [315, 305, 15, 15],
@@ -189,7 +182,6 @@
                 "室内栽培の作物",
                 "실내 재배하고 있는 작물을 촬영하기"
             ],
-            "StartPosDesc": "在室内作物任务开始位置附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingWulingCity4",
             "MapName": "map02_lv002",
             "MapTarget": [240, 695, 15, 15],
@@ -222,7 +214,6 @@
                 "腹が膨らんで光る虫吐き長脚獣",
                 "배를 부풀려 빛을 내는 버그스피팅 랭키비스트"
             ],
-            "StartPosDesc": "在肚子鼓气后发光的吐虫长股兽任务开始位置附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley7",
             "MapName": "map02_lv001",
             "MapTarget": [280, 580, 15, 15],
@@ -253,7 +244,6 @@
                 "キョロキョロする黒腹羽獣",
                 "두리번거리는 검은 배의 파울비스트"
             ],
-            "StartPosDesc": "在东张西望的黑腹雉羽兽任务开始位置附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley0",
             "MapName": "map02_lv001",
             "MapTarget": [342.2, 124.2, 4, 4],
@@ -268,7 +258,6 @@
             "Name": "七彩鳞",
             "ExpectedText": ["七彩鳞", "七彩鱗", "Rainbow Fin", "七色鱗獣", "무지개 린수"],
             "InExpectedText": ["七彩鳞", "七彩鱗", "Rainbow Fin", "七色鱗獣", "무지개 린수"],
-            "StartPosDesc": "在七彩鳞任务开始位置附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley10",
             "MapName": "map02_lv001",
             "MapTarget": [125, 815, 15, 15],
@@ -301,7 +290,6 @@
                 "活発になっている貯水オリジムシ",
                 "활기찬 저수 원석충"
             ],
-            "StartPosDesc": "在充满活力的蓄水源石虫任务开始位置附近",
             "JumpBackNode": "[JumpBack]SceneEnterWorldWulingWulingCity3",
             "MapName": "map02_lv002",
             "MapTarget": [422.0, 577.7, 4, 4],

--- a/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/data.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/data.json
@@ -6,7 +6,7 @@
             "Name": "古树",
             "ExpectedText": ["古树", "古樹", "Ancient Tree", "古木", "고목"],
             "InExpectedText": ["古树", "古樹", "Ancient Tree", "古木", "고목"],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley7",
+            "EnterMap": "SceneEnterWorldWulingJingyuValley7",
             "MapName": "map02_lv001",
             "MapTarget": [280, 580, 15, 15],
             "MapPath": [
@@ -47,7 +47,7 @@
                 "侵蝕潮で壊れたビーコン",
                 "침식 조류로 인해 훼손된 신호기"
             ],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingWulingCity0",
+            "EnterMap": "SceneEnterWorldWulingWulingCity0",
             "MapName": "map02_lv002",
             "MapTarget": [640, 255, 15, 15],
             "MapPath": [
@@ -70,7 +70,7 @@
             "Name": "蓄水源石虫",
             "ExpectedText": ["蓄水源石虫", "蓄水源石蟲", "Cistern Originium Slugs", "貯水オリジムシ", "저수 원석충"],
             "InExpectedText": ["蓄水源石虫", "蓄水源石蟲", "Cistern Originium Slugs", "貯水オリジムシ", "저수 원석충"],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley7",
+            "EnterMap": "SceneEnterWorldWulingJingyuValley7",
             "MapName": "map02_lv001",
             "MapTarget": [280, 580, 15, 15],
             "MapPath": [
@@ -87,7 +87,7 @@
             "Name": "漱玉",
             "ExpectedText": ["漱玉", "漱玉", "Cleansing Jade", "漱玉", "수옥"],
             "InExpectedText": ["漱玉", "漱玉", "Cleansing Jade", "漱玉", "수옥"],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley4",
+            "EnterMap": "SceneEnterWorldWulingJingyuValley4",
             "MapName": "map02_lv001_tier_277",
             "MapTarget": [255, 395, 15, 15],
             "MapPath": [[246, 394]],
@@ -110,7 +110,7 @@
                 "倒れた天師杭",
                 "무너진 천사장"
             ],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley8",
+            "EnterMap": "SceneEnterWorldWulingJingyuValley8",
             "MapName": "map02_lv001",
             "MapTarget": [210, 635, 15, 15],
             "MapPath": [
@@ -138,7 +138,7 @@
                 "備蓄施設周辺の生態環境",
                 "보급소 주변의 생태 환경"
             ],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingWulingCity8",
+            "EnterMap": "SceneEnterWorldWulingWulingCity8",
             "MapName": "map02_lv002",
             "MapTarget": [689.6, 917.3, 6.0, 5.5],
             "MapPath": [
@@ -162,7 +162,7 @@
             "Name": "栖霞驻影",
             "ExpectedText": ["栖霞驻影", "棲霞駐影", "Eternal Sunset", "棲霞留影", "노을의 그림자"],
             "InExpectedText": ["栖霞驻影", "棲霞駐影", "Eternal Sunset", "棲霞留影", "노을의 그림자"],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley2",
+            "EnterMap": "SceneEnterWorldWulingJingyuValley2",
             "MapName": "map02_lv001",
             "MapTarget": [315, 305, 15, 15],
             "MapPath": [
@@ -182,7 +182,7 @@
                 "室内栽培の作物",
                 "실내 재배하고 있는 작물을 촬영하기"
             ],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingWulingCity4",
+            "EnterMap": "SceneEnterWorldWulingWulingCity4",
             "MapName": "map02_lv002",
             "MapTarget": [240, 695, 15, 15],
             "MapPath": [
@@ -214,7 +214,7 @@
                 "腹が膨らんで光る虫吐き長脚獣",
                 "배를 부풀려 빛을 내는 버그스피팅 랭키비스트"
             ],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley7",
+            "EnterMap": "SceneEnterWorldWulingJingyuValley7",
             "MapName": "map02_lv001",
             "MapTarget": [280, 580, 15, 15],
             "MapPath": [
@@ -244,7 +244,7 @@
                 "キョロキョロする黒腹羽獣",
                 "두리번거리는 검은 배의 파울비스트"
             ],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley0",
+            "EnterMap": "SceneEnterWorldWulingJingyuValley0",
             "MapName": "map02_lv001",
             "MapTarget": [342.2, 124.2, 4, 4],
             "MapPath": [
@@ -258,7 +258,7 @@
             "Name": "七彩鳞",
             "ExpectedText": ["七彩鳞", "七彩鱗", "Rainbow Fin", "七色鱗獣", "무지개 린수"],
             "InExpectedText": ["七彩鳞", "七彩鱗", "Rainbow Fin", "七色鱗獣", "무지개 린수"],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingJingyuValley10",
+            "EnterMap": "SceneEnterWorldWulingJingyuValley10",
             "MapName": "map02_lv001",
             "MapTarget": [125, 815, 15, 15],
             "MapPath": [
@@ -290,7 +290,7 @@
                 "活発になっている貯水オリジムシ",
                 "활기찬 저수 원석충"
             ],
-            "JumpBackNode": "[JumpBack]SceneEnterWorldWulingWulingCity3",
+            "EnterMap": "SceneEnterWorldWulingWulingCity3",
             "MapName": "map02_lv002",
             "MapTarget": [422.0, 577.7, 4, 4],
             "MapPath": [

--- a/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/template.jsonc
+++ b/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/template.jsonc
@@ -145,10 +145,17 @@
         ]
     },
     "GoTo${Id}": {
-        "desc": "前往${Name}",
+        "desc": "前往${Name}，先回到大世界再进行判断",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ]
+        },
         "next": [
             "GoTo${Id}StartPos",
-            "${JumpBackNode}"
+            "GoTo${Id}NotAtStartPos"
         ]
     },
     "GoTo${Id}StartPos": {
@@ -161,6 +168,19 @@
                     "map_name": "${MapName}",
                     "target": "${MapTarget}"
                 }
+            ]
+        },
+        "next": [
+            "GoTo${Id}MapTrackerMove"
+        ]
+    },
+    "GoTo${Id}NotAtStartPos": {
+        "desc": "不在${Name}任务开始位置附近",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "${EnterMap}"
             ]
         },
         "next": [

--- a/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/template.jsonc
+++ b/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/template.jsonc
@@ -152,7 +152,7 @@
         ]
     },
     "GoTo${Id}StartPos": {
-        "desc": "${StartPosDesc}",
+        "desc": "在${Name}任务开始位置附近",
         "recognition": "Custom",
         "custom_recognition": "MapTrackerAssertLocation",
         "custom_recognition_param": {


### PR DESCRIPTION
## Summary by Sourcery

更新环境监测外围监控终端任务，以在传送前正确处理返回主世界的逻辑，并使任务元数据和文档与新的行为保持一致。

Bug Fixes:
- 确保环境监测外围监控终端任务在执行传送操作前先返回主世界，以避免出现错误的导航状态。

Enhancements:
- 刷新外围监控终端任务定义和生成器模板，以反映更新后的传送流程和元数据字段。

Documentation:
- 从外围监控终端生成器文档中移除已弃用的 `StartPosDesc` 字段，使其与当前的任务配置模式保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Environment Monitoring Outskirts Monitoring Terminal tasks to correctly handle returning to the overworld before teleporting and align task metadata and documentation with the new behavior.

Bug Fixes:
- Ensure Environment Monitoring Outskirts Monitoring Terminal tasks return to the main world before performing teleport actions to avoid incorrect navigation states.

Enhancements:
- Refresh Outskirts Monitoring Terminal task definitions and generator templates to reflect the revised teleportation flow and metadata fields.

Documentation:
- Remove the deprecated StartPosDesc field from the Outskirts Monitoring Terminal generator documentation to match the current task configuration schema.

</details>