### PR TITLE
docs: 修改可复用节点与测试说明，强调减少使用可复用 Custom 节点

### DIFF
--- a/docs/en_us/developers/development.md
+++ b/docs/en_us/developers/development.md
@@ -99,19 +99,31 @@ This will fully set up the environment required for development.
     ]
     ```
 
-### About Reusable Nodes (Common Nodes)
+### About Qin Shi Huang Nodes (Custom or Reusable Pipeline Nodes)
 
-Some highly reusable nodes have been encapsulated with detailed documentation to avoid reinventing the wheel. See:
+Some highly reusable nodes have already been encapsulated and documented in detail to avoid reinventing the wheel. See:
+
+#### Reusable Nodes
+
+The following are reusable nodes based on Pipeline. You can call them directly to implement related logic; see the corresponding documents for details:
+
+- [Common Buttons Reference Document](./common-buttons.md): Common button nodes.
+- [SceneManager Reference Document](./scene-manager.md): Interfaces related to universal jumps and scene navigation.
+
+#### Reusable Custom Nodes
+
+The following are reusable nodes based on `Custom`. They are more business-specific and can be used when appropriate. However,**according to [Go Service Code Specifications](#go-service-code-specifications) and [Cpp Algo Code Specifications](#cpp-algo-code-specifications), you should avoid using these nodes unless necessary**. The reasons are explained in those two sections.
 
 - [MapTracker Reference Document](./map-tracker.md): Nodes related to minimap positioning and automatic pathfinding.
 - [MapNavigator Reference Document](./map-navigator.md): Path recording tool and the `MapNavigateAction` automatic navigation node.
-- [Common Buttons Reference Document](./common-buttons.md): Common button nodes.
 - [Custom Action Reference Document](./custom-action.md): Invoke custom logic in go-service via the `Custom` node.
-- [AutoFight Reference Document](./auto-fight.md): In-game automatic operation module. After the user has entered the game battle scene, it automatically completes the battle until the battle ends and exits.
-- [SceneManager Reference Document](./scene-manager.md): Universal jump and scene navigation related interfaces.
-- [CharacterController Reference Document](./character-controller.md): Nodes for character view rotation, movement, and automatic movement toward a recognized target.
+- [AutoFight Reference Document](./auto-fight.md): In-game automatic operation module. After the user has entered the battle scene, it automatically plays the battle until it ends and exits.
+- [CharacterController Reference Document](./character-controller.md): Nodes for character view rotation, movement, and automatic movement toward a target.
 - [QuantizedSliding Reference Document](./quantized-sliding.md): A shared custom action for adjusting discrete quantity sliders to a target value.
-- [Node Testing Reference Document](./node-testing.md): Directory conventions, schema, and writing guidelines for static screenshot node tests.
+
+### About Testing
+
+MaaEnd uses `maa-tools` to provide node testing, which is used to verify whether recognition can correctly match the corresponding position in the game. For details, see the [Node Testing Reference Document](./node-testing.md). When you create nodes that rely on recognition, try to add corresponding test cases whenever possible. This helps with future task maintenance and logic refactoring.
 
 ### About Task Maintenance
 

--- a/docs/en_us/developers/development.md
+++ b/docs/en_us/developers/development.md
@@ -112,7 +112,7 @@ The following are reusable nodes based on Pipeline. You can call them directly t
 
 #### Reusable Custom Nodes
 
-The following are reusable nodes based on `Custom`. They are more business-specific and can be used when appropriate. However,**according to [Go Service Code Specifications](#go-service-code-specifications) and [Cpp Algo Code Specifications](#cpp-algo-code-specifications), you should avoid using these nodes unless necessary**. The reasons are explained in those two sections.
+The following are reusable nodes based on `Custom`. They are more business-specific and can be used when appropriate. However, **according to [Go Service Code Specifications](#go-service-code-specifications) and [Cpp Algo Code Specifications](#cpp-algo-code-specifications), you should avoid using these nodes unless necessary**. The reasons are explained in those two sections.
 
 - [MapTracker Reference Document](./map-tracker.md): Nodes related to minimap positioning and automatic pathfinding.
 - [MapNavigator Reference Document](./map-navigator.md): Path recording tool and the `MapNavigateAction` automatic navigation node.

--- a/docs/zh_cn/developers/development.md
+++ b/docs/zh_cn/developers/development.md
@@ -112,7 +112,7 @@ python tools/setup_workspace.py
 
 #### 可复用 Custom 节点
 
-以下是基于 Custom 的可复用节点，具有高业务化的特点，在需要调用时可以酌情使用，但**根据 [Go Service 代码规范](#go-service-代码规范) 和 [Cpp Algo 代码规范](#cpp-algo-代码规范) 您不应该在非必要情况使用以下这些节点**，具体原因已在这两部分文档指出。
+以下是基于 Custom 的可复用节点，具有高业务化的特点，在需要调用时可以酌情使用，但**根据 [Go Service 代码规范](#go-service-代码规范) 和 [Cpp Algo 代码规范](#cpp-algo-代码规范) 您不应该在非必要情况下使用以下这些节点**，具体原因已在这两部分文档指出。
 
 - [MapTracker 参考文档](./map-tracker.md)：小地图定位和自动寻路相关节点。
 - [MapNavigator 参考文档](./map-navigator.md)：路径录制工具与 `MapNavigateAction` 自动导航节点。

--- a/docs/zh_cn/developers/development.md
+++ b/docs/zh_cn/developers/development.md
@@ -99,19 +99,31 @@ python tools/setup_workspace.py
     ]
     ```
 
