### PR TITLE
ci: 添加PR提交规范检查工作流和本地校验

### DIFF
--- a/.github/workflows/pr-commit-check.yml
+++ b/.github/workflows/pr-commit-check.yml
@@ -1,0 +1,99 @@
+name: PR Commit Check
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  check-commits:
+    name: Check Commits in PR
+    if: ${{ !github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean up previous comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- pr-commit-check -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const previousComments = comments.filter(comment =>
+              comment.user.login === 'github-actions[bot]' && comment.body.includes(marker)
+            );
+
+            for (const comment of previousComments) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+              });
+            }
+
+      - name: Check commits
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- pr-commit-check -->';
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const regex = /^(?:(?:build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|styles|test|i18n|typo|debug|ai)(?:\([^)]+\))?!?:\s|(?:[Rr]evert|[Rr]elease|[Rr]eapply)\b)/;
+
+            const invalidCommits = commits.filter(commit => {
+              const title = commit.commit.message.split('\n')[0];
+              return !regex.test(title) || commit.parents.length > 1;
+            });
+
+            console.log(`Checked ${commits.length} commit(s)`);
+
+            if (invalidCommits.length === 0) {
+              console.log('All commits passed validation');
+              return;
+            }
+
+            const invalidCommitNames = invalidCommits.map(commit => commit.commit.message);
+            const invalidCommitInfoList = invalidCommits
+              .map(commit => {
+                const title = commit.commit.message.split('\n')[0];
+                const reason = commit.parents.length > 1 ? 'merge commit' : 'invalid format';
+                return `- ${title} [\`${commit.sha.substring(0, 7)}\`](${commit.html_url}) (${reason})`;
+              })
+              .join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `${marker}
+## ⚠️ Found ${invalidCommits.length} invalid commit(s)
+
+${invalidCommitInfoList}
+
+---
+Please follow the Conventional Commits format used in this repository, and **do not** use merge commits in pull requests.
+
+Accepted prefixes include: \`build\`, \`chore\`, \`ci\`, \`docs\`, \`feat\`, \`fix\`, \`perf\`, \`refactor\`, \`rft\`, \`style\`, \`test\`, \`i18n\`, \`typo\`, \`debug\`, \`ai\`.
+
+请遵循本仓库使用的 Conventional Commits 规范，并且**不要**在 Pull Request 中使用 Merge Commit。`,
+            });
+
+            core.setFailed(`Found ${invalidCommits.length} invalid commit(s):\n${invalidCommitNames.join('\n-------------------\n')}`);

--- a/.github/workflows/pr-commit-check.yml
+++ b/.github/workflows/pr-commit-check.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   check-commits:
-    name: Check Commits in PR
+    name: Check PR Title and Commits
     if: ${{ !github.event.pull_request.merged }}
     runs-on: ubuntu-latest
     steps:
@@ -48,11 +48,12 @@ jobs:
               }
             }
 
-      - name: Check commits
+      - name: Check PR title and commits
         uses: actions/github-script@v8
         with:
           script: |
             const marker = '<!-- pr-commit-check -->';
+            const prTitle = context.payload.pull_request.title || '';
             const commits = await github.paginate(github.rest.pulls.listCommits, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -61,18 +62,19 @@ jobs:
             });
 
             const regex = /^(?:(?:build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|styles|test|i18n|typo|ai)(?:\([^)]+\))?!?:\s.+|revert:\s.+)$/;
+            const invalidPrTitle = !regex.test(prTitle);
 
             const invalidCommits = commits.filter(commit => {
               const title = commit.commit.message.split('\n')[0];
               return !regex.test(title) || commit.parents.length > 1;
             });
 
-            console.log(`Checked ${commits.length} commit(s)`);
+            console.log(`Checked PR title and ${commits.length} commit(s)`);
 
