### PR TITLE
feat(map): MapTracker初步支持ADB控制器

### DIFF
--- a/agent/go-service/map-tracker/big_map_pick.go
+++ b/agent/go-service/map-tracker/big_map_pick.go
@@ -85,7 +85,11 @@ func (a *MapTrackerBigMapPick) Run(ctx *maa.Context, arg *maa.CustomActionArg) b
 	}
 
 	ctrl := ctx.GetTasker().GetController()
-	ca := control.NewControlAdaptor(ctx, ctrl, mt.WORK_W, mt.WORK_H)
+	ca, err := control.NewControlAdaptor(ctx, ctrl, mt.WORK_W, mt.WORK_H)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to create control adaptor")
+		return false
+	}
 
 	if !param.NoZoom {
 		if err := a.doAutoZoom(ctx, ctrl, ca); err != nil {

--- a/agent/go-service/map-tracker/big_map_pick.go
+++ b/agent/go-service/map-tracker/big_map_pick.go
@@ -401,7 +401,7 @@ func doDragViewport(ca control.ControlAdaptor, viewport *mt.BigMapViewport, delt
 		return false
 	}
 
-	ca.Swipe(startX, startY, dragDx, dragDy, 100, 50)
+	ca.Swipe(0, startX, startY, dragDx, dragDy, 100, 50)
 	return true
 }
 

--- a/agent/go-service/map-tracker/infer.go
+++ b/agent/go-service/map-tracker/infer.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	mt "github.com/MaaXYZ/MaaEnd/agent/go-service/map-tracker/internal"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/control"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv"
 	"github.com/MaaXYZ/maa-framework-go/v4"
@@ -82,22 +83,6 @@ const (
 	VIRTUAL_HIT     InferLocationHitMode = "VirtualHit"
 )
 
-// Location inference configuration
-const (
-	// Mini-map crop area
-	LOC_CENTER_X = 108
-	LOC_CENTER_Y = 111
-	LOC_RADIUS   = 40
-)
-
-// Rotation inference configuration
-const (
-	// Pointer crop area
-	ROT_CENTER_X = 108
-	ROT_CENTER_Y = 111
-	ROT_RADIUS   = 12
-)
-
 // Time-series empirical optimization configuration
 const (
 	PENDING_TAKEOVER_TIME_MS         = 1000
@@ -142,6 +127,11 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 		return nil, false
 	}
 
+	ctrlType := control.CachedControlType
+	if ctrlType == "" {
+		ctrlType, _ = control.GetControlType(ctx.GetTasker().GetController())
+	}
+
 	// Compile regex
 	mapNameRegex, err := regexp.Compile(param.MapNameRegex)
 	if err != nil {
@@ -170,12 +160,12 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 
 	go func() {
 		defer wg.Done()
-		loc = i.inferLocation(screenImg, mapNameRegex, param)
+		loc = i.inferLocation(control.CachedControlType, screenImg, mapNameRegex, param)
 	}()
 
 	go func() {
 		defer wg.Done()
-		rot = i.inferRotation(screenImg, rotStep)
+		rot = i.inferRotation(control.CachedControlType, screenImg, rotStep)
 	}()
 
 	wg.Wait()
@@ -394,7 +384,7 @@ func isMapNameCoreMatch(mapName1, mapName2 string) bool {
 
 // inferLocation infers the player's location on the map.
 // Returns a raw result with mapName, x/y (map coordinates), conf, source, and elapsedTimeMs.
-func (i *MapTrackerInfer) inferLocation(screenImg *image.RGBA, mapNameRegex *regexp.Regexp, param *MapTrackerInferParam) *InferLocationRawResult {
+func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, mapNameRegex *regexp.Regexp, param *MapTrackerInferParam) *InferLocationRawResult {
 	t0 := time.Now()
 
 	// Use cached scaled maps
@@ -406,7 +396,15 @@ func (i *MapTrackerInfer) inferLocation(screenImg *image.RGBA, mapNameRegex *reg
 	}
 
 	// Crop and scale mini-map area from screen
-	miniMap := minicv.ImageCropSquareByRadius(screenImg, LOC_CENTER_X, LOC_CENTER_Y, LOC_RADIUS)
+	var miniMap *image.RGBA
+	switch ctrlType {
+	case control.CONTROL_TYPE_ADB:
+		miniMap = minicv.ImageCropSquareByRadius(screenImg, 134, 129, 50)
+		miniMap = minicv.ImageScale(miniMap, 0.8)
+	default: // Win32 and others
+		miniMap = minicv.ImageCropSquareByRadius(screenImg, 108, 111, 40)
+	}
+
 	miniMap = minicv.ImageScale(miniMap, scale)
 	miniMapBounds := miniMap.Bounds()
 	miniMapW, miniMapH := miniMapBounds.Dx(), miniMapBounds.Dy()
@@ -590,7 +588,7 @@ func (i *MapTrackerInfer) inferLocation(screenImg *image.RGBA, mapNameRegex *reg
 
 // inferRotation infers the player's rotation angle
 // Returns (angle, confidence)
-func (i *MapTrackerInfer) inferRotation(screenImg *image.RGBA, rotStep int) *InferRotationRawResult {
+func (i *MapTrackerInfer) inferRotation(ctrlType string, screenImg *image.RGBA, rotStep int) *InferRotationRawResult {
 	t0 := time.Now()
 
 	pointerTemplate, err := mt.Resource.PointerTemplateLoader.Get()
@@ -600,7 +598,14 @@ func (i *MapTrackerInfer) inferRotation(screenImg *image.RGBA, rotStep int) *Inf
 	}
 
 	// Crop pointer area from screen
-	patch := minicv.ImageCropSquareByRadius(screenImg, ROT_CENTER_X, ROT_CENTER_Y, ROT_RADIUS)
+	var patch *image.RGBA
+	switch ctrlType {
+	case control.CONTROL_TYPE_ADB:
+		patch = minicv.ImageCropSquareByRadius(screenImg, 134, 129, 15)
+		patch = minicv.ImageScale(patch, 0.8)
+	default: // Win32 and others
+		patch = minicv.ImageCropSquareByRadius(screenImg, 108, 111, 12)
+	}
 
 	// Try all rotation angles in parallel
 	type result struct {

--- a/agent/go-service/map-tracker/move.go
+++ b/agent/go-service/map-tracker/move.go
@@ -80,18 +80,6 @@ var mapTrackerInferParamForMove = MapTrackerInferParam{
 	Threshold: 0.3,
 }
 
-// PlayerMovement represents different movement state in the game
-type PlayerMovement struct {
-	Speed         float64 // Movement speed (px/s)
-	RotationSpeed float64 // Rotation adjustment response speed (degrees/s)
-}
-
-var (
-	MovementWalk   = PlayerMovement{2.0, 270.0}
-	MovementRun    = PlayerMovement{8.0, 540.0}
-	MovementSprint = PlayerMovement{12.0, 1080.0}
-)
-
 // PlayerRotationAdjustmentState keeps track of one rotation adjustment
 type PlayerRotationAdjustmentState struct {
 	fromPos         [2]float64    // Last position where rotation adjustment started to apply
@@ -128,7 +116,12 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 	}
 
 	ctrl := ctx.GetTasker().GetController()
-	ca := control.NewControlAdaptor(ctx, ctrl, mt.WORK_W, mt.WORK_H)
+	ca, err := control.NewControlAdaptor(ctx, ctrl, mt.WORK_W, mt.WORK_H)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to create control adaptor")
+		return false
+	}
+
 	loopInterval := time.Duration(mt.INFER_INTERVAL_MS) * time.Millisecond
 
 	if param.PathTrim && len(param.Path) > 1 {
@@ -153,12 +146,8 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 
 	log.Info().Str("map", param.MapName).Int("targetsCount", len(param.Path)).Msg("Starting navigation to targets")
 
-	// Reset player movement type by sprint once
-	ca.KeyDown(control.KEY_S, 50)
-	ca.KeyType(control.KEY_SHIFT, 50)
-	ca.KeyUp(control.KEY_S, 50)
-	ca.KeyType(control.KEY_W, 50)
-	movement := &MovementRun
+	// Reset player movement state
+	ca.AggressivelyResetPlayerMovement()
 
 	// Adaptive rotation sensitivity local state
 	rotationSpeed := mt.ROTATION_DEFAULT_SPEED
@@ -206,7 +195,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 			// Check stopping signal
 			if ctx.GetTasker().Stopping() {
 				log.Warn().Msg("Task is stopping, exiting navigation loop")
-				ca.KeyUp(control.KEY_W, 25)
+				ca.PlayerStop()
 				return false
 			}
 
@@ -227,7 +216,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 			result, err := doInfer(ctx, ctrl, param)
 			if err != nil {
 				log.Error().Err(err).Msg("Inference failed during navigation")
-				ca.KeyUp(control.KEY_W, 25)
+				ca.PlayerStop()
 				continue
 			}
 			curX, curY := result.X, result.Y
@@ -246,7 +235,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					nextDeltaRot := calcDeltaRotation(rot, nextTargetRot)
 					// Pause slightly if next target is in a very different direction
 					if math.Abs(float64(nextDeltaRot)) > param.RotationUpperThreshold {
-						ca.KeyUp(control.KEY_W, 25)
+						ca.PlayerStop()
 					}
 				}
 			}
@@ -261,13 +250,9 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				if dist < param.ArrivalThreshold {
 					if enableFineApproach {
 						fineApproachOngoing = true
-						fineApproachExpectedElapsed := time.Duration(float64(time.Second) * (dist / MovementWalk.Speed))
+						fineApproachExpectedElapsed := control.MovementWalk.EtaOfDistance(dist)
 						fineApproachExpectedEndTime = loopStartTime.Add(fineApproachExpectedElapsed)
-						if movement.Speed > MovementWalk.Speed {
-							ca.KeyType(control.KEY_CTRL, 25)
-							movement = &MovementWalk
-						}
-						ca.KeyDown(control.KEY_W, 25)
+						ca.SetPlayerMovement(control.MovementWalk)
 						log.Info().Int("index", i).Float64("dist", dist).Dur("expectedElapsed", fineApproachExpectedElapsed).Msg("Entering fine approach")
 					} else {
 						log.Info().Int("index", i).Float64("x", curX).Float64("y", curY).Msg("Target point reached (ordinary approach)")
@@ -293,7 +278,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				}
 				if deltaLocationMs > param.StuckThreshold {
 					log.Info().Msg("Stuck detected, jumping...")
-					ca.KeyType(control.KEY_SPACE, 100)
+					ca.PlayerJump()
 				}
 			} else {
 				prevLocation = &[2]float64{curX, curY}
@@ -306,7 +291,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				if loopStartTime.Sub(rotAdjState.startTime) > rotAdjState.expectedElapsed {
 					// Check if player is moving and rotating sufficiently to trust rotation measurement
 					distTravel := math.Hypot(curX-rotAdjState.fromPos[0], curY-rotAdjState.fromPos[1])
-					if distTravel > rotAdjState.expectedElapsed.Seconds()*MovementWalk.Speed {
+					if distTravel > control.MovementWalk.DistanceDuring(rotAdjState.expectedElapsed) {
 						// Check if rotation difference is sufficient to consider adjusting rotation speed
 						actualDeltaRot := calcDeltaRotation(rotAdjState.fromRot, rot)
 						if math.Abs(float64(actualDeltaRot))+math.Abs(rotAdjState.deltaRot) > param.RotationLowerThreshold {
@@ -331,24 +316,14 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				// Check if rotation is not good enough to sprint
 				if absRawDeltaRot > param.RotationLowerThreshold {
 					// Ensure no sprinting: forcibly set to 'walk'
-					if movement.Speed > MovementRun.Speed {
-						ca.KeyType(control.KEY_CTRL, 25)
-						movement = &MovementWalk
-					}
+					ca.SetPlayerMovement(control.MovementWalk)
 				} else if !fineApproachOngoing {
 					// Rotation is good: at least set to 'run'
-					if movement.Speed < MovementRun.Speed {
-						ca.KeyType(control.KEY_CTRL, 25)
-						movement = &MovementRun
-					}
-					ca.KeyDown(control.KEY_W, 5)
+					ca.SetPlayerMovement(control.MovementRun)
 
 					if dist > param.SprintThreshold {
 						// Target is far enough: enable 'sprint'
-						if movement.Speed < MovementSprint.Speed {
-							ca.KeyType(control.KEY_SHIFT, 100)
-							movement = &MovementSprint
-						}
+						ca.SetPlayerMovement(control.MovementSprint)
 					}
 				}
 
@@ -359,20 +334,12 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					// Select appropriate rotation method based on how bad the rotation is
 					if absRawDeltaRot > param.RotationUpperThreshold {
 						// Rotation is very bad: forcibly set to 'walk' for better control
-						if movement.Speed > MovementWalk.Speed {
-							ca.KeyType(control.KEY_CTRL, 25)
-							movement = &MovementWalk
-						}
-						ca.RotateCamera(int(finalDeltaRot*rotationSpeed), 0, 75, 25)
-						ca.KeyDown(control.KEY_W, 25)
+						ca.SetPlayerMovement(control.MovementWalk)
+						ca.RotateCamera(int(finalDeltaRot*rotationSpeed), 0, 50, 25)
 					} else if !fineApproachOngoing {
 						// Rotation is acceptable but can be improved: at least ensure 'run'
-						if movement.Speed < MovementRun.Speed {
-							ca.KeyType(control.KEY_CTRL, 25)
-							movement = &MovementRun
-						}
-						ca.KeyDown(control.KEY_W, 25)
-						ca.RotateCamera(int(finalDeltaRot*rotationSpeed), 0, 75, 25)
+						ca.SetPlayerMovement(control.MovementRun)
+						ca.RotateCamera(int(finalDeltaRot*rotationSpeed), 0, 50, 25)
 					}
 
 					// Update adaptive rotation state
@@ -381,20 +348,21 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 						fromRot:         rot,
 						deltaRot:        finalDeltaRot,
 						startTime:       time.Now(),
-						expectedElapsed: time.Duration(float64(time.Second) * math.Abs(finalDeltaRot) / movement.RotationSpeed),
+						expectedElapsed: ca.GetPlayerMovement().EtaOfRotation(math.Abs(finalDeltaRot)),
 					}
-					ca.RotateCameraEliminateSideEffect(25)
+					ca.AggressivelyResetCamera()
 				}
 			}
+			loopEndTime := time.Now()
+			loopTotalElapsed := loopEndTime.Sub(loopStartTime)
+			log.Info().Int("index", i).Dur("elapsed", loopElapsed).Float64("FPS", 1.0/loopTotalElapsed.Seconds()).Msg("Finished navigating to target point")
 		}
 		// End of loop, one target reached
 	}
 
-	// End of all targets reached, stop movement and reset to running mode
-	ca.KeyUp(control.KEY_W, 25)
-	if movement.Speed < MovementRun.Speed {
-		ca.KeyType(control.KEY_CTRL, 25)
-	}
+	// End of all targets reached, reset to running mode and stop movement
+	ca.SetPlayerMovement(control.MovementRun)
+	ca.PlayerStop()
 
 	// Show finished UI summary
 	if !param.NoPrint {
@@ -507,7 +475,7 @@ func doEmergencyStop(ca control.ControlAdaptor, noPrint bool) {
 	if !noPrint {
 		maafocus.NodeActionStarting(ca.Ctx(), emergencyStopHTML)
 	}
-	ca.KeyUp(control.KEY_W, 100)
+	ca.PlayerStop()
 	ca.Ctx().GetTasker().PostStop()
 }
 

--- a/agent/go-service/map-tracker/move.go
+++ b/agent/go-service/map-tracker/move.go
@@ -233,10 +233,12 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					nextX, nextY := param.Path[i+1][0], param.Path[i+1][1]
 					nextTargetRot := calcTargetRotation(curX, curY, nextX, nextY)
 					nextDeltaRot := calcDeltaRotation(rot, nextTargetRot)
-					// Pause slightly if next target is in a very different direction
+					// Foresee rotation adjustment
+					foreseeDeltaRot := float64(rawDeltaRot) / 2.0
 					if math.Abs(float64(nextDeltaRot)) > param.RotationUpperThreshold {
-						ca.PlayerStop()
+						ca.SetPlayerMovement(control.MovementWalk)
 					}
+					ca.RotateCamera(int(foreseeDeltaRot*rotationSpeed), 0)
 				}
 			}
 			dist := math.Hypot(curX-targetX, curY-targetY)
@@ -335,11 +337,11 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					if absRawDeltaRot > param.RotationUpperThreshold {
 						// Rotation is very bad: forcibly set to 'walk' for better control
 						ca.SetPlayerMovement(control.MovementWalk)
-						ca.RotateCamera(int(finalDeltaRot*rotationSpeed), 0, 50, 25)
+						ca.RotateCamera(int(finalDeltaRot*rotationSpeed), 0)
 					} else if !fineApproachOngoing {
 						// Rotation is acceptable but can be improved: at least ensure 'run'
 						ca.SetPlayerMovement(control.MovementRun)
-						ca.RotateCamera(int(finalDeltaRot*rotationSpeed), 0, 50, 25)
+						ca.RotateCamera(int(finalDeltaRot*rotationSpeed), 0)
 					}
 
 					// Update adaptive rotation state

--- a/agent/go-service/pkg/control/adaptor.go
+++ b/agent/go-service/pkg/control/adaptor.go
@@ -27,10 +27,10 @@ type ControlAdaptor interface {
 	TouchClick(contact, x, y int, durationMillis, delayMillis int)
 
 	// Swipe performs an actual swipe from (x, y) to (x+dx, y+dy) with the given duration and delay after the action.
-	Swipe(x, y, dx, dy int, durationMillis, delayMillis int)
+	Swipe(contact, x, y, dx, dy int, durationMillis, delayMillis int)
 
 	// SwipeHover performs an only-hover swipe from (x, y) to (x+dx, y+dy) with the given duration and delay after the action.
-	SwipeHover(x, y, dx, dy int, durationMillis, delayMillis int)
+	SwipeHover(contact, x, y, dx, dy int, durationMillis, delayMillis int)
 
 	// KeyDown performs a key down of the given key code with delay after the action.
 	KeyDown(keyCode int, delayMillis int)
@@ -43,7 +43,7 @@ type ControlAdaptor interface {
 
 	// RotateCamera performs a camera rotation by only-hover swipe starting from the center of the screen
 	// with the given delta, duration and delay after the action.
-	RotateCamera(dx, dy int, durationMillis, delayMillis int)
+	RotateCamera(dx, dy int)
 
 	// GetPlayerMovement returns the current player movement state.
 	GetPlayerMovement() PlayerMovement

--- a/agent/go-service/pkg/control/adaptor.go
+++ b/agent/go-service/pkg/control/adaptor.go
@@ -76,39 +76,67 @@ type ControlAdaptor interface {
 // NewControlAdaptor creates a new ControlAdaptor instance.
 // The implementation type is determined by the controller info obtained from the Maa Controller.
 func NewControlAdaptor(ctx *maa.Context, ctrl *maa.Controller, w, h int) (ControlAdaptor, error) {
+	controlType, err := GetControlType(ctrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get control type: %w", err)
+	}
+
+	switch controlType {
+	case CONTROL_TYPE_WIN32:
+		return newWindowsControlAdaptor(ctx, ctrl, w, h), nil
+	case CONTROL_TYPE_ADB:
+		return newADBControlAdaptor(ctx, ctrl, w, h), nil
+	default:
+		return nil, fmt.Errorf("unsupported control type: %s", controlType)
+	}
+}
+
+func GetControlType(ctrl *maa.Controller) (string, error) {
 	infoStr, err := ctrl.GetInfo()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	log.Info().Str("controllerInfo", infoStr).Msg("Fetched controller info")
 	if infoStr == "" {
-		return nil, fmt.Errorf("empty controller info")
+		return "", fmt.Errorf("empty controller info")
 	}
 
-	const typeWindows = "win32"
-	const typeADB = "adb"
+	type maaControllerInfo struct {
+		Type string `json:"type"`
+	}
 
 	var info maaControllerInfo
 	if err := json.Unmarshal([]byte(infoStr), &info); err != nil || info.Type == "" {
 		log.Warn().Msg("Failed to parse controller info via JSON, now trying fallback parsing")
 		// Fallback
-		if strings.Contains(infoStr, typeWindows) {
-			return newWindowsControlAdaptor(ctx, ctrl, w, h), nil
+		if strings.Contains(infoStr, CONTROL_TYPE_WIN32) {
+			CachedControlType = CONTROL_TYPE_WIN32
+			return CONTROL_TYPE_WIN32, nil
 		}
-		if strings.Contains(infoStr, typeADB) {
-			// return newADBControlAdaptor(ctx, ctrl, w, h), nil
+		if strings.Contains(infoStr, CONTROL_TYPE_ADB) {
+			CachedControlType = CONTROL_TYPE_ADB
+			return CONTROL_TYPE_ADB, nil
 		}
-		return nil, fmt.Errorf("failed to parse controller info via JSON: %w, and failed to using fallback", err)
+		return "", fmt.Errorf("failed to parse controller info via JSON: %w, and failed to using fallback", err)
 	}
 
-	if info.Type == typeWindows {
-		return newWindowsControlAdaptor(ctx, ctrl, w, h), nil
+	if info.Type == CONTROL_TYPE_WIN32 {
+		CachedControlType = CONTROL_TYPE_WIN32
+		return CONTROL_TYPE_WIN32, nil
 	}
-	if info.Type == typeADB {
-		// return newADBControlAdaptor(ctx, ctrl, w, h), nil
+	if info.Type == CONTROL_TYPE_ADB {
+		CachedControlType = CONTROL_TYPE_ADB
+		return CONTROL_TYPE_ADB, nil
 	}
-	return nil, fmt.Errorf("unsupported controller type: %s", info.Type)
+	return "", fmt.Errorf("unsupported controller type: %s", info.Type)
 }
+
+const (
+	CONTROL_TYPE_WIN32 = "win32"
+	CONTROL_TYPE_ADB   = "adb"
+)
+
+var CachedControlType string = ""
 
 // PlayerMovement represents different movement state in the game
 type PlayerMovement struct {
@@ -153,7 +181,3 @@ var (
 	MovementRun    = PlayerMovement{8.0, 540.0}
 	MovementSprint = PlayerMovement{12.0, 1080.0}
 )
-
-type maaControllerInfo struct {
-	Type string `json:"type"` // Possible values: "adb", "win32"
-}

--- a/agent/go-service/pkg/control/adaptor.go
+++ b/agent/go-service/pkg/control/adaptor.go
@@ -2,7 +2,14 @@
 package control
 
 import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
 )
 
 // ControlAdaptor defines an interface for abstracting control actions, allowing different implementations for different platforms.
@@ -38,13 +45,115 @@ type ControlAdaptor interface {
 	// with the given delta, duration and delay after the action.
 	RotateCamera(dx, dy int, durationMillis, delayMillis int)
 
-	// RotateCameraEliminateSideEffect eliminates the side effect of camera rotation with delay after the action.
+	// GetPlayerMovement returns the current player movement state.
+	GetPlayerMovement() PlayerMovement
+
+	// SetPlayerMovement sets the player movement state to the given value,
+	// and performs necessary control actions to achieve that state.
+	SetPlayerMovement(movement PlayerMovement)
+
+	// PlayerJump performs the player jump action once.
+	// This will not change the player movement state.
+	PlayerJump()
+
+	// PlayerSprint performs the player sprint action once.
+	// This will set the player movement state to at least sprint.
+	PlayerSprint()
+
+	// PlayerStop lets the player stop moving forward.
+	// This will set the player movement state to stop.
+	PlayerStop()
+
+	// AggressivelyResetCamera eliminates the side effect of camera rotation.
 	// Different implementations may have different ways to achieve this.
-	RotateCameraEliminateSideEffect(delayMillis int)
+	AggressivelyResetCamera()
+
+	// AggressivelyResetPlayerMovement provides an aggressive way to reset player movement state to stop
+	// for initialization purpose. Different implementations may have different ways to achieve this.
+	AggressivelyResetPlayerMovement()
 }
 
 // NewControlAdaptor creates a new ControlAdaptor instance.
-func NewControlAdaptor(ctx *maa.Context, ctrl *maa.Controller, w, h int) ControlAdaptor {
-	// Currently only Windows is supported
-	return newWindowsControlAdaptor(ctx, ctrl, w, h)
+// The implementation type is determined by the controller info obtained from the Maa Controller.
+func NewControlAdaptor(ctx *maa.Context, ctrl *maa.Controller, w, h int) (ControlAdaptor, error) {
+	infoStr, err := ctrl.GetInfo()
+	if err != nil {
+		return nil, err
+	}
+	log.Info().Str("controllerInfo", infoStr).Msg("Fetched controller info")
+	if infoStr == "" {
+		return nil, fmt.Errorf("empty controller info")
+	}
+
+	const typeWindows = "win32"
+	const typeADB = "adb"
+
+	var info maaControllerInfo
+	if err := json.Unmarshal([]byte(infoStr), &info); err != nil || info.Type == "" {
+		log.Warn().Msg("Failed to parse controller info via JSON, now trying fallback parsing")
+		// Fallback
+		if strings.Contains(infoStr, typeWindows) {
+			return newWindowsControlAdaptor(ctx, ctrl, w, h), nil
+		}
+		if strings.Contains(infoStr, typeADB) {
+			// return newADBControlAdaptor(ctx, ctrl, w, h), nil
+		}
+		return nil, fmt.Errorf("failed to parse controller info via JSON: %w, and failed to using fallback", err)
+	}
+
+	if info.Type == typeWindows {
+		return newWindowsControlAdaptor(ctx, ctrl, w, h), nil
+	}
+	if info.Type == typeADB {
+		// return newADBControlAdaptor(ctx, ctrl, w, h), nil
+	}
+	return nil, fmt.Errorf("unsupported controller type: %s", info.Type)
+}
+
+// PlayerMovement represents different movement state in the game
+type PlayerMovement struct {
+	speed         float64 // Movement speed (px/s)
+	rotationSpeed float64 // Rotation adjustment response speed (degrees/s)
+}
+
+// Equals checks if this PlayerMovement is approximately equal to another one.
+func (pm PlayerMovement) Equals(other PlayerMovement) bool {
+	return math.Abs(pm.speed-other.speed) <= 1e-6 && math.Abs(pm.rotationSpeed-other.rotationSpeed) <= 1e-6
+}
+
+// EtaOfDistance returns the minimal estimated time to cover the given distance at this movement speed.
+func (pm PlayerMovement) EtaOfDistance(dist float64) time.Duration {
+	if pm.speed <= 1e-6 {
+		return time.Duration(math.Inf(1))
+	}
+	return time.Duration(float64(time.Second) * dist / pm.speed)
+}
+
+// EtaOfRotation returns the minimal estimated time to adjust the given rotation at this rotation speed.
+func (pm PlayerMovement) EtaOfRotation(rot float64) time.Duration {
+	if pm.rotationSpeed <= 1e-6 {
+		return time.Duration(math.Inf(1))
+	}
+	return time.Duration(float64(time.Second) * math.Abs(rot) / pm.rotationSpeed)
+}
+
+// DistanceDuring returns the maximal distance that can be covered during the given duration at this movement speed.
+func (pm PlayerMovement) DistanceDuring(duration time.Duration) float64 {
+	return pm.speed * duration.Seconds()
+}
+
+// RotationDuring returns the maximal rotation adjustment that can be achieved during the given duration at this rotation speed.
+func (pm PlayerMovement) RotationDuring(duration time.Duration) float64 {
+	return pm.rotationSpeed * duration.Seconds()
+}
+
+var (
+	MovementStop   = PlayerMovement{0.0, 0.0}
+	MovementWalk   = PlayerMovement{2.0, 270.0}
+	MovementRun    = PlayerMovement{8.0, 540.0}
+	MovementSprint = PlayerMovement{12.0, 1080.0}
+)
+
+type maaControllerInfo struct {
+	Type string `json:"type"` // Possible values: "adb", "win32"
 }

--- a/agent/go-service/pkg/control/adaptor_adb.go
+++ b/agent/go-service/pkg/control/adaptor_adb.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Harry Huang
+package control
+
+import (
+	"time"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+)
+
+type ADBControlAdaptor struct {
+	ctx  *maa.Context
+	ctrl *maa.Controller
+	w    int
+	h    int
+
+	pm               PlayerMovement
+	lastMotionIsWalk bool
+}
+
+func newADBControlAdaptor(ctx *maa.Context, ctrl *maa.Controller, w, h int) *ADBControlAdaptor {
+	return &ADBControlAdaptor{ctx, ctrl, w, h, MovementStop, false}
+}
+
+func (aca *ADBControlAdaptor) Ctx() *maa.Context {
+	return aca.ctx
+}
+
+func (aca *ADBControlAdaptor) TouchDown(contact, x, y int, delayMillis int) {
+	aca.ctrl.PostTouchMove(int32(contact), int32(x), int32(y), 1).Wait()
+	aca.ctrl.PostTouchDown(int32(contact), int32(x), int32(y), 1).Wait()
+	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
+}
+
+func (aca *ADBControlAdaptor) TouchUp(contact int, delayMillis int) {
+	aca.ctrl.PostTouchUp(int32(contact)).Wait()
+	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
+}
+
+func (aca *ADBControlAdaptor) TouchClick(contact, x, y int, durationMillis, delayMillis int) {
+	aca.ctrl.PostTouchMove(int32(contact), int32(x), int32(y), 1).Wait()
+	aca.ctrl.PostTouchDown(int32(contact), int32(x), int32(y), 1).Wait()
+	time.Sleep(time.Duration(durationMillis) * time.Millisecond)
+	aca.ctrl.PostTouchUp(int32(contact)).Wait()
+	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
+}
+
+func (aca *ADBControlAdaptor) Swipe(x, y, dx, dy int, durationMillis, delayMillis int) {
+	aca.ctrl.PostSwipeV2(int32(x), int32(y), int32(x+dx), int32(y+dy), time.Duration(durationMillis)*time.Millisecond, 1, 1).Wait()
+	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
+}
+
+func (aca *ADBControlAdaptor) SwipeHover(x, y, dx, dy int, durationMillis, delayMillis int) {
+	// ADB not supports only-hover swipe, fallback to normal swipe
+	aca.Swipe(x, y, dx, dy, durationMillis, delayMillis)
+}
+
+func (aca *ADBControlAdaptor) KeyDown(keyCode int, delayMillis int) {
+	aca.ctrl.PostKeyDown(int32(keyCode)).Wait()
+	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
+}
+
+func (aca *ADBControlAdaptor) KeyUp(keyCode int, delayMillis int) {
+	aca.ctrl.PostKeyUp(int32(keyCode)).Wait()
+	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
+}
+
+func (aca *ADBControlAdaptor) KeyType(keyCode int, delayMillis int) {
+	aca.ctrl.PostClickKey(int32(keyCode)).Wait()
+	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
+}
+
+func (aca *ADBControlAdaptor) RotateCamera(dx, dy int, durationMillis, delayMillis int) {
+	cx, cy := aca.w/4*3, aca.h/2
+	aca.Swipe(cx, cy, dx, dy, durationMillis*4, 0)
+}
+
+func (aca *ADBControlAdaptor) GetPlayerMovement() PlayerMovement {
+	return aca.pm
+}
+
+func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
+	if movement.Equals(aca.pm) {
+		return
+	}
+
+	// Important: Currently "sprint" is temporarily disabled in ADB
+	if movement.speed >= MovementSprint.speed {
+		movement = MovementRun
+	}
+
+	if movement.speed <= MovementStop.speed {
+		// Stop moving forward
+		aca.TouchUp(0, defaultTouchActionDelayMillis)
+	} else {
+		if aca.lastMotionIsWalk {
+			if movement.speed >= MovementSprint.speed {
+				// Set to "sprint"
+				aca.TouchClick(2, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
+				aca.lastMotionIsWalk = false
+			} else if movement.speed >= MovementRun.speed {
+				// Set to "run"
+				aca.TouchDown(0, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+				aca.lastMotionIsWalk = false
+			} else {
+				// Already in "walk", do nothing
+			}
+		} else {
+			if movement.speed < MovementRun.speed {
+				// Set to "walk"
+				aca.TouchDown(0, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_WALK_DY, 0)
+				aca.lastMotionIsWalk = true
+			} else if movement.speed < MovementSprint.speed {
+				if aca.pm.speed >= MovementSprint.speed {
+					// Set to "stop" temporarily to terminate the "sprint" state, then set to "run"
+					aca.TouchUp(0, defaultTouchActionDelayMillis)
+					aca.TouchDown(0, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+				} else {
+					// Already in "run", do nothing else
+				}
+				aca.TouchDown(0, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+			} else {
+				// Set to "sprint"
+				aca.TouchClick(2, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
+				aca.TouchDown(0, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+			}
+		}
+	}
+	aca.pm = movement
+}
+
+func (aca *ADBControlAdaptor) PlayerJump() {
+	aca.TouchClick(3, JUMP_BUTTON_X, JUMP_BUTTON_Y, defaultTouchActionDelayMillis*4, 0)
+}
+
+func (aca *ADBControlAdaptor) PlayerSprint() {
+	aca.TouchClick(2, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
+	aca.pm = MovementSprint
+	aca.lastMotionIsWalk = false
+}
+
+func (aca *ADBControlAdaptor) PlayerStop() {
+	aca.TouchUp(0, defaultTouchActionDelayMillis)
+	aca.pm = MovementStop
+}
+
+func (aca *ADBControlAdaptor) AggressivelyResetCamera() {
+	// ADB has no need to reset camera aggressively
+}
+
+func (aca *ADBControlAdaptor) AggressivelyResetPlayerMovement() {
+	// ADB has no need to reset player movement aggressively
+}
+
+const (
+	JOYSTICK_CENTER_X = 195
+	JOYSTICK_CENTER_Y = 551
+	JOYSTICK_WALK_DY  = -15
+	JOYSTICK_RUN_DY   = -90
+
+	JUMP_BUTTON_X = 1166
+	JUMP_BUTTON_Y = 475
+
+	SPRINT_BUTTON_X = 1166
+	SPRINT_BUTTON_Y = 620
+)
+
+const defaultTouchActionDelayMillis = 50

--- a/agent/go-service/pkg/control/adaptor_adb.go
+++ b/agent/go-service/pkg/control/adaptor_adb.go
@@ -44,14 +44,14 @@ func (aca *ADBControlAdaptor) TouchClick(contact, x, y int, durationMillis, dela
 	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
 }
 
-func (aca *ADBControlAdaptor) Swipe(x, y, dx, dy int, durationMillis, delayMillis int) {
-	aca.ctrl.PostSwipeV2(int32(x), int32(y), int32(x+dx), int32(y+dy), time.Duration(durationMillis)*time.Millisecond, 1, 1).Wait()
+func (aca *ADBControlAdaptor) Swipe(contact, x, y, dx, dy int, durationMillis, delayMillis int) {
+	aca.ctrl.PostSwipeV2(int32(x), int32(y), int32(x+dx), int32(y+dy), time.Duration(durationMillis)*time.Millisecond, int32(contact), 1).Wait()
 	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
 }
 
-func (aca *ADBControlAdaptor) SwipeHover(x, y, dx, dy int, durationMillis, delayMillis int) {
-	// ADB not supports only-hover swipe, fallback to normal swipe
-	aca.Swipe(x, y, dx, dy, durationMillis, delayMillis)
+func (aca *ADBControlAdaptor) SwipeHover(contact, x, y, dx, dy int, durationMillis, delayMillis int) {
+	aca.ctrl.PostSwipeV2(int32(x), int32(y), int32(x+dx), int32(y+dy), time.Duration(durationMillis)*time.Millisecond, int32(contact), 0).Wait()
+	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
 }
 
 func (aca *ADBControlAdaptor) KeyDown(keyCode int, delayMillis int) {
@@ -69,9 +69,9 @@ func (aca *ADBControlAdaptor) KeyType(keyCode int, delayMillis int) {
 	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
 }
 
-func (aca *ADBControlAdaptor) RotateCamera(dx, dy int, durationMillis, delayMillis int) {
+func (aca *ADBControlAdaptor) RotateCamera(dx, dy int) {
 	cx, cy := aca.w/4*3, aca.h/2
-	aca.Swipe(cx, cy, dx, dy, durationMillis*4, 0)
+	aca.Swipe(cameraContact, cx, cy, dx, dy, defaultTouchActionDelayMillis*2, 0)
 }
 
 func (aca *ADBControlAdaptor) GetPlayerMovement() PlayerMovement {
@@ -83,23 +83,23 @@ func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
 		return
 	}
 
-	// Important: Currently "sprint" is temporarily disabled in ADB
+	// Note: Currently "sprint" is temporarily disabled in ADB
 	if movement.speed >= MovementSprint.speed {
 		movement = MovementRun
 	}
 
 	if movement.speed <= MovementStop.speed {
 		// Stop moving forward
-		aca.TouchUp(0, defaultTouchActionDelayMillis)
+		aca.TouchUp(joystickContact, defaultTouchActionDelayMillis)
 	} else {
 		if aca.lastMotionIsWalk {
 			if movement.speed >= MovementSprint.speed {
 				// Set to "sprint"
-				aca.TouchClick(2, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
+				aca.TouchClick(sprintButtonContact, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
 				aca.lastMotionIsWalk = false
 			} else if movement.speed >= MovementRun.speed {
 				// Set to "run"
-				aca.TouchDown(0, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+				aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
 				aca.lastMotionIsWalk = false
 			} else {
 				// Already in "walk", do nothing
@@ -107,21 +107,21 @@ func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
 		} else {
 			if movement.speed < MovementRun.speed {
 				// Set to "walk"
-				aca.TouchDown(0, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_WALK_DY, 0)
+				aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_WALK_DY, 0)
 				aca.lastMotionIsWalk = true
 			} else if movement.speed < MovementSprint.speed {
 				if aca.pm.speed >= MovementSprint.speed {
 					// Set to "stop" temporarily to terminate the "sprint" state, then set to "run"
-					aca.TouchUp(0, defaultTouchActionDelayMillis)
-					aca.TouchDown(0, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+					aca.TouchUp(joystickContact, defaultTouchActionDelayMillis)
+					aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
 				} else {
 					// Already in "run", do nothing else
 				}
-				aca.TouchDown(0, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+				aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
 			} else {
 				// Set to "sprint"
-				aca.TouchClick(2, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
-				aca.TouchDown(0, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+				aca.TouchClick(sprintButtonContact, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
+				aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
 			}
 		}
 	}
@@ -129,17 +129,17 @@ func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
 }
 
 func (aca *ADBControlAdaptor) PlayerJump() {
-	aca.TouchClick(3, JUMP_BUTTON_X, JUMP_BUTTON_Y, defaultTouchActionDelayMillis*4, 0)
+	aca.TouchClick(jumpButtonContact, JUMP_BUTTON_X, JUMP_BUTTON_Y, defaultTouchActionDelayMillis*4, 0)
 }
 
 func (aca *ADBControlAdaptor) PlayerSprint() {
-	aca.TouchClick(2, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
+	aca.TouchClick(sprintButtonContact, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
 	aca.pm = MovementSprint
 	aca.lastMotionIsWalk = false
 }
 
 func (aca *ADBControlAdaptor) PlayerStop() {
-	aca.TouchUp(0, defaultTouchActionDelayMillis)
+	aca.TouchUp(joystickContact, defaultTouchActionDelayMillis)
 	aca.pm = MovementStop
 }
 
@@ -164,4 +164,10 @@ const (
 	SPRINT_BUTTON_Y = 620
 )
 
-const defaultTouchActionDelayMillis = 50
+const (
+	joystickContact               = 0
+	cameraContact                 = 1
+	sprintButtonContact           = 2
+	jumpButtonContact             = 3
+	defaultTouchActionDelayMillis = 50
+)

--- a/agent/go-service/pkg/control/adaptor_win.go
+++ b/agent/go-service/pkg/control/adaptor_win.go
@@ -42,20 +42,20 @@ func (wca *WindowsControlAdaptor) TouchClick(contact, x, y int, durationMillis, 
 	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
 }
 
-func (wca *WindowsControlAdaptor) Swipe(x, y, dx, dy int, durationMillis, delayMillis int) {
+func (wca *WindowsControlAdaptor) Swipe(contact, x, y, dx, dy int, durationMillis, delayMillis int) {
 	stepDurationMillis := durationMillis / 2
-	wca.ctrl.PostTouchDown(0, int32(x), int32(y), 1).Wait()
+	wca.ctrl.PostTouchDown(int32(contact), int32(x), int32(y), 1).Wait()
 	time.Sleep(time.Duration(stepDurationMillis) * time.Millisecond)
-	wca.ctrl.PostTouchMove(0, int32(x+dx), int32(y+dy), 1).Wait()
+	wca.ctrl.PostTouchMove(int32(contact), int32(x+dx), int32(y+dy), 1).Wait()
 	time.Sleep(time.Duration(stepDurationMillis) * time.Millisecond)
-	wca.ctrl.PostTouchUp(0).Wait()
+	wca.ctrl.PostTouchUp(int32(contact)).Wait()
 	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
 }
 
-func (wca *WindowsControlAdaptor) SwipeHover(x, y, dx, dy int, durationMillis, delayMillis int) {
-	wca.ctrl.PostTouchMove(0, int32(x), int32(y), 0).Wait()
+func (wca *WindowsControlAdaptor) SwipeHover(contact, x, y, dx, dy int, durationMillis, delayMillis int) {
+	wca.ctrl.PostTouchMove(int32(contact), int32(x), int32(y), 0).Wait()
 	time.Sleep(time.Duration(durationMillis) * time.Millisecond)
-	wca.ctrl.PostTouchMove(0, int32(x+dx), int32(y+dy), 0).Wait()
+	wca.ctrl.PostTouchMove(int32(contact), int32(x+dx), int32(y+dy), 0).Wait()
 	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
 }
 
@@ -74,9 +74,9 @@ func (wca *WindowsControlAdaptor) KeyType(keyCode int, delayMillis int) {
 	time.Sleep(time.Duration(delayMillis) * time.Millisecond)
 }
 
-func (wca *WindowsControlAdaptor) RotateCamera(dx, dy int, durationMillis, delayMillis int) {
+func (wca *WindowsControlAdaptor) RotateCamera(dx, dy int) {
 	cx, cy := wca.w/2, wca.h/2
-	wca.SwipeHover(cx, cy, dx, dy, durationMillis, delayMillis)
+	wca.SwipeHover(0, cx, cy, dx, dy, defaultKeyActionDelayMillis*2, defaultKeyActionDelayMillis)
 }
 
 func (wca *WindowsControlAdaptor) GetPlayerMovement() PlayerMovement {

--- a/agent/go-service/pkg/control/adaptor_win.go
+++ b/agent/go-service/pkg/control/adaptor_win.go
@@ -12,10 +12,13 @@ type WindowsControlAdaptor struct {
 	ctrl *maa.Controller
 	w    int
 	h    int
+
+	pm               PlayerMovement
+	lastMotionIsWalk bool
 }
 
 func newWindowsControlAdaptor(ctx *maa.Context, ctrl *maa.Controller, w, h int) *WindowsControlAdaptor {
-	return &WindowsControlAdaptor{ctx, ctrl, w, h}
+	return &WindowsControlAdaptor{ctx, ctrl, w, h, MovementStop, false}
 }
 
 func (wca *WindowsControlAdaptor) Ctx() *maa.Context {
@@ -76,12 +79,86 @@ func (wca *WindowsControlAdaptor) RotateCamera(dx, dy int, durationMillis, delay
 	wca.SwipeHover(cx, cy, dx, dy, durationMillis, delayMillis)
 }
 
-func (wca *WindowsControlAdaptor) RotateCameraEliminateSideEffect(delayMillis int) {
+func (wca *WindowsControlAdaptor) GetPlayerMovement() PlayerMovement {
+	return wca.pm
+}
+
+func (wca *WindowsControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
+	if movement.Equals(wca.pm) {
+		return
+	}
+
+	if movement.speed <= MovementStop.speed {
+		// Stop moving forward
+		wca.KeyUp(KEY_W, defaultKeyActionDelayMillis)
+	} else {
+		if wca.lastMotionIsWalk {
+			if movement.speed >= MovementSprint.speed {
+				// Set to "sprint"
+				wca.KeyType(KEY_SHIFT, defaultKeyActionDelayMillis)
+				wca.lastMotionIsWalk = false
+			} else if movement.speed >= MovementRun.speed {
+				// Set to "run"
+				wca.KeyType(KEY_CTRL, defaultKeyActionDelayMillis)
+				wca.lastMotionIsWalk = false
+			} else {
+				// Already in "walk", do nothing
+			}
+		} else {
+			if movement.speed < MovementRun.speed {
+				// Set to "walk"
+				wca.KeyType(KEY_CTRL, defaultKeyActionDelayMillis)
+				wca.lastMotionIsWalk = true
+			} else if movement.speed < MovementSprint.speed {
+				if wca.pm.speed >= MovementSprint.speed {
+					// Set to "walk" temporarily to terminate the "sprint" state, then set to "run"
+					wca.KeyType(KEY_CTRL, defaultKeyActionDelayMillis)
+					wca.KeyType(KEY_CTRL, defaultKeyActionDelayMillis)
+				} else {
+					// Already in "run", do nothing
+				}
+			} else {
+				// Set to "sprint"
+				wca.KeyType(KEY_SHIFT, defaultKeyActionDelayMillis)
+			}
+		}
+		// Ensure moving forward
+		wca.KeyDown(KEY_W, defaultKeyActionDelayMillis/4)
+	}
+	wca.pm = movement
+}
+
+func (wca *WindowsControlAdaptor) PlayerJump() {
+	wca.KeyType(KEY_SPACE, defaultKeyActionDelayMillis*4)
+}
+
+func (wca *WindowsControlAdaptor) PlayerSprint() {
+	wca.KeyDown(KEY_SHIFT, defaultKeyActionDelayMillis)
+	wca.pm = MovementSprint
+	wca.lastMotionIsWalk = false
+}
+
+func (wca *WindowsControlAdaptor) PlayerStop() {
+	wca.KeyUp(KEY_W, defaultKeyActionDelayMillis)
+	wca.pm = MovementStop
+}
+
+func (wca *WindowsControlAdaptor) AggressivelyResetCamera() {
+	// Policy: use ALT key to release mouse cursor and reset its position using a click, then release ALT key
 	cx, cy := wca.w/2, wca.h/2
-	stepDelayMillis := delayMillis / 3
+	stepDelayMillis := defaultKeyActionDelayMillis / 3
 	wca.KeyDown(KEY_ALT, stepDelayMillis)
 	wca.TouchClick(0, cx, cy, stepDelayMillis, 0)
 	wca.KeyUp(KEY_ALT, stepDelayMillis)
+}
+
+func (wca *WindowsControlAdaptor) AggressivelyResetPlayerMovement() {
+	// Policy: sprint backward and immediately move forward to ensure the initial motional state is "run"
+	wca.KeyDown(KEY_S, defaultKeyActionDelayMillis*2)
+	wca.KeyType(KEY_SHIFT, defaultKeyActionDelayMillis*2)
+	wca.KeyUp(KEY_S, defaultKeyActionDelayMillis*2)
+	wca.KeyType(KEY_W, defaultKeyActionDelayMillis*2)
+	wca.pm = MovementRun
 }
 
 const (
@@ -94,3 +171,5 @@ const (
 	KEY_ALT   = 0x12
 	KEY_SPACE = 0x20
 )
+
+const defaultKeyActionDelayMillis = 25


### PR DESCRIPTION
## 概要

此 PR 为 MapTracker 系列节点及 control adaptor 相关辅助类添加了针对 **ADB 控制器**的支持。

## 关联

此 PR 的重要前置 PR 是 #1447 。

## Summary by Sourcery

添加具备“控制器类型感知”的控制适配器及共享玩家移动模型，并将其集成到地图追踪导航和大地图点选中，包含对 ADB 控制器的支持。

新功能：
- 引入基于 ADB 的 `ControlAdaptor` 实现，用于触摸与按键操作，包括移动、镜头旋转、跳跃、冲刺与停止等。
- 支持从 Maa 控制器信息中检测控制器类型并进行缓存，并据此在 Win32 和 ADB 控制适配器之间进行选择。
- 向地图追踪逻辑暴露更高级别的玩家移动 API（有状态的移动模式和 ETA 辅助方法），以及镜头/移动重置操作。
- 调整地图追踪器的位置和朝向推断逻辑，以便根据不同控制器类型对应的不同小地图布局进行处理。

增强：
- 优化 Windows 控制适配器，支持多触点滑动，跟踪玩家移动状态，并提供更高级别的移动和镜头重置工具方法。
- 更新地图追踪移动流程和大地图点选流程，改用新的控制适配器工厂和高级移动 API，而非直接按键处理，从而提升在不同控制器之间的可移植性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add controller-type-aware control adaptor with shared player movement model and integrate it into map tracker navigation and big map picking, including ADB controller support.

New Features:
- Introduce an ADB-based ControlAdaptor implementation for touch and key actions, including movement, camera rotation, jumping, sprinting, and stopping.
- Support controller type detection from Maa controller info with caching and use it to select between Win32 and ADB control adaptors.
- Expose higher-level player movement APIs (stateful movement modes and ETA helpers) and camera/movement reset operations to map tracker logic.
- Adjust map-tracker location and rotation inference to handle different mini-map layouts based on controller type.

Enhancements:
- Refine the Windows control adaptor to support multi-contact swipes, track player movement state, and provide higher-level movement and camera reset utilities.
- Update map tracker movement and big-map picking flows to use the new control adaptor factory and high-level movement APIs instead of direct key handling, improving portability across controllers.

</details>