### PR TITLE
fix(自动生态农场): bug修复和识别质量优化

### DIFF
--- a/assets/resource/pipeline/AutoEcoFarm.json
+++ b/assets/resource/pipeline/AutoEcoFarm.json
@@ -18,41 +18,5 @@
         "desc": "退出并返回任务失败",
         "action": "Custom",
         "custom_action": "325"
-    },
-    "AutoEcoFarmtest": {
-        "desc": "全屏寻找农田,识别到了后点击",
-        "recognition": {
-            "type": "TemplateMatch",
-            "param": {
-                "roi": [
-                    0,
-                    0,
-                    1280,
-                    720
-                ],
-                "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
-                "order_by": "Horizontal"
-            }
-        },
-        "next": [
-            "AutoEcoFarmtest2",
-            "AutoEcoFarmExit"
-        ]
-    },
-    "AutoEcoFarmtest2": {
-        "recognition": {
-            "type": "Custom",
-            "param": {
-                "custom_recognition": "autoEcoFarmFindNearestRecognitionResult",
-                "custom_recognition_param": {
-                    "RecognitionNodeName": "AutoEcoFarmtest",
-                    "XRatio": 0.5,
-                    "YRatio": 0.5
-                }
-            }
-        },
-        "next": [
-            "AutoEcoFarmExit"
-        ]
     }
 }

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmCommon.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmCommon.json
@@ -151,7 +151,8 @@
                 ],
                 "template": [
                     "AutoEcoFarm/autoecofarmQuickStash.png"
-                ]
+                ],
+                "order_by": "Score"
             }
         },
         "action": {
@@ -174,7 +175,8 @@
                 ],
                 "template": [
                     "AutoEcoFarm/AutoecofarmBlackcloseWhitegrouund.png"
-                ]
+                ],
+                "order_by": "Score"
             }
         },
         "action": {

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
@@ -265,9 +265,31 @@
             "[JumpBack]_AutoEcoFarmMutiSelection",
             "_AutoEcoFarmAlreadySetTarget",
             "_AutoEcoFarmSetTarget",
+            "_AutoEcoFarmFarmlandStillVisibleRetry",
             "[JumpBack]_AutoEcoFarmMoveMouse",
             //识别不到农田的话不结束脚本，而是只结束该子任务，因为农田可能就在边上
             "_AutoEcoFarmFindFarmlandExit"
+        ]
+    },
+    "_AutoEcoFarmFarmlandStillVisibleRetry": {
+        "desc": "点击后仍未匹配到追踪条等分支，但全屏仍能识别农田标记，则回到就近点击重试",
+        "max_hit": 3,
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    0,
+                    0,
+                    1280,
+                    720
+                ],
+                "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
+                "threshold": 0.7,
+                "order_by": "Horizontal"
+            }
+        },
+        "next": [
+            "_AutoEcoFarmFindFarmlandCustom"
         ]
     },
     "_AutoEcoFarmIsMrarking": {

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
@@ -192,7 +192,8 @@
                 "template": "AutoEcoFarm/AutoEcoFarmPlusGrey.png",
                 "green_mask": true,
                 "method": 5,
-                "threshold": 0.9
+                "threshold": 0.9,
+                "order_by": "Score"
             }
         },
         "pre_delay": 0,
@@ -238,6 +239,7 @@
                     720
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
+                "threshold": 0.7,
                 "order_by": "Horizontal"
             }
         }

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
@@ -238,7 +238,8 @@
                     1280,
                     720
                 ],
-                "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
+                "template": "AutoEcoFarm/AutoEcoFarmFarmlandGAI.png",
+                "green_mask": true,
                 "threshold": 0.7,
                 "order_by": "Horizontal"
             }
@@ -283,7 +284,8 @@
                     1280,
                     720
                 ],
-                "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
+                "template": "AutoEcoFarm/AutoEcoFarmFarmlandGAI.png",
+                "green_mask": true,
                 "threshold": 0.7,
                 "order_by": "Horizontal"
             }

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
@@ -303,7 +303,7 @@
             }
         },
         "post_wait_freezes": {
-            "time": 200,
+            "time": 500,
             "target": [
                 548,
                 589,

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
@@ -139,7 +139,8 @@
                     300
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
-                "threshold": 0.4
+                "threshold": 0.6,
+                "order_by": "Score"
             }
         },
         "pre_delay": 0,
