### PR TITLE
feat: 全局env管理器（PI v2.5 新增env）

### DIFF
--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/bytedance/sonic"
 	"github.com/rs/zerolog/log"
@@ -23,6 +24,7 @@ func main() {
 		Str("version", Version).
 		Msg("MaaEnd Agent Service")
 
+	pienv.Init()
 	i18n.Init()
 
 	if len(os.Args) < 2 {

--- a/agent/go-service/pkg/i18n/i18n.go
+++ b/agent/go-service/pkg/i18n/i18n.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"text/template"
 
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
 	"github.com/rs/zerolog/log"
 )
 
@@ -22,7 +23,6 @@ const (
 	LangKoKR = "ko_kr"
 
 	DefaultLang        = LangZhCN
-	envKey             = "PI_CLIENT_LANGUAGE"
 	localeRelDir       = "locales/go-service"
 	localeAssetsRelDir = "assets/locales/go-service"
 )
@@ -63,7 +63,8 @@ var (
 )
 
 func Init() {
-	lang := strings.ToLower(strings.TrimSpace(os.Getenv(envKey)))
+	raw := pienv.ClientLanguage()
+	lang := strings.ToLower(strings.TrimSpace(raw))
 	if lang == "" {
 		lang = DefaultLang
 	}
@@ -81,7 +82,7 @@ func Init() {
 	mu.Unlock()
 
 	log.Info().
-		Str("PI_CLIENT_LANGUAGE", os.Getenv(envKey)).
+		Str("PI_CLIENT_LANGUAGE", raw).
 		Str("resolved_lang", lang).
 		Str("locale_dir", resolved).
 		Int("message_count", messageCount).

--- a/agent/go-service/pkg/pienv/pienv.go
+++ b/agent/go-service/pkg/pienv/pienv.go
@@ -22,6 +22,7 @@ const (
 
 // ---- Controller sub-object types (per PI protocol) ----
 
+// Win32Config holds Win32 controller-specific fields (class/window regex, screencap and input methods).
 type Win32Config struct {
 	ClassRegex  string `json:"class_regex,omitempty"`
 	WindowRegex string `json:"window_regex,omitempty"`
@@ -30,16 +31,19 @@ type Win32Config struct {
 	Keyboard    string `json:"keyboard,omitempty"`
 }
 
+// MacOSConfig holds macOS controller-specific fields (title regex, screencap and input methods).
 type MacOSConfig struct {
 	TitleRegex string `json:"title_regex,omitempty"`
 	Screencap  string `json:"screencap,omitempty"`
 	Input      string `json:"input,omitempty"`
 }
 
+// PlayCoverConfig holds PlayCover (macOS) controller-specific fields.
 type PlayCoverConfig struct {
 	UUID string `json:"uuid,omitempty"`
 }
 
+// GamepadConfig holds Gamepad (Windows, requires ViGEm) controller-specific fields.
 type GamepadConfig struct {
 	ClassRegex  string `json:"class_regex,omitempty"`
 	WindowRegex string `json:"window_regex,omitempty"`
@@ -101,126 +105,106 @@ var (
 	once   sync.Once
 )
 
-// Init reads and parses all PI_* environment variables into the global singleton.
-// Call once at startup, before modules that depend on PI context.
-func Init() {
-	once.Do(func() {
-		env := &Env{
-			InterfaceVersion:   os.Getenv(EnvInterfaceVersion),
-			ClientName:         os.Getenv(EnvClientName),
-			ClientVersion:      os.Getenv(EnvClientVersion),
-			ClientLanguage:     os.Getenv(EnvClientLanguage),
-			ClientMaaFWVersion: os.Getenv(EnvClientMaaFWVersion),
-			Version:            os.Getenv(EnvVersion),
-			ControllerRaw:      os.Getenv(EnvController),
-			ResourceRaw:        os.Getenv(EnvResource),
+func doInit() {
+	env := &Env{
+		InterfaceVersion:   os.Getenv(EnvInterfaceVersion),
+		ClientName:         os.Getenv(EnvClientName),
+		ClientVersion:      os.Getenv(EnvClientVersion),
+		ClientLanguage:     os.Getenv(EnvClientLanguage),
+		ClientMaaFWVersion: os.Getenv(EnvClientMaaFWVersion),
+		Version:            os.Getenv(EnvVersion),
+		ControllerRaw:      os.Getenv(EnvController),
+		ResourceRaw:        os.Getenv(EnvResource),
+	}
+
+	if env.ControllerRaw != "" {
+		var ctrl Controller
+		if err := json.Unmarshal([]byte(env.ControllerRaw), &ctrl); err != nil {
+			log.Warn().Err(err).
+				Str("component", "pienv").
+				Str("env_key", EnvController).
+				Msg("failed to parse env")
+		} else {
+			env.Controller = &ctrl
 		}
+	}
 
-		if env.ControllerRaw != "" {
-			var ctrl Controller
-			if err := json.Unmarshal([]byte(env.ControllerRaw), &ctrl); err != nil {
-				log.Warn().Err(err).Msg("pienv: failed to parse PI_CONTROLLER")
-			} else {
-				env.Controller = &ctrl
-			}
+	if env.ResourceRaw != "" {
+		var res Resource
+		if err := json.Unmarshal([]byte(env.ResourceRaw), &res); err != nil {
+			log.Warn().Err(err).
+				Str("component", "pienv").
+				Str("env_key", EnvResource).
+				Msg("failed to parse env")
+		} else {
+			env.Resource = &res
 		}
+	}
 
-		if env.ResourceRaw != "" {
-			var res Resource
-			if err := json.Unmarshal([]byte(env.ResourceRaw), &res); err != nil {
-				log.Warn().Err(err).Msg("pienv: failed to parse PI_RESOURCE")
-			} else {
-				env.Resource = &res
-			}
-		}
+	global = env
 
-		global = env
+	le := log.Info().
+		Str("component", "pienv").
+		Str("interface_version", env.InterfaceVersion).
+		Str("client_name", env.ClientName).
+		Str("client_version", env.ClientVersion).
+		Str("client_language", env.ClientLanguage).
+		Str("client_maafw_version", env.ClientMaaFWVersion).
+		Str("pi_version", env.Version).
+		Bool("controller_ok", env.Controller != nil).
+		Bool("resource_ok", env.Resource != nil)
 
-		le := log.Info().
-			Str("interface_version", env.InterfaceVersion).
-			Str("client_name", env.ClientName).
-			Str("client_version", env.ClientVersion).
-			Str("client_language", env.ClientLanguage).
-			Str("client_maafw_version", env.ClientMaaFWVersion).
-			Str("pi_version", env.Version).
-			Bool("controller_ok", env.Controller != nil).
-			Bool("resource_ok", env.Resource != nil)
+	if env.Controller != nil {
+		le = le.Str("ctrl_name", env.Controller.Name).
+			Str("ctrl_type", env.Controller.Type)
+	}
+	if env.Resource != nil {
+		le = le.Str("res_name", env.Resource.Name)
+	}
 
-		if env.Controller != nil {
-			le = le.Str("ctrl_name", env.Controller.Name).
-				Str("ctrl_type", env.Controller.Type)
-		}
-		if env.Resource != nil {
-			le = le.Str("res_name", env.Resource.Name)
-		}
-
-		le.Msg("PI environment initialized")
-	})
+	le.Msg("PI environment initialized")
 }
 
-// Get returns the global Env. Returns nil if Init has not been called.
+// Init reads and parses all PI_* environment variables into the global singleton.
+// Safe to call multiple times; only the first call performs actual initialization.
+func Init() {
+	once.Do(doInit)
+}
+
+// Get returns the global Env, initializing on first access if needed.
+// The underlying sync.Once ensures no data race between Init and Get.
 func Get() *Env {
+	once.Do(doInit)
 	return global
 }
 
-// ---- Convenience accessors (nil-safe) ----
+// ---- Convenience accessors ----
 
-func InterfaceVersion() string {
-	if global == nil {
-		return ""
-	}
-	return global.InterfaceVersion
-}
+// InterfaceVersion returns the PI_INTERFACE_VERSION value (e.g. "v2.5.0").
+func InterfaceVersion() string { return Get().InterfaceVersion }
 
-func ClientName() string {
-	if global == nil {
-		return ""
-	}
-	return global.ClientName
-}
+// ClientName returns the PI_CLIENT_NAME value (e.g. "MFAA", "MXU").
+func ClientName() string { return Get().ClientName }
 
-func ClientVersion() string {
-	if global == nil {
-		return ""
-	}
-	return global.ClientVersion
-}
+// ClientVersion returns the PI_CLIENT_VERSION value.
+func ClientVersion() string { return Get().ClientVersion }
 
-func ClientLanguage() string {
-	if global == nil {
-		return ""
-	}
-	return global.ClientLanguage
-}
+// ClientLanguage returns the PI_CLIENT_LANGUAGE value (e.g. "zh_cn", "en_us").
+func ClientLanguage() string { return Get().ClientLanguage }
 
-func ClientMaaFWVersion() string {
-	if global == nil {
-		return ""
-	}
-	return global.ClientMaaFWVersion
-}
+// ClientMaaFWVersion returns the PI_CLIENT_MAAFW_VERSION value.
+func ClientMaaFWVersion() string { return Get().ClientMaaFWVersion }
 
-func ProjectVersion() string {
-	if global == nil {
-		return ""
-	}
-	return global.Version
-}
+// ProjectVersion returns the PI_VERSION value (resource project version from interface.json).
+func ProjectVersion() string { return Get().Version }
 
-func GetController() *Controller {
-	if global == nil {
-		return nil
-	}
-	return global.Controller
-}
+// GetController returns the parsed Controller, or nil if PI_CONTROLLER was absent or empty.
+func GetController() *Controller { return Get().Controller }
 
-func GetResource() *Resource {
-	if global == nil {
-		return nil
-	}
-	return global.Resource
-}
+// GetResource returns the parsed Resource, or nil if PI_RESOURCE was absent or empty.
+func GetResource() *Resource { return Get().Resource }
 
+// ControllerType returns the controller type (e.g. "Win32", "Adb"), or empty if unavailable.
 func ControllerType() string {
 	if c := GetController(); c != nil {
 		return c.Type
@@ -228,6 +212,7 @@ func ControllerType() string {
 	return ""
 }
 
+// ControllerName returns the controller name identifier, or empty if unavailable.
 func ControllerName() string {
 	if c := GetController(); c != nil {
 		return c.Name
@@ -235,6 +220,7 @@ func ControllerName() string {
 	return ""
 }
 
+// ResourceName returns the resource name identifier, or empty if unavailable.
 func ResourceName() string {
 	if r := GetResource(); r != nil {
 		return r.Name

--- a/agent/go-service/pkg/pienv/pienv.go
+++ b/agent/go-service/pkg/pienv/pienv.go
@@ -1,0 +1,243 @@
+package pienv
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+)
+
+// PI v2.5.0 environment variable keys.
+const (
+	EnvInterfaceVersion   = "PI_INTERFACE_VERSION"
+	EnvClientName         = "PI_CLIENT_NAME"
+	EnvClientVersion      = "PI_CLIENT_VERSION"
+	EnvClientLanguage     = "PI_CLIENT_LANGUAGE"
+	EnvClientMaaFWVersion = "PI_CLIENT_MAAFW_VERSION"
+	EnvVersion            = "PI_VERSION"
+	EnvController         = "PI_CONTROLLER"
+	EnvResource           = "PI_RESOURCE"
+)
+
+// ---- Controller sub-object types (per PI protocol) ----
+
+type Win32Config struct {
+	ClassRegex  string `json:"class_regex,omitempty"`
+	WindowRegex string `json:"window_regex,omitempty"`
+	Screencap   string `json:"screencap,omitempty"`
+	Mouse       string `json:"mouse,omitempty"`
+	Keyboard    string `json:"keyboard,omitempty"`
+}
+
+type MacOSConfig struct {
+	TitleRegex string `json:"title_regex,omitempty"`
+	Screencap  string `json:"screencap,omitempty"`
+	Input      string `json:"input,omitempty"`
+}
+
+type PlayCoverConfig struct {
+	UUID string `json:"uuid,omitempty"`
+}
+
+type GamepadConfig struct {
+	ClassRegex  string `json:"class_regex,omitempty"`
+	WindowRegex string `json:"window_regex,omitempty"`
+	GamepadType string `json:"gamepad_type,omitempty"`
+	Screencap   string `json:"screencap,omitempty"`
+}
+
+// Controller is the parsed PI_CONTROLLER single-line JSON.
+// i18n-capable fields (label, description, icon) are pre-resolved by the Client.
+type Controller struct {
+	Name               string           `json:"name"`
+	Label              string           `json:"label,omitempty"`
+	Description        string           `json:"description,omitempty"`
+	Icon               string           `json:"icon,omitempty"`
+	Type               string           `json:"type"`
+	DisplayShortSide   *int             `json:"display_short_side,omitempty"`
+	DisplayLongSide    *int             `json:"display_long_side,omitempty"`
+	DisplayRaw         *bool            `json:"display_raw,omitempty"`
+	PermissionRequired bool             `json:"permission_required,omitempty"`
+	AttachResourcePath []string         `json:"attach_resource_path,omitempty"`
+	Option             []string         `json:"option,omitempty"`
+	Win32              *Win32Config     `json:"win32,omitempty"`
+	Adb                json.RawMessage  `json:"adb,omitempty"`
+	MacOS              *MacOSConfig     `json:"macos,omitempty"`
+	PlayCover          *PlayCoverConfig `json:"playcover,omitempty"`
+	Gamepad            *GamepadConfig   `json:"gamepad,omitempty"`
+	WlRoots            json.RawMessage  `json:"wlroots,omitempty"`
+}
+
+// Resource is the parsed PI_RESOURCE single-line JSON.
+// i18n-capable fields (label, description, icon) are pre-resolved by the Client.
+type Resource struct {
+	Name        string   `json:"name"`
+	Label       string   `json:"label,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Icon        string   `json:"icon,omitempty"`
+	Path        []string `json:"path"`
+	Controller  []string `json:"controller,omitempty"`
+	Option      []string `json:"option,omitempty"`
+}
+
+// Env holds all parsed PI_* environment variables (PI v2.5.0).
+type Env struct {
+	InterfaceVersion   string
+	ClientName         string
+	ClientVersion      string
+	ClientLanguage     string
+	ClientMaaFWVersion string
+	Version            string
+
+	Controller    *Controller
+	ControllerRaw string
+	Resource      *Resource
+	ResourceRaw   string
+}
+
+var (
+	global *Env
+	once   sync.Once
+)
+
+// Init reads and parses all PI_* environment variables into the global singleton.
+// Call once at startup, before modules that depend on PI context.
+func Init() {
+	once.Do(func() {
+		env := &Env{
+			InterfaceVersion:   os.Getenv(EnvInterfaceVersion),
+			ClientName:         os.Getenv(EnvClientName),
+			ClientVersion:      os.Getenv(EnvClientVersion),
+			ClientLanguage:     os.Getenv(EnvClientLanguage),
+			ClientMaaFWVersion: os.Getenv(EnvClientMaaFWVersion),
+			Version:            os.Getenv(EnvVersion),
+			ControllerRaw:      os.Getenv(EnvController),
+			ResourceRaw:        os.Getenv(EnvResource),
+		}
+
+		if env.ControllerRaw != "" {
+			var ctrl Controller
+			if err := json.Unmarshal([]byte(env.ControllerRaw), &ctrl); err != nil {
+				log.Warn().Err(err).Msg("pienv: failed to parse PI_CONTROLLER")
+			} else {
+				env.Controller = &ctrl
+			}
+		}
+
+		if env.ResourceRaw != "" {
+			var res Resource
+			if err := json.Unmarshal([]byte(env.ResourceRaw), &res); err != nil {
+				log.Warn().Err(err).Msg("pienv: failed to parse PI_RESOURCE")
+			} else {
+				env.Resource = &res
+			}
+		}
+
+		global = env
+
+		le := log.Info().
+			Str("interface_version", env.InterfaceVersion).
+			Str("client_name", env.ClientName).
+			Str("client_version", env.ClientVersion).
+			Str("client_language", env.ClientLanguage).
+			Str("client_maafw_version", env.ClientMaaFWVersion).
+			Str("pi_version", env.Version).
+			Bool("controller_ok", env.Controller != nil).
+			Bool("resource_ok", env.Resource != nil)
+
+		if env.Controller != nil {
+			le = le.Str("ctrl_name", env.Controller.Name).
+				Str("ctrl_type", env.Controller.Type)
+		}
+		if env.Resource != nil {
+			le = le.Str("res_name", env.Resource.Name)
+		}
+
+		le.Msg("PI environment initialized")
+	})
+}
+
+// Get returns the global Env. Returns nil if Init has not been called.
+func Get() *Env {
+	return global
+}
+
+// ---- Convenience accessors (nil-safe) ----
+
+func InterfaceVersion() string {
+	if global == nil {
+		return ""
+	}
+	return global.InterfaceVersion
+}
+
+func ClientName() string {
+	if global == nil {
+		return ""
+	}
+	return global.ClientName
+}
+
+func ClientVersion() string {
+	if global == nil {
+		return ""
+	}
+	return global.ClientVersion
+}
+
+func ClientLanguage() string {
+	if global == nil {
+		return ""
+	}
+	return global.ClientLanguage
+}
+
+func ClientMaaFWVersion() string {
+	if global == nil {
+		return ""
+	}
+	return global.ClientMaaFWVersion
+}
+
+func ProjectVersion() string {
+	if global == nil {
+		return ""
+	}
+	return global.Version
+}
+
+func GetController() *Controller {
+	if global == nil {
+		return nil
+	}
+	return global.Controller
+}
+
+func GetResource() *Resource {
+	if global == nil {
+		return nil
+	}
+	return global.Resource
+}
+
+func ControllerType() string {
+	if c := GetController(); c != nil {
+		return c.Type
+	}
+	return ""
+}
+
+func ControllerName() string {
+	if c := GetController(); c != nil {
+		return c.Name
+	}
+	return ""
+}
+
+func ResourceName() string {
+	if r := GetResource(); r != nil {
+		return r.Name
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary by Sourcery

引入集中式的 PI 环境管理器，并将其集成到 agent 服务的初始化流程中。

新功能：
- 新增全局 PI 环境管理器，用于解析并暴露 PI v2.5.0 的环境变量，包括 controller 和 resource 元数据。
- 提供便捷的访问方法，用于获取关键的 PI 客户端和项目属性，例如语言、版本、controller 和 resource 信息。

增强点：
- 更新 i18n 初始化逻辑，从新的 PI 环境管理器中读取客户端语言，而不是直接从环境变量中读取。
- 在服务启动时初始化 PI 环境管理器，使 PI 上下文在各模块间可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a centralized PI environment manager and integrate it into the agent service initialization.

New Features:
- Add a global PI environment manager that parses and exposes PI v2.5.0 environment variables, including controller and resource metadata.
- Provide convenience accessors for key PI client and project attributes, such as language, versions, controller, and resource info.

Enhancements:
- Update i18n initialization to read the client language from the new PI environment manager instead of directly from the environment.
- Initialize the PI environment manager at service startup to make PI context available across modules.

</details>