### PR TITLE
fix(WeaponUpgrade): 点击升级按钮未切场时重试 close #2112

### DIFF
--- a/assets/resource/pipeline/Weapon.json
+++ b/assets/resource/pipeline/Weapon.json
@@ -73,7 +73,7 @@
         ]
     },
     "WeaponUpgradeClickLevelUpButton": {
-        "desc": "进入升级UI",
+        "desc": "进入升级UI。next 含自身以便点击未切场时重试一次",
         "recognition": "And",
         "all_of": [
             "LevelUpButton"
@@ -94,7 +94,8 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "WeaponUpgradeClickAddUpgradeMaterial"
+            "WeaponUpgradeClickAddUpgradeMaterial",
+            "WeaponUpgradeClickLevelUpButton"
         ]
     },
     "WeaponUpgradeClickAddUpgradeMaterial": {


### PR DESCRIPTION
## 问题

issue #2112：`🔫升级武器` 任务在点击武器详情页右下角 **升级** 按钮后，20s 超时失败。

## 日志证据（from logs zip）

- `17:20:32.869` `WeaponUpgradeClickLevelUpButton` 识别成功：`box=[1231,649,23,25]`，`__LevelUpButton` 模板 score=0.990，阈值 0.9
- `17:20:33.364` Click 动作成功：`point=[1253,671]`
- `17:20:40.991 - 17:20:52.xxx` `WeaponUpgradeClickAddUpgradeMaterial` 连续识别失败：`AddUpgradeMaterialButton.png` 模板 score≈0.17 << 0.8 阈值
- `17:20:53.379` save on_error，`Tasker.Task.Failed`
- **on_error 截图确认仍停在武器详情页**，右下"升级"按钮依旧可见 → 点击未让游戏切场

## 根因

`WeaponUpgradeClickLevelUpButton.next` 只覆盖 `WeaponUpgradeClickAddUpgradeMaterial` 一个节点，无"点击未生效则重试"分支。只要这一次点击没能让游戏切到升级材料界面（可能前台点击丢失、UI 过渡时机、游戏侧拦截等），就只能空等到 task 超时直接失败。

## 修复

参照 `GiftOperatorBranchReceive` / `GiftOperatorSkipDialog` 的自重试模式，把节点自身加入 `next`：

\`\`\`json
"next": [
    "WeaponUpgradeClickAddUpgradeMaterial",
    "WeaponUpgradeClickLevelUpButton"
]
\`\`\`

- 若 UI 已切场 → `AddUpgradeMaterialButton` 在上方命中，正常推进
- 若 UI 未切场 → `LevelUpButton` 仍可命中，进入下一轮重新点击
- 20s task 超时自然兜底，不会无限重试

符合 AGENTS.md 的"高命中率"与"原子化操作"规范，不改坐标 / 模板 / 阈值，仅扩展状态分支。

## 测试

- `node -e ... JSON.parse(...)` 校验 JSONC 语法有效
- 未在真实游戏中复现（点击未切场难以稳定复现）；改动仅扩展 next，风险面小

## Summary by Sourcery

Bug Fixes:
- 通过允许在点击步骤失败前进行重试，防止在游戏未接受升级按钮点击时武器升级任务超时。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent weapon upgrade tasks from timing out when the upgrade button click is not accepted by the game by allowing the click step to retry before failing.

</details>