### PR TITLE
fix(基质筛选锁定):修复战后筛选基质时因识别到其他不明物体导致任务无法进行的bug

### DIFF
--- a/assets/resource/pipeline/EssenceFilter/EssenceFilterAfterBattleLockDiscard.json
+++ b/assets/resource/pipeline/EssenceFilter/EssenceFilterAfterBattleLockDiscard.json
@@ -266,7 +266,8 @@
         "post_wait_freezes": 200,
         "post_delay": 0,
         "next": [
-            "EssenceFindLockItem"
+            "EssenceFindLockItem",
+            "EssenceFilterAfterBattleRowNextItem"
         ],
         "on_error": [
             "EssenceFilterAfterBattleExit"


### PR DESCRIPTION
bug修复：
临时修复战后筛选基质时因识别到其他不明物体导致任务无法进行的bug：在识别基质成功但未找到上锁图标时，跳过并点击下一个识别结果，而不是直接退出任务。后续想办法提升识别质量来从根本上解决

## Summary by Sourcery

错误修复：
- 防止在检测到无关对象且在已识别的精华上找不到锁定图标时，战斗后精华筛选流程卡住。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the after-battle essence filtering flow from getting stuck when extraneous objects are detected and a lock icon is not found for a recognized essence.

</details>