### PR TITLE
feat: 基质筛选，更加优雅的报告数据日期功能

### DIFF
--- a/agent/go-service/essencefilter/integration.go
+++ b/agent/go-service/essencefilter/integration.go
@@ -2,9 +2,11 @@ package essencefilter
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/essencefilter/matchapi"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
@@ -18,6 +20,17 @@ func dataDirFromResourceBase() string {
 		base = "data"
 	}
 	return filepath.Join(base, "EssenceFilter")
+}
+
+// weaponsOutputDataVersionString returns the local modification date of weapons_output.json
+// (same file the match engine loads), so the UI notice stays in sync without editing matcher_config.
+func weaponsOutputDataVersionString() string {
+	p := filepath.Join(dataDirFromResourceBase(), "weapons_output.json")
+	info, err := os.Stat(p)
+	if err != nil {
+		return ""
+	}
+	return info.ModTime().In(time.Local).Format("2006-01-02")
 }
 
 func reportFocusByKey(ctx *maa.Context, _ *RunState, key string, args ...any) {
@@ -194,7 +207,7 @@ func reportDataVersionNotice(ctx *maa.Context, st *RunState) {
 	if st == nil || st.MatchEngine == nil {
 		return
 	}
-	v := strings.TrimSpace(st.MatchEngine.DataVersion())
+	v := strings.TrimSpace(weaponsOutputDataVersionString())
 	if v == "" {
 		return
 	}

--- a/assets/data/EssenceFilter/matcher_config.json
+++ b/assets/data/EssenceFilter/matcher_config.json
@@ -1,5 +1,4 @@
 {
-    "data_version": "12/3/2026",
     "similarWordMap": {
         "进发": "迸发",
         "进": "迸",


### PR DESCRIPTION
从智能人工变成人工智能自动获取日期。

## Summary by Sourcery

增强内容：
- 使用 `weapons_output.json` 的本地修改日期作为报告中的数据版本，而不是依赖预先配置的引擎数据版本字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Use the local modification date of weapons_output.json as the reported data version instead of relying on a configured engine data version string.

</details>