### PR TITLE
fix(AutoEcoFarm): 队友等待改为可中断分片休眠，避免长 post_delay 无法停任务

### DIFF
--- a/agent/go-service/autoecofarm/interruptiblesleep.go
+++ b/agent/go-service/autoecofarm/interruptiblesleep.go
@@ -1,0 +1,54 @@
+package autoecofarm
+
+import (
+	"encoding/json"
+	"time"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+// 单次休眠粒度，便于在两次 sleep 之间检查 Stopping，避免长 post_delay 无法停止任务。
+const interruptibleSleepChunkMs = 250
+
+type interruptibleSleepParams struct {
+	DurationMs int `json:"durationMs"`
+}
+
+type autoEcoFarmInterruptibleSleep struct{}
+
+var _ maa.CustomActionRunner = &autoEcoFarmInterruptibleSleep{}
+
+// Run 在约 durationMs 毫秒内分片休眠；若收到停止任务信号则提前结束并返回 true。
+func (a *autoEcoFarmInterruptibleSleep) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	if arg == nil {
+		log.Error().Str("component", "AutoEcoFarm").Msg("interruptible sleep: nil arg")
+		return false
+	}
+	var params interruptibleSleepParams
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().
+			Err(err).
+			Str("component", "AutoEcoFarm").
+			Str("param", arg.CustomActionParam).
+			Msg("interruptible sleep: parse param failed")
+		return false
+	}
+	if params.DurationMs <= 0 {
+		return true
+	}
+	remaining := params.DurationMs
+	for remaining > 0 {
+		if ctx.GetTasker().Stopping() {
+			log.Info().Str("component", "AutoEcoFarm").Msg("interruptible sleep: task stopping, exit early")
+			return true
+		}
+		chunk := interruptibleSleepChunkMs
+		if remaining < chunk {
+			chunk = remaining
+		}
+		time.Sleep(time.Duration(chunk) * time.Millisecond)
+		remaining -= chunk
+	}
+	return true
+}

--- a/agent/go-service/autoecofarm/register.go
+++ b/agent/go-service/autoecofarm/register.go
@@ -12,6 +12,7 @@ func Register() {
 	maa.AgentServerRegisterCustomRecognition("autoEcoFarmCalculateSwipeTarget", &autoEcoFarmCalculateSwipeTarget{})
 	maa.AgentServerRegisterCustomRecognition("autoEcoFarmFindNearestRecognitionResult", &autoEcoFarmFindNearestRecognitionResult{})
 	maa.AgentServerRegisterCustomAction("autoEcoFarmResetSwipeState", &autoEcoFarmResetSwipeState{})
+	maa.AgentServerRegisterCustomAction("autoEcoFarmInterruptibleSleep", &autoEcoFarmInterruptibleSleep{})
 }
 
 type autoEcoFarmResetSwipeState struct{}

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
@@ -47,7 +47,7 @@
         ]
     },
     "_AutoEcoFarmJump3": {
-        "desc": "松开w，动作后等待 _AutoEcoFarmFindMenuIcon 同 roi 区域画面静止",
+        "desc": "松开w",
         "action": {
             "type": "KeyUp",
             "param": {
@@ -330,11 +330,20 @@
         ]
     },
     "_AutoEcoFarmWaitForTeammate": {
-        "desc": "等待30秒让队友完成工作",
+        "desc": "等待若干秒让队友完成工作（Custom 分片休眠，可响应停止任务）",
         "recognition": "DirectHit",
-        "action": "DoNothing",
-        //每次操作后休息30秒等队友完成工作
-        "post_delay": 30000,
+        "pre_delay": 0,
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "autoEcoFarmInterruptibleSleep",
+                "custom_action_param": {
+                    "durationMs": 30000
+                }
+            }
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "[JumpBack]_AutoEcoFarmExitCameraMode",
             "_AutoEcoFarmFindMenuLoop"

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
@@ -349,7 +349,7 @@
             "_AutoEcoFarmFindMenuLoop"
         ],
         "focus": {
-            "Node.Action.Succeeded": "等待30秒，让队友多干点活，不是脚本卡咯，别担心"
+            "Node.Action.Starting": "等待30秒，让队友多干点活，不是脚本卡咯，别担心"
         }
     },
     "_AutoEcoFarmCancelMove": {

--- a/assets/tasks/AutoEcoFarm.json
+++ b/assets/tasks/AutoEcoFarm.json
@@ -116,7 +116,7 @@
                                 }
                             },
                             "focus": {
-                                "Node.Action.Succeeded": "等待60秒，让队友多干点活，不是脚本卡咯，别担心"
+                                "Node.Action.Starting": "等待60秒，让队友多干点活，不是脚本卡咯，别担心"
                             }
                         }
                     }
@@ -150,7 +150,7 @@
                                 }
                             },
                             "focus": {
-                                "Node.Action.Succeeded": "等待60秒，让队友多干点活，不是脚本卡咯，别担心"
+                                "Node.Action.Starting": "等待60秒，让队友多干点活，不是脚本卡咯，别担心"
                             }
                         },
                         "_AutoEcoFarmInAnyFarm": {

--- a/assets/tasks/AutoEcoFarm.json
+++ b/assets/tasks/AutoEcoFarm.json
@@ -106,7 +106,15 @@
                             }
                         },
                         "_AutoEcoFarmWaitForTeammate": {
-                            "post_delay": 60000,
+                            "action": {
+                                "type": "Custom",
+                                "param": {
+                                    "custom_action": "autoEcoFarmInterruptibleSleep",
+                                    "custom_action_param": {
+                                        "durationMs": 60000
+                                    }
+                                }
+                            },
                             "focus": {
                                 "Node.Action.Succeeded": "等待60秒，让队友多干点活，不是脚本卡咯，别担心"
                             }
@@ -132,7 +140,15 @@
                             "enabled": true
                         },
                         "_AutoEcoFarmWaitForTeammate": {
-                            "post_delay": 60000,
+                            "action": {
+                                "type": "Custom",
+                                "param": {
+                                    "custom_action": "autoEcoFarmInterruptibleSleep",
+                                    "custom_action_param": {
+                                        "durationMs": 60000
+                                    }
+                                }
+                            },
                             "focus": {
                                 "Node.Action.Succeeded": "等待60秒，让队友多干点活，不是脚本卡咯，别担心"
                             }


### PR DESCRIPTION
如题

## Summary by Sourcery

为 AutoEcoFarm 引入可中断的睡眠动作，使长时间等待可以被拆分为可停止的片段。

新功能：
- 添加一个自定义的 AutoEcoFarm 动作，根据可配置的持续时间执行可中断睡眠。

错误修复：
- 当收到任务停止信号时，允许中断 AutoEcoFarm 的长时间延迟等待，防止任务在长时间延迟期间陷入卡住状态。

增强优化：
- 在 AutoEcoFarm 服务中注册新的可中断睡眠动作，并将其集成到相关的 AutoEcoFarm 任务/流水线定义中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an interruptible sleep action for AutoEcoFarm to allow long waits to be broken into stoppable chunks.

New Features:
- Add a custom AutoEcoFarm action that performs interruptible sleep based on a configurable duration.

Bug Fixes:
- Allow long AutoEcoFarm post-delay waits to be interrupted when a task stop signal is received, preventing tasks from being stuck during extended delays.

Enhancements:
- Register the new interruptible sleep action in the AutoEcoFarm service and integrate it into the relevant AutoEcoFarm task/pipeline definitions.

</details>