### PR TITLE
fix(SellProduct): 修复设置优先售卖柑实罐头会选择优质柑实罐头导致卖不了柑实罐头的问题

### DIFF
--- a/assets/resource/pipeline/SellProduct/ChangeGoods.json
+++ b/assets/resource/pipeline/SellProduct/ChangeGoods.json
@@ -40,6 +40,15 @@
         "all_of": [
             "SellProductCheckSelectGoodsText"
         ],
+        "pre_wait_freezes": {
+            "time": 80,
+            "target": [
+                145,
+                103,
+                998,
+                518
+            ]
+        },
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/tasks/SellProduct.json
+++ b/assets/tasks/SellProduct.json
@@ -197,11 +197,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -213,11 +213,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -229,11 +229,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -245,11 +245,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -261,11 +261,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -277,11 +277,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -293,11 +293,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "蕎癒膠囊",
-                                "荞愈胶囊",
-                                "蕎花カプセルⅠ",
-                                "메밀꽃 치유 캡슐",
-                                "Buck Capsule [C]"
+                                "^蕎癒膠囊$",
+                                "^荞愈胶囊$",
+                                "^蕎花カプセルⅠ$",
+                                "^메밀꽃 치유 캡슐$",
+                                "^Buck Capsule [C]$"
                             ]
                         }
                     },
@@ -309,11 +309,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -325,11 +325,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "紫晶質瓶",
-                                "紫晶质瓶",
-                                "紫晶製ボトル",
-                                "자수정 병",
-                                "Amethyst Bottle"
+                                "^紫晶質瓶$",
+                                "^紫晶质瓶$",
+                                "^紫晶製ボトル$",
+                                "^자수정 병$",
+                                "^Amethyst Bottle$"
                             ]
                         }
                     },
@@ -341,11 +341,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "晶體外殼",
-                                "晶体外壳",
-                                "結晶外殻",
-                                "오리고 크러스트",
-                                "Origocrust"
+                                "^晶體外殼$",
+                                "^晶体外壳$",
+                                "^結晶外殻$",
+                                "^오리고 크러스트$",
+                                "^Origocrust$"
                             ]
                         }
                     },
@@ -357,11 +357,11 @@
                         "SellProductRefugeeCampSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "紫晶零件",
-                                "紫晶零件",
-                                "紫晶部品",
-                                "자수정 부품",
-                                "Amethyst Part"
+                                "^紫晶零件$",
+                                "^紫晶零件$",
+                                "^紫晶部品$",
+                                "^자수정 부품$",
+                                "^Amethyst Part$"
                             ]
                         }
                     },
@@ -388,11 +388,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -404,11 +404,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -420,11 +420,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -436,11 +436,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -452,11 +452,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -468,11 +468,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -484,11 +484,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "蕎癒膠囊",
-                                "荞愈胶囊",
-                                "蕎花カプセルⅠ",
-                                "메밀꽃 치유 캡슐",
-                                "Buck Capsule [C]"
+                                "^蕎癒膠囊$",
+                                "^荞愈胶囊$",
+                                "^蕎花カプセルⅠ$",
+                                "^메밀꽃 치유 캡슐$",
+                                "^Buck Capsule [C]$"
                             ]
                         }
                     },
@@ -500,11 +500,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -516,11 +516,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "紫晶質瓶",
-                                "紫晶质瓶",
-                                "紫晶製ボトル",
-                                "자수정 병",
-                                "Amethyst Bottle"
+                                "^紫晶質瓶$",
+                                "^紫晶质瓶$",
+                                "^紫晶製ボトル$",
+                                "^자수정 병$",
+                                "^Amethyst Bottle$"
                             ]
                         }
                     },
@@ -532,11 +532,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "晶體外殼",
-                                "晶体外壳",
-                                "結晶外殻",
-                                "오리고 크러스트",
-                                "Origocrust"
+                                "^晶體外殼$",
+                                "^晶体外壳$",
+                                "^結晶外殻$",
+                                "^오리고 크러스트$",
+                                "^Origocrust$"
                             ]
                         }
                     },
@@ -548,11 +548,11 @@
                         "SellProductRefugeeCampSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "紫晶零件",
-                                "紫晶零件",
-                                "紫晶部品",
-                                "자수정 부품",
-                                "Amethyst Part"
+                                "^紫晶零件$",
+                                "^紫晶零件$",
+                                "^紫晶部品$",
+                                "^자수정 부품$",
+                                "^Amethyst Part$"
                             ]
                         }
                     },
@@ -579,11 +579,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -595,11 +595,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -611,11 +611,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -627,11 +627,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -643,11 +643,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -659,11 +659,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -675,11 +675,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "蕎癒膠囊",
-                                "荞愈胶囊",
-                                "蕎花カプセルⅠ",
-                                "메밀꽃 치유 캡슐",
-                                "Buck Capsule [C]"
+                                "^蕎癒膠囊$",
+                                "^荞愈胶囊$",
+                                "^蕎花カプセルⅠ$",
+                                "^메밀꽃 치유 캡슐$",
+                                "^Buck Capsule [C]$"
                             ]
                         }
                     },
@@ -691,11 +691,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -707,11 +707,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "紫晶質瓶",
-                                "紫晶质瓶",
-                                "紫晶製ボトル",
-                                "자수정 병",
-                                "Amethyst Bottle"
+                                "^紫晶質瓶$",
+                                "^紫晶质瓶$",
+                                "^紫晶製ボトル$",
+                                "^자수정 병$",
+                                "^Amethyst Bottle$"
                             ]
                         }
                     },
@@ -723,11 +723,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "晶體外殼",
-                                "晶体外壳",
-                                "結晶外殻",
-                                "오리고 크러스트",
-                                "Origocrust"
+                                "^晶體外殼$",
+                                "^晶体外壳$",
+                                "^結晶外殻$",
+                                "^오리고 크러스트$",
+                                "^Origocrust$"
                             ]
                         }
                     },
@@ -739,11 +739,11 @@
                         "SellProductRefugeeCampSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "紫晶零件",
-                                "紫晶零件",
-                                "紫晶部品",
-                                "자수정 부품",
-                                "Amethyst Part"
+                                "^紫晶零件$",
+                                "^紫晶零件$",
+                                "^紫晶部品$",
+                                "^자수정 부품$",
+                                "^Amethyst Part$"
                             ]
                         }
                     },
@@ -770,11 +770,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -786,11 +786,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -802,11 +802,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -818,11 +818,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -834,11 +834,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -850,11 +850,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -866,11 +866,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "蕎癒膠囊",
-                                "荞愈胶囊",
-                                "蕎花カプセルⅠ",
-                                "메밀꽃 치유 캡슐",
-                                "Buck Capsule [C]"
+                                "^蕎癒膠囊$",
+                                "^荞愈胶囊$",
+                                "^蕎花カプセルⅠ$",
+                                "^메밀꽃 치유 캡슐$",
+                                "^Buck Capsule [C]$"
                             ]
                         }
                     },
@@ -882,11 +882,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -898,11 +898,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "紫晶質瓶",
-                                "紫晶质瓶",
-                                "紫晶製ボトル",
-                                "자수정 병",
-                                "Amethyst Bottle"
+                                "^紫晶質瓶$",
+                                "^紫晶质瓶$",
+                                "^紫晶製ボトル$",
+                                "^자수정 병$",
+                                "^Amethyst Bottle$"
                             ]
                         }
                     },
@@ -914,11 +914,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "晶體外殼",
-                                "晶体外壳",
-                                "結晶外殻",
-                                "오리고 크러스트",
-                                "Origocrust"
+                                "^晶體外殼$",
+                                "^晶体外壳$",
+                                "^結晶外殻$",
+                                "^오리고 크러스트$",
+                                "^Origocrust$"
                             ]
                         }
                     },
@@ -930,11 +930,11 @@
                         "SellProductRefugeeCampSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "紫晶零件",
-                                "紫晶零件",
-                                "紫晶部品",
-                                "자수정 부품",
-                                "Amethyst Part"
+                                "^紫晶零件$",
+                                "^紫晶零件$",
+                                "^紫晶部品$",
+                                "^자수정 부품$",
+                                "^Amethyst Part$"
                             ]
                         }
                     },
@@ -1095,11 +1095,11 @@
                         "SellProductInfrastructureOutpostSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -1111,11 +1111,11 @@
                         "SellProductInfrastructureOutpostSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -1127,11 +1127,11 @@
                         "SellProductInfrastructureOutpostSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -1143,11 +1143,11 @@
                         "SellProductInfrastructureOutpostSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -1159,11 +1159,11 @@
                         "SellProductInfrastructureOutpostSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -1175,11 +1175,11 @@
                         "SellProductInfrastructureOutpostSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -1191,11 +1191,11 @@
                         "SellProductInfrastructureOutpostSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "低容量谷地電池",
-                                "低容谷地电池",
-                                "小容量谷地バッテリー",
-                                "저용량 협곡 배터리",
-                                "LC Valley Battery"
+                                "^低容量谷地電池$",
+                                "^低容谷地电池$",
+                                "^小容量谷地バッテリー$",
+                                "^저용량 협곡 배터리$",
+                                "^LC Valley Battery$"
                             ]
                         }
                     },
@@ -1207,11 +1207,11 @@
                         "SellProductInfrastructureOutpostSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -1223,11 +1223,11 @@
                         "SellProductInfrastructureOutpostSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "鐵製零件",
-                                "铁制零件",
-                                "鉄製部品",
-                                "페리움 부품",
-                                "Ferrium Part"
+                                "^鐵製零件$",
+                                "^铁制零件$",
+                                "^鉄製部品$",
+                                "^페리움 부품$",
+                                "^Ferrium Part$"
                             ]
                         }
                     },
@@ -1254,11 +1254,11 @@
                         "SellProductInfrastructureOutpostSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -1270,11 +1270,11 @@
                         "SellProductInfrastructureOutpostSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -1286,11 +1286,11 @@
                         "SellProductInfrastructureOutpostSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -1302,11 +1302,11 @@
                         "SellProductInfrastructureOutpostSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -1318,11 +1318,11 @@
                         "SellProductInfrastructureOutpostSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -1334,11 +1334,11 @@
                         "SellProductInfrastructureOutpostSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -1350,11 +1350,11 @@
                         "SellProductInfrastructureOutpostSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "低容量谷地電池",
-                                "低容谷地电池",
-                                "小容量谷地バッテリー",
-                                "저용량 협곡 배터리",
-                                "LC Valley Battery"
+                                "^低容量谷地電池$",
+                                "^低容谷地电池$",
+                                "^小容量谷地バッテリー$",
+                                "^저용량 협곡 배터리$",
+                                "^LC Valley Battery$"
                             ]
                         }
                     },
@@ -1366,11 +1366,11 @@
                         "SellProductInfrastructureOutpostSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -1382,11 +1382,11 @@
                         "SellProductInfrastructureOutpostSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "鐵製零件",
-                                "铁制零件",
-                                "鉄製部品",
-                                "페리움 부품",
-                                "Ferrium Part"
+                                "^鐵製零件$",
+                                "^铁制零件$",
+                                "^鉄製部品$",
+                                "^페리움 부품$",
+                                "^Ferrium Part$"
                             ]
                         }
                     },
@@ -1413,11 +1413,11 @@
                         "SellProductInfrastructureOutpostSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -1429,11 +1429,11 @@
                         "SellProductInfrastructureOutpostSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -1445,11 +1445,11 @@
                         "SellProductInfrastructureOutpostSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -1461,11 +1461,11 @@
                         "SellProductInfrastructureOutpostSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -1477,11 +1477,11 @@
                         "SellProductInfrastructureOutpostSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -1493,11 +1493,11 @@
                         "SellProductInfrastructureOutpostSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -1509,11 +1509,11 @@
                         "SellProductInfrastructureOutpostSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "低容量谷地電池",
-                                "低容谷地电池",
-                                "小容量谷地バッテリー",
-                                "저용량 협곡 배터리",
-                                "LC Valley Battery"
+                                "^低容量谷地電池$",
+                                "^低容谷地电池$",
+                                "^小容量谷地バッテリー$",
+                                "^저용량 협곡 배터리$",
+                                "^LC Valley Battery$"
                             ]
                         }
                     },
@@ -1525,11 +1525,11 @@
                         "SellProductInfrastructureOutpostSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -1541,11 +1541,11 @@
                         "SellProductInfrastructureOutpostSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "鐵製零件",
-                                "铁制零件",
-                                "鉄製部品",
-                                "페리움 부품",
-                                "Ferrium Part"
+                                "^鐵製零件$",
+                                "^铁制零件$",
+                                "^鉄製部品$",
+                                "^페리움 부품$",
+                                "^Ferrium Part$"
                             ]
                         }
                     },
@@ -1572,11 +1572,11 @@
                         "SellProductInfrastructureOutpostSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -1588,11 +1588,11 @@
                         "SellProductInfrastructureOutpostSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -1604,11 +1604,11 @@
                         "SellProductInfrastructureOutpostSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -1620,11 +1620,11 @@
                         "SellProductInfrastructureOutpostSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -1636,11 +1636,11 @@
                         "SellProductInfrastructureOutpostSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -1652,11 +1652,11 @@
                         "SellProductInfrastructureOutpostSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -1668,11 +1668,11 @@
                         "SellProductInfrastructureOutpostSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "低容量谷地電池",
-                                "低容谷地电池",
-                                "小容量谷地バッテリー",
-                                "저용량 협곡 배터리",
-                                "LC Valley Battery"
+                                "^低容量谷地電池$",
+                                "^低容谷地电池$",
+                                "^小容量谷地バッテリー$",
+                                "^저용량 협곡 배터리$",
+                                "^LC Valley Battery$"
                             ]
                         }
                     },
@@ -1684,11 +1684,11 @@
                         "SellProductInfrastructureOutpostSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -1700,11 +1700,11 @@
                         "SellProductInfrastructureOutpostSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "鐵製零件",
-                                "铁制零件",
-                                "鉄製部品",
-                                "페리움 부품",
-                                "Ferrium Part"
+                                "^鐵製零件$",
+                                "^铁制零件$",
+                                "^鉄製部品$",
+                                "^페리움 부품$",
+                                "^Ferrium Part$"
                             ]
                         }
                     },
@@ -1865,11 +1865,11 @@
                         "SellProductReconstructionCommandSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -1881,11 +1881,11 @@
                         "SellProductReconstructionCommandSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -1897,11 +1897,11 @@
                         "SellProductReconstructionCommandSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -1913,11 +1913,11 @@
                         "SellProductReconstructionCommandSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -1929,11 +1929,11 @@
                         "SellProductReconstructionCommandSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -1945,11 +1945,11 @@
                         "SellProductReconstructionCommandSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -1961,11 +1961,11 @@
                         "SellProductReconstructionCommandSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -1977,11 +1977,11 @@
                         "SellProductReconstructionCommandSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "鐵製零件",
-                                "铁制零件",
-                                "鉄製部品",
-                                "페리움 부품",
-                                "Ferrium Part"
+                                "^鐵製零件$",
+                                "^铁制零件$",
+                                "^鉄製部品$",
+                                "^페리움 부품$",
+                                "^Ferrium Part$"
                             ]
                         }
                     },
@@ -2008,11 +2008,11 @@
                         "SellProductReconstructionCommandSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -2024,11 +2024,11 @@
                         "SellProductReconstructionCommandSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -2040,11 +2040,11 @@
                         "SellProductReconstructionCommandSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -2056,11 +2056,11 @@
                         "SellProductReconstructionCommandSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -2072,11 +2072,11 @@
                         "SellProductReconstructionCommandSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -2088,11 +2088,11 @@
                         "SellProductReconstructionCommandSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -2104,11 +2104,11 @@
                         "SellProductReconstructionCommandSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -2120,11 +2120,11 @@
                         "SellProductReconstructionCommandSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "鐵製零件",
-                                "铁制零件",
-                                "鉄製部品",
-                                "페리움 부품",
-                                "Ferrium Part"
+                                "^鐵製零件$",
+                                "^铁制零件$",
+                                "^鉄製部品$",
+                                "^페리움 부품$",
+                                "^Ferrium Part$"
                             ]
                         }
                     },
