### PR TITLE
fix: 应急理智药，修复理智上限为1000的问题

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -548,7 +548,7 @@
     "task.AutoUseSpMedication.description": "Automatically use one emergency sanity booster (+40 sanity)",
     "task.AutoUseSpMedication.label": "💊 Emergency Sanity Booster",
     "option.UseAllExpireSoonMedication.label": "Use all soon-to-expire emergency sanity boosters",
-    "option.UseAllExpireSoonMedication.description": "When enabled, uses all emergency sanity boosters expiring within 3 days (timer turns red). When disabled, expiring boosters are skipped.",
+    "option.UseAllExpireSoonMedication.description": "When enabled, uses all emergency sanity boosters expiring within 3 days (timer turns red, up to 15). When disabled, expiring boosters are skipped.",
     "option.UseRegularSpMedication.label": "Use regular emergency sanity booster",
     "option.UseRegularSpMedication.description": "Enabled by default. Uses one regular emergency sanity booster when found. Disable to skip regular boosters.",
     "task.AutoCollect.description": "Automatically collect wild resources (the game must stay in the foreground; do not move the mouse).\nNote: if crops have not fully grown, they may grow randomly, which can lead to incomplete collection.\nDue to recognition accuracy limits, even when fully grown some may not be collected.",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -548,7 +548,7 @@
     "task.AutoUseSpMedication.description": "緊急理智強化剤を1つ自動で使用する（+40理智）",
     "task.AutoUseSpMedication.label": "💊緊急理智強化剤",
     "option.UseAllExpireSoonMedication.label": "期限切れ間近の緊急理智強化剤をすべて使用",
-    "option.UseAllExpireSoonMedication.description": "有効にすると、残り3日未満（タイマーが赤くなる）の緊急理智強化剤をすべて使用します。無効にすると期限切れ間近の強化剤はスキップされます。",
+    "option.UseAllExpireSoonMedication.description": "有効にすると、残り3日未満（タイマーが赤くなる）の緊急理智強化剤をすべて使用します（最大15個）。無効にすると期限切れ間近の強化剤はスキップされます。",
     "option.UseRegularSpMedication.label": "通常の緊急理智強化剤を使用",
     "option.UseRegularSpMedication.description": "デフォルトで有効。通常の緊急理智強化剤が見つかった場合に1つ使用します。無効にすると通常の強化剤はスキップされます。",
     "task.AutoCollect.description": "フィールド資源を自動採集します（ゲームを常に前面に表示し、マウスを動かさないでください）。\n注意：作物が完全に成長していない場合、作物がランダムに成長し、採集漏れが発生することがあります。\n認識精度の制限により、成長済みでも一部採集できない場合があります。",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -548,7 +548,7 @@
     "task.AutoUseSpMedication.description": "응급 이성 강화제 1개 자동 사용(+40 이성)",
     "task.AutoUseSpMedication.label": "💊응급 이성 강화제",
     "option.UseAllExpireSoonMedication.label": "곧 만료될 응급 이성 강화제 모두 사용",
-    "option.UseAllExpireSoonMedication.description": "활성화하면 만료까지 3일 미만인 응급 이성 강화제를 모두 사용합니다(시간 표시가 빨갛게 변함). 비활성화하면 만료 예정 강화제를 건너뜁니다.",
+    "option.UseAllExpireSoonMedication.description": "활성화하면 만료까지 3일 미만인 응급 이성 강화제를 모두 사용합니다(시간 표시가 빨갛게 변함, 최대 15개). 비활성화하면 만료 예정 강화제를 건너뜁니다.",
     "option.UseRegularSpMedication.label": "일반 응급 이성 강화제 사용",
     "option.UseRegularSpMedication.description": "기본 활성화. 일반 응급 이성 강화제를 발견하면 1개 사용합니다. 비활성화하면 일반 강화제는 건너뜁니다.",
     "task.AutoCollect.description": "야외 자원을 자동 수집합니다(게임을 계속 전면에 유지하고 마우스를 움직이지 마세요).\n참고: 작물이 완전히 자라기 전에 랜덤 성장으로 인해 수집이 누락될 수 있습니다.\n인식 정확도의 한계로 인해 완전히 자라도 일부는 수집되지 않을 수 있습니다.",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -548,7 +548,7 @@
     "task.AutoUseSpMedication.description": "自动使用一次应急理智加强剂(+40理智)",
     "task.AutoUseSpMedication.label": "💊应急理智加强剂",
     "option.UseAllExpireSoonMedication.label": "使用所有要过期的应急理智加强剂",