-### 关于秦始皇节点（可复用节点或 Custom ）
+### 关于秦始皇节点（Custom 或 Pipeline 可复用节点）
 
 某些具有高可复用性的节点已经予以封装，并撰写了详细文档，以避免重复造轮子。参见：
 
+#### 可复用节点
+
+以下是基于 Pipeline 的可复用节点，可以调用这些节点来实现逻辑，具体可以看对应的文档：
+
+- [通用按钮 参考文档](./common-buttons.md)：通用按钮节点。
+- [SceneManager 参考文档](./scene-manager.md)：万能跳转和场景导航相关接口。
+
+#### 可复用 Custom 节点
+
+以下是基于 Custom 的可复用节点，具有高业务化的特点，在需要调用时可以酌情使用，但**根据 [Go Service 代码规范](#go-service-代码规范) 和 [Cpp Algo 代码规范](#cpp-algo-代码规范) 您不应该在非必要情况使用以下这些节点**，具体原因已在这两部分文档指出。
+
 - [MapTracker 参考文档](./map-tracker.md)：小地图定位和自动寻路相关节点。
 - [MapNavigator 参考文档](./map-navigator.md)：路径录制工具与 `MapNavigateAction` 自动导航节点。
-- [通用按钮 参考文档](./common-buttons.md)：通用按钮节点。
 - [Custom 自定义动作参考文档](./custom-action.md)：通过 `Custom` 节点调用 go-service 中的自定义逻辑。
 - [自动战斗 参考文档](./auto-fight.md)：战斗内自动操作模块，在用户已进入游戏战斗场景后，自动完成战斗直至战斗结束退出。
-- [SceneManager 参考文档](./scene-manager.md)：万能跳转和场景导航相关接口。
 - [CharacterController 参考文档](./character-controller.md)：角色视角旋转、移动及朝向目标自动移动等控制节点。
 - [QuantizedSliding 参考文档](./quantized-sliding.md)：用于按目标值调节离散数量滑条的公共自定义动作。
-- [节点测试参考文档](./node-testing.md)：节点静态截图测试的目录约定、Schema 和编写建议。
+
+### 关于测试
+
+MaaEnd 采用 maa-tools 来提供节点测试，验证识别是否能正确命中游戏中相应的位置，具体使用请参考 [节点测试参考文档](./node-testing.md) 相关文档，当您编写需要识别的节点时尽量添加对应的测试用例，这可以为以后的任务维护和逻辑重构打下地基。
 
 ### 关于任务维护
 


### PR DESCRIPTION
## Summary by Sourcery

在英文和中文指引中澄清关于秦始皇（自定义与可复用流水线）节点以及节点测试的开发者文档。

Documentation:
- 区分可复用的 Pipeline 节点与可复用的 Custom 节点，并根据 Go 和 Cpp 代码规范补充指导，尽量减少对非必要的、与业务强相关的 Custom 节点的使用。
- 在英文和中文开发者文档中更新和扩展常见可复用节点的文档链接和说明，以及相关参考资料。
- 新增专门的测试章节，说明基于 MaaEnd 的 maa-tools 的节点测试方式，并鼓励为新节点编写识别类测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify developer documentation around Qin Shi Huang (custom and reusable pipeline) nodes and node testing in both English and Chinese guides.

Documentation:
- Distinguish between reusable Pipeline nodes and reusable Custom nodes, adding guidance to minimize non-essential use of business-specific Custom nodes per Go and Cpp code specifications.
- Update and expand documentation links and descriptions for common reusable nodes and their reference materials in both English and Chinese developer docs.
- Introduce a dedicated testing section explaining MaaEnd's maa-tools–based node testing and encouraging adding recognition test cases for new nodes.

</details>