### PR TITLE
fix: 修复售卖弹性物资ocr匹配文本错误的问题

### DIFF
--- a/agent/go-service/autosell/autosell.go
+++ b/agent/go-service/autosell/autosell.go
@@ -176,7 +176,7 @@ func firstContainedKeyword(s string, subs []string) string {
 }
 
 var (
-	moderatePriceKeywords = []string{"锚点", "悬空", "巫术", "天使", "岳硏", "冬虫", "武陵", "武侠"}
+	moderatePriceKeywords = []string{"锚点", "悬空", "巫术", "天使", "岳研", "冬虫", "武陵", "武侠"}
 	largePriceKeywords    = []string{"谷地水", "团结", "塞什", "星体", "天师"}
 	massivePriceKeywords  = []string{"源石", "警戒", "硬脑", "边角"}
 )


### PR DESCRIPTION
修复ocr识别条件里面把“岳研”写成了“岳硏”的bug

## Summary by Sourcery

错误修复：
- 修正中等价格 OCR 关键词列表，将错误的术语“岳硏”替换为正确的“岳研”，以与实际识别到的文本保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix moderate price OCR keyword list by replacing the incorrect term "岳硏" with the correct "岳研" to align with actual recognized text.

</details>