### PR TITLE
fix:修复了基质筛选swipe会在720p下出错的问题

### DIFF
--- a/agent/go-service/essencefilter/actions.go
+++ b/agent/go-service/essencefilter/actions.go
@@ -516,7 +516,7 @@ func (a *EssenceFilterFinishAction) Run(ctx *maa.Context, arg *maa.CustomActionA
 const firstRowTargetY = 86       //首行Y
 const calibrateTolerance = 8     //校准误差
 const calibrateScrollRatio = 1.1 //校准滑动比例
-const calibrateSwipeMin = 13     //校准滑动最小值（10px）
+const calibrateSwipeMin = 13     //校准滑动最小值（13px）
 const calibrateSwipeMax = 40     //校准滑动最大值
 
 // EssenceFilterSwipeCalibrateAction - 根据首个 box 的 Y 校准到基准 firstRowTargetY

--- a/agent/go-service/essencefilter/actions.go
+++ b/agent/go-service/essencefilter/actions.go
@@ -516,7 +516,7 @@ func (a *EssenceFilterFinishAction) Run(ctx *maa.Context, arg *maa.CustomActionA
 const firstRowTargetY = 86       //首行Y
 const calibrateTolerance = 8     //校准误差
 const calibrateScrollRatio = 1.1 //校准滑动比例
-const calibrateSwipeMin = 8      //校准滑动最小值
+const calibrateSwipeMin = 13     //校准滑动最小值（10px）
 const calibrateSwipeMax = 40     //校准滑动最大值
 
 // EssenceFilterSwipeCalibrateAction - 根据首个 box 的 Y 校准到基准 firstRowTargetY

--- a/assets/resource/pipeline/EssenceFilter/Swipe.json
+++ b/assets/resource/pipeline/EssenceFilter/Swipe.json
@@ -122,7 +122,7 @@
                     18,
                     72,
                     956,
-                    119
+                    145
                 ],
                 "template": "EssenceFilter/EssenceGeneral.png",
                 "method": 5,


### PR DESCRIPTION
fix #1800 #832 
## 由 Sourcery 提供的总结

错误修复：
- 增加用于精华过滤器校准的最小滑动距离，以防止在 720p 显示器上出现校准失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Increase the minimum swipe distance used for essence filter calibration to prevent failures on 720p displays.

</details>

## 由 Sourcery 提供的摘要

错误修复：
- 增加在本质过滤器校准中使用的最小滑动距离，以避免在 720p 显示器上出现异常行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Increase the minimum swipe distance used in essence filter calibration to avoid misbehavior on 720p displays.

</details>