### PR TITLE
feat(AutoUseSpMedication): 支持仅使用即将过期的应急理智加强剂

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "global.region.ValleyIV": "Valley IV",
     "global.region.Wuling": "Wuling",
     "global.region.OriginiumSciencePark": "Originium Science Park",
@@ -512,7 +512,9 @@
     "task.AutoUseSpMedication.description": "Automatically use one emergency sanity booster (+40 sanity)",
     "task.AutoUseSpMedication.label": "💊 Emergency Sanity Booster",
     "option.UseAllExpireSoonMedication.label": "Use all soon-to-expire emergency sanity boosters",
-    "option.UseAllExpireSoonMedication.description": "Use all emergency sanity boosters with less than three days remaining (timer turns red).",
+    "option.UseAllExpireSoonMedication.description": "When enabled, uses all emergency sanity boosters expiring within 3 days (timer turns red). When disabled, expiring boosters are skipped.",
+    "option.UseRegularSpMedication.label": "Use regular emergency sanity booster",
+    "option.UseRegularSpMedication.description": "Enabled by default. Uses one regular emergency sanity booster when found. Disable to skip regular boosters.",
     "task.AutoCollect.description": "Automatically collect wild resources (the game must stay in the foreground; do not move the mouse).\nNote: if crops have not fully grown, they may grow randomly, which can lead to incomplete collection.\nDue to recognition accuracy limits, even when fully grown some may not be collected.",
     "task.AutoCollect.label": "🧺 Auto Collect Resources",
     "option.AutoCollectRoutes.label": "Collect Routes",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "global.region.ValleyIV": "第4谷地 (Valley IV)",
     "global.region.Wuling": "武陵 (Wuling)",
     "global.region.OriginiumSciencePark": "源石研究パーク",
@@ -512,7 +512,9 @@
     "task.AutoUseSpMedication.description": "緊急理智強化剤を1つ自動で使用する（+40理智）",
     "task.AutoUseSpMedication.label": "💊緊急理智強化剤",
     "option.UseAllExpireSoonMedication.label": "期限切れ間近の緊急理智強化剤をすべて使用",
-    "option.UseAllExpireSoonMedication.description": "残り3日未満（タイマーが赤くなる）の緊急理智強化剤をすべて使用します。",
+    "option.UseAllExpireSoonMedication.description": "有効にすると、残り3日未満（タイマーが赤くなる）の緊急理智強化剤をすべて使用します。無効にすると期限切れ間近の強化剤はスキップされます。",
+    "option.UseRegularSpMedication.label": "通常の緊急理智強化剤を使用",
+    "option.UseRegularSpMedication.description": "デフォルトで有効。通常の緊急理智強化剤が見つかった場合に1つ使用します。無効にすると通常の強化剤はスキップされます。",
     "task.AutoCollect.description": "フィールド資源を自動採集します（ゲームを常に前面に表示し、マウスを動かさないでください）。\n注意：作物が完全に成長していない場合、作物がランダムに成長し、採集漏れが発生することがあります。\n認識精度の制限により、成長済みでも一部採集できない場合があります。",
     "task.AutoCollect.label": "🧺資源自動収集",
     "option.AutoCollectRoutes.label": "採集ルート",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "global.region.ValleyIV": "제4 계곡 (Valley IV)",
     "global.region.Wuling": "무릉 (Wuling)",
     "global.region.OriginiumSciencePark": "오리지늄 연구 구역",
@@ -512,7 +512,9 @@
     "task.AutoUseSpMedication.description": "응급 이성 강화제 1개 자동 사용(+40 이성)",
     "task.AutoUseSpMedication.label": "💊응급 이성 강화제",
     "option.UseAllExpireSoonMedication.label": "곧 만료될 응급 이성 강화제 모두 사용",