@@ -2151,11 +2151,11 @@
                         "SellProductReconstructionCommandSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -2167,11 +2167,11 @@
                         "SellProductReconstructionCommandSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -2183,11 +2183,11 @@
                         "SellProductReconstructionCommandSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -2199,11 +2199,11 @@
                         "SellProductReconstructionCommandSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -2215,11 +2215,11 @@
                         "SellProductReconstructionCommandSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -2231,11 +2231,11 @@
                         "SellProductReconstructionCommandSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -2247,11 +2247,11 @@
                         "SellProductReconstructionCommandSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -2263,11 +2263,11 @@
                         "SellProductReconstructionCommandSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "鐵製零件",
-                                "铁制零件",
-                                "鉄製部品",
-                                "페리움 부품",
-                                "Ferrium Part"
+                                "^鐵製零件$",
+                                "^铁制零件$",
+                                "^鉄製部品$",
+                                "^페리움 부품$",
+                                "^Ferrium Part$"
                             ]
                         }
                     },
@@ -2294,11 +2294,11 @@
                         "SellProductReconstructionCommandSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "精選蕎癒膠囊",
-                                "精选荞愈胶囊",
-                                "蕎花カプセルⅢ",
-                                "메밀꽃 치유 캡슐(대)",
-                                "Buck Capsule [A]"
+                                "^精選蕎癒膠囊$",
+                                "^精选荞愈胶囊$",
+                                "^蕎花カプセルⅢ$",
+                                "^메밀꽃 치유 캡슐(대)$",
+                                "^Buck Capsule [A]$"
                             ]
                         }
                     },
@@ -2310,11 +2310,11 @@
                         "SellProductReconstructionCommandSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "高容量谷地電池",
-                                "高容谷地电池",
-                                "大容量谷地バッテリー",
-                                "대용량 협곡 배터리",
-                                "HC Valley Battery"
+                                "^高容量谷地電池$",
+                                "^高容谷地电池$",
+                                "^大容量谷地バッテリー$",
+                                "^대용량 협곡 배터리$",
+                                "^HC Valley Battery$"
                             ]
                         }
                     },
@@ -2326,11 +2326,11 @@
                         "SellProductReconstructionCommandSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "精選柑實罐頭",
-                                "精选柑实罐头",
-                                "シトロームの缶詰Ⅲ",
-                                "시트론 통조림(대)",
-                                "Canned Citrome [A]"
+                                "^精選柑實罐頭$",
+                                "^精选柑实罐头$",
+                                "^シトロームの缶詰Ⅲ$",
+                                "^시트론 통조림(대)$",
+                                "^Canned Citrome [A]$"
                             ]
                         }
                     },
@@ -2342,11 +2342,11 @@
                         "SellProductReconstructionCommandSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "中容量谷地電池",
-                                "中容谷地电池",
-                                "中容量谷地バッテリー",
-                                "중용량 협곡 배터리",
-                                "SC Valley Battery"
+                                "^中容量谷地電池$",
+                                "^中容谷地电池$",
+                                "^中容量谷地バッテリー$",
+                                "^중용량 협곡 배터리$",
+                                "^SC Valley Battery$"
                             ]
                         }
                     },
@@ -2358,11 +2358,11 @@
                         "SellProductReconstructionCommandSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "優質柑實罐頭",
-                                "优质柑实罐头",
-                                "シトロームの缶詰Ⅱ",
-                                "시트론 통조림(중)",
-                                "Canned Citrome [B]"
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^시트론 통조림(중)$",
+                                "^Canned Citrome [B]$"
                             ]
                         }
                     },
@@ -2374,11 +2374,11 @@
                         "SellProductReconstructionCommandSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "優質蕎癒膠囊",
-                                "优质荞愈胶囊",
-                                "蕎花カプセルⅡ",
-                                "메밀꽃 치유 캡슐(중)",
-                                "Buck Capsule [B]"
+                                "^優質蕎癒膠囊$",
+                                "^优质荞愈胶囊$",
+                                "^蕎花カプセルⅡ$",
+                                "^메밀꽃 치유 캡슐(중)$",
+                                "^Buck Capsule [B]$"
                             ]
                         }
                     },
@@ -2390,11 +2390,11 @@
                         "SellProductReconstructionCommandSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "柑實罐頭",
-                                "柑实罐头",
-                                "シトロームの缶詰Ⅰ",
-                                "시트론 통조림",
-                                "Canned Citrome [C]"
+                                "^柑實罐頭$",
+                                "^柑实罐头$",
+                                "^シトロームの缶詰Ⅰ$",
+                                "^시트론 통조림$",
+                                "^Canned Citrome [C]$"
                             ]
                         }
                     },
@@ -2406,11 +2406,11 @@
                         "SellProductReconstructionCommandSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "鐵製零件",
-                                "铁制零件",
-                                "鉄製部品",
-                                "페리움 부품",
-                                "Ferrium Part"
+                                "^鐵製零件$",
+                                "^铁制零件$",
+                                "^鉄製部品$",
+                                "^페리움 부품$",
+                                "^Ferrium Part$"
                             ]
                         }
                     },
@@ -2598,11 +2598,11 @@
                         "SellProductSkyKingFlatsSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "中容武陵电池",
-                                "中容量武陵電池",
-                                "SC Wuling Battery",
-                                "中容量武陵バッテリー",
-                                "중용량 무릉 배터리"
+                                "^中容武陵电池$",
+                                "^中容量武陵電池$",
+                                "^SC Wuling Battery$",
+                                "^中容量武陵バッテリー$",
+                                "^중용량 무릉 배터리$"
                             ]
                         }
                     },
@@ -2614,11 +2614,11 @@
                         "SellProductSkyKingFlatsSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "优质芽针针剂",
-                                "優質芽針針劑",
-                                "Yazhen Syringe [A]",
-                                "芽針注射剤Ⅱ",
-                                "고급 야침 주사약"
+                                "^优质芽针针剂$",
+                                "^優質芽針針劑$",
+                                "^Yazhen Syringe [A]$",
+                                "^芽針注射剤Ⅱ$",
+                                "^고급 야침 주사약$"
                             ]
                         }
                     },
@@ -2630,11 +2630,11 @@
                         "SellProductSkyKingFlatsSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "低容量武陵電池",
-                                "低容武陵电池",
-                                "低容量武陵電池",
-                                "저용량 무릉 배터리",
-                                "LC Wuling Battery"
+                                "^低容量武陵電池$",
+                                "^低容武陵电池$",
+                                "^低容量武陵電池$",
+                                "^저용량 무릉 배터리$",
+                                "^LC Wuling Battery$"
                             ]
                         }
                     },
@@ -2646,11 +2646,11 @@
                         "SellProductSkyKingFlatsSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "芽針針劑",
-                                "芽针针剂",
-                                "芽針注射剤Ⅰ",
-                                "야침 주사약",
-                                "Yazhen Syringe [C]"
+                                "^芽針針劑$",
+                                "^芽针针剂$",
+                                "^芽針注射剤Ⅰ$",
+                                "^야침 주사약$",
+                                "^Yazhen Syringe [C]$"
                             ]
                         }
                     },
@@ -2662,11 +2662,11 @@
                         "SellProductSkyKingFlatsSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "錦草飲料",
-                                "锦草软饮",
-                                "錦草ソーダⅠ",
-                                "금초 청량음료",
-                                "Jincao Drink"
+                                "^錦草飲料$",
+                                "^锦草软饮$",
+                                "^錦草ソーダⅠ$",
+                                "^금초 청량음료$",
+                                "^Jincao Drink$"
                             ]
                         }
                     },
@@ -2678,11 +2678,11 @@
                         "SellProductSkyKingFlatsSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "赤铜零件",
-                                "赤銅零件",
-                                "Cuprium Part",
-                                "赤銅部品",
-                                "적동 부품"
+                                "^赤铜零件$",
+                                "^赤銅零件$",
+                                "^Cuprium Part$",
+                                "^赤銅部品$",
+                                "^적동 부품$"
                             ]
                         }
                     },
@@ -2694,11 +2694,11 @@
                         "SellProductSkyKingFlatsSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "息壤",
-                                "息壤",
-                                "息壤",
-                                "식양",
-                                "Xiranite"
+                                "^息壤$",
+                                "^息壤$",
+                                "^息壤$",
+                                "^식양$",
+                                "^Xiranite$"
                             ]
                         }
                     },
@@ -2725,11 +2725,11 @@
                         "SellProductSkyKingFlatsSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "中容武陵电池",
-                                "中容量武陵電池",
-                                "SC Wuling Battery",
-                                "中容量武陵バッテリー",
-                                "중용량 무릉 배터리"
+                                "^中容武陵电池$",
+                                "^中容量武陵電池$",
+                                "^SC Wuling Battery$",
+                                "^中容量武陵バッテリー$",
+                                "^중용량 무릉 배터리$"
                             ]
                         }
                     },
@@ -2741,11 +2741,11 @@
                         "SellProductSkyKingFlatsSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "优质芽针针剂",
-                                "優質芽針針劑",
-                                "Yazhen Syringe [A]",
-                                "芽針注射剤Ⅱ",
-                                "고급 야침 주사약"
+                                "^优质芽针针剂$",
+                                "^優質芽針針劑$",
+                                "^Yazhen Syringe [A]$",
+                                "^芽針注射剤Ⅱ$",
+                                "^고급 야침 주사약$"
                             ]
                         }
                     },
@@ -2757,11 +2757,11 @@
                         "SellProductSkyKingFlatsSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "低容量武陵電池",
-                                "低容武陵电池",
-                                "低容量武陵電池",
-                                "저용량 무릉 배터리",
-                                "LC Wuling Battery"
+                                "^低容量武陵電池$",
+                                "^低容武陵电池$",
+                                "^低容量武陵電池$",
+                                "^저용량 무릉 배터리$",
+                                "^LC Wuling Battery$"
                             ]
                         }
                     },
@@ -2773,11 +2773,11 @@
                         "SellProductSkyKingFlatsSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "芽針針劑",
-                                "芽针针剂",
-                                "芽針注射剤Ⅰ",
-                                "야침 주사약",
-                                "Yazhen Syringe [C]"
+                                "^芽針針劑$",
+                                "^芽针针剂$",
+                                "^芽針注射剤Ⅰ$",
+                                "^야침 주사약$",
+                                "^Yazhen Syringe [C]$"
                             ]
                         }
                     },
@@ -2789,11 +2789,11 @@
                         "SellProductSkyKingFlatsSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "錦草飲料",
-                                "锦草软饮",
-                                "錦草ソーダⅠ",
-                                "금초 청량음료",
-                                "Jincao Drink"
+                                "^錦草飲料$",
+                                "^锦草软饮$",
+                                "^錦草ソーダⅠ$",
+                                "^금초 청량음료$",
+                                "^Jincao Drink$"
                             ]
                         }
                     },
@@ -2805,11 +2805,11 @@
                         "SellProductSkyKingFlatsSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "赤铜零件",
-                                "赤銅零件",
-                                "Cuprium Part",
-                                "赤銅部品",
-                                "적동 부품"
+                                "^赤铜零件$",
+                                "^赤銅零件$",
+                                "^Cuprium Part$",
+                                "^赤銅部品$",
+                                "^적동 부품$"
                             ]
                         }
                     },
@@ -2821,11 +2821,11 @@
                         "SellProductSkyKingFlatsSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "息壤",
-                                "息壤",
-                                "息壤",
-                                "식양",
-                                "Xiranite"
+                                "^息壤$",
+                                "^息壤$",
+                                "^息壤$",
+                                "^식양$",
+                                "^Xiranite$"
                             ]
                         }
                     },
@@ -2852,11 +2852,11 @@
                         "SellProductSkyKingFlatsSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "中容武陵电池",
-                                "中容量武陵電池",
-                                "SC Wuling Battery",
-                                "中容量武陵バッテリー",
-                                "중용량 무릉 배터리"
+                                "^中容武陵电池$",
+                                "^中容量武陵電池$",
+                                "^SC Wuling Battery$",
+                                "^中容量武陵バッテリー$",
+                                "^중용량 무릉 배터리$"
                             ]
                         }
                     },
@@ -2868,11 +2868,11 @@
                         "SellProductSkyKingFlatsSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "优质芽针针剂",
-                                "優質芽針針劑",
-                                "Yazhen Syringe [A]",
-                                "芽針注射剤Ⅱ",
-                                "고급 야침 주사약"
+                                "^优质芽针针剂$",
+                                "^優質芽針針劑$",
+                                "^Yazhen Syringe [A]$",
+                                "^芽針注射剤Ⅱ$",
+                                "^고급 야침 주사약$"
                             ]
                         }
                     },
@@ -2884,11 +2884,11 @@
                         "SellProductSkyKingFlatsSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "低容量武陵電池",
-                                "低容武陵电池",
-                                "低容量武陵電池",
-                                "저용량 무릉 배터리",
-                                "LC Wuling Battery"
+                                "^低容量武陵電池$",
+                                "^低容武陵电池$",
+                                "^低容量武陵電池$",
+                                "^저용량 무릉 배터리$",
+                                "^LC Wuling Battery$"
                             ]
                         }
                     },
@@ -2900,11 +2900,11 @@
                         "SellProductSkyKingFlatsSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "芽針針劑",
-                                "芽针针剂",
-                                "芽針注射剤Ⅰ",
-                                "야침 주사약",
-                                "Yazhen Syringe [C]"
+                                "^芽針針劑$",
+                                "^芽针针剂$",
+                                "^芽針注射剤Ⅰ$",
+                                "^야침 주사약$",
+                                "^Yazhen Syringe [C]$"
                             ]
                         }
                     },
@@ -2916,11 +2916,11 @@
                         "SellProductSkyKingFlatsSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "錦草飲料",
-                                "锦草软饮",
-                                "錦草ソーダⅠ",
-                                "금초 청량음료",
-                                "Jincao Drink"
+                                "^錦草飲料$",
+                                "^锦草软饮$",
+                                "^錦草ソーダⅠ$",
+                                "^금초 청량음료$",
+                                "^Jincao Drink$"
                             ]
                         }
                     },
@@ -2932,11 +2932,11 @@
                         "SellProductSkyKingFlatsSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "赤铜零件",
-                                "赤銅零件",
-                                "Cuprum Part",
-                                "赤銅部品",
-                                "적동 부품"
+                                "^赤铜零件$",
+                                "^赤銅零件$",
+                                "^Cuprum Part$",
+                                "^赤銅部品$",
+                                "^적동 부품$"
                             ]
                         }
                     },
@@ -2948,11 +2948,11 @@
                         "SellProductSkyKingFlatsSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "息壤",
-                                "息壤",
-                                "息壤",
-                                "식양",
-                                "Xiranite"
+                                "^息壤$",
+                                "^息壤$",
+                                "^息壤$",
+                                "^식양$",
+                                "^Xiranite$"
                             ]
                         }
                     },
@@ -2979,11 +2979,11 @@
                         "SellProductSkyKingFlatsSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "中容武陵电池",
-                                "中容量武陵電池",
-                                "SC Wuling Battery",
-                                "中容量武陵バッテリー",
-                                "중용량 무릉 배터리"
+                                "^中容武陵电池$",
+                                "^中容量武陵電池$",
+                                "^SC Wuling Battery$",
+                                "^中容量武陵バッテリー$",
+                                "^중용량 무릉 배터리$"
                             ]
                         }
                     },
@@ -2995,11 +2995,11 @@
                         "SellProductSkyKingFlatsSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "优质芽针针剂",
-                                "優質芽針針劑",
-                                "Yazhen Syringe [A]",
-                                "芽針注射剤Ⅱ",
-                                "고급 야침 주사약"
+                                "^优质芽针针剂$",
+                                "^優質芽針針劑$",
+                                "^Yazhen Syringe [A]$",
+                                "^芽針注射剤Ⅱ$",
+                                "^고급 야침 주사약$"
                             ]
                         }
                     },
