### PR TITLE
fix: 增加传送后位置判断

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
@@ -36,15 +36,15 @@
     "CheckAncientTreeIcon": {
         "desc": "检查古树文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckAncientTreeText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckAncientTreeReadyText": {
         "desc": "检查古树委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
@@ -36,15 +36,15 @@
     "CheckAncientTreeIcon": {
         "desc": "检查古树文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckAncientTreeText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckAncientTreeReadyText": {
         "desc": "检查古树委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToAncientTreeNotAtStartPos": {
-        "desc": "不在古树任务开始位置附近",
+        "desc": "不在古树任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToAncientTreeRecheckStartPos",
+            "GoToAncientTreeReEnterMap"
+        ]
+    },
+    "GoToAncientTreeRecheckStartPos": {
+        "desc": "传送后再次检查是否已在古树任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        280,
+                        580,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToAncientTreeMapTrackerMove"
         ]
+    },
+    "GoToAncientTreeReEnterMap": {
+        "desc": "传送后仍未到达古树任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley7"
+            ]
+        },
+        "next": [
+            "GoToAncientTreeFinalCheckStartPos",
+            "GoToAncientTreeStartPosFailed"
+        ]
+    },
+    "GoToAncientTreeFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在古树任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        280,
+                        580,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToAncientTreeMapTrackerMove"
+        ]
+    },
+    "GoToAncientTreeStartPosFailed": {
+        "desc": "古树传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToAncientTreeMapTrackerMove": {
         "desc": "前往古树",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInBlightTide.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInBlightTide.json
@@ -36,15 +36,15 @@
     "CheckBeaconDamagedInBlightTideIcon": {
         "desc": "检查侵蚀潮中损坏的信标文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckBeaconDamagedInBlightTideText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckBeaconDamagedInBlightTideReadyText": {
         "desc": "检查侵蚀潮中损坏的信标委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInBlightTide.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInBlightTide.json
@@ -36,15 +36,15 @@
     "CheckBeaconDamagedInBlightTideIcon": {
         "desc": "检查侵蚀潮中损坏的信标文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckBeaconDamagedInBlightTideText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckBeaconDamagedInBlightTideReadyText": {
         "desc": "检查侵蚀潮中损坏的信标委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToBeaconDamagedInBlightTideNotAtStartPos": {
-        "desc": "不在侵蚀潮中损坏的信标任务开始位置附近",
+        "desc": "不在侵蚀潮中损坏的信标任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToBeaconDamagedInBlightTideRecheckStartPos",
+            "GoToBeaconDamagedInBlightTideReEnterMap"
+        ]
+    },
+    "GoToBeaconDamagedInBlightTideRecheckStartPos": {
+        "desc": "传送后再次检查是否已在侵蚀潮中损坏的信标任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv002",
+                    "target": [
+                        640,
+                        255,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToBeaconDamagedInBlightTideMapTrackerMove"
         ]
+    },
+    "GoToBeaconDamagedInBlightTideReEnterMap": {
+        "desc": "传送后仍未到达侵蚀潮中损坏的信标任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity0"
+            ]
+        },
+        "next": [
+            "GoToBeaconDamagedInBlightTideFinalCheckStartPos",
+            "GoToBeaconDamagedInBlightTideStartPosFailed"
+        ]
+    },
+    "GoToBeaconDamagedInBlightTideFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在侵蚀潮中损坏的信标任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv002",
+                    "target": [
+                        640,
+                        255,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToBeaconDamagedInBlightTideMapTrackerMove"
+        ]
+    },
+    "GoToBeaconDamagedInBlightTideStartPosFailed": {
+        "desc": "侵蚀潮中损坏的信标传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToBeaconDamagedInBlightTideMapTrackerMove": {
         "desc": "前往侵蚀潮中损坏的信标",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
@@ -36,15 +36,15 @@
     "CheckCisternOriginiumSlugsIcon": {
         "desc": "检查蓄水源石虫文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckCisternOriginiumSlugsText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckCisternOriginiumSlugsReadyText": {
         "desc": "检查蓄水源石虫委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
@@ -36,15 +36,15 @@
     "CheckCisternOriginiumSlugsIcon": {
         "desc": "检查蓄水源石虫文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckCisternOriginiumSlugsText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckCisternOriginiumSlugsReadyText": {
         "desc": "检查蓄水源石虫委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToCisternOriginiumSlugsNotAtStartPos": {
-        "desc": "不在蓄水源石虫任务开始位置附近",
+        "desc": "不在蓄水源石虫任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToCisternOriginiumSlugsRecheckStartPos",
+            "GoToCisternOriginiumSlugsReEnterMap"
+        ]
+    },
+    "GoToCisternOriginiumSlugsRecheckStartPos": {
+        "desc": "传送后再次检查是否已在蓄水源石虫任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        280,
+                        580,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToCisternOriginiumSlugsMapTrackerMove"
         ]
+    },
+    "GoToCisternOriginiumSlugsReEnterMap": {
+        "desc": "传送后仍未到达蓄水源石虫任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley7"
+            ]
+        },
+        "next": [
+            "GoToCisternOriginiumSlugsFinalCheckStartPos",
+            "GoToCisternOriginiumSlugsStartPosFailed"
+        ]
+    },
+    "GoToCisternOriginiumSlugsFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在蓄水源石虫任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        280,
+                        580,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToCisternOriginiumSlugsMapTrackerMove"
+        ]
+    },
+    "GoToCisternOriginiumSlugsStartPosFailed": {
+        "desc": "蓄水源石虫传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToCisternOriginiumSlugsMapTrackerMove": {
         "desc": "前往蓄水源石虫",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
@@ -36,15 +36,15 @@
     "CheckCleansingJadeIcon": {
         "desc": "检查漱玉文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckCleansingJadeText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckCleansingJadeReadyText": {
         "desc": "检查漱玉委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
@@ -36,15 +36,15 @@
     "CheckCleansingJadeIcon": {
         "desc": "检查漱玉文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckCleansingJadeText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckCleansingJadeReadyText": {
         "desc": "检查漱玉委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToCleansingJadeNotAtStartPos": {
-        "desc": "不在漱玉任务开始位置附近",
+        "desc": "不在漱玉任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToCleansingJadeRecheckStartPos",
+            "GoToCleansingJadeReEnterMap"
+        ]
+    },
+    "GoToCleansingJadeRecheckStartPos": {
+        "desc": "传送后再次检查是否已在漱玉任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001_tier_277",
+                    "target": [
+                        255,
+                        395,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToCleansingJadeMapTrackerMove"
         ]
+    },
+    "GoToCleansingJadeReEnterMap": {
+        "desc": "传送后仍未到达漱玉任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley4"
+            ]
+        },
+        "next": [
+            "GoToCleansingJadeFinalCheckStartPos",
+            "GoToCleansingJadeStartPosFailed"
+        ]
+    },
+    "GoToCleansingJadeFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在漱玉任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001_tier_277",
+                    "target": [
+                        255,
+                        395,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToCleansingJadeMapTrackerMove"
+        ]
+    },
+    "GoToCleansingJadeStartPosFailed": {
+        "desc": "漱玉传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToCleansingJadeMapTrackerMove": {
         "desc": "前往漱玉",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
@@ -36,15 +36,15 @@
     "CheckCollapsedTianshiPillarIcon": {
         "desc": "检查倒塌的天师桩文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckCollapsedTianshiPillarText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckCollapsedTianshiPillarReadyText": {
         "desc": "检查倒塌的天师桩委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
@@ -36,15 +36,15 @@
     "CheckCollapsedTianshiPillarIcon": {
         "desc": "检查倒塌的天师桩文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckCollapsedTianshiPillarText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckCollapsedTianshiPillarReadyText": {
         "desc": "检查倒塌的天师桩委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToCollapsedTianshiPillarNotAtStartPos": {
-        "desc": "不在倒塌的天师桩任务开始位置附近",
+        "desc": "不在倒塌的天师桩任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToCollapsedTianshiPillarRecheckStartPos",
+            "GoToCollapsedTianshiPillarReEnterMap"
+        ]
+    },
+    "GoToCollapsedTianshiPillarRecheckStartPos": {
+        "desc": "传送后再次检查是否已在倒塌的天师桩任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        210,
+                        635,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToCollapsedTianshiPillarMapTrackerMove"
         ]
+    },
+    "GoToCollapsedTianshiPillarReEnterMap": {
+        "desc": "传送后仍未到达倒塌的天师桩任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley8"
+            ]
+        },
+        "next": [
+            "GoToCollapsedTianshiPillarFinalCheckStartPos",
+            "GoToCollapsedTianshiPillarStartPosFailed"
+        ]
+    },
+    "GoToCollapsedTianshiPillarFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在倒塌的天师桩任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        210,
+                        635,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToCollapsedTianshiPillarMapTrackerMove"
+        ]
+    },
+    "GoToCollapsedTianshiPillarStartPosFailed": {
+        "desc": "倒塌的天师桩传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToCollapsedTianshiPillarMapTrackerMove": {
         "desc": "前往倒塌的天师桩",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
@@ -36,15 +36,15 @@
     "CheckEcologyNearTheFieldLogisticsDepotIcon": {
         "desc": "检查储备站周围的生态环境文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckEcologyNearTheFieldLogisticsDepotText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckEcologyNearTheFieldLogisticsDepotReadyText": {
         "desc": "检查储备站周围的生态环境委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
@@ -36,15 +36,15 @@
     "CheckEcologyNearTheFieldLogisticsDepotIcon": {
         "desc": "检查储备站周围的生态环境文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckEcologyNearTheFieldLogisticsDepotText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckEcologyNearTheFieldLogisticsDepotReadyText": {
         "desc": "检查储备站周围的生态环境委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToEcologyNearTheFieldLogisticsDepotNotAtStartPos": {
-        "desc": "不在储备站周围的生态环境任务开始位置附近",
+        "desc": "不在储备站周围的生态环境任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToEcologyNearTheFieldLogisticsDepotRecheckStartPos",
+            "GoToEcologyNearTheFieldLogisticsDepotReEnterMap"
+        ]
+    },
+    "GoToEcologyNearTheFieldLogisticsDepotRecheckStartPos": {
+        "desc": "传送后再次检查是否已在储备站周围的生态环境任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv002",
+                    "target": [
+                        689.6,
+                        917.3,
+                        6.0,
+                        5.5
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove"
         ]
+    },
+    "GoToEcologyNearTheFieldLogisticsDepotReEnterMap": {
+        "desc": "传送后仍未到达储备站周围的生态环境任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity8"
+            ]
+        },
+        "next": [
+            "GoToEcologyNearTheFieldLogisticsDepotFinalCheckStartPos",
+            "GoToEcologyNearTheFieldLogisticsDepotStartPosFailed"
+        ]
+    },
+    "GoToEcologyNearTheFieldLogisticsDepotFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在储备站周围的生态环境任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv002",
+                    "target": [
+                        689.6,
+                        917.3,
+                        6.0,
+                        5.5
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove"
+        ]
+    },
+    "GoToEcologyNearTheFieldLogisticsDepotStartPosFailed": {
+        "desc": "储备站周围的生态环境传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove": {
         "desc": "前往储备站周围的生态环境",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -36,15 +36,15 @@
     "CheckEternalSunsetIcon": {
         "desc": "检查栖霞驻影文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckEternalSunsetText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckEternalSunsetReadyText": {
         "desc": "检查栖霞驻影委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -36,15 +36,15 @@
     "CheckEternalSunsetIcon": {
         "desc": "检查栖霞驻影文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckEternalSunsetText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckEternalSunsetReadyText": {
         "desc": "检查栖霞驻影委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToEternalSunsetNotAtStartPos": {
-        "desc": "不在栖霞驻影任务开始位置附近",
+        "desc": "不在栖霞驻影任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToEternalSunsetRecheckStartPos",
+            "GoToEternalSunsetReEnterMap"
+        ]
+    },
+    "GoToEternalSunsetRecheckStartPos": {
+        "desc": "传送后再次检查是否已在栖霞驻影任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        315,
+                        305,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToEternalSunsetMapTrackerMove"
         ]
+    },
+    "GoToEternalSunsetReEnterMap": {
+        "desc": "传送后仍未到达栖霞驻影任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley2"
+            ]
+        },
+        "next": [
+            "GoToEternalSunsetFinalCheckStartPos",
+            "GoToEternalSunsetStartPosFailed"
+        ]
+    },
+    "GoToEternalSunsetFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在栖霞驻影任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        315,
+                        305,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToEternalSunsetMapTrackerMove"
+        ]
+    },
+    "GoToEternalSunsetStartPosFailed": {
+        "desc": "栖霞驻影传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToEternalSunsetMapTrackerMove": {
         "desc": "前往栖霞驻影",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
@@ -36,15 +36,15 @@
     "CheckIndoorCropsIcon": {
         "desc": "检查室内作物文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckIndoorCropsText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckIndoorCropsReadyText": {
         "desc": "检查室内作物委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
@@ -36,15 +36,15 @@
     "CheckIndoorCropsIcon": {
         "desc": "检查室内作物文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckIndoorCropsText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckIndoorCropsReadyText": {
         "desc": "检查室内作物委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToIndoorCropsNotAtStartPos": {
-        "desc": "不在室内作物任务开始位置附近",
+        "desc": "不在室内作物任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToIndoorCropsRecheckStartPos",
+            "GoToIndoorCropsReEnterMap"
+        ]
+    },
+    "GoToIndoorCropsRecheckStartPos": {
+        "desc": "传送后再次检查是否已在室内作物任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv002",
+                    "target": [
+                        240,
+                        695,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToIndoorCropsMapTrackerMove"
         ]
+    },
+    "GoToIndoorCropsReEnterMap": {
+        "desc": "传送后仍未到达室内作物任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity4"
+            ]
+        },
+        "next": [
+            "GoToIndoorCropsFinalCheckStartPos",
+            "GoToIndoorCropsStartPosFailed"
+        ]
+    },
+    "GoToIndoorCropsFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在室内作物任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv002",
+                    "target": [
+                        240,
+                        695,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToIndoorCropsMapTrackerMove"
+        ]
+    },
+    "GoToIndoorCropsStartPosFailed": {
+        "desc": "室内作物传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToIndoorCropsMapTrackerMove": {
         "desc": "前往室内作物",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
@@ -36,15 +36,15 @@
     "CheckInflatedAndGlowingBugspittingLankybeastIcon": {
         "desc": "检查肚子鼓气后发光的吐虫长股兽文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckInflatedAndGlowingBugspittingLankybeastText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckInflatedAndGlowingBugspittingLankybeastReadyText": {
         "desc": "检查肚子鼓气后发光的吐虫长股兽委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
@@ -36,15 +36,15 @@
     "CheckInflatedAndGlowingBugspittingLankybeastIcon": {
         "desc": "检查肚子鼓气后发光的吐虫长股兽文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckInflatedAndGlowingBugspittingLankybeastText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckInflatedAndGlowingBugspittingLankybeastReadyText": {
         "desc": "检查肚子鼓气后发光的吐虫长股兽委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToInflatedAndGlowingBugspittingLankybeastNotAtStartPos": {
-        "desc": "不在肚子鼓气后发光的吐虫长股兽任务开始位置附近",
+        "desc": "不在肚子鼓气后发光的吐虫长股兽任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToInflatedAndGlowingBugspittingLankybeastRecheckStartPos",
+            "GoToInflatedAndGlowingBugspittingLankybeastReEnterMap"
+        ]
+    },
+    "GoToInflatedAndGlowingBugspittingLankybeastRecheckStartPos": {
+        "desc": "传送后再次检查是否已在肚子鼓气后发光的吐虫长股兽任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        280,
+                        580,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove"
         ]
+    },
+    "GoToInflatedAndGlowingBugspittingLankybeastReEnterMap": {
+        "desc": "传送后仍未到达肚子鼓气后发光的吐虫长股兽任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley7"
+            ]
+        },
+        "next": [
+            "GoToInflatedAndGlowingBugspittingLankybeastFinalCheckStartPos",
+            "GoToInflatedAndGlowingBugspittingLankybeastStartPosFailed"
+        ]
+    },
+    "GoToInflatedAndGlowingBugspittingLankybeastFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在肚子鼓气后发光的吐虫长股兽任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        280,
+                        580,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove"
+        ]
+    },
+    "GoToInflatedAndGlowingBugspittingLankybeastStartPosFailed": {
+        "desc": "肚子鼓气后发光的吐虫长股兽传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove": {
         "desc": "前往肚子鼓气后发光的吐虫长股兽",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
@@ -36,15 +36,15 @@
     "CheckObservantSableChestedFowlbeastIcon": {
         "desc": "检查东张西望的黑腹雉羽兽文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckObservantSableChestedFowlbeastText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckObservantSableChestedFowlbeastReadyText": {
         "desc": "检查东张西望的黑腹雉羽兽委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
@@ -36,15 +36,15 @@
     "CheckObservantSableChestedFowlbeastIcon": {
         "desc": "检查东张西望的黑腹雉羽兽文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckObservantSableChestedFowlbeastText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckObservantSableChestedFowlbeastReadyText": {
         "desc": "检查东张西望的黑腹雉羽兽委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToObservantSableChestedFowlbeastNotAtStartPos": {
-        "desc": "不在东张西望的黑腹雉羽兽任务开始位置附近",
+        "desc": "不在东张西望的黑腹雉羽兽任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToObservantSableChestedFowlbeastRecheckStartPos",
+            "GoToObservantSableChestedFowlbeastReEnterMap"
+        ]
+    },
+    "GoToObservantSableChestedFowlbeastRecheckStartPos": {
+        "desc": "传送后再次检查是否已在东张西望的黑腹雉羽兽任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        342.2,
+                        124.2,
+                        4,
+                        4
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToObservantSableChestedFowlbeastMapTrackerMove"
         ]
+    },
+    "GoToObservantSableChestedFowlbeastReEnterMap": {
+        "desc": "传送后仍未到达东张西望的黑腹雉羽兽任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley0"
+            ]
+        },
+        "next": [
+            "GoToObservantSableChestedFowlbeastFinalCheckStartPos",
+            "GoToObservantSableChestedFowlbeastStartPosFailed"
+        ]
+    },
+    "GoToObservantSableChestedFowlbeastFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在东张西望的黑腹雉羽兽任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        342.2,
+                        124.2,
+                        4,
+                        4
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToObservantSableChestedFowlbeastMapTrackerMove"
+        ]
+    },
+    "GoToObservantSableChestedFowlbeastStartPosFailed": {
+        "desc": "东张西望的黑腹雉羽兽传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToObservantSableChestedFowlbeastMapTrackerMove": {
         "desc": "前往东张西望的黑腹雉羽兽",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
@@ -36,15 +36,15 @@
     "CheckRainbowFinIcon": {
         "desc": "检查七彩鳞文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckRainbowFinText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckRainbowFinReadyText": {
         "desc": "检查七彩鳞委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
@@ -36,15 +36,15 @@
     "CheckRainbowFinIcon": {
         "desc": "检查七彩鳞文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckRainbowFinText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckRainbowFinReadyText": {
         "desc": "检查七彩鳞委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToRainbowFinNotAtStartPos": {
-        "desc": "不在七彩鳞任务开始位置附近",
+        "desc": "不在七彩鳞任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToRainbowFinRecheckStartPos",
+            "GoToRainbowFinReEnterMap"
+        ]
+    },
+    "GoToRainbowFinRecheckStartPos": {
+        "desc": "传送后再次检查是否已在七彩鳞任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        125,
+                        815,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToRainbowFinMapTrackerMove"
         ]
+    },
+    "GoToRainbowFinReEnterMap": {
+        "desc": "传送后仍未到达七彩鳞任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley10"
+            ]
+        },
+        "next": [
+            "GoToRainbowFinFinalCheckStartPos",
+            "GoToRainbowFinStartPosFailed"
+        ]
+    },
+    "GoToRainbowFinFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在七彩鳞任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv001",
+                    "target": [
+                        125,
+                        815,
+                        15,
+                        15
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToRainbowFinMapTrackerMove"
+        ]
+    },
+    "GoToRainbowFinStartPosFailed": {
+        "desc": "七彩鳞传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToRainbowFinMapTrackerMove": {
         "desc": "前往七彩鳞",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
@@ -36,15 +36,15 @@
     "CheckVigorousCisternOriginiumSlugIcon": {
         "desc": "检查充满活力的蓄水源石虫文本下方的图标",
         "recognition": "TemplateMatch",
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8,
         "roi": "CheckVigorousCisternOriginiumSlugText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ]
+        ],
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8
     },
     "CheckVigorousCisternOriginiumSlugReadyText": {
         "desc": "检查充满活力的蓄水源石虫委托是否准备好",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
@@ -36,15 +36,15 @@
     "CheckVigorousCisternOriginiumSlugIcon": {
         "desc": "检查充满活力的蓄水源石虫文本下方的图标",
         "recognition": "TemplateMatch",
+        "template": "EnvironmentMonitoring/PhotoIcon.png",
+        "threshold": 0.8,
         "roi": "CheckVigorousCisternOriginiumSlugText",
         "roi_offset": [
             -18,
             0,
             0,
             28
-        ],
-        "template": "EnvironmentMonitoring/PhotoIcon.png",
-        "threshold": 0.8
+        ]
     },
     "CheckVigorousCisternOriginiumSlugReadyText": {
         "desc": "检查充满活力的蓄水源石虫委托是否准备好",
@@ -209,7 +209,7 @@
         ]
     },
     "GoToVigorousCisternOriginiumSlugNotAtStartPos": {
-        "desc": "不在充满活力的蓄水源石虫任务开始位置附近",
+        "desc": "不在充满活力的蓄水源石虫任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -218,8 +218,68 @@
             ]
         },
         "next": [
+            "GoToVigorousCisternOriginiumSlugRecheckStartPos",
+            "GoToVigorousCisternOriginiumSlugReEnterMap"
+        ]
+    },
+    "GoToVigorousCisternOriginiumSlugRecheckStartPos": {
+        "desc": "传送后再次检查是否已在充满活力的蓄水源石虫任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv002",
+                    "target": [
+                        422.0,
+                        577.7,
+                        4,
+                        4
+                    ]
+                }
+            ]
+        },
+        "next": [
             "GoToVigorousCisternOriginiumSlugMapTrackerMove"
         ]
+    },
+    "GoToVigorousCisternOriginiumSlugReEnterMap": {
+        "desc": "传送后仍未到达充满活力的蓄水源石虫任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity3"
+            ]
+        },
+        "next": [
+            "GoToVigorousCisternOriginiumSlugFinalCheckStartPos",
+            "GoToVigorousCisternOriginiumSlugStartPosFailed"
+        ]
+    },
+    "GoToVigorousCisternOriginiumSlugFinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在充满活力的蓄水源石虫任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv002",
+                    "target": [
+                        422.0,
+                        577.7,
+                        4,
+                        4
+                    ]
+                }
+            ]
+        },
+        "next": [
+            "GoToVigorousCisternOriginiumSlugMapTrackerMove"
+        ]
+    },
+    "GoToVigorousCisternOriginiumSlugStartPosFailed": {
+        "desc": "充满活力的蓄水源石虫传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToVigorousCisternOriginiumSlugMapTrackerMove": {
         "desc": "前往充满活力的蓄水源石虫",

--- a/assets/resource/pipeline/SceneManager/SceneDijiang.json
+++ b/assets/resource/pipeline/SceneManager/SceneDijiang.json
@@ -172,6 +172,7 @@
                 ]
             }
         },
