### PR TITLE
feat(map): 使用自适应大地图拖动系数

### DIFF
--- a/agent/go-service/map-tracker/big_map_pick.go
+++ b/agent/go-service/map-tracker/big_map_pick.go
@@ -98,6 +98,9 @@ func (a *MapTrackerBigMapPick) Run(ctx *maa.Context, arg *maa.CustomActionArg) b
 		}
 	}
 
+	panFactor := mt.BIG_MAP_PAN_FACTOR_NUMERATOR / control.GetScreenDiagonalSize(ctrl)
+	log.Info().Float64("panFactor", panFactor).Msg("Calculated big-map pan factor")
+
 	for attempt := 1; attempt <= mt.BIG_MAP_PICK_RETRY; attempt++ {
 		inferRes, err := doBigMapInferForMap(ctx, ctrl, param.MapName)
 		if err != nil {
@@ -140,7 +143,7 @@ func (a *MapTrackerBigMapPick) Run(ctx *maa.Context, arg *maa.CustomActionArg) b
 			Float64("targetInViewY", targetInViewY).
 			Msg("Panning big-map toward target")
 
-		if !doDragViewport(ca, &inferRes.ViewPort, deltaInViewX, deltaInViewY) {
+		if !doDragViewport(ca, &inferRes.ViewPort, deltaInViewX, deltaInViewY, panFactor) {
 			continue
 		}
 	}
@@ -352,14 +355,14 @@ func doBigMapInferForMap(ctx *maa.Context, ctrl *maa.Controller, mapName string)
 	return &result, nil
 }
 
-func doDragViewport(ca control.ControlAdaptor, viewport *mt.BigMapViewport, deltaInViewX, deltaInViewY float64) bool {
+func doDragViewport(ca control.ControlAdaptor, viewport *mt.BigMapViewport, deltaInViewX, deltaInViewY, panFactor float64) bool {
 	left := int(math.Round(viewport.Left))
 	top := int(math.Round(viewport.Top))
 	right := int(math.Round(viewport.Right))
 	bottom := int(math.Round(viewport.Bottom))
 
-	rawDragDx := -deltaInViewX * mt.BIG_MAP_PAN_FACTOR
-	rawDragDy := -deltaInViewY * mt.BIG_MAP_PAN_FACTOR
+	rawDragDx := -deltaInViewX * panFactor
+	rawDragDy := -deltaInViewY * panFactor
 	startX, startY := pickDragStartCorner(left, top, right, bottom, rawDragDx, rawDragDy)
 
 	dragDx := int(math.Round(rawDragDx))

--- a/agent/go-service/map-tracker/internal/const.go
+++ b/agent/go-service/map-tracker/internal/const.go
@@ -34,8 +34,8 @@ const (
 
 // Big map pick configuration
 const (
-	BIG_MAP_PAN_FACTOR = 1.5
-	BIG_MAP_PICK_RETRY = 10
+	BIG_MAP_PAN_FACTOR_NUMERATOR = 2500.0 // panFactor = this constant / screen diagonal size
+	BIG_MAP_PICK_RETRY           = 10
 )
 
 // Move action configuration

--- a/agent/go-service/pkg/control/adaptor.go
+++ b/agent/go-service/pkg/control/adaptor.go
@@ -2,15 +2,14 @@
 package control
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
-	"github.com/rs/zerolog/log"
 )
+
+/* ******** Control Adaptor Base Interface ******** */
 
 // ControlAdaptor defines an interface for abstracting control actions, allowing different implementations for different platforms.
 type ControlAdaptor interface {
@@ -93,63 +92,7 @@ func NewControlAdaptor(ctx *maa.Context, ctrl *maa.Controller, w, h int) (Contro
 	}
 }
 
-func GetControlType(ctrl *maa.Controller) (string, error) {
-	infoStr, err := ctrl.GetInfo()
-	if err != nil {
-		return "", err
-	}
-	log.Info().Str("controllerInfo", infoStr).Msg("Fetched controller info")
-	if infoStr == "" {
-		return "", fmt.Errorf("empty controller info")
-	}
-
-	type maaControllerInfo struct {
-		Type string `json:"type"`
-	}
-
-	var info maaControllerInfo
-	if err := json.Unmarshal([]byte(infoStr), &info); err != nil {
-		// Fallback
-		if strings.Contains(infoStr, CONTROL_TYPE_WIN32) {
-			CachedControlType = CONTROL_TYPE_WIN32
-			return CONTROL_TYPE_WIN32, nil
-		}
-		if strings.Contains(infoStr, CONTROL_TYPE_WLROOTS) {
-			CachedControlType = CONTROL_TYPE_WLROOTS
-			return CONTROL_TYPE_WLROOTS, nil
-		}
-		if strings.Contains(infoStr, CONTROL_TYPE_ADB) {
-			CachedControlType = CONTROL_TYPE_ADB
-			return CONTROL_TYPE_ADB, nil
-		}
-		return "", fmt.Errorf("failed to parse controller info via JSON: %w, and fallback parsing also failed", err)
-	}
-	if info.Type == "" {
-		return "", fmt.Errorf("controller type is empty in parsed info")
-	}
-
-	if info.Type == CONTROL_TYPE_WIN32 {
-		CachedControlType = CONTROL_TYPE_WIN32
-		return CONTROL_TYPE_WIN32, nil
-	}
-	if info.Type == CONTROL_TYPE_WLROOTS {
-		CachedControlType = CONTROL_TYPE_WLROOTS
-		return CONTROL_TYPE_WLROOTS, nil
-	}
-	if info.Type == CONTROL_TYPE_ADB {
-		CachedControlType = CONTROL_TYPE_ADB
-		return CONTROL_TYPE_ADB, nil
-	}
-	return "", fmt.Errorf("unsupported controller type: %s", info.Type)
-}
-
-const (
-	CONTROL_TYPE_WIN32 = "win32"
-	CONTROL_TYPE_WLROOTS = "wlroots"
-	CONTROL_TYPE_ADB   = "adb"
-)
-
-var CachedControlType string = ""
+/* ******** Player Movement Enumeration ******** */
 
 // PlayerMovement represents different movement state in the game
 type PlayerMovement struct {

--- a/agent/go-service/pkg/control/utils.go
+++ b/agent/go-service/pkg/control/utils.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Harry Huang
+package control
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+/* ******** Controller Type ******** */
+
+// GetControlType retrieves the control type of the given controller by parsing its info string.
+func GetControlType(ctrl *maa.Controller) (string, error) {
+	infoStr, err := ctrl.GetInfo()
+	if err != nil {
+		return "", err
+	}
+	log.Info().Str("controllerInfo", infoStr).Msg("Fetched controller info")
+	if infoStr == "" {
+		return "", fmt.Errorf("empty controller info")
+	}
+
+	type maaControllerInfo struct {
+		Type string `json:"type"`
+	}
+
+	var info maaControllerInfo
+	if err := json.Unmarshal([]byte(infoStr), &info); err != nil {
+		// Fallback
+		if strings.Contains(infoStr, CONTROL_TYPE_WIN32) {
+			CachedControlType = CONTROL_TYPE_WIN32
+			return CONTROL_TYPE_WIN32, nil
+		}
+		if strings.Contains(infoStr, CONTROL_TYPE_WLROOTS) {
+			CachedControlType = CONTROL_TYPE_WLROOTS
+			return CONTROL_TYPE_WLROOTS, nil
+		}
+		if strings.Contains(infoStr, CONTROL_TYPE_ADB) {
+			CachedControlType = CONTROL_TYPE_ADB
+			return CONTROL_TYPE_ADB, nil
+		}
+		return "", fmt.Errorf("failed to parse controller info via JSON: %w, and fallback parsing also failed", err)
+	}
+	if info.Type == "" {
+		return "", fmt.Errorf("controller type is empty in parsed info")
+	}
+
+	if info.Type == CONTROL_TYPE_WIN32 {
+		CachedControlType = CONTROL_TYPE_WIN32
+		return CONTROL_TYPE_WIN32, nil
+	}
+	if info.Type == CONTROL_TYPE_WLROOTS {
+		CachedControlType = CONTROL_TYPE_WLROOTS
+		return CONTROL_TYPE_WLROOTS, nil
+	}
+	if info.Type == CONTROL_TYPE_ADB {
+		CachedControlType = CONTROL_TYPE_ADB
+		return CONTROL_TYPE_ADB, nil
+	}
+	return "", fmt.Errorf("unsupported controller type: %s", info.Type)
+}
+
+const (
+	CONTROL_TYPE_WIN32   = "win32"
+	CONTROL_TYPE_WLROOTS = "wlroots"
+	CONTROL_TYPE_ADB     = "adb"
+)
+
+var CachedControlType string = ""
+
+/* ******** Screen Diagonal Size ******** */
+
+// GetScreenDiagonalSize calculates the diagonal size of the screen based on the controller's raw resolution,
+// which can be used for dynamic adjustments in control logic.
+//
+// When failed to get the diagonal size, or the diagonal size is less than 800.0,
+// it will fallback to the default value 800.0 (640x480).
+func GetScreenDiagonalSize(ctrl *maa.Controller) float64 {
+	const FALLBACK = 800.0
+
+	if ctrl == nil {
+		return FALLBACK
+	}
+
+	rawWidth, rawHeight, err := ctrl.GetResolution()
+	if err != nil || rawWidth <= 0 || rawHeight <= 0 {
+		return FALLBACK
+	}
+
+	diagonal := math.Hypot(float64(rawWidth), float64(rawHeight))
+	return max(diagonal, FALLBACK)
+}


### PR DESCRIPTION
## 概要

此 PR 引入了对角线尺寸计算，并据此获得大地图拖动系数的合适值。

## 关联

Fix #2142

## Summary by Sourcery

通过基于控制器屏幕对角线来计算平移因子，使大地图的平移速度适应屏幕尺寸，并将控制相关的工具函数重构到单独的辅助模块中。

New Features:
- 引入基于屏幕对角线尺寸计算的自适应大地图平移因子，以在不同分辨率下统一拖动行为。

Enhancements:
- 将控制器类型解析与缓存提取到独立的控制工具文件中，并添加用于计算屏幕对角线尺寸的辅助方法，同时提供合理的回退方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make big-map panning speed adapt to the screen size by basing the pan factor on the controller’s screen diagonal, and refactor control utilities into a separate helper module.

New Features:
- Introduce an adaptive big-map pan factor computed from the screen diagonal size to normalize dragging behavior across different resolutions.

Enhancements:
- Extract controller type parsing and caching into a dedicated control utilities file and add a helper to compute screen diagonal size with sensible fallbacks.

</details>