-            if (invalidCommits.length === 0) {
+            if (!invalidPrTitle && invalidCommits.length === 0) {
               await core.summary
-                .addHeading('Commit check passed')
-                .addRaw(`Checked ${commits.length} commit(s).`, true)
+                .addHeading('PR check passed')
+                .addRaw(`Checked PR title and ${commits.length} commit(s).`, true)
                 .write();
               return;
             }
@@ -84,19 +86,28 @@ jobs:
               return `- ${title} [\`${commit.sha.substring(0, 7)}\`](${commit.html_url}) (${reason})`;
             });
 
-            const commentBody = [
-              marker,
-              `## Found ${invalidCommits.length} invalid commit(s)`,
-              '',
-              invalidCommitInfoList.join('\n'),
-              '',
-              '---',
-              'Please follow the Conventional Commits format used in this repository, and **do not** use merge commits in pull requests.',
-              '',
-              'Accepted prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `rft`, `style`, `styles`, `test`, `i18n`, `typo`, `ai`, `revert`.',
-              '',
-              '请遵循本仓库使用的 Conventional Commits 规范，并且**不要**在 Pull Request 中使用 Merge Commit。',
-            ].join('\n');
+            const commentLines = [marker, '## PR title / commit check failed', ''];
+
+            if (invalidPrTitle) {
+              commentLines.push('### Invalid PR title');
+              commentLines.push(`- ${prTitle || '(empty title)'}`);
+              commentLines.push('');
+            }
+
+            if (invalidCommits.length > 0) {
+              commentLines.push(`### Invalid commit(s): ${invalidCommits.length}`);
+              commentLines.push(invalidCommitInfoList.join('\n'));
+              commentLines.push('');
+            }
+
+            commentLines.push('---');
+            commentLines.push('Please follow the Conventional Commits format used in this repository, and **do not** use merge commits in pull requests.');
+            commentLines.push('');
+            commentLines.push('Accepted prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `rft`, `style`, `styles`, `test`, `i18n`, `typo`, `ai`, `revert`.');
+            commentLines.push('');
+            commentLines.push('请遵循本仓库使用的 Conventional Commits 规范，并且**不要**在 Pull Request 中使用 Merge Commit。');
+
+            const commentBody = commentLines.join('\n');
 
             try {
               await github.rest.issues.createComment({
@@ -110,11 +121,32 @@ jobs:
             }
 
             await core.summary
-              .addHeading(`Found ${invalidCommits.length} invalid commit(s)`)
-              .addRaw(invalidCommitInfoList.join('\n'), true)
+              .addHeading('PR title / commit check failed');
+
+            if (invalidPrTitle) {
+              await core.summary
+                .addHeading('Invalid PR title', 3)
+                .addRaw(`- ${prTitle || '(empty title)'}`, true);
+            }
+
+            if (invalidCommits.length > 0) {
+              await core.summary
+                .addHeading(`Invalid commit(s): ${invalidCommits.length}`, 3)
+                .addRaw(invalidCommitInfoList.join('\n'), true);
+            }
+
+            await core.summary
               .addSeparator()
               .addRaw('Accepted prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `rft`, `style`, `styles`, `test`, `i18n`, `typo`, `ai`, `revert`.', true)
               .addRaw('Do not use merge commits in pull requests.', true)
               .write();
 
-            core.setFailed(`Found ${invalidCommits.length} invalid commit(s):\n${invalidCommitNames.join('\n-------------------\n')}`);
+            const failureReasons = [];
+            if (invalidPrTitle) {
+              failureReasons.push(`Invalid PR title: ${prTitle || '(empty title)'}`);
+            }
+            if (invalidCommits.length > 0) {
+              failureReasons.push(`Found ${invalidCommits.length} invalid commit(s):\n${invalidCommitNames.join('\n-------------------\n')}`);
+            }
+
+            core.setFailed(failureReasons.join('\n===================\n'));

--- a/.github/workflows/pr-commit-check.yml
+++ b/.github/workflows/pr-commit-check.yml
@@ -79,7 +79,7 @@ jobs:
               return;
             }
 
-            const invalidCommitNames = invalidCommits.map(commit => commit.commit.message);
+            const invalidCommitTitles = invalidCommits.map(commit => commit.commit.message.split('\n')[0]);
             const invalidCommitInfoList = invalidCommits.map(commit => {
               const title = commit.commit.message.split('\n')[0];
               const reason = commit.parents.length > 1 ? 'merge commit' : 'invalid format';
@@ -146,7 +146,7 @@ jobs:
               failureReasons.push(`Invalid PR title: ${prTitle || '(empty title)'}`);
             }
             if (invalidCommits.length > 0) {
-              failureReasons.push(`Found ${invalidCommits.length} invalid commit(s):\n${invalidCommitNames.join('\n-------------------\n')}`);
+              failureReasons.push(`Found ${invalidCommits.length} invalid commit(s):\n${invalidCommitTitles.join('\n-------------------\n')}`);
             }
 
             core.setFailed(failureReasons.join('\n===================\n'));

--- a/.github/workflows/pr-commit-check.yml
+++ b/.github/workflows/pr-commit-check.yml
@@ -56,7 +56,7 @@ jobs:
               per_page: 100,
             });
 
