### PR TITLE
refactor: simplify map tracker infer concurrency

### DIFF
--- a/agent/go-service/map-tracker/infer.go
+++ b/agent/go-service/map-tracker/infer.go
@@ -146,23 +146,14 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 	screenImg := minicv.ImageConvertRGBA(arg.Img)
 	t0 := time.Now()
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	var loc *InferLocationRawResult
-	var rot *InferRotationRawResult
+	ch := make(chan *InferLocationRawResult, 1)
 
 	go func() {
-		defer wg.Done()
-		loc = i.inferLocation(ctrlType, screenImg, mapNameRegex, param)
+		ch <- i.inferLocation(ctrlType, screenImg, mapNameRegex, param)
 	}()
 
-	go func() {
-		defer wg.Done()
-		rot = i.inferRotation(ctrlType, screenImg, rotStep)
-	}()
-
-	wg.Wait()
+	rot := i.inferRotation(ctrlType, screenImg, rotStep)
+	loc := <-ch
 
 	// Determine if recognition hit natively
 	internalLocHit := loc != nil && loc.conf > param.Threshold


### PR DESCRIPTION
## Summary by Sourcery

增强内容：
- 重构 `MapTrackerInfer.Run`，使用通道（channel）进行位置推断，而不是使用等待组（wait group），以实现更清晰、更简洁的并发控制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refactor MapTrackerInfer.Run to use a channel for location inference instead of a wait group for clearer and more concise concurrency control.

</details>