### PR TITLE
fix(战斗后基质筛选):略微增大技能3的识别范围

### DIFF
--- a/assets/resource/pipeline/EssenceFilter/EssenceFilterAfterBattleCheckItem.json
+++ b/assets/resource/pipeline/EssenceFilter/EssenceFilterAfterBattleCheckItem.json
@@ -396,10 +396,10 @@
             "param": {
                 "roi": "EssenceAfterBattleYellowSlot3",
                 "roi_offset": [
-                    8,
+                    2,
                     -24,
-                    169,
-                    10
+                    175,
+                    12
                 ],
                 "expected": [
                     ".*"


### PR DESCRIPTION
原roi范围太小，没有完全覆盖技能3文字范围，识别的“夜幕”这种技能名时会识别不出来，现将其略微调大

## Summary by Sourcery

Bug Fixes:
- 扩大战后礼装筛选中技能3的作用范围（ROI），以便正确识别诸如“夜幕”之类的技能名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Expand the ROI for skill 3 in the after-battle essence filter so skill names like '夜幕' are correctly recognized.

</details>