### PR TITLE
fix: :bug: 略拓宽 BakerExpend 的匹配阈值和处理一个全局跳转中检测Baker文本问题

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -1155,7 +1155,7 @@
                     100
                 ],
                 "expected": [
-                    "Baker"
+                    "(?i)Baker"
                 ]
             }
         },

--- a/assets/resource_adb/pipeline/BAKER.json
+++ b/assets/resource_adb/pipeline/BAKER.json
@@ -80,7 +80,7 @@
             645
         ],
         "template": "Baker/Expend.png",
-        "threshold": 0.95,
+        "threshold": 0.9,
         "action": "Click",
         "next": [
             "BakerTalkWith",


### PR DESCRIPTION
在模拟器上复现了报错：

1. 此次报错中，原因是在节点 `BakerExpend` 的模板匹配精度较低导致没能通过。
		
	![Image](https://github.com/user-attachments/assets/111d0534-3065-4e84-b009-e5da1706fccb)

2. 还有个问题是因为被替换了匹配文字导致的识别错误

	<img width="1534" height="391" alt="QQ_1774285266495" src="https://github.com/user-attachments/assets/fc0e5534-ae88-43a5-a78d-6b3d575a7323" />

## Summary by Sourcery

调整与 Baker 相关的场景和 ADB 流水线定义，以提升 BakerExpend 匹配和 Baker 文本检测的健壮性。

Bug 修复：
- 放宽 BakerExpend 节点的匹配阈值，以避免在模板识别中出现误判为不匹配的情况。
- 修正在全局导航流程中，当匹配到的文本被修改或替换时的 Baker 文本检测问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Baker-related scene and ADB pipeline definitions to improve robustness of BakerExpend matching and Baker text detection.

Bug Fixes:
- Relax the matching threshold for the BakerExpend node to avoid false negatives in template recognition.
- Correct Baker text detection in a global navigation flow when the matched text has been altered or replaced.

</details>