### PR TITLE
feat: 万能跳转新增2个枢纽区锚点和5个清波寨锚点

### DIFF
--- a/assets/resource/pipeline/Interface/SceneValleyIV.json
+++ b/assets/resource/pipeline/Interface/SceneValleyIV.json
@@ -69,6 +69,32 @@
             "[JumpBack]SceneEnterMapAny"
         ]
     },
+    "SceneEnterWorldValleyIVTheHub1": {
+        "desc": "从任意界面进入四号谷地-枢纽区-旧供水设施东侧大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapValleyIVEnterVallyIVTheHub1"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateMapValleyIVTheHubEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapValleyIVTheHub"
+        ]
+    },
+    "SceneEnterWorldValleyIVTheHub2": {
+        "desc": "从任意界面进入四号谷地-枢纽区-岩丘通道大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapValleyIVEnterVallyIVTheHub2"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateMapValleyIVTheHubEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapValleyIVTheHub"
+        ]
+    },
     "SceneEnterWorldValleyIVOriginiumSciencePark0": {
         "desc": "从任意界面进入四号谷地-源石研究园-矿脉源区入口大世界",
         "pre_delay": 0,

--- a/assets/resource/pipeline/Interface/SceneValleyIV.json
+++ b/assets/resource/pipeline/Interface/SceneValleyIV.json
@@ -73,7 +73,7 @@
         "desc": "从任意界面进入四号谷地-枢纽区-旧供水设施东侧大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapValleyIVEnterVallyIVTheHub1"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapValleyIVEnterValleyIVTheHub1"
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -86,7 +86,7 @@
         "desc": "从任意界面进入四号谷地-枢纽区-岩丘通道大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapValleyIVEnterVallyIVTheHub2"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapValleyIVEnterValleyIVTheHub2"
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/Interface/SceneWuling.json
+++ b/assets/resource/pipeline/Interface/SceneWuling.json
@@ -17,6 +17,15 @@
             "[JumpBack]SceneEnterMapAny"
         ]
     },
+    "SceneEnterMapWulingQingboStockade": {
+        "desc": "从任意界面进入武陵-清波寨地图界面",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingQingboStockade",
+            "[JumpBack]SceneEnterMapAny"
+        ]
+    },
     "SceneEnterWorldWulingJingyuValley0": {
         "desc": "从任意界面进入-景玉谷-生态实验站",
         "pre_delay": 0,
@@ -277,6 +286,66 @@
         "next": [
             "__ScenePrivateMapWulingWulingCityEnterWorldAnchorWithPick",
             "[JumpBack]SceneEnterMapWulingWulingCity"
+        ]
+    },
+    "SceneEnterWorldWulingQingboStockade0": {
+        "desc": "从任意界面进入武陵-清波寨-顶天梁大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade0"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingQingboStockadeEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingQingboStockade"
+        ]
+    },
+    "SceneEnterWorldWulingQingboStockade1": {
+        "desc": "从任意界面进入武陵-清波寨-栈桥道大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade1"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingQingboStockadeEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingQingboStockade"
+        ]
+    },
+    "SceneEnterWorldWulingQingboStockade2": {
+        "desc": "从任意界面进入武陵-清波寨-主寨西南大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade2"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingQingboStockadeEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingQingboStockade"
+        ]
+    },
+    "SceneEnterWorldWulingQingboStockade4": {
+        "desc": "从任意界面进入武陵-清波寨-祖泉大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade4"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingQingboStockadeEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingQingboStockade"
+        ]
+    },
+    "SceneEnterWorldWulingQingboStockade5": {
+        "desc": "从任意界面进入武陵-清波寨-主寨东南大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade5"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingQingboStockadeEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingQingboStockade"
         ]
     }
 }

