### PR TITLE
feat(DeliveryJobs): 添加仅装箱货物的选项

### DIFF
--- a/assets/misc/locales/en_us.json
+++ b/assets/misc/locales/en_us.json
@@ -326,6 +326,8 @@
     "task.DeliveryJobs.OngoingDelivery": "There are pending goods to deliver. Please complete the delivery first, then rerun the task.",
     "task.DeliveryJobs.label": "🚚Delivery Jobs",
     "task.DeliveryJobs.description": "Accept and hand over delivery jobs.\nPlease select the regions to enable:",
+    "task.DeliveryJobs.PackCargoOnly.label": "Pack Cargo Only",
+    "task.DeliveryJobs.PackCargoOnly.description": "When enabled, it only automatically packs cargo and does not accept jobs.",
     "task.ClaimSimulationRewards.label": "📦Claim Simulation Rewards",
     "task.ClaimSimulationRewards.error_not_found": "Simulation UI not detected. Please switch manually.",
     "task.ClaimSimulationRewards.success_finished": "Simulation  rewards claimed successfully.",

--- a/assets/misc/locales/ja_jp.json
+++ b/assets/misc/locales/ja_jp.json
@@ -287,6 +287,8 @@
     "task.DeliveryJobs.OngoingDelivery": "配達待ちの貨物があります。先に配達を完了してから、タスクを再実行してください",
     "task.DeliveryJobs.label": "🚚配達任務の転送",
     "task.DeliveryJobs.description": "配達任務を受注・転送します。\n有効にする地域を選択してください：",
+    "task.DeliveryJobs.PackCargoOnly.label": "貨物パッキングのみ",
+    "task.DeliveryJobs.PackCargoOnly.description": "有効にすると、貨物の自動パッキングのみを行い、依頼の受注は行いません。",
     "task.ClaimSimulationRewards.label": "📦模擬空間報酬受取",
     "task.ClaimSimulationRewards.error_not_found": "模擬空間が見つかりません。手動で切り替えてください。",
     "task.ClaimSimulationRewards.success_finished": "模擬空間報酬の受取が完了しました。",

--- a/assets/misc/locales/ko_kr.json
+++ b/assets/misc/locales/ko_kr.json
@@ -287,6 +287,8 @@
     "task.DeliveryJobs.OngoingDelivery": "운송 대기 중인 화물이 있습니다. 먼저 배송을 완료한 뒤 작업을 다시 실행해 주세요.",
     "task.DeliveryJobs.label": "🚚배달 임무 전달",
     "task.DeliveryJobs.description": "배달 임무를 수락하고 전달합니다.\n활성화할 지역을 선택하세요:",
+    "task.DeliveryJobs.PackCargoOnly.label": "화물 포장만",
+    "task.DeliveryJobs.PackCargoOnly.description": "활성화하면 화물 자동 포장만 수행하고 임무를 수락하지 않습니다.",
     "task.ClaimSimulationRewards.label": "📦시뮬레이션 공간 보상 수령",
     "task.ClaimSimulationRewards.error_not_found": "[시뮬레이션 공간] 화면을 찾을 수 없습니다. 수동으로 전환해 주세요.",
     "task.ClaimSimulationRewards.success_finished": "시뮬레이션 공간 보상 수령 완료.",

--- a/assets/misc/locales/zh_cn.json
+++ b/assets/misc/locales/zh_cn.json
@@ -287,6 +287,8 @@
     "task.DeliveryJobs.OngoingDelivery": "有待运送的货物，请先完成送货，再重新运行任务",
     "task.DeliveryJobs.label": "🚚转交送货任务",
     "task.DeliveryJobs.description": "接取并转交送货任务。\n请选择需要启用的地区：",
+    "task.DeliveryJobs.PackCargoOnly.label": "仅装箱货物",
+    "task.DeliveryJobs.PackCargoOnly.description": "开启后仅会自动装箱货物，不会接取任务。",
     "task.ClaimSimulationRewards.label": "📦领取模拟空间奖励",
     "task.ClaimSimulationRewards.error_not_found": "未检测到[模拟空间]界面，请手动切换",
     "task.ClaimSimulationRewards.success_finished": "模拟空间奖励领取完毕",

--- a/assets/misc/locales/zh_tw.json
+++ b/assets/misc/locales/zh_tw.json
@@ -287,6 +287,8 @@
     "task.DeliveryJobs.OngoingDelivery": "有待運送的貨物，請先完成送貨，再重新執行任務",
     "task.DeliveryJobs.label": "🚚轉交送貨任務",
     "task.DeliveryJobs.description": "接取並轉交送貨任務。\n請選擇需要啟用的地區：",