@@ -160,7 +161,8 @@
                     63
                 ],
                 "template": "AutoEcoFarm/AutoecofarmBlackcloseWhitegrouund.png",
-                "threshold": 0.7
+                "threshold": 0.7,
+                "order_by": "Score"
             }
         },
         "action": "Click",
@@ -180,7 +182,8 @@
                     31
                 ],
                 "template": "AutoEcoFarm/AutoecofarmWhitecloseblackgrouund.png",
-                "threshold": 0.7
+                "threshold": 0.7,
+                "order_by": "Score"
             }
         },
         "action": "Click",
@@ -410,7 +413,8 @@
                     300
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
-                "threshold": 0.4
+                "threshold": 0.6,
+                "order_by": "Score"
             }
         },
         "inverse": true,

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
@@ -138,7 +138,8 @@
                     440,
                     300
                 ],
-                "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
+                "template": "AutoEcoFarm/AutoEcoFarmFarmlandGAI.png",
+                "green_mask": true,
                 "threshold": 0.6,
                 "order_by": "Score"
             }
@@ -412,7 +413,8 @@
                     440,
                     300
                 ],
-                "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
+                "template": "AutoEcoFarm/AutoEcoFarmFarmlandGAI.png",
+                "green_mask": true,
                 "threshold": 0.6,
                 "order_by": "Score"
             }

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
@@ -1,4 +1,23 @@
 {
+    "AutoEcoFarmEnterCameraModeFailKeyUp": {
+        "desc": "进入拍照模式失败时松开R，避免长按占用，并退出拍照子流程",
+        "action": "KeyUp",
+        "key": 82, // R 0x52
+        "pre_delay": 0,
+        "post_delay": 0,
+        "post_wait_freezes": {
+            "time": 400,
+            "target": [
+                1065,
+                551,
+                62,
+                51
+            ]
+        },
+        "next": [
+            "_AutoEcoFarmJumpBack"
+        ]
+    },
     "AutoEcoFarmEnterCameraModeKeyDownR": {
         "desc": "通过长按R进入拍照模式",
         "recognition": "And",
@@ -8,7 +27,7 @@
         "action": "KeyDown",
         "key": 82, // R 0x52
         "post_wait_freezes": {
-            "time": 200,
+            "time": 500,
             "target": [
                 1065,
                 551,
@@ -20,7 +39,7 @@
             "AutoEcoFarmEnterCameraModeChooseCamera"
         ],
         "on_error": [
-            "AutoEcoFarmExitErr"
+            "AutoEcoFarmEnterCameraModeFailKeyUp"
         ]
     },
     "_AutoEcoFarmExitCameraMode": {
@@ -86,7 +105,7 @@
             "AutoEcoFarmEnterCameraModeKeyUpR"
         ],
         "on_error": [
-            "AutoEcoFarmExitErr"
+            "AutoEcoFarmEnterCameraModeFailKeyUp"
         ]
     },
     "AutoEcoFarmEnterCameraModeKeyUpR": {
@@ -97,7 +116,7 @@
             "AutoEcoFarmClickPhotoScene"
         ],
         "on_error": [
-            "AutoEcoFarmExitErr"
+            "_AutoEcoFarmJumpBack"
         ]
     },
     ///////点击画面部分