-    "option.UseAllExpireSoonMedication.description": "만료까지 3일 미만인 모든 응급 이성 강화제를 사용합니다 (시간 표시가 빨갛게 변함).",
+    "option.UseAllExpireSoonMedication.description": "활성화하면 만료까지 3일 미만인 응급 이성 강화제를 모두 사용합니다(시간 표시가 빨갛게 변함). 비활성화하면 만료 예정 강화제를 건너뜁니다.",
+    "option.UseRegularSpMedication.label": "일반 응급 이성 강화제 사용",
+    "option.UseRegularSpMedication.description": "기본 활성화. 일반 응급 이성 강화제를 발견하면 1개 사용합니다. 비활성화하면 일반 강화제는 건너뜁니다.",
     "task.AutoCollect.description": "야외 자원을 자동 수집합니다(게임을 계속 전면에 유지하고 마우스를 움직이지 마세요).\n참고: 작물이 완전히 자라기 전에 랜덤 성장으로 인해 수집이 누락될 수 있습니다.\n인식 정확도의 한계로 인해 완전히 자라도 일부는 수집되지 않을 수 있습니다.",
     "task.AutoCollect.label": "🧺자원 자동 수집",
     "option.AutoCollectRoutes.label": "채집 경로",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "global.region.ValleyIV": "四号谷地",
     "global.region.Wuling": "武陵",
     "global.region.OriginiumSciencePark": "源石研究园",
@@ -512,7 +512,9 @@
     "task.AutoUseSpMedication.description": "自动使用一次应急理智加强剂(+40理智)",
     "task.AutoUseSpMedication.label": "💊应急理智加强剂",
     "option.UseAllExpireSoonMedication.label": "使用所有要过期的应急理智加强剂",
-    "option.UseAllExpireSoonMedication.description": "使用所有时限小于三天的应急理智加强剂，即时限变红的应急理智药",
+    "option.UseAllExpireSoonMedication.description": "开启后吃完所有时限小于三天的应急理智加强剂（时限变红）；关闭则跳过过期药",
+    "option.UseRegularSpMedication.label": "使用应急理智加强剂",
+    "option.UseRegularSpMedication.description": "默认开启，找到普通应急理智加强剂时使用一颗；关闭后跳过普通药",
     "task.AutoCollect.description": "自动采集野外资源（需一直保持前台，不要乱动鼠标）\n 注意，作物没有完全生长齐的时候作物会随机生长，会导致收集不齐的情况。\n 受限于识别精度即使齐了也会有个别无法收集",
     "task.AutoCollect.label": "🧺自动采集资源",
     "option.AutoCollectRoutes.label": "采集线路",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "global.region.ValleyIV": "四號谷地",
     "global.region.Wuling": "武陵",
     "global.region.OriginiumSciencePark": "源石研究園",
@@ -358,7 +358,9 @@
     "task.AutoUseSpMedication.description": "自動使用一次應急理智加強劑(+40理智)",
     "task.AutoUseSpMedication.label": "💊應急理智加強劑",
     "option.UseAllExpireSoonMedication.label": "使用所有即將過期的應急理智強化劑",
-    "option.UseAllExpireSoonMedication.description": "使用所有時限小於三天的應急理智強化劑，即時限變紅的應急理智藥",
+    "option.UseAllExpireSoonMedication.description": "開啟後吃完所有時限小於三天的應急理智強化劑（時限變紅）；關閉則跳過過期藥",
+    "option.UseRegularSpMedication.label": "使用應急理智加強劑",
+    "option.UseRegularSpMedication.description": "預設開啟，找到普通應急理智加強劑時使用一顆；關閉後跳過普通藥",
     "task.AutoCollect.description": "自動採集野外資源（需一直保持前台，不要亂動滑鼠）\n注意，作物沒有完全生長齊的時候作物會隨機生長，會導致收集不齊的情況。\n受限於識別精度即使齊了也會有個別無法收集",
     "task.AutoCollect.label": "🧺自動採集資源",
     "option.AutoCollectRoutes.label": "採集路線",

--- a/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
@@ -196,6 +196,37 @@
             "Node.Action.Succeeded": "没有应急理智加强剂，结束任务"
         }
     },