+        "pre_wait_freezes": 80,
         "pre_delay": 0,
         "action": {
             "type": "Custom",
@@ -179,7 +180,6 @@
                 "custom_action": "AutoAltClickAction"
             }
         },
-        "pre_wait_freezes": 80,
         "post_delay": 0,
         "rate_limit": 0,
         "next": [

--- a/assets/resource/pipeline/SellProduct/ValleyIV.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV.json
@@ -412,11 +412,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -434,11 +434,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -528,11 +528,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -550,11 +550,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -644,11 +644,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -666,11 +666,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -688,11 +688,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -710,11 +710,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -732,11 +732,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -754,11 +754,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -776,11 +776,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -798,11 +798,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [

--- a/assets/resource/pipeline/SellProduct/Wuling.json
+++ b/assets/resource/pipeline/SellProduct/Wuling.json
@@ -206,11 +206,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -228,11 +228,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -250,11 +250,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -272,11 +272,11 @@
             518
         ],
         "expected": [],
+        "pre_delay": 0,
+        "action": "Click",
         "anchor": {
             "SellProductSelectGoodFirstTime": ""
         },
-        "pre_delay": 0,
-        "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [

--- a/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/template.jsonc
+++ b/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/template.jsonc
@@ -192,7 +192,7 @@
         ]
     },
     "GoTo${Id}NotAtStartPos": {
-        "desc": "不在${Name}任务开始位置附近",
+        "desc": "不在${Name}任务开始位置附近，先传送再复核落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -201,8 +201,58 @@
             ]
         },
         "next": [
+            "GoTo${Id}RecheckStartPos",
+            "GoTo${Id}ReEnterMap"
+        ]
+    },
+    "GoTo${Id}RecheckStartPos": {
+        "desc": "传送后再次检查是否已在${Name}任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "${MapName}",
+                    "target": "${MapTarget}"
+                }
+            ]
+        },
+        "next": [
             "GoTo${Id}MapTrackerMove"
         ]