@@ -122,7 +141,7 @@
             "_AutoEcoFarmHideFactoryFacilities"
         ],
         "on_error": [
-            "AutoEcoFarmExitErr"
+            "_AutoEcoFarmJumpBack"
         ]
     },
     "AutoEcoFarmPhotoScene": {
@@ -179,7 +198,7 @@
             "_AutoEcoFarmJumpBack"
         ],
         "on_error": [
-            "AutoEcoFarmExitErr"
+            "_AutoEcoFarmJumpBack"
         ]
     },
     "_AutoEcoFarmFindShowFactoryFacilities": {

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
@@ -1,23 +1,4 @@
 {
-    "AutoEcoFarmEnterCameraModeFailKeyUp": {
-        "desc": "进入拍照模式失败时松开R，避免长按占用，并退出拍照子流程",
-        "pre_delay": 0,
-        "action": "KeyUp",
-        "key": 82, // R 0x52
-        "post_wait_freezes": {
-            "time": 400,
-            "target": [
-                1065,
-                551,
-                62,
-                51
-            ]
-        },
-        "post_delay": 0,
-        "next": [
-            "_AutoEcoFarmJumpBack"
-        ]
-    },
     "AutoEcoFarmEnterCameraModeKeyDownR": {
         "desc": "通过长按R进入拍照模式",
         "recognition": "And",
@@ -36,10 +17,27 @@
             ]
         },
         "next": [
-            "AutoEcoFarmEnterCameraModeChooseCamera"
-        ],
-        "on_error": [
+            "AutoEcoFarmEnterCameraModeChooseCamera",
             "AutoEcoFarmEnterCameraModeFailKeyUp"
+        ]
+    },
+    "AutoEcoFarmEnterCameraModeFailKeyUp": {
+        "desc": "未出现选相机界面时松开R（next 兜底，不用 on_error），再 JumpBack",
+        "pre_delay": 0,
+        "action": "KeyUp",
+        "key": 82, // R 0x52
+        "post_wait_freezes": {
+            "time": 400,
+            "target": [
+                1065,
+                551,
+                62,
+                51
+            ]
+        },
+        "post_delay": 0,
+        "next": [
+            "_AutoEcoFarmJumpBack"
         ]
     },
     "_AutoEcoFarmExitCameraMode": {
@@ -105,9 +103,6 @@
         },
         "next": [
             "AutoEcoFarmEnterCameraModeKeyUpR"
-        ],
-        "on_error": [
-            "AutoEcoFarmEnterCameraModeFailKeyUp"
         ]
     },
     "AutoEcoFarmEnterCameraModeKeyUpR": {
@@ -116,9 +111,6 @@
         "key": 82, // R 0x52
         "next": [
             "AutoEcoFarmClickPhotoScene"
-        ],
-        "on_error": [
-            "_AutoEcoFarmJumpBack"
         ]
     },
     ///////点击画面部分
@@ -141,9 +133,6 @@
         },
         "next": [
             "_AutoEcoFarmHideFactoryFacilities"
-        ],
-        "on_error": [
-            "_AutoEcoFarmJumpBack"
         ]
     },
     "AutoEcoFarmPhotoScene": {

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
@@ -1,10 +1,9 @@
 {
     "AutoEcoFarmEnterCameraModeFailKeyUp": {
         "desc": "进入拍照模式失败时松开R，避免长按占用，并退出拍照子流程",
+        "pre_delay": 0,
         "action": "KeyUp",
         "key": 82, // R 0x52
-        "pre_delay": 0,
-        "post_delay": 0,
         "post_wait_freezes": {
             "time": 400,
             "target": [
@@ -14,6 +13,7 @@
                 51
             ]
         },
+        "post_delay": 0,
         "next": [
             "_AutoEcoFarmJumpBack"
         ]
@@ -198,9 +198,6 @@
         ],
         "action": "Click",
         "next": [
-            "_AutoEcoFarmJumpBack"
-        ],
-        "on_error": [
             "_AutoEcoFarmJumpBack"
         ]
     },

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
@@ -35,7 +35,8 @@
                     51
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmBigCamera.png",
-                "threshold": 0.8
+                "threshold": 0.8,
+                "order_by": "Score"
             }
         },
         "action": {
@@ -69,7 +70,8 @@
                     464
                 ],
                 "template": "Common/CameraMode.png",
-                "threshold": 0.8
+                "threshold": 0.8,
+                "order_by": "Score"
             }
         },
         "action": "Click",
@@ -136,6 +138,7 @@
         ],
         "template": "AutoEcoFarm/AutoEcoFarmPhotoScene.png",
         "threshold": 0.8,
+        "order_by": "Score",
         "action": "Click"
     },
     "AutoEcoFarmPhotoSceneIsWhite": {

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPrepare.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPrepare.json
@@ -39,7 +39,8 @@
                 ],
                 "template": [
                     "AutoEcoFarm/autoecofarmTeamIcon.png"
-                ]
+                ],
+                "order_by": "Score"
             }
         },
         "next": []
