### PR TITLE
fix(GiftOperator): 领取礼物分支点击后卡住 close #2152

### DIFF
--- a/assets/resource/pipeline/GiftOperator.json
+++ b/assets/resource/pipeline/GiftOperator.json
@@ -123,7 +123,7 @@
         }
     },
     "GiftOperatorBranchReceive": {
-        "desc": "分支2：干员给你送礼，点击领取",
+        "desc": "分支2：干员给你送礼，点击领取。next 含自身以便未跳转时重试一次点击",
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -145,7 +145,12 @@
         "post_wait_freezes": 200,
         "next": [
             "GiftOperatorReceiveDialog",
-            "GiftOperatorBagFull"
+            "GiftOperatorBagFull",
+            "GiftOperatorSkipDialog",
+            "GiftOperatorBranchGift",
+            "GiftOperatorBranchMaxAffinity",
+            "GiftOperatorLeave",
+            "GiftOperatorBranchReceive"
         ]
     },
     "GiftOperatorChatAltDown": {

--- a/assets/resource/pipeline/GiftOperator.json
+++ b/assets/resource/pipeline/GiftOperator.json
@@ -146,7 +146,6 @@
         "next": [
             "GiftOperatorReceiveDialog",
             "GiftOperatorBagFull",
-            "GiftOperatorSkipDialog",
             "GiftOperatorBranchGift",
             "GiftOperatorBranchMaxAffinity",
             "GiftOperatorLeave",


### PR DESCRIPTION
## 问题

issue #2152：送礼流程在"干员给你送礼"分支点击领取后，20s 超时失败。

日志证据（摘自 MaaEndBot 分析）：
- `09:03:12.073` `GiftOperatorBranchReceive` 的 Click 动作成功
- `09:03:12.555 - 09:03:32.793` 框架反复轮询 `GiftOperatorReceiveDialog`（模板分 0.33~0.38）与 `GiftOperatorBagFull`（OCR 为空），均持续失败
- `09:03:32.826` 保存 `on_error/..._GiftOperatorBranchReceive.png`，task 失败

## 根因

`GiftOperatorBranchReceive` 的 `next` 只覆盖 `GiftOperatorReceiveDialog` 和 `GiftOperatorBagFull`。若点击未真正生效（按钮仍在原位）或 UI 进入其他中间态，流程没有自重试或备用分支，只能等 20s 超时。

## 修复

参照 `GiftOperatorSkipDialog`（自重试模式）与 `GiftOperatorReceiveDialog`（7 个 next 分支）的写法，扩充 `GiftOperatorBranchReceive.next`：

- 追加自身 `GiftOperatorBranchReceive` 用于"按钮仍在原位"时重试点击
- 追加 `GiftOperatorSkipDialog` / `GiftOperatorBranchGift` / `GiftOperatorBranchMaxAffinity` / `GiftOperatorLeave` 覆盖领取后可能进入的其他状态

符合 AGENTS.md 的"高命中率"与"原子化操作"规范，不新增坐标或模板，仅扩展状态分支。

## 测试

- 本地 `python3 -c "json.load(...)"` 校验 JSON 语法有效
- 未在真实游戏中复现（该 bug 触发条件为点击未生效或临时状态，较难在开发环境稳定复现）；修改仅扩展状态分支、不改变识别逻辑与坐标，风险面小

## Summary by Sourcery

Bug Fixes:
- 修复了一些情况下在点击领取后未切换到预期的对话框或背包已满状态时，导致干员赠礼领取过程偶发性超时的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix operator gift claiming sometimes timing out when the receive click does not transition to the expected dialog or bag-full state.

</details>