### PR TITLE
fix: 修复售卖弹性物资不切换到武陵问题 close

### DIFF
--- a/assets/resource/pipeline/AutoSell/Recognition.json
+++ b/assets/resource/pipeline/AutoSell/Recognition.json
@@ -51,7 +51,8 @@
                     10,
                     20
                 ],
-                "order_by": "Vertical"
+                "order_by": "Vertical",
+                "only_rec": true
             }
         ]
     },


### PR DESCRIPTION
close #2077
## Summary by Sourcery

错误修复：
- 修复 AutoSell 逻辑，使出售弹性材料时能够正确触发切换到五菱区域配置

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix AutoSell logic so selling elastic materials correctly triggers switching to the Wuling region configuration

</details>