@@ -57,7 +58,8 @@
                 ],
                 "template": [
                     "AutoEcoFarm/autoecofarmTeamIcon.png"
-                ]
+                ],
+                "order_by": "Score"
             }
         },
         "next": []

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
@@ -56,7 +56,8 @@
                     40,
                     300
                 ],
-                "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
+                "template": "AutoEcoFarm/AutoEcoFarmFarmlandGAI.png",
+                "green_mask": true,
                 "threshold": 0.6,
                 "order_by": "Score"
             }
@@ -78,7 +79,8 @@
                     675,
                     243
                 ],
-                "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
+                "template": "AutoEcoFarm/AutoEcoFarmFarmlandGAI.png",
+                "green_mask": true,
                 "threshold": 0.6,
                 "order_by": "Score"
             }

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
@@ -35,7 +35,8 @@
                 "template": "AutoEcoFarm/AutoEcoFarmFarmlandGAI.png",
                 "green_mask": true,
                 "method": 5,
-                "threshold": 0.6
+                "threshold": 0.6,
+                "order_by": "Score"
             }
         },
         "pre_delay": 0,
@@ -56,7 +57,8 @@
                     300
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
-                "threshold": 0.6
+                "threshold": 0.6,
+                "order_by": "Score"
             }
         },
         "pre_delay": 0,
@@ -77,7 +79,8 @@
                     243
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
-                "threshold": 0.6
+                "threshold": 0.6,
+                "order_by": "Score"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
@@ -35,7 +35,7 @@
                 "template": "AutoEcoFarm/AutoEcoFarmFarmlandGAI.png",
                 "green_mask": true,
                 "method": 5,
-                "threshold": 0.4
+                "threshold": 0.6
             }
         },
         "pre_delay": 0,
@@ -56,7 +56,7 @@
                     300
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
-                "threshold": 0.4
+                "threshold": 0.6
             }
         },
         "pre_delay": 0,
@@ -77,7 +77,7 @@
                     299
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
-                "threshold": 0.4
+                "threshold": 0.6
             }
         },
         "pre_delay": 0,
@@ -148,7 +148,6 @@
         "next": [
             "_AutoEcoFarmTargeInBack",
             "_AutoEcoFarmTargeRecognition",
-            "[JumpBack]_AutoEcoFarmSwipeToGround",
             "[JumpBack]_AutoEcoFarmSwipeRandomWithErr",
             "_AutoEcoFarmMoveToTargetErrFindTarget"
         ]

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
@@ -71,10 +71,10 @@
             "type": "TemplateMatch",
             "param": {
                 "roi": [
-                    22,
+                    336,
                     406,
-                    1230,
-                    299
+                    675,
+                    243
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmland.png",
                 "threshold": 0.6


### PR DESCRIPTION
## 变更说明

### 农田标记与识别

- 提高农田标记 TemplateMatch 阈值，缩小「标记位于背后」场景的判定区域，降低误识别概率。  
- 对匹配结果按分数排序（`order_by: Score`），并补全此前缺少 `order_by` 的 TemplateMatch 节点。  
- 移除效果不佳的拉视角相关节点及无用测试节点。  
- 将原 `AutoEcoFarmFarmland.png` 模板统一替换为 `AutoEcoFarmFarmlandGAI.png`，并在对应 `param` 中启用 `green_mask`。  

### 找农田与追踪

- 点击农田后若未进入追踪相关界面，但全屏仍可识别农田标记，则在限定次数内重试就近点击。  

### 收菜

- 收菜后将菜单稳定等待时间由 200ms 调整为 500ms，以提升后续识别稳定性。  

### 拍照模式

- 适度增加进入拍照模式前的等待时间；失败路径不再使用 `ExitErr`，改为通过松开 R 或 JumpBack 退出子流程。  
- 拍照相关 Pipeline 不使用 `on_error`；长按 R 后若未进入选相机界面，通过 `next` 列表中的兜底节点释放 R 并 JumpBack。  
- 修复「关工业设备」节点中 `next` 与 `on_error` 指向同一目标导致的 maa-tools 重复路由校验问题（移除重复 `on_error`）。  

### 其他

- 已合并分支 `fix/AutoEcoFarmissue1951` 中与上述拍照、收菜相关的改动。  