+    "AutoUseSpMedicationCloseDetailNotExpSoon": {
+        "desc": "关闭详情页（非过期药误匹配），尝试应急药剂",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "WhiteConfirmButtonType1"
+                ],
+                "box_index": 0
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    1084,
+                    203,
+                    33,
+                    31
+                ]
+            }
+        },
+        "post_wait_freezes": 300,
+        "next": [
+            "AutoUseSpMedicationChooseEmergencySanityBooster",
+            "AutoUseSpMedicationUseNoEmergencySanityBooster"
+        ]
+    },
+    "AutoUseSpMedicationSkipRegular": {
+        "desc": "用户选择不使用应急药剂，静默结束"
+    },
     "AutoUseSpMedicationAdd": {
         "desc": "点击添加按钮",
         "recognition": {

--- a/assets/tasks/AutoUseSpMedication.json
+++ b/assets/tasks/AutoUseSpMedication.json
@@ -5,13 +5,41 @@
             "entry": "AutoUseSpMedicationEntry",
             "label": "$task.AutoUseSpMedication.label",
             "name": "AutoUseSpMedication",
-            "group": ["utility"],
+            "group": [
+                "utility"
+            ],
             "option": [
+                "UseRegularSpMedication",
                 "UseAllExpireSoonSpMedication"
             ]
         }
     ],
     "option": {
+        "UseRegularSpMedication": {
+            "type": "switch",
+            "description": "$option.UseRegularSpMedication.description",
+            "label": "$option.UseRegularSpMedication.label",
+            "default_case": "Yes",
+            "cases": [
+                {
+                    "name": "Yes"
+                },
+                {
+                    "name": "No",
+                    "pipeline_override": {
+                        "AutoUseSpMedicationChooseEmergencySanityBooster": {
+                            "action": "DoNothing",
+                            "focus": {
+                                "Node.Action.Starting": "未选择使用应急药剂，跳过"
+                            },
+                            "next": [
+                                "AutoUseSpMedicationSkipRegular"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
         "UseAllExpireSoonSpMedication": {
             "type": "switch",
             "description": "$option.UseAllExpireSoonMedication.description",
@@ -21,10 +49,12 @@
                 {
                     "name": "No",
                     "pipeline_override": {
-                        "AutoUseSpMedicationChooseEmergencySanityBoosterExpSoon": {
-                            "next": [
-                                "AutoUseSpMedicationUseEmergencySpBooster"
-                            ]
+                        "AutoUseSpMedicationEntry": {
+                            "anchor": {
+                                "ValuableStashValuablesTabInNext": "AutoUseSpMedicationChooseEmergencySanityBooster",
+                                "ValuableStashValuablesTabInNext2": "AutoUseSpMedicationUseNoEmergencySanityBooster",
+                                "ValuableStashValuablesTabInNext3": "AutoUseSpMedicationUseNoEmergencySanityBooster"
+                            }
                         }
                     }
                 },
@@ -34,7 +64,7 @@
                         "AutoUseSpMedicationChooseEmergencySanityBoosterExpSoon": {
                             "next": [
                                 "AutoUseSpMedicationIfExpireSoon",
-                                "AutoUseSpMedicationUseEmergencySpBooster"
+                                "AutoUseSpMedicationCloseDetailNotExpSoon"
                             ]
                         }
                     }


### PR DESCRIPTION
## 背景

原有逻辑每次固定使用一颗应急理智加强剂，无法只使用过期药，

## 变更内容

新增两个独立开关：

**UseRegularSpMedication**（默认开启）
- 开：找到应急理智加强剂时使用一颗
- 关：跳过普通应急理智加强剂

**UseAllExpireSoonSpMedication**（默认关闭）
- 开：使用所有时限小于三天（时限变红）的应急理智加强剂
- 关：跳过过期药


## Summary by Sourcery

为自动使用特殊理智药物新增可配置选项，包括仅消耗临期物品的支持。

新功能：
- 在 AutoUseSpMedication 流水线中，引入单独的开关，用于控制使用常规特殊理智药物以及使用所有即将过期的特殊理智药物。

增强：
- 更新 AutoUseSpMedication 任务和流水线配置，使其遵循新的药物使用开关设置。

文档：
- 为新的 AutoUseSpMedication 配置选项，在所有支持的语言中新增本地化 UI 文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable options to control automatic use of special sanity medication, including support for consuming only items that are close to expiry.

New Features:
- Introduce separate switches for using regular special sanity medication and using all soon-to-expire special sanity medication in the AutoUseSpMedication pipeline.

Enhancements:
- Update AutoUseSpMedication task and pipeline configuration to respect the new medication usage switches.

Documentation:
- Add localized UI strings for the new AutoUseSpMedication configuration options in all supported languages.

</details>