### PR TITLE
feat(CreditShopping): 优化稳健模式购买逻辑，实现分层购买策略

### DIFF
--- a/assets/resource/pipeline/CreditShopping/Shopping.json
+++ b/assets/resource/pipeline/CreditShopping/Shopping.json
@@ -363,47 +363,190 @@
     "CreditShoppingPrudentRefresh": {
         "desc": "稳健模式下改为直接购买（选项：稳健模式刷新、稳健刷新阈值）",
         "recognition": {
-            "type": "And",
+            "type": "Custom",
             "param": {
-                "all_of": [
-                    {
-                        "recognition": {
-                            "type": "Custom",
-                            "param": {
-                                "custom_recognition": "ExpressionRecognition",
-                                "custom_recognition_param": {
-                                    "expression": "{CreditShoppingReserveCreditOCRInternal}-{RefreshCost}<400"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "recognition": {
-                            "type": "And",
-                            "param": {
-                                "all_of": [
-                                    "CreditIcon",
-                                    "NotSoldOut",
-                                    "CanAfford"
-                                ],
-                                "box_index": 2
-                            }
-                        }
-                    }
-                ],
-                "box_index": 1
+                "custom_recognition": "ExpressionRecognition",
+                "custom_recognition_param": {
+                    "expression": "{CreditShoppingReserveCreditOCRInternal}-{RefreshCost}<400"
+                }
             }
         },
-        "pre_wait_freezes": 100,
-        "action": {
-            "type": "Click"
-        },
         "next": [
-            "CreditShoppingBuyItem"
+            "CreditShoppingPrudentRefreshPriority1",
+            "CreditShoppingPrudentRefreshPriority2",
+            "CreditShoppingPrudentRefreshPriority3",
+            "CreditShoppingPrudentRefreshRepeatWhitelist",
+            "CreditShoppingPrudentRefreshBuyAny"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$task.CreditShopping.prudent_refresh_triggered"
         }
+    },
+    "CreditShoppingPrudentRefreshPriority1": {
+        "desc": "稳健模式-优先购买",
+        "recognition": "And",
+        "all_of": [
+            "CreditIcon",
+            "NotSoldOut",
+            "CanAfford",
+            "BuyFirstOCR",
+            "IsDiscountPriority1",
+            "CreditShoppingPriority1ReserveCreditGate"
+        ],
+        "box_index": 4,
+        "pre_wait_freezes": 100,
+        "action": "Click",
+        "target_offset": [
+            -30,
+            70,
+            0,
+            0
+        ],
+        "next": [
+            "CreditShoppingBuyItem"
+        ]
+    },
+    "CreditShoppingPrudentRefreshPriority2": {
+        "desc": "稳健模式-普通购买1",
+        "recognition": "And",
+        "all_of": [
+            "CreditIcon",
+            "NotSoldOut",
+            "CanAfford",
+            "Priority2OCR",
+            "IsDiscountPriority2",
+            "CreditShoppingPriority2ReserveCreditGate"
+        ],
+        "box_index": 4,
+        "pre_wait_freezes": 100,
+        "action": "Click",
+        "target_offset": [
+            -30,
+            70,
+            0,
+            0
+        ],
+        "next": [
+            "CreditShoppingBuyItem"
+        ]
+    },
+    "CreditShoppingPrudentRefreshPriority3": {
+        "desc": "稳健模式-普通购买2",
+        "recognition": "And",
+        "all_of": [
+            "CreditIcon",
+            "NotSoldOut",
+            "CanAfford",
+            "Priority3OCR",
+            "IsDiscountPriority3",
+            "CreditShoppingPriority3ReserveCreditGate"
+        ],
+        "box_index": 4,
+        "pre_wait_freezes": 100,
+        "action": "Click",
+        "target_offset": [
+            -30,
+            70,
+            0,
+            0
+        ],
+        "next": [
+            "CreditShoppingBuyItem"
+        ]
+    },
+    "CreditShoppingPrudentRefreshRepeatWhitelist": {
+        "desc": "稳健模式-重复购买白名单（无折扣要求）",
+        "recognition": "Or",
+        "any_of": [
+            "CreditShoppingPrudentRefreshRepeatPriority1",
+            "CreditShoppingPrudentRefreshRepeatPriority2",
+            "CreditShoppingPrudentRefreshRepeatPriority3"
+        ]
+    },
+    "CreditShoppingPrudentRefreshRepeatPriority1": {
+        "desc": "稳健模式-重复购买Priority1（无折扣要求）",
+        "recognition": "And",
+        "all_of": [
+            "CreditIcon",
+            "NotSoldOut",
+            "CanAfford",
+            "BuyFirstOCR",
+            "CreditShoppingPriority1ReserveCreditGate"
+        ],
+        "box_index": 4,
+        "pre_wait_freezes": 100,
+        "action": "Click",
+        "target_offset": [
+            -30,
+            70,
+            0,
+            0
+        ],
+        "next": [
+            "CreditShoppingBuyItem"
+        ]
+    },
+    "CreditShoppingPrudentRefreshRepeatPriority2": {
+        "desc": "稳健模式-重复购买Priority2（无折扣要求）",
+        "recognition": "And",
+        "all_of": [
+            "CreditIcon",
+            "NotSoldOut",
+            "CanAfford",
+            "Priority2OCR",
+            "CreditShoppingPriority2ReserveCreditGate"
+        ],
+        "box_index": 4,
+        "pre_wait_freezes": 100,
+        "action": "Click",
+        "target_offset": [
+            -30,
+            70,
+            0,
+            0
+        ],
+        "next": [
+            "CreditShoppingBuyItem"
+        ]
+    },
+    "CreditShoppingPrudentRefreshRepeatPriority3": {
+        "desc": "稳健模式-重复购买Priority3（无折扣要求）",
+        "recognition": "And",
+        "all_of": [
+            "CreditIcon",
+            "NotSoldOut",
+            "CanAfford",
+            "Priority3OCR",
+            "CreditShoppingPriority3ReserveCreditGate"
+        ],
+        "box_index": 4,
+        "pre_wait_freezes": 100,
+        "action": "Click",
+        "target_offset": [
+            -30,
+            70,
+            0,
+            0
+        ],
+        "next": [
+            "CreditShoppingBuyItem"
+        ]
+    },
+    "CreditShoppingPrudentRefreshBuyAny": {
+        "desc": "稳健模式-购买黑名单物品",
+        "recognition": "And",
+        "all_of": [
+            "CreditIcon",
+            "NotSoldOut",
+            "CanAfford",
+            "BlacklistOCR"
+        ],
+        "box_index": 2,
+        "pre_wait_freezes": 100,
+        "action": "Click",
+        "next": [
+            "CreditShoppingBuyItem"
+        ]
     },
     "CreditShoppingRefreshCountReached": {
         "desc": "刷新次数已用尽时直接购买（选项：没有可购买物品时=执行刷新）",


### PR DESCRIPTION
## 优化内容  
解决旧逻辑在直接随机情况下可能购买高价物品让信用点略亏的问题

- 重构稳健模式购买逻辑，增加完整的购买优先级链路  
- 新增重复购买白名单机制（无折扣要求）  
- 完善边界情况处理（刷新次数用尽、信用点不足等）  

原有逻辑：

触发条件：{当前信用}-{刷新花费}<400
行为：直接点击任意可购买商品（box_index: 2）


新逻辑：

触发条件：保持不变 {当前信用}-{刷新花费}<400
行为：按优先级链路购买
CreditShoppingPrudentRefreshPriority1/2/3 - 按优先级购买（含折扣要求）
CreditShoppingPrudentRefreshRepeatWhitelist - 重复购买白名单（无折扣要求）
CreditShoppingPrudentRefreshBuyAny - 购买黑名单物品兜底
  
## 测试验证  
- ✅ 代码格式检查通过  
- ✅ maa-tools 资源检查通过    
- ✅ JSON Schema 验证通过  
- ✅ 符合 Pipeline 低代码规范  
  
Closes #2123

## Summary by Sourcery

优化 CreditShopping 审慎模式下的购买流程，在积分不足时通过分层优先级链来选择商品，降低为高价商品多付积分的概率。

新功能：
- 在审慎模式的 CreditShopping 中，当扣除刷新成本后的积分低于配置阈值时，引入多级购买优先级序列。
- 新增重复购买白名单，允许指定商品在不受折扣约束的情况下重复购买。
- 新增回退路径，当没有更高优先级选项可用时，允许将原本在黑名单中的商品作为最后的兜底选择进行购买。

缺陷修复：
- 缓解之前随机选择逻辑在审慎模式下可能购买高价商品并导致少量积分损失的情况。

改进增强：
- 改进 CreditShopping 流水线在边界条件下的处理，如刷新次数耗尽和积分不足等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the CreditShopping prudent mode purchase pipeline to use a tiered priority chain for item selection when credits are low, reducing the chance of overpaying for high-priced items.

New Features:
- Introduce a multi-level purchase priority sequence for prudent CreditShopping when credit after refresh cost falls below the configured threshold.
- Add a repeat-purchase whitelist that allows specified items to be repurchased without discount constraints.
- Add a fallback path to purchase otherwise blacklisted items as a last resort when no higher-priority options are available.

Bug Fixes:
- Mitigate cases where the previous random selection logic could buy high-priced items and cause slight credit loss in prudent mode.

Enhancements:
- Improve boundary condition handling in the CreditShopping pipeline for cases such as exhausted refresh attempts and insufficient credits.

</details>