### PR TITLE
fix: 重新修复线索交换弹窗漏点击问题

### DIFF
--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -101,7 +101,7 @@
                 100
             ]
         },
-        "pre_delay": 1500, // 等待可能出现的情报交流结束弹窗
+        "pre_delay": 3000, // 等待可能出现的情报交流结束弹窗
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -167,8 +167,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "ReceptionRoomSendCluesClueCollectionOpen",
-            "ReceptionRoomClueExchangeWait"
+            "ReceptionRoomSendCluesClueCollectionOpen"
         ]
     },
     "ReceptionRoomSendCluesClueCollectionOpen": {
@@ -315,8 +314,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "SceneNoticeRewardsConfirm",
-            "ReceptionRoomClueExchangeWait"
+            "SceneNoticeRewardsConfirm"
         ]
     },
     "ReceptionRoomReceiveClues": {
@@ -340,8 +338,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "ReceptionRoomReceiveCluesOpen",
-            "ReceptionRoomClueExchangeWait"
+            "ReceptionRoomReceiveCluesOpen"
         ]
     },
     "ReceptionRoomReceiveCluesOpen": {
@@ -771,8 +768,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "ReceptionRoomSetCluesChooseClues",
-            "ReceptionRoomClueExchangeWait"
+            "ReceptionRoomSetCluesChooseClues"
         ]
     },
     "ReceptionRoomSetCluesChooseClues": {


### PR DESCRIPTION
重新分析问题 #1759 
pipeline设计：线索交换弹窗是在ReceptionRoomViewWait内进行捕获
日志分析：用户在ReceptionRoomViewIn节点失败，期望进入会客室界面，实际上还在线索交流弹窗中，ReceptionRoomViewWait内未进行有效捕获，说明该用户会客室弹窗出现较晚
原有修改方案：在每个会客室子任务内添加线索交换弹窗捕获，不符合pipeline设计，补丁较多后期维护困难
新修复方式：尝试继续增大sleep延迟，把线索交换弹窗在ReceptionRoomViewWait内处理掉
<img width="1841" height="862" alt="image" src="https://github.com/user-attachments/assets/316bc3e6-af90-4c97-b17a-df5d0110acdf" />

## Summary by Sourcery

错误修复：
- 提升 ReceptionRoom 流程的健壮性：当线索交换对话框比预期更晚出现时，不再在每个子任务中分别处理，而是统一在 `ReceptionRoomViewWait` 中进行集中处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Improve robustness of the ReceptionRoom flow when the clue-exchange dialog appears later than expected by handling it centrally in ReceptionRoomViewWait instead of per subtask.

</details>