### PR TITLE
fix: 修复抢订单roi错误的问题

### DIFF
--- a/assets/resource/pipeline/SeizeEntrustTask.json
+++ b/assets/resource/pipeline/SeizeEntrustTask.json
@@ -124,7 +124,7 @@
                         }
                     }
                 ],
-                "box_index": 0
+                "box_index": 1
             }
         },
         "next": [
@@ -198,7 +198,7 @@
                         }
                     }
                 ],
-                "box_index": 0
+                "box_index": 1
             }
         },
         "post_wait_freezes": 1000,


### PR DESCRIPTION
fix #1970 
修正了之前忘记指定输出roi的问题。

## Summary by Sourcery

Bug Fixes:
- 修正 SeizeEntrustTask 流水线中配置的输出 ROI，以解决在抢单过程中错误使用 ROI 的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the configured output ROI in the SeizeEntrustTask pipeline to resolve incorrect ROI usage during order seizing.

</details>