### PR TITLE
refactor: 统一Go侧JSON资源读取逻辑

### DIFF
--- a/agent/go-service/essencefilter/matchapi/loader.go
+++ b/agent/go-service/essencefilter/matchapi/loader.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/resource"
 )
 
 const defaultLoadLocale = LocaleCN
@@ -82,7 +84,7 @@ func fileExists(p string) bool {
 }
 
 func loadMatcherConfig(dataDir string, locale string) (MatcherConfig, error) {
-	b, err := os.ReadFile(filepath.Join(dataDir, "matcher_config.json"))
+	b, err := resource.ReadResource(filepath.Join(dataDir, "matcher_config.json"))
 	if err != nil {
 		return MatcherConfig{}, err
 	}
@@ -246,17 +248,12 @@ func pickSkillPoolEnglish(s skillPoolJSON) string {
 }
 
 func loadSkillPools(dataDir string, locale string) (SkillPools, error) {
-	b, err := os.ReadFile(filepath.Join(dataDir, "skill_pools.json"))
-	if err != nil {
-		return SkillPools{}, err
-	}
-
 	var raw struct {
 		Slot1 []skillPoolJSON `json:"slot1"`
 		Slot2 []skillPoolJSON `json:"slot2"`
 		Slot3 []skillPoolJSON `json:"slot3"`
 	}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := resource.ReadJsonResource(filepath.Join(dataDir, "skill_pools.json"), &raw); err != nil {
 		return SkillPools{}, err
 	}
 
@@ -340,13 +337,8 @@ func pickLocalizedSkillSlice(m map[string][]string, locale string) []string {
 }
 
 func loadWeaponsOutputAndConvert(dataDir string, cfg MatcherConfig, pools SkillPools, locale string) ([]WeaponData, error) {
-	b, err := os.ReadFile(filepath.Join(dataDir, "weapons_output.json"))
-	if err != nil {
-		return nil, err
-	}
-
 	var raw WeaponsOutputRaw
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := resource.ReadJsonResource(filepath.Join(dataDir, "weapons_output.json"), &raw); err != nil {
 		return nil, err
 	}
 
@@ -397,13 +389,8 @@ func loadWeaponsOutputAndConvert(dataDir string, cfg MatcherConfig, pools SkillP
 }
 
 func loadLocations(dataDir string) ([]Location, error) {
-	b, err := os.ReadFile(filepath.Join(dataDir, "locations.json"))
-	if err != nil {
-		return nil, err
-	}
-
 	var locs []Location
-	if err := json.Unmarshal(b, &locs); err != nil {
+	if err := resource.ReadJsonResource(filepath.Join(dataDir, "locations.json"), &locs); err != nil {
 		return nil, err
 	}
 	return locs, nil

--- a/agent/go-service/itemtransfer/types.go
+++ b/agent/go-service/itemtransfer/types.go
@@ -54,7 +54,7 @@ var (
 func loadItemOrderData() (*itemOrderData, error) {
 	cachedDataOnce.Do(func() {
 		var data itemOrderData
-		err := resource.ReadJsonResource("data/ItemTransfer/item_order.json", data)
+		err := resource.ReadJsonResource("data/ItemTransfer/item_order.json", &data)
 		if err != nil {
 			cachedDataErr = err
 			return

--- a/agent/go-service/itemtransfer/types.go
+++ b/agent/go-service/itemtransfer/types.go
@@ -1,7 +1,6 @@
 package itemtransfer
 
 import (
-	"encoding/json"
 	"strings"
 	"sync"
 
@@ -54,16 +53,13 @@ var (
 
 func loadItemOrderData() (*itemOrderData, error) {
 	cachedDataOnce.Do(func() {
-		b, err := resource.ReadResource("data/ItemTransfer/item_order.json")
+		var data itemOrderData
+		err := resource.ReadJsonResource("data/ItemTransfer/item_order.json", data)
 		if err != nil {
 			cachedDataErr = err
 			return
 		}
-		var data itemOrderData
-		if err := json.Unmarshal(b, &data); err != nil {
-			cachedDataErr = err
-			return
-		}
+
 		cachedData = &data
 		log.Info().
 			Str("component", componentName).

--- a/agent/go-service/map-tracker/big_map_pick.go
+++ b/agent/go-service/map-tracker/big_map_pick.go
@@ -186,15 +186,9 @@ func (a *MapTrackerBigMapPick) parseParam(paramStr string) (*MapTrackerBigMapPic
 func (a *MapTrackerBigMapPick) getSceneManagerNode(mapName string) (string, bool, error) {
 	a.externalOnce.Do(func() {
 		a.externalData = map[string]mapExternalDataItem{}
-
-		data, err := resource.ReadResource(mt.MAP_EXTERNAL_DATA_PATH)
+		err := resource.ReadJsonResource(mt.MAP_EXTERNAL_DATA_PATH, &a.externalData)
 		if err != nil {
-			a.externalErr = fmt.Errorf("failed to read map external data: %w", err)
-			return
-		}
-
-		if err := json.Unmarshal(data, &a.externalData); err != nil {
-			a.externalErr = fmt.Errorf("failed to unmarshal map external data: %w", err)
+			a.externalErr = fmt.Errorf("failed to load map external data: %w", err)
 			return
 		}
 	})

--- a/agent/go-service/map-tracker/internal/const.go
+++ b/agent/go-service/map-tracker/internal/const.go
@@ -38,13 +38,6 @@ const (
 	BIG_MAP_PICK_RETRY = 10
 )
 
-// Resource paths
-const (
-	MAP_BBOX_DATA_PATH     = "data/MapTracker/map_bbox_data.json"
-	MAP_EXTERNAL_DATA_PATH = "data/MapTracker/map_external_data.json"
-	MAP_DIR                = "resource/image/MapTracker/map"
-)
-
 // Move action configuration
 const (
 	INFER_INTERVAL_MS      = 100

--- a/agent/go-service/map-tracker/internal/resource.go
+++ b/agent/go-service/map-tracker/internal/resource.go
@@ -2,7 +2,6 @@
 package maptracker
 
 import (
-	"encoding/json"
 	"fmt"
 	"image"
 	"os"
@@ -28,6 +27,12 @@ var (
 			func() string { return resource.FindResource("resource/image/MapTracker/BigMapZoomOut.png") },
 		),
 	}
+)
+
+const (
+	MAP_BBOX_DATA_PATH     = "data/MapTracker/map_bbox_data.json"
+	MAP_EXTERNAL_DATA_PATH = "data/MapTracker/map_external_data.json"
+	MAP_DIR                = "resource/image/MapTracker/map"
 )
 
 // MapTrackerResource stores globally shared map resources for map-tracker.
@@ -85,14 +90,9 @@ func (r *MapTrackerResource) LoadMaps() ([]MapCache, error) {
 	}
 
 	rectList := make(map[string][]int)
-	if data, err := resource.ReadResource(MAP_BBOX_DATA_PATH); err == nil {
-		if err := json.Unmarshal(data, &rectList); err != nil {
-			log.Warn().Err(err).Msg("Failed to unmarshal map bbox data")
-		} else {
-			log.Info().Msg("Map bbox data loaded")
-		}
-	} else {
-		log.Warn().Err(err).Msg("Failed to read map bbox data")
+	err := resource.ReadJsonResource(MAP_BBOX_DATA_PATH, rectList)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to load map bbox data")
 	}
 
 	entries, err := os.ReadDir(mapDir)

--- a/agent/go-service/map-tracker/internal/resource.go
+++ b/agent/go-service/map-tracker/internal/resource.go
@@ -90,7 +90,7 @@ func (r *MapTrackerResource) LoadMaps() ([]MapCache, error) {
 	}
 
 	rectList := make(map[string][]int)
-	err := resource.ReadJsonResource(MAP_BBOX_DATA_PATH, rectList)
+	err := resource.ReadJsonResource(MAP_BBOX_DATA_PATH, &rectList)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to load map bbox data")
 	}

--- a/agent/go-service/pkg/resource/resource_reader.go
+++ b/agent/go-service/pkg/resource/resource_reader.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,15 +9,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// FindResource tries to find and read the specified resource file as bytes array.
+// ReadResource tries to find and read the specified resource file as bytes array.
 //
-// The path will be resolved in the following order:
-//
-// 1. Directly using the provided relative path.
-//
-// 2. Searching in the resource base path set by resource sink.
-//
-// 3. Searching in "resource" and "assets" directories in the current working directory and its parent/grandparent directories.
+// To understand how the resource file is located, please refer to the [FindResource] function.
 func ReadResource(relativePath string) ([]byte, error) {
 	resolvedPath := FindResource(relativePath)
 	if resolvedPath == "" {
@@ -30,6 +25,21 @@ func ReadResource(relativePath string) ([]byte, error) {
 		return nil, err
 	}
 	return content, nil
+}
+
+// ReadJsonResource tries to find and read the specified resource file as JSON and unmarshal it into the provided variable.
+//
+// To understand how the resource file is located, please refer to the [FindResource] function.
+func ReadJsonResource(relativePath string, out any) error {
+	content, err := ReadResource(relativePath)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(content, out); err != nil {
+		log.Error().Err(err).Str("relativePath", relativePath).Int("contentLength", len(content)).Msg("Resource JSON cannot be parsed")
+		return err
+	}
+	return nil
 }
 
 // FindResource tries to find a file in the cached resource path or standard fallback paths.

--- a/agent/go-service/pkg/resource/resource_reader.go
+++ b/agent/go-service/pkg/resource/resource_reader.go
@@ -52,9 +52,6 @@ func ReadJsonResource(relativePath string, out any) error {
 //
 // 3. Searching in "resource" and "assets" directories in the current working directory and its parent/grandparent directories.
 func FindResource(relativePath string) string {
-	rel := filepath.FromSlash(strings.TrimSpace(relativePath))
-	rel = strings.TrimPrefix(rel, string(filepath.Separator))
-
 	tryPath := func(path string) string {
 		if path == "" {
 			return ""
@@ -65,11 +62,26 @@ func FindResource(relativePath string) string {
 		return ""
 	}
 
-	findPath := func(rel string) string {
-		if found := tryPath(rel); found != "" {
+	rawPath := filepath.Clean(filepath.FromSlash(strings.TrimSpace(relativePath)))
+	if rawPath == "." {
+		rawPath = ""
+	}
+
+	if filepath.IsAbs(rawPath) {
+		if found := tryPath(rawPath); found != "" {
+			log.Debug().Str("relativePath", relativePath).Str("resolvedPath", found).Msg("Absolute resource path found")
 			return found
 		}
+	}
 
+	if found := tryPath(rawPath); found != "" {
+		log.Debug().Str("relativePath", relativePath).Str("resolvedPath", found).Msg("Direct resource path found")
+		return found
+	}
+
+	rel := strings.TrimPrefix(rawPath, string(filepath.Separator))
+
+	findPath := func(rel string) string {
 		if base := getResourceBase(); base != "" {
 			base = filepath.Clean(base)
 			if found := tryPath(filepath.Join(base, rel)); found != "" {


### PR DESCRIPTION
## 概述

此 PR 对基质筛选锁定、物品转移、MapTracker 的 JSON 外部资源的读取逻辑进行了统一。

该重构逻辑可以让调用方实现 `os.ReadFile` + `json.Unmarshal` 的一键组合调用。

## 由 Sourcery 提供的总结

通过将文件发现与 JSON 反序列化集中到共享的资源助手中，在各个 Go 服务之间统一基于 JSON 的外部资源加载方式。

增强内容：
- 引入共享的 `ReadJsonResource` 助手，用于定位、读取并反序列化 JSON 资源，并在解析失败时提供一致的日志记录。
- 重构 essence filter、item transfer 和 MapTracker 组件，使其使用集中化的资源读取助手，而不是零散的 `os.ReadFile` 和 `json.Unmarshal` 调用。
- 将 MapTracker 的资源路径常量整合到内部资源模块中，以更好地与共享的加载逻辑保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify JSON-based external resource loading across Go services by centralizing file discovery and JSON unmarshalling into shared resource helpers.

Enhancements:
- Introduce a shared ReadJsonResource helper to locate, read, and unmarshal JSON resources with consistent logging on parse failures.
- Refactor essence filter, item transfer, and MapTracker components to use the centralized resource reading helpers instead of ad hoc os.ReadFile and json.Unmarshal calls.
- Consolidate MapTracker resource path constants into the internal resource module to better align with shared loading logic.

</details>