-    "option.UseAllExpireSoonMedication.description": "开启后吃完所有时限小于三天的应急理智加强剂（时限变红）；关闭则跳过过期药",
+    "option.UseAllExpireSoonMedication.description": "开启后吃完所有时限小于三天的应急理智加强剂（时限变红的理智药，最多使用15个）；关闭则跳过过期药",
     "option.UseRegularSpMedication.label": "使用应急理智加强剂",
     "option.UseRegularSpMedication.description": "默认开启，找到普通应急理智加强剂时使用一颗；关闭后跳过普通药",
     "task.AutoCollect.description": "自动采集野外资源（需一直保持前台，不要乱动鼠标）\n 注意，作物没有完全生长齐的时候作物会随机生长，会导致收集不齐的情况。\n 受限于识别精度即使齐了也会有个别无法收集",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -390,7 +390,7 @@
     "task.AutoUseSpMedication.description": "自動使用一次應急理智加強劑(+40理智)",
     "task.AutoUseSpMedication.label": "💊應急理智加強劑",
     "option.UseAllExpireSoonMedication.label": "使用所有即將過期的應急理智強化劑",
-    "option.UseAllExpireSoonMedication.description": "開啟後吃完所有時限小於三天的應急理智強化劑（時限變紅）；關閉則跳過過期藥",
+    "option.UseAllExpireSoonMedication.description": "開啟後吃完所有時限小於三天的應急理智強化劑（時限變紅的理智藥，最多使用15個）；關閉則跳過過期藥",
     "option.UseRegularSpMedication.label": "使用應急理智加強劑",
     "option.UseRegularSpMedication.description": "預設開啟，找到普通應急理智加強劑時使用一顆；關閉後跳過普通藥",
     "task.AutoCollect.description": "自動採集野外資源（需一直保持前台，不要亂動滑鼠）\n注意，作物沒有完全生長齊的時候作物會隨機生長，會導致收集不齊的情況。\n受限於識別精度即使齊了也會有個別無法收集",

--- a/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
@@ -252,7 +252,8 @@
         "next": [
             "AutoUseSpMedicationAdd", //loop until add button unavailable
             "AutoUseSpMedicationCantAdd"
-        ]
+        ],
+        "max_hit": 14 // 理智上限为1000，最高使用14+1次总共加600理智
     },
     "AutoUseSpMedicationCantAdd": {
         "desc": "无法添加",


### PR DESCRIPTION
理智上限为1000，最多使用15次应急理智药一共加600

## Summary by Sourcery

调整理智药物的行为和文本，使其遵守 1000 点理智上限，并修正其最大累积恢复量。

Bug 修复：
- 修复紧急理智药物，使其无法将理智值提升到超过 1000 点的上限，并正确限制总恢复量。

文档：
- 更新本地化界面文本，以反映紧急理智药物修正后的最大理智恢复值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust sanity medication behavior and text to respect the 1000 sanity cap and correct its maximum cumulative gain.

Bug Fixes:
- Fix emergency sanity medication so it cannot increase sanity beyond the 1000-point maximum and correctly limits total recovery.

Documentation:
- Update localized interface text to reflect the corrected maximum sanity gain from emergency sanity medication.

</details>