### PR TITLE
ci: 为 i18n 的 ci 添加非主仓库跳过定时执行

### DIFF
--- a/.github/workflows/i18n-sync.yml
+++ b/.github/workflows/i18n-sync.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   sync-ocr-expected:
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'MaaEnd/MaaEnd'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
~~ci工作流失败塞满了我的通知~~

## Summary by Sourcery

CI：
- 将 i18n 同步任务限制为仅在手动触发或工作流在主仓库中执行时运行，在 fork 仓库中跳过定时触发的运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Restrict the i18n sync job to run only when manually triggered or when the workflow is executed in the primary repository, skipping scheduled runs in forks.

</details>