### PR TITLE
fix: 修复日常奖励领取中滑到底检测的roi,添加 max_hit 防止死循环

### DIFF
--- a/assets/resource/pipeline/DailyRewards/Tasks.json
+++ b/assets/resource/pipeline/DailyRewards/Tasks.json
@@ -162,7 +162,8 @@
             238
         ],
         "end_hold": 300,
-        "post_wait_freezes": 1
+        "post_wait_freezes": 20,
+        "max_hit": 50
     },
     "DailyTaskScrollFinished": {
         "desc": "日常任务滑到底了，结束",
@@ -170,10 +171,10 @@
             "type": "TemplateMatch",
             "param": {
                 "roi": [
-                    927,
-                    474,
-                    160,
-                    115
+                    929,
+                    432,
+                    162,
+                    108
                 ],
                 "template": [
                     "DailyRewards/FinishedTaskIcon.png"
@@ -225,6 +226,7 @@
             "type": "DoNothing",
             "param": {}
         },
+        "timeout": 10000,
         "post_delay": 0,
         "next": [
             "DailyTaskUpgradeWeapon",


### PR DESCRIPTION
fix #1952 
## Summary by Sourcery

修复每日奖励领取行为并提升其健壮性。

错误修复：
- 更正每日奖励领取流程中列表底部检测的 ROI，以确保可以可靠地领取奖励。
- 为每日奖励滚动逻辑添加最大命中次数保护机制，防止潜在的无限循环。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix daily rewards claiming behavior and improve its robustness.

Bug Fixes:
- Correct bottom-of-list detection ROI in the daily rewards claiming flow to ensure rewards can be claimed reliably.
- Add a maximum hit safeguard to the daily rewards scrolling logic to prevent potential infinite loops.

</details>