### PR TITLE
refactor: 提取Go资源加载的共用逻辑

### DIFF
--- a/agent/go-service/itemtransfer/README.md
+++ b/agent/go-service/itemtransfer/README.md
@@ -176,9 +176,3 @@ assets/data/ItemTransfer/
 | `tooltipOffsetY`  | 0   | `types.go`      | tooltip 相对悬停点的 Y 偏移 |
 | `tooltipWidth`    | 155 | `types.go`      | tooltip OCR 区域宽度        |
 | `tooltipHeight`   | 70  | `types.go`      | tooltip OCR 区域高度        |
-
-## 环境变量
-
-| 变量                           | 说明                                                                                                 |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `MAAEND_ITEMTRANSFER_DATA_DIR` | 手动指定 `item_order.json` 所在目录；未设置时自动从 cwd / exe 向上搜索 `assets/data/ItemTransfer/`。 |

--- a/agent/go-service/itemtransfer/register.go
+++ b/agent/go-service/itemtransfer/register.go
@@ -5,7 +5,6 @@ import (
 )
 
 func Register() {
-	maa.AgentServerAddResourceSink(&resourcePathSink{})
 	maa.AgentServerRegisterCustomAction(
 		"ItemTransferFallbackAction",
 		&ItemTransferFallbackAction{},

--- a/agent/go-service/itemtransfer/types.go
+++ b/agent/go-service/itemtransfer/types.go
@@ -2,14 +2,10 @@ package itemtransfer
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 
-	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/resource"
 	"github.com/rs/zerolog/log"
 )
 
@@ -54,43 +50,11 @@ var (
 	cachedData     *itemOrderData
 	cachedDataOnce sync.Once
 	cachedDataErr  error
-
-	resourcePath atomic.Value // string – set by resourcePathSink
 )
-
-type resourcePathSink struct{}
-
-var _ maa.ResourceEventSink = &resourcePathSink{}
-
-func (c *resourcePathSink) OnResourceLoading(_ *maa.Resource, status maa.EventStatus, detail maa.ResourceLoadingDetail) {
-	if status != maa.EventStatusSucceeded || detail.Path == "" {
-		return
-	}
-	abs := detail.Path
-	if p, err := filepath.Abs(detail.Path); err == nil {
-		abs = p
-	}
-	resourcePath.Store(abs)
-	log.Debug().Str("resource_path", abs).Msg("resource loaded; cached path for itemtransfer")
-}
-
-func getResourceBase() string {
-	if v := resourcePath.Load(); v != nil {
-		if s, ok := v.(string); ok && s != "" {
-			return s
-		}
-	}
-	return ""
-}
 
 func loadItemOrderData() (*itemOrderData, error) {
 	cachedDataOnce.Do(func() {
-		dir, err := findDataDir()
-		if err != nil {
-			cachedDataErr = err
-			return
-		}
-		b, err := os.ReadFile(filepath.Join(dir, "item_order.json"))
+		b, err := resource.ReadResource("data/ItemTransfer/item_order.json")
 		if err != nil {
 			cachedDataErr = err
 			return
@@ -108,83 +72,6 @@ func loadItemOrderData() (*itemOrderData, error) {
 			Msg("item order data loaded")
 	})
 	return cachedData, cachedDataErr
-}
-
-func findDataDir() (string, error) {
-	const target = "item_order.json"
-
-	relPaths := []string{
-		filepath.Join("assets", "data", "ItemTransfer"),
-		filepath.Join("data", "ItemTransfer"),
-	}
-
-	var tried []string
-
-	check := func(base string) (string, bool) {
-		for _, rel := range relPaths {
-			cand := filepath.Join(base, rel)
-			if fileExists(filepath.Join(cand, target)) {
-				return cand, true
-			}
-			tried = append(tried, cand)
-		}
-		return "", false
-	}
-
-	// 1. Environment variable override.
-	if v := strings.TrimSpace(os.Getenv("MAAEND_ITEMTRANSFER_DATA_DIR")); v != "" {
-		if fileExists(filepath.Join(v, target)) {
-			return v, nil
-		}
-		tried = append(tried, v)
-	}
-
-	// 2. Walk up from cwd.
-	if wd, err := os.Getwd(); err == nil {
-		base := wd
-		for i := 0; i < 8; i++ {
-			if dir, ok := check(base); ok {
-				return dir, nil
-			}
-			parent := filepath.Dir(base)
-			if parent == base {
-				break
-			}
-			base = parent
-		}
-	}
-
-	// 3. Walk up from executable path.
-	if exePath, err := os.Executable(); err == nil {
-		base := filepath.Dir(exePath)
-		for i := 0; i < 8; i++ {
-			if dir, ok := check(base); ok {
-				return dir, nil
-			}
-			parent := filepath.Dir(base)
-			if parent == base {
-				break
-			}
-			base = parent
-		}
-	}
-
-	// 4. Fallback: MaaFramework resource path (e.g. assets/resource); try parent & grandparent.
-	if base := getResourceBase(); base != "" {
-		base = filepath.Clean(base)
-		for _, b := range []string{filepath.Dir(base), filepath.Dir(filepath.Dir(base))} {
-			if dir, ok := check(b); ok {
-				return dir, nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("cannot find %s in any of %d candidate paths: %v; set MAAEND_ITEMTRANSFER_DATA_DIR", target, len(tried), tried)
-}
-
-func fileExists(p string) bool {
-	_, err := os.Stat(p)
-	return err == nil
 }
 
 // inferSide returns the side from params if set, otherwise infers from the

--- a/agent/go-service/map-tracker/big_map_pick.go
+++ b/agent/go-service/map-tracker/big_map_pick.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"image"
 	"math"
-	"os"
 	"regexp"
 	"sync"
 
 	mt "github.com/MaaXYZ/MaaEnd/agent/go-service/map-tracker/internal"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/control"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/resource"
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -186,12 +186,7 @@ func (a *MapTrackerBigMapPick) getSceneManagerNode(mapName string) (string, bool
 	a.externalOnce.Do(func() {
 		a.externalData = map[string]mapExternalDataItem{}
 
-		path := mt.FindResource(mt.MAP_EXTERNAL_DATA_PATH)
-		if path == "" {
-			return
-		}
-
-		data, err := os.ReadFile(path)
+		data, err := resource.ReadResource(mt.MAP_EXTERNAL_DATA_PATH)
 		if err != nil {
 			a.externalErr = fmt.Errorf("failed to read map external data: %w", err)
 			return

--- a/agent/go-service/map-tracker/internal/resource.go
+++ b/agent/go-service/map-tracker/internal/resource.go
@@ -9,26 +9,23 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/resource"
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
 
 var (
-	resourcePath     atomic.Value // string
-	registerSinkOnce sync.Once
-
 	Resource = &MapTrackerResource{
 		PointerTemplateLoader: minicv.NewTemplateLoaderOfDynamicPath(
-			func() string { return FindResource("resource/image/MapTracker/pointer.png") },
+			func() string { return resource.FindResource("resource/image/MapTracker/pointer.png") },
 		),
 		ZoomInTemplate: minicv.NewTemplateLoaderOfDynamicPath(
-			func() string { return FindResource("resource/image/MapTracker/BigMapZoomIn.png") },
+			func() string { return resource.FindResource("resource/image/MapTracker/BigMapZoomIn.png") },
 		),
 		ZoomOutTemplate: minicv.NewTemplateLoaderOfDynamicPath(
-			func() string { return FindResource("resource/image/MapTracker/BigMapZoomOut.png") },
+			func() string { return resource.FindResource("resource/image/MapTracker/BigMapZoomOut.png") },
 		),
 	}
 )
@@ -68,101 +65,6 @@ func (m *MapCache) GetIntegralArray() minicv.IntegralArray {
 	return *m.cachedIntegralArray
 }
 
-// EnsureResourcePathSink ensures the resource path sink is registered.
-func EnsureResourcePathSink() {
-	registerSinkOnce.Do(func() {
-		maa.AgentServerAddResourceSink(&resourcePathSink{})
-		log.Debug().Msg("Resource path sink registered for map-tracker")
-	})
-}
-
-type resourcePathSink struct{}
-
-// OnResourceLoading captures the resource path when a resource is loaded.
-func (c *resourcePathSink) OnResourceLoading(resource *maa.Resource, status maa.EventStatus, detail maa.ResourceLoadingDetail) {
-	if status != maa.EventStatusSucceeded || detail.Path == "" {
-		return
-	}
-	abs := detail.Path
-	if p, err := filepath.Abs(detail.Path); err == nil {
-		abs = p
-	}
-	resourcePath.Store(abs)
-	log.Debug().Str("resource_path", abs).Msg("Resource loaded; cached path for map-tracker")
-}
-
-// getResourceBase returns the cached resource path or common defaults as fallback.
-func getResourceBase() string {
-	if v := resourcePath.Load(); v != nil {
-		if s, ok := v.(string); ok && s != "" {
-			return s
-		}
-	}
-	return ""
-}
-
-// FindResource tries to find a file in the cached resource path or standard fallbacks.
-func FindResource(relativePath string) string {
-	rel := filepath.FromSlash(strings.TrimSpace(relativePath))
-	rel = strings.TrimPrefix(rel, string(filepath.Separator))
-	relNoResourcePrefix := strings.TrimPrefix(rel, "resource"+string(filepath.Separator))
-
-	tryPath := func(path string) string {
-		if path == "" {
-			return ""
-		}
-		if _, err := os.Stat(path); err == nil {
-			return path
-		}
-		return ""
-	}
-
-	candidates := make([]string, 0, 18)
-
-	if base := getResourceBase(); base != "" {
-		base = filepath.Clean(base)
-		baseParent := filepath.Dir(base)
-
-		candidates = append(candidates,
-			filepath.Join(base, rel),
-			filepath.Join(base, relNoResourcePrefix),
-			filepath.Join(baseParent, rel),
-		)
-	}
-
-	cwd, _ := os.Getwd()
-	wd := filepath.Clean(cwd)
-	wdParent := filepath.Dir(wd)
-	wdGrandParent := filepath.Dir(wdParent)
-
-	fallbacks := []string{
-		wd,
-		wdParent,
-		wdGrandParent,
-		filepath.Join(wd, "resource"),
-		filepath.Join(wdParent, "resource"),
-		filepath.Join(wdGrandParent, "resource"),
-		filepath.Join(wd, "assets"),
-		filepath.Join(wdParent, "assets"),
-		filepath.Join(wdGrandParent, "assets"),
-	}
-
-	for _, base := range fallbacks {
-		candidates = append(candidates,
-			filepath.Join(base, rel),
-			filepath.Join(base, relNoResourcePrefix),
-		)
-	}
-
-	for _, p := range candidates {
-		if found := tryPath(filepath.Clean(p)); found != "" {
-			return found
-		}
-	}
-
-	return ""
-}
-
 // InitRawMaps initializes global raw maps cache exactly once.
 func (r *MapTrackerResource) InitRawMaps(ctx *maa.Context) {
 	r.RawMapsOnce.Do(func() {
@@ -177,23 +79,20 @@ func (r *MapTrackerResource) InitRawMaps(ctx *maa.Context) {
 
 // LoadMaps loads all map images from the resource directory and crops them when map bbox data exists.
 func (r *MapTrackerResource) LoadMaps() ([]MapCache, error) {
-	mapDir := FindResource(MAP_DIR)
+	mapDir := resource.FindResource(MAP_DIR)
 	if mapDir == "" {
 		return nil, fmt.Errorf("map directory not found (searched in cache and standard locations)")
 	}
 
 	rectList := make(map[string][]int)
-	rectPath := FindResource(MAP_BBOX_DATA_PATH)
-	if rectPath != "" {
-		if data, err := os.ReadFile(rectPath); err == nil {
-			if err := json.Unmarshal(data, &rectList); err != nil {
-				log.Warn().Err(err).Str("path", rectPath).Msg("Failed to unmarshal map bbox data")
-			} else {
-				log.Info().Str("path", rectPath).Msg("Map bbox data loaded")
-			}
+	if data, err := resource.ReadResource(MAP_BBOX_DATA_PATH); err == nil {
+		if err := json.Unmarshal(data, &rectList); err != nil {
+			log.Warn().Err(err).Msg("Failed to unmarshal map bbox data")
 		} else {
-			log.Warn().Err(err).Str("path", rectPath).Msg("Failed to read map bbox data")
+			log.Info().Msg("Map bbox data loaded")
 		}
+	} else {
+		log.Warn().Err(err).Msg("Failed to read map bbox data")
 	}
 
 	entries, err := os.ReadDir(mapDir)

--- a/agent/go-service/map-tracker/move.go
+++ b/agent/go-service/map-tracker/move.go
@@ -21,6 +21,7 @@ import (
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/resource"
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -727,7 +728,7 @@ func buildNavigationPreviewDataURL(path [][2]float64, targetIndex int, mapName s
 }
 
 func getCachedPreviewMapRGBA(mapName string) (*image.RGBA, error) {
-	mapPath := mt.FindResource(filepath.ToSlash(filepath.Join(mt.MAP_DIR, mapName+".png")))
+	mapPath := resource.FindResource(filepath.ToSlash(filepath.Join(mt.MAP_DIR, mapName+".png")))
 	if mapPath == "" {
 		return nil, fmt.Errorf("map image not found")
 	}

--- a/agent/go-service/map-tracker/register.go
+++ b/agent/go-service/map-tracker/register.go
@@ -2,14 +2,11 @@
 package maptracker
 
 import (
-	mt "github.com/MaaXYZ/MaaEnd/agent/go-service/map-tracker/internal"
 	"github.com/MaaXYZ/maa-framework-go/v4"
 )
 
 // Register registers all custom recognition components for map-tracker package
 func Register() {
-	mt.EnsureResourcePathSink()
-
 	maa.AgentServerRegisterCustomRecognition("MapTrackerInfer", &MapTrackerInfer{})
 	maa.AgentServerRegisterCustomRecognition("MapTrackerBigMapInfer", &MapTrackerBigMapInfer{})
 	maa.AgentServerRegisterCustomRecognition("MapTrackerAssertLocation", &MapTrackerAssertLocation{})

--- a/agent/go-service/pkg/resource/resource_reader.go
+++ b/agent/go-service/pkg/resource/resource_reader.go
@@ -1,0 +1,88 @@
+package resource
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// FindResource tries to find and read the specified resource file as bytes array.
+//
+// The path will be resolved in the following order:
+//
+// 1. Directly using the provided relative path.
+//
+// 2. Searching in the resource base path set by resource sink.
+//
+// 3. Searching in "resource" and "assets" directories in the current working directory and its parent/grandparent directories.
+func ReadResource(relativePath string) ([]byte, error) {
+	resolvedPath := FindResource(relativePath)
+	if resolvedPath == "" {
+		log.Error().Str("relativePath", relativePath).Msg("Resource cannot be found")
+		return nil, os.ErrNotExist
+	}
+
+	content, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		log.Error().Err(err).Str("relativePath", relativePath).Str("resolvedPath", resolvedPath).Msg("Resource cannot be read")
+		return nil, err
+	}
+	return content, nil
+}
+
+// FindResource tries to find a file in the cached resource path or standard fallback paths.
+//
+// The path will be resolved in the following order:
+//
+// 1. Directly using the provided relative path.
+//
+// 2. Searching in the resource base path set by resource sink.
+//
+// 3. Searching in "resource" and "assets" directories in the current working directory and its parent/grandparent directories.
+func FindResource(relativePath string) string {
+	rel := filepath.FromSlash(strings.TrimSpace(relativePath))
+	rel = strings.TrimPrefix(rel, string(filepath.Separator))
+
+	tryPath := func(path string) string {
+		if path == "" {
+			return ""
+		}
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+		return ""
+	}
+
+	findPath := func(rel string) string {
+		if found := tryPath(rel); found != "" {
+			return found
+		}
+
+		if base := getResourceBase(); base != "" {
+			base = filepath.Clean(base)
+			if found := tryPath(filepath.Join(base, rel)); found != "" {
+				return found
+			}
+		}
+
+		for _, base := range getStandardResourceBase() {
+			if base != "" {
+				base = filepath.Clean(base)
+				if found := tryPath(filepath.Join(base, rel)); found != "" {
+					return found
+				}
+			}
+		}
+
+		return ""
+	}
+
+	if result := findPath(rel); result != "" {
+		log.Debug().Str("relativePath", relativePath).Str("resolvedPath", result).Msg("Resource found")
+		return result
+	}
+	log.Warn().Str("relativePath", relativePath).Msg("Resource cannot be found in any known location")
+	return ""
+}

--- a/agent/go-service/pkg/resource/resource_sink.go
+++ b/agent/go-service/pkg/resource/resource_sink.go
@@ -1,0 +1,69 @@
+package resource
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	resourcePath         atomic.Value // string
+	registerPathSinkOnce sync.Once
+)
+
+// EnsureResourcePathSink ensures the resource path sink is registered.
+func EnsureResourcePathSink() {
+	registerPathSinkOnce.Do(func() {
+		maa.AgentServerAddResourceSink(&resourcePathSink{})
+		log.Debug().Msg("Resource path sink registered for Go service")
+	})
+}
+
+type resourcePathSink struct{}
+
+// OnResourceLoading captures the resource path when a resource is loaded.
+func (c *resourcePathSink) OnResourceLoading(resource *maa.Resource, status maa.EventStatus, detail maa.ResourceLoadingDetail) {
+	if status != maa.EventStatusSucceeded || detail.Path == "" {
+		return
+	}
+	absPath := detail.Path
+	if p, err := filepath.Abs(detail.Path); err == nil {
+		absPath = p
+	}
+	resourcePath.Store(absPath)
+	log.Debug().Str("absPath", absPath).Msg("Resource path sink captured resource path")
+}
+
+// getResourceBase returns the cached resource base path or an empty string if unavailable.
+func getResourceBase() string {
+	if v := resourcePath.Load(); v != nil {
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// getStandardResourceBase returns a list of standard base paths to search for resources.
+func getStandardResourceBase() []string {
+	cwd, _ := os.Getwd()
+	wd := filepath.Clean(cwd)
+	wdParent := filepath.Dir(wd)
+	wdGrandParent := filepath.Dir(wdParent)
+
+	return []string{
+		wd,
+		filepath.Join(wd, "resource"),
+		filepath.Join(wd, "assets"),
+		wdParent,
+		filepath.Join(wdParent, "resource"),
+		filepath.Join(wdParent, "assets"),
+		wdGrandParent,
+		filepath.Join(wdGrandParent, "resource"),
+		filepath.Join(wdGrandParent, "assets"),
+	}
+}

--- a/agent/go-service/register.go
+++ b/agent/go-service/register.go
@@ -16,6 +16,7 @@ import (
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/expressionrecognition"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/itemtransfer"
 	maptracker "github.com/MaaXYZ/MaaEnd/agent/go-service/map-tracker"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/resource"
 	puzzle "github.com/MaaXYZ/MaaEnd/agent/go-service/puzzle-solver"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/quantizedsliding"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/resell"
@@ -28,6 +29,9 @@ import (
 )
 
 func registerAll() {
+	// Resource Sink
+	resource.EnsureResourcePathSink()
+
 	// Pre-Check Custom
 	aspectratio.Register()
 	hdrcheck.Register()


### PR DESCRIPTION
## 概要

此 PR 将 MapTracker 和 ItemTransfer 所使用的资源加载逻辑合并到 resource 包。

## Summary by Sourcery

将通用的 Go 资源加载和路径解析逻辑提取到一个共享的 `pkg/resource` 模块中，并更新现有使用方以使用该模块。

增强内容：
- 引入 `pkg/resource` 工具，用于以统一的搜索策略并结合 Maa 资源下沉集成来解析和读取资源文件。
- 重构 `map-tracker`，使其在模板、地图目录、预览图片和外部数据加载方面依赖共享的资源辅助工具。
- 重构 `itemtransfer`，通过共享的资源读取器加载 `item_order.json`，而不是使用自定义的目录发现逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract shared Go resource loading and path resolution logic into a common pkg/resource module and update existing consumers to use it.

Enhancements:
- Introduce pkg/resource utilities for resolving and reading resource files with a shared search strategy and Maa resource sink integration.
- Refactor map-tracker to rely on the shared resource helpers for templates, map directories, preview images, and external data loading.
- Refactor itemtransfer to load item_order.json via the shared resource reader instead of custom directory discovery logic.

</details>