### PR TITLE
feat: 添加刷新信用点功能，允许在任务选项中启用或禁用

### DIFF
--- a/assets/resource/pipeline/CreditShopping/Shopping.json
+++ b/assets/resource/pipeline/CreditShopping/Shopping.json
@@ -53,6 +53,7 @@
             "CreditShoppingRefreshCountReached",
             "CreditShoppingPrudentRefresh",
             "CreditShoppingBuyBlacklist",
+            "RefreshGetCredits",
             "CreditShippingCanNotToBuy",
             "ADBSpecial",
             "RefreshItem",
@@ -86,6 +87,7 @@
             "CreditShoppingPrudentRefresh",
             "CreditShoppingBuyBlacklist",
             "CreditShippingCanNotToBuy",
+            "RefreshGetCredits",
             "RefreshItem",
             "CreditShoppingNothingToBuy"
         ]
@@ -358,6 +360,22 @@
         "action": "Click",
         "next": [
             "CreditShoppingBuyItem"
+        ]
+    },
+    "RefreshGetCredits": {
+        "desc": "刷新信用点不足触发获取信用点，默认关闭，由任务选项开启",
+        "max_hit": 1,
+        "enabled": false,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "CanNotFlash"
+                ]
+            }
+        },
+        "next": [
+            "GoToNeedCredit"
         ]
     },
     "CreditShoppingPrudentRefresh": {

--- a/assets/tasks/CreditShopping.json
+++ b/assets/tasks/CreditShopping.json
@@ -1727,8 +1727,33 @@
                         }
                     },
                     "option": [
+                        "RefreshGetCredits",
                         "PrudentRefresh"
                     ]
+                }
+            ]
+        },
+        "RefreshGetCredits": {
+            "type": "switch",
+            "label": "$option.RefreshGetCredits.label",
+            "description": "$option.RefreshGetCredits.description",
+            "default_case": "No",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "RefreshGetCredits": {
+                            "enabled": true
+                        }
+                    }
+                },
+                {
+                    "name": "No",
+                    "pipeline_override": {
+                        "RefreshGetCredits": {
+                            "enabled": false
+                        }
+                    }
                 }
             ]
         },


### PR DESCRIPTION
## Summary by Sourcery

新功能：
- 允许在 CreditShopping 工作流中通过任务选项启用或禁用信用点数刷新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Allow enabling or disabling credit points refresh via task options in the CreditShopping workflow.

</details>
- 在 CreditShopping 流水线和任务定义中引入可配置的 refresh-credit-points 行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

新功能：
- 允许在 CreditShopping 工作流中通过任务选项启用或禁用信用点数刷新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Allow enabling or disabling credit points refresh via task options in the CreditShopping workflow.

</details>

</details>