### PR TITLE
fix: 修复协议空间偶现无法找到标签页问题

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/OperationalManual.json
+++ b/assets/resource/pipeline/ProtocolSpace/OperationalManual.json
@@ -40,7 +40,6 @@
             "協約空間"
         ],
         "action": "Click",
-        "post_wait_freezes": 200,
         "next": [
             "ProtocolSpaceOperationalManualSwitchProtocolSpaceTab"
         ]
@@ -59,12 +58,13 @@
             "員養成",
             "Operator Progression"
         ],
+        "pre_wait_freezes": 200,
         "action": "Click",
         "anchor": {
             "ProtocolSpaceOperationalManualFindProtocolSpaceEnableAnchor": "ProtocolSpaceOperationalManualFindProtocolSpaceNormalEnable",
             "ProtocolSpaceOperationalManualFindProtocolSpaceDisableAnchor": "ProtocolSpaceOperationalManualFindProtocolSpaceNormalDisable"
         },
-        "post_wait_freezes": 200,
+        "post_wait_freezes": 400,
         "next": [
             "[Anchor]ProtocolSpaceOperationalManualFindProtocolSpaceEnableAnchor",
             "[Anchor]ProtocolSpaceOperationalManualFindProtocolSpaceDisableAnchor",


### PR DESCRIPTION
close #1871

## Summary by Sourcery

Bug Fixes:
- 通过更新 OperationalManual 配置，修复了在 ProtocolSpace 视图中偶发无法定位选项卡的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve an intermittent issue where tabs in the ProtocolSpace view could not be located by updating the OperationalManual configuration.

</details>