### PR TITLE
feat(quantizedsliding): 支持目标超上限时自动钳制

### DIFF
--- a/agent/go-service/quantizedsliding/handlers.go
+++ b/agent/go-service/quantizedsliding/handlers.go
@@ -132,15 +132,8 @@ func (a *QuantizedSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa
 	}
 
 	a.maxQuantity = maxQuantity
-	nextNode, err := resolveMaxQuantityNext(a.maxQuantity, a.Target, a.ClampTargetToMax)
-	if err != nil {
-		a.logger.Error().
-			Int("max_quantity", a.maxQuantity).
-			Int("target", a.Target).
-			Msg("max quantity lower than target")
-		return false
-	}
 
+	// 先钳制 Target，再计算 nextNode，避免 maxQuantity==1 时的除零问题
 	if a.ClampTargetToMax && a.maxQuantity < a.Target {
 		originalTarget := a.Target
 		a.Target = a.maxQuantity
@@ -149,6 +142,15 @@ func (a *QuantizedSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa
 			Int("clamped_target", a.Target).
 			Int("max_quantity", a.maxQuantity).
 			Msg("target clamped to max quantity")
+	}
+
+	nextNode, err := resolveMaxQuantityNext(a.maxQuantity, a.Target)
+	if err != nil {
+		a.logger.Error().
+			Int("max_quantity", a.maxQuantity).
+			Int("target", a.Target).
+			Msg("max quantity lower than target")
+		return false
 	}
 	if nextNode != "" {
 		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nextNode, buttonTarget{}, 0); err != nil {
@@ -421,11 +423,8 @@ func (a *QuantizedSlidingAction) resetState() {
 	a.maxQuantity = 0
 }
 
-func resolveMaxQuantityNext(maxQuantity int, target int, clampTargetToMax bool) (string, error) {
+func resolveMaxQuantityNext(maxQuantity int, target int) (string, error) {
 	if maxQuantity < target {
-		if clampTargetToMax {
-			return "", nil
-		}
 		return "", fmt.Errorf("max quantity %d lower than target %d", maxQuantity, target)
 	}
 	if maxQuantity == 1 && target == 1 {

--- a/agent/go-service/quantizedsliding/handlers.go
+++ b/agent/go-service/quantizedsliding/handlers.go
@@ -132,13 +132,23 @@ func (a *QuantizedSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa
 	}
 
 	a.maxQuantity = maxQuantity
-	nextNode, err := resolveMaxQuantityNext(a.maxQuantity, a.Target)
+	nextNode, err := resolveMaxQuantityNext(a.maxQuantity, a.Target, a.ClampTargetToMax)
 	if err != nil {
 		a.logger.Error().
 			Int("max_quantity", a.maxQuantity).
 			Int("target", a.Target).
 			Msg("max quantity lower than target")
 		return false
+	}
+
+	if a.ClampTargetToMax && a.maxQuantity < a.Target {
+		originalTarget := a.Target
+		a.Target = a.maxQuantity
+		a.logger.Warn().
+			Int("original_target", originalTarget).
+			Int("clamped_target", a.Target).
+			Int("max_quantity", a.maxQuantity).
+			Msg("target clamped to max quantity")
 	}
 	if nextNode != "" {
 		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nextNode, buttonTarget{}, 0); err != nil {
@@ -343,7 +353,9 @@ func (a *QuantizedSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.
 }
 
 func (a *QuantizedSlidingAction) handleDone(_ *maa.Context, _ *maa.CustomActionArg) bool {
-	a.logger.Info().Msg("quantity adjustment completed")
+	a.logger.Info().
+		Int("target", a.Target).
+		Msg("quantity adjustment completed")
 	return true
 }
 
@@ -409,8 +421,11 @@ func (a *QuantizedSlidingAction) resetState() {
 	a.maxQuantity = 0
 }
 
-func resolveMaxQuantityNext(maxQuantity int, target int) (string, error) {
+func resolveMaxQuantityNext(maxQuantity int, target int, clampTargetToMax bool) (string, error) {
 	if maxQuantity < target {
+		if clampTargetToMax {
+			return "", nil
+		}
 		return "", fmt.Errorf("max quantity %d lower than target %d", maxQuantity, target)
 	}
 	if maxQuantity == 1 && target == 1 {

--- a/agent/go-service/quantizedsliding/params.go
+++ b/agent/go-service/quantizedsliding/params.go
@@ -15,6 +15,7 @@ type parsedQuantizedSlidingParams struct {
 	increaseButton    buttonTarget
 	decreaseButton    buttonTarget
 	centerPointOffset [2]int
+	clampTargetToMax  bool
 }
 
 func parseQuantizedSlidingParam(customActionParam string) (quantizedSlidingParam, error) {
@@ -94,6 +95,7 @@ func (a *QuantizedSlidingAction) normalizeActionParams(params quantizedSlidingPa
 		increaseButton:    increaseButton,
 		decreaseButton:    decreaseButton,
 		centerPointOffset: centerPointOffset,
+		clampTargetToMax:  params.ClampTargetToMax,
 	}, true
 }
 
@@ -105,6 +107,7 @@ func (a *QuantizedSlidingAction) applyActionParams(params parsedQuantizedSliding
 	a.IncreaseButton = params.increaseButton
 	a.DecreaseButton = params.decreaseButton
 	a.CenterPointOffset = params.centerPointOffset
+	a.ClampTargetToMax = params.clampTargetToMax
 }
 
 func (a *QuantizedSlidingAction) logParsedActionParams() {
@@ -115,7 +118,8 @@ func (a *QuantizedSlidingAction) logParsedActionParams() {
 		Interface("increase_button", a.IncreaseButton.logValue()).
 		Interface("decrease_button", a.DecreaseButton.logValue()).
 		Bool("quantity_filter_enabled", a.QuantityFilter != nil).
-		Ints("center_point_offset", []int{a.CenterPointOffset[0], a.CenterPointOffset[1]})
+		Ints("center_point_offset", []int{a.CenterPointOffset[0], a.CenterPointOffset[1]}).
+		Bool("clamp_target_to_max", a.ClampTargetToMax)
 
 	if a.QuantityFilter != nil {
 		parseLog = parseLog.

--- a/agent/go-service/quantizedsliding/types.go
+++ b/agent/go-service/quantizedsliding/types.go
@@ -32,8 +32,8 @@ type quantityFilterParam struct {
 //   - QuantityBox: OCR 识别数量的 ROI 区域 [x,y,w,h]
 //   - QuantityFilter: 可选的数量 OCR 颜色过滤参数
 //   - Direction: 滑动方向 (left/right/up/down)
-//   - IncreaseButton: 增加数量按钮的坐标
-//   - DecreaseButton: 减少数量按钮的坐标
+//   - IncreaseButton: 增加数量按钮的模板路径或坐标
+//   - DecreaseButton: 减少数量按钮的模板路径或坐标
 //   - CenterPointOffset: 滑动条中心点坐标偏移量
 //   - ClampTargetToMax: 为 true 时，若 Target 超过 maxQuantity，自动将 Target 钳制为 maxQuantity 并继续（默认 false 时直接失败）
 type QuantizedSlidingAction struct {

--- a/agent/go-service/quantizedsliding/types.go
+++ b/agent/go-service/quantizedsliding/types.go
@@ -13,6 +13,7 @@ type quantizedSlidingParam struct {
 	IncreaseButton    any                  `json:"IncreaseButton"`
 	DecreaseButton    any                  `json:"DecreaseButton"`
 	CenterPointOffset any                  `json:"CenterPointOffset"`
+	ClampTargetToMax  bool                 `json:"ClampTargetToMax"`
 }
 
 // quantityFilterParam 定义数量 OCR 预处理使用的单组颜色阈值。
@@ -33,6 +34,8 @@ type quantityFilterParam struct {
 //   - Direction: 滑动方向 (left/right/up/down)
 //   - IncreaseButton: 增加数量按钮的坐标
 //   - DecreaseButton: 减少数量按钮的坐标
+//   - CenterPointOffset: 滑动条中心点坐标偏移量
+//   - ClampTargetToMax: 为 true 时，若 Target 超过 maxQuantity，自动将 Target 钳制为 maxQuantity 并继续（默认 false 时直接失败）
 type QuantizedSlidingAction struct {
 	Target            int
 	QuantityBox       []int
@@ -41,6 +44,7 @@ type QuantizedSlidingAction struct {
 	IncreaseButton    buttonTarget
 	DecreaseButton    buttonTarget
 	CenterPointOffset [2]int
+	ClampTargetToMax  bool
 
 	startBox    []int
 	endBox      []int

--- a/docs/en_us/developers/quantized-sliding.md
+++ b/docs/en_us/developers/quantized-sliding.md
@@ -94,15 +94,16 @@ Pass `custom_action_param` as a JSON object directly.
 
 `custom_action_param` should be passed as a JSON object directly. The commonly used fields are:
 
-| Field               | Type                    | Required | Description                                                                                               |
-| ------------------- | ----------------------- | -------- | --------------------------------------------------------------------------------------------------------- |
-| `Target`            | `int`                   | Yes      | The target quantity. The final discrete value you want to reach.                                          |
-| `QuantityBox`       | `int[4]`                | Yes      | OCR region for the current quantity. The format must be `[x, y, w, h]`.                                   |
-| `QuantityFilter`    | `object`                | No       | Optional color filtering for quantity OCR, useful when digit color is stable but the background is noisy. |
-| `Direction`         | `string`                | Yes      | Drag direction. Supports `left` / `right` / `up` / `down`.                                                |
-| `IncreaseButton`    | `string` or `int[2\|4]` | Yes      | The “increase quantity” button. Can be a template path or coordinates.                                    |
-| `DecreaseButton`    | `string` or `int[2\|4]` | Yes      | The “decrease quantity” button. Can be a template path or coordinates.                                    |
-| `CenterPointOffset` | `int[2]`                | No       | Click offset relative to the slider handle center, default `[-10, 0]`.                                    |
+| Field               | Type                    | Required | Description                                                                                                                                                                             |
+| ------------------- | ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Target`            | `int`                   | Yes      | The target quantity. The final discrete value you want to reach.                                                                                                                        |
+| `QuantityBox`       | `int[4]`                | Yes      | OCR region for the current quantity. The format must be `[x, y, w, h]`.                                                                                                                 |
+| `QuantityFilter`    | `object`                | No       | Optional color filtering for quantity OCR, useful when digit color is stable but the background is noisy.                                                                               |
+| `Direction`         | `string`                | Yes      | Drag direction. Supports `left` / `right` / `up` / `down`.                                                                                                                              |
+| `IncreaseButton`    | `string` or `int[2\|4]` | Yes      | The “increase quantity” button. Can be a template path or coordinates.                                                                                                                  |
+| `DecreaseButton`    | `string` or `int[2\|4]` | Yes      | The “decrease quantity” button. Can be a template path or coordinates.                                                                                                                  |
+| `CenterPointOffset` | `int[2]`                | No       | Click offset relative to the slider handle center, default `[-10, 0]`.                                                                                                                  |
+| `ClampTargetToMax`  | `bool`                  | No       | If `true`, when `Target` exceeds the recognized `maxQuantity`, the target is clamped to `maxQuantity` and the action continues instead of failing. Default: `false` (fail immediately). |
 
 `CenterPointOffset` is used to fine-tune the final click position for `QuantizedSlidingPreciseClick`. Its format must be `[x, y]`:
 
@@ -302,7 +303,7 @@ File location: `assets/resource/pipeline/AutoStockpile/Task.json`
 - The slider start point can be recognized;
 - It can be dragged to the maximum value successfully;
 - OCR can read both the maximum value and the current value;
-- The target value `Target` is not greater than the maximum value;
+- The target value `Target` is not greater than the maximum value, or `ClampTargetToMax` is `true` (in which case `Target` is clamped to `maxQuantity`);
 - After the proportional click and fine-tuning, the current value finally equals `Target`.
 
 ### Common failure conditions
@@ -310,7 +311,7 @@ File location: `assets/resource/pipeline/AutoStockpile/Task.json`
 - `QuantityBox` is not a 4-tuple `[x, y, w, h]`;
 - `Direction` is not one of `left/right/up/down`;
 - OCR does not read any digits;
-- The maximum value `maxQuantity` is smaller than `Target`;
+- The maximum value `maxQuantity` is smaller than `Target`, and `ClampTargetToMax` is `false` (default);
 - The maximum value is less than or equal to `1`, so the ratio cannot be calculated;
 - The increase/decrease buttons cannot be recognized or clicked;
 - Too many fine-tuning attempts still do not converge.
@@ -342,7 +343,7 @@ This is much faster than relying only on repeated button clicks, and much more s
 - **Making `QuantityBox` too tight**: OCR easily fails when digits move or outlines change.
 - **Using only button coordinates without a recognition fallback**: small UI shifts can make clicks miss.
 - **Assuming the slider template is universally reusable**: the shared template may fail if different screens use different slider styles.
-- **Using a target value above the limit**: `Target > maxQuantity` fails immediately and does not automatically fall back to the maximum value.
+- **Using a target value above the limit**: `Target > maxQuantity` fails immediately by default. Set `ClampTargetToMax: true` to automatically clamp to the maximum value instead of failing, but note that the actual final quantity will be `maxQuantity`, not the original `Target`.
 - **Adding extra hard waits without thinking**: this shared flow already uses `post_wait_freezes`, so business integration should not stack many more hard delays on top.
 
 ## Self-checklist
@@ -354,7 +355,8 @@ After integration, check at least the following:
 3. Whether `Direction` matches the direction where the maximum value lies.
 4. Whether `IncreaseButton` / `DecreaseButton` use template paths whenever possible.
 5. Whether `Target` can exceed the maximum value allowed by the current scenario.
-6. Whether the failure branch has a clear handling strategy, such as a prompt, skip, or canceling the current task.
+6. If `ClampTargetToMax` is enabled, whether the caller can handle the case where the actual final quantity may be less than the original `Target`.
+7. Whether the failure branch has a clear handling strategy, such as a prompt, skip, or canceling the current task.
 
 ## Code references
 

--- a/docs/zh_cn/developers/quantized-sliding.md
+++ b/docs/zh_cn/developers/quantized-sliding.md
@@ -92,15 +92,16 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 `custom_action_param` 请直接传入一个 JSON 对象。常用字段如下：
 
-| 字段                | 类型                    | 必填 | 说明                                                                |
-| ------------------- | ----------------------- | ---- | ------------------------------------------------------------------- |
-| `Target`            | `int`                   | 是   | 目标数量。最终希望调到的档位值。                                    |
-| `QuantityBox`       | `int[4]`                | 是   | 当前数量 OCR 区域，格式固定为 `[x, y, w, h]`。                      |
-| `QuantityFilter`    | `object`                | 否   | 数量 OCR 的可选颜色过滤参数，适合数字颜色稳定但背景干扰较多的场景。 |
-| `Direction`         | `string`                | 是   | 拖动方向，支持 `left` / `right` / `up` / `down`。                   |
-| `IncreaseButton`    | `string` 或 `int[2\|4]` | 是   | “增加数量”按钮。可传模板路径，也可传坐标。                          |
-| `DecreaseButton`    | `string` 或 `int[2\|4]` | 是   | “减少数量”按钮。可传模板路径，也可传坐标。                          |
-| `CenterPointOffset` | `int[2]`                | 否   | 相对滑块识别框中心点的点击偏移，默认 `[-10, 0]`。                   |
+| 字段                | 类型                    | 必填 | 说明                                                                                                                                              |
+| ------------------- | ----------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Target`            | `int`                   | 是   | 目标数量。最终希望调到的档位值。                                                                                                                  |
+| `QuantityBox`       | `int[4]`                | 是   | 当前数量 OCR 区域，格式固定为 `[x, y, w, h]`。                                                                                                    |
+| `QuantityFilter`    | `object`                | 否   | 数量 OCR 的可选颜色过滤参数，适合数字颜色稳定但背景干扰较多的场景。                                                                               |
+| `Direction`         | `string`                | 是   | 拖动方向，支持 `left` / `right` / `up` / `down`。                                                                                                 |
+| `IncreaseButton`    | `string` 或 `int[2\|4]` | 是   | “增加数量”按钮。可传模板路径，也可传坐标。                                                                                                        |
+| `DecreaseButton`    | `string` 或 `int[2\|4]` | 是   | “减少数量”按钮。可传模板路径，也可传坐标。                                                                                                        |
+| `CenterPointOffset` | `int[2]`                | 否   | 相对滑块识别框中心点的点击偏移，默认 `[-10, 0]`。                                                                                                 |
+| `ClampTargetToMax`  | `bool`                  | 否   | 为 `true` 时，若 `Target` 超过识别到的 `maxQuantity`，自动将目标值钳制为 `maxQuantity` 并继续，而非直接失败。默认 `false`（超过上限时直接失败）。 |
 
 `CenterPointOffset` 用于微调 `QuantizedSlidingPreciseClick` 的落点。格式固定为 `[x, y]`：
 
@@ -291,7 +292,7 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 - 能识别到滑块起点；
 - 能成功拖到最大值；
 - 能 OCR 出最大值与当前值；
-- 目标值 `Target` 不大于最大值；
+- 目标值 `Target` 不大于最大值，或 `ClampTargetToMax` 为 `true`（此时 `Target` 会被钳制为 `maxQuantity`）；
 - 经过精确点击与微调后，当前值最终等于 `Target`。
 
 ### 常见失败条件
@@ -299,7 +300,7 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 - `QuantityBox` 不是 `[x, y, w, h]` 四元组；
 - `Direction` 不是 `left/right/up/down` 之一；
 - OCR 没有读到数字；
-- 最大值 `maxQuantity` 小于 `Target`；
+- 最大值 `maxQuantity` 小于 `Target`，且 `ClampTargetToMax` 为 `false`（默认值）；
 - 最大值小于等于 `1`，无法计算比例；
 - 加减按钮无法识别或无法点击；
 - 微调次数过多仍未收敛。
@@ -331,7 +332,7 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 - **`QuantityBox` 截得太紧**：数字跳动或描边变化时 OCR 容易失败。
 - **只给按钮坐标，不做识别兜底**：界面轻微偏移后就可能点歪。
 - **滑块模板不通用**：不同界面滑块样式不一致时，公共模板可能失效。
-- **目标值超过上限**：`Target > maxQuantity` 会直接失败，不会自动回退到最大值。
+- **目标值超过上限**：`Target > maxQuantity` 默认会直接失败。设置 `ClampTargetToMax: true` 可自动将目标值钳制为最大值继续执行，但需注意最终实际数量为 `maxQuantity`，而非原始 `Target`。
 - **没有考虑冻结等待**：该公共流程内部已经使用了 `post_wait_freezes`，业务接入时不要再额外叠很多硬延迟。
 
 ## 自检清单
@@ -343,7 +344,8 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 3. `Direction` 是否与“最大值所在方向”一致。
 4. `IncreaseButton` / `DecreaseButton` 是否优先使用模板路径。
 5. `Target` 是否有可能大于当前场景允许的最大值。
-6. 失败分支是否有明确处理，例如提示、跳过或取消当前任务。
+6. 若启用了 `ClampTargetToMax`，调用方是否能处理"实际数量可能小于原始 `Target`"的情况。
+7. 失败分支是否有明确处理，例如提示、跳过或取消当前任务。
 
 ## 代码定位
 


### PR DESCRIPTION
- 新增 ClampTargetToMax 可选参数
- 目标超过 maxQuantity 时可钳制后继续执行
- 同步补充中英文开发文档与接入说明

## 由 Sourcery 生成的摘要

为量化滑动目标添加可选的钳制行为，当目标超过检测到的最大值时进行钳制，并在英文和中文指南中记录该新行为和参数。

新功能：
- 引入 `ClampTargetToMax` 参数，用于在 `Target` 超过检测到的 `maxQuantity` 时，可选地将其钳制到 `maxQuantity`，而不是在目标超过最大值时直接失败。

增强改进：
- 通过量化滑动操作参数以及数量调整完成日志传递并记录新的钳制选项，以提高可观测性。

文档：
- 在英文和中文的量化滑动开发者指南中记录 `ClampTargetToMax` 参数、其行为以及集成注意事项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为量化滑动目标添加可选的截断（clamp）行为，用于处理超过已识别最大值的目标，并在英文和中文开发者指南中记录这一新行为。

新功能：
- 引入 `ClampTargetToMax` 参数，可选地将 `Target` 截断到已识别的 `maxQuantity`，而不是在请求的目标超过最大值时直接失败。

功能增强：
- 在量化滑动操作的参数和状态中传递 `ClampTargetToMax`，包括记录截断行为以及最终目标值的日志。

文档更新：
- 在英文和中文的量化滑动开发者指南中记录 `ClampTargetToMax` 选项、其行为以及相关集成注意事项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional clamping behavior for quantized sliding targets that exceed the recognized maximum and document the new behavior in both English and Chinese developer guides.

New Features:
- Introduce a ClampTargetToMax parameter to optionally clamp Target to the recognized maxQuantity instead of failing when the requested target exceeds the maximum.

Enhancements:
- Propagate ClampTargetToMax through quantized sliding action parameters and state, including logging of clamping behavior and final target values.

Documentation:
- Document the ClampTargetToMax option, its behavior, and related integration caveats in the English and Chinese quantized sliding developer guides.

</details>

</details>