-            const regex = /^(?:(?:build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|styles|test|i18n|typo|debug|ai)(?:\([^)]+\))?!?:\s|(?:[Rr]evert|[Rr]elease|[Rr]eapply)\b)/;
+            const regex = /^(?:(?:build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|styles|test|i18n|typo|debug|ai)(?:\([^)]+\))?!?:\s.+|revert:\s.+)$/;
 
             const invalidCommits = commits.filter(commit => {
               const title = commit.commit.message.split('\n')[0];
@@ -79,21 +79,25 @@ jobs:
               })
               .join('\n');
 
+            const commentBody = [
+              marker,
+              `## Found ${invalidCommits.length} invalid commit(s)`,
+              '',
+              invalidCommitInfoList,
+              '',
+              '---',
+              'Please follow the Conventional Commits format used in this repository, and **do not** use merge commits in pull requests.',
+              '',
+              'Accepted prefixes include: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `rft`, `style`, `styles`, `test`, `i18n`, `typo`, `debug`, `ai`, `revert`.',
+              '',
+              '请遵循本仓库使用的 Conventional Commits 规范，并且**不要**在 Pull Request 中使用 Merge Commit。',
+            ].join('\n');
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `${marker}
-## ⚠️ Found ${invalidCommits.length} invalid commit(s)
-
-${invalidCommitInfoList}
-
----
-Please follow the Conventional Commits format used in this repository, and **do not** use merge commits in pull requests.
-
-Accepted prefixes include: \`build\`, \`chore\`, \`ci\`, \`docs\`, \`feat\`, \`fix\`, \`perf\`, \`refactor\`, \`rft\`, \`style\`, \`test\`, \`i18n\`, \`typo\`, \`debug\`, \`ai\`.
-
-请遵循本仓库使用的 Conventional Commits 规范，并且**不要**在 Pull Request 中使用 Merge Commit。`,
+              body: commentBody,
             });
 
             core.setFailed(`Found ${invalidCommits.length} invalid commit(s):\n${invalidCommitNames.join('\n-------------------\n')}`);

--- a/.github/workflows/pr-commit-check.yml
+++ b/.github/workflows/pr-commit-check.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   check-commits:
@@ -60,7 +60,7 @@ jobs:
               per_page: 100,
             });
 
