### PR TITLE
ai: dmp analysis

### DIFF
--- a/.claude/skills/dmp-analysis/SKILL.md
+++ b/.claude/skills/dmp-analysis/SKILL.md
@@ -13,7 +13,7 @@ description: 分析 Windows 崩溃转储文件（.dmp），诊断 MaaEnd 及其�
 
 ## Prerequisites
 
-`minidump-stackwalk` and `dump_syms` are pre-installed in the CI environment (see `.github/workflows/issue-ai-analysis.yml`).
+在本仓库的 `issue-ai-analysis` workflow 中会安装并确保 `minidump-stackwalk` 和 `dump_syms` 可用（见 `.github/workflows/issue-ai-analysis.yml`）。如果你在本地复现或手动运行本流程，需要自行安装这些工具（可参考下文安装命令）。
 
 Verify before proceeding:
 
@@ -190,11 +190,13 @@ Look up the function and line from the symbolicated stack trace in the cloned so
 - 崩溃模块：`<module_name>` (版本 `<version>`)
 - 崩溃函数：`<symbolicated function name>`
 
-## 崩溃堆栈（crashing thread）
+## DMP 崩溃分析
 
-<top 10–15 symbolicated frames>
+### 崩溃堆栈（crashing thread）
 
-## 关键模块版本
+<crashing thread 的全部有效符号化堆栈帧；如堆栈被截断/损坏，请在此说明原因>
+
+### 关键模块版本
 
 | Module | Version |
 |--------|---------|
@@ -202,13 +204,13 @@ Look up the function and line from the symbolicated stack trace in the cloned so
 | MaaFramework.dll | ... |
 | ... | ... |
 
-## 根因判断
+### 根因判断
 
 - 崩溃归属：MaaFramework / MXU / 第三方依赖 / 未知
 - 分析：...
 - 置信度：高 / 中 / 低
 
-## 建议
+### 建议
 
 - 对用户的建议（升级、绕过方案等）
 - 对开发者的建议（上游报告、修复方向）

