### PR TITLE
fix: 修复进入培养舱时过早缓存OCR结果

### DIFF
--- a/assets/resource/pipeline/DijiangRewards/GrowthChamber.json
+++ b/assets/resource/pipeline/DijiangRewards/GrowthChamber.json
@@ -220,7 +220,7 @@
         },
         "pre_delay": 0,
         "post_wait_freezes": {
-            "time": 80,
+            "time": 200,
             "timeout": 1000,
             "target": [
                 79,
@@ -671,7 +671,14 @@
             "type": "Click"
         },
         "post_wait_freezes": {
-            "time": 80
+            "time": 200,
+            "timeout": 1000,
+            "target": [
+                79,
+                81,
+                431,
+                639
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0
@@ -745,6 +752,16 @@
         "pre_delay": 0,
         "action": {
             "type": "Click"
+        },
+        "post_wait_freezes": {
+            "time": 200,
+            "timeout": 1000,
+            "target": [
+                79,
+                81,
+                431,
+                639
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复在进入 Growth Chamber 场景时被触发的 OCR 结果过早缓存的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix premature caching of OCR results triggered on entering the Growth Chamber scene.

</details>
- 修正进入 Growth Chamber 时 OCR 结果缓存的时机，避免结果被过早存储。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复在进入 Growth Chamber 场景时被触发的 OCR 结果过早缓存的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix premature caching of OCR results triggered on entering the Growth Chamber scene.

</details>

</details>