### PR TITLE
fix: 修复可售卖物品为0时依然售卖问题

### DIFF
--- a/agent/go-service/autosell/autosell.go
+++ b/agent/go-service/autosell/autosell.go
@@ -213,7 +213,7 @@ func (a *AutoSellStockRedistributionOpenItemTextAction) Run(ctx *maa.Context, ar
 
 	// 翻译有缘再写
 	targetPrice := 4600
-	var targetName string
+	targetName := "unknown"
 	if k := firstContainedKeyword(resultItem.Text, moderatePriceKeywords); k != "" {
 		targetPrice = param.ModeratePrice
 		targetName = k

--- a/agent/go-service/autosell/autosell.go
+++ b/agent/go-service/autosell/autosell.go
@@ -165,6 +165,22 @@ func (r *AutoSellStockRedistributionOpenItemTextRecognition) Run(ctx *maa.Contex
 	}, true
 }
 
+// firstContainedKeyword 按 subs 顺序返回首个被 s 包含的关键词，无匹配则返回空串。
+func firstContainedKeyword(s string, subs []string) string {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return sub
+		}
+	}
+	return ""
+}
+
+var (
+	moderatePriceKeywords = []string{"锚点", "悬空", "巫术", "天使", "岳硏", "冬虫", "武陵", "武侠"}
+	largePriceKeywords    = []string{"谷地水", "团结", "塞什", "星体"}
+	massivePriceKeywords  = []string{"源石", "警戒", "硬脑", "边角"}
+)
+
 type AutoSellStockRedistributionOpenItemTextAction struct{}
 
 func (a *AutoSellStockRedistributionOpenItemTextAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
@@ -196,31 +212,26 @@ func (a *AutoSellStockRedistributionOpenItemTextAction) Run(ctx *maa.Context, ar
 	}
 
 	// 翻译有缘再写
-	var targetPrice = 4600
-	if strings.Contains(resultItem.Text, "锚点") ||
-		strings.Contains(resultItem.Text, "悬空") ||
-		strings.Contains(resultItem.Text, "巫术") ||
-		strings.Contains(resultItem.Text, "天使") ||
-		strings.Contains(resultItem.Text, "岳硏") ||
-		strings.Contains(resultItem.Text, "冬虫") ||
-		strings.Contains(resultItem.Text, "武陵") ||
-		strings.Contains(resultItem.Text, "武侠") {
+	targetPrice := 4600
+	var targetName string
+	if k := firstContainedKeyword(resultItem.Text, moderatePriceKeywords); k != "" {
 		targetPrice = param.ModeratePrice
+		targetName = k
 		maafocus.Print(ctx, i18n.T("autosell.check_item_price_moderate", resultItem.Text))
-	} else if strings.Contains(resultItem.Text, "谷地水") ||
-		strings.Contains(resultItem.Text, "团结") ||
-		strings.Contains(resultItem.Text, "塞什") ||
-		strings.Contains(resultItem.Text, "星体") {
+	} else if k := firstContainedKeyword(resultItem.Text, largePriceKeywords); k != "" {
 		targetPrice = param.LargePrice
+		targetName = k
 		maafocus.Print(ctx, i18n.T("autosell.check_item_price_large", resultItem.Text))
-	} else if strings.Contains(resultItem.Text, "源石") ||
-		strings.Contains(resultItem.Text, "警戒") ||
-		strings.Contains(resultItem.Text, "硬脑") ||
-		strings.Contains(resultItem.Text, "边角") {
+	} else if k := firstContainedKeyword(resultItem.Text, massivePriceKeywords); k != "" {
 		targetPrice = param.MassivePrice
+		targetName = k
 		maafocus.Print(ctx, i18n.T("autosell.check_item_price_massive", resultItem.Text))
 	} else {
-		log.Warn().Str("component", "autosell").Str("step", "open_item_text").Str("item_name", resultItem.Text).Msg("unknown item, default price")
+		log.Warn().
+			Str("component", "autosell").
+			Str("step", "open_item_text").
+			Str("item_name", resultItem.Text).
+			Msg("unknown item, default price")
 		maafocus.Print(ctx, i18n.T("autosell.check_item_price_unknown", resultItem.Text))
 	}
 
@@ -236,6 +247,26 @@ func (a *AutoSellStockRedistributionOpenItemTextAction) Run(ctx *maa.Context, ar
 				resultItem.Box[1],
 				resultItem.Box[2],
 				resultItem.Box[3],
+			},
+		},
+		"AutoSellStockRedistributionItemTicketByText": map[string]any{
+			"roi": maa.Rect{
+				resultItem.Box[0],
+				resultItem.Box[1],
+				resultItem.Box[2],
+				resultItem.Box[3],
+			},
+		},
+		"AutoSellStockRedistributionItemCountEmpty": map[string]any{
+			"custom_action_param": map[string]any{
+				"item_name":   resultItem.Text,
+				"record_type": "record",
+			},
+		},
+		"AutoSellSellGoodsEmpty": map[string]any{
+			"custom_action_param": map[string]any{
+				"item_name":   resultItem.Text,
+				"record_type": "record",
 			},
 		},
 		"AutoSellFriendsPricesUnExpected": map[string]any{
@@ -255,9 +286,12 @@ func (a *AutoSellStockRedistributionOpenItemTextAction) Run(ctx *maa.Context, ar
 				"lowest_price": targetPrice,
 			},
 		},
+		"AutoSellStockRedistributionItemFindTextRecognition": map[string]any{
+			"expected": targetName,
+		},
 	}
 