-            const regex = /^(?:(?:build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|styles|test|i18n|typo|debug|ai)(?:\([^)]+\))?!?:\s.+|revert:\s.+)$/;
+            const regex = /^(?:(?:build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|styles|test|i18n|typo|ai)(?:\([^)]+\))?!?:\s.+|revert:\s.+)$/;
 
             const invalidCommits = commits.filter(commit => {
               const title = commit.commit.message.split('\n')[0];
@@ -70,29 +70,30 @@ jobs:
             console.log(`Checked ${commits.length} commit(s)`);
 
             if (invalidCommits.length === 0) {
-              console.log('All commits passed validation');
+              await core.summary
+                .addHeading('Commit check passed')
+                .addRaw(`Checked ${commits.length} commit(s).`, true)
+                .write();
               return;
             }
 
             const invalidCommitNames = invalidCommits.map(commit => commit.commit.message);
-            const invalidCommitInfoList = invalidCommits
-              .map(commit => {
-                const title = commit.commit.message.split('\n')[0];
-                const reason = commit.parents.length > 1 ? 'merge commit' : 'invalid format';
-                return `- ${title} [\`${commit.sha.substring(0, 7)}\`](${commit.html_url}) (${reason})`;
-              })
-              .join('\n');
+            const invalidCommitInfoList = invalidCommits.map(commit => {
+              const title = commit.commit.message.split('\n')[0];
+              const reason = commit.parents.length > 1 ? 'merge commit' : 'invalid format';
+              return `- ${title} [\`${commit.sha.substring(0, 7)}\`](${commit.html_url}) (${reason})`;
+            });
 
             const commentBody = [
               marker,
               `## Found ${invalidCommits.length} invalid commit(s)`,
               '',
-              invalidCommitInfoList,
+              invalidCommitInfoList.join('\n'),
               '',
               '---',
               'Please follow the Conventional Commits format used in this repository, and **do not** use merge commits in pull requests.',
               '',
-              'Accepted prefixes include: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `rft`, `style`, `styles`, `test`, `i18n`, `typo`, `debug`, `ai`, `revert`.',
+              'Accepted prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `rft`, `style`, `styles`, `test`, `i18n`, `typo`, `ai`, `revert`.',
               '',
               '请遵循本仓库使用的 Conventional Commits 规范，并且**不要**在 Pull Request 中使用 Merge Commit。',
             ].join('\n');
@@ -107,5 +108,13 @@ jobs:
             } catch (error) {
               core.warning(`Failed to create PR comment: ${error.message}`);
             }
+
+            await core.summary
+              .addHeading(`Found ${invalidCommits.length} invalid commit(s)`)
+              .addRaw(invalidCommitInfoList.join('\n'), true)
+              .addSeparator()
+              .addRaw('Accepted prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `rft`, `style`, `styles`, `test`, `i18n`, `typo`, `ai`, `revert`.', true)
+              .addRaw('Do not use merge commits in pull requests.', true)
+              .write();
 
             core.setFailed(`Found ${invalidCommits.length} invalid commit(s):\n${invalidCommitNames.join('\n-------------------\n')}`);

--- a/.github/workflows/pr-commit-check.yml
+++ b/.github/workflows/pr-commit-check.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   check-commits:
@@ -37,11 +37,15 @@ jobs:
             );
 
             for (const comment of previousComments) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: comment.id,
-              });
+              try {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id,
+                });
+              } catch (error) {
+                core.warning(`Failed to delete previous bot comment: ${error.message}`);
+              }
             }
 
       - name: Check commits
@@ -93,11 +97,15 @@ jobs:
               '请遵循本仓库使用的 Conventional Commits 规范，并且**不要**在 Pull Request 中使用 Merge Commit。',
             ].join('\n');
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: commentBody,
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: commentBody,
+              });
+            } catch (error) {
+              core.warning(`Failed to create PR comment: ${error.message}`);
+            }
 
             core.setFailed(`Found ${invalidCommits.length} invalid commit(s):\n${invalidCommitNames.join('\n-------------------\n')}`);

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+node scripts/validate-commit-msg.mjs "$1"

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
         "format:go": "cd agent/go-service && go fmt ./...",
         "format:all": "pnpm format && pnpm format:go",
         "check": "maa-tools check",