@@ -3011,11 +3011,11 @@
                         "SellProductSkyKingFlatsSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "低容量武陵電池",
-                                "低容武陵电池",
-                                "低容量武陵電池",
-                                "저용량 무릉 배터리",
-                                "LC Wuling Battery"
+                                "^低容量武陵電池$",
+                                "^低容武陵电池$",
+                                "^低容量武陵電池$",
+                                "^저용량 무릉 배터리$",
+                                "^LC Wuling Battery$"
                             ]
                         }
                     },
@@ -3027,11 +3027,11 @@
                         "SellProductSkyKingFlatsSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "芽針針劑",
-                                "芽针针剂",
-                                "芽針注射剤Ⅰ",
-                                "야침 주사약",
-                                "Yazhen Syringe [C]"
+                                "^芽針針劑$",
+                                "^芽针针剂$",
+                                "^芽針注射剤Ⅰ$",
+                                "^야침 주사약$",
+                                "^Yazhen Syringe [C]$"
                             ]
                         }
                     },
@@ -3043,11 +3043,11 @@
                         "SellProductSkyKingFlatsSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "錦草飲料",
-                                "锦草软饮",
-                                "錦草ソーダⅠ",
-                                "금초 청량음료",
-                                "Jincao Drink"
+                                "^錦草飲料$",
+                                "^锦草软饮$",
+                                "^錦草ソーダⅠ$",
+                                "^금초 청량음료$",
+                                "^Jincao Drink$"
                             ]
                         }
                     },
@@ -3059,11 +3059,11 @@
                         "SellProductSkyKingFlatsSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "赤铜零件",
-                                "赤銅零件",
-                                "Cuprum Part",
-                                "赤銅部品",
-                                "적동 부품"
+                                "^赤铜零件$",
+                                "^赤銅零件$",
+                                "^Cuprum Part$",
+                                "^赤銅部品$",
+                                "^적동 부품$"
                             ]
                         }
                     },
@@ -3075,11 +3075,11 @@
                         "SellProductSkyKingFlatsSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "息壤",
-                                "息壤",
-                                "息壤",
-                                "식양",
-                                "Xiranite"
+                                "^息壤$",
+                                "^息壤$",
+                                "^息壤$",
+                                "^식양$",
+                                "^Xiranite$"
                             ]
                         }
                     },

--- a/assets/tasks/SellProduct.json
+++ b/assets/tasks/SellProduct.json
@@ -44,6 +44,34 @@
                 }
             ]
         },
+        "WulingSell": {
+            "type": "switch",
+            "label": "$global.region.Wuling",
+            "description": "$task.SellProduct.regionToggleDescription",
+            "default_case": "Yes",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "SellProductWuling": {
+                            "enabled": true
+                        }
+                    },
+                    "option": [
+                        "WulingSkyKingFlats"
+                    ]
+                },
+                {
+                    "name": "No",
+                    "pipeline_override": {
+                        "SellProductWuling": {
+                            "enabled": false
+                        }
+                    }
+                }
+            ]
+        },
+        // ===== 售卖点开关 =====
         "ValleyIVRefugeeCamp": {
             "type": "switch",
             "label": "$task.SellProduct.ValleyIVRefugeeCamp",
@@ -73,6 +101,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 1（默认开启，含描述） =====
         "ValleyIVRefugeeCampAttempt1": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt1",
@@ -100,6 +129,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 2（默认开启） =====
         "ValleyIVRefugeeCampAttempt2": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt2",
@@ -126,6 +156,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 3（默认关闭） =====
         "ValleyIVRefugeeCampAttempt3": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt3",
@@ -152,6 +183,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 4（默认关闭） =====
         "ValleyIVRefugeeCampAttempt4": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt4",
@@ -178,6 +210,7 @@
                 }
             ]
         },
+        // ===== 优先物品选择 1-4 =====
         "ValleyIVRefugeeCampItem1": {
             "type": "select",
             "label": "$task.SellProduct.PriorityItem1",
@@ -200,7 +233,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -216,7 +248,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -232,7 +263,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -248,28 +278,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductRefugeeCampSelectItem1": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -280,12 +293,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductRefugeeCampSelectItem1": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "荞愈胶囊",
@@ -296,7 +323,6 @@
                                 "^蕎癒膠囊$",
                                 "^荞愈胶囊$",
                                 "^蕎花カプセルⅠ$",
-                                "^메밀꽃 치유 캡슐$",
                                 "^Buck Capsule [C]$"
                             ]
                         }
@@ -312,7 +338,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -328,7 +353,6 @@
                                 "^紫晶質瓶$",
                                 "^紫晶质瓶$",
                                 "^紫晶製ボトル$",
-                                "^자수정 병$",
                                 "^Amethyst Bottle$"
                             ]
                         }
@@ -344,7 +368,6 @@
                                 "^晶體外殼$",
                                 "^晶体外壳$",
                                 "^結晶外殻$",
-                                "^오리고 크러스트$",
                                 "^Origocrust$"
                             ]
                         }
@@ -360,7 +383,6 @@
                                 "^紫晶零件$",
                                 "^紫晶零件$",
                                 "^紫晶部品$",
-                                "^자수정 부품$",
                                 "^Amethyst Part$"
                             ]
                         }
@@ -391,7 +413,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -407,7 +428,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -423,7 +443,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -439,28 +458,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductRefugeeCampSelectItem2": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -471,12 +473,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductRefugeeCampSelectItem2": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "荞愈胶囊",
@@ -487,7 +503,6 @@
                                 "^蕎癒膠囊$",
                                 "^荞愈胶囊$",
                                 "^蕎花カプセルⅠ$",
-                                "^메밀꽃 치유 캡슐$",
                                 "^Buck Capsule [C]$"
                             ]
                         }
@@ -503,7 +518,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -519,7 +533,6 @@
                                 "^紫晶質瓶$",
                                 "^紫晶质瓶$",
                                 "^紫晶製ボトル$",
-                                "^자수정 병$",
                                 "^Amethyst Bottle$"
                             ]
                         }
@@ -535,7 +548,6 @@
                                 "^晶體外殼$",
                                 "^晶体外壳$",
                                 "^結晶外殻$",
-                                "^오리고 크러스트$",
                                 "^Origocrust$"
                             ]
                         }
@@ -551,7 +563,6 @@
                                 "^紫晶零件$",
                                 "^紫晶零件$",
                                 "^紫晶部品$",
-                                "^자수정 부품$",
                                 "^Amethyst Part$"
                             ]
                         }
@@ -582,7 +593,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -598,7 +608,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -614,7 +623,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -630,28 +638,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductRefugeeCampSelectItem3": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -662,12 +653,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductRefugeeCampSelectItem3": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "荞愈胶囊",
@@ -678,7 +683,6 @@
                                 "^蕎癒膠囊$",
                                 "^荞愈胶囊$",
                                 "^蕎花カプセルⅠ$",
-                                "^메밀꽃 치유 캡슐$",
                                 "^Buck Capsule [C]$"
                             ]
                         }
@@ -694,7 +698,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -710,7 +713,6 @@
                                 "^紫晶質瓶$",
                                 "^紫晶质瓶$",
                                 "^紫晶製ボトル$",
-                                "^자수정 병$",
                                 "^Amethyst Bottle$"
                             ]
                         }
@@ -726,7 +728,6 @@
                                 "^晶體外殼$",
                                 "^晶体外壳$",
                                 "^結晶外殻$",
-                                "^오리고 크러스트$",
                                 "^Origocrust$"
                             ]
                         }
@@ -742,7 +743,6 @@
                                 "^紫晶零件$",
                                 "^紫晶零件$",
                                 "^紫晶部品$",
-                                "^자수정 부품$",
                                 "^Amethyst Part$"
                             ]
                         }
@@ -773,7 +773,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -789,7 +788,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -805,7 +803,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -821,28 +818,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductRefugeeCampSelectItem4": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -853,12 +833,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductRefugeeCampSelectItem4": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "荞愈胶囊",
@@ -869,7 +863,6 @@
                                 "^蕎癒膠囊$",
                                 "^荞愈胶囊$",
                                 "^蕎花カプセルⅠ$",
-                                "^메밀꽃 치유 캡슐$",
                                 "^Buck Capsule [C]$"
                             ]
                         }
@@ -885,7 +878,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -901,7 +893,6 @@
                                 "^紫晶質瓶$",
                                 "^紫晶质瓶$",
                                 "^紫晶製ボトル$",
-                                "^자수정 병$",
                                 "^Amethyst Bottle$"
                             ]
                         }
@@ -917,7 +908,6 @@
                                 "^晶體外殼$",
                                 "^晶体外壳$",
                                 "^結晶外殻$",
-                                "^오리고 크러스트$",
                                 "^Origocrust$"
                             ]
                         }
@@ -933,7 +923,6 @@
                                 "^紫晶零件$",
                                 "^紫晶零件$",
                                 "^紫晶部品$",
-                                "^자수정 부품$",
                                 "^Amethyst Part$"
                             ]
                         }
@@ -942,6 +931,7 @@
                 }
             ]
         },
+        // ===== 售卖点开关 =====
         "ValleyIVInfrastructureOutpost": {
             "type": "switch",
             "label": "$task.SellProduct.ValleyIVInfrastructureOutpost",
@@ -971,6 +961,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 1（默认开启，含描述） =====
         "ValleyIVInfrastructureOutpostAttempt1": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt1",
@@ -998,6 +989,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 2（默认开启） =====
         "ValleyIVInfrastructureOutpostAttempt2": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt2",
@@ -1024,6 +1016,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 3（默认关闭） =====
         "ValleyIVInfrastructureOutpostAttempt3": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt3",
@@ -1050,6 +1043,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 4（默认关闭） =====
         "ValleyIVInfrastructureOutpostAttempt4": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt4",
@@ -1076,6 +1070,7 @@
                 }
             ]
         },
+        // ===== 优先物品选择 1-4 =====
         "ValleyIVInfrastructureOutpostItem1": {
             "type": "select",
             "label": "$task.SellProduct.PriorityItem1",
@@ -1098,7 +1093,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -1114,7 +1108,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -1130,7 +1123,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -1146,28 +1138,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductInfrastructureOutpostSelectItem1": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -1178,12 +1153,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductInfrastructureOutpostSelectItem1": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "低容谷地电池",
@@ -1194,7 +1183,6 @@
                                 "^低容量谷地電池$",
                                 "^低容谷地电池$",
                                 "^小容量谷地バッテリー$",
-                                "^저용량 협곡 배터리$",
                                 "^LC Valley Battery$"
                             ]
                         }
@@ -1210,7 +1198,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -1226,7 +1213,6 @@
                                 "^鐵製零件$",
                                 "^铁制零件$",
                                 "^鉄製部品$",
-                                "^페리움 부품$",
                                 "^Ferrium Part$"
                             ]
                         }
@@ -1257,7 +1243,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -1273,7 +1258,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -1289,7 +1273,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -1305,28 +1288,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductInfrastructureOutpostSelectItem2": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -1337,12 +1303,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductInfrastructureOutpostSelectItem2": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "低容谷地电池",
@@ -1353,7 +1333,6 @@
                                 "^低容量谷地電池$",
                                 "^低容谷地电池$",
                                 "^小容量谷地バッテリー$",
-                                "^저용량 협곡 배터리$",
                                 "^LC Valley Battery$"
                             ]
                         }
@@ -1369,7 +1348,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -1385,7 +1363,6 @@
                                 "^鐵製零件$",
                                 "^铁制零件$",
                                 "^鉄製部品$",
-                                "^페리움 부품$",
                                 "^Ferrium Part$"
                             ]
                         }
@@ -1416,7 +1393,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -1432,7 +1408,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -1448,7 +1423,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -1464,28 +1438,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductInfrastructureOutpostSelectItem3": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -1496,12 +1453,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductInfrastructureOutpostSelectItem3": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "低容谷地电池",
@@ -1512,7 +1483,6 @@
                                 "^低容量谷地電池$",
                                 "^低容谷地电池$",
                                 "^小容量谷地バッテリー$",
-                                "^저용량 협곡 배터리$",
                                 "^LC Valley Battery$"
                             ]
                         }
@@ -1528,7 +1498,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -1544,7 +1513,6 @@
                                 "^鐵製零件$",
                                 "^铁制零件$",
                                 "^鉄製部品$",
-                                "^페리움 부품$",
                                 "^Ferrium Part$"
                             ]
                         }
@@ -1575,7 +1543,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -1591,7 +1558,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -1607,7 +1573,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -1623,28 +1588,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductInfrastructureOutpostSelectItem4": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -1655,12 +1603,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductInfrastructureOutpostSelectItem4": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "低容谷地电池",
@@ -1671,7 +1633,6 @@
                                 "^低容量谷地電池$",
                                 "^低容谷地电池$",
                                 "^小容量谷地バッテリー$",
-                                "^저용량 협곡 배터리$",
                                 "^LC Valley Battery$"
                             ]
                         }
@@ -1687,7 +1648,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -1703,7 +1663,6 @@
                                 "^鐵製零件$",
                                 "^铁制零件$",
                                 "^鉄製部品$",
-                                "^페리움 부품$",
                                 "^Ferrium Part$"
                             ]
                         }
@@ -1712,6 +1671,7 @@
                 }
             ]
         },
+        // ===== 售卖点开关 =====
         "ValleyIVReconstructionCommand": {
             "type": "switch",
             "label": "$task.SellProduct.ValleyIVReconstructionCommand",
@@ -1741,6 +1701,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 1（默认开启，含描述） =====
         "ValleyIVReconstructionCommandAttempt1": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt1",
@@ -1768,6 +1729,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 2（默认开启） =====
         "ValleyIVReconstructionCommandAttempt2": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt2",
@@ -1794,6 +1756,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 3（默认关闭） =====
         "ValleyIVReconstructionCommandAttempt3": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt3",
@@ -1820,6 +1783,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 4（默认关闭） =====
         "ValleyIVReconstructionCommandAttempt4": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt4",
@@ -1846,6 +1810,7 @@
                 }
             ]
         },
+        // ===== 优先物品选择 1-4 =====
         "ValleyIVReconstructionCommandItem1": {
             "type": "select",
             "label": "$task.SellProduct.PriorityItem1",
@@ -1868,7 +1833,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -1884,7 +1848,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -1900,7 +1863,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -1916,28 +1878,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductReconstructionCommandSelectItem1": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -1948,12 +1893,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductReconstructionCommandSelectItem1": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "柑实罐头",
@@ -1964,7 +1923,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -1972,20 +1930,19 @@
                     "label": "$item.CannedCitromeC"
                 },
                 {
-                    "name": "铁制零件",
+                    "name": "钢制零件",
                     "pipeline_override": {
                         "SellProductReconstructionCommandSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "^鐵製零件$",
-                                "^铁制零件$",
-                                "^鉄製部品$",
-                                "^페리움 부품$",
-                                "^Ferrium Part$"
+                                "^鋼製零件$",
+                                "^钢制零件$",
+                                "^鋼製部品$",
+                                "^Steel Part$"
                             ]
                         }
                     },
-                    "label": "$item.FerriumPart"
+                    "label": "$item.SteelPart"
                 }
             ]
         },
@@ -2011,7 +1968,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -2027,7 +1983,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -2043,7 +1998,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -2059,28 +2013,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductReconstructionCommandSelectItem2": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -2091,12 +2028,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductReconstructionCommandSelectItem2": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "柑实罐头",
@@ -2107,7 +2058,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -2115,20 +2065,19 @@
                     "label": "$item.CannedCitromeC"
                 },
                 {
-                    "name": "铁制零件",
+                    "name": "钢制零件",
                     "pipeline_override": {
                         "SellProductReconstructionCommandSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "^鐵製零件$",
-                                "^铁制零件$",
-                                "^鉄製部品$",
-                                "^페리움 부품$",
-                                "^Ferrium Part$"
+                                "^鋼製零件$",
+                                "^钢制零件$",
+                                "^鋼製部品$",
+                                "^Steel Part$"
                             ]
                         }
                     },