-	_, err := ctx.RunTask("AutoSellStockRedistributionItemOpen", override)
+	_, err := ctx.RunTask("AutoSellStockRedistributionItemOpenPrepare", override)
 	if err != nil {
 		log.Error().Err(err).Str("component", "autosell").Str("step", "open_item_text").Msg("run task")
 		return false

--- a/assets/resource/pipeline/AutoSell/Common.json
+++ b/assets/resource/pipeline/AutoSell/Common.json
@@ -1,0 +1,154 @@
+{
+    "AutoSellShipEnterStockRedistribution": {
+        "desc": "从飞船走向弹性需求物资界面",
+        "recognition": "TemplateMatch",
+        "roi": [
+            0,
+            0,
+            100,
+            100
+        ],
+        "template": "VisitFriends/ShipEscButton.png",
+        "threshold": 0.9,
+        "pre_wait_freezes": 100,
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "ZONE",
+                    "zone_id": "OMVBase01"
+                },
+                [
+                    192,
+                    141
+                ],
+                [
+                    187,
+                    141,
+                    true
+                ]
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoSellShipEnterStockRedistribution2"
+        ],
+        "focus": {
+            "Node.Action.Starting": "正在走向物资调度终端"
+        }
+    },
+    "AutoSellShipEnterStockRedistribution2": {
+        "desc": "cpp寻路转向太慢了，容易走到别的房间回不来，因此写两段能快速转向",
+        "recognition": "TemplateMatch",
+        "roi": [
+            0,
+            0,
+            100,
+            100
+        ],
+        "template": "VisitFriends/ShipEscButton.png",
+        "threshold": 0.9,
+        "pre_wait_freezes": 100,
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "ZONE",
+                    "zone_id": "OMVBase01"
+                },
+                [
+                    187,
+                    141
+                ],
+                [
+                    187,
+                    131,
+                    true
+                ]
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoSellEnterStockRedistribution"
+        ]
+    },
+    // "AutoSellEnterShipSuccess": {
+    //     "desc": "进入好友船成功的标志，go寻路走向终点不稳定",
+    //     "recognition": "TemplateMatch",
+    //     "roi": [
+    //         0,
+    //         0,
+    //         100,
+    //         100
+    //     ],
+    //     "template": "VisitFriends/ShipEscButton.png",
+    //     "threshold": 0.9,
+    //     "pre_delay": 0,
+    //     "post_delay": 0,
+    //     "pre_wait_freezes": 100,
+    //     "rate_limit": 0,
+    //     "action": "Custom",
+    //     "custom_action": "MapTrackerMove",
+    //     "custom_action_param": {
+    //         "map_name": "base01_lv003",
+    //         "path": [
+    //             [
+    //                 196.9,
+    //                 143.6
+    //             ],
+    //             [
+    //                 190.3,
+    //                 143.6
+    //             ],
+    //             [
+    //                 190.3,
+    //                 139.1
+    //             ]
+    //         ]
+    //     },
+    //     "focus": {
+    //         "Node.Action.Starting": "正在走向物资调度终端"
+    //     },
+    //     "next": [
+    //         "AutoSellEnterStockRedistribution"
+    //     ]
+    // },
+    "AutoSellEnterStockRedistribution": {
+        "desc": "进入物资调度页面",
+        "recognition": "TemplateMatch",
+        "roi": [
+            -600,
+            -350,
+            600,
+            350
+        ],
+        "template": "AutoSell/StockRedistributionButton.png",
+        "threshold": 0.9,
+        "pre_wait_freezes": 100,
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "AutoAltClickAction",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoSellEnterStockRedistributionSuccess"
+        ]
+    },
+    "AutoSellEnterStockRedistributionSuccess": {
+        "desc": "成功进入物资调度页面",
+        "recognition": "And",
+        "all_of": [
+            "InFriendsStockRedistribution"
+        ],
+        "pre_wait_freezes": 100,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    }
+}

--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -324,7 +324,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            // "AutoSellFriendsPricesExpectedBuySlide",
+            "AutoSellFriendsPricesExpectedBuySlide",
             "AutoSellFriendsPricesExpectedBuyClick"
         ]
     },

--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -1,4 +1,92 @@
 {
+    "AutoSellStockRedistributionItemOpenPrepare": {
+        "desc": "打开物资调度item界面",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoSellStockRedistributionItemCountEmpty",
+            "AutoSellStockRedistributionItemOpen"
+        ]
+    },
+    "AutoSellStockRedistributionItemTicketByText": {
+        "desc": "基于货物名称位置识别item界面的票券icon",
+        "recognition": "TemplateMatch",
+        "roi": [
+            0,
+            200,
+            1280,
+            500
+        ],
+        "roi_offset": [
+            0,
+            -60,
+            0,
+            40
+        ],
+        "template": [
+            "AutoSell/SellTicketItemValleyIV.png",
+            "AutoSell/SellTicketItemWuling.png"
+        ],
+        "threshold": 0.9
+    },
+    "AutoSellStockRedistributionItemCountEmpty": {
+        "desc": "物资调度数量为0",
+        "recognition": "And",
+        "all_of": [
+            "AutoSellStockRedistributionItemTicketByText",
+            {
+                "recognition": "ColorMatch",
+                "roi": "AutoSellStockRedistributionItemTicketByText",
+                "roi_offset": [
+                    -70,
+                    -35,
+                    135,
+                    30
+                ],
+                "lower": [
+                    34,
+                    34,
+                    34
+                ],
+                "upper": [
+                    54,
+                    54,
+                    54
+                ],
+                "count": 500,
+                "sub_name": "count_text"
+            },
+            {
+                "recognition": "OCR",
+                "roi": "count_text",
+                "roi_offset": [
+                    -10,
+                    -10,
+                    -50,
+                    20
+                ],
+                "expected": [
+                    "^(?=.*0)[^1-9]*$"
+                ]
+            }
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "action": "Custom",
+        "custom_action": "AutoSellItemRecordAction",
+        "custom_action_param": {
+            "item_name": "锚点厨具货组",
+            "record_type": "record"
+        },
+        "next": [
+            "AutoSellStockRedistributionItemNext"
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "物资数量为空，跳过"
+        }
+    },
     "AutoSellStockRedistributionItemOpen": {
         "desc": "打开物资调度item界面",
         "pre_delay": 0,
@@ -19,43 +107,95 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutoSellSellGoodsOpen"
+            "AutoSellSellGoodsOpenSuccess"
         ]
     },
-    "AutoSellSellGoodsOpen": {
-        "desc": "打开出售物资界面",
+    "AutoSellSellGoodsOpenSuccess": {
+        "desc": "打开出售物资界面成功",
+        "recognition": "And",
+        "all_of": [
+            "InFriendsStockRedistributionSellGoods"
+        ],
+        "pre_wait_freezes": 100,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoSellSellGoodsEmpty",
+            "AutoSellFriendsPricesOpen"
+        ]
+    },
+    "AutoSellSellGoodsEmpty": {
+        "desc": "物资出售界面没有物资可以出售",
         "recognition": "And",
         "all_of": [
             "InFriendsStockRedistributionSellGoods",
             {
-                "recognition": "OCR",
+                "recognition": "ColorMatch",
                 "roi": [
-                    850,
-                    400,
-                    300,
-                    130
+                    200,
+                    450,
+                    440,
+                    180
                 ],
-                "expected": [
-                    "查看好友价格",
-                    "查看好友價格",
-                    "Friend's Price",
-                    "フレンドの価格を確認",
-                    "친구의 가격 보기"
-                ]
+                "lower": [
+                    200,
+                    84,
+                    94
+                ],
+                "upper": [
+                    220,
+                    104,
+                    114
+                ],
+                "connected": true,
+                "count": 1000
             }
         ],
-        "box_index": 1,
+        "pre_wait_freezes": 100,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "action": "Custom",
+        "custom_action": "AutoSellItemRecordAction",
+        "custom_action_param": {
+            "item_name": "锚点厨具货组",
+            "record_type": "record"
+        },
+        "next": [
+            "AutoSellFriendsPricesBackToView0"
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "没有可售卖的物资"
+        }
+    },
+    "AutoSellFriendsPricesOpen": {
+        "desc": "打开好友价格界面",
+        "recognition": "OCR",
+        "roi": [
+            850,
+            400,
+            300,
+            130
+        ],
+        "expected": [
+            "查看好友价格",
+            "查看好友價格",
+            "Friend's Price",
+            "フレンドの価格を確認",
+            "친구의 가격 보기"
+        ],
         "pre_wait_freezes": 100,
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutoSellFriendsPricesOpen"
+            "AutoSellFriendsPricesOpenSuccess"
         ]
     },
-    "AutoSellFriendsPricesOpen": {
-        "desc": "打开好友价格界面",
+    "AutoSellFriendsPricesOpenSuccess": {
+        "desc": "打开好友价格界面成功",
         "recognition": "And",
         "all_of": [
             "InFriendsStockRedistributionFriendsPrices",
@@ -140,7 +280,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutoSellEnterStockRedistributionSuccess"
+            "AutoSellStockRedistributionItemNext"
         ]
     },
     "AutoSellFriendsPricesExpectedBuy": {
@@ -184,7 +324,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutoSellFriendsPricesExpectedBuySlide",
+            // "AutoSellFriendsPricesExpectedBuySlide",
             "AutoSellFriendsPricesExpectedBuyClick"
         ]
     },
@@ -235,13 +375,11 @@
             "item_name": "锚点厨具货组",
             "record_type": "record"
         },
-        "anchor": {
-            "SceneNoticeRewardsConfirmNextAnchor": "AutoSellEnterStockRedistributionSuccess"
-        },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "SceneNoticeRewardsConfirmWithAnchor"
+            "AutoSellStockRedistributionItemNext",
+            "[JumpBack]SceneNoticeRewardsConfirm"
         ]
     },
     "AutoSellFriendsPricesExpectedGoTo": {
@@ -311,8 +449,62 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "AutoSellStockRedistributionItemFind",
             "[JumpBack]SceneWaitLoadingExit",
-            "AutoSellEnterShipSuccess"
+            "[JumpBack]AutoSellShipEnterStockRedistribution"
         ]
+    },
+    "AutoSellStockRedistributionItemFind": {
+        "desc": "进入物资调度界面，查找目标item",
+        "recognition": "And",
+        "all_of": [
+            "InFriendsStockRedistribution"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack][Anchor]AutoSellEnterStockRedistributionAreaSwitchAnchor",
+            "AutoSellStockRedistributionItemFindText"
+        ]
+    },
+    "AutoSellStockRedistributionItemFindTextRecognition": {
+        "desc": "识别目标item的文本区域",
+        "recognition": "OCR",
+        "roi": "AutoSellStockRedistributionItemNameAreaRecognition",
+        "roi_offset": [
+            -10,
+            -10,
+            10,
+            20
+        ],
+        "expected": "锚点"
+    },
+    "AutoSellStockRedistributionItemFindText": {
+        "desc": "打开物资调度item界面",
+        "recognition": "And",
+        "all_of": [
+            "AutoSellStockRedistributionItemTicketRecognition",
+            "AutoSellStockRedistributionItemNameAreaRecognition",
+            "AutoSellStockRedistributionItemFindTextRecognition"
+        ],
+        "box_index": 2,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "action": "Click",
+        // item左右20个像素无法点击
+        "target_offset": [
+            30,
+            -50,
+            -40,
+            0
+        ],
+        "next": [
+            "AutoSellSellGoodsOpenSuccess"
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "打开指定物品"
+        }
     }
 }

--- a/assets/resource/pipeline/AutoSell/Main.json
+++ b/assets/resource/pipeline/AutoSell/Main.json
@@ -93,212 +93,121 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "AutoSellStockRedistributionItemNext",
             "[JumpBack]SceneWaitLoadingExit",
-            "AutoSellEnterShipSuccess"
+            "[JumpBack]AutoSellShipEnterStockRedistribution"
         ]
     },
-    "AutoSellEnterShipSuccess": {
-        "desc": "进入好友船成功的标志",
-        "recognition": "TemplateMatch",
-        "roi": [
-            0,
-            0,
-            100,
-            100
-        ],
-        "template": "VisitFriends/ShipEscButton.png",
-        "threshold": 0.9,
-        "pre_wait_freezes": 100,
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "MapNavigateAction",
-        "custom_action_param": {
-            "path": [
-                {
-                    "action": "ZONE",
-                    "zone_id": "OMVBase01"
-                },
-                [
-                    192,
-                    141
-                ],
-                [
-                    187,
-                    141,
-                    true
-                ]
-            ]
-        },
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
-            "AutoSellEnterShipSuccess2"
-        ],
-        "focus": {
-            "Node.Action.Starting": "正在走向物资调度终端"
-        }
-    },
-    "AutoSellEnterShipSuccess2": {
-        "desc": "cpp寻路转向太慢了，容易走到别的房间回不来，因此写两段能快速转向",
-        "recognition": "TemplateMatch",
-        "roi": [
-            0,
-            0,
-            100,
-            100
-        ],
-        "template": "VisitFriends/ShipEscButton.png",
-        "threshold": 0.9,
-        "pre_wait_freezes": 100,
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "MapNavigateAction",
-        "custom_action_param": {
-            "path": [
-                {
-                    "action": "ZONE",
-                    "zone_id": "OMVBase01"
-                },
-                [
-                    187,
-                    141
-                ],
-                [
-                    187,
-                    131,
-                    true
-                ]
-            ]
-        },
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
-            "AutoSellEnterStockRedistribution"
-        ]
-    },
-    // "AutoSellEnterShipSuccess": {
-    //     "desc": "进入好友船成功的标志，go寻路走向终点不稳定",
-    //     "recognition": "TemplateMatch",
-    //     "roi": [
-    //         0,
-    //         0,
-    //         100,
-    //         100
-    //     ],
-    //     "template": "VisitFriends/ShipEscButton.png",
-    //     "threshold": 0.9,
-    //     "pre_delay": 0,
-    //     "post_delay": 0,
-    //     "pre_wait_freezes": 100,
-    //     "rate_limit": 0,
-    //     "action": "Custom",
-    //     "custom_action": "MapTrackerMove",
-    //     "custom_action_param": {
-    //         "map_name": "base01_lv003",
-    //         "path": [
-    //             [
-    //                 196.9,
-    //                 143.6
-    //             ],
-    //             [
-    //                 190.3,
-    //                 143.6
-    //             ],
-    //             [
-    //                 190.3,
-    //                 139.1
-    //             ]
-    //         ]
-    //     },
-    //     "focus": {
-    //         "Node.Action.Starting": "正在走向物资调度终端"
-    //     },
-    //     "next": [
-    //         "AutoSellEnterStockRedistribution"
-    //     ]
-    // },
-    "AutoSellEnterStockRedistribution": {
-        "desc": "进入物资调度页面",
-        "recognition": "TemplateMatch",
-        "roi": [
-            -600,
-            -350,
-            600,
-            350
-        ],
-        "template": "AutoSell/StockRedistributionButton.png",
-        "threshold": 0.9,
-        "pre_wait_freezes": 100,
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "AutoAltClickAction",
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
-            "AutoSellEnterStockRedistributionSuccess"
-        ]
-    },
-    "AutoSellEnterStockRedistributionSuccess": {
-        "desc": "成功进入物资调度页面",
+    "AutoSellStockRedistributionItemNext": {
+        "desc": "进入物资调度界面，继续任务",
         "recognition": "And",
         "all_of": [
             "InFriendsStockRedistribution"
         ],
-        "pre_wait_freezes": 100,
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "[Anchor]AutoSellEnterStockRedistributionAreaSwitchAnchor"
+            "[JumpBack][Anchor]AutoSellEnterStockRedistributionAreaSwitchAnchor",
+            "AutoSellEnterStockRedistributionOpenItem",
+            "AutoSellEnterStockRedistributionOpenItemFinish"
         ]
     },
     "AutoSellEnterStockRedistributionAreaSwitchValleyIV": {
         "desc": "切换地区到四号谷地",
-        "recognition": "TemplateMatch",
-        "roi": [
-            0,
-            0,
-            600,
-            150
+        "recognition": "And",
+        "all_of": [
+            {
+                "recognition": "TemplateMatch",
+                "roi": [
+                    0,
+                    0,
+                    600,
+                    150
+                ],
+                "template": [
+                    "AutoSell/StockRedistributionValleyIVChoose.png",
+                    "AutoSell/StockRedistributionValleyIVNotChoose.png"
+                ],
+                "threshold": 0.9,
+                "sub_name": "icon"
+            },
+            {
+                "recognition": "ColorMatch",
+                "roi": "icon",
+                "roi_offset": [
+                    0,
+                    15,
+                    0,
+                    0
+                ],
+                "lower": [
+                    60,
+                    60,
+                    60
+                ],
+                "upper": [
+                    80,
+                    80,
+                    80
+                ],
+                "connected": true,
+                "count": 300
+            }
         ],
-        "template": [
-            "AutoSell/StockRedistributionValleyIVChoose.png",
-            "AutoSell/StockRedistributionValleyIVNotChoose.png"
-        ],
-        "threshold": 0.9,
         "pre_delay": 0,
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
-            "AutoSellEnterStockRedistributionOpenItem",
-            "AutoSellEnterStockRedistributionOpenItemFinish"
-        ]
+        "rate_limit": 0
     },
     "AutoSellEnterStockRedistributionAreaSwitchWuling": {
         "desc": "切换地区到武陵",
-        "recognition": "TemplateMatch",
-        "roi": [
-            0,
-            0,
-            600,
-            150
+        "recognition": "And",
+        "all_of": [
+            {
+                "recognition": "TemplateMatch",
+                "roi": [
+                    0,
+                    0,
+                    600,
+                    150
+                ],
+                "template": [
+                    "AutoSell/StockRedistributionWulingChoose.png",
+                    "AutoSell/StockRedistributionWulingNotChoose.png"
+                ],
+                "threshold": 0.9,
+                "sub_name": "icon"
+            },
+            {
+                "recognition": "ColorMatch",
+                "roi": "icon",
+                "roi_offset": [
+                    0,
+                    15,
+                    0,
+                    0
+                ],
+                "lower": [
+                    60,
+                    60,
+                    60
+                ],
+                "upper": [
+                    80,
+                    80,
+                    80
+                ],
+                "connected": true,
+                "count": 300
+            }
         ],
-        "template": [
-            "AutoSell/StockRedistributionWulingChoose.png",
-            "AutoSell/StockRedistributionWulingNotChoose.png"
-        ],
-        "threshold": 0.9,
         "pre_delay": 0,
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
-            "AutoSellEnterStockRedistributionOpenItem",
-            "AutoSellEnterStockRedistributionOpenItemFinish"
-        ]
+        "rate_limit": 0
     },
     "AutoSellEnterStockRedistributionOpenItem": {
         "desc": "打开目标物资调度界面下一个待识别item",
@@ -345,7 +254,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutoSellEnterStockRedistributionSuccess"
+            "AutoSellStockRedistributionItemNext"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "四号谷地物资检查完毕，前往武陵物资检查"

--- a/assets/resource/pipeline/AutoSell/Recognition.json
+++ b/assets/resource/pipeline/AutoSell/Recognition.json
@@ -1,50 +1,56 @@
 {
+    "AutoSellStockRedistributionItemTicketRecognition": {
+        "desc": "识别物资调度界面中的item",
+        "recognition": "TemplateMatch",
+        "roi": [
+            0,
+            200,
+            1280,
+            500
+        ],
+        "template": [
+            "AutoSell/SellTicketItemValleyIV.png",
+            "AutoSell/SellTicketItemWuling.png"
+        ],
+        "threshold": 0.9
+    },
+    "AutoSellStockRedistributionItemNameAreaRecognition": {
+        "desc": "识别物资调度界面中的item",
+        "recognition": "ColorMatch",
+        "roi": "AutoSellStockRedistributionItemTicketRecognition",
+        "roi_offset": [
+            -70,
+            35,
+            135,
+            10
+        ],
+        "lower": [
+            61,
+            60,
+            60
+        ],
+        "upper": [
+            81,
+            80,
+            80
+        ],
+        "count": 100
+    },
     "AutoSellStockRedistributionOpenItemText": {
         "desc": "识别物资调度界面中的item",
         "recognition": "And",
         "all_of": [
-            {
-                "sub_name": "ticket_icon",
-                "recognition": "TemplateMatch",
-                "roi": [
-                    0,
-                    200,
-                    1280,
-                    500
-                ],
-                "template": [
-                    "AutoSell/SellTicketItemValleyIV.png",
-                    "AutoSell/SellTicketItemWuling.png"
-                ],
-                "threshold": 0.9
-            },
-            {
-                "sub_name": "item_text",
-                "recognition": "ColorMatch",
-                "roi": "ticket_icon",
-                "roi_offset": [
-                    -70,
-                    35,
-                    135,
-                    10
-                ],
-                "lower": [
-                    61,
-                    60,
-                    60
-                ],
-                "upper": [
-                    81,
-                    80,
-                    80
-                ],
-                "connected": true,
-                "count": 100
-            },
+            "AutoSellStockRedistributionItemTicketRecognition",
+            "AutoSellStockRedistributionItemNameAreaRecognition",
             {
                 "recognition": "OCR",
-                "roi": "item_text",
-                "only_rec": true,
+                "roi": "AutoSellStockRedistributionItemNameAreaRecognition",
+                "roi_offset": [
+                    -10,
+                    -10,
+                    10,
+                    20
+                ],
                 "order_by": "Vertical"
             }
         ]

--- a/assets/resource/pipeline/Interface/Example/Scene.json
+++ b/assets/resource/pipeline/Interface/Example/Scene.json
@@ -49,5 +49,21 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": []
+    },
+    "SceneExampleRewardAndNext": {
+        "desc": "奖励接口使用示例，完成后继续业务流程",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "anchor": {
+            "SceneNoticeRewardsConfirmWithAnchor": "SceneExampleRewardNext"
+        },
+        "next": [
+            "SceneNoticeRewardsConfirmWithAnchor"
+        ]
+    },
+    "SceneExampleRewardNext": {
+        "desc": "后续业务流程",
+        "pre_delay": 0,
+        "post_delay": 0
     }
 }

--- a/assets/resource/pipeline/Interface/Example/Scene.json
+++ b/assets/resource/pipeline/Interface/Example/Scene.json
@@ -55,7 +55,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "anchor": {
-            "SceneNoticeRewardsConfirmWithAnchor": "SceneExampleRewardNext"
+            "SceneNoticeRewardsConfirmNextAnchor": "SceneExampleRewardNext"
         },
         "next": [
             "SceneNoticeRewardsConfirmWithAnchor"


### PR DESCRIPTION
close #1984

## Summary by Sourcery

修复在遇到可出售数量为零的物品时的自动售卖行为，并改进自动售卖流程中的物品价格处理和识别。

Bug 修复：
- 当某个物品的可出售数量为零时，阻止自动售卖继续进行，确保该物品在流水线中被正确处理和记录。

增强功能：
- 通过集中化关键字匹配逻辑，并将解析后的物品名称传递给下游识别任务，优化自动售卖价格的选择。
- 通过新增任务和共享配置扩展自动售卖流水线，以更好地协调整物单识别以及对异常状态的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix autosell behavior when items with zero sellable quantity are encountered and improve item price handling and recognition in the autosell pipeline.

Bug Fixes:
- Prevent autosell from proceeding when an item has zero sellable quantity, ensuring it is handled and recorded correctly in the pipeline.

Enhancements:
- Refine autosell price selection by centralizing keyword matching and passing the resolved item name into downstream recognition tasks.
- Extend the autosell pipeline with additional tasks and shared configuration to better coordinate item ticket recognition and unexpected states.

</details>