### PR TITLE
feat: cursor move sink

### DIFF
--- a/agent/go-service/register.go
+++ b/agent/go-service/register.go
@@ -22,6 +22,7 @@ import (
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/resell"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/scenemanager"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/taskersink/aspectratio"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/taskersink/cursormove"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/taskersink/hdrcheck"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/taskersink/processcheck"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/visitfriends"
@@ -36,6 +37,7 @@ func registerAll() {
 	aspectratio.Register()
 	hdrcheck.Register()
 	processcheck.Register()
+	cursormove.Register()
 
 	// General Custom
 	subtask.Register()

--- a/agent/go-service/taskersink/cursormove/register.go
+++ b/agent/go-service/taskersink/cursormove/register.go
@@ -1,0 +1,21 @@
+package cursormove
+
+import (
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
+	"github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+var _ maa.ContextEventSink = &CursorMoveSink{}
+
+// Register adds the cursor-move context sink when the controller is Win32.
+func Register() {
+	if pienv.ControllerType() != "Win32" {
+		return
+	}
+
+	maa.AgentServerAddContextSink(&CursorMoveSink{})
+	log.Info().
+		Str("controller", pienv.ControllerName()).
+		Msg("[cursormove] context sink registered for Win32 controller")
+}

--- a/agent/go-service/taskersink/cursormove/register.go
+++ b/agent/go-service/taskersink/cursormove/register.go
@@ -13,7 +13,7 @@ var (
 
 // Register adds the cursor-move sinks when the controller is Win32.
 func Register() {
-	if pienv.ControllerType() != "Win32" {
+	if pienv.ControllerName() != "Win32-Front" {
 		return
 	}
 

--- a/agent/go-service/taskersink/cursormove/register.go
+++ b/agent/go-service/taskersink/cursormove/register.go
@@ -6,16 +6,21 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var _ maa.ContextEventSink = &CursorMoveSink{}
+var (
+	_ maa.ContextEventSink = &CursorMoveSink{}
+	_ maa.TaskerEventSink  = &CursorMoveSink{}
+)
 
-// Register adds the cursor-move context sink when the controller is Win32.
+// Register adds the cursor-move sinks when the controller is Win32.
 func Register() {
 	if pienv.ControllerType() != "Win32" {
 		return
 	}
 
-	maa.AgentServerAddContextSink(&CursorMoveSink{})
+	sink := &CursorMoveSink{}
+	maa.AgentServerAddContextSink(sink)
+	maa.AgentServerAddTaskerSink(sink)
 	log.Info().
 		Str("controller", pienv.ControllerName()).
-		Msg("[cursormove] context sink registered for Win32 controller")
+		Msg("[cursormove] sinks registered for Win32 controller")
 }

--- a/agent/go-service/taskersink/cursormove/register.go
+++ b/agent/go-service/taskersink/cursormove/register.go
@@ -6,11 +6,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var (
-	_ maa.ContextEventSink = &CursorMoveSink{}
-	_ maa.TaskerEventSink  = &CursorMoveSink{}
-)
-
 // Register adds the cursor-move sinks when the controller is Win32.
 func Register() {
 	if pienv.ControllerName() != "Win32-Front" {
@@ -21,6 +16,7 @@ func Register() {
 	maa.AgentServerAddContextSink(sink)
 	maa.AgentServerAddTaskerSink(sink)
 	log.Info().
+		Str("component", "cursormove").
 		Str("controller", pienv.ControllerName()).
-		Msg("[cursormove] sinks registered for Win32 controller")
+		Msg("sinks registered for Win32 controller")
 }

--- a/agent/go-service/taskersink/cursormove/sink.go
+++ b/agent/go-service/taskersink/cursormove/sink.go
@@ -1,0 +1,40 @@
+package cursormove
+
+import (
+	"github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+// CursorMoveSink resets the cursor to (0,0) on every Node.NextList.Starting
+// event. This prevents the Win32 controller's SendMessage-based mouse input
+// from being blocked by the physical cursor sitting inside the game window.
+type CursorMoveSink struct{}
+
+func (s *CursorMoveSink) OnNodeNextList(ctx *maa.Context, event maa.EventStatus, _ maa.NodeNextListDetail) {
+	if event != maa.EventStatusStarting {
+		return
+	}
+
+	ctrl := ctx.GetTasker().GetController()
+	if ctrl == nil {
+		log.Warn().Msg("[cursormove] failed to get controller from context")
+		return
+	}
+
+	ctrl.PostTouchMove(0, 0, 0, 0)
+}
+
+func (s *CursorMoveSink) OnNodePipelineNode(_ *maa.Context, _ maa.EventStatus, _ maa.NodePipelineNodeDetail) {
+}
+
+func (s *CursorMoveSink) OnNodeRecognitionNode(_ *maa.Context, _ maa.EventStatus, _ maa.NodeRecognitionNodeDetail) {
+}
+
+func (s *CursorMoveSink) OnNodeActionNode(_ *maa.Context, _ maa.EventStatus, _ maa.NodeActionNodeDetail) {
+}
+
+func (s *CursorMoveSink) OnNodeRecognition(_ *maa.Context, _ maa.EventStatus, _ maa.NodeRecognitionDetail) {
+}
+
+func (s *CursorMoveSink) OnNodeAction(_ *maa.Context, _ maa.EventStatus, _ maa.NodeActionDetail) {
+}

--- a/agent/go-service/taskersink/cursormove/sink.go
+++ b/agent/go-service/taskersink/cursormove/sink.go
@@ -5,6 +5,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+var (
+	_ maa.ContextEventSink = &CursorMoveSink{}
+	_ maa.TaskerEventSink  = &CursorMoveSink{}
+)
+
 // CursorMoveSink moves the cursor to the bottom-right corner before the next
 // recognition cycle when the previous action repositioned the cursor.
 // This prevents the cursor from occluding game UI elements during Win32 screencap.
@@ -25,13 +30,13 @@ func (s *CursorMoveSink) OnTaskerTask(tasker *maa.Tasker, event maa.EventStatus,
 
 	ctrl := tasker.GetController()
 	if ctrl == nil {
-		log.Warn().Msg("[cursormove] failed to get controller from tasker")
+		log.Warn().Str("component", "cursormove").Msg("failed to get controller from tasker")
 		return
 	}
 
 	img, err := ctrl.CacheImage()
 	if err != nil || img == nil {
-		log.Warn().Err(err).Msg("[cursormove] failed to get cached image for size")
+		log.Warn().Err(err).Str("component", "cursormove").Msg("failed to get cached image for size")
 		return
 	}
 
@@ -39,9 +44,10 @@ func (s *CursorMoveSink) OnTaskerTask(tasker *maa.Tasker, event maa.EventStatus,
 	s.imgW = int32(bounds.Dx())
 	s.imgH = int32(bounds.Dy())
 	log.Info().
+		Str("component", "cursormove").
 		Int32("width", s.imgW).
 		Int32("height", s.imgH).
-		Msg("[cursormove] captured image size")
+		Msg("captured image size")
 
 	s.moveCursor(ctrl)
 }
@@ -74,7 +80,7 @@ func (s *CursorMoveSink) OnNodeNextList(ctx *maa.Context, event maa.EventStatus,
 
 	ctrl := ctx.GetTasker().GetController()
 	if ctrl == nil {
-		log.Warn().Msg("[cursormove] failed to get controller from context")
+		log.Warn().Str("component", "cursormove").Msg("failed to get controller from context")
 		return
 	}
 

--- a/agent/go-service/taskersink/cursormove/sink.go
+++ b/agent/go-service/taskersink/cursormove/sink.go
@@ -1,17 +1,41 @@
 package cursormove
 
 import (
+	"sync/atomic"
+
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
 
-// CursorMoveSink resets the cursor to (0,0) on every Node.NextList.Starting
-// event. This prevents the Win32 controller's SendMessage-based mouse input
-// from being blocked by the physical cursor sitting inside the game window.
-type CursorMoveSink struct{}
+// CursorMoveSink moves the cursor to (0,0) before the next recognition cycle
+// when the previous action repositioned the cursor. This prevents the cursor
+// from occluding game UI elements during Win32 screencap.
+type CursorMoveSink struct {
+	dirty atomic.Bool
+}
+
+func (s *CursorMoveSink) OnNodeAction(ctx *maa.Context, event maa.EventStatus, detail maa.NodeActionDetail) {
+	if event != maa.EventStatusSucceeded && event != maa.EventStatusFailed {
+		return
+	}
+
+	ad, err := ctx.GetTasker().GetActionDetail(int64(detail.ActionID))
+	if err != nil || ad == nil {
+		return
+	}
+
+	switch ad.Action {
+	case "Click", "Swipe", "Scroll", "Custom":
+		s.dirty.Store(true)
+	}
+}
 
 func (s *CursorMoveSink) OnNodeNextList(ctx *maa.Context, event maa.EventStatus, _ maa.NodeNextListDetail) {
 	if event != maa.EventStatusStarting {
+		return
+	}
+
+	if !s.dirty.CompareAndSwap(true, false) {
 		return
 	}
 
@@ -34,7 +58,4 @@ func (s *CursorMoveSink) OnNodeActionNode(_ *maa.Context, _ maa.EventStatus, _ m
 }
 
 func (s *CursorMoveSink) OnNodeRecognition(_ *maa.Context, _ maa.EventStatus, _ maa.NodeRecognitionDetail) {
-}
-
-func (s *CursorMoveSink) OnNodeAction(_ *maa.Context, _ maa.EventStatus, _ maa.NodeActionDetail) {
 }

--- a/agent/go-service/taskersink/cursormove/sink.go
+++ b/agent/go-service/taskersink/cursormove/sink.go
@@ -1,17 +1,50 @@
 package cursormove
 
 import (
-	"sync/atomic"
-
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
 
-// CursorMoveSink moves the cursor to (0,0) before the next recognition cycle
-// when the previous action repositioned the cursor. This prevents the cursor
-// from occluding game UI elements during Win32 screencap.
+// CursorMoveSink moves the cursor to the bottom-right corner before the next
+// recognition cycle when the previous action repositioned the cursor.
+// This prevents the cursor from occluding game UI elements during Win32 screencap.
 type CursorMoveSink struct {
-	dirty atomic.Bool
+	dirty bool
+	imgW  int32
+	imgH  int32
+}
+
+func (s *CursorMoveSink) moveCursor(ctrl *maa.Controller) {
+	ctrl.PostTouchMove(0, s.imgW, s.imgH, 0).Wait()
+}
+
+func (s *CursorMoveSink) OnTaskerTask(tasker *maa.Tasker, event maa.EventStatus, _ maa.TaskerTaskDetail) {
+	if event != maa.EventStatusStarting {
+		return
+	}
+
+	ctrl := tasker.GetController()
+	if ctrl == nil {
+		log.Warn().Msg("[cursormove] failed to get controller from tasker")
+		return
+	}
+
+	ctrl.PostScreencap().Wait()
+	img, err := ctrl.CacheImage()
+	if err != nil || img == nil {
+		log.Warn().Err(err).Msg("[cursormove] failed to get cached image for size")
+		return
+	}
+
+	bounds := img.Bounds()
+	s.imgW = int32(bounds.Dx())
+	s.imgH = int32(bounds.Dy())
+	log.Info().
+		Int32("width", s.imgW).
+		Int32("height", s.imgH).
+		Msg("[cursormove] captured image size")
+
+	s.moveCursor(ctrl)
 }
 
 func (s *CursorMoveSink) OnNodeAction(ctx *maa.Context, event maa.EventStatus, detail maa.NodeActionDetail) {
@@ -26,7 +59,7 @@ func (s *CursorMoveSink) OnNodeAction(ctx *maa.Context, event maa.EventStatus, d
 
 	switch ad.Action {
 	case "Click", "Swipe", "Scroll", "Custom":
-		s.dirty.Store(true)
+		s.dirty = true
 	}
 }
 
@@ -35,9 +68,10 @@ func (s *CursorMoveSink) OnNodeNextList(ctx *maa.Context, event maa.EventStatus,
 		return
 	}
 
-	if !s.dirty.CompareAndSwap(true, false) {
+	if !s.dirty {
 		return
 	}
+	s.dirty = false
 
 	ctrl := ctx.GetTasker().GetController()
 	if ctrl == nil {
@@ -45,7 +79,7 @@ func (s *CursorMoveSink) OnNodeNextList(ctx *maa.Context, event maa.EventStatus,
 		return
 	}
 
-	ctrl.PostTouchMove(0, 0, 0, 0)
+	s.moveCursor(ctrl)
 }
 
 func (s *CursorMoveSink) OnNodePipelineNode(_ *maa.Context, _ maa.EventStatus, _ maa.NodePipelineNodeDetail) {

--- a/agent/go-service/taskersink/cursormove/sink.go
+++ b/agent/go-service/taskersink/cursormove/sink.go
@@ -29,7 +29,6 @@ func (s *CursorMoveSink) OnTaskerTask(tasker *maa.Tasker, event maa.EventStatus,
 		return
 	}
 
-	ctrl.PostScreencap().Wait()
 	img, err := ctrl.CacheImage()
 	if err != nil || img == nil {
 		log.Warn().Err(err).Msg("[cursormove] failed to get cached image for size")


### PR DESCRIPTION
## Sourcery 总结

为 Win32 控制器添加一个光标移动接收器（cursor movement sink），通过在识别周期之间重新定位光标，防止光标遮挡游戏界面。

新功能：
- 引入一个 `CursorMoveSink`，用于跟踪影响光标的操作，并在使用 Win32 控制器时，于后续识别周期前重新定位光标。

增强内容：
- 当控制器为 Win32 时，在服务启动期间自动注册光标移动上下文和任务接收器（cursor-move context and tasker sinks），并记录相关注册详情到日志中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a cursor movement sink for Win32 controllers to prevent the cursor from obstructing the game UI by repositioning it between recognition cycles.

New Features:
- Introduce a CursorMoveSink that tracks cursor-affecting actions and repositions the cursor before subsequent recognition cycles when using a Win32 controller.

Enhancements:
- Automatically register the cursor-move context and tasker sinks during service startup when the controller is Win32, and log the registration details.

</details>

新功能：
- 引入 `CursorMoveSink`，用于跟踪影响光标位置的操作，并在使用 Win32 控制器时，在随后的识别周期之前重新定位光标。

增强：
- 当控制器类型为 Win32 时，在服务启动过程中自动注册光标移动上下文和任务接收器（context and tasker sinks），并记录相关注册日志。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为 Win32 控制器添加一个光标移动接收器（cursor movement sink），通过在识别周期之间重新定位光标，防止光标遮挡游戏界面。

新功能：
- 引入一个 `CursorMoveSink`，用于跟踪影响光标的操作，并在使用 Win32 控制器时，于后续识别周期前重新定位光标。

增强内容：
- 当控制器为 Win32 时，在服务启动期间自动注册光标移动上下文和任务接收器（cursor-move context and tasker sinks），并记录相关注册详情到日志中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a cursor movement sink for Win32 controllers to prevent the cursor from obstructing the game UI by repositioning it between recognition cycles.

New Features:
- Introduce a CursorMoveSink that tracks cursor-affecting actions and repositions the cursor before subsequent recognition cycles when using a Win32 controller.

Enhancements:
- Automatically register the cursor-move context and tasker sinks during service startup when the controller is Win32, and log the registration details.

</details>

</details>

新功能：
- 引入一个 `CursorMoveSink`，在使用 Win32 控制器时，在每个节点列表开始时重置光标位置。

增强内容：
- 当控制器类型为 Win32 时，在服务启动期间自动注册光标移动上下文接收器，并在注册成功时记录日志。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为 Win32 控制器添加一个光标移动接收器（cursor movement sink），通过在识别周期之间重新定位光标，防止光标遮挡游戏界面。

新功能：
- 引入一个 `CursorMoveSink`，用于跟踪影响光标的操作，并在使用 Win32 控制器时，于后续识别周期前重新定位光标。

增强内容：
- 当控制器为 Win32 时，在服务启动期间自动注册光标移动上下文和任务接收器（cursor-move context and tasker sinks），并记录相关注册详情到日志中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a cursor movement sink for Win32 controllers to prevent the cursor from obstructing the game UI by repositioning it between recognition cycles.

New Features:
- Introduce a CursorMoveSink that tracks cursor-affecting actions and repositions the cursor before subsequent recognition cycles when using a Win32 controller.

Enhancements:
- Automatically register the cursor-move context and tasker sinks during service startup when the controller is Win32, and log the registration details.

</details>

新功能：
- 引入 `CursorMoveSink`，用于跟踪影响光标位置的操作，并在使用 Win32 控制器时，在随后的识别周期之前重新定位光标。

增强：
- 当控制器类型为 Win32 时，在服务启动过程中自动注册光标移动上下文和任务接收器（context and tasker sinks），并记录相关注册日志。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为 Win32 控制器添加一个光标移动接收器（cursor movement sink），通过在识别周期之间重新定位光标，防止光标遮挡游戏界面。

新功能：
- 引入一个 `CursorMoveSink`，用于跟踪影响光标的操作，并在使用 Win32 控制器时，于后续识别周期前重新定位光标。

增强内容：
- 当控制器为 Win32 时，在服务启动期间自动注册光标移动上下文和任务接收器（cursor-move context and tasker sinks），并记录相关注册详情到日志中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a cursor movement sink for Win32 controllers to prevent the cursor from obstructing the game UI by repositioning it between recognition cycles.

New Features:
- Introduce a CursorMoveSink that tracks cursor-affecting actions and repositions the cursor before subsequent recognition cycles when using a Win32 controller.

Enhancements:
- Automatically register the cursor-move context and tasker sinks during service startup when the controller is Win32, and log the registration details.

</details>

</details>

</details>