### PR TITLE
style: 调整hdr检测提示时机

### DIFF
--- a/agent/go-service/taskersink/hdrcheck/checker.go
+++ b/agent/go-service/taskersink/hdrcheck/checker.go
@@ -1,9 +1,6 @@
 package hdrcheck
 
 import (
-	"fmt"
-
-	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -42,7 +39,7 @@ func (c *HDRChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventStatus, det
 		log.Warn().Msg("HDR is enabled! This may cause issues with image recognition.")
 
 		// Print warning message (HTML formatted for MXU display)
-		fmt.Println(i18n.RenderHTML("tasker.hdr_warning", nil))
+		// fmt.Println(i18n.RenderHTML("tasker.hdr_warning", nil))
 
 		// Mark as warned to avoid repeated warnings
 		c.warned = true

--- a/assets/resource/pipeline/SceneManager/SceneLoading.json
+++ b/assets/resource/pipeline/SceneManager/SceneLoading.json
@@ -62,7 +62,7 @@
             "__SceneCheckColorFailedScreenShot"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜:</span><span style=\"color: #807F00; font-weight: bold;\">黄色 (#807F00)</span>"
+            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜或hdr:</span><span style=\"color: #807F00; font-weight: bold;\">黄色 (#807F00)</span>"
         }
     },
     "__SceneCheckTealColor": {
@@ -128,7 +128,7 @@
             "__SceneCheckColorFailedScreenShot"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜:</span><span style=\"color: #007F7F; font-weight: bold;\">青色 (#007F7F)</span>"
+            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜或hdr:</span><span style=\"color: #007F7F; font-weight: bold;\">青色 (#007F7F)</span>"
         }
     },
     "__SceneCheckPurpleColor": {
@@ -194,7 +194,7 @@
             "__SceneCheckColorFailedScreenShot"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜:</span><span style=\"color: #80007F; font-weight: bold;\">紫色 (#80007F)</span>"
+            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜或hdr:</span><span style=\"color: #80007F; font-weight: bold;\">紫色 (#80007F)</span>"
         }
     },
     "__SceneCheckColorFailedScreenShot": {

--- a/assets/resource/pipeline/SceneManager/SceneLoading.json
+++ b/assets/resource/pipeline/SceneManager/SceneLoading.json
@@ -62,7 +62,7 @@
             "__SceneCheckColorFailedScreenShot"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜或hdr:</span><span style=\"color: #807F00; font-weight: bold;\">黄色 (#807F00)</span>"
+            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜或 HDR:</span><span style=\"color: #807F00; font-weight: bold;\">黄色 (#807F00)</span>"
         }
     },
     "__SceneCheckTealColor": {
@@ -128,7 +128,7 @@
             "__SceneCheckColorFailedScreenShot"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜或hdr:</span><span style=\"color: #007F7F; font-weight: bold;\">青色 (#007F7F)</span>"
+            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜或 HDR:</span><span style=\"color: #007F7F; font-weight: bold;\">青色 (#007F7F)</span>"
         }
     },
     "__SceneCheckPurpleColor": {
@@ -194,7 +194,7 @@
             "__SceneCheckColorFailedScreenShot"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜或hdr:</span><span style=\"color: #80007F; font-weight: bold;\">紫色 (#80007F)</span>"
+            "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">识别颜色失败，请尝试关闭滤镜或 HDR:</span><span style=\"color: #80007F; font-weight: bold;\">紫色 (#80007F)</span>"
         }
     },
     "__SceneCheckColorFailedScreenShot": {


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

增强功能：
- 在检测到 HDR 时，保留内部日志记录的同时，禁用面向用户的 HDR 警告输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Disable the user-facing HDR warning printout while keeping internal logging when HDR is detected.

</details>