+    },
+    "GoTo${Id}ReEnterMap": {
+        "desc": "传送后仍未到达${Name}任务开始位置附近，重试一次传送",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "${EnterMap}"
+            ]
+        },
+        "next": [
+            "GoTo${Id}FinalCheckStartPos",
+            "GoTo${Id}StartPosFailed"
+        ]
+    },
+    "GoTo${Id}FinalCheckStartPos": {
+        "desc": "二次传送后再次检查是否已在${Name}任务开始位置附近",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "${MapName}",
+                    "target": "${MapTarget}"
+                }
+            ]
+        },
+        "next": [
+            "GoTo${Id}MapTrackerMove"
+        ]
+    },
+    "GoTo${Id}StartPosFailed": {
+        "desc": "${Name}传送后仍未到达预期起点，结束当前子任务"
     },
     "GoTo${Id}MapTrackerMove": {
         "desc": "前往${Name}",


### PR DESCRIPTION
当判断进入"GoTo${Id}NotAtStartPos"时，直接传送然后进行寻路的逻辑改为传送后判断两次位置是否在目标附近，如果处于附近状态再进行寻路，不然退出任务。

## Summary by Sourcery

调整 EnvironmentMonitoring OutskirtsMonitoringTerminal 任务，在传送后先验证玩家位置再继续后续流程。

Bug 修复：
- 在 EnvironmentMonitoring OutskirtsMonitoringTerminal 流程中，当传送后的玩家位置不在预期目标附近时，防止任务错误地继续进行路径规划。

改进：
- 将所有相关的 EnvironmentMonitoring OutskirtsMonitoringTerminal JSON 配置及其生成模板与新的传送后位置验证逻辑对齐。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust EnvironmentMonitoring OutskirtsMonitoringTerminal tasks to validate player position after teleporting before proceeding.

Bug Fixes:
- Prevent tasks from incorrectly continuing pathfinding when post-teleport position is not near the intended target in EnvironmentMonitoring OutskirtsMonitoringTerminal flows.

Enhancements:
- Align all related EnvironmentMonitoring OutskirtsMonitoringTerminal JSON configs and their generation template with the new post-teleport position validation logic.

</details>