-                    "label": "$item.FerriumPart"
+                    "label": "$item.SteelPart"
                 }
             ]
         },
@@ -2154,7 +2103,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -2170,7 +2118,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -2186,7 +2133,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -2202,28 +2148,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductReconstructionCommandSelectItem3": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -2234,12 +2163,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductReconstructionCommandSelectItem3": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "柑实罐头",
@@ -2250,7 +2193,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -2258,20 +2200,19 @@
                     "label": "$item.CannedCitromeC"
                 },
                 {
-                    "name": "铁制零件",
+                    "name": "钢制零件",
                     "pipeline_override": {
                         "SellProductReconstructionCommandSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "^鐵製零件$",
-                                "^铁制零件$",
-                                "^鉄製部品$",
-                                "^페리움 부품$",
-                                "^Ferrium Part$"
+                                "^鋼製零件$",
+                                "^钢制零件$",
+                                "^鋼製部品$",
+                                "^Steel Part$"
                             ]
                         }
                     },
-                    "label": "$item.FerriumPart"
+                    "label": "$item.SteelPart"
                 }
             ]
         },
@@ -2297,7 +2238,6 @@
                                 "^精選蕎癒膠囊$",
                                 "^精选荞愈胶囊$",
                                 "^蕎花カプセルⅢ$",
-                                "^메밀꽃 치유 캡슐(대)$",
                                 "^Buck Capsule [A]$"
                             ]
                         }
@@ -2313,7 +2253,6 @@
                                 "^高容量谷地電池$",
                                 "^高容谷地电池$",
                                 "^大容量谷地バッテリー$",
-                                "^대용량 협곡 배터리$",
                                 "^HC Valley Battery$"
                             ]
                         }
@@ -2329,7 +2268,6 @@
                                 "^精選柑實罐頭$",
                                 "^精选柑实罐头$",
                                 "^シトロームの缶詰Ⅲ$",
-                                "^시트론 통조림(대)$",
                                 "^Canned Citrome [A]$"
                             ]
                         }
@@ -2345,28 +2283,11 @@
                                 "^中容量谷地電池$",
                                 "^中容谷地电池$",
                                 "^中容量谷地バッテリー$",
-                                "^중용량 협곡 배터리$",
                                 "^SC Valley Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCValleyBattery"
-                },
-                {
-                    "name": "优质柑实罐头",
-                    "pipeline_override": {
-                        "SellProductReconstructionCommandSelectItem4": {
-                            "enabled": true,
-                            "expected": [
-                                "^優質柑實罐頭$",
-                                "^优质柑实罐头$",
-                                "^シトロームの缶詰Ⅱ$",
-                                "^시트론 통조림(중)$",
-                                "^Canned Citrome [B]$"
-                            ]
-                        }
-                    },
-                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "优质荞愈胶囊",
@@ -2377,12 +2298,26 @@
                                 "^優質蕎癒膠囊$",
                                 "^优质荞愈胶囊$",
                                 "^蕎花カプセルⅡ$",
-                                "^메밀꽃 치유 캡슐(중)$",
                                 "^Buck Capsule [B]$"
                             ]
                         }
                     },
                     "label": "$item.BuckCapsuleB"
+                },
+                {
+                    "name": "优质柑实罐头",
+                    "pipeline_override": {
+                        "SellProductReconstructionCommandSelectItem4": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質柑實罐頭$",
+                                "^优质柑实罐头$",
+                                "^シトロームの缶詰Ⅱ$",
+                                "^Canned Citrome [B]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.CannedCitromeB"
                 },
                 {
                     "name": "柑实罐头",
@@ -2393,7 +2328,6 @@
                                 "^柑實罐頭$",
                                 "^柑实罐头$",
                                 "^シトロームの缶詰Ⅰ$",
-                                "^시트론 통조림$",
                                 "^Canned Citrome [C]$"
                             ]
                         }
@@ -2401,50 +2335,23 @@
                     "label": "$item.CannedCitromeC"
                 },
                 {
-                    "name": "铁制零件",
+                    "name": "钢制零件",
                     "pipeline_override": {
                         "SellProductReconstructionCommandSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "^鐵製零件$",
-                                "^铁制零件$",
-                                "^鉄製部品$",
-                                "^페리움 부품$",
-                                "^Ferrium Part$"
+                                "^鋼製零件$",
+                                "^钢制零件$",
+                                "^鋼製部品$",
+                                "^Steel Part$"
                             ]
                         }
                     },
-                    "label": "$item.FerriumPart"
+                    "label": "$item.SteelPart"
                 }
             ]
         },
-        "WulingSell": {
-            "type": "switch",
-            "label": "$global.region.Wuling",
-            "description": "$task.SellProduct.regionToggleDescription",
-            "default_case": "Yes",
-            "cases": [
-                {
-                    "name": "Yes",
-                    "pipeline_override": {
-                        "SellProductWuling": {
-                            "enabled": true
-                        }
-                    },
-                    "option": [
-                        "WulingSkyKingFlats"
-                    ]
-                },
-                {
-                    "name": "No",
-                    "pipeline_override": {
-                        "SellProductWuling": {
-                            "enabled": false
-                        }
-                    }
-                }
-            ]
-        },
+        // ===== 售卖点开关 =====
         "WulingSkyKingFlats": {
             "type": "switch",
             "label": "$task.SellProduct.WulingSkyKingFlats",
@@ -2474,6 +2381,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 1（默认开启，含描述） =====
         "WulingSkyKingFlatsAttempt1": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt1",
@@ -2501,6 +2409,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 2（默认开启） =====
         "WulingSkyKingFlatsAttempt2": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt2",
@@ -2527,6 +2436,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 3（默认关闭） =====
         "WulingSkyKingFlatsAttempt3": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt3",
@@ -2553,6 +2463,7 @@
                 }
             ]
         },
+        // ===== 售卖尝试 4（默认关闭） =====
         "WulingSkyKingFlatsAttempt4": {
             "type": "switch",
             "label": "$task.SellProduct.SellAttempt4",
@@ -2579,6 +2490,7 @@
                 }
             ]
         },
+        // ===== 优先物品选择 1-4 =====
         "WulingSkyKingFlatsItem1": {
             "type": "select",
             "label": "$task.SellProduct.PriorityItem1",
@@ -2598,31 +2510,14 @@
                         "SellProductSkyKingFlatsSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "^中容武陵电池$",
                                 "^中容量武陵電池$",
-                                "^SC Wuling Battery$",
+                                "^中容武陵电池$",
                                 "^中容量武陵バッテリー$",
-                                "^중용량 무릉 배터리$"
+                                "^SC Wuling Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCWulingBattery"
-                },
-                {
-                    "name": "优质芽针针剂",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem1": {
-                            "enabled": true,
-                            "expected": [
-                                "^优质芽针针剂$",
-                                "^優質芽針針劑$",
-                                "^Yazhen Syringe [A]$",
-                                "^芽針注射剤Ⅱ$",
-                                "^고급 야침 주사약$"
-                            ]
-                        }
-                    },
-                    "label": "$item.YazhenSyringeB"
                 },
                 {
                     "name": "低容武陵电池",
@@ -2632,13 +2527,27 @@
                             "expected": [
                                 "^低容量武陵電池$",
                                 "^低容武陵电池$",
-                                "^低容量武陵電池$",
-                                "^저용량 무릉 배터리$",
+                                "^小容量武陵バッテリー$",
                                 "^LC Wuling Battery$"
                             ]
                         }
                     },
                     "label": "$item.LCWulingBattery"
+                },
+                {
+                    "name": "优质芽针针剂",
+                    "pipeline_override": {
+                        "SellProductSkyKingFlatsSelectItem1": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質芽針針劑$",
+                                "^优质芽针针剂$",
+                                "^芽針注射剤Ⅱ$",
+                                "^Yazhen Syringe [A]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.YazhenSyringeB"
                 },
                 {
                     "name": "芽针针剂",
@@ -2649,7 +2558,6 @@
                                 "^芽針針劑$",
                                 "^芽针针剂$",
                                 "^芽針注射剤Ⅰ$",
-                                "^야침 주사약$",
                                 "^Yazhen Syringe [C]$"
                             ]
                         }
@@ -2665,7 +2573,6 @@
                                 "^錦草飲料$",
                                 "^锦草软饮$",
                                 "^錦草ソーダⅠ$",
-                                "^금초 청량음료$",
                                 "^Jincao Drink$"
                             ]
                         }
@@ -2678,11 +2585,10 @@
                         "SellProductSkyKingFlatsSelectItem1": {
                             "enabled": true,
                             "expected": [
-                                "^赤铜零件$",
                                 "^赤銅零件$",
-                                "^Cuprium Part$",
+                                "^赤铜零件$",
                                 "^赤銅部品$",
-                                "^적동 부품$"
+                                "^Cuprium Part$"
                             ]
                         }
                     },
@@ -2696,8 +2602,7 @@
                             "expected": [
                                 "^息壤$",
                                 "^息壤$",
-                                "^息壤$",
-                                "^식양$",
+                                "^息壌$",
                                 "^Xiranite$"
                             ]
                         }
@@ -2725,31 +2630,14 @@
                         "SellProductSkyKingFlatsSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "^中容武陵电池$",
                                 "^中容量武陵電池$",
-                                "^SC Wuling Battery$",
+                                "^中容武陵电池$",
                                 "^中容量武陵バッテリー$",
-                                "^중용량 무릉 배터리$"
+                                "^SC Wuling Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCWulingBattery"
-                },
-                {
-                    "name": "优质芽针针剂",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem2": {
-                            "enabled": true,
-                            "expected": [
-                                "^优质芽针针剂$",
-                                "^優質芽針針劑$",
-                                "^Yazhen Syringe [A]$",
-                                "^芽針注射剤Ⅱ$",
-                                "^고급 야침 주사약$"
-                            ]
-                        }
-                    },
-                    "label": "$item.YazhenSyringeB"
                 },
                 {
                     "name": "低容武陵电池",
@@ -2759,13 +2647,27 @@
                             "expected": [
                                 "^低容量武陵電池$",
                                 "^低容武陵电池$",
-                                "^低容量武陵電池$",
-                                "^저용량 무릉 배터리$",
+                                "^小容量武陵バッテリー$",
                                 "^LC Wuling Battery$"
                             ]
                         }
                     },
                     "label": "$item.LCWulingBattery"
+                },
+                {
+                    "name": "优质芽针针剂",
+                    "pipeline_override": {
+                        "SellProductSkyKingFlatsSelectItem2": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質芽針針劑$",
+                                "^优质芽针针剂$",
+                                "^芽針注射剤Ⅱ$",
+                                "^Yazhen Syringe [A]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.YazhenSyringeB"
                 },
                 {
                     "name": "芽针针剂",
@@ -2776,7 +2678,6 @@
                                 "^芽針針劑$",
                                 "^芽针针剂$",
                                 "^芽針注射剤Ⅰ$",
-                                "^야침 주사약$",
                                 "^Yazhen Syringe [C]$"
                             ]
                         }
@@ -2792,7 +2693,6 @@
                                 "^錦草飲料$",
                                 "^锦草软饮$",
                                 "^錦草ソーダⅠ$",
-                                "^금초 청량음료$",
                                 "^Jincao Drink$"
                             ]
                         }
@@ -2805,11 +2705,10 @@
                         "SellProductSkyKingFlatsSelectItem2": {
                             "enabled": true,
                             "expected": [
-                                "^赤铜零件$",
                                 "^赤銅零件$",
-                                "^Cuprium Part$",
+                                "^赤铜零件$",
                                 "^赤銅部品$",
-                                "^적동 부품$"
+                                "^Cuprium Part$"
                             ]
                         }
                     },
@@ -2823,8 +2722,7 @@
                             "expected": [
                                 "^息壤$",
                                 "^息壤$",
-                                "^息壤$",
-                                "^식양$",
+                                "^息壌$",
                                 "^Xiranite$"
                             ]
                         }
@@ -2852,31 +2750,14 @@
                         "SellProductSkyKingFlatsSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "^中容武陵电池$",
                                 "^中容量武陵電池$",
-                                "^SC Wuling Battery$",
+                                "^中容武陵电池$",
                                 "^中容量武陵バッテリー$",
-                                "^중용량 무릉 배터리$"
+                                "^SC Wuling Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCWulingBattery"
-                },
-                {
-                    "name": "优质芽针针剂",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem3": {
-                            "enabled": true,
-                            "expected": [
-                                "^优质芽针针剂$",
-                                "^優質芽針針劑$",
-                                "^Yazhen Syringe [A]$",
-                                "^芽針注射剤Ⅱ$",
-                                "^고급 야침 주사약$"
-                            ]
-                        }
-                    },
-                    "label": "$item.YazhenSyringeB"
                 },
                 {
                     "name": "低容武陵电池",
@@ -2886,13 +2767,27 @@
                             "expected": [
                                 "^低容量武陵電池$",
                                 "^低容武陵电池$",
-                                "^低容量武陵電池$",
-                                "^저용량 무릉 배터리$",
+                                "^小容量武陵バッテリー$",
                                 "^LC Wuling Battery$"
                             ]
                         }
                     },
                     "label": "$item.LCWulingBattery"
+                },
+                {
+                    "name": "优质芽针针剂",
+                    "pipeline_override": {
+                        "SellProductSkyKingFlatsSelectItem3": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質芽針針劑$",
+                                "^优质芽针针剂$",
+                                "^芽針注射剤Ⅱ$",
+                                "^Yazhen Syringe [A]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.YazhenSyringeB"
                 },
                 {
                     "name": "芽针针剂",
@@ -2903,7 +2798,6 @@
                                 "^芽針針劑$",
                                 "^芽针针剂$",
                                 "^芽針注射剤Ⅰ$",
-                                "^야침 주사약$",
                                 "^Yazhen Syringe [C]$"
                             ]
                         }
@@ -2919,7 +2813,6 @@
                                 "^錦草飲料$",
                                 "^锦草软饮$",
                                 "^錦草ソーダⅠ$",
-                                "^금초 청량음료$",
                                 "^Jincao Drink$"
                             ]
                         }
@@ -2932,11 +2825,10 @@
                         "SellProductSkyKingFlatsSelectItem3": {
                             "enabled": true,
                             "expected": [
-                                "^赤铜零件$",
                                 "^赤銅零件$",
-                                "^Cuprum Part$",
+                                "^赤铜零件$",
                                 "^赤銅部品$",
-                                "^적동 부품$"
+                                "^Cuprium Part$"
                             ]
                         }
                     },
@@ -2950,8 +2842,7 @@
                             "expected": [
                                 "^息壤$",
                                 "^息壤$",
-                                "^息壤$",
-                                "^식양$",
+                                "^息壌$",
                                 "^Xiranite$"
                             ]
                         }
@@ -2979,31 +2870,14 @@
                         "SellProductSkyKingFlatsSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "^中容武陵电池$",
                                 "^中容量武陵電池$",
-                                "^SC Wuling Battery$",
+                                "^中容武陵电池$",
                                 "^中容量武陵バッテリー$",
-                                "^중용량 무릉 배터리$"
+                                "^SC Wuling Battery$"
                             ]
                         }
                     },
                     "label": "$item.SCWulingBattery"
-                },
-                {
-                    "name": "优质芽针针剂",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem4": {
-                            "enabled": true,
-                            "expected": [
-                                "^优质芽针针剂$",
-                                "^優質芽針針劑$",
-                                "^Yazhen Syringe [A]$",
-                                "^芽針注射剤Ⅱ$",
-                                "^고급 야침 주사약$"
-                            ]
-                        }
-                    },
-                    "label": "$item.YazhenSyringeB"
                 },
                 {
                     "name": "低容武陵电池",
@@ -3013,13 +2887,27 @@
                             "expected": [
                                 "^低容量武陵電池$",
                                 "^低容武陵电池$",
-                                "^低容量武陵電池$",
-                                "^저용량 무릉 배터리$",
+                                "^小容量武陵バッテリー$",
                                 "^LC Wuling Battery$"
                             ]
                         }
                     },
                     "label": "$item.LCWulingBattery"