-        "test": "maa-tools test"
+        "test": "maa-tools test",
+        "prepare": "husky"
     },
     "devDependencies": {
         "@nekosu/maa-tools": "1.0.22",
         "@nekosu/prettier-plugin-maafw-sort": "1.0.4",
         "@types/node": "^24.11.0",
+        "husky": "^9.1.7",
         "prettier": "3.5.3",
         "prettier-plugin-multiline-arrays": "4.1.4"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@types/node':
         specifier: ^24.11.0
         version: 24.11.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       prettier:
         specifier: 3.5.3
         version: 3.5.3
@@ -279,6 +282,11 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -875,6 +883,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  husky@9.1.7: {}
 
   iconv-lite@0.7.2:
     dependencies:

--- a/scripts/validate-commit-msg.mjs
+++ b/scripts/validate-commit-msg.mjs
@@ -1,0 +1,84 @@
+import {readFileSync} from "node:fs";
+import {resolve} from "node:path";
+
+const [
+    ,
+    ,
+    commitMsgPath,
+] = process.argv;
+
+if (!commitMsgPath) {
+    console.error("Missing commit message file path.");
+    process.exit(1);
+}
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const cliffTomlPath = resolve(repoRoot, ".github", "cliff.toml");
+
+function extractAllowedTypes(cliffToml) {
+    const typeSet = new Set();
+    const parserPattern = /message\s*=\s*"(\^[^"]+)"/g;
+
+    for (const match of cliffToml.matchAll(parserPattern)) {
+        const source = match[1];
+
+        if (!source.startsWith("^") || source.includes("[skip changelog]")) {
+            continue;
+        }
+
+        const normalized = source.slice(1).replaceAll("\\\\(", "(").replaceAll("\\\\)", ")");
+
+        if (normalized.startsWith("(")) {
+            const groupEnd = normalized.indexOf(")");
+
+            if (groupEnd > 1) {
+                for (const type of normalized.slice(1, groupEnd).split("|")) {
+                    if (/^[a-z][a-z0-9-]*$/.test(type)) {
+                        typeSet.add(type);
+                    }
+                }
+            }
+
+            continue;
+        }
+
+        const typeMatch = normalized.match(/^([a-z][a-z0-9-]*)/);
+
+        if (typeMatch) {
+            typeSet.add(typeMatch[1]);
+        }
+    }
+
+    return [...typeSet].sort();
+}
+
+const commitMessage = readFileSync(commitMsgPath, "utf8");
+const title = commitMessage.split(/\r?\n/, 1)[0]?.trim() ?? "";
+
+if (!title) {
+    console.error("Commit title cannot be empty.");
+    process.exit(1);
+}
+
+const allowedTypes = extractAllowedTypes(readFileSync(cliffTomlPath, "utf8"));
+
+if (allowedTypes.length === 0) {
+    console.error(`Failed to parse commit types from ${cliffTomlPath}.`);
+    process.exit(1);
+}
+
+if (title.length > 72) {
+    console.error(`Commit title is too long (${title.length}/72).`);
+    process.exit(1);
+}
+
+const escapedTypes = allowedTypes.map((type) => type.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"));
+const titlePattern = new RegExp(`^(?<type>${escapedTypes.join("|")})(\\([^)\\r\\n]+\\))?(!)?: (?<subject>\\S.*)$`);
+
+if (!titlePattern.test(title)) {
+    console.error("Invalid commit title.");
+    console.error("Expected: <type>(<scope>)?: <subject> or <type>(<scope>)!: <subject>");
+    console.error(`Allowed types: ${allowedTypes.join(", ")}`);
+    console.error(`Read from: ${cliffTomlPath}`);
+    process.exit(1);
+}


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

CI：
- 引入一个 PR 提交检查工作流，强制使用 Conventional Commits 前缀并阻止合并提交，同时在 PR 上直接对有问题的提交发表评论说明细节。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

CI：
- 引入一个 PR 提交检查工作流，用于强制使用 Conventional Commits 前缀、拒绝合并提交，并在存在违规提交时发布包含详细反馈的评论。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI：
- 引入一个用于检查 PR 提交的工作流，对 PR 标题和提交信息强制要求符合 Conventional Commit 前缀规范，阻止合并提交（merge commits），并在违反规则时发布包含详细说明的反馈评论。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Introduce a PR commit-check workflow that enforces Conventional Commit prefixes on PR titles and commit messages, blocks merge commits, and posts detailed feedback comments on violations.

</details>

</details>

</details>