### PR TITLE
fix: 协议空间当理智不足并选择使用许可，尝试不使用理智许可

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -342,6 +342,26 @@
             130
         ]
     },
+    "ProtocolSpaceRewardUsePermitSanityLow": {
+        "desc": "使用理智消耗许可时理智不足",
+        "recognition": "OCR",
+        "roi": [
+            680,
+            530,
+            90,
+            35
+        ],
+        "expected": [
+            "\\d"
+        ],
+        "color_filter": "ProtocolSpaceRewardSanityLowFilter",
+        "focus": {
+            "Node.Recognition.Succeeded": "理智不足，尝试不使用理智消耗许可"
+        },
+        "next": [
+            "ProtocolSpaceRewardDontUsePermit"
+        ]
+    },
     "ProtocolSpaceRewardSanityLow": {
         "desc": "理智不足",
         "recognition": "OCR",
@@ -398,7 +418,7 @@
         ],
         "action": "Click",
         "next": [
-            "ProtocolSpaceRewardSanityLow",
+            "ProtocolSpaceRewardUsePermitSanityLow",
             "ProtocolSpaceRewardClaim"
         ],
         "focus": {


### PR DESCRIPTION
fix #1713 
fix #1675

## Summary by Sourcery

调整 Protocol Space 中的 InSpace 配置，以在理智值不足时正确处理理智许可（sanity permit）的使用。

Bug 修复：
- 修复在 Protocol Space 中选择使用许可但理智值不足时，仍可能错误消耗理智值的情况。
- 解决与问题 #1713 和 #1675 相关的 Protocol Space 许可处理边界情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Protocol Space InSpace configuration to correctly handle sanity permit usage when sanity is insufficient.

Bug Fixes:
- Fix cases where choosing to use a permit in Protocol Space with insufficient sanity could still consume sanity incorrectly.
- Resolve edge cases in Protocol Space permit handling related to issues #1713 and #1675.

</details>