### PR TITLE
fix: 修复 issue-upload-check 工作流未识别上传失败

### DIFF
--- a/.github/workflows/issue-upload-check.yml
+++ b/.github/workflows/issue-upload-check.yml
@@ -41,9 +41,10 @@ jobs:
             
             const hasUploadFailed = uploadFailedPattern.test(textToCheck);
             const hasUploading = uploadingPattern.test(textToCheck);
-            const hasUploadedLogs = uploadedLogsPattern.test(textToCheck);
             const hasAttachmentUrl = attachmentUrlPattern.test(textToCheck);
             const hasMissingInfoLabel = currentLabels.includes(missingInfoLabel);
+            // 只有在同时有文件名和 GitHub URL 时，才认为真的上传了日志文件，避免误判 HTML 注释或文本中提到的文件名
+            const hasUploadedLogs = uploadedLogsPattern.test(textToCheck) && hasAttachmentUrl;
             const shouldRemoveLabel = isIssueEvent
               ? hasUploadedLogs
               : hasUploadedLogs && hasAttachmentUrl;
@@ -73,7 +74,8 @@ jobs:
               return;
             }
             
-            if (isIssueEvent && (hasUploadFailed || hasUploading)) {
+            // 只有在没有真正上传日志的情况下，才检查上传失败并添加标签，确保只要有日志就不会被判断为缺少信息
+            if (isIssueEvent && (hasUploadFailed || hasUploading) && !hasUploadedLogs) {
                if (!hasMissingInfoLabel) {
                  await github.rest.issues.addLabels({
                    owner: context.repo.owner,

--- a/.github/workflows/issue-upload-check.yml
+++ b/.github/workflows/issue-upload-check.yml
@@ -45,9 +45,7 @@ jobs:
             const hasMissingInfoLabel = currentLabels.includes(missingInfoLabel);
             // 只有在同时有文件名和 GitHub URL 时，才认为真的上传了日志文件，避免误判 HTML 注释或文本中提到的文件名
             const hasUploadedLogs = uploadedLogsPattern.test(textToCheck) && hasAttachmentUrl;
-            const shouldRemoveLabel = isIssueEvent
-              ? hasUploadedLogs
-              : hasUploadedLogs && hasAttachmentUrl;
+            const shouldRemoveLabel = hasUploadedLogs;
 
             if (shouldRemoveLabel) {
               if (hasMissingInfoLabel) {


### PR DESCRIPTION
实现方式: 检查一下是不是真的有链接

## Summary by Sourcery

调整 issue-upload-check 工作流逻辑，更准确地检测真实的日志上传，仅在合适的情况下应用 `missing-info` 标签。

错误修复：
- 仅在同时存在文件名和有效的 GitHub 附件 URL 时才视为日志已上传，避免将纯文本或 HTML 注释误判为成功上传。
- 当 issue 中已经包含成功上传的日志时，即使存在上传失败标记，也不再添加 `missing-info` 标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust issue-upload-check workflow logic to more accurately detect real log uploads and apply the missing-info label only when appropriate.

Bug Fixes:
- Only treat logs as uploaded when both a filename and a valid GitHub attachment URL are present, avoiding false positives from plain text or HTML comments.
- Prevent adding the missing-info label when an issue already contains successfully uploaded logs even if upload failure markers exist.

</details>