--- a/assets/resource/pipeline/Interface/SceneWuling.json
+++ b/assets/resource/pipeline/Interface/SceneWuling.json
@@ -292,7 +292,7 @@
         "desc": "从任意界面进入武陵-清波寨-顶天梁大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingQingboStockadeEnterWorldWulingQingboStockade0"
         },
         "post_delay": 0,
         "next": [
@@ -304,7 +304,7 @@
         "desc": "从任意界面进入武陵-清波寨-栈桥道大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade1"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingQingboStockadeEnterWorldWulingQingboStockade1"
         },
         "post_delay": 0,
         "next": [
@@ -316,7 +316,19 @@
         "desc": "从任意界面进入武陵-清波寨-主寨西南大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade2"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingQingboStockadeEnterWorldWulingQingboStockade2"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingQingboStockadeEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingQingboStockade"
+        ]
+    },
+    "SceneEnterWorldWulingQingboStockade3": {
+        "desc": "从任意界面进入武陵-清波寨-祖泉大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingQingboStockadeEnterWorldWulingQingboStockade3"
         },
         "post_delay": 0,
         "next": [
@@ -325,22 +337,10 @@
         ]
     },
     "SceneEnterWorldWulingQingboStockade4": {
-        "desc": "从任意界面进入武陵-清波寨-祖泉大世界",
-        "pre_delay": 0,
-        "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade4"
-        },
-        "post_delay": 0,
-        "next": [
-            "__ScenePrivateMapWulingQingboStockadeEnterWorldAnchorWithPick",
-            "[JumpBack]SceneEnterMapWulingQingboStockade"
-        ]
-    },
-    "SceneEnterWorldWulingQingboStockade5": {
         "desc": "从任意界面进入武陵-清波寨-主寨东南大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade5"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingQingboStockadeEnterWorldWulingQingboStockade4"
         },
         "post_delay": 0,
         "next": [

--- a/assets/resource/pipeline/SceneManager/Region.json
+++ b/assets/resource/pipeline/SceneManager/Region.json
@@ -72,6 +72,27 @@
             }
         ]
     },
+    "InMapWulingQingboStockade": {
+        "desc": "在武陵-清波寨地图界面",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny",
+            {
+                "recognition": "OCR",
+                "roi": [
+                    0,
+                    0,
+                    250,
+                    60
+                ],
+                "expected": [
+                    "清波寨",
+                    "Qingbo Stockade",
+                    "청파채"
+                ]
+            }
+        ]
+    },
     "InMapDijiang": {
         "desc": "在帝江号地图界面",
         "recognition": "And",
@@ -87,6 +108,29 @@
                 ],
                 "expected": [
                     "[Oo].?[Mm].?[Vv]"
+                ]
+            }
+        ]
+    },
+    "InMapValleyIVTheHub": {
+        "desc": "在四号谷地-枢纽区地图界面",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny",
+            {
+                "recognition": "OCR",
+                "roi": [
+                    0,
+                    0,
+                    250,
+                    60
+                ],
+                "expected": [
+                    "枢纽区",
+                    "樞紐區",
+                    "中枢エリア",
+                    "The Hub",
+                    "거점 지역"
                 ]
             }
         ]