+    "task.DeliveryJobs.PackCargoOnly.label": "僅裝箱貨物",
+    "task.DeliveryJobs.PackCargoOnly.description": "啟用後僅會自動裝箱貨物，不會接取任務。",
     "task.ClaimSimulationRewards.label": "📦領取模擬空間獎勵",
     "task.ClaimSimulationRewards.error_not_found": "未檢測到[模擬空間]介面，請手動切換",
     "task.ClaimSimulationRewards.success_finished": "模擬空間獎勵領取完畢",

--- a/assets/resource/pipeline/DeliveryJobs/PackCargo.json
+++ b/assets/resource/pipeline/DeliveryJobs/PackCargo.json
@@ -365,5 +365,20 @@
         "next": [
             "[Anchor]DeliveryJobsGoToDepot"
         ]
+    },
+    "DeliveryJobsBackToDepotFromBid": {
+        "desc": "从调度申请界面回到本地仓储界面",
+        "recognition": "And",
+        "all_of": [
+            "CloseButtonType1",
+            "DeliveryJobsInCargoRedistributionBid"
+        ],
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "InLocalDepotNode"
+        ]
     }
 }

--- a/assets/tasks/DeliveryJobs.json
+++ b/assets/tasks/DeliveryJobs.json
@@ -9,9 +9,12 @@
                 "ValleyIV",
                 "Wuling",
                 "PackCargoSelectItem",
-                "DeliveryJobsAcceptJobOnly"
+                "DeliveryJobsAcceptJobOnly",
+                "DeliveryJobsPackCargoOnly"
             ],
-            "group": ["daily"]
+            "group": [
+                "daily"
+            ]
         }
     ],
     "option": {
@@ -324,6 +327,66 @@
                         "DeliveryJobsBackToDepot": {
                             "next": [
                                 "DeliveryJobsAcceptJobOnly"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "No"
+                }
+            ],
+            "default_case": "No"
+        },
+        "DeliveryJobsPackCargoOnly": {
+            "type": "switch",
+            "label": "$task.DeliveryJobs.PackCargoOnly.label",
+            "description": "$task.DeliveryJobs.PackCargoOnly.description",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "DeliveryJobsEnterDeliveryJob": {
+                            "enabled": false
+                        },
+                        "DeliveryJobsInCargoRedistributionBid": {
+                            "next": [
+                                "DeliveryJobsBackToDepotFromBid"
+                            ]
+                        },
+                        "DeliveryJobsCheckOriginiumScienceParkCargo": {
+                            "expected": [
+                                "货物装箱",
+                                "貨物裝箱",
+                                "(?i)Pack\\s*Goods",
+                                "パッキング",
+                                "화물 포장"
+                            ]
+                        },
+                        "DeliveryJobsCheckOriginLodespringCargo": {
+                            "expected": [
+                                "货物装箱",
+                                "貨物裝箱",
+                                "(?i)Pack\\s*Goods",
+                                "パッキング",
+                                "화물 포장"
+                            ]
+                        },
+                        "DeliveryJobsCheckPowerPlateauCargo": {
+                            "expected": [
+                                "货物装箱",
+                                "貨物裝箱",
+                                "(?i)Pack\\s*Goods",
+                                "パッキング",
+                                "화물 포장"
+                            ]
+                        },
+                        "DeliveryJobsCheckWulingCityCargo": {
+                            "expected": [
+                                "货物装箱",
+                                "貨物裝箱",
+                                "(?i)Pack\\s*Goods",
+                                "パッキング",
+                                "화물 포장"
                             ]
                         }
                     }


### PR DESCRIPTION
close #1538

## Summary by Sourcery

在 DeliveryJobs 中新增对仅箱装货物打包选项的支持。

New Features:
- 在 DeliveryJobs 任务中引入一个配置选项，用于将任务限制为只打包箱装货物。

Enhancements:
- 更新 PackCargo 配送流水线（delivery pipeline）配置，以支持新的“仅箱装货物”选项。

Documentation:
- 在多种语言的本地化字符串中新增或更新条目，用于描述 DeliveryJobs 中新的“仅箱装货物”选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support in DeliveryJobs for a new option to handle box-only cargo packing.

New Features:
- Introduce a configuration option in DeliveryJobs tasks to restrict jobs to packing boxed cargo only.

Enhancements:
- Update the PackCargo delivery pipeline configuration to support the new box-only cargo option.

Documentation:
- Add or update localization strings in multiple languages to describe the new box-only cargo option in DeliveryJobs.

</details>