### PR TITLE
docs: 为 AutoStockpile 任务在 development 添加维护文档链接

### DIFF
--- a/docs/en_us/developers/development.md
+++ b/docs/en_us/developers/development.md
@@ -113,6 +113,12 @@ Some highly reusable nodes have been encapsulated with detailed documentation to
 - [QuantizedSliding Reference Document](./quantized-sliding.md): A shared custom action for adjusting discrete quantity sliders to a target value.
 - [Node Testing Reference Document](./node-testing.md): Directory conventions, schema, and writing guidelines for static screenshot node tests.
 
+### About Task Maintenance
+
+The following tasks have maintenance documentation. When writing new features and modifying other functions, there is no need to review them, but **when you modify these tasks, be sure to read the maintenance documentation for the relevant tasks**. See:
+
+- [AutoStockpile Maintenance Documentation](./auto-stockpile-maintain.md): This document explains how to maintain the item templates, item mappings, price thresholds, and region extensions for `AutoStockpile` (Automatic Stockpiling).
+
 ## Code Specifications
 
 ### Pipeline Low-Code Specifications

--- a/docs/zh_cn/developers/development.md
+++ b/docs/zh_cn/developers/development.md
@@ -113,6 +113,12 @@ python tools/setup_workspace.py
 - [QuantizedSliding 参考文档](./quantized-sliding.md)：用于按目标值调节离散数量滑条的公共自定义动作。
 - [节点测试参考文档](./node-testing.md)：节点静态截图测试的目录约定、Schema 和编写建议。
 
+### 关于任务维护
+
+以下的这些任务具有维护文档，在写新功能和修改其他功能时无需查看，**但在您更改这些任务时，一定要阅读相关任务的维护文档**。参见：
+
+- [AutoStockpile 维护文档](./auto-stockpile-maintain.md)：该文档说明 `AutoStockpile`（自动囤货）的商品模板、商品映射、价格阈值与地区扩展应如何维护。
+
 ## 代码规范
 
 ### Pipeline 低代码规范


### PR DESCRIPTION
## Summary by Sourcery

为 AutoStockpile 任务在英文和中文的开发者文档中补充任务专用的维护指南。

Documentation:
- 在开发者文档中新增 “About Task Maintenance（关于任务维护）” 章节，列出拥有专门维护文档的任务。
- 在英文和中文的开发者指南中添加指向 AutoStockpile 维护文档的链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document task-specific maintenance guidance for the AutoStockpile task in both English and Chinese developer docs.

Documentation:
- Add a new "About Task Maintenance" section to the developer docs listing tasks with dedicated maintenance documentation.
- Link to the AutoStockpile maintenance document from the developer guides in both English and Chinese.

</details>