--- a/.claude/skills/dmp-analysis/SKILL.md
+++ b/.claude/skills/dmp-analysis/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: windows-dmp-analysis
+description: 分析 Windows 崩溃转储文件（.dmp），诊断 MaaEnd 及其依赖项（MaaFramework、MXU）的崩溃。自动从 GitHub Releases 下载对应版本 PDB 符号，使用 minidump-stackwalk 解析堆栈轨迹并定位崩溃根因。当 issue 日志包或附件中发现 .dmp 文件，或用户要求分析 DMP/崩溃转储时使用。
+---
+
+# Windows DMP Analysis
+
+## Scope
+
+- Windows minidump (.dmp) files from MaaEnd.
+- `MaaEnd.dmp` crashes almost always originate in **MaaFramework** (C++) or **MXU** (Rust/Tauri), not MaaEnd's Go code.
+- Only x86_64 covered below; for aarch64, substitute `x86_64` → `aarch64` in all download URLs.
+
+## Prerequisites
+
+`minidump-stackwalk` and `dump_syms` are pre-installed in the CI environment (see `.github/workflows/issue-ai-analysis.yml`).
+
+Verify before proceeding:
+
+```bash
+which minidump-stackwalk && which dump_syms
+```
+
+If either is missing, install via:
+
+```bash
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+cargo binstall -y --no-confirm minidump-stackwalk dump_syms
+```
+
+## Workflow
+
+### 1. Obtain DMP
+
+Download `.dmp` to `.cache/dmp-analysis/issue-<number>/`.
+
+Sources:
+- Direct issue attachment (image/file link ending in `.dmp`)
+- Inside `MaaEnd-logs-*.zip` log package
+
+```bash
+WORK=".cache/dmp-analysis/issue-<NUMBER>"
+mkdir -p "$WORK"
+curl -L "<dmp_url>" -o "$WORK/MaaEnd.dmp"
+```
+
+### 2. Quick unsymbolicated analysis
+
+```bash
+minidump-stackwalk "$WORK/MaaEnd.dmp" 2>/dev/null
+```
+
+This gives without any symbols: OS info, exception type, module list with versions, raw stack frames.
+
+Identify the **crashing module** from the exception address or the top stack frame.
+
+### 3. Correlate DMP with logs
+
+The DMP filename often contains the crashing PID (e.g. `MaaEnd.exe.18188.dmp` → PID 18188).
+Match this with `maa.log` entries tagged `[Px18188]` to pinpoint the exact crashing session and its timeline.
+
+### 4. Determine dependency versions
+
+DMP module version info is frequently empty/unavailable. Prefer log and config sources:
+
+| Priority | Source | How |
+|----------|--------|-----|
+| 1 | `mxu-tauri.log` | `maa_init success, version: v5.x.x` |
+| 2 | `go-service.log` | `client_maafw_version` / `client_version` in PI environment log |
+| 3 | Config files from logs package | `interface.json`, `maa_option.json` |
+| 4 | Issue text | User-reported version |
+| 5 | Module list in stackwalk output | Version column (often shows `?`) |
+
+Record:
+- **MaaFramework version** (e.g. `5.9.2`)
+- **MXU version** (e.g. `1.21.2`)
+
+### 5. Download PDB symbols
+
+#### MaaFramework
+
+```bash
+MAA_VER="<version>"   # e.g. 5.9.2
+curl -sL "https://github.com/MaaXYZ/MaaFramework/releases/download/v${MAA_VER}/MAA-win-x86_64-v${MAA_VER}.zip" \
+  -o "$WORK/maa-fw.zip"
+unzip -joq "$WORK/maa-fw.zip" 'symbol/*.pdb' -d "$WORK/pdb/"
+```
+
+PDB files inside `symbol/`:
+
+| PDB | Corresponding Module |
+|-----|---------------------|
+| MaaFramework.pdb | MaaFramework.dll — core pipeline runtime |
+| MaaUtils.pdb | MaaUtils.dll — utility library |
+| MaaToolkit.pdb | MaaToolkit.dll — toolkit |
+| MaaWin32ControlUnit.pdb | MaaWin32ControlUnit.dll — Win32 controller |
+| MaaAdbControlUnit.pdb | MaaAdbControlUnit.dll — ADB controller |
+| MaaAgentServer.pdb | MaaAgentServer.dll — agent server |
+| MaaAgentClient.pdb | MaaAgentClient.dll — agent client |
+| MaaPiCli.pdb | MaaPiCli.exe — CLI entry |
+| Others | GamepadControlUnit, CustomControlUnit, NodeServer, Node |
+
+#### MXU
+
+```bash
+MXU_VER="<version>"   # e.g. 1.21.2
+curl -sL "https://github.com/MistEO/MXU/releases/download/v${MXU_VER}/MXU-win-x86_64-v${MXU_VER}.zip" \
+  -o "$WORK/mxu.zip"
+unzip -joq "$WORK/mxu.zip" 'mxu.pdb' -d "$WORK/pdb/"
+```
+
+`mxu.pdb` is at the zip root (≈230 MB).
+
+### 6. Convert PDB → Breakpad .sym
+
+```bash
+mkdir -p "$WORK/symbols"
+for pdb in "$WORK/pdb/"*.pdb; do
+  name=$(basename "$pdb" .pdb)
+  header=$(dump_syms "$pdb" 2>/dev/null | head -1)
+  debug_id=$(echo "$header" | awk '{print $4}')
+  dest="$WORK/symbols/${name}.pdb/${debug_id}"
+  mkdir -p "$dest"
+  dump_syms "$pdb" > "$dest/${name}.sym" 2>/dev/null
+done
+```
+
+### 7. Full symbolicated stack walk
+
+```bash
+minidump-stackwalk "$WORK/MaaEnd.dmp" "$WORK/symbols" 2>/dev/null
+```
+
+Now stack traces include function names, source paths, and line numbers.
+
+### 8. Analyze results
+
+#### What to focus on
+
+1. **Crashing thread** — read stack top-down.
+2. **Exception type**:
+    - `EXCEPTION_ACCESS_VIOLATION` (0xC0000005) — null/dangling pointer, use-after-free
+    - `EXCEPTION_STACK_OVERFLOW` (0xC00000FD) — infinite recursion or oversized stack allocation
+    - `EXCEPTION_ILLEGAL_INSTRUCTION` (0xC000001D) — corrupted code or wrong CPU feature
+    - `STATUS_STACK_BUFFER_OVERRUN` (0xC0000409) — **NOT always a real buffer overrun.** This is the Windows fast-fail mechanism. Check the first exception parameter:
+        - `0x7` = `FAST_FAIL_FATAL_APP_EXIT` — means `std::terminate()` / `abort()` was called, typically from an **unhandled C++ exception** (e.g. `cv::Exception` from OpenCV receiving an empty `cv::Mat`). This is the most common MaaEnd crash pattern.
+        - `0x2` = `FAST_FAIL_RANGE_CHECK_FAILURE`
+        - Other values: see [FAST_FAIL codes](https://learn.microsoft.com/en-us/windows/win32/debug/fast-fail-constants)
+    - `EXCEPTION_BREAKPOINT` (0x80000003) — deliberate crash / assertion failure / Rust panic
+3. **Faulting module ownership**:
+    - `Maa*.dll` → MaaFramework → upstream `MaaXYZ/MaaFramework`
+    - `mxu.exe` → MXU → upstream `MistEO/MXU`
+    - `onnxruntime_maa.dll`, `opencv_world4_maa.dll`, `fastdeploy_ppocr_maa.dll` → third-party inference/vision
+    - `DirectML.dll` → DirectX ML runtime
+    - `ViGEmClient.dll` → virtual gamepad
+    - `ntdll.dll`, `KERNELBASE.dll`, `ucrtbase.dll` → OS / CRT; look at the caller frames above
+    - If crash address is in `ucrtbase.dll` with code 0xC0000409, the real crash site is in the **caller frames**, not ucrtbase itself
+4. **Recurring patterns**:
+    - Multiple threads crashing or deadlocked
+    - Stack corruption (truncated / nonsensical frames)
+    - Heap corruption indicators (`RtlReportCriticalFailure`, `RtlpLogHeapFailure`)
+    - Rust panic (`rust_begin_unwind`, `core::panicking::*`)
+
+### 9. Cross-reference with source
+
+If the crash is in MaaFramework:
+
+```bash
+git clone --depth 1 --branch "v${MAA_VER}" \
+  https://github.com/MaaXYZ/MaaFramework.git ".cache/upstream-src/MaaFramework"
+```
+
+If the crash is in MXU:
+
+```bash
+git clone --depth 1 --branch "v${MXU_VER}" \
+  https://github.com/MistEO/MXU.git ".cache/upstream-src/MXU"
+```
+
+Look up the function and line from the symbolicated stack trace in the cloned source.
+
+## Output Format
+
+```markdown
+## DMP 分析结果
+
+- DMP 文件：`<filename>`
+- 操作系统：`<OS version>`
+- 异常类型：`<EXCEPTION_*>`
+- 崩溃模块：`<module_name>` (版本 `<version>`)
+- 崩溃函数：`<symbolicated function name>`
+
+## 崩溃堆栈（crashing thread）
+
+<top 10–15 symbolicated frames>
+
+## 关键模块版本
+
+| Module | Version |
+|--------|---------|
+| mxu.exe | ... |
+| MaaFramework.dll | ... |
+| ... | ... |
+
+## 根因判断
+
+- 崩溃归属：MaaFramework / MXU / 第三方依赖 / 未知
+- 分析：...
+- 置信度：高 / 中 / 低
+
+## 建议
+
+- 对用户的建议（升级、绕过方案等）
+- 对开发者的建议（上游报告、修复方向）
+```
+
+## Cleanup
+
+After analysis is complete:
+
+```bash
+rm -rf ".cache/dmp-analysis/issue-<NUMBER>"
+```

--- a/.claude/skills/maaend-issue-log-analysis/SKILL.md
+++ b/.claude/skills/maaend-issue-log-analysis/SKILL.md
@@ -41,22 +41,43 @@ description: 分析 MaaEnd 上游仓库公开 Issue（`https://github.com/MaaEnd
         - `maa.bak.log`
         - `config/` 目录
         - 没有 `on_error/`，或只有部分现场图
+        - `.dmp` 崩溃转储文件（如 `MaaEnd.dmp`、`MaaEnd.exe.<pid>.dmp`）
+    - 如果发现 `.dmp` 文件，记录其文件名和路径，将在步骤 5 中单独处理。
 
-5. 建立时间线。
+5. **DMP 崩溃转储分析（如有 `.dmp` 文件则必须执行此步骤）。**
+
+    如果在日志包内或 issue 附件中发现了 `.dmp` 文件，**立即读取 `.claude/skills/dmp-analysis/SKILL.md` 并严格按其流程执行**。不要跳过这一步，不要只凭日志文本猜测崩溃原因。
+
+    a. 按照 `dmp-analysis/SKILL.md` 的完整流程完成崩溃转储分析，包括：
+        - 解析异常类型、崩溃地址、崩溃模块
+        - 提取 crashing thread 的完整堆栈帧
+        - 下载对应版本的 PDB 符号并使用 `dump_syms` + `minidump-stackwalk` 完成符号化
+    b. DMP 的进程 PID（通常在文件名中，如 `MaaEnd.exe.18188.dmp` → PID 18188）必须与 `maa.log` 中的 `[Px<pid>]` 标签交叉验证，确认是同一次崩溃会话。
+    c. 最终报告中必须包含 **`## DMP 崩溃分析`** 区域（见 Output Format），内容包括：
+        - 异常类型和异常码（如 `0xC0000409`），以及异常码的含义
+        - 崩溃模块和偏移
+        - **crashing thread 的全部有效堆栈帧**（module+offset 或符号化后的 function+line），不要省略或截断
+        - 关键模块列表
+    d. 如果堆栈中涉及 MaaFramework 或 MXU 的帧且已完成符号化（有函数名+源码行号），**必须**按对应版本 clone 上游仓库源码，定位到具体代码行，并以远端 GitHub `blob` 行号链接（尖括号包裹）的形式贴出。clone 命令参考：
+        - `git clone --depth 1 --branch "v<VERSION>" https://github.com/MaaXYZ/MaaFramework.git .cache/upstream-src/MaaFramework`
+        - `git clone --depth 1 --branch "v<VERSION>" https://github.com/MistEO/MXU.git .cache/upstream-src/MXU`
+    e. 如果符号化失败或无法下载 PDB，在报告中明确说明，但仍必须输出 module+offset 级别的堆栈。
+
+6. 建立时间线。
 
     - 先从 issue 文本判断“用户觉得出问题的时刻”。
     - 再把 `mxu-web-*`、`mxu-tauri.log`、`go-service.log`、`maa.log`、`mxu-agent*.log` 串成一条时间线。
     - 先用 `mxu-tauri.log` 或 `maa.log` 找本次提交的 `task_id`，因为一个日志包里经常混有很多历史运行。
     - 如果有 `on_error/` 截图，用它校验当时实际停留画面；如果没有，要检查是否是未触发 `on_error`，还是日志导出因体积限制把图片截断了。
 
-6. 回溯到代码和文档。
+7. 回溯到代码和文档。
 
     - 任务入口、节点名、控制器限制先看 MaaEnd 仓库。
     - Pipeline 运行语义不确定时查 MaaFramework 文档。
     - MXU 行为或日志分层不确定时，先查 MXU README / 文档；只有文档不足或证据已指向实现层时才看源码。
     - 输出给用户时，如果提到任务入口、任务说明、选项名、提示文案，先到 `assets/locales/interface/zh_cn.json` 查中文文案，不要直接把 `task id` / `option id` 当成最终展示文本。
 
-7. 只有在满足条件时才下钻第三方仓库。
+8. 只有在满足条件时才下钻第三方仓库。
 
     - 先用 issue、日志、MaaEnd 仓库和 MaaFramework 文档做初步归因。
     - 如果怀疑问题在 MXU、MaaFramework 或 binding 实现层，且现有证据不足以确认，再按需查看对应上游仓库源码。
@@ -328,6 +349,35 @@ description: 分析 MaaEnd 上游仓库公开 Issue（`https://github.com/MaaEnd
 - 任务 / 相关选项：优先写 `assets/locales/interface/zh_cn.json` 中的中文 `label` / `description`
 - 用户现象：
 
+## DMP 崩溃分析
+
+（仅当 issue 存在 .dmp 文件时输出此区域。如果没有 .dmp 文件，删除整个区域。）
+
+- DMP 文件：`<filename>`（PID `<pid>`，与 `maa.log` 中 `[Px<pid>]` 已交叉验证）
+- 异常类型：`<EXCEPTION_*>`（`<hex code>`），含义：...
+- 崩溃模块：`<module_name>+<offset>`
+- 符号化状态：已符号化 / 仅 module+offset（原因：...）
+
+### 崩溃堆栈（crashing thread 全部有效帧，禁止省略）
+
+```
+Frame 0: <module>+<offset>  [或 <function> at <file>:<line>]
+Frame 1: ...
+Frame 2: ...
+...
+```
+
+（如果符号化成功且帧涉及 MaaFramework 或 MXU，在每个相关帧后面附上游源码链接：）
+- Frame N: `<function>` → <https://github.com/MaaXYZ/MaaFramework/blob/v5.x.x/src/...#L123>
+
+### 关键模块
+
+| Module | Base | Size |
+|--------|------|------|
+| MaaFramework.dll | ... | ... |
+| MaaWin32ControlUnit.dll | ... | ... |
+| ... | ... | ... |
+
 ## 关键证据
 
 <details><summary>点击此处展开</summary>
@@ -394,6 +444,8 @@ Translate the complete conclusion directly into English and paste it here. Note 
 
 ## Reminders
 
+- **DMP 堆栈必须完整输出**：如果 issue 存在 `.dmp` 文件，最终报告中必须包含 `## DMP 崩溃分析` 区域，其中的崩溃堆栈必须列出 crashing thread 的全部有效帧（module+offset 或 function+line），禁止省略或用"等"代替。如果符号化帧涉及 MaaFramework/MXU，必须附上游 GitHub blob 行号链接。如果最终报告中缺少此区域而 issue 明确有 DMP，说明分析流程不完整，需要返回步骤 5 补做。
+- **DMP 分析必须先读 skill**：发现 `.dmp` 时必须先读取 `.claude/skills/dmp-analysis/SKILL.md` 再动手，不要自行发明解析流程。特别注意该 skill 中关于 `0xC0000409` 子参数含义等分析细节。
 - 不要只看一个日志文件下结论。
 - 不要把“维护者评论”当成唯一证据。
 - 不要把环境告警自动等同于根因。

--- a/.claude/skills/maaend-issue-log-analysis/SKILL.md
+++ b/.claude/skills/maaend-issue-log-analysis/SKILL.md
@@ -349,7 +349,19 @@ description: 分析 MaaEnd 上游仓库公开 Issue（`https://github.com/MaaEnd
 - 任务 / 相关选项：优先写 `assets/locales/interface/zh_cn.json` 中的中文 `label` / `description`
 - 用户现象：
 
-## DMP 崩溃分析
+## 关键证据
+
+<details><summary>点击此处展开</summary>
+
+- `maa.log`：...
+- `go-service.log`：...
+- `mxu-tauri.log`：...
+- `mxu-web-*.log`：...
+- `mxu-agent.log` / `on_error`：...
+- 代码依据：如需指向具体实现，直接附远端 GitHub 行号链接
+
+
+### DMP 崩溃分析
 
 （仅当 issue 存在 .dmp 文件时输出此区域。如果没有 .dmp 文件，删除整个区域。）
 
@@ -358,7 +370,7 @@ description: 分析 MaaEnd 上游仓库公开 Issue（`https://github.com/MaaEnd
 - 崩溃模块：`<module_name>+<offset>`
 - 符号化状态：已符号化 / 仅 module+offset（原因：...）
 
-### 崩溃堆栈（crashing thread 全部有效帧，禁止省略）
+#### 崩溃堆栈（crashing thread 全部有效帧，禁止省略）
 
 ```
 Frame 0: <module>+<offset>  [或 <function> at <file>:<line>]
@@ -370,7 +382,7 @@ Frame 2: ...
 （如果符号化成功且帧涉及 MaaFramework 或 MXU，在每个相关帧后面附上游源码链接：）
 - Frame N: `<function>` → <https://github.com/MaaXYZ/MaaFramework/blob/v5.x.x/src/...#L123>
 
-### 关键模块
+#### 关键模块
 
 | Module | Base | Size |
 |--------|------|------|
@@ -378,16 +390,6 @@ Frame 2: ...
 | MaaWin32ControlUnit.dll | ... | ... |
 | ... | ... | ... |
 
-## 关键证据
-
-<details><summary>点击此处展开</summary>
-
-- `maa.log`：...
-- `go-service.log`：...
-- `mxu-tauri.log`：...
-- `mxu-web-*.log`：...
-- `mxu-agent.log` / `on_error`：...
-- 代码依据：如需指向具体实现，直接附远端 GitHub 行号链接
 
 </details>
 

--- a/.github/workflows/issue-ai-analysis.yml
+++ b/.github/workflows/issue-ai-analysis.yml
@@ -26,6 +26,11 @@ jobs:
       contents: read
       issues: write
     steps:
+      - name: Install DMP analysis tools
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall -y --no-confirm minidump-stackwalk dump_syms
+
       # 这个 action 只负责编排，分析质量仍依赖配套的 issue/log analysis skill。
       # 详细使用文档：https://github.com/MistEO/ai-issue-analysis
       # 最佳实践参考：

--- a/.github/workflows/issue-ai-analysis.yml
+++ b/.github/workflows/issue-ai-analysis.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install DMP analysis tools
         run: |
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall -y --no-confirm minidump-stackwalk dump_syms
+          cargo binstall -y minidump-stackwalk dump_syms
 
       # 这个 action 只负责编排，分析质量仍依赖配套的 issue/log analysis skill。
       # 详细使用文档：https://github.com/MistEO/ai-issue-analysis


### PR DESCRIPTION
## Summary by Sourcery

添加专门的 Windows DMP 崩溃转储分析技能，并将其集成到 MaaEnd 的问题分析工作流中。

新功能：
- 引入新的 `.claude/skills/dmp-analysis` 技能，记录针对 MaaEnd 及其依赖项分析 Windows `.dmp` 崩溃转储的完整工作流程。
- 扩展 MaaEnd 问题日志分析技能，当存在 `.dmp` 文件时，要求并组织基于 DMP 的崩溃分析，包括一个专门用于 DMP 结果的输出部分。

增强：
- 在分析崩溃时，明确并强化关于完整 DMP 堆栈输出、符号化以及与上游源码交叉引用的更严格指引和提醒。

构建：
- 更新 `issue-ai-analysis` GitHub Actions 工作流，以安装自动化 DMP 分析所需的 `minidump-stackwalk` 和 `dump_syms` 工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a dedicated Windows DMP crash-dump analysis skill and integrate it into the MaaEnd issue analysis workflow.

New Features:
- Introduce a new `.claude/skills/dmp-analysis` skill that documents a full workflow for analyzing Windows `.dmp` crash dumps for MaaEnd and its dependencies.
- Extend the MaaEnd issue log analysis skill to require and structure DMP-based crash analysis when `.dmp` files are present, including a dedicated output section for DMP results.

Enhancements:
- Clarify and enforce stricter guidance and reminders around complete DMP stack output, symbolization, and cross-referencing with upstream source when analyzing crashes.

Build:
- Update the `issue-ai-analysis` GitHub Actions workflow to install `minidump-stackwalk` and `dump_syms` tools needed for automated DMP analysis.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加专门的 Windows DMP 崩溃转储分析技能，并将其集成到 MaaEnd 的问题分析工作流中。

新功能：
- 引入新的 `.claude/skills/dmp-analysis` 技能，记录针对 MaaEnd 及其依赖项分析 Windows `.dmp` 崩溃转储的完整工作流程。
- 扩展 MaaEnd 问题日志分析技能，当存在 `.dmp` 文件时，要求并组织基于 DMP 的崩溃分析，包括一个专门用于 DMP 结果的输出部分。

增强：
- 在分析崩溃时，明确并强化关于完整 DMP 堆栈输出、符号化以及与上游源码交叉引用的更严格指引和提醒。

构建：
- 更新 `issue-ai-analysis` GitHub Actions 工作流，以安装自动化 DMP 分析所需的 `minidump-stackwalk` 和 `dump_syms` 工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a dedicated Windows DMP crash-dump analysis skill and integrate it into the MaaEnd issue analysis workflow.

New Features:
- Introduce a new `.claude/skills/dmp-analysis` skill that documents a full workflow for analyzing Windows `.dmp` crash dumps for MaaEnd and its dependencies.
- Extend the MaaEnd issue log analysis skill to require and structure DMP-based crash analysis when `.dmp` files are present, including a dedicated output section for DMP results.

Enhancements:
- Clarify and enforce stricter guidance and reminders around complete DMP stack output, symbolization, and cross-referencing with upstream source when analyzing crashes.

Build:
- Update the `issue-ai-analysis` GitHub Actions workflow to install `minidump-stackwalk` and `dump_syms` tools needed for automated DMP analysis.

</details>

</details>