### PR TITLE
fix(AutoEcoFarm): 下调农田标记 TemplateMatch 匹配阈值

### DIFF
--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
@@ -140,7 +140,7 @@
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmlandWithBack.png",
                 "green_mask": true,
-                "threshold": 0.6,
+                "threshold": 0.5,
                 "order_by": "Score"
             }
         },
@@ -415,7 +415,7 @@
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmlandWithBack.png",
                 "green_mask": true,
-                "threshold": 0.6,
+                "threshold": 0.5,
                 "order_by": "Score"
             }
         },

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
@@ -35,7 +35,7 @@
                 "template": "AutoEcoFarm/AutoEcoFarmFarmlandWithBack.png",
                 "green_mask": true,
                 "method": 5,
-                "threshold": 0.6,
+                "threshold": 0.5,
                 "order_by": "Score"
             }
         },
@@ -58,7 +58,7 @@
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmlandWithBack.png",
                 "green_mask": true,
-                "threshold": 0.6,
+                "threshold": 0.5,
                 "order_by": "Score"
             }
         },
@@ -81,7 +81,7 @@
                 ],
                 "template": "AutoEcoFarm/AutoEcoFarmFarmlandWithBack.png",
                 "green_mask": true,
-                "threshold": 0.6,
+                "threshold": 0.5,
                 "order_by": "Score"
             }
         },


### PR DESCRIPTION
将使用 AutoEcoFarmFarmlandWithBack.png 且 order_by 为 Score 的 TemplateMatch 节点 threshold 由 0.6 调整为 0.5。

| 文件 | 节点 |
| --- | --- |
| AutoEcoFarmSwipeToTarget.json | _AutoEcoFarmTargeRecognition、_AutoEcoFarmTargeInCenter、_AutoEcoFarmTargeInBack | | AutoEcoFarmMoveAndWork.json | _AutoEcoFarmTargetExists、_AutoEcoFarmTargetNotExists |

Made-with: Cursor

## Summary by Sourcery

改进内容：
- 将多个 AutoEcoFarm 目标识别节点中的模板匹配阈值从 0.6 放宽至 0.5，以提高农田标记检测的灵敏度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Relax template match thresholds from 0.6 to 0.5 for multiple AutoEcoFarm target recognition nodes to improve farmland marker detection sensitivity.

</details>