### PR TITLE
fix(QuantizedSliding): 收紧识别取值并支持 Filtered 拼接

### DIFF
--- a/agent/go-service/quantizedsliding/handlers.go
+++ b/agent/go-service/quantizedsliding/handlers.go
@@ -125,7 +125,7 @@ func (a *QuantizedSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa
 		return false
 	}
 
-	maxQuantity, err := readQuantityValue(arg.RecognitionDetail)
+	maxQuantity, err := readQuantityValue(arg.RecognitionDetail, a.ConcatAllFilteredDigits)
 	if err != nil {
 		a.logger.Error().Err(err).Msg("failed to parse max quantity from ocr")
 		return false
@@ -268,7 +268,7 @@ func (a *QuantizedSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.
 		return false
 	}
 
-	currentQuantity, err := readQuantityValue(arg.RecognitionDetail)
+	currentQuantity, err := readQuantityValue(arg.RecognitionDetail, a.ConcatAllFilteredDigits)
 	if err != nil {
 		a.logger.Error().Err(err).Msg("failed to parse current quantity from ocr")
 		return false

--- a/agent/go-service/quantizedsliding/handlers.go
+++ b/agent/go-service/quantizedsliding/handlers.go
@@ -11,7 +11,7 @@ import (
 func (a *QuantizedSlidingAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 	if arg == nil {
 		log.Error().
-			Str("component", "QuantizedSliding").
+			Str("component", quantizedSlidingActionName).
 			Msg("got nil custom action arg")
 		return false
 	}
@@ -32,17 +32,17 @@ func (a *QuantizedSlidingAction) Run(ctx *maa.Context, arg *maa.CustomActionArg)
 func (a *QuantizedSlidingAction) dispatchActionNode(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 
 	switch arg.CurrentTaskName {
-	case "QuantizedSlidingMain":
+	case nodeQuantizedSlidingMain:
 		return a.handleMain(ctx, arg)
-	case "QuantizedSlidingFindStart":
+	case nodeQuantizedSlidingFindStart:
 		return a.handleFindStart(ctx, arg)
-	case "QuantizedSlidingGetMaxQuantity":
+	case nodeQuantizedSlidingGetMaxQuantity:
 		return a.handleGetMaxQuantity(ctx, arg)
-	case "QuantizedSlidingFindEnd":
+	case nodeQuantizedSlidingFindEnd:
 		return a.handleFindEnd(ctx, arg)
-	case "QuantizedSlidingCheckQuantity":
+	case nodeQuantizedSlidingCheckQuantity:
 		return a.handleCheckQuantity(ctx, arg)
-	case "QuantizedSlidingDone":
+	case nodeQuantizedSlidingDone:
 		return a.handleDone(ctx, arg)
 	default:
 		a.logger.Warn().Msg("unknown current task name")
@@ -104,7 +104,7 @@ func (a *QuantizedSlidingAction) handleFindStart(_ *maa.Context, arg *maa.Custom
 		return false
 	}
 
-	box, ok := extractHitBox(arg.RecognitionDetail)
+	box, ok := readHitBox(arg.RecognitionDetail)
 	if !ok {
 		a.logger.Error().Msg("failed to extract start box from recognition detail")
 		return false
@@ -125,7 +125,7 @@ func (a *QuantizedSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa
 		return false
 	}
 
-	maxQuantity, err := parseOCRText(arg.RecognitionDetail)
+	maxQuantity, err := readQuantityValue(arg.RecognitionDetail)
 	if err != nil {
 		a.logger.Error().Err(err).Msg("failed to parse max quantity from ocr")
 		return false
@@ -198,7 +198,7 @@ func (a *QuantizedSlidingAction) handleFindEnd(ctx *maa.Context, arg *maa.Custom
 		return false
 	}
 
-	endBox, ok := extractHitBox(arg.RecognitionDetail)
+	endBox, ok := readHitBox(arg.RecognitionDetail)
 	if !ok {
 		a.logger.Error().Msg("failed to extract end box from recognition detail")
 		return false
@@ -234,7 +234,7 @@ func (a *QuantizedSlidingAction) handleFindEnd(ctx *maa.Context, arg *maa.Custom
 	clickY := startY + (endY-startY)*numerator/denominator
 
 	if err := ctx.OverridePipeline(map[string]any{
-		"QuantizedSlidingPreciseClick": map[string]any{
+		nodeQuantizedSlidingPreciseClick: map[string]any{
 			"action": map[string]any{
 				"param": map[string]any{
 					"target": []int{clickX, clickY},
@@ -268,7 +268,7 @@ func (a *QuantizedSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.
 		return false
 	}
 
-	currentQuantity, err := parseOCRText(arg.RecognitionDetail)
+	currentQuantity, err := readQuantityValue(arg.RecognitionDetail)
 	if err != nil {
 		a.logger.Error().Err(err).Msg("failed to parse current quantity from ocr")
 		return false
@@ -276,7 +276,7 @@ func (a *QuantizedSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.
 
 	switch {
 	case currentQuantity == a.Target:
-		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, "QuantizedSlidingDone", buttonTarget{}, 0); err != nil {
+		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeQuantizedSlidingDone, buttonTarget{}, 0); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
 				Int("current_quantity", currentQuantity).
@@ -292,13 +292,13 @@ func (a *QuantizedSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.
 		a.logger.Info().
 			Int("current_quantity", currentQuantity).
 			Int("target", a.Target).
-			Str("next", "QuantizedSlidingDone").
+			Str("next", nodeQuantizedSlidingDone).
 			Msg("quantity matched target")
 		return true
 	case currentQuantity < a.Target:
 		diff := a.Target - currentQuantity
 		repeat := clampClickRepeat(diff)
-		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, "QuantizedSlidingIncreaseQuantity", a.IncreaseButton, repeat); err != nil {
+		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeQuantizedSlidingIncreaseQuantity, a.IncreaseButton, repeat); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
 				Int("current_quantity", currentQuantity).
@@ -320,13 +320,13 @@ func (a *QuantizedSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.
 			Int("diff", diff).
 			Int("repeat", repeat).
 			Interface("button", a.IncreaseButton.logValue()).
-			Str("next", "QuantizedSlidingIncreaseQuantity").
+			Str("next", nodeQuantizedSlidingIncreaseQuantity).
 			Msg("quantity below target, branch to increase")
 		return true
 	default:
 		diff := currentQuantity - a.Target
 		repeat := clampClickRepeat(diff)
-		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, "QuantizedSlidingDecreaseQuantity", a.DecreaseButton, repeat); err != nil {
+		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeQuantizedSlidingDecreaseQuantity, a.DecreaseButton, repeat); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
 				Int("current_quantity", currentQuantity).
@@ -348,7 +348,7 @@ func (a *QuantizedSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.
 			Int("diff", diff).
 			Int("repeat", repeat).
 			Interface("button", a.DecreaseButton.logValue()).
-			Str("next", "QuantizedSlidingDecreaseQuantity").
+			Str("next", nodeQuantizedSlidingDecreaseQuantity).
 			Msg("quantity above target, branch to decrease")
 		return true
 	}
@@ -376,7 +376,7 @@ func (a *QuantizedSlidingAction) runInternalPipeline(ctx *maa.Context, arg *maa.
 		return false
 	}
 
-	detail, err := ctx.RunTask("QuantizedSlidingMain", override)
+	detail, err := ctx.RunTask(nodeQuantizedSlidingMain, override)
 	if err != nil {
 		a.logger.Error().
 			Err(err).
@@ -428,7 +428,7 @@ func resolveMaxQuantityNext(maxQuantity int, target int) (string, error) {
 		return "", fmt.Errorf("max quantity %d lower than target %d", maxQuantity, target)
 	}
 	if maxQuantity == 1 && target == 1 {
-		return "QuantizedSlidingDone", nil
+		return nodeQuantizedSlidingDone, nil
 	}
 
 	return "", nil

--- a/agent/go-service/quantizedsliding/nodes.go
+++ b/agent/go-service/quantizedsliding/nodes.go
@@ -1,0 +1,32 @@
+package quantizedsliding
+
+const (
+	quantizedSlidingActionName = "QuantizedSliding"
+
+	nodeQuantizedSlidingMain           = "QuantizedSlidingMain"
+	nodeQuantizedSlidingFindStart      = "QuantizedSlidingFindStart"
+	nodeQuantizedSlidingGetMaxQuantity = "QuantizedSlidingGetMaxQuantity"
+	nodeQuantizedSlidingFindEnd        = "QuantizedSlidingFindEnd"
+	nodeQuantizedSlidingCheckQuantity  = "QuantizedSlidingCheckQuantity"
+	nodeQuantizedSlidingDone           = "QuantizedSlidingDone"
+
+	nodeQuantizedSlidingSwipeToMax       = "QuantizedSlidingSwipeToMax"
+	nodeQuantizedSlidingGetQuantity      = "QuantizedSlidingGetQuantity"
+	nodeQuantizedSlidingQuantityFilter   = "QuantizedSlidingQuantityFilter"
+	nodeQuantizedSlidingSwipeButton      = "QuantizedSlidingSwipeButton"
+	nodeQuantizedSlidingPreciseClick     = "QuantizedSlidingPreciseClick"
+	nodeQuantizedSlidingClearMaxHit      = "QuantizedSlidingClearMaxHit"
+	nodeQuantizedSlidingJumpBackNode     = "QuantizedSlidingJumpBackNode"
+	nodeQuantizedSlidingFail             = "QuantizedSlidingFail"
+	nodeQuantizedSlidingIncreaseQuantity = "QuantizedSlidingIncreaseQuantity"
+	nodeQuantizedSlidingDecreaseQuantity = "QuantizedSlidingDecreaseQuantity"
+)
+
+var quantizedSlidingActionNodes = []string{
+	nodeQuantizedSlidingMain,
+	nodeQuantizedSlidingFindStart,
+	nodeQuantizedSlidingGetMaxQuantity,
+	nodeQuantizedSlidingFindEnd,
+	nodeQuantizedSlidingCheckQuantity,
+	nodeQuantizedSlidingDone,
+}

--- a/agent/go-service/quantizedsliding/ocr.go
+++ b/agent/go-service/quantizedsliding/ocr.go
@@ -32,10 +32,6 @@ func readHitBox(detail *maa.RecognitionDetail) ([]int, bool) {
 		return []int{detail.Box[0], detail.Box[1], detail.Box[2], detail.Box[3]}, true
 	}
 
-	if len(detail.Box) >= 4 {
-		return []int{detail.Box[0], detail.Box[1], detail.Box[2], detail.Box[3]}, true
-	}
-
 	return nil, false
 }
 

--- a/agent/go-service/quantizedsliding/ocr.go
+++ b/agent/go-service/quantizedsliding/ocr.go
@@ -3,6 +3,7 @@ package quantizedsliding
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -161,13 +162,13 @@ func joinFilteredOCRText(results *maa.RecognitionResults) string {
 		return ""
 	}
 
-	for i := 0; i < len(fragments)-1; i++ {
-		for j := i + 1; j < len(fragments); j++ {
-			if fragments[j].y < fragments[i].y || (fragments[j].y == fragments[i].y && fragments[j].x < fragments[i].x) {
-				fragments[i], fragments[j] = fragments[j], fragments[i]
-			}
+	sort.SliceStable(fragments, func(i int, j int) bool {
+		if fragments[i].y != fragments[j].y {
+			return fragments[i].y < fragments[j].y
 		}
-	}
+
+		return fragments[i].x < fragments[j].x
+	})
 
 	var builder strings.Builder
 	for _, fragment := range fragments {

--- a/agent/go-service/quantizedsliding/ocr.go
+++ b/agent/go-service/quantizedsliding/ocr.go
@@ -3,63 +3,60 @@ package quantizedsliding
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 )
 
-func extractHitBox(recognitionDetail *maa.RecognitionDetail) ([]int, bool) {
-	if recognitionDetail == nil {
+func readHitBox(detail *maa.RecognitionDetail) ([]int, bool) {
+	if detail == nil {
 		return nil, false
 	}
 
-	if len(recognitionDetail.Box) >= 4 {
-		return []int{recognitionDetail.Box[0], recognitionDetail.Box[1], recognitionDetail.Box[2], recognitionDetail.Box[3]}, true
+	candidate := findRecognitionDetailByName(detail, nodeQuantizedSlidingSwipeButton)
+	if candidate == nil {
+		candidate = detail
 	}
 
-	if recognitionDetail.Results == nil {
-		return nil, false
+	if box, ok := readTemplateMatchBestBox(candidate); ok {
+		return box, true
 	}
 
-	if recognitionDetail.Results.Best != nil {
-		if tm, ok := recognitionDetail.Results.Best.AsTemplateMatch(); ok {
-			return []int{tm.Box.X(), tm.Box.Y(), tm.Box.Width(), tm.Box.Height()}, true
-		}
-		if ocr, ok := recognitionDetail.Results.Best.AsOCR(); ok {
-			return []int{ocr.Box.X(), ocr.Box.Y(), ocr.Box.Width(), ocr.Box.Height()}, true
-		}
-	}
-
-	for _, result := range recognitionDetail.Results.Filtered {
-		if tm, ok := result.AsTemplateMatch(); ok {
-			return []int{tm.Box.X(), tm.Box.Y(), tm.Box.Width(), tm.Box.Height()}, true
-		}
-		if ocr, ok := result.AsOCR(); ok {
-			return []int{ocr.Box.X(), ocr.Box.Y(), ocr.Box.Width(), ocr.Box.Height()}, true
-		}
-	}
-
-	for _, result := range recognitionDetail.Results.All {
-		if tm, ok := result.AsTemplateMatch(); ok {
-			return []int{tm.Box.X(), tm.Box.Y(), tm.Box.Width(), tm.Box.Height()}, true
-		}
-		if ocr, ok := result.AsOCR(); ok {
-			return []int{ocr.Box.X(), ocr.Box.Y(), ocr.Box.Width(), ocr.Box.Height()}, true
-		}
+	if len(detail.Box) >= 4 {
+		return []int{detail.Box[0], detail.Box[1], detail.Box[2], detail.Box[3]}, true
 	}
 
 	return nil, false
 }
 
-func parseOCRText(recognitionDetail *maa.RecognitionDetail) (int, error) {
-	if recognitionDetail == nil {
-		return 0, fmt.Errorf("recognition detail is nil")
+func readQuantityText(detail *maa.RecognitionDetail) string {
+	if detail == nil {
+		return ""
 	}
 
-	text := extractOCRText(recognitionDetail)
+	candidate := findRecognitionDetailByName(detail, nodeQuantizedSlidingGetQuantity)
+	if candidate == nil {
+		candidate = detail
+	}
 
+	if text := joinFilteredOCRText(candidate.Results); text != "" {
+		return text
+	}
+
+	if text := extractOCRTextFromDetailJSON(candidate.DetailJson); text != "" {
+		return text
+	}
+
+	if candidate != detail {
+		return extractOCRTextFromDetailJSON(detail.DetailJson)
+	}
+
+	return ""
+}
+
+func readQuantityValue(detail *maa.RecognitionDetail) (int, error) {
+	text := readQuantityText(detail)
 	if text == "" {
 		return 0, fmt.Errorf("ocr text not found in recognition detail")
 	}
@@ -70,6 +67,7 @@ func parseOCRText(recognitionDetail *maa.RecognitionDetail) (int, error) {
 			digits.WriteRune(r)
 		}
 	}
+
 	if digits.Len() == 0 {
 		return 0, fmt.Errorf("ocr text has no digit: %s", text)
 	}
@@ -82,36 +80,88 @@ func parseOCRText(recognitionDetail *maa.RecognitionDetail) (int, error) {
 	return value, nil
 }
 
-func extractOCRText(detail *maa.RecognitionDetail) string {
+func findRecognitionDetailByName(detail *maa.RecognitionDetail, targetName string) *maa.RecognitionDetail {
 	if detail == nil {
-		return ""
+		return nil
 	}
-
-	if text := extractOCRTextFromResults(detail.Results); text != "" {
-		return text
+	if detail.Name == targetName {
+		return detail
 	}
 
 	for _, child := range detail.CombinedResult {
-		if text := extractOCRText(child); text != "" {
-			return text
+		if found := findRecognitionDetailByName(child, targetName); found != nil {
+			return found
 		}
 	}
 
-	return extractOCRTextFromDetailJSON(detail.DetailJson)
+	return nil
 }
 
-func extractOCRTextFromResults(results *maa.RecognitionResults) string {
-	if results == nil {
+func readTemplateMatchBestBox(detail *maa.RecognitionDetail) ([]int, bool) {
+	if detail == nil || detail.Results == nil || detail.Results.Best == nil {
+		return nil, false
+	}
+
+	tm, ok := detail.Results.Best.AsTemplateMatch()
+	if !ok {
+		return nil, false
+	}
+
+	return []int{tm.Box.X(), tm.Box.Y(), tm.Box.Width(), tm.Box.Height()}, true
+}
+
+func joinFilteredOCRText(results *maa.RecognitionResults) string {
+	if results == nil || len(results.Filtered) == 0 {
 		return ""
 	}
 
-	candidates := []ocrCandidate{
-		buildOCRCandidate([]*maa.RecognitionResult{results.Best}, 0),
-		buildOCRCandidate(results.Filtered, 1),
-		buildOCRCandidate(results.All, 2),
+	fragments := make([]ocrFragment, 0, len(results.Filtered))
+	for _, result := range results.Filtered {
+		if result == nil {
+			continue
+		}
+
+		ocrResult, ok := result.AsOCR()
+		if !ok {
+			continue
+		}
+
+		text := strings.TrimSpace(ocrResult.Text)
+		if text == "" {
+			continue
+		}
+
+		fragments = append(fragments, ocrFragment{
+			text: text,
+			x:    ocrResult.Box.X(),
+			y:    ocrResult.Box.Y(),
+		})
 	}
 
-	return selectOCRCandidate(candidates).text
+	if len(fragments) == 0 {
+		return ""
+	}
+
+	for i := 0; i < len(fragments)-1; i++ {
+		for j := i + 1; j < len(fragments); j++ {
+			if fragments[j].y < fragments[i].y || (fragments[j].y == fragments[i].y && fragments[j].x < fragments[i].x) {
+				fragments[i], fragments[j] = fragments[j], fragments[i]
+			}
+		}
+	}
+
+	var builder strings.Builder
+	for _, fragment := range fragments {
+		builder.WriteString(fragment.text)
+	}
+
+	return builder.String()
+}
+
+type ocrFragment struct {
+	text string
+	x    int
+	y    int
 }
 
 func extractOCRTextFromDetailJSON(detailJSON string) string {
@@ -160,21 +210,6 @@ func extractOCRTextFromDetailJSON(detailJSON string) string {
 		}
 	}
 
-	var combinedArray []struct {
-		Detail json.RawMessage `json:"detail"`
-		Text   string          `json:"text"`
-	}
-	if err := json.Unmarshal([]byte(detailJSON), &combinedArray); err == nil {
-		for _, item := range combinedArray {
-			if text := strings.TrimSpace(item.Text); text != "" {
-				return text
-			}
-			if text := extractOCRTextFromRawJSON(item.Detail); text != "" {
-				return text
-			}
-		}
-	}
-
 	return ""
 }
 
@@ -189,146 +224,4 @@ func extractOCRTextFromRawJSON(raw json.RawMessage) string {
 	}
 
 	return extractOCRTextFromDetailJSON(string(raw))
-}
-
-type ocrFragment struct {
-	text string
-	x    int
-	y    int
-	w    int
-	h    int
-}
-
-type ocrCandidate struct {
-	text          string
-	digitCount    int
-	fragmentCount int
-	priority      int
-}
-
-func buildOCRCandidate(results []*maa.RecognitionResult, priority int) ocrCandidate {
-	return buildOCRCandidateFromFragments(collectOCRFragments(results), priority)
-}
-
-func buildOCRCandidateFromFragments(fragments []ocrFragment, priority int) ocrCandidate {
-	uniqueFragments := uniqueOCRFragments(fragments)
-	text := joinOCRFragments(uniqueFragments)
-
-	return ocrCandidate{
-		text:          text,
-		digitCount:    countDigits(text),
-		fragmentCount: len(uniqueFragments),
-		priority:      priority,
-	}
-}
-
-func collectOCRFragments(results []*maa.RecognitionResult) []ocrFragment {
-	fragments := make([]ocrFragment, 0, len(results))
-	for _, result := range results {
-		if result == nil {
-			continue
-		}
-
-		ocrResult, ok := result.AsOCR()
-		if !ok {
-			continue
-		}
-
-		text := strings.TrimSpace(ocrResult.Text)
-		if text == "" {
-			continue
-		}
-
-		fragments = append(fragments, ocrFragment{
-			text: text,
-			x:    ocrResult.Box.X(),
-			y:    ocrResult.Box.Y(),
-			w:    ocrResult.Box.Width(),
-			h:    ocrResult.Box.Height(),
-		})
-	}
-
-	return fragments
-}
-
-func selectOCRCandidate(candidates []ocrCandidate) ocrCandidate {
-	best := ocrCandidate{}
-	found := false
-	for _, candidate := range candidates {
-		if candidate.text == "" {
-			continue
-		}
-		if !found || betterOCRCandidate(candidate, best) {
-			best = candidate
-			found = true
-		}
-	}
-
-	return best
-}
-
-func betterOCRCandidate(candidate ocrCandidate, current ocrCandidate) bool {
-	if candidate.digitCount != current.digitCount {
-		return candidate.digitCount > current.digitCount
-	}
-	if candidate.fragmentCount != current.fragmentCount {
-		return candidate.fragmentCount < current.fragmentCount
-	}
-
-	return candidate.priority < current.priority
-}
-
-func countDigits(text string) int {
-	count := 0
-	for _, r := range text {
-		if r >= '0' && r <= '9' {
-			count++
-		}
-	}
-
-	return count
-}
-
-func uniqueOCRFragments(fragments []ocrFragment) []ocrFragment {
-	if len(fragments) == 0 {
-		return nil
-	}
-
-	unique := make([]ocrFragment, 0, len(fragments))
-	seen := make(map[string]struct{}, len(fragments))
-	for _, fragment := range fragments {
-		fragment.text = strings.TrimSpace(fragment.text)
-		if fragment.text == "" {
-			continue
-		}
-
-		key := fmt.Sprintf("%d:%d:%d:%d:%s", fragment.x, fragment.y, fragment.w, fragment.h, fragment.text)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		unique = append(unique, fragment)
-	}
-
-	sort.SliceStable(unique, func(i, j int) bool {
-		if unique[i].y != unique[j].y {
-			return unique[i].y < unique[j].y
-		}
-		return unique[i].x < unique[j].x
-	})
-
-	return unique
-}
-
-func joinOCRFragments(fragments []ocrFragment) string {
-	if len(fragments) == 0 {
-		return ""
-	}
-
-	var builder strings.Builder
-	for _, fragment := range fragments {
-		builder.WriteString(fragment.text)
-	}
-
-	return builder.String()
 }

--- a/agent/go-service/quantizedsliding/ocr.go
+++ b/agent/go-service/quantizedsliding/ocr.go
@@ -30,7 +30,7 @@ func readHitBox(detail *maa.RecognitionDetail) ([]int, bool) {
 	return nil, false
 }
 
-func readQuantityText(detail *maa.RecognitionDetail) string {
+func readQuantityText(detail *maa.RecognitionDetail, concatAllFilteredDigits bool) string {
 	if detail == nil {
 		return ""
 	}
@@ -40,8 +40,14 @@ func readQuantityText(detail *maa.RecognitionDetail) string {
 		candidate = detail
 	}
 
-	if text := joinFilteredOCRText(candidate.Results); text != "" {
-		return text
+	if concatAllFilteredDigits {
+		if text := joinFilteredOCRText(candidate.Results); text != "" {
+			return text
+		}
+	} else {
+		if text := readBestOCRText(candidate.Results); text != "" {
+			return text
+		}
 	}
 
 	if text := extractOCRTextFromDetailJSON(candidate.DetailJson); text != "" {
@@ -55,8 +61,8 @@ func readQuantityText(detail *maa.RecognitionDetail) string {
 	return ""
 }
 
-func readQuantityValue(detail *maa.RecognitionDetail) (int, error) {
-	text := readQuantityText(detail)
+func readQuantityValue(detail *maa.RecognitionDetail, concatAllFilteredDigits bool) (int, error) {
+	text := readQuantityText(detail, concatAllFilteredDigits)
 	if text == "" {
 		return 0, fmt.Errorf("ocr text not found in recognition detail")
 	}
@@ -78,6 +84,19 @@ func readQuantityValue(detail *maa.RecognitionDetail) (int, error) {
 	}
 
 	return value, nil
+}
+
+func readBestOCRText(results *maa.RecognitionResults) string {
+	if results == nil || results.Best == nil {
+		return ""
+	}
+
+	ocrResult, ok := results.Best.AsOCR()
+	if !ok {
+		return ""
+	}
+
+	return strings.TrimSpace(ocrResult.Text)
 }
 
 func findRecognitionDetailByName(detail *maa.RecognitionDetail, targetName string) *maa.RecognitionDetail {

--- a/agent/go-service/quantizedsliding/ocr.go
+++ b/agent/go-service/quantizedsliding/ocr.go
@@ -24,6 +24,14 @@ func readHitBox(detail *maa.RecognitionDetail) ([]int, bool) {
 		return box, true
 	}
 
+	if len(candidate.Box) >= 4 {
+		return []int{candidate.Box[0], candidate.Box[1], candidate.Box[2], candidate.Box[3]}, true
+	}
+
+	if candidate != detail && len(detail.Box) >= 4 {
+		return []int{detail.Box[0], detail.Box[1], detail.Box[2], detail.Box[3]}, true
+	}
+
 	if len(detail.Box) >= 4 {
 		return []int{detail.Box[0], detail.Box[1], detail.Box[2], detail.Box[3]}, true
 	}

--- a/agent/go-service/quantizedsliding/overrides.go
+++ b/agent/go-service/quantizedsliding/overrides.go
@@ -30,14 +30,14 @@ func buildMainInitializationOverride(end []int, quantityBox []int, quantityFilte
 	}
 
 	override := map[string]any{
-		"QuantizedSlidingSwipeToMax": map[string]any{
+		nodeQuantizedSlidingSwipeToMax: map[string]any{
 			"action": map[string]any{
 				"param": map[string]any{
 					"end": append([]int(nil), end...),
 				},
 			},
 		},
-		"QuantizedSlidingGetQuantity": map[string]any{
+		nodeQuantizedSlidingGetQuantity: map[string]any{
 			"recognition": map[string]any{
 				"param": map[string]any{
 					"roi": quantityParam["roi"],
@@ -50,13 +50,13 @@ func buildMainInitializationOverride(end []int, quantityBox []int, quantityFilte
 		return override
 	}
 
-	quantityParam["color_filter"] = "QuantizedSlidingQuantityFilter"
-	override["QuantizedSlidingGetQuantity"] = map[string]any{
+	quantityParam["color_filter"] = nodeQuantizedSlidingQuantityFilter
+	override[nodeQuantizedSlidingGetQuantity] = map[string]any{
 		"recognition": map[string]any{
 			"param": quantityParam,
 		},
 	}
-	override["QuantizedSlidingQuantityFilter"] = map[string]any{
+	override[nodeQuantizedSlidingQuantityFilter] = map[string]any{
 		"recognition": map[string]any{
 			"param": map[string]any{
 				"method": quantityFilter.Method,
@@ -71,18 +71,18 @@ func buildMainInitializationOverride(end []int, quantityBox []int, quantityFilte
 
 func buildCheckQuantityBranchOverride(nextNode string, target buttonTarget, repeat int) map[string]any {
 	override := map[string]any{
-		"QuantizedSlidingDone": map[string]any{
-			"enabled": nextNode == "QuantizedSlidingDone",
+		nodeQuantizedSlidingDone: map[string]any{
+			"enabled": nextNode == nodeQuantizedSlidingDone,
 		},
-		"QuantizedSlidingIncreaseQuantity": map[string]any{
-			"enabled": nextNode == "QuantizedSlidingIncreaseQuantity",
+		nodeQuantizedSlidingIncreaseQuantity: map[string]any{
+			"enabled": nextNode == nodeQuantizedSlidingIncreaseQuantity,
 		},
-		"QuantizedSlidingDecreaseQuantity": map[string]any{
-			"enabled": nextNode == "QuantizedSlidingDecreaseQuantity",
+		nodeQuantizedSlidingDecreaseQuantity: map[string]any{
+			"enabled": nextNode == nodeQuantizedSlidingDecreaseQuantity,
 		},
 	}
 
-	if nextNode != "QuantizedSlidingIncreaseQuantity" && nextNode != "QuantizedSlidingDecreaseQuantity" {
+	if nextNode != nodeQuantizedSlidingIncreaseQuantity && nextNode != nodeQuantizedSlidingDecreaseQuantity {
 		return override
 	}
 

--- a/agent/go-service/quantizedsliding/params.go
+++ b/agent/go-service/quantizedsliding/params.go
@@ -133,7 +133,7 @@ func (a *QuantizedSlidingAction) logParsedActionParams() {
 
 func (a *QuantizedSlidingAction) initLogger(taskName string) {
 	a.logger = log.With().
-		Str("component", "QuantizedSliding").
+		Str("component", quantizedSlidingActionName).
 		Str("task", taskName).
 		Logger()
 }

--- a/agent/go-service/quantizedsliding/params.go
+++ b/agent/go-service/quantizedsliding/params.go
@@ -8,14 +8,15 @@ import (
 )
 
 type parsedQuantizedSlidingParams struct {
-	target            int
-	quantityBox       []int
-	quantityFilter    *quantityFilterParam
-	direction         string
-	increaseButton    buttonTarget
-	decreaseButton    buttonTarget
-	centerPointOffset [2]int
-	clampTargetToMax  bool
+	target                  int
+	quantityBox             []int
+	quantityFilter          *quantityFilterParam
+	concatAllFilteredDigits bool
+	direction               string
+	increaseButton          buttonTarget
+	decreaseButton          buttonTarget
+	centerPointOffset       [2]int
+	clampTargetToMax        bool
 }
 
 func parseQuantizedSlidingParam(customActionParam string) (quantizedSlidingParam, error) {
@@ -88,14 +89,15 @@ func (a *QuantizedSlidingAction) normalizeActionParams(params quantizedSlidingPa
 	}
 
 	return parsedQuantizedSlidingParams{
-		target:            params.Target,
-		quantityBox:       append([]int(nil), params.QuantityBox...),
-		quantityFilter:    quantityFilter,
-		direction:         strings.ToLower(strings.TrimSpace(params.Direction)),
-		increaseButton:    increaseButton,
-		decreaseButton:    decreaseButton,
-		centerPointOffset: centerPointOffset,
-		clampTargetToMax:  params.ClampTargetToMax,
+		target:                  params.Target,
+		quantityBox:             append([]int(nil), params.QuantityBox...),
+		quantityFilter:          quantityFilter,
+		concatAllFilteredDigits: params.ConcatAllFilteredDigits,
+		direction:               strings.ToLower(strings.TrimSpace(params.Direction)),
+		increaseButton:          increaseButton,
+		decreaseButton:          decreaseButton,
+		centerPointOffset:       centerPointOffset,
+		clampTargetToMax:        params.ClampTargetToMax,
 	}, true
 }
 
@@ -103,6 +105,7 @@ func (a *QuantizedSlidingAction) applyActionParams(params parsedQuantizedSliding
 	a.Target = params.target
 	a.QuantityBox = params.quantityBox
 	a.QuantityFilter = params.quantityFilter
+	a.ConcatAllFilteredDigits = params.concatAllFilteredDigits
 	a.Direction = params.direction
 	a.IncreaseButton = params.increaseButton
 	a.DecreaseButton = params.decreaseButton
@@ -118,6 +121,7 @@ func (a *QuantizedSlidingAction) logParsedActionParams() {
 		Interface("increase_button", a.IncreaseButton.logValue()).
 		Interface("decrease_button", a.DecreaseButton.logValue()).
 		Bool("quantity_filter_enabled", a.QuantityFilter != nil).
+		Bool("concat_all_filtered_digits", a.ConcatAllFilteredDigits).
 		Ints("center_point_offset", []int{a.CenterPointOffset[0], a.CenterPointOffset[1]}).
 		Bool("clamp_target_to_max", a.ClampTargetToMax)
 

--- a/agent/go-service/quantizedsliding/register.go
+++ b/agent/go-service/quantizedsliding/register.go
@@ -4,5 +4,5 @@ import maa "github.com/MaaXYZ/maa-framework-go/v4"
 
 // Register registers the quantized sliding custom action.
 func Register() {
-	maa.AgentServerRegisterCustomAction("QuantizedSliding", &QuantizedSlidingAction{})
+	maa.AgentServerRegisterCustomAction(quantizedSlidingActionName, &QuantizedSlidingAction{})
 }

--- a/agent/go-service/quantizedsliding/types.go
+++ b/agent/go-service/quantizedsliding/types.go
@@ -65,15 +65,6 @@ func (b buttonTarget) logValue() any {
 	return append([]int(nil), b.coordinates...)
 }
 
-var quantizedSlidingActionNodes = []string{
-	"QuantizedSlidingMain",
-	"QuantizedSlidingFindStart",
-	"QuantizedSlidingGetMaxQuantity",
-	"QuantizedSlidingFindEnd",
-	"QuantizedSlidingCheckQuantity",
-	"QuantizedSlidingDone",
-}
-
 const maxClickRepeat = 30
 
 var defaultCenterPointOffset = [2]int{-10, 0}

--- a/agent/go-service/quantizedsliding/types.go
+++ b/agent/go-service/quantizedsliding/types.go
@@ -32,6 +32,7 @@ type quantityFilterParam struct {
 //   - Target: 目标数量
 //   - QuantityBox: OCR 识别数量的 ROI 区域 [x,y,w,h]
 //   - QuantityFilter: 可选的数量 OCR 颜色过滤参数
+//   - ConcatAllFilteredDigits: 数量解析策略开关。false（默认）只读 Best OCR；true 时按 y 再 x 顺序拼接 Filtered OCR 片段后再解析
 //   - Direction: 滑动方向 (left/right/up/down)
 //   - IncreaseButton: 增加数量按钮的模板路径或坐标
 //   - DecreaseButton: 减少数量按钮的模板路径或坐标

--- a/agent/go-service/quantizedsliding/types.go
+++ b/agent/go-service/quantizedsliding/types.go
@@ -6,14 +6,15 @@ import (
 )
 
 type quantizedSlidingParam struct {
-	Target            int                  `json:"Target"`
-	QuantityBox       []int                `json:"QuantityBox"`
-	QuantityFilter    *quantityFilterParam `json:"QuantityFilter"`
-	Direction         string               `json:"Direction"`
-	IncreaseButton    any                  `json:"IncreaseButton"`
-	DecreaseButton    any                  `json:"DecreaseButton"`
-	CenterPointOffset any                  `json:"CenterPointOffset"`
-	ClampTargetToMax  bool                 `json:"ClampTargetToMax"`
+	Target                  int                  `json:"Target"`
+	QuantityBox             []int                `json:"QuantityBox"`
+	QuantityFilter          *quantityFilterParam `json:"QuantityFilter"`
+	ConcatAllFilteredDigits bool                 `json:"ConcatAllFilteredDigits"`
+	Direction               string               `json:"Direction"`
+	IncreaseButton          any                  `json:"IncreaseButton"`
+	DecreaseButton          any                  `json:"DecreaseButton"`
+	CenterPointOffset       any                  `json:"CenterPointOffset"`
+	ClampTargetToMax        bool                 `json:"ClampTargetToMax"`
 }
 
 // quantityFilterParam 定义数量 OCR 预处理使用的单组颜色阈值。
@@ -37,14 +38,15 @@ type quantityFilterParam struct {
 //   - CenterPointOffset: 滑动条中心点坐标偏移量
 //   - ClampTargetToMax: 为 true 时，若 Target 超过 maxQuantity，自动将 Target 钳制为 maxQuantity 并继续（默认 false 时直接失败）
 type QuantizedSlidingAction struct {
-	Target            int
-	QuantityBox       []int
-	QuantityFilter    *quantityFilterParam
-	Direction         string
-	IncreaseButton    buttonTarget
-	DecreaseButton    buttonTarget
-	CenterPointOffset [2]int
-	ClampTargetToMax  bool
+	Target                  int
+	QuantityBox             []int
+	QuantityFilter          *quantityFilterParam
+	ConcatAllFilteredDigits bool
+	Direction               string
+	IncreaseButton          buttonTarget
+	DecreaseButton          buttonTarget
+	CenterPointOffset       [2]int
+	ClampTargetToMax        bool
 
 	startBox    []int
 	endBox      []int

--- a/assets/resource/pipeline/AutoStockpile/Task.json
+++ b/assets/resource/pipeline/AutoStockpile/Task.json
@@ -410,6 +410,7 @@
                         140
                     ],
                     "Target": 1,
+                    "ConcatAllFilteredDigits": true,
                     "QuantityFilter": {
                         "lower": [
                             20,

--- a/assets/resource/pipeline/QuantizedSliding/Main.json
+++ b/assets/resource/pipeline/QuantizedSliding/Main.json
@@ -181,16 +181,14 @@
             "type": "Swipe",
             "param": {
                 "begin": "QuantizedSlidingFindStart",
+                "begin_offset": [
+                    5,
+                    5,
+                    -5,
+                    -5
+                ],
                 "end": [
                     "QuantizedSlidingFindStart"
-                ],
-                "end_offset": [
-                    [
-                        0,
-                        0,
-                        0,
-                        0
-                    ]
                 ]
             }
         },

--- a/docs/en_us/developers/quantized-sliding.md
+++ b/docs/en_us/developers/quantized-sliding.md
@@ -1,7 +1,6 @@
 # Development Guide - QuantizedSliding Reference Document
 
-`QuantizedSliding` is a go-service custom action implementation invoked through the `Custom` action type.
-It is used for interfaces where you drag a slider to choose a quantity, but the target value is a discrete level rather than a continuous value.
+`QuantizedSliding` is a go-service custom action invoked through the `Custom` action type. It handles interfaces where you drag a slider to choose a quantity, but the target value is a discrete level rather than a continuous value.
 
 It is suitable for scenarios like these:
 
@@ -14,7 +13,7 @@ The current implementation is located at:
 - Go action package: `agent/go-service/quantizedsliding/`
 - Package-local registration: `agent/go-service/quantizedsliding/register.go`
 - go-service global registration entry: `agent/go-service/register.go`
-- Shared Pipeline: `assets/resource/pipeline/QuantizedSliding/Main.json`
+- Shared Pipeline: `assets/resource/pipeline/QuantizedSliding/Main.json` and `Helper.json`
 - Existing integration example: `assets/resource/pipeline/AutoStockpile/Task.json`
 
 `agent/go-service/quantizedsliding/` is now split by responsibility:
@@ -22,6 +21,7 @@ The current implementation is located at:
 | File           | Responsibility                                                         |
 | -------------- | ---------------------------------------------------------------------- |
 | `types.go`     | Parameter structs, action type, runtime state, and package-level types |
+| `params.go`    | Parameter parsing and normalization                                    |
 | `nodes.go`     | Shared action name, internal node names, and override key constants    |
 | `handlers.go`  | `Run()` dispatch, per-stage handlers, and state reset                  |
 | `overrides.go` | Pipeline override construction                                         |
@@ -36,11 +36,11 @@ The current implementation is located at:
 1. **External invocation mode**: when a business task calls it with `custom_action: "QuantizedSliding"`, the Go side automatically constructs the internal Pipeline override and starts running the full internal flow from `QuantizedSlidingMain` through its downstream nodes.
 2. **Internal node mode**: when the current node itself is one of `QuantizedSlidingMain`, `QuantizedSlidingFindStart`, `QuantizedSlidingGetMaxQuantity`, `QuantizedSlidingFindEnd`, `QuantizedSlidingCheckQuantity`, or `QuantizedSlidingDone`, the Go side directly handles that specific stage.
 
-In other words, the business-side caller usually only needs to pass `custom_action_param` once and does **not** need to manually chain the internal nodes.
+The business-side caller usually only needs to pass `custom_action_param` once and does **not** need to manually chain the internal nodes.
 
 ## How it works
 
-`QuantizedSliding` does not simply “swipe to a fixed percentage.” Instead, it uses a **detect, calculate, then fine-tune** flow.
+`QuantizedSliding` does not simply "swipe to a fixed percentage." Instead, it uses a **detect, calculate, then fine-tune** flow.
 
 The overall steps are:
 
@@ -64,13 +64,9 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 The computed `[clickX, clickY]` is then dynamically written into `QuantizedSlidingPreciseClick.action.param.target`.
 
-The internal nodes are executed by `QuantizedSliding` itself through `QuantizedSlidingMain` and its downstream nodes. The caller does **not** need to manually chain those internal nodes.
-
 ## How to call it
 
 In a business Pipeline, call it like a normal `Custom` action. The example below uses MaaFramework Pipeline protocol v2 syntax.
-
-Pass `custom_action_param` as a JSON object directly.
 
 ```json
 "SomeTaskAdjustQuantity": {
@@ -94,19 +90,19 @@ Pass `custom_action_param` as a JSON object directly.
 
 ## Parameter description
 
-`custom_action_param` should be passed as a JSON object directly. The commonly used fields are:
+Commonly used fields are:
 
-| Field                     | Type                    | Required | Description                                                                                                                                                                             |
-| ------------------------- | ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Target`                  | `int`                   | Yes      | The target quantity. The final discrete value you want to reach.                                                                                                                        |
-| `QuantityBox`             | `int[4]`                | Yes      | OCR region for the current quantity. The format must be `[x, y, w, h]`.                                                                                                                 |
-| `QuantityFilter`          | `object`                | No       | Optional color filtering for quantity OCR, useful when digit color is stable but the background is noisy.                                                                               |
-| `ConcatAllFilteredDigits` | `bool`                  | No       | Quantity parsing strategy switch. `false` (default): read only `Results.Best` OCR text. `true`: read all `Results.Filtered` OCR fragments, sort by y then x, concatenate, then parse.   |
-| `Direction`               | `string`                | Yes      | Drag direction. Supports `left` / `right` / `up` / `down`.                                                                                                                              |
-| `IncreaseButton`          | `string` or `int[2\|4]` | Yes      | The “increase quantity” button. Can be a template path or coordinates.                                                                                                                  |
-| `DecreaseButton`          | `string` or `int[2\|4]` | Yes      | The “decrease quantity” button. Can be a template path or coordinates.                                                                                                                  |
-| `CenterPointOffset`       | `int[2]`                | No       | Click offset relative to the slider handle center, default `[-10, 0]`.                                                                                                                  |
-| `ClampTargetToMax`        | `bool`                  | No       | If `true`, when `Target` exceeds the recognized `maxQuantity`, the target is clamped to `maxQuantity` and the action continues instead of failing. Default: `false` (fail immediately). |
+| Field                     | Type                    | Required | Description                                                                                                                                                                                   |
+| ------------------------- | ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Target`                  | `int` (positive)        | Yes      | The target quantity. The final discrete value you want to reach. Must be greater than 0.                                                                                                      |
+| `QuantityBox`             | `int[4]`                | Yes      | OCR region for the current quantity. The format must be `[x, y, w, h]`.                                                                                                                       |
+| `QuantityFilter`          | `object`                | No       | Optional color filtering for quantity OCR, useful when digit color is stable but the background is noisy.                                                                                     |
+| `ConcatAllFilteredDigits` | `bool`                  | No       | Quantity parsing strategy switch. `false` (default): read only Go-side `Results.Best` OCR text. `true`: read all `Results.Filtered` OCR fragments, sort by y then x, concatenate, then parse. |
+| `Direction`               | `string`                | Yes      | Drag direction. Supports `left` / `right` / `up` / `down`. The Go side trims surrounding whitespace and lowercases it before validation.                                                      |
+| `IncreaseButton`          | `string` or `int[2\|4]` | Yes      | The "increase quantity" button. Can be a template path or coordinates.                                                                                                                        |
+| `DecreaseButton`          | `string` or `int[2\|4]` | Yes      | The "decrease quantity" button. Can be a template path or coordinates.                                                                                                                        |
+| `CenterPointOffset`       | `int[2]`                | No       | Click offset relative to the slider handle center, default `[-10, 0]`.                                                                                                                        |
+| `ClampTargetToMax`        | `bool`                  | No       | If `true`, when `Target` exceeds the recognized `maxQuantity`, the target is clamped to `maxQuantity` and the action continues instead of failing. Default: `false` (fail immediately).       |
 
 `CenterPointOffset` is used to fine-tune the final click position for `QuantizedSlidingPreciseClick`. Its format must be `[x, y]`:
 
@@ -116,21 +112,7 @@ Pass `custom_action_param` as a JSON object directly.
 
 ### `QuantityFilter`
 
-`QuantityFilter` is an **optional enhancement**. If omitted, `QuantizedSliding` behaves exactly like the current version. If provided, OCR for `QuantizedSlidingGetQuantity` first applies color filtering and then reads the digits.
-
-Important: quantity parsing now has two strategies controlled by `ConcatAllFilteredDigits`:
-
-- `false` (default): read only `QuantizedSlidingGetQuantity.Results.Best.AsOCR().Text`, then extract **all digit characters** from that single text.
-- `true`: concatenate OCR fragments from `QuantizedSlidingGetQuantity.Results.Filtered` after sorting by **y ascending, then x ascending**, then extract **all digit characters** from the concatenated text.
-
-`DetailJson` is still a compatibility fallback when typed OCR results are missing. If `QuantityBox` includes unrelated numbers, those digits may still be merged into the parsed value. One main purpose of `QuantityFilter` is to keep only the actual quantity visible before OCR runs.
-
-It is a good fit when:
-
-- the digit color itself is stable;
-- the background, outline, shadow, or nearby numbers introduce OCR noise;
-- `QuantityBox` is already hard to tighten further, but color still separates the target digits from the interference;
-- `QuantityBox` is already correct, but OCR needs one more preprocessing step.
+`QuantityFilter` is an **optional enhancement**. If omitted, it only means color-filter preprocessing is disabled for `QuantizedSlidingGetQuantity`; if provided, that OCR result is color-filtered before reading digits.
 
 Minimal example:
 
@@ -145,11 +127,20 @@ Minimal example:
 Constraints and limits:
 
 - `lower` and `upper` must both be present and must have the same length;
-- use the common `ColorMatch` methods already used in this repo: `4` (RGB), `40` (HSV), or `6` (GRAY);
-- only a **single** color range is supported for now; `[[...], [...]]` multi-range input is not supported;
-- you can treat it as an approximate color-based binarization step for the quantity area before OCR;
-- if the interfering digits use exactly the same color as the target digits, `QuantityFilter` cannot fundamentally separate them, so tightening `QuantityBox` is still the first choice;
+- The channel count must match the `method`: `4` (RGB) and `40` (HSV) require 3 channels, `6` (GRAY) requires 1 channel;
+- Only a **single** color range is supported for now; `[[...], [...]]` multi-range input is not supported;
+- You can treat it as an approximate color-based binarization step for the quantity area before OCR;
+- If the interfering digits use exactly the same color as the target digits, `QuantityFilter` cannot fundamentally separate them, so tightening `QuantityBox` is still the first choice;
 - `QuantityFilter` improves OCR preprocessing, but it is not a substitute for an inaccurate `QuantityBox`.
+
+### Quantity parsing strategy
+
+Quantity parsing has two strategies controlled by `ConcatAllFilteredDigits`:
+
+- `false` (default): The Go side reads `Results.Best.AsOCR().Text` from the recognition result of `QuantizedSlidingGetQuantity`, then extracts **all digit characters** from that single text.
+- `true`: The Go side reads `Results.Filtered`, sorts by **y ascending, then x ascending**, concatenates, then extracts **all digit characters** from the concatenated text.
+
+`DetailJson` is a compatibility fallback only when the Go-side typed path does not return text. `Results.Best`, `Results.Filtered`, and `DetailJson` are not Pipeline JSON fields, but internal paths used by Go code to read recognition results.
 
 ### `IncreaseButton` / `DecreaseButton` formats
 
@@ -182,14 +173,14 @@ Also note that after JSON deserialization on the Go side, these arrays may appea
 
 ## Direction convention
 
-`Direction` determines which direction is treated as “toward the maximum value.” The current implementation uses these hardcoded override end regions:
+`Direction` determines which direction is treated as "toward the maximum value." The current implementation uses these hardcoded override end regions:
 
 - `right` / `up`: `[1260, 10, 10, 10]`
 - `left` / `down`: `[10, 700, 10, 10]`
 
 This does not mean the slider handle literally moves along the screen diagonal. The current implementation simply overrides the `Swipe` node with a sufficiently distant end region to force the slider toward the corresponding endpoint.
 
-Because of that, when `Direction` is set incorrectly, the most common result is not “slightly off,” but rather:
+Because of that, when `Direction` is set incorrectly, the most common result is not "slightly off," but rather:
 
 - The maximum value is recognized incorrectly;
 - The slider is not pushed to the real endpoint;
@@ -197,11 +188,15 @@ Because of that, when `Direction` is set incorrectly, the most common result is 
 
 ## Shared nodes it depends on
 
-Internally, `QuantizedSliding` depends on shared nodes in `assets/resource/pipeline/QuantizedSliding/Main.json`, mainly including:
+Internally, `QuantizedSliding` depends on shared nodes in `assets/resource/pipeline/QuantizedSliding/`. The `Helper.json` contains basic recognition nodes:
 
 - `QuantizedSlidingSwipeButton`: recognizes the slider template `QuantizedSliding/SwipeButton.png`
-- `QuantizedSlidingSwipeToMax`: drags to the maximum value
 - `QuantizedSlidingGetQuantity`: OCR for the current quantity
+- `QuantizedSlidingQuantityFilter`: color filtering helper for `GetQuantity`
+
+`Main.json` contains the main flow nodes:
+
+- `QuantizedSlidingSwipeToMax`: drags to the maximum value
 - `QuantizedSlidingCheckQuantity`: determines whether fine-tuning is needed
 - `QuantizedSlidingIncreaseQuantity` / `QuantizedSlidingDecreaseQuantity`: clicks the increase/decrease buttons
 - `QuantizedSlidingDone`: successful exit
@@ -217,7 +212,7 @@ The current Go-side recognition reading rules are intentionally narrow:
 
 - The slider hit box is read from `QuantizedSlidingSwipeButton` and prefers `Results.Best.AsTemplateMatch()`.
 - The quantity text is read from `QuantizedSlidingGetQuantity`: default (`ConcatAllFilteredDigits: false`) reads only `Results.Best`; explicit `true` switches to concatenating `Results.Filtered` fragments in y-then-x order.
-- `DetailJson` is kept only as a compatibility fallback when the typed result path does not produce usable data.
+- `DetailJson` is kept only as a compatibility fallback when the typed result path does not return text.
 
 For maintainers, this means `Best`, `Filtered`, and fallback parsing are not interchangeable in the current implementation.
 
@@ -266,7 +261,7 @@ That means:
 - `12/99` is parsed as `1299`, not `12`;
 - If OCR frequently misreads digits as letters, the whole action will fail.
 
-So `QuantityBox` must not only “read digits,” but should also avoid including unrelated numeric groups whenever possible.
+So `QuantityBox` must not only "read digits," but should also avoid including unrelated numeric groups whenever possible.
 If screen constraints make `QuantityBox` difficult to shrink further, but the target digits have a stable color, combine it with `QuantityFilter` to suppress the background or nearby interfering digits before OCR.
 
 ### 4. Choose how to locate the buttons
@@ -279,8 +274,7 @@ The recommended priority is:
 
 ### 5. Call it in the business task
 
-See the actual usage currently in this repository.
-The human-readable strings below are kept exactly as they appear in the current repo:
+See the actual usage currently in this repository:
 
 ```json
 "AutoStockpileSwipeSpecificQuantity": {
@@ -308,7 +302,7 @@ The human-readable strings below are kept exactly as they appear in the current 
     },
     "post_delay": 0,
     "rate_limit": 0,
-    "next": ["AutoStockpileRelayNode"],
+    "next": ["AutoStockpileRelayNodeSwipe"],
     "focus": {
         "Node.Action.Failed": "定量滑动失败，取消购买"
     }
@@ -325,6 +319,7 @@ File location: `assets/resource/pipeline/AutoStockpile/Task.json`
 - It can be dragged to the maximum value successfully;
 - OCR can read both the maximum value and the current value;
 - The target value `Target` is not greater than the maximum value, or `ClampTargetToMax` is `true` (in which case `Target` is clamped to `maxQuantity`);
+- If the recognized `maxQuantity` is `1` and the final target is also `1` (including the case after `ClampTargetToMax`), the flow branches directly to success without proportional clicking;
 - After the proportional click and fine-tuning, the current value finally equals `Target`.
 
 ### Common failure conditions
@@ -332,8 +327,7 @@ File location: `assets/resource/pipeline/AutoStockpile/Task.json`
 - `QuantityBox` is not a 4-tuple `[x, y, w, h]`;
 - `Direction` is not one of `left/right/up/down`;
 - OCR does not read any digits;
-- The maximum value `maxQuantity` is smaller than `Target`, and `ClampTargetToMax` is `false` (default);
-- The maximum value is less than or equal to `1`, so the ratio cannot be calculated;
+- The maximum value `maxQuantity` is smaller than `Target`, and `ClampTargetToMax` is `false` (default); this also covers the case where the maximum is only `1` but the target still remains greater than `1`;
 - The increase/decrease buttons cannot be recognized or clicked;
 - Too many fine-tuning attempts still do not converge.
 
@@ -359,13 +353,13 @@ This is much faster than relying only on repeated button clicks, and much more s
 ## Common pitfalls
 
 - **Treating it like a single `Swipe` action**: it is essentially a complete internal flow, not just one `Swipe` step.
-- **Setting `Direction` backwards**: this breaks the “swipe to max” step itself.
+- **Setting `Direction` backwards**: this breaks the "swipe to max" step itself.
 - **Including multiple number groups in `QuantityBox`**: for example, `12/99` is parsed as `1299`, not automatically treated as the first number only.
 - **Making `QuantityBox` too tight**: OCR easily fails when digits move or outlines change.
 - **Using only button coordinates without a recognition fallback**: small UI shifts can make clicks miss.
 - **Assuming the slider template is universally reusable**: the shared template may fail if different screens use different slider styles.
 - **Using a target value above the limit**: `Target > maxQuantity` fails immediately by default. Set `ClampTargetToMax: true` to automatically clamp to the maximum value instead of failing, but note that the actual final quantity will be `maxQuantity`, not the original `Target`.
-- **Adding extra hard waits without thinking**: this shared flow already uses `post_wait_freezes`, so business integration should not stack many more hard delays on top.
+- **Adding redundant hard waits**: this shared flow already uses `post_wait_freezes`, so business integration should not stack many more hard delays on top.
 
 ## Self-checklist
 
@@ -386,10 +380,12 @@ If you need to follow the implementation further, review in this order:
 1. `agent/go-service/quantizedsliding/register.go`: confirm the registered action name.
 2. `agent/go-service/quantizedsliding/handlers.go`: see how `Run()` distinguishes external invocation mode from internal node mode.
 3. `agent/go-service/quantizedsliding/nodes.go`: see the shared action name, internal node names, and override keys.
-4. `agent/go-service/quantizedsliding/overrides.go`: see how internal Pipeline overrides, direction end regions, and button branches are generated.
-5. `agent/go-service/quantizedsliding/ocr.go`: see typed-first quantity and hit box extraction logic.
-6. `agent/go-service/quantizedsliding/normalize.go`: see button parameter normalization, click-repeat clamping, and center-point calculation.
-7. `assets/resource/pipeline/QuantizedSliding/Main.json`: see default shared-node configuration such as `max_hit`, `post_wait_freezes`, and default `next` relationships.
+4. `agent/go-service/quantizedsliding/params.go`: see parameter parsing and normalization.
+5. `agent/go-service/quantizedsliding/overrides.go`: see how internal Pipeline overrides, direction end regions, and button branches are generated.
+6. `agent/go-service/quantizedsliding/ocr.go`: see typed-first quantity and hit box extraction logic.
+7. `agent/go-service/quantizedsliding/normalize.go`: see button parameter normalization, click-repeat clamping, and center-point calculation.
+8. `assets/resource/pipeline/QuantizedSliding/Main.json`: see default shared-node configuration such as `max_hit`, `post_wait_freezes`, and default `next` relationships.
+9. `assets/resource/pipeline/QuantizedSliding/Helper.json`: see basic recognition node configuration.
 
 ## Related documents
 

--- a/docs/en_us/developers/quantized-sliding.md
+++ b/docs/en_us/developers/quantized-sliding.md
@@ -21,10 +21,11 @@ The current implementation is located at:
 
 | File           | Responsibility                                                         |
 | -------------- | ---------------------------------------------------------------------- |
-| `types.go`     | Parameter structs, action type, constants, and package-level variables |
+| `types.go`     | Parameter structs, action type, runtime state, and package-level types |
+| `nodes.go`     | Shared action name, internal node names, and override key constants    |
 | `handlers.go`  | `Run()` dispatch, per-stage handlers, and state reset                  |
 | `overrides.go` | Pipeline override construction                                         |
-| `ocr.go`       | OCR text extraction and recognition box parsing                        |
+| `ocr.go`       | Typed-first recognition helpers for hit-box and quantity reads         |
 | `normalize.go` | Button parameter normalization and basic calculation helpers           |
 | `register.go`  | Registers the `QuantizedSliding` action into go-service                |
 
@@ -79,6 +80,7 @@ Pass `custom_action_param` as a JSON object directly.
             "custom_action": "QuantizedSliding",
             "custom_action_param": {
                 "Target": 1,
+                "ConcatAllFilteredDigits": false,
                 "QuantityBox": [360, 490, 110, 70],
                 "Direction": "right",
                 "IncreaseButton": "AutoStockpile/IncreaseButton.png",
@@ -94,16 +96,17 @@ Pass `custom_action_param` as a JSON object directly.
 
 `custom_action_param` should be passed as a JSON object directly. The commonly used fields are:
 
-| Field               | Type                    | Required | Description                                                                                                                                                                             |
-| ------------------- | ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Target`            | `int`                   | Yes      | The target quantity. The final discrete value you want to reach.                                                                                                                        |
-| `QuantityBox`       | `int[4]`                | Yes      | OCR region for the current quantity. The format must be `[x, y, w, h]`.                                                                                                                 |
-| `QuantityFilter`    | `object`                | No       | Optional color filtering for quantity OCR, useful when digit color is stable but the background is noisy.                                                                               |
-| `Direction`         | `string`                | Yes      | Drag direction. Supports `left` / `right` / `up` / `down`.                                                                                                                              |
-| `IncreaseButton`    | `string` or `int[2\|4]` | Yes      | The “increase quantity” button. Can be a template path or coordinates.                                                                                                                  |
-| `DecreaseButton`    | `string` or `int[2\|4]` | Yes      | The “decrease quantity” button. Can be a template path or coordinates.                                                                                                                  |
-| `CenterPointOffset` | `int[2]`                | No       | Click offset relative to the slider handle center, default `[-10, 0]`.                                                                                                                  |
-| `ClampTargetToMax`  | `bool`                  | No       | If `true`, when `Target` exceeds the recognized `maxQuantity`, the target is clamped to `maxQuantity` and the action continues instead of failing. Default: `false` (fail immediately). |
+| Field                     | Type                    | Required | Description                                                                                                                                                                             |
+| ------------------------- | ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Target`                  | `int`                   | Yes      | The target quantity. The final discrete value you want to reach.                                                                                                                        |
+| `QuantityBox`             | `int[4]`                | Yes      | OCR region for the current quantity. The format must be `[x, y, w, h]`.                                                                                                                 |
+| `QuantityFilter`          | `object`                | No       | Optional color filtering for quantity OCR, useful when digit color is stable but the background is noisy.                                                                               |
+| `ConcatAllFilteredDigits` | `bool`                  | No       | Quantity parse strategy switch. `false` (default): read only `Results.Best` OCR text. `true`: read all `Results.Filtered` OCR fragments, sort by y then x, concatenate, then parse.     |
+| `Direction`               | `string`                | Yes      | Drag direction. Supports `left` / `right` / `up` / `down`.                                                                                                                              |
+| `IncreaseButton`          | `string` or `int[2\|4]` | Yes      | The “increase quantity” button. Can be a template path or coordinates.                                                                                                                  |
+| `DecreaseButton`          | `string` or `int[2\|4]` | Yes      | The “decrease quantity” button. Can be a template path or coordinates.                                                                                                                  |
+| `CenterPointOffset`       | `int[2]`                | No       | Click offset relative to the slider handle center, default `[-10, 0]`.                                                                                                                  |
+| `ClampTargetToMax`        | `bool`                  | No       | If `true`, when `Target` exceeds the recognized `maxQuantity`, the target is clamped to `maxQuantity` and the action continues instead of failing. Default: `false` (fail immediately). |
 
 `CenterPointOffset` is used to fine-tune the final click position for `QuantizedSlidingPreciseClick`. Its format must be `[x, y]`:
 
@@ -115,7 +118,12 @@ Pass `custom_action_param` as a JSON object directly.
 
 `QuantityFilter` is an **optional enhancement**. If omitted, `QuantizedSliding` behaves exactly like the current version. If provided, OCR for `QuantizedSlidingGetQuantity` first applies color filtering and then reads the digits.
 
-Important: the current implementation first concatenates OCR fragments from the same pass in positional order, then extracts **all digit characters** from the combined text and converts them to an integer. If `QuantityBox` includes unrelated numbers, those digits may also be merged into the final parsed value. One main purpose of `QuantityFilter` is to keep only the actual quantity visible before OCR runs.
+Important: quantity parsing now has two strategies controlled by `ConcatAllFilteredDigits`:
+
+- `false` (default): read only `QuantizedSlidingGetQuantity.Results.Best.AsOCR().Text`, then extract **all digit characters** from that single text.
+- `true`: concatenate OCR fragments from `QuantizedSlidingGetQuantity.Results.Filtered` after sorting by **y ascending, then x ascending**, then extract **all digit characters** from the concatenated text.
+
+`DetailJson` is still a compatibility fallback when typed OCR results are missing. If `QuantityBox` includes unrelated numbers, those digits may still be merged into the parsed value. One main purpose of `QuantityFilter` is to keep only the actual quantity visible before OCR runs.
 
 It is a good fit when:
 
@@ -205,6 +213,14 @@ Two points are the most critical:
 
 If either of these prerequisites is not met, more accurate proportional calculations will not help.
 
+The current Go-side recognition read rules are intentionally narrow:
+
+- The slider hit box is read from `QuantizedSlidingSwipeButton` and prefers `Results.Best.AsTemplateMatch()`.
+- The quantity text is read from `QuantizedSlidingGetQuantity`: default (`ConcatAllFilteredDigits: false`) reads only `Results.Best`; explicit `true` switches to concatenating `Results.Filtered` fragments in y-then-x order.
+- `DetailJson` is kept only as a compatibility fallback when the typed result path does not produce usable data.
+
+For maintainers, this means `Best`, `Filtered`, and fallback parsing are not interchangeable in the current implementation.
+
 ## Integration steps
 
 It is recommended to integrate it in the following order.
@@ -279,9 +295,14 @@ The human-readable strings below are kept exactly as they appear in the current 
                 "DecreaseButton": "AutoStockpile/DecreaseButton.png",
                 "Direction": "right",
                 "IncreaseButton": "AutoStockpile/IncreaseButton.png",
-                "QuantityBox": [360, 490, 110, 70],
-                "CenterPointOffset": [-10, 0],
-                "Target": 1
+                "QuantityBox": [340, 430, 200, 140],
+                "Target": 1,
+                "ConcatAllFilteredDigits": true,
+                "QuantityFilter": {
+                    "lower": [20, 150, 150],
+                    "upper": [35, 255, 255],
+                    "method": 40
+                }
             }
         }
     },
@@ -364,10 +385,11 @@ If you need to follow the implementation further, review in this order:
 
 1. `agent/go-service/quantizedsliding/register.go`: confirm the registered action name.
 2. `agent/go-service/quantizedsliding/handlers.go`: see how `Run()` distinguishes external invocation mode from internal node mode.
-3. `agent/go-service/quantizedsliding/overrides.go`: see how internal Pipeline overrides, direction end regions, and button branches are generated.
-4. `agent/go-service/quantizedsliding/ocr.go`: see OCR text and recognition box extraction logic.
-5. `agent/go-service/quantizedsliding/normalize.go`: see button parameter normalization, click-repeat clamping, and center-point calculation.
-6. `assets/resource/pipeline/QuantizedSliding/Main.json`: see default shared-node configuration such as `max_hit`, `post_wait_freezes`, and default `next` relationships.
+3. `agent/go-service/quantizedsliding/nodes.go`: see the shared action name, internal node names, and override keys.
+4. `agent/go-service/quantizedsliding/overrides.go`: see how internal Pipeline overrides, direction end regions, and button branches are generated.
+5. `agent/go-service/quantizedsliding/ocr.go`: see typed-first quantity and hit-box extraction logic.
+6. `agent/go-service/quantizedsliding/normalize.go`: see button parameter normalization, click-repeat clamping, and center-point calculation.
+7. `assets/resource/pipeline/QuantizedSliding/Main.json`: see default shared-node configuration such as `max_hit`, `post_wait_freezes`, and default `next` relationships.
 
 ## Related documents
 

--- a/docs/en_us/developers/quantized-sliding.md
+++ b/docs/en_us/developers/quantized-sliding.md
@@ -25,7 +25,7 @@ The current implementation is located at:
 | `nodes.go`     | Shared action name, internal node names, and override key constants    |
 | `handlers.go`  | `Run()` dispatch, per-stage handlers, and state reset                  |
 | `overrides.go` | Pipeline override construction                                         |
-| `ocr.go`       | Typed-first recognition helpers for hit-box and quantity reads         |
+| `ocr.go`       | Typed-first recognition helpers for hit box and quantity reads         |
 | `normalize.go` | Button parameter normalization and basic calculation helpers           |
 | `register.go`  | Registers the `QuantizedSliding` action into go-service                |
 
@@ -101,7 +101,7 @@ Pass `custom_action_param` as a JSON object directly.
 | `Target`                  | `int`                   | Yes      | The target quantity. The final discrete value you want to reach.                                                                                                                        |
 | `QuantityBox`             | `int[4]`                | Yes      | OCR region for the current quantity. The format must be `[x, y, w, h]`.                                                                                                                 |
 | `QuantityFilter`          | `object`                | No       | Optional color filtering for quantity OCR, useful when digit color is stable but the background is noisy.                                                                               |
-| `ConcatAllFilteredDigits` | `bool`                  | No       | Quantity parse strategy switch. `false` (default): read only `Results.Best` OCR text. `true`: read all `Results.Filtered` OCR fragments, sort by y then x, concatenate, then parse.     |
+| `ConcatAllFilteredDigits` | `bool`                  | No       | Quantity parsing strategy switch. `false` (default): read only `Results.Best` OCR text. `true`: read all `Results.Filtered` OCR fragments, sort by y then x, concatenate, then parse.   |
 | `Direction`               | `string`                | Yes      | Drag direction. Supports `left` / `right` / `up` / `down`.                                                                                                                              |
 | `IncreaseButton`          | `string` or `int[2\|4]` | Yes      | The “increase quantity” button. Can be a template path or coordinates.                                                                                                                  |
 | `DecreaseButton`          | `string` or `int[2\|4]` | Yes      | The “decrease quantity” button. Can be a template path or coordinates.                                                                                                                  |
@@ -213,7 +213,7 @@ Two points are the most critical:
 
 If either of these prerequisites is not met, more accurate proportional calculations will not help.
 
-The current Go-side recognition read rules are intentionally narrow:
+The current Go-side recognition reading rules are intentionally narrow:
 
 - The slider hit box is read from `QuantizedSlidingSwipeButton` and prefers `Results.Best.AsTemplateMatch()`.
 - The quantity text is read from `QuantizedSlidingGetQuantity`: default (`ConcatAllFilteredDigits: false`) reads only `Results.Best`; explicit `true` switches to concatenating `Results.Filtered` fragments in y-then-x order.
@@ -387,7 +387,7 @@ If you need to follow the implementation further, review in this order:
 2. `agent/go-service/quantizedsliding/handlers.go`: see how `Run()` distinguishes external invocation mode from internal node mode.
 3. `agent/go-service/quantizedsliding/nodes.go`: see the shared action name, internal node names, and override keys.
 4. `agent/go-service/quantizedsliding/overrides.go`: see how internal Pipeline overrides, direction end regions, and button branches are generated.
-5. `agent/go-service/quantizedsliding/ocr.go`: see typed-first quantity and hit-box extraction logic.
+5. `agent/go-service/quantizedsliding/ocr.go`: see typed-first quantity and hit box extraction logic.
 6. `agent/go-service/quantizedsliding/normalize.go`: see button parameter normalization, click-repeat clamping, and center-point calculation.
 7. `assets/resource/pipeline/QuantizedSliding/Main.json`: see default shared-node configuration such as `max_hit`, `post_wait_freezes`, and default `next` relationships.
 

--- a/docs/zh_cn/developers/quantized-sliding.md
+++ b/docs/zh_cn/developers/quantized-sliding.md
@@ -1,9 +1,8 @@
 # 开发手册 - QuantizedSliding 参考文档
 
-`QuantizedSliding` 是一个通过 `Custom` 动作类型调用的 go-service 自定义动作实现，
-用于处理“拖动滑条选择数量，但目标值是离散档位”的界面。
+`QuantizedSliding` 是一个通过 `Custom` 动作类型调用的 go-service 自定义动作，用于处理"拖动滑条选择数量，但目标值是离散档位"的界面。
 
-它适合下面这类场景：
+适合下面这类场景：
 
 - 先拖到大致位置，再通过 `+` / `-` 按钮微调数量；
 - 拖条本身没有稳定的固定坐标，但滑块模板可以识别；
@@ -14,7 +13,7 @@
 - Go 动作包：`agent/go-service/quantizedsliding/`
 - 包内注册：`agent/go-service/quantizedsliding/register.go`
 - go-service 总注册入口：`agent/go-service/register.go`
-- 公共 Pipeline：`assets/resource/pipeline/QuantizedSliding/Main.json`
+- 公共 Pipeline：`assets/resource/pipeline/QuantizedSliding/Main.json` 与 `Helper.json`
 - 现有接入示例：`assets/resource/pipeline/AutoStockpile/Task.json`
 
 其中 `agent/go-service/quantizedsliding/` 已按职责拆分为多个文件：
@@ -22,6 +21,7 @@
 | 文件           | 作用                                       |
 | -------------- | ------------------------------------------ |
 | `types.go`     | 参数结构、动作类型、运行期状态与包级类型   |
+| `params.go`    | 参数解析与归一化                           |
 | `nodes.go`     | 公共动作名、内部节点名与 override key 常量 |
 | `handlers.go`  | `Run()` 分发、各阶段处理函数、状态重置     |
 | `overrides.go` | Pipeline override 构造逻辑                 |
@@ -36,11 +36,11 @@
 1. **对外调用模式**：当业务任务以 `custom_action: "QuantizedSliding"` 调用它时，Go 侧会自动构造内部 Pipeline override，并从 `QuantizedSlidingMain` 开始执行整条内部节点链。
 2. **内部节点模式**：当当前节点本身就是 `QuantizedSlidingMain`、`QuantizedSlidingFindStart`、`QuantizedSlidingGetMaxQuantity`、`QuantizedSlidingFindEnd`、`QuantizedSlidingCheckQuantity`、`QuantizedSlidingDone` 之一时，Go 侧会直接处理该阶段逻辑。
 
-也就是说，业务接入方通常只需要传一次 `custom_action_param`，**不需要**手动串起内部节点。
+业务接入方通常只需要传一次 `custom_action_param`，**不需要**手动串起内部节点。
 
 ## 它是怎么工作的
 
-`QuantizedSliding` 不是“按固定百分比滑到某个位置”，而是一个**先探测、再计算、再微调**的流程。
+`QuantizedSliding` 不是"按固定百分比滑到某个位置"，而是一个**先探测、再计算、再微调**的流程。
 
 整体步骤如下：
 
@@ -53,7 +53,7 @@
 7. OCR 再次识别当前数量；若仍不等于目标值，则通过加减按钮微调。
 8. 数量与目标一致后结束。
 
-其中第 5 步的精确点击位置，当前实现按线性插值计算：
+其中第 5 步的精确点击位置按线性插值计算：
 
 ```text
 numerator = Target - 1
@@ -64,11 +64,9 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 计算出的 `[clickX, clickY]` 会被动态写入公共节点 `QuantizedSlidingPreciseClick` 的 `action.param.target`。
 
-对应的内部节点由 `QuantizedSliding` 自己调用 `QuantizedSlidingMain` 及其后继节点链完成，调用方**不需要**手动串这些内部节点。
-
 ## 调用方式
 
-在业务 Pipeline 中，像普通 `Custom` 动作一样调用即可。下面示例采用 MaaFramework Pipeline 协议 v2 写法。
+在业务 Pipeline 中，像普通 `Custom` 动作一样调用即可。示例采用 MaaFramework Pipeline 协议 v2 写法。
 
 ```json
 "SomeTaskAdjustQuantity": {
@@ -92,19 +90,19 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 ## 参数说明
 
-`custom_action_param` 请直接传入一个 JSON 对象。常用字段如下：
+常用字段如下：
 
-| 字段                      | 类型                    | 必填 | 说明                                                                                                                                              |
-| ------------------------- | ----------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Target`                  | `int`                   | 是   | 目标数量。最终希望调到的档位值。                                                                                                                  |
-| `QuantityBox`             | `int[4]`                | 是   | 当前数量 OCR 区域，格式固定为 `[x, y, w, h]`。                                                                                                    |
-| `QuantityFilter`          | `object`                | 否   | 数量 OCR 的可选颜色过滤参数，适合数字颜色稳定但背景干扰较多的场景。                                                                               |
-| `ConcatAllFilteredDigits` | `bool`                  | 否   | 数量解析策略开关。`false`（默认）：只读 `Results.Best` 的 OCR 文本；`true`：读取 `Results.Filtered` 全片段，按 y 再 x 排序拼接后再解析数字。      |
-| `Direction`               | `string`                | 是   | 拖动方向，支持 `left` / `right` / `up` / `down`。                                                                                                 |
-| `IncreaseButton`          | `string` 或 `int[2\|4]` | 是   | “增加数量”按钮。可传模板路径，也可传坐标。                                                                                                        |
-| `DecreaseButton`          | `string` 或 `int[2\|4]` | 是   | “减少数量”按钮。可传模板路径，也可传坐标。                                                                                                        |
-| `CenterPointOffset`       | `int[2]`                | 否   | 相对滑块识别框中心点的点击偏移，默认 `[-10, 0]`。                                                                                                 |
-| `ClampTargetToMax`        | `bool`                  | 否   | 为 `true` 时，若 `Target` 超过识别到的 `maxQuantity`，自动将目标值钳制为 `maxQuantity` 并继续，而非直接失败。默认 `false`（超过上限时直接失败）。 |
+| 字段                      | 类型                    | 必填 | 说明                                                                                                                                               |
+| ------------------------- | ----------------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Target`                  | `int`（正整数）         | 是   | 目标数量。最终希望调到的档位值，必须大于 0。                                                                                                       |
+| `QuantityBox`             | `int[4]`                | 是   | 当前数量 OCR 区域，格式固定为 `[x, y, w, h]`。                                                                                                     |
+| `QuantityFilter`          | `object`                | 否   | 数量 OCR 的可选颜色过滤参数，适合数字颜色稳定但背景干扰较多的场景。                                                                                |
+| `ConcatAllFilteredDigits` | `bool`                  | 否   | 数量解析策略开关。`false`（默认）：只读 Go 侧 `Results.Best` 的 OCR 文本；`true`：读取 `Results.Filtered` 全片段，按 y 再 x 排序拼接后再解析数字。 |
+| `Direction`               | `string`                | 是   | 拖动方向，支持 `left` / `right` / `up` / `down`。Go 侧会先去掉首尾空白并转成小写后再校验。                                                         |
+| `IncreaseButton`          | `string` 或 `int[2\|4]` | 是   | "增加数量"按钮。可传模板路径，也可传坐标。                                                                                                         |
+| `DecreaseButton`          | `string` 或 `int[2\|4]` | 是   | "减少数量"按钮。可传模板路径，也可传坐标。                                                                                                         |
+| `CenterPointOffset`       | `int[2]`                | 否   | 相对滑块识别框中心点的点击偏移，默认 `[-10, 0]`。                                                                                                  |
+| `ClampTargetToMax`        | `bool`                  | 否   | 为 `true` 时，若 `Target` 超过识别到的 `maxQuantity`，自动将目标值钳制为 `maxQuantity` 并继续，而非直接失败。默认 `false`（超过上限时直接失败）。  |
 
 `CenterPointOffset` 用于微调 `QuantizedSlidingPreciseClick` 的落点。格式固定为 `[x, y]`：
 
@@ -114,21 +112,7 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 ### `QuantityFilter`
 
-`QuantityFilter` 是一个**可选增强项**。不传时，`QuantizedSliding` 的行为与旧版本一致；传入后，会先对 `QuantizedSlidingGetQuantity` 的 OCR 结果做颜色过滤，再识别数字。
-
-需要注意：当前数量解析由 `ConcatAllFilteredDigits` 控制两种策略：
-
-- `false`（默认）：只读取 `QuantizedSlidingGetQuantity.Results.Best.AsOCR().Text`，然后从该单条文本中提取**全部数字字符**。
-- `true`：读取 `QuantizedSlidingGetQuantity.Results.Filtered`，按 **y 升序、y 相同按 x 升序** 排序后拼接，再从拼接文本中提取**全部数字字符**。
-
-`DetailJson` 仍仅作为 typed 路径缺失时的兼容兜底。如果 `QuantityBox` 里混入了其他数字，它们仍可能被一起解析。`QuantityFilter` 的核心用途之一，是在 OCR 前尽量只保留目标数量本身。
-
-它适合这类场景：
-
-- 数字本身颜色稳定；
-- 背景、描边、阴影或其他数字干扰较多；
-- `QuantityBox` 已经不太方便继续缩小，但还能通过颜色把目标数字和干扰数字拉开；
-- `QuantityBox` 本身已经框准，只是 OCR 前缺少一层颜色筛选。
+`QuantityFilter` 是一个**可选增强项**。不传时，仅表示不启用 `QuantizedSlidingGetQuantity` 的颜色过滤预处理；传入后，会先对该 OCR 结果做颜色过滤，再识别数字。
 
 最小示例：
 
@@ -142,12 +126,21 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 约束与限制：
 
-- `lower` / `upper` 必须同时存在，且长度一致；
-- 当前建议使用仓库内已有的常见 `ColorMatch` 模式：`4`（RGB）、`40`（HSV）或 `6`（GRAY）；
+- `lower` / `upper` 必须同时存在，且长度必须一致；
+- 通道数量必须与 `method` 匹配：`4`（RGB）和 `40`（HSV）需要 3 个通道，`6`（GRAY）需要 1 个通道；
 - 当前仅支持**单组**颜色阈值，不支持 `[[...], [...]]` 这种多段范围；
-- 可以把它理解为对数量区域先做一次按颜色的“近似二值化”，尽量只留下目标数字再交给 OCR；
+- 可以把它理解为对数量区域先做一次按颜色的"近似二值化"，尽量只留下目标数字再交给 OCR；
 - 如果干扰数字和目标数字颜色完全一致，`QuantityFilter` 也无法从根本上区分，这时仍应优先收紧 `QuantityBox`；
 - `QuantityFilter` 只是增强 OCR 预处理，不是 `QuantityBox` 选区不准时的替代品。
+
+### 数量解析策略
+
+数量解析由 `ConcatAllFilteredDigits` 控制两种策略：
+
+- `false`（默认）：Go 侧从 `QuantizedSlidingGetQuantity` 的识别结果中读取 `Results.Best.AsOCR().Text`，然后从该单条文本中提取**全部数字字符**。
+- `true`：Go 侧读取 `Results.Filtered`，按 **y 升序、y 相同按 x 升序** 排序后拼接，再从拼接文本中提取**全部数字字符**。
+
+`DetailJson` 仅作为 Go 侧 typed 路径取不到文本时的兼容兜底。`Results.Best`、`Results.Filtered` 与 `DetailJson` 不是 Pipeline JSON 字段，而是 Go 代码读取识别结果的内部路径。
 
 ### `IncreaseButton` / `DecreaseButton` 的写法
 
@@ -180,23 +173,35 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 ## 方向约定
 
-`Direction` 决定“滑到最大值”时的目标方向。当前实现写死的覆盖终点为：
+`Direction` 决定"滑到最大值"时的目标方向。当前实现写死的覆盖终点为：
 
 - `right` / `up`：`[1260, 10, 10, 10]`
 - `left` / `down`：`[10, 700, 10, 10]`
 
+这并不意味着滑块会真的沿着屏幕对角线移动。当前实现只是用一个足够远的终点区域来强制滑块向对应端点移动。
+
+因此，当 `Direction` 设置错误时，常见结果不是"稍微偏一点"，而是：
+
+- 最大值识别错误；
+- 滑块没有被推到真正的端点；
+- 后续所有比例点击都发生偏移。
+
 ## 依赖的公共节点
 
-`QuantizedSliding` 内部依赖 `assets/resource/pipeline/QuantizedSliding/Main.json` 中的公共节点，主要包括：
+`QuantizedSliding` 内部依赖 `assets/resource/pipeline/QuantizedSliding/` 下的公共节点。其中 `Helper.json` 包含基础识别节点：
 
 - `QuantizedSlidingSwipeButton`：识别滑块模板 `QuantizedSliding/SwipeButton.png`
-- `QuantizedSlidingSwipeToMax`：拖到最大值
 - `QuantizedSlidingGetQuantity`：OCR 当前数量
+- `QuantizedSlidingQuantityFilter`：辅助 `GetQuantity` 的颜色过滤
+
+`Main.json` 包含主流程节点：
+
+- `QuantizedSlidingSwipeToMax`：拖到最大值
 - `QuantizedSlidingCheckQuantity`：判断是否需要微调
 - `QuantizedSlidingIncreaseQuantity` / `QuantizedSlidingDecreaseQuantity`：执行加减按钮点击
 - `QuantizedSlidingDone`：成功结束
 
-其中有两点最关键：
+有两点最关键：
 
 1. 必须能稳定识别滑块模板 `QuantizedSliding/SwipeButton.png`；
 2. `QuantityBox` 对应的 OCR 必须能稳定读出数字。
@@ -207,7 +212,7 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 - 滑块识别框优先从 `QuantizedSlidingSwipeButton` 的 `Results.Best.AsTemplateMatch()` 读取；
 - 数量文本来自 `QuantizedSlidingGetQuantity`：默认（`ConcatAllFilteredDigits: false`）只读 `Results.Best`；显式传 `true` 时改为按 y→x 顺序拼接 `Results.Filtered`；
-- `DetailJson` 只作为 typed 路径失败后的兼容兜底。
+- `DetailJson` 只作为 typed 路径取不到文本时的兼容兜底。
 
 对维护者来说，`Best`、`Filtered` 与 fallback 不是可以随意互换的数据来源，而是当前实现的一部分约束。
 
@@ -256,7 +261,7 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 - `12/99` 会被解析为 `1299`，而不是 `12`；
 - 如果 OCR 容易把数字识别成字母，整个动作就会失败。
 
-所以 `QuantityBox` 不仅要“能读到数字”，还要尽量避免把其他数字组一起框进去。
+所以 `QuantityBox` 不仅要"能读到数字"，还要尽量避免把其他数字组一起框进去。
 如果画面限制导致 `QuantityBox` 无法再继续缩小，但目标数字颜色足够稳定，可以再配合 `QuantityFilter` 做颜色过滤，先压掉背景或旁边的干扰数字。
 
 ### 4. 选择按钮定位方式
@@ -297,7 +302,7 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
     },
     "post_delay": 0,
     "rate_limit": 0,
-    "next": ["AutoStockpileRelayNode"],
+    "next": ["AutoStockpileRelayNodeSwipe"],
     "focus": {
         "Node.Action.Failed": "定量滑动失败，取消购买"
     }
@@ -314,6 +319,7 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 - 能成功拖到最大值；
 - 能 OCR 出最大值与当前值；
 - 目标值 `Target` 不大于最大值，或 `ClampTargetToMax` 为 `true`（此时 `Target` 会被钳制为 `maxQuantity`）；
+- 若识别到的 `maxQuantity` 为 `1`，且目标值最终也是 `1`（包括被 `ClampTargetToMax` 钳制后的情况），流程会直接分支到成功，不会再走比例点击；
 - 经过精确点击与微调后，当前值最终等于 `Target`。
 
 ### 常见失败条件
@@ -321,8 +327,7 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 - `QuantityBox` 不是 `[x, y, w, h]` 四元组；
 - `Direction` 不是 `left/right/up/down` 之一；
 - OCR 没有读到数字；
-- 最大值 `maxQuantity` 小于 `Target`，且 `ClampTargetToMax` 为 `false`（默认值）；
-- 最大值小于等于 `1`，无法计算比例；
+- 最大值 `maxQuantity` 小于 `Target`，且 `ClampTargetToMax` 为 `false`（默认值）；当上限只有 `1` 且目标值仍大于 `1` 时，也属于这一类失败；
 - 加减按钮无法识别或无法点击；
 - 微调次数过多仍未收敛。
 
@@ -343,12 +348,12 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 
 > 先用比例点击快速靠近目标，再用加减按钮收尾。
 
-这比“全靠加减按钮硬点”快得多，也比“只点一次比例位置”稳得多。
+这比"全靠加减按钮硬点"快得多，也比"只点一次比例位置"稳得多。
 
 ## 常见坑
 
 - **把它当成普通滑动节点**：它本质上是一个完整子流程，不只是一次 `Swipe`。
-- **`Direction` 填反**：会导致“滑到最大值”这一步本身就不成立。
+- **`Direction` 填反**：会导致"滑到最大值"这一步本身就不成立。
 - **OCR 框进了多个数字组**：例如 `12/99` 会被拼成 `1299`，不是自动取第一个数字。
 - **`QuantityBox` 截得太紧**：数字跳动或描边变化时 OCR 容易失败。
 - **只给按钮坐标，不做识别兜底**：界面轻微偏移后就可能点歪。
@@ -362,7 +367,7 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 
 1. 滑块模板 `QuantizedSliding/SwipeButton.png` 是否能稳定命中。
 2. `QuantityBox` 是否基于 **1280×720**，且 OCR 能稳定读出数字。
-3. `Direction` 是否与“最大值所在方向”一致。
+3. `Direction` 是否与"最大值所在方向"一致。
 4. `IncreaseButton` / `DecreaseButton` 是否优先使用模板路径。
 5. `Target` 是否有可能大于当前场景允许的最大值。
 6. 若启用了 `ClampTargetToMax`，调用方是否能处理"实际数量可能小于原始 `Target`"的情况。
@@ -373,12 +378,14 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 如果需要继续追实现，建议按下面顺序看：
 
 1. `agent/go-service/quantizedsliding/register.go`：确认动作注册名。
-2. `agent/go-service/quantizedsliding/handlers.go`：看 `Run()` 如何区分“对外调用模式”和“内部节点模式”。
+2. `agent/go-service/quantizedsliding/handlers.go`：看 `Run()` 如何区分"对外调用模式"和"内部节点模式"。
 3. `agent/go-service/quantizedsliding/nodes.go`：看公共动作名、内部节点名与 override key 常量。
-4. `agent/go-service/quantizedsliding/overrides.go`：看内部 Pipeline override、方向终点和按钮分支是怎么生成的。
-5. `agent/go-service/quantizedsliding/ocr.go`：看 typed-first 的数量与识别框提取逻辑。
-6. `agent/go-service/quantizedsliding/normalize.go`：看按钮参数归一化、点击次数限制和中心点计算。
-7. `assets/resource/pipeline/QuantizedSliding/Main.json`：看公共节点默认配置，例如 `max_hit`、`post_wait_freezes`、默认 `next` 关系。
+4. `agent/go-service/quantizedsliding/params.go`：看参数解析与归一化。
+5. `agent/go-service/quantizedsliding/overrides.go`：看内部 Pipeline override、方向终点和按钮分支是怎么生成的。
+6. `agent/go-service/quantizedsliding/ocr.go`：看 typed-first 的数量与识别框提取逻辑。
+7. `agent/go-service/quantizedsliding/normalize.go`：看按钮参数归一化、点击次数限制和中心点计算。
+8. `assets/resource/pipeline/QuantizedSliding/Main.json`：看公共节点默认配置，例如 `max_hit`、`post_wait_freezes`、默认 `next` 关系。
+9. `assets/resource/pipeline/QuantizedSliding/Helper.json`：看基础识别节点配置。
 
 ## 相关文档
 

--- a/docs/zh_cn/developers/quantized-sliding.md
+++ b/docs/zh_cn/developers/quantized-sliding.md
@@ -21,10 +21,11 @@
 
 | 文件           | 作用                                       |
 | -------------- | ------------------------------------------ |
-| `types.go`     | 参数结构、动作类型、常量与包级变量         |
+| `types.go`     | 参数结构、动作类型、运行期状态与包级类型   |
+| `nodes.go`     | 公共动作名、内部节点名与 override key 常量 |
 | `handlers.go`  | `Run()` 分发、各阶段处理函数、状态重置     |
 | `overrides.go` | Pipeline override 构造逻辑                 |
-| `ocr.go`       | OCR 文本提取与识别框解析                   |
+| `ocr.go`       | typed-first 的识别框/数量读取辅助逻辑      |
 | `normalize.go` | 按钮参数归一化与基础计算辅助               |
 | `register.go`  | 向 go-service 注册 `QuantizedSliding` 动作 |
 
@@ -77,6 +78,7 @@ clickY = startY + (endY - startY) * numerator / denominator
             "custom_action": "QuantizedSliding",
             "custom_action_param": {
                 "Target": 1,
+                "ConcatAllFilteredDigits": false,
                 "QuantityBox": [360, 490, 110, 70],
                 "Direction": "right",
                 "IncreaseButton": "AutoStockpile/IncreaseButton.png",
@@ -92,16 +94,17 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 `custom_action_param` 请直接传入一个 JSON 对象。常用字段如下：
 
-| 字段                | 类型                    | 必填 | 说明                                                                                                                                              |
-| ------------------- | ----------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Target`            | `int`                   | 是   | 目标数量。最终希望调到的档位值。                                                                                                                  |
-| `QuantityBox`       | `int[4]`                | 是   | 当前数量 OCR 区域，格式固定为 `[x, y, w, h]`。                                                                                                    |
-| `QuantityFilter`    | `object`                | 否   | 数量 OCR 的可选颜色过滤参数，适合数字颜色稳定但背景干扰较多的场景。                                                                               |
-| `Direction`         | `string`                | 是   | 拖动方向，支持 `left` / `right` / `up` / `down`。                                                                                                 |
-| `IncreaseButton`    | `string` 或 `int[2\|4]` | 是   | “增加数量”按钮。可传模板路径，也可传坐标。                                                                                                        |
-| `DecreaseButton`    | `string` 或 `int[2\|4]` | 是   | “减少数量”按钮。可传模板路径，也可传坐标。                                                                                                        |
-| `CenterPointOffset` | `int[2]`                | 否   | 相对滑块识别框中心点的点击偏移，默认 `[-10, 0]`。                                                                                                 |
-| `ClampTargetToMax`  | `bool`                  | 否   | 为 `true` 时，若 `Target` 超过识别到的 `maxQuantity`，自动将目标值钳制为 `maxQuantity` 并继续，而非直接失败。默认 `false`（超过上限时直接失败）。 |
+| 字段                      | 类型                    | 必填 | 说明                                                                                                                                              |
+| ------------------------- | ----------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Target`                  | `int`                   | 是   | 目标数量。最终希望调到的档位值。                                                                                                                  |
+| `QuantityBox`             | `int[4]`                | 是   | 当前数量 OCR 区域，格式固定为 `[x, y, w, h]`。                                                                                                    |
+| `QuantityFilter`          | `object`                | 否   | 数量 OCR 的可选颜色过滤参数，适合数字颜色稳定但背景干扰较多的场景。                                                                               |
+| `ConcatAllFilteredDigits` | `bool`                  | 否   | 数量解析策略开关。`false`（默认）：只读 `Results.Best` 的 OCR 文本；`true`：读取 `Results.Filtered` 全片段，按 y 再 x 排序拼接后再解析数字。      |
+| `Direction`               | `string`                | 是   | 拖动方向，支持 `left` / `right` / `up` / `down`。                                                                                                 |
+| `IncreaseButton`          | `string` 或 `int[2\|4]` | 是   | “增加数量”按钮。可传模板路径，也可传坐标。                                                                                                        |
+| `DecreaseButton`          | `string` 或 `int[2\|4]` | 是   | “减少数量”按钮。可传模板路径，也可传坐标。                                                                                                        |
+| `CenterPointOffset`       | `int[2]`                | 否   | 相对滑块识别框中心点的点击偏移，默认 `[-10, 0]`。                                                                                                 |
+| `ClampTargetToMax`        | `bool`                  | 否   | 为 `true` 时，若 `Target` 超过识别到的 `maxQuantity`，自动将目标值钳制为 `maxQuantity` 并继续，而非直接失败。默认 `false`（超过上限时直接失败）。 |
 
 `CenterPointOffset` 用于微调 `QuantizedSlidingPreciseClick` 的落点。格式固定为 `[x, y]`：
 
@@ -113,7 +116,12 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 `QuantityFilter` 是一个**可选增强项**。不传时，`QuantizedSliding` 的行为与旧版本一致；传入后，会先对 `QuantizedSlidingGetQuantity` 的 OCR 结果做颜色过滤，再识别数字。
 
-需要注意：当前实现会先按位置顺序拼接同一轮 OCR 命中的文本片段，再从中提取**全部数字字符**转成整数。因此，如果 `QuantityBox` 里混入了其他数字，它们也可能被一起拼进最终结果。`QuantityFilter` 的一个核心用途，就是在 OCR 前尽量只保留目标数量本身。
+需要注意：当前数量解析由 `ConcatAllFilteredDigits` 控制两种策略：
+
+- `false`（默认）：只读取 `QuantizedSlidingGetQuantity.Results.Best.AsOCR().Text`，然后从该单条文本中提取**全部数字字符**。
+- `true`：读取 `QuantizedSlidingGetQuantity.Results.Filtered`，按 **y 升序、y 相同按 x 升序** 排序后拼接，再从拼接文本中提取**全部数字字符**。
+
+`DetailJson` 仍仅作为 typed 路径缺失时的兼容兜底。如果 `QuantityBox` 里混入了其他数字，它们仍可能被一起解析。`QuantityFilter` 的核心用途之一，是在 OCR 前尽量只保留目标数量本身。
 
 它适合这类场景：
 
@@ -195,6 +203,14 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 只要这两个前提不成立，后面的比例计算再准确也没有意义。
 
+当前 Go 侧的识别读取策略也有明确边界：
+
+- 滑块识别框优先从 `QuantizedSlidingSwipeButton` 的 `Results.Best.AsTemplateMatch()` 读取；
+- 数量文本来自 `QuantizedSlidingGetQuantity`：默认（`ConcatAllFilteredDigits: false`）只读 `Results.Best`；显式传 `true` 时改为按 y→x 顺序拼接 `Results.Filtered`；
+- `DetailJson` 只作为 typed 路径失败后的兼容兜底。
+
+对维护者来说，`Best`、`Filtered` 与 fallback 不是可以随意互换的数据来源，而是当前实现的一部分约束。
+
 ## 接入步骤
 
 建议按下面的顺序接入。
@@ -268,9 +284,14 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
                 "DecreaseButton": "AutoStockpile/DecreaseButton.png",
                 "Direction": "right",
                 "IncreaseButton": "AutoStockpile/IncreaseButton.png",
-                "QuantityBox": [360, 490, 110, 70],
-                "CenterPointOffset": [-10, 0],
-                "Target": 1
+                "QuantityBox": [340, 430, 200, 140],
+                "Target": 1,
+                "ConcatAllFilteredDigits": true,
+                "QuantityFilter": {
+                    "lower": [20, 150, 150],
+                    "upper": [35, 255, 255],
+                    "method": 40
+                }
             }
         }
     },
@@ -353,10 +374,11 @@ assets/resource/image/QuantizedSliding/SwipeButton.png
 
 1. `agent/go-service/quantizedsliding/register.go`：确认动作注册名。
 2. `agent/go-service/quantizedsliding/handlers.go`：看 `Run()` 如何区分“对外调用模式”和“内部节点模式”。
-3. `agent/go-service/quantizedsliding/overrides.go`：看内部 Pipeline override、方向终点和按钮分支是怎么生成的。
-4. `agent/go-service/quantizedsliding/ocr.go`：看 OCR 文本与识别框提取逻辑。
-5. `agent/go-service/quantizedsliding/normalize.go`：看按钮参数归一化、点击次数限制和中心点计算。
-6. `assets/resource/pipeline/QuantizedSliding/Main.json`：看公共节点默认配置，例如 `max_hit`、`post_wait_freezes`、默认 `next` 关系。
+3. `agent/go-service/quantizedsliding/nodes.go`：看公共动作名、内部节点名与 override key 常量。
+4. `agent/go-service/quantizedsliding/overrides.go`：看内部 Pipeline override、方向终点和按钮分支是怎么生成的。
+5. `agent/go-service/quantizedsliding/ocr.go`：看 typed-first 的数量与识别框提取逻辑。
+6. `agent/go-service/quantizedsliding/normalize.go`：看按钮参数归一化、点击次数限制和中心点计算。
+7. `assets/resource/pipeline/QuantizedSliding/Main.json`：看公共节点默认配置，例如 `max_hit`、`post_wait_freezes`、默认 `next` 关系。
 
 ## 相关文档
 


### PR DESCRIPTION
summary:
- 收紧 QuantizedSliding 的识别取值边界：滑块识别优先只读 SwipeButton 的 Best 模板结果，数量默认只读 GetQuantity 的 Best OCR，缺失时才回退到 DetailJson。
- 新增 ConcatAllFilteredDigits 开关，允许按 y→x 顺序拼接 Results.Filtered 的 OCR 片段；AutoStockpile 显式启用该模式并继续配合颜色过滤读取数量。
- 调整共享 QuantizedSliding Pipeline 的滑动起点偏移，并将动作名与内部节点名抽成常量，统一 Go 侧注册、分发与 override 引用。
- 同步更新中英文开发文档与示例，明确 Best / Filtered / fallback 的读取边界、新参数含义和接入方式。

close #1613

## Summary by Sourcery

收紧 QuantizedSliding 的命中框（hit-box）和读数逻辑，使其优先使用带类型的 Best 结果；引入可配置的策略用于拼接已过滤的 OCR 数字；并在 QuantizedSliding 流水线中统一共享节点命名、重写规则和文档。

New Features:
- 为 QuantizedSliding 新增 `ConcatAllFilteredDigits` 参数，用于控制数量 OCR 是仅使用 Best 结果，还是按位置顺序拼接所有 Filtered OCR 片段。

Enhancements:
- 将 QuantizedSliding 的命中框与数量解析限制为节点作用域内、具有类型的识别结果，仅在必要时回退使用 `DetailJson`。
- 将 QuantizedSliding 的动作名和节点名集中到共享常量中，以便在各处理器、重写配置和注册流程中统一使用。

Documentation:
- 更新 QuantizedSliding 的中英文开发者文档，说明新的数量解析策略、收紧后的 Best/Filtered/回退（fallback）边界、辅助流水线节点以及修订后的 AutoStockpile 示例配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten QuantizedSliding hit-box and quantity reading to prefer typed Best results, introduce a configurable strategy for concatenating filtered OCR digits, and align shared node naming, overrides, and docs with the QuantizedSliding pipeline.

New Features:
- Add a ConcatAllFilteredDigits parameter to QuantizedSliding to control whether quantity OCR uses only the Best result or concatenates all Filtered OCR fragments in positional order.

Enhancements:
- Restrict QuantizedSliding hit-box and quantity parsing to node-scoped, typed recognition results with DetailJson used only as a fallback.
- Centralize QuantizedSliding action and node names into shared constants used across handlers, overrides, and registration.

Documentation:
- Update Chinese and English QuantizedSliding developer documentation to describe the new quantity parsing strategies, tightened Best/Filtered/fallback boundaries, helper pipeline nodes, and revised AutoStockpile example configuration.

</details>