--- a/assets/resource/pipeline/SceneManager/SceneTeleportValleyIV.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportValleyIV.json
@@ -1,5 +1,5 @@
 {
-    "__ScenePrivateMapValleyIVEnterVallyIVTheHub1": {
+    "__ScenePrivateMapValleyIVEnterValleyIVTheHub1": {
         "desc": "在地图界面找锚点 (枢纽区-旧供水设施东侧)",
         "recognition": "And",
         "all_of": [
@@ -20,12 +20,13 @@
             "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
         },
         "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "[JumpBack]__ScenePrivateMapTeleportChoose",
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapValleyIVEnterVallyIVTheHub2": {
+    "__ScenePrivateMapValleyIVEnterValleyIVTheHub2": {
         "desc": "在地图界面找锚点 (枢纽区-岩丘通道)",
         "recognition": "And",
         "all_of": [
@@ -46,6 +47,7 @@
             "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
         },
         "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "[JumpBack]__ScenePrivateMapTeleportChoose",
             "__ScenePrivateMapTeleportConfirm"

--- a/assets/resource/pipeline/SceneManager/SceneTeleportValleyIV.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportValleyIV.json
@@ -1,4 +1,57 @@
 {
+    "__ScenePrivateMapValleyIVEnterVallyIVTheHub1": {
+        "desc": "在地图界面找锚点 (枢纽区-旧供水设施东侧)",
+        "recognition": "And",
+        "all_of": [
+            "InMapValleyIVTheHub"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map01_lv001",
+            "target": [
+                392.6,
+                498.7
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapValleyIVEnterVallyIVTheHub2": {
+        "desc": "在地图界面找锚点 (枢纽区-岩丘通道)",
+        "recognition": "And",
+        "all_of": [
+            "InMapValleyIVTheHub"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map01_lv001",
+            "target": [
+                474.5,
+                265.5
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    // 下方所有节点是基于目标匹配的旧版实现
     "__ScenePrivateMapUnknownEnterWorldValleyIVOriginiumSciencePark0Try1": {
         "desc": "在地图界面找锚点",
         "recognition": "TemplateMatch",

--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -791,7 +791,137 @@
             "map_name": "map02_lv002",
             "target": [
                 694,
-                914
+                916
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade0": {
+        "desc": "在地图界面找锚点 (清波寨-顶天梁)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingQingboStockade"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv003",
+            "target": [
+                177,
+                318
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade1": {
+        "desc": "在地图界面找锚点 (清波寨-栈桥道)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingQingboStockade"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv003",
+            "target": [
+                215,
+                466
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade2": {
+        "desc": "在地图界面找锚点 (清波寨-主寨西南)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingQingboStockade"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv003",
+            "target": [
+                302,
+                543
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade4": {
+        "desc": "在地图界面找锚点 (清波寨-祖泉)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingQingboStockade"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv003",
+            "target": [
+                409,
+                368
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade5": {
+        "desc": "在地图界面找锚点 (清波寨-主寨东南)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingQingboStockade"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv003",
+            "target": [
+                446,
+                626
             ],
             "on_find": "Click"
         },

--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -799,12 +799,13 @@
             "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
         },
         "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "[JumpBack]__ScenePrivateMapTeleportChoose",
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade0": {
+    "__ScenePrivateMapWulingQingboStockadeEnterWorldWulingQingboStockade0": {
         "desc": "在地图界面找锚点 (清波寨-顶天梁)",
         "recognition": "And",
         "all_of": [
@@ -825,12 +826,13 @@
             "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
         },
         "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "[JumpBack]__ScenePrivateMapTeleportChoose",
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade1": {
+    "__ScenePrivateMapWulingQingboStockadeEnterWorldWulingQingboStockade1": {
         "desc": "在地图界面找锚点 (清波寨-栈桥道)",
         "recognition": "And",
         "all_of": [
@@ -851,12 +853,13 @@
             "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
         },
         "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "[JumpBack]__ScenePrivateMapTeleportChoose",
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade2": {
+    "__ScenePrivateMapWulingQingboStockadeEnterWorldWulingQingboStockade2": {
         "desc": "在地图界面找锚点 (清波寨-主寨西南)",
         "recognition": "And",
         "all_of": [
@@ -877,12 +880,13 @@
             "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
         },
         "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "[JumpBack]__ScenePrivateMapTeleportChoose",
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade4": {
+    "__ScenePrivateMapWulingQingboStockadeEnterWorldWulingQingboStockade3": {
         "desc": "在地图界面找锚点 (清波寨-祖泉)",
         "recognition": "And",
         "all_of": [
@@ -903,12 +907,13 @@
             "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
         },
         "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "[JumpBack]__ScenePrivateMapTeleportChoose",
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingQingboStockade5": {
+    "__ScenePrivateMapWulingQingboStockadeEnterWorldWulingQingboStockade4": {
         "desc": "在地图界面找锚点 (清波寨-主寨东南)",
         "recognition": "And",
         "all_of": [
@@ -929,6 +934,7 @@
             "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
         },
         "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "[JumpBack]__ScenePrivateMapTeleportChoose",
             "__ScenePrivateMapTeleportConfirm"

--- a/assets/resource/pipeline/SceneManager/SceneValleyIV.json
+++ b/assets/resource/pipeline/SceneManager/SceneValleyIV.json
@@ -629,6 +629,20 @@
             "[JumpBack][Anchor]__ScenePrivateMapSwipeToStepFinishAnchor"
         ]
     },
+    "__ScenePrivateMapValleyIVTheHubEnterWorldAnchorWithPick": {
+        "desc": "在四号谷地-枢纽区地图界面，进入[锚点]大世界 (MapTracker 模式)",
+        "recognition": "And",
+        "all_of": [
+            "InMapValleyIVTheHub"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapTeleportSuccess",
+            "[JumpBack]__ScenePrivateMapZoomOut",
+            "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
+        ]
+    },
     "__ScenePrivateMapValleyIVPowerPlateauEnterWorldAnchor": {
         "desc": "在四号谷地-供能高地地图界面，进入[锚点]大世界",
         "recognition": "And",

--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -23,6 +23,18 @@
             "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
         ]
     },
+    "__ScenePrivateMapAnyEnterMapWulingQingboStockade": {
+        "desc": "在任意地图界面，进入武陵-清波寨地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny"
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingQingboStockadeSuccess",
+            "__ScenePrivateMapOverviewEnterMapWulingQingboStockade",
+            "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
+        ]
+    },
     "__ScenePrivateMapAnyEnterMapWulingWulingCitySuccess": {
         "desc": "在地图界面，成功进入武陵-武陵城地图",
         "recognition": "And",
@@ -37,6 +49,15 @@
         "recognition": "And",
         "all_of": [
             "InMapWulingJingyuValley"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0
+    },
+    "__ScenePrivateMapAnyEnterMapWulingQingboStockadeSuccess": {
+        "desc": "在地图界面，成功进入武陵-清波寨地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingQingboStockade"
         ],
         "pre_delay": 0,
         "post_delay": 0
@@ -109,6 +130,29 @@
             "__ScenePrivateMapOverviewWulingEnterMapWulingJingyuValley"
         ]
     },
+    "__ScenePrivateMapOverviewEnterMapWulingQingboStockade": {
+        "desc": "在地图地总览界面，进入武陵-清波寨地图",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    -450,
+                    -150,
+                    350,
+                    150
+                ],
+                "template": [
+                    "SceneManager/MapOverviewWulingChoose.png",
+                    "SceneManager/MapOverviewWulingNotChoose.png"
+                ],
+                "threshold": 0.9
+            }
+        },
+        "next": [
+            "[JumpBack]__ScenePrivateMapOverviewSwitchMapOverviewWuling",
+            "__ScenePrivateMapOverviewWulingEnterMapWulingQingboStockade"
+        ]
+    },
     "__ScenePrivateMapOverviewWulingEnterMapWulingWulingCity": {
         "desc": "在武陵总览界面，进入武陵-武陵城地图",
         // "recognition": {
@@ -171,6 +215,19 @@
             "__ScenePrivateMapAnyEnterMapWulingJingyuValleySuccess"
         ]
     },
+    "__ScenePrivateMapOverviewWulingEnterMapWulingQingboStockade": {
+        "desc": "在武陵总览界面，进入武陵-清波寨地图",
+        "action": "Click",
+        "target": [
+            770,
+            360,
+            115,
+            55
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingQingboStockadeSuccess"
+        ]
+    },
     "__ScenePrivateMapWulingWulingCityEnterWorldAnchor": {
         "desc": "在武陵-武陵城地图界面，进入[锚点]大世界",
         "recognition": "And",
@@ -223,6 +280,20 @@
         "recognition": "And",
         "all_of": [
             "InMapWulingWulingCity"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapTeleportSuccess",
+            "[JumpBack]__ScenePrivateMapZoomOut",
+            "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
+        ]
+    },
+    "__ScenePrivateMapWulingQingboStockadeEnterWorldAnchorWithPick": {
+        "desc": "在武陵-清波寨地图界面，进入[锚点]大世界",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingQingboStockade"
         ],
         "pre_delay": 0,
         "post_delay": 0,

--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -131,7 +131,7 @@
         ]
     },
     "__ScenePrivateMapOverviewEnterMapWulingQingboStockade": {
-        "desc": "在地图地总览界面，进入武陵-清波寨地图",
+        "desc": "在地图总览界面，进入武陵-清波寨地图",
         "recognition": {
             "type": "TemplateMatch",
             "param": {


### PR DESCRIPTION
## 概述

此 PR 给万能跳转新增了 2 个枢纽区锚点和 6 个清波寨锚点。

## 关联

1 个枢纽区锚点和 1 个清波寨锚点用于后续的自动基质刷取任务。

1 个枢纽区锚点用于解决 #2115 。

Close #2115

## Summary by Sourcery

在枢纽区域和青波寨区域中新增传送锚点，并将其接入场景和区域配置中。

新功能：
- 在枢纽区域新增 2 个用于通用跳转导航的传送锚点。
- 在青波寨区域新增 6 个用于通用跳转导航的传送锚点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new teleport anchors in the hub and Qingbozhai regions and wire them into the scene and region configuration.

New Features:
- Introduce 2 new teleport anchors in the hub region for universal jump navigation.
- Introduce 6 new teleport anchors in the Qingbozhai region for universal jump navigation.

</details>