### PR TITLE
perf:优化放置线索逻辑,无需退出后重新进入线索选择界面

### DIFF
--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -714,6 +714,18 @@
                 "all_of": [
                     "InReceptionRoom",
                     "ReceptionRoomSetClueTips"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target_offset": [
+                    -40,
+                    50,
+                    0,
+                    0
                 ]
             }
         },
@@ -882,6 +894,7 @@
             "InReceptionRoomSetClues",
             "CloseButtonType1"
         ],
+        "box_index": 1,
         "pre_delay": 0,
         "action": {
             "type": "Click"

--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -712,16 +712,39 @@
         ]
     },
     "ReceptionRoomSetClues": {
-        "desc": "[会客室·线索] 点击会客室内的任务红点，放置线索",
+        "desc": "[会客室·线索] 识别到会客室内的线索红点，准备放置线索",
         "recognition": {
             "type": "And",
             "param": {
                 "all_of": [
+                    "InReceptionRoom",
                     "ReceptionRoomSetClueTips"
                 ]
             }
         },
         "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]ReceptionRoomSetCluesChooseClues",
+            "ReceptionRoomSetCluesClose"
+        ]
+    },
+    "ReceptionRoomSetCluesChooseClues": {
+        "desc": "[会客室·线索] 识别到会客室内的线索界面和线索红点，点击进入放置",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "InReceptionRoomSetClues",
+                    "ReceptionRoomSetClueTips"
+                ],
+                "box_index": 1
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
         "action": {
             "type": "Click",
             "param": {
@@ -733,44 +756,6 @@
                 ]
             }
         },
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
-            "ReceptionRoomSetCluesOpen"
-        ]
-    },
-    "ReceptionRoomSetCluesOpen": {
-        "desc": "[会客室·线索] 点击会客室内的任务红点，打开放置线索界面",
-        "recognition": {
-            "type": "OCR",
-            "param": {
-                "roi": [
-                    -600,
-                    0,
-                    600,
-                    150
-                ],
-                "expected": [
-                    "线索库存",
-                    "線索庫存",
-                    "Clue Library",
-                    "在庫",
-                    "단서 보관"
-                ]
-            }
-        },
-        "pre_wait_freezes": {
-            "time": 200,
-            "target": [
-                -300,
-                0,
-                300,
-                150
-            ]
-        },
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
         "next": [
             "ReceptionRoomSetCluesItem"
         ]
@@ -852,10 +837,7 @@
         },
         "pre_delay": 0,
         "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
-            "ReceptionRoomSetCluesClose"
-        ]
+        "rate_limit": 0
     },
     "ReceptionRoomSetCluesItemPut": {
         "desc": "[会客室·线索] 点击空位或已有线索格以放置/替换线索",
@@ -888,18 +870,21 @@
         "post_wait_freezes": {
             "time": 100,
             "timeout": 1000,
-            "target": "ReceptionRoomSetClueTips"
+            "target": [
+                859,
+                189,
+                388,
+                119
+            ]
         },
         "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
-            "ReceptionRoomSetCluesClose"
-        ]
+        "rate_limit": 0
     },
     "ReceptionRoomSetCluesClose": {
         "desc": "[会客室·线索] 关闭侧边栏",
         "recognition": "And",
         "all_of": [
+            "InReceptionRoomSetClues",
             "CloseButtonType1"
         ],
         "pre_delay": 0,

--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -259,8 +259,10 @@
         "desc": "[会客室·赠送线索] 关闭线索收集侧边栏",
         "recognition": "And",
         "all_of": [
+            "InReceptionRoomCollectionClues",
             "CloseButtonType1"
         ],
+        "box_index": 1,
         "pre_delay": 0,
         "action": {
             "type": "Click",
@@ -381,17 +383,16 @@
         ]
     },
     "ReceptionRoomReceiveExit": {
-        "desc": "[会客室·线索] 关闭领取界面",
+        "desc": "[会客室·线索] 关闭接收线索界面",
         "recognition": "And",
         "all_of": [
+            "InReceptionRoomReceiveClues",
             "CloseButtonType1"
         ],
+        "box_index": 1,
         "pre_delay": 0,
         "action": {
-            "type": "Click",
-            "param": {
-                "contact": 0
-            }
+            "type": "Click"
         },
         "post_wait_freezes": {
             "time": 200,
@@ -582,10 +583,7 @@
         },
         "pre_delay": 0,
         "action": {
-            "type": "Click",
-            "param": {
-                "contact": 0
-            }
+            "type": "Click"
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -700,10 +698,7 @@
         ],
         "pre_delay": 0,
         "action": {
-            "type": "Click",
-            "param": {
-                "contact": 0
-            }
+            "type": "Click"
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -901,8 +896,10 @@
         "desc": "[会客室·退出] 识别会客室界面，点击返回退出",
         "recognition": "And",
         "all_of": [
+            "InReceptionRoom",
             "CloseButtonType1"
         ],
+        "box_index": 1,
         "pre_delay": 0,
         "action": {
             "type": "Click"

--- a/assets/resource/pipeline/DijiangRewards/Template/Location.json
+++ b/assets/resource/pipeline/DijiangRewards/Template/Location.json
@@ -78,6 +78,30 @@
         "post_delay": 0,
         "rate_limit": 0
     },
+    "InReceptionRoomSetClues": {
+        "desc": "[会客室·线索] 识别到会客室内的线索库存界面",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    -600,
+                    0,
+                    600,
+                    150
+                ],
+                "expected": [
+                    "线索库存",
+                    "線索庫存",
+                    "Clue Library",
+                    "在庫",
+                    "단서 보관"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
     "InGrowthChamber": {
         "desc": "[培养舱] 在培养舱界面，识别培养舱标题",
         "recognition": {

--- a/assets/resource/pipeline/DijiangRewards/Template/Location.json
+++ b/assets/resource/pipeline/DijiangRewards/Template/Location.json
@@ -102,6 +102,46 @@
         "post_delay": 0,
         "rate_limit": 0
     },
+    "InReceptionRoomCollectionClues": {
+        "desc": "[会客室·线索] 识别到会客室内的收集线索界面",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    -600,
+                    0,
+                    600,
+                    150
+                ],
+                "expected": [
+                    "收集线索"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "InReceptionRoomReceiveClues": {
+        "desc": "[会客室·线索] 识别到会客室内的接收线索界面",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    -600,
+                    0,
+                    600,
+                    150
+                ],
+                "expected": [
+                    "接收线索"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
     "InGrowthChamber": {
         "desc": "[培养舱] 在培养舱界面，识别培养舱标题",
         "recognition": {


### PR DESCRIPTION
## Summary by Sourcery

优化帝江奖励（DijiangRewards）接待室和地点流水线配置中的线索放置逻辑，避免用户在放置线索后需要重新进入线索选择视图。

增强内容：
- 调整帝江奖励接待室（DijiangRewards ReceptionRoom）流水线配置，以支持更顺畅的就地线索放置体验。
- 更新帝江奖励模板位置（template location）流水线配置，使其与新的优化线索放置行为保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize clue placement logic in the DijiangRewards reception room and location pipeline configurations to avoid requiring users to re-enter the clue selection view after placement.

Enhancements:
- Adjust DijiangRewards ReceptionRoom pipeline configuration to support smoother in-place clue placement.
- Update DijiangRewards template location pipeline configuration to align with the new optimized clue placement behavior.

</details>