### PR TITLE
fix: 修复万能跳转动画没播完点击按钮导致失败问题

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneMap.json
+++ b/assets/resource/pipeline/SceneManager/SceneMap.json
@@ -186,6 +186,16 @@
                 "green_mask": true
             }
         },
+        "pre_wait_freezes": {
+            "target": [
+                70,
+                80,
+                70,
+                60
+            ],
+            "time": 800,
+            "timeout": 2000
+        },
         "pre_delay": 0,
         "post_delay": 0
     },

--- a/assets/resource/pipeline/SceneManager/SceneWorld.json
+++ b/assets/resource/pipeline/SceneManager/SceneWorld.json
@@ -16,7 +16,7 @@
                 70,
                 60
             ],
-            "time": 400,
+            "time": 800,
             "timeout": 2000
         },
         "pre_delay": 0,


### PR DESCRIPTION
close #1644 
close #1642

## Summary by Sourcery

错误修复：
- 通过调整场景配置，防止在过渡动画尚未完成时点击按钮导致通用导航失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent failure of universal navigation when buttons are clicked before transition animations complete by adjusting scene configuration.

</details>