+                },
+                {
+                    "name": "优质芽针针剂",
+                    "pipeline_override": {
+                        "SellProductSkyKingFlatsSelectItem4": {
+                            "enabled": true,
+                            "expected": [
+                                "^優質芽針針劑$",
+                                "^优质芽针针剂$",
+                                "^芽針注射剤Ⅱ$",
+                                "^Yazhen Syringe [A]$"
+                            ]
+                        }
+                    },
+                    "label": "$item.YazhenSyringeB"
                 },
                 {
                     "name": "芽针针剂",
@@ -3030,7 +2918,6 @@
                                 "^芽針針劑$",
                                 "^芽针针剂$",
                                 "^芽針注射剤Ⅰ$",
-                                "^야침 주사약$",
                                 "^Yazhen Syringe [C]$"
                             ]
                         }
@@ -3046,7 +2933,6 @@
                                 "^錦草飲料$",
                                 "^锦草软饮$",
                                 "^錦草ソーダⅠ$",
-                                "^금초 청량음료$",
                                 "^Jincao Drink$"
                             ]
                         }
@@ -3059,11 +2945,10 @@
                         "SellProductSkyKingFlatsSelectItem4": {
                             "enabled": true,
                             "expected": [
-                                "^赤铜零件$",
                                 "^赤銅零件$",
-                                "^Cuprum Part$",
+                                "^赤铜零件$",
                                 "^赤銅部品$",
-                                "^적동 부품$"
+                                "^Cuprium Part$"
                             ]
                         }
                     },
@@ -3077,8 +2962,7 @@
                             "expected": [
                                 "^息壤$",
                                 "^息壤$",
-                                "^息壤$",
-                                "^식양$",
+                                "^息壌$",
                                 "^Xiranite$"
                             ]
                         }

--- a/tools/pipeline-generate/SellProduct/README.md
+++ b/tools/pipeline-generate/SellProduct/README.md
@@ -1,0 +1,5 @@
+# 售卖物品
+
+```shell
+npx @joebao/maa-pipeline-generate
+```

--- a/tools/pipeline-generate/SellProduct/README.md
+++ b/tools/pipeline-generate/SellProduct/README.md
@@ -3,3 +3,7 @@
 ```shell
 npx @joebao/maa-pipeline-generate
 ```
+
+## 致谢
+
+- 感谢 `zmdmap` 提供的数据

--- a/tools/pipeline-generate/SellProduct/config.json
+++ b/tools/pipeline-generate/SellProduct/config.json
@@ -1,0 +1,6 @@
+{
+    "template": "template.jsonc",
+    "data": "data.mjs",
+    "format": true,
+    "merged": true
+}

--- a/tools/pipeline-generate/SellProduct/data.mjs
+++ b/tools/pipeline-generate/SellProduct/data.mjs
@@ -1,299 +1,112 @@
 // SellProduct 数据源
-// 定义各售卖点的物品列表和多语言 OCR 识别文本
+// 基于 settlement_trade_outposts.json 自动构建物品列表（取所有繁荣度等级的并集）
 
-// ===== 物品定义 =====
-// 每个物品: { id, name(简中), label(i18n key), expected(多语言 OCR 识别) }
-const ITEMS = {
-    BuckCapsuleA: {
-        name: "精选荞愈胶囊",
-        label: "$item.BuckCapsuleA",
-        expected: [
-            "^精選蕎癒膠囊$",
-            "^精选荞愈胶囊$",
-            "^蕎花カプセルⅢ$",
-            "^메밀꽃 치유 캡슐(대)$",
-            "^Buck Capsule [A]$",
-        ],
-    },
-    HCValleyBattery: {
-        name: "高容谷地电池",
-        label: "$item.HCValleyBattery",
-        expected: [
-            "^高容量谷地電池$",
-            "^高容谷地电池$",
-            "^大容量谷地バッテリー$",
-            "^대용량 협곡 배터리$",
-            "^HC Valley Battery$",
-        ],
-    },
-    CannedCitromeA: {
-        name: "精选柑实罐头",
-        label: "$item.CannedCitromeA",
-        expected: [
-            "^精選柑實罐頭$",
-            "^精选柑实罐头$",
-            "^シトロームの缶詰Ⅲ$",
-            "^시트론 통조림(대)$",
-            "^Canned Citrome [A]$",
-        ],
-    },
-    SCValleyBattery: {
-        name: "中容谷地电池",
-        label: "$item.SCValleyBattery",
-        expected: [
-            "^中容量谷地電池$",
-            "^中容谷地电池$",
-            "^中容量谷地バッテリー$",
-            "^중용량 협곡 배터리$",
-            "^SC Valley Battery$",
-        ],
-    },
-    CannedCitromeB: {
-        name: "优质柑实罐头",
-        label: "$item.CannedCitromeB",
-        expected: [
-            "^優質柑實罐頭$",
-            "^优质柑实罐头$",
-            "^シトロームの缶詰Ⅱ$",
-            "^시트론 통조림(중)$",
-            "^Canned Citrome [B]$",
-        ],
-    },
-    BuckCapsuleB: {
-        name: "优质荞愈胶囊",
-        label: "$item.BuckCapsuleB",
-        expected: [
-            "^優質蕎癒膠囊$",
-            "^优质荞愈胶囊$",
-            "^蕎花カプセルⅡ$",
-            "^메밀꽃 치유 캡슐(중)$",
-            "^Buck Capsule [B]$",
-        ],
-    },
-    BuckCapsuleC: {
-        name: "荞愈胶囊",
-        label: "$item.BuckCapsuleC",
-        expected: [
-            "^蕎癒膠囊$",
-            "^荞愈胶囊$",
-            "^蕎花カプセルⅠ$",
-            "^메밀꽃 치유 캡슐$",
-            "^Buck Capsule [C]$",
-        ],
-    },
-    CannedCitromeC: {
-        name: "柑实罐头",
-        label: "$item.CannedCitromeC",
-        expected: [
-            "^柑實罐頭$",
-            "^柑实罐头$",
-            "^シトロームの缶詰Ⅰ$",
-            "^시트론 통조림$",
-            "^Canned Citrome [C]$",
-        ],
-    },
-    AmethystBottle: {
-        name: "紫晶质瓶",
-        label: "$item.AmethystBottle",
-        expected: [
-            "^紫晶質瓶$",
-            "^紫晶质瓶$",
-            "^紫晶製ボトル$",
-            "^자수정 병$",
-            "^Amethyst Bottle$",
-        ],
-    },
-    Origocrust: {
-        name: "晶体外壳",
-        label: "$item.Origocrust",
-        expected: [
-            "^晶體外殼$",
-            "^晶体外壳$",
-            "^結晶外殻$",
-            "^오리고 크러스트$",
-            "^Origocrust$",
-        ],
-    },
-    AmethystPart: {
-        name: "紫晶零件",
-        label: "$item.AmethystPart",
-        expected: [
-            "^紫晶零件$",
-            "^紫晶零件$",
-            "^紫晶部品$",
-            "^자수정 부품$",
-            "^Amethyst Part$",
-        ],
-    },
-    LCValleyBattery: {
-        name: "低容谷地电池",
-        label: "$item.LCValleyBattery",
-        expected: [
-            "^低容量谷地電池$",
-            "^低容谷地电池$",
-            "^小容量谷地バッテリー$",
-            "^저용량 협곡 배터리$",
-            "^LC Valley Battery$",
-        ],
-    },
-    FerriumPart: {
-        name: "铁制零件",
-        label: "$item.FerriumPart",
-        expected: [
-            "^鐵製零件$",
-            "^铁制零件$",
-            "^鉄製部品$",
-            "^페리움 부품$",
-            "^Ferrium Part$",
-        ],
-    },
-    SCWulingBattery: {
-        name: "中容武陵电池",
-        label: "$item.SCWulingBattery",
-        expected: [
-            "^中容武陵电池$",
-            "^中容量武陵電池$",
-            "^SC Wuling Battery$",
-            "^中容量武陵バッテリー$",
-            "^중용량 무릉 배터리$",
-        ],
-    },
-    YazhenSyringeB: {
-        name: "优质芽针针剂",
-        label: "$item.YazhenSyringeB",
-        expected: [
-            "^优质芽针针剂$",
-            "^優質芽針針劑$",
-            "^Yazhen Syringe [A]$",
-            "^芽針注射剤Ⅱ$",
-            "^고급 야침 주사약$",
-        ],
-    },
-    LCWulingBattery: {
-        name: "低容武陵电池",
-        label: "$item.LCWulingBattery",
-        expected: [
-            "^低容量武陵電池$",
-            "^低容武陵电池$",
-            "^低容量武陵電池$",
-            "^저용량 무릉 배터리$",
-            "^LC Wuling Battery$",
-        ],
-    },
-    YazhenSyringe: {
-        name: "芽针针剂",
-        label: "$item.YazhenSyringe",
-        expected: [
-            "^芽針針劑$",
-            "^芽针针剂$",
-            "^芽針注射剤Ⅰ$",
-            "^야침 주사약$",
-            "^Yazhen Syringe [C]$",
-        ],
-    },
-    JincaoDrink: {
-        name: "锦草软饮",
-        label: "$item.JincaoDrink",
-        expected: [
-            "^錦草飲料$",
-            "^锦草软饮$",
-            "^錦草ソーダⅠ$",
-            "^금초 청량음료$",
-            "^Jincao Drink$",
-        ],
-    },
-    CuprumPart: {
-        name: "赤铜零件",
-        label: "$item.CuprumPart",
-        expected: [
-            "^赤铜零件$",
-            "^赤銅零件$",
-            "^Cuprium Part$",
-            "^赤銅部品$",
-            "^적동 부품$",
-        ],
-    },
-    Xiranite: {
-        name: "息壤",
-        label: "$item.Xiranite",
-        expected: [
-            "^息壤$",
-            "^息壤$",
-            "^息壤$",
-            "^식양$",
-            "^Xiranite$",
-        ],
-    },
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const settlementData = require("./settlement_trade_outposts.json");
+
+// ===== itemId → 内部 key / label 映射 =====
+const ITEM_META = {
+    item_bottled_rec_hp_3: { key: "BuckCapsuleA", label: "$item.BuckCapsuleA" },
+    item_proc_battery_3: { key: "HCValleyBattery", label: "$item.HCValleyBattery" },
+    item_bottled_food_3: { key: "CannedCitromeA", label: "$item.CannedCitromeA" },
+    item_proc_battery_2: { key: "SCValleyBattery", label: "$item.SCValleyBattery" },
+    item_bottled_food_2: { key: "CannedCitromeB", label: "$item.CannedCitromeB" },
+    item_bottled_rec_hp_2: { key: "BuckCapsuleB", label: "$item.BuckCapsuleB" },
+    item_bottled_rec_hp_1: { key: "BuckCapsuleC", label: "$item.BuckCapsuleC" },
+    item_bottled_food_1: { key: "CannedCitromeC", label: "$item.CannedCitromeC" },
+    item_glass_bottle: { key: "AmethystBottle", label: "$item.AmethystBottle" },
+    item_crystal_shell: { key: "Origocrust", label: "$item.Origocrust" },
+    item_glass_cmpt: { key: "AmethystPart", label: "$item.AmethystPart" },
+    item_proc_battery_1: { key: "LCValleyBattery", label: "$item.LCValleyBattery" },
+    item_iron_cmpt: { key: "FerriumPart", label: "$item.FerriumPart" },
+    item_iron_enr_cmpt: { key: "SteelPart", label: "$item.SteelPart" },
+    item_proc_battery_5: { key: "SCWulingBattery", label: "$item.SCWulingBattery" },
+    item_bottled_rec_hp_5: { key: "YazhenSyringeB", label: "$item.YazhenSyringeB" },
+    item_proc_battery_4: { key: "LCWulingBattery", label: "$item.LCWulingBattery" },
+    item_bottled_rec_hp_4: { key: "YazhenSyringe", label: "$item.YazhenSyringe" },
+    item_bottled_food_4: { key: "JincaoDrink", label: "$item.JincaoDrink" },
+    item_copper_cmpt: { key: "CuprumPart", label: "$item.CuprumPart" },
+    item_xiranite_powder: { key: "Xiranite", label: "$item.Xiranite" },
 };
 
-// ===== 售卖点配置 =====
-// NodePrefix: pipeline_override 中使用的节点前缀
-// items: 该售卖点可售卖的物品 ID 列表
-const LOCATIONS = [
-    {
+// ===== 从 settlement 数据提取全局物品字典 =====
+// expected 顺序: TC, CN, JP, EN
+const ITEMS = {};
+for (const settlement of Object.values(settlementData.settlements)) {
+    for (const level of Object.values(settlement.byProsperityLevel)) {
+        for (const item of level.tradeItems) {
+            const meta = ITEM_META[item.itemId];
+            if (!meta) continue;
+            if (ITEMS[meta.key]) continue; // 已收集过
+            ITEMS[meta.key] = {
+                name: item.name.CN,
+                label: meta.label,
+                expected: [
+                    `^${item.name.TC}$`,
+                    `^${item.name.CN}$`,
+                    `^${item.name.JP}$`,
+                    `^${item.name.EN}$`,
+                ],
+            };
+        }
+    }
+}
+
+// ===== settlementId → 售卖点配置映射 =====
+const SETTLEMENT_MAP = {
+    stm_tundra_1: {
         RegionPrefix: "ValleyIV",
         LocationId: "RefugeeCamp",
         NodePrefix: "RefugeeCamp",
-        items: [
-            "BuckCapsuleA",
-            "HCValleyBattery",
-            "CannedCitromeA",
-            "SCValleyBattery",
-            "CannedCitromeB",
-            "BuckCapsuleB",
-            "BuckCapsuleC",
-            "CannedCitromeC",
-            "AmethystBottle",
-            "Origocrust",
-            "AmethystPart",
-        ],
     },
-    {
+    stm_tundra_2: {
         RegionPrefix: "ValleyIV",
         LocationId: "InfrastructureOutpost",
         NodePrefix: "InfrastructureOutpost",
-        items: [
-            "BuckCapsuleA",
-            "HCValleyBattery",
-            "CannedCitromeA",
-            "SCValleyBattery",
-            "CannedCitromeB",
-            "BuckCapsuleB",
-            "LCValleyBattery",
-            "CannedCitromeC",
-            "FerriumPart",
-        ],
     },
-    {
+    stm_tundra_3: {
         RegionPrefix: "ValleyIV",
         LocationId: "ReconstructionCommand",
         NodePrefix: "ReconstructionCommand",
-        items: [
-            "BuckCapsuleA",
-            "HCValleyBattery",
-            "CannedCitromeA",
-            "SCValleyBattery",
-            "CannedCitromeB",
-            "BuckCapsuleB",
-            "CannedCitromeC",
-            "FerriumPart",
-        ],
     },
-    {
+    stm_hongs_1: {
         RegionPrefix: "Wuling",
         LocationId: "SkyKingFlats",
         NodePrefix: "SkyKingFlats",
-        items: [
-            "SCWulingBattery",
-            "YazhenSyringeB",
-            "LCWulingBattery",
-            "YazhenSyringe",
-            "JincaoDrink",
-            "CuprumPart",
-            "Xiranite",
-        ],
     },
-];
+};
+
+// ===== 从 settlement 数据构建 LOCATIONS（取所有繁荣度等级的物品并集） =====
+const LOCATIONS = Object.entries(SETTLEMENT_MAP).map(
+    ([settlementId, config]) => {
+        const settlement = settlementData.settlements[settlementId];
+        // 取所有 level 的 tradeItems 并集（按 itemId 去重），记录 rarity 和最高 unitPrice
+        const itemMap = new Map();
+        for (const level of Object.values(settlement.byProsperityLevel)) {
+            for (const item of level.tradeItems) {
+                const meta = ITEM_META[item.itemId];
+                if (!meta) continue;
+                const prev = itemMap.get(meta.key);
+                if (!prev || item.unitPrice > prev.unitPrice) {
+                    itemMap.set(meta.key, {
+                        rarity: item.rarity,
+                        unitPrice: item.unitPrice,
+                    });
+                }
+            }
+        }
+        // 按 rarity 降序 → unitPrice 降序 排列
+        const items = [...itemMap.entries()]
+            .sort(
+                (a, b) =>
+                    b[1].rarity - a[1].rarity ||
+                    b[1].unitPrice - a[1].unitPrice,
+            )
+            .map(([key]) => key);
+        return { ...config, items };
+    },
+);
 
 // ===== 构建 cases 数组 =====
 function buildItemCases(nodePrefix, itemNum, itemIds) {

--- a/tools/pipeline-generate/SellProduct/data.mjs
+++ b/tools/pipeline-generate/SellProduct/data.mjs
@@ -1,0 +1,334 @@
+// SellProduct 数据源
+// 定义各售卖点的物品列表和多语言 OCR 识别文本
+
+// ===== 物品定义 =====
+// 每个物品: { id, name(简中), label(i18n key), expected(多语言 OCR 识别) }
+const ITEMS = {
+    BuckCapsuleA: {
+        name: "精选荞愈胶囊",
+        label: "$item.BuckCapsuleA",
+        expected: [
+            "^精選蕎癒膠囊$",
+            "^精选荞愈胶囊$",
+            "^蕎花カプセルⅢ$",
+            "^메밀꽃 치유 캡슐(대)$",
+            "^Buck Capsule [A]$",
+        ],
+    },
+    HCValleyBattery: {
+        name: "高容谷地电池",
+        label: "$item.HCValleyBattery",
+        expected: [
+            "^高容量谷地電池$",
+            "^高容谷地电池$",
+            "^大容量谷地バッテリー$",
+            "^대용량 협곡 배터리$",
+            "^HC Valley Battery$",
+        ],
+    },
+    CannedCitromeA: {
+        name: "精选柑实罐头",
+        label: "$item.CannedCitromeA",
+        expected: [
+            "^精選柑實罐頭$",
+            "^精选柑实罐头$",
+            "^シトロームの缶詰Ⅲ$",
+            "^시트론 통조림(대)$",
+            "^Canned Citrome [A]$",
+        ],
+    },
+    SCValleyBattery: {
+        name: "中容谷地电池",
+        label: "$item.SCValleyBattery",
+        expected: [
+            "^中容量谷地電池$",
+            "^中容谷地电池$",
+            "^中容量谷地バッテリー$",
+            "^중용량 협곡 배터리$",
+            "^SC Valley Battery$",
+        ],
+    },
+    CannedCitromeB: {
+        name: "优质柑实罐头",
+        label: "$item.CannedCitromeB",
+        expected: [
+            "^優質柑實罐頭$",
+            "^优质柑实罐头$",
+            "^シトロームの缶詰Ⅱ$",
+            "^시트론 통조림(중)$",
+            "^Canned Citrome [B]$",
+        ],
+    },
+    BuckCapsuleB: {
+        name: "优质荞愈胶囊",
+        label: "$item.BuckCapsuleB",
+        expected: [
+            "^優質蕎癒膠囊$",
+            "^优质荞愈胶囊$",
+            "^蕎花カプセルⅡ$",
+            "^메밀꽃 치유 캡슐(중)$",
+            "^Buck Capsule [B]$",
+        ],
+    },
+    BuckCapsuleC: {
+        name: "荞愈胶囊",
+        label: "$item.BuckCapsuleC",
+        expected: [
+            "^蕎癒膠囊$",
+            "^荞愈胶囊$",
+            "^蕎花カプセルⅠ$",
+            "^메밀꽃 치유 캡슐$",
+            "^Buck Capsule [C]$",
+        ],
+    },
+    CannedCitromeC: {
+        name: "柑实罐头",
+        label: "$item.CannedCitromeC",
+        expected: [
+            "^柑實罐頭$",
+            "^柑实罐头$",
+            "^シトロームの缶詰Ⅰ$",
+            "^시트론 통조림$",
+            "^Canned Citrome [C]$",
+        ],
+    },
+    AmethystBottle: {
+        name: "紫晶质瓶",
+        label: "$item.AmethystBottle",
+        expected: [
+            "^紫晶質瓶$",
+            "^紫晶质瓶$",
+            "^紫晶製ボトル$",
+            "^자수정 병$",
+            "^Amethyst Bottle$",
+        ],
+    },
+    Origocrust: {
+        name: "晶体外壳",
+        label: "$item.Origocrust",
+        expected: [
+            "^晶體外殼$",
+            "^晶体外壳$",
+            "^結晶外殻$",
+            "^오리고 크러스트$",
+            "^Origocrust$",
+        ],
+    },
+    AmethystPart: {
+        name: "紫晶零件",
+        label: "$item.AmethystPart",
+        expected: [
+            "^紫晶零件$",
+            "^紫晶零件$",
+            "^紫晶部品$",
+            "^자수정 부품$",
+            "^Amethyst Part$",
+        ],
+    },
+    LCValleyBattery: {
+        name: "低容谷地电池",
+        label: "$item.LCValleyBattery",
+        expected: [
+            "^低容量谷地電池$",
+            "^低容谷地电池$",
+            "^小容量谷地バッテリー$",
+            "^저용량 협곡 배터리$",
+            "^LC Valley Battery$",
+        ],
+    },
+    FerriumPart: {
+        name: "铁制零件",
+        label: "$item.FerriumPart",
+        expected: [
+            "^鐵製零件$",
+            "^铁制零件$",
+            "^鉄製部品$",
+            "^페리움 부품$",
+            "^Ferrium Part$",
+        ],
+    },
+    SCWulingBattery: {
+        name: "中容武陵电池",
+        label: "$item.SCWulingBattery",
+        expected: [
+            "^中容武陵电池$",
+            "^中容量武陵電池$",
+            "^SC Wuling Battery$",
+            "^中容量武陵バッテリー$",
+            "^중용량 무릉 배터리$",
+        ],
+    },
+    YazhenSyringeB: {
+        name: "优质芽针针剂",
+        label: "$item.YazhenSyringeB",
+        expected: [
+            "^优质芽针针剂$",
+            "^優質芽針針劑$",
+            "^Yazhen Syringe [A]$",
+            "^芽針注射剤Ⅱ$",
+            "^고급 야침 주사약$",
+        ],
+    },
+    LCWulingBattery: {
+        name: "低容武陵电池",
+        label: "$item.LCWulingBattery",
+        expected: [
+            "^低容量武陵電池$",
+            "^低容武陵电池$",
+            "^低容量武陵電池$",
+            "^저용량 무릉 배터리$",
+            "^LC Wuling Battery$",
+        ],
+    },
+    YazhenSyringe: {
+        name: "芽针针剂",
+        label: "$item.YazhenSyringe",
+        expected: [
+            "^芽針針劑$",
+            "^芽针针剂$",
+            "^芽針注射剤Ⅰ$",
+            "^야침 주사약$",
+            "^Yazhen Syringe [C]$",
+        ],
+    },
+    JincaoDrink: {
+        name: "锦草软饮",
+        label: "$item.JincaoDrink",
+        expected: [
+            "^錦草飲料$",
+            "^锦草软饮$",
+            "^錦草ソーダⅠ$",
+            "^금초 청량음료$",
+            "^Jincao Drink$",
+        ],
+    },
+    CuprumPart: {
+        name: "赤铜零件",
+        label: "$item.CuprumPart",
+        expected: [
+            "^赤铜零件$",
+            "^赤銅零件$",
+            "^Cuprium Part$",
+            "^赤銅部品$",
+            "^적동 부품$",
+        ],
+    },
+    Xiranite: {
+        name: "息壤",
+        label: "$item.Xiranite",
+        expected: [
+            "^息壤$",
+            "^息壤$",
+            "^息壤$",
+            "^식양$",
+            "^Xiranite$",
+        ],
+    },
+};
+
+// ===== 售卖点配置 =====
+// NodePrefix: pipeline_override 中使用的节点前缀
+// items: 该售卖点可售卖的物品 ID 列表
+const LOCATIONS = [
+    {
+        RegionPrefix: "ValleyIV",
+        LocationId: "RefugeeCamp",
+        NodePrefix: "RefugeeCamp",
+        items: [
+            "BuckCapsuleA",
+            "HCValleyBattery",
+            "CannedCitromeA",
+            "SCValleyBattery",
+            "CannedCitromeB",
+            "BuckCapsuleB",
+            "BuckCapsuleC",
+            "CannedCitromeC",
+            "AmethystBottle",
+            "Origocrust",
+            "AmethystPart",
+        ],
+    },
+    {
+        RegionPrefix: "ValleyIV",
+        LocationId: "InfrastructureOutpost",
+        NodePrefix: "InfrastructureOutpost",
+        items: [
+            "BuckCapsuleA",
+            "HCValleyBattery",
+            "CannedCitromeA",
+            "SCValleyBattery",
+            "CannedCitromeB",
+            "BuckCapsuleB",
+            "LCValleyBattery",
+            "CannedCitromeC",
+            "FerriumPart",
+        ],
+    },
+    {
+        RegionPrefix: "ValleyIV",
+        LocationId: "ReconstructionCommand",
+        NodePrefix: "ReconstructionCommand",
+        items: [
+            "BuckCapsuleA",
+            "HCValleyBattery",
+            "CannedCitromeA",
+            "SCValleyBattery",
+            "CannedCitromeB",
+            "BuckCapsuleB",
+            "CannedCitromeC",
+            "FerriumPart",
+        ],
+    },
+    {
+        RegionPrefix: "Wuling",
+        LocationId: "SkyKingFlats",
+        NodePrefix: "SkyKingFlats",
+        items: [
+            "SCWulingBattery",
+            "YazhenSyringeB",
+            "LCWulingBattery",
+            "YazhenSyringe",
+            "JincaoDrink",
+            "CuprumPart",
+            "Xiranite",
+        ],
+    },
+];
+
+// ===== 构建 cases 数组 =====
+function buildItemCases(nodePrefix, itemNum, itemIds) {
+    const selectKey = `SellProduct${nodePrefix}SelectItem${itemNum}`;
+    const cases = [
+        {
+            name: "无",
+            pipeline_override: {
+                [selectKey]: { enabled: false },
+            },
+        },
+    ];
+    for (const id of itemIds) {
+        const item = ITEMS[id];
+        cases.push({
+            name: item.name,
+            pipeline_override: {
+                [selectKey]: {
+                    enabled: true,
+                    expected: item.expected,
+                },
+            },
+            label: item.label,
+        });
+    }
+    return cases;
+}
+
+// ===== 导出数据 =====
+export default LOCATIONS.map((loc) => ({
+    RegionPrefix: loc.RegionPrefix,
+    LocationId: loc.LocationId,
+    NodePrefix: loc.NodePrefix,
+    ItemCases1: buildItemCases(loc.NodePrefix, 1, loc.items),
+    ItemCases2: buildItemCases(loc.NodePrefix, 2, loc.items),
+    ItemCases3: buildItemCases(loc.NodePrefix, 3, loc.items),
+    ItemCases4: buildItemCases(loc.NodePrefix, 4, loc.items),
+}));

--- a/tools/pipeline-generate/SellProduct/settlement_trade_outposts.json
+++ b/tools/pipeline-generate/SellProduct/settlement_trade_outposts.json
@@ -1,0 +1,1497 @@
+{
+  "source": "SettlementBasicDataTable.settlementTradeItemMap（据点收购/供货交易）",
+  "locales": [
+    "CN",
+    "EN",
+    "JP",
+    "TC"
+  ],
+  "settlements": {
+    "stm_hongs_1": {
+      "settlementId": "stm_hongs_1",
+      "settlementName": {
+        "CN": "天王坪援建点",
+        "EN": "Sky King Flats Construction Site",
+        "JP": "天王原建設支援拠点",
+        "TC": "天王坪援助點"
+      },
+      "domainId": "domain_2",
+      "domainLevelId": "map02_lv001",
+      "domainLevelShowName": {
+        "CN": "景玉谷",
+        "EN": "Jingyu Valley",
+        "JP": "景玉谷",
+        "TC": "景玉谷"
+      },
+      "levelIdAlsoThisSettlement": "map02_lv001",
+      "paymentItemId": "item_domain_jinlong_coupon",
+      "paymentItemName": {
+        "CN": "武陵调度券",
+        "EN": "Wuling Stock Bill",
+        "JP": "武陵取引券",
+        "TC": "武陵調度券"
+      },
+      "byProsperityLevel": {
+        "1": {
+          "prosperityLevel": 1,
+          "recoItemId": "item_bottled_rec_hp_4",
+          "tradeItems": [
+            {
+              "itemId": "item_proc_battery_4",
+              "rarity": 4,
+              "name": {
+                "CN": "低容武陵电池",
+                "EN": "LC Wuling Battery",
+                "JP": "小容量武陵バッテリー",
+                "TC": "低容量武陵電池"
+              },
+              "unitPrice": 25,
+              "stmExp": 25,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_4",
+              "rarity": 3,
+              "name": {
+                "CN": "芽针针剂",
+                "EN": "Yazhen Syringe [C]",
+                "JP": "芽針注射剤Ⅰ",
+                "TC": "芽針針劑"
+              },
+              "unitPrice": 16,
+              "stmExp": 16,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_xiranite_powder",
+              "rarity": 2,
+              "name": {
+                "CN": "息壤",
+                "EN": "Xiranite",
+                "JP": "息壌",
+                "TC": "息壤"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "2": {
+          "prosperityLevel": 2,
+          "recoItemId": "item_proc_battery_4",
+          "tradeItems": [
+            {
+              "itemId": "item_proc_battery_4",
+              "rarity": 4,
+              "name": {
+                "CN": "低容武陵电池",
+                "EN": "LC Wuling Battery",
+                "JP": "小容量武陵バッテリー",
+                "TC": "低容量武陵電池"
+              },
+              "unitPrice": 25,
+              "stmExp": 25,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_bottled_food_4",
+              "rarity": 3,
+              "name": {
+                "CN": "锦草软饮",
+                "EN": "Jincao Drink",
+                "JP": "錦草ソーダⅠ",
+                "TC": "錦草飲料"
+              },
+              "unitPrice": 16,
+              "stmExp": 16,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_4",
+              "rarity": 3,
+              "name": {
+                "CN": "芽针针剂",
+                "EN": "Yazhen Syringe [C]",
+                "JP": "芽針注射剤Ⅰ",
+                "TC": "芽針針劑"
+              },
+              "unitPrice": 16,
+              "stmExp": 16,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_copper_cmpt",
+              "rarity": 3,
+              "name": {
+                "CN": "赤铜零件",
+                "EN": "Cuprium Part",
+                "JP": "赤銅部品",
+                "TC": "赤銅零件"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v1d1d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_xiranite_powder",
+              "rarity": 2,
+              "name": {
+                "CN": "息壤",
+                "EN": "Xiranite",
+                "JP": "息壌",
+                "TC": "息壤"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "3": {
+          "prosperityLevel": 3,
+          "recoItemId": "item_bottled_rec_hp_5",
+          "tradeItems": [
+            {
+              "itemId": "item_proc_battery_5",
+              "rarity": 4,
+              "name": {
+                "CN": "中容武陵电池",
+                "EN": "SC Wuling Battery",
+                "JP": "中容量武陵バッテリー",
+                "TC": "中容量武陵電池"
+              },
+              "unitPrice": 54,
+              "stmExp": 54,
+              "versionStart": "v1d1d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_4",
+              "rarity": 4,
+              "name": {
+                "CN": "低容武陵电池",
+                "EN": "LC Wuling Battery",
+                "JP": "小容量武陵バッテリー",
+                "TC": "低容量武陵電池"
+              },
+              "unitPrice": 25,
+              "stmExp": 25,
+              "versionStart": "v1d1d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_5",
+              "rarity": 4,
+              "name": {
+                "CN": "优质芽针针剂",
+                "EN": "Yazhen Syringe [A]",
+                "JP": "芽針注射剤Ⅱ",
+                "TC": "優質芽針針劑"
+              },
+              "unitPrice": 22,
+              "stmExp": 22,
+              "versionStart": "v1d1d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_bottled_food_4",
+              "rarity": 3,
+              "name": {
+                "CN": "锦草软饮",
+                "EN": "Jincao Drink",
+                "JP": "錦草ソーダⅠ",
+                "TC": "錦草飲料"
+              },
+              "unitPrice": 16,
+              "stmExp": 16,
+              "versionStart": "v1d1d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_4",
+              "rarity": 3,
+              "name": {
+                "CN": "芽针针剂",
+                "EN": "Yazhen Syringe [C]",
+                "JP": "芽針注射剤Ⅰ",
+                "TC": "芽針針劑"
+              },
+              "unitPrice": 16,
+              "stmExp": 16,
+              "versionStart": "v1d1d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_copper_cmpt",
+              "rarity": 3,
+              "name": {
+                "CN": "赤铜零件",
+                "EN": "Cuprium Part",
+                "JP": "赤銅部品",
+                "TC": "赤銅零件"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v1d1d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_xiranite_powder",
+              "rarity": 2,
+              "name": {
+                "CN": "息壤",
+                "EN": "Xiranite",
+                "JP": "息壌",
+                "TC": "息壤"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v1d1d0",
+              "isRecommended": false
+            }
+          ]
+        }
+      }
+    },
+    "stm_tundra_1": {
+      "settlementId": "stm_tundra_1",
+      "settlementName": {
+        "CN": "难民暂居处",
+        "EN": "Refugee Camp",
+        "JP": "仮設居住地",
+        "TC": "難民暫居處"
+      },
+      "domainId": "domain_1",
+      "domainLevelId": "map01_lv002",
+      "domainLevelShowName": {
+        "CN": "谷地通道",
+        "EN": "Valley Pass",
+        "JP": "谷地通路",
+        "TC": "谷地通道"
+      },
+      "levelIdAlsoThisSettlement": "map01_lv002",
+      "paymentItemId": "item_domain_tundra_coupon",
+      "paymentItemName": {
+        "CN": "谷地调度券",
+        "EN": "Valley Stock Bill",
+        "JP": "谷地取引券",
+        "TC": "谷地調度券"
+      },
+      "byProsperityLevel": {
+        "1": {
+          "prosperityLevel": 1,
+          "recoItemId": "item_bottled_rec_hp_1",
+          "tradeItems": [
+            {
+              "itemId": "item_bottled_rec_hp_1",
+              "rarity": 3,
+              "name": {
+                "CN": "荞愈胶囊",
+                "EN": "Buck Capsule [C]",
+                "JP": "蕎花カプセルⅠ",
+                "TC": "蕎癒膠囊"
+              },
+              "unitPrice": 10,
+              "stmExp": 10,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_glass_bottle",
+              "rarity": 2,
+              "name": {
+                "CN": "紫晶质瓶",
+                "EN": "Amethyst Bottle",
+                "JP": "紫晶製ボトル",
+                "TC": "紫晶質瓶"
+              },
+              "unitPrice": 2,
+              "stmExp": 2,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_crystal_shell",
+              "rarity": 2,
+              "name": {
+                "CN": "晶体外壳",
+                "EN": "Origocrust",
+                "JP": "結晶外殻",
+                "TC": "晶體外殼"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_glass_cmpt",
+              "rarity": 2,
+              "name": {
+                "CN": "紫晶零件",
+                "EN": "Amethyst Part",
+                "JP": "紫晶部品",
+                "TC": "紫晶零件"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "2": {
+          "prosperityLevel": 2,
+          "recoItemId": "item_bottled_rec_hp_2",
+          "tradeItems": [
+            {
+              "itemId": "item_proc_battery_2",
+              "rarity": 3,
+              "name": {
+                "CN": "中容谷地电池",
+                "EN": "SC Valley Battery",
+                "JP": "中容量谷地バッテリー",
+                "TC": "中容量谷地電池"
+              },
+              "unitPrice": 30,
+              "stmExp": 30,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质荞愈胶囊",
+                "EN": "Buck Capsule [B]",
+                "JP": "蕎花カプセルⅡ",
+                "TC": "優質蕎癒膠囊"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_bottled_food_1",
+              "rarity": 3,
+              "name": {
+                "CN": "柑实罐头",
+                "EN": "Canned Citrome [C]",
+                "JP": "シトロームの缶詰Ⅰ",
+                "TC": "柑實罐頭"
+              },
+              "unitPrice": 10,
+              "stmExp": 10,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_1",
+              "rarity": 3,
+              "name": {
+                "CN": "荞愈胶囊",
+                "EN": "Buck Capsule [C]",
+                "JP": "蕎花カプセルⅠ",
+                "TC": "蕎癒膠囊"
+              },
+              "unitPrice": 10,
+              "stmExp": 10,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_glass_bottle",
+              "rarity": 2,
+              "name": {
+                "CN": "紫晶质瓶",
+                "EN": "Amethyst Bottle",
+                "JP": "紫晶製ボトル",
+                "TC": "紫晶質瓶"
+              },
+              "unitPrice": 2,
+              "stmExp": 2,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_crystal_shell",
+              "rarity": 2,
+              "name": {
+                "CN": "晶体外壳",
+                "EN": "Origocrust",
+                "JP": "結晶外殻",
+                "TC": "晶體外殼"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_glass_cmpt",
+              "rarity": 2,
+              "name": {
+                "CN": "紫晶零件",
+                "EN": "Amethyst Part",
+                "JP": "紫晶部品",
+                "TC": "紫晶零件"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "3": {
+          "prosperityLevel": 3,
+          "recoItemId": "item_bottled_rec_hp_3",
+          "tradeItems": [
+            {
+              "itemId": "item_bottled_rec_hp_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选荞愈胶囊",
+                "EN": "Buck Capsule [A]",
+                "JP": "蕎花カプセルⅢ",
+                "TC": "精選蕎癒膠囊"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_proc_battery_3",
+              "rarity": 4,
+              "name": {
+                "CN": "高容谷地电池",
+                "EN": "HC Valley Battery",
+                "JP": "大容量谷地バッテリー",
+                "TC": "高容量谷地電池"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_2",
+              "rarity": 3,
+              "name": {
+                "CN": "中容谷地电池",
+                "EN": "SC Valley Battery",
+                "JP": "中容量谷地バッテリー",
+                "TC": "中容量谷地電池"
+              },
+              "unitPrice": 30,
+              "stmExp": 30,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_food_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质柑实罐头",
+                "EN": "Canned Citrome [B]",
+                "JP": "シトロームの缶詰Ⅱ",
+                "TC": "優質柑實罐頭"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质荞愈胶囊",
+                "EN": "Buck Capsule [B]",
+                "JP": "蕎花カプセルⅡ",
+                "TC": "優質蕎癒膠囊"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_food_1",
+              "rarity": 3,
+              "name": {
+                "CN": "柑实罐头",
+                "EN": "Canned Citrome [C]",
+                "JP": "シトロームの缶詰Ⅰ",
+                "TC": "柑實罐頭"
+              },
+              "unitPrice": 10,
+              "stmExp": 10,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_1",
+              "rarity": 3,
+              "name": {
+                "CN": "荞愈胶囊",
+                "EN": "Buck Capsule [C]",
+                "JP": "蕎花カプセルⅠ",
+                "TC": "蕎癒膠囊"
+              },
+              "unitPrice": 10,
+              "stmExp": 10,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_glass_bottle",
+              "rarity": 2,
+              "name": {
+                "CN": "紫晶质瓶",
+                "EN": "Amethyst Bottle",
+                "JP": "紫晶製ボトル",
+                "TC": "紫晶質瓶"
+              },
+              "unitPrice": 2,
+              "stmExp": 2,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_crystal_shell",
+              "rarity": 2,
+              "name": {
+                "CN": "晶体外壳",
+                "EN": "Origocrust",
+                "JP": "結晶外殻",
+                "TC": "晶體外殼"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_glass_cmpt",
+              "rarity": 2,
+              "name": {
+                "CN": "紫晶零件",
+                "EN": "Amethyst Part",
+                "JP": "紫晶部品",
+                "TC": "紫晶零件"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "4": {
+          "prosperityLevel": 4,
+          "recoItemId": "item_bottled_rec_hp_3",
+          "tradeItems": [
+            {
+              "itemId": "item_bottled_food_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选柑实罐头",
+                "EN": "Canned Citrome [A]",
+                "JP": "シトロームの缶詰Ⅲ",
+                "TC": "精選柑實罐頭"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选荞愈胶囊",
+                "EN": "Buck Capsule [A]",
+                "JP": "蕎花カプセルⅢ",
+                "TC": "精選蕎癒膠囊"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_proc_battery_3",
+              "rarity": 4,
+              "name": {
+                "CN": "高容谷地电池",
+                "EN": "HC Valley Battery",
+                "JP": "大容量谷地バッテリー",
+                "TC": "高容量谷地電池"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_2",
+              "rarity": 3,
+              "name": {
+                "CN": "中容谷地电池",
+                "EN": "SC Valley Battery",
+                "JP": "中容量谷地バッテリー",
+                "TC": "中容量谷地電池"
+              },
+              "unitPrice": 30,
+              "stmExp": 30,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_food_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质柑实罐头",
+                "EN": "Canned Citrome [B]",
+                "JP": "シトロームの缶詰Ⅱ",
+                "TC": "優質柑實罐頭"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质荞愈胶囊",
+                "EN": "Buck Capsule [B]",
+                "JP": "蕎花カプセルⅡ",
+                "TC": "優質蕎癒膠囊"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_food_1",
+              "rarity": 3,
+              "name": {
+                "CN": "柑实罐头",
+                "EN": "Canned Citrome [C]",
+                "JP": "シトロームの缶詰Ⅰ",
+                "TC": "柑實罐頭"
+              },
+              "unitPrice": 10,
+              "stmExp": 10,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_1",
+              "rarity": 3,
+              "name": {
+                "CN": "荞愈胶囊",
+                "EN": "Buck Capsule [C]",
+                "JP": "蕎花カプセルⅠ",
+                "TC": "蕎癒膠囊"
+              },
+              "unitPrice": 10,
+              "stmExp": 10,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_glass_bottle",
+              "rarity": 2,
+              "name": {
+                "CN": "紫晶质瓶",
+                "EN": "Amethyst Bottle",
+                "JP": "紫晶製ボトル",
+                "TC": "紫晶質瓶"
+              },
+              "unitPrice": 2,
+              "stmExp": 2,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_crystal_shell",
+              "rarity": 2,
+              "name": {
+                "CN": "晶体外壳",
+                "EN": "Origocrust",
+                "JP": "結晶外殻",
+                "TC": "晶體外殼"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_glass_cmpt",
+              "rarity": 2,
+              "name": {
+                "CN": "紫晶零件",
+                "EN": "Amethyst Part",
+                "JP": "紫晶部品",
+                "TC": "紫晶零件"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        }
+      }
+    },
+    "stm_tundra_2": {
+      "settlementId": "stm_tundra_2",
+      "settlementName": {
+        "CN": "基建前站",
+        "EN": "Infra-Station",
+        "JP": "建設基地",
+        "TC": "基建前站"
+      },
+      "domainId": "domain_1",
+      "domainLevelId": "map01_lv005",
+      "domainLevelShowName": {
+        "CN": "源石研究园",
+        "EN": "Originium Science Park",
+        "JP": "源石研究パーク",
+        "TC": "源石研究園"
+      },
+      "levelIdAlsoThisSettlement": "map01_lv005",
+      "paymentItemId": "item_domain_tundra_coupon",
+      "paymentItemName": {
+        "CN": "谷地调度券",
+        "EN": "Valley Stock Bill",
+        "JP": "谷地取引券",
+        "TC": "谷地調度券"
+      },
+      "byProsperityLevel": {
+        "1": {
+          "prosperityLevel": 1,
+          "recoItemId": "item_proc_battery_1",
+          "tradeItems": [
+            {
+              "itemId": "item_proc_battery_1",
+              "rarity": 3,
+              "name": {
+                "CN": "低容谷地电池",
+                "EN": "LC Valley Battery",
+                "JP": "小容量谷地バッテリー",
+                "TC": "低容量谷地電池"
+              },
+              "unitPrice": 16,
+              "stmExp": 16,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_iron_cmpt",
+              "rarity": 2,
+              "name": {
+                "CN": "铁制零件",
+                "EN": "Ferrium Part",
+                "JP": "鉄製部品",
+                "TC": "鐵製零件"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "2": {
+          "prosperityLevel": 2,
+          "recoItemId": "item_proc_battery_2",
+          "tradeItems": [
+            {
+              "itemId": "item_proc_battery_2",
+              "rarity": 3,
+              "name": {
+                "CN": "中容谷地电池",
+                "EN": "SC Valley Battery",
+                "JP": "中容量谷地バッテリー",
+                "TC": "中容量谷地電池"
+              },
+              "unitPrice": 30,
+              "stmExp": 30,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_bottled_rec_hp_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质荞愈胶囊",
+                "EN": "Buck Capsule [B]",
+                "JP": "蕎花カプセルⅡ",
+                "TC": "優質蕎癒膠囊"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_1",
+              "rarity": 3,
+              "name": {
+                "CN": "低容谷地电池",
+                "EN": "LC Valley Battery",
+                "JP": "小容量谷地バッテリー",
+                "TC": "低容量谷地電池"
+              },
+              "unitPrice": 16,
+              "stmExp": 16,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_iron_cmpt",
+              "rarity": 2,
+              "name": {
+                "CN": "铁制零件",
+                "EN": "Ferrium Part",
+                "JP": "鉄製部品",
+                "TC": "鐵製零件"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "3": {
+          "prosperityLevel": 3,
+          "recoItemId": "item_proc_battery_3",
+          "tradeItems": [
+            {
+              "itemId": "item_bottled_rec_hp_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选荞愈胶囊",
+                "EN": "Buck Capsule [A]",
+                "JP": "蕎花カプセルⅢ",
+                "TC": "精選蕎癒膠囊"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_3",
+              "rarity": 4,
+              "name": {
+                "CN": "高容谷地电池",
+                "EN": "HC Valley Battery",
+                "JP": "大容量谷地バッテリー",
+                "TC": "高容量谷地電池"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_proc_battery_2",
+              "rarity": 3,
+              "name": {
+                "CN": "中容谷地电池",
+                "EN": "SC Valley Battery",
+                "JP": "中容量谷地バッテリー",
+                "TC": "中容量谷地電池"
+              },
+              "unitPrice": 30,
+              "stmExp": 30,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质荞愈胶囊",
+                "EN": "Buck Capsule [B]",
+                "JP": "蕎花カプセルⅡ",
+                "TC": "優質蕎癒膠囊"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_1",
+              "rarity": 3,
+              "name": {
+                "CN": "低容谷地电池",
+                "EN": "LC Valley Battery",
+                "JP": "小容量谷地バッテリー",
+                "TC": "低容量谷地電池"
+              },
+              "unitPrice": 16,
+              "stmExp": 16,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_iron_cmpt",
+              "rarity": 2,
+              "name": {
+                "CN": "铁制零件",
+                "EN": "Ferrium Part",
+                "JP": "鉄製部品",
+                "TC": "鐵製零件"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "4": {
+          "prosperityLevel": 4,
+          "recoItemId": "item_proc_battery_3",
+          "tradeItems": [
+            {
+              "itemId": "item_bottled_food_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选柑实罐头",
+                "EN": "Canned Citrome [A]",
+                "JP": "シトロームの缶詰Ⅲ",
+                "TC": "精選柑實罐頭"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选荞愈胶囊",
+                "EN": "Buck Capsule [A]",
+                "JP": "蕎花カプセルⅢ",
+                "TC": "精選蕎癒膠囊"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_3",
+              "rarity": 4,
+              "name": {
+                "CN": "高容谷地电池",
+                "EN": "HC Valley Battery",
+                "JP": "大容量谷地バッテリー",
+                "TC": "高容量谷地電池"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_proc_battery_2",
+              "rarity": 3,
+              "name": {
+                "CN": "中容谷地电池",
+                "EN": "SC Valley Battery",
+                "JP": "中容量谷地バッテリー",
+                "TC": "中容量谷地電池"
+              },
+              "unitPrice": 30,
+              "stmExp": 30,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_food_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质柑实罐头",
+                "EN": "Canned Citrome [B]",
+                "JP": "シトロームの缶詰Ⅱ",
+                "TC": "優質柑實罐頭"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质荞愈胶囊",
+                "EN": "Buck Capsule [B]",
+                "JP": "蕎花カプセルⅡ",
+                "TC": "優質蕎癒膠囊"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_1",
+              "rarity": 3,
+              "name": {
+                "CN": "低容谷地电池",
+                "EN": "LC Valley Battery",
+                "JP": "小容量谷地バッテリー",
+                "TC": "低容量谷地電池"
+              },
+              "unitPrice": 16,
+              "stmExp": 16,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_food_1",
+              "rarity": 3,
+              "name": {
+                "CN": "柑实罐头",
+                "EN": "Canned Citrome [C]",
+                "JP": "シトロームの缶詰Ⅰ",
+                "TC": "柑實罐頭"
+              },
+              "unitPrice": 10,
+              "stmExp": 10,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_iron_cmpt",
+              "rarity": 2,
+              "name": {
+                "CN": "铁制零件",
+                "EN": "Ferrium Part",
+                "JP": "鉄製部品",
+                "TC": "鐵製零件"
+              },
+              "unitPrice": 1,
+              "stmExp": 1,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        }
+      }
+    },
+    "stm_tundra_3": {
+      "settlementId": "stm_tundra_3",
+      "settlementName": {
+        "CN": "重建指挥部",
+        "EN": "Reconstruction HQ",
+        "JP": "再建管理本部",
+        "TC": "重建指揮部"
+      },
+      "domainId": "domain_1",
+      "domainLevelId": "map01_lv007",
+      "domainLevelShowName": {
+        "CN": "供能高地",
+        "EN": "Power Plateau",
+        "JP": "エネルギー高地",
+        "TC": "供能高地"
+      },
+      "levelIdAlsoThisSettlement": "map01_lv007",
+      "paymentItemId": "item_domain_tundra_coupon",
+      "paymentItemName": {
+        "CN": "谷地调度券",
+        "EN": "Valley Stock Bill",
+        "JP": "谷地取引券",
+        "TC": "谷地調度券"
+      },
+      "byProsperityLevel": {
+        "1": {
+          "prosperityLevel": 1,
+          "recoItemId": "item_bottled_rec_hp_2",
+          "tradeItems": [
+            {
+              "itemId": "item_proc_battery_2",
+              "rarity": 3,
+              "name": {
+                "CN": "中容谷地电池",
+                "EN": "SC Valley Battery",
+                "JP": "中容量谷地バッテリー",
+                "TC": "中容量谷地電池"
+              },
+              "unitPrice": 30,
+              "stmExp": 30,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质荞愈胶囊",
+                "EN": "Buck Capsule [B]",
+                "JP": "蕎花カプセルⅡ",
+                "TC": "優質蕎癒膠囊"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_iron_enr_cmpt",
+              "rarity": 3,
+              "name": {
+                "CN": "钢制零件",
+                "EN": "Steel Part",
+                "JP": "鋼製部品",
+                "TC": "鋼製零件"
+              },
+              "unitPrice": 3,
+              "stmExp": 3,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "2": {
+          "prosperityLevel": 2,
+          "recoItemId": "item_bottled_rec_hp_3",
+          "tradeItems": [
+            {
+              "itemId": "item_bottled_rec_hp_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选荞愈胶囊",
+                "EN": "Buck Capsule [A]",
+                "JP": "蕎花カプセルⅢ",
+                "TC": "精選蕎癒膠囊"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_proc_battery_3",
+              "rarity": 4,
+              "name": {
+                "CN": "高容谷地电池",
+                "EN": "HC Valley Battery",
+                "JP": "大容量谷地バッテリー",
+                "TC": "高容量谷地電池"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_2",
+              "rarity": 3,
+              "name": {
+                "CN": "中容谷地电池",
+                "EN": "SC Valley Battery",
+                "JP": "中容量谷地バッテリー",
+                "TC": "中容量谷地電池"
+              },
+              "unitPrice": 30,
+              "stmExp": 30,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质荞愈胶囊",
+                "EN": "Buck Capsule [B]",
+                "JP": "蕎花カプセルⅡ",
+                "TC": "優質蕎癒膠囊"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_iron_enr_cmpt",
+              "rarity": 3,
+              "name": {
+                "CN": "钢制零件",
+                "EN": "Steel Part",
+                "JP": "鋼製部品",
+                "TC": "鋼製零件"
+              },
+              "unitPrice": 3,
+              "stmExp": 3,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "3": {
+          "prosperityLevel": 3,
+          "recoItemId": "item_bottled_rec_hp_3",
+          "tradeItems": [
+            {
+              "itemId": "item_bottled_food_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选柑实罐头",
+                "EN": "Canned Citrome [A]",
+                "JP": "シトロームの缶詰Ⅲ",
+                "TC": "精選柑實罐頭"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选荞愈胶囊",
+                "EN": "Buck Capsule [A]",
+                "JP": "蕎花カプセルⅢ",
+                "TC": "精選蕎癒膠囊"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_proc_battery_3",
+              "rarity": 4,
+              "name": {
+                "CN": "高容谷地电池",
+                "EN": "HC Valley Battery",
+                "JP": "大容量谷地バッテリー",
+                "TC": "高容量谷地電池"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_2",
+              "rarity": 3,
+              "name": {
+                "CN": "中容谷地电池",
+                "EN": "SC Valley Battery",
+                "JP": "中容量谷地バッテリー",
+                "TC": "中容量谷地電池"
+              },
+              "unitPrice": 30,
+              "stmExp": 30,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_food_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质柑实罐头",
+                "EN": "Canned Citrome [B]",
+                "JP": "シトロームの缶詰Ⅱ",
+                "TC": "優質柑實罐頭"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质荞愈胶囊",
+                "EN": "Buck Capsule [B]",
+                "JP": "蕎花カプセルⅡ",
+                "TC": "優質蕎癒膠囊"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_food_1",
+              "rarity": 3,
+              "name": {
+                "CN": "柑实罐头",
+                "EN": "Canned Citrome [C]",
+                "JP": "シトロームの缶詰Ⅰ",
+                "TC": "柑實罐頭"
+              },
+              "unitPrice": 10,
+              "stmExp": 10,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_iron_enr_cmpt",
+              "rarity": 3,
+              "name": {
+                "CN": "钢制零件",
+                "EN": "Steel Part",
+                "JP": "鋼製部品",
+                "TC": "鋼製零件"
+              },
+              "unitPrice": 3,
+              "stmExp": 3,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        },
+        "4": {
+          "prosperityLevel": 4,
+          "recoItemId": "item_bottled_rec_hp_3",
+          "tradeItems": [
+            {
+              "itemId": "item_bottled_food_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选柑实罐头",
+                "EN": "Canned Citrome [A]",
+                "JP": "シトロームの缶詰Ⅲ",
+                "TC": "精選柑實罐頭"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_3",
+              "rarity": 4,
+              "name": {
+                "CN": "精选荞愈胶囊",
+                "EN": "Buck Capsule [A]",
+                "JP": "蕎花カプセルⅢ",
+                "TC": "精選蕎癒膠囊"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": true
+            },
+            {
+              "itemId": "item_proc_battery_3",
+              "rarity": 4,
+              "name": {
+                "CN": "高容谷地电池",
+                "EN": "HC Valley Battery",
+                "JP": "大容量谷地バッテリー",
+                "TC": "高容量谷地電池"
+              },
+              "unitPrice": 70,
+              "stmExp": 70,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_proc_battery_2",
+              "rarity": 3,
+              "name": {
+                "CN": "中容谷地电池",
+                "EN": "SC Valley Battery",
+                "JP": "中容量谷地バッテリー",
+                "TC": "中容量谷地電池"
+              },
+              "unitPrice": 30,
+              "stmExp": 30,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_food_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质柑实罐头",
+                "EN": "Canned Citrome [B]",
+                "JP": "シトロームの缶詰Ⅱ",
+                "TC": "優質柑實罐頭"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_rec_hp_2",
+              "rarity": 3,
+              "name": {
+                "CN": "优质荞愈胶囊",
+                "EN": "Buck Capsule [B]",
+                "JP": "蕎花カプセルⅡ",
+                "TC": "優質蕎癒膠囊"
+              },
+              "unitPrice": 27,
+              "stmExp": 27,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_bottled_food_1",
+              "rarity": 3,
+              "name": {
+                "CN": "柑实罐头",
+                "EN": "Canned Citrome [C]",
+                "JP": "シトロームの缶詰Ⅰ",
+                "TC": "柑實罐頭"
+              },
+              "unitPrice": 10,
+              "stmExp": 10,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            },
+            {
+              "itemId": "item_iron_enr_cmpt",
+              "rarity": 3,
+              "name": {
+                "CN": "钢制零件",
+                "EN": "Steel Part",
+                "JP": "鋼製部品",
+                "TC": "鋼製零件"
+              },
+              "unitPrice": 3,
+              "stmExp": 3,
+              "versionStart": "v0d8d0",
+              "isRecommended": false
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tools/pipeline-generate/SellProduct/template.jsonc
+++ b/tools/pipeline-generate/SellProduct/template.jsonc
@@ -1,0 +1,166 @@
+{
+    // ===== 售卖点开关 =====
+    "${RegionPrefix}${LocationId}": {
+        "type": "switch",
+        "label": "$task.SellProduct.${RegionPrefix}${LocationId}",
+        "default_case": "Yes",
+        "cases": [
+            {
+                "name": "Yes",
+                "pipeline_override": {
+                    "SellProduct${NodePrefix}": {
+                        "enabled": true
+                    }
+                },
+                "option": [
+                    "${RegionPrefix}${LocationId}Attempt1",
+                    "${RegionPrefix}${LocationId}Attempt2",
+                    "${RegionPrefix}${LocationId}Attempt3",
+                    "${RegionPrefix}${LocationId}Attempt4"
+                ]
+            },
+            {
+                "name": "No",
+                "pipeline_override": {
+                    "SellProduct${NodePrefix}": {
+                        "enabled": false
+                    }
+                }
+            }
+        ]
+    },
+    // ===== 售卖尝试 1（默认开启，含描述） =====
+    "${RegionPrefix}${LocationId}Attempt1": {
+        "type": "switch",
+        "label": "$task.SellProduct.SellAttempt1",
+        "description": "$task.SellProduct.SellAttemptDescription",
+        "default_case": "Yes",
+        "cases": [
+            {
+                "name": "Yes",
+                "pipeline_override": {
+                    "SellProduct${NodePrefix}SellAttempt1": {
+                        "enabled": true
+                    }
+                },
+                "option": [
+                    "${RegionPrefix}${LocationId}Item1"
+                ]
+            },
+            {
+                "name": "No",
+                "pipeline_override": {
+                    "SellProduct${NodePrefix}SellAttempt1": {
+                        "enabled": false
+                    }
+                }
+            }
+        ]
+    },
+    // ===== 售卖尝试 2（默认开启） =====
+    "${RegionPrefix}${LocationId}Attempt2": {
+        "type": "switch",
+        "label": "$task.SellProduct.SellAttempt2",
+        "default_case": "Yes",
+        "cases": [
+            {
+                "name": "Yes",
+                "pipeline_override": {
+                    "SellProduct${NodePrefix}SellAttempt2": {
+                        "enabled": true
+                    }
+                },
+                "option": [
+                    "${RegionPrefix}${LocationId}Item2"
+                ]
+            },
+            {
+                "name": "No",
+                "pipeline_override": {
+                    "SellProduct${NodePrefix}SellAttempt2": {
+                        "enabled": false
+                    }
+                }
+            }
+        ]
+    },
+    // ===== 售卖尝试 3（默认关闭） =====
+    "${RegionPrefix}${LocationId}Attempt3": {
+        "type": "switch",
+        "label": "$task.SellProduct.SellAttempt3",
+        "default_case": "No",
+        "cases": [
+            {
+                "name": "Yes",
+                "pipeline_override": {
+                    "SellProduct${NodePrefix}SellAttempt3": {
+                        "enabled": true
+                    }
+                },
+                "option": [
+                    "${RegionPrefix}${LocationId}Item3"
+                ]
+            },
+            {
+                "name": "No",
+                "pipeline_override": {
+                    "SellProduct${NodePrefix}SellAttempt3": {
+                        "enabled": false
+                    }
+                }
+            }
+        ]
+    },
+    // ===== 售卖尝试 4（默认关闭） =====
+    "${RegionPrefix}${LocationId}Attempt4": {
+        "type": "switch",
+        "label": "$task.SellProduct.SellAttempt4",
+        "default_case": "No",
+        "cases": [
+            {
+                "name": "Yes",
+                "pipeline_override": {
+                    "SellProduct${NodePrefix}SellAttempt4": {
+                        "enabled": true
+                    }
+                },
+                "option": [
+                    "${RegionPrefix}${LocationId}Item4"
+                ]
+            },
+            {
+                "name": "No",
+                "pipeline_override": {
+                    "SellProduct${NodePrefix}SellAttempt4": {
+                        "enabled": false
+                    }
+                }
+            }
+        ]
+    },
+    // ===== 优先物品选择 1-4 =====
+    "${RegionPrefix}${LocationId}Item1": {
+        "type": "select",
+        "label": "$task.SellProduct.PriorityItem1",
+        "default_case": "无",
+        "cases": "${ItemCases1}"
+    },
+    "${RegionPrefix}${LocationId}Item2": {
+        "type": "select",
+        "label": "$task.SellProduct.PriorityItem2",
+        "default_case": "无",
+        "cases": "${ItemCases2}"
+    },
+    "${RegionPrefix}${LocationId}Item3": {
+        "type": "select",
+        "label": "$task.SellProduct.PriorityItem3",
+        "default_case": "无",
+        "cases": "${ItemCases3}"
+    },
+    "${RegionPrefix}${LocationId}Item4": {
+        "type": "select",
+        "label": "$task.SellProduct.PriorityItem4",
+        "default_case": "无",
+        "cases": "${ItemCases4}"
+    }
+}


### PR DESCRIPTION
同时修复据点内优先物品列表不正确的问题。

不过还需要等 https://github.com/Joe-Bao/MAA-pipeline-generate/issues/1 实现才能直接生成 task 文件。

fixed #1793

## Summary by Sourcery

修复 SellProduct 任务的物品选择逻辑，使用自动生成的物品/前哨站配置，并添加用于自动任务生成的支持数据和工具。

新功能：
- 引入基于定居点贸易前哨站数据的数据驱动 SellProduct 配置生成器。

缺陷修复：
- 修正 SellProduct 物品选择逻辑，使罐头食品和其他前哨站商品能够映射到预期的变体，并能在各定居点正确出售。

优化改进：
- 新增结构化的物品元数据与定居点映射层，用于在不同繁荣等级间统一 SellProduct 配置。

文档：
- 在 `tools/pipeline-generate/SellProduct` 目录下新增 README，记录 SellProduct 管线生成工具的使用方法及其数据来源。

日常维护：
- 提交 SellProduct 管线生成工具所需的源数据、配置和模板文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SellProduct task item selection using a generated item/outpost configuration and add supporting data and tooling for automatic task generation.

New Features:
- Introduce a data-driven SellProduct configuration generator based on settlement trade outpost data.

Bug Fixes:
- Correct SellProduct item selection so canned goods and other outpost items map to the intended variants and can be sold correctly at each settlement.

Enhancements:
- Add a structured item metadata and settlement mapping layer to unify SellProduct configuration across prosperity levels.

Documentation:
- Document the SellProduct pipeline-generate usage and data source in a new README under tools/pipeline-generate/SellProduct.

Chores:
- Check in source data, config, and template files required by the SellProduct pipeline generation tooling.

</details>