### PR TITLE
fix: 日常任务识别到已经做完的任务时失败

### DIFF
--- a/assets/resource/pipeline/DailyRewards/Tasks.json
+++ b/assets/resource/pipeline/DailyRewards/Tasks.json
@@ -261,7 +261,8 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "DailyTaskUpgradeWeaponIsValid"
+            "DailyTaskUpgradeWeaponIsValid",
+            "DailyTaskStart"
         ]
     },
     "DailyTaskCreation": {
@@ -288,7 +289,8 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "DailyTaskCreationIsValid"
+            "DailyTaskCreationIsValid",
+            "DailyTaskStart"
         ]
     },
     "DailyTaskAssemble": {
@@ -316,7 +318,8 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "DailyTaskAssembleIsValid"
+            "DailyTaskAssembleIsValid",
+            "DailyTaskStart"
         ]
     },
     "DailyTaskCreationIsValid": {

--- a/assets/resource/pipeline/DailyRewards/Tasks.json
+++ b/assets/resource/pipeline/DailyRewards/Tasks.json
@@ -262,7 +262,7 @@
         "post_delay": 0,
         "next": [
             "DailyTaskUpgradeWeaponIsValid",
-            "DailyTaskStart"
+            "DailyTaskActivityLimitNotReached"
         ]
     },
     "DailyTaskCreation": {
@@ -290,7 +290,7 @@
         "post_delay": 0,
         "next": [
             "DailyTaskCreationIsValid",
-            "DailyTaskStart"
+            "DailyTaskActivityLimitNotReached"
         ]
     },
     "DailyTaskAssemble": {
@@ -319,7 +319,7 @@
         "post_delay": 0,
         "next": [
             "DailyTaskAssembleIsValid",
-            "DailyTaskStart"
+            "DailyTaskActivityLimitNotReached"
         ]
     },
     "DailyTaskCreationIsValid": {


### PR DESCRIPTION
还没测试(
修复的是 #1968 部分问题

## Summary by Sourcery

错误修复：
- 调整每日奖励任务的定义，以防止已完成的每日任务在识别时再次失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust daily rewards task definitions so recognition of already-completed daily tasks no longer fails.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 调整每日奖励任务的定义，以防止已完成的每日任务在识别时再次失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust daily rewards task definitions so recognition of already-completed daily tasks no longer fails.

</details>

</details>