### PR TITLE
feat(map): 添加寻路结束后的后复位

### DIFF
--- a/agent/go-service/map-tracker/move.go
+++ b/agent/go-service/map-tracker/move.go
@@ -189,7 +189,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 			// Check stopping signal
 			if ctx.GetTasker().Stopping() {
 				log.Warn().Msg("Task is stopping, exiting navigation loop")
-				ca.PlayerStop()
+				doPlayerStop(ca)
 				return false
 			}
 
@@ -210,7 +210,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 			result, err := doInfer(ctx, ctrl, param)
 			if err != nil {
 				log.Error().Err(err).Msg("Inference failed during navigation")
-				ca.PlayerStop()
+				ca.SetPlayerMovement(control.MovementStop, control.PolicyDefault)
 				continue
 			}
 			curX, curY := result.X, result.Y
@@ -229,7 +229,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					nextTargetRot := calcTargetRotation(curX, curY, nextX, nextY)
 					nextDeltaRot := calcDeltaRotation(rot, nextTargetRot)
 					if math.Abs(float64(nextDeltaRot)) > param.RotationUpperThreshold {
-						ca.SetPlayerMovement(control.MovementWalk)
+						ca.SetPlayerMovement(control.MovementWalk, control.PolicyDefault)
 					}
 					log.Debug().Float64("nextDeltaRot", float64(nextDeltaRot)).Msg("Finishing target, foreseeing rotation adjustment for next target")
 					augNextDeltaRot := float64(nextDeltaRot) * 0.618
@@ -264,7 +264,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 						fineApproachOngoing = true
 						fineApproachExpectedElapsed := control.MovementWalk.EtaOfDistance(dist)
 						fineApproachExpectedEndTime = loopStartTime.Add(fineApproachExpectedElapsed)
-						ca.SetPlayerMovement(control.MovementWalk)
+						ca.SetPlayerMovement(control.MovementWalk, control.PolicyDefault)
 						log.Info().Int("index", i).Float64("dist", dist).Dur("expectedElapsed", fineApproachExpectedElapsed).Msg("Entering fine approach")
 					} else {
 						log.Info().Int("index", i).Float64("x", curX).Float64("y", curY).Msg("Target point reached (ordinary approach)")
@@ -290,6 +290,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				}
 				if deltaLocationMs > param.StuckThreshold {
 					log.Info().Msg("Stuck detected, jumping...")
+					ca.SetPlayerMovement(ca.GetPlayerMovement(), control.PolicyActive)
 					ca.PlayerJump()
 				}
 			} else {
@@ -329,7 +330,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				if ca.GetPlayerMovement().Equals(control.MovementSprint) {
 					if absRawDeltaRot > param.RotationLowerThreshold {
 						// Ensure no sprinting: forcibly set to 'walk'
-						ca.SetPlayerMovement(control.MovementWalk)
+						ca.SetPlayerMovement(control.MovementWalk, control.PolicyDefault)
 					}
 				}
 
@@ -337,21 +338,21 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				if !fineApproachOngoing {
 					if absRawDeltaRot > param.RotationUpperThreshold {
 						// Rotation is bad: set to 'walk'
-						ca.SetPlayerMovement(control.MovementWalk)
+						ca.SetPlayerMovement(control.MovementWalk, control.PolicyDefault)
 					} else if absRawDeltaRot > param.RotationLowerThreshold {
 						// Rotation is good: at least set to 'run'
-						ca.SetPlayerMovement(control.MovementRun)
+						ca.SetPlayerMovement(control.MovementRun, control.PolicyDefault)
 					} else {
 						// Rotation is very good: can try 'sprint' if target is far enough
 						if dist > param.SprintThreshold {
-							ca.SetPlayerMovement(control.MovementSprint)
+							ca.SetPlayerMovement(control.MovementSprint, control.PolicyDefault)
 						} else {
-							ca.SetPlayerMovement(control.MovementRun)
+							ca.SetPlayerMovement(control.MovementRun, control.PolicyDefault)
 						}
 					}
 				} else {
 					// During fine approach: always use 'walk'
-					ca.SetPlayerMovement(control.MovementWalk)
+					ca.SetPlayerMovement(control.MovementWalk, control.PolicyLazy)
 				}
 
 				// Start a new rotation adjustment
@@ -374,8 +375,8 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		// End of loop, one target reached
 	}
 
-	// End of all targets reached
-	ca.PlayerStop()
+	// End of all targets reached, reset and stop movement
+	doPlayerStop(ca)
 
 	// Show finished UI summary
 	if !param.NoPrint {
@@ -483,12 +484,21 @@ func (a *MapTrackerMove) parseParam(paramStr string) (*MapTrackerMoveParam, erro
 	return &param, nil
 }
 
+func doPlayerStop(ca control.ControlAdaptor) {
+	// Softly stop movement first
+	ca.SetPlayerMovement(control.MovementStop, control.PolicyLazy)
+	// Then reset player to running state to ensure consistent movement state for next navigation
+	ca.SetPlayerMovement(control.MovementRun, control.PolicyLazy)
+	// Finally set to stop to ensure immediate response to stopping signal
+	ca.SetPlayerMovement(control.MovementStop, control.PolicyDefault)
+}
+
 func doEmergencyStop(ca control.ControlAdaptor, noPrint bool) {
 	log.Warn().Msg("Emergency stop triggered")
 	if !noPrint {
 		maafocus.Print(ca.Ctx(), i18n.RenderHTML("maptracker.emergency_stop", nil))
 	}
-	ca.PlayerStop()
+	doPlayerStop(ca)
 	ca.Ctx().GetTasker().PostStop()
 }
 

--- a/agent/go-service/pkg/control/adaptor.go
+++ b/agent/go-service/pkg/control/adaptor.go
@@ -49,19 +49,11 @@ type ControlAdaptor interface {
 
 	// SetPlayerMovement sets the player movement state to the given value,
 	// and performs necessary control actions to achieve that state.
-	SetPlayerMovement(movement PlayerMovement)
+	SetPlayerMovement(movement PlayerMovement, policy PlayerMovementPolicy)
 
 	// PlayerJump performs the player jump action once.
 	// This will not change the player movement state.
 	PlayerJump()
-
-	// PlayerSprint performs the player sprint action once.
-	// This will set the player movement state to at least sprint.
-	PlayerSprint()
-
-	// PlayerStop lets the player stop moving forward.
-	// This will set the player movement state to stop.
-	PlayerStop()
 
 	// AggressivelyResetCamera eliminates the side effect of camera rotation.
 	// Different implementations may have different ways to achieve this.
@@ -136,4 +128,19 @@ var (
 	MovementWalk   = PlayerMovement{2.0, 270.0}
 	MovementRun    = PlayerMovement{8.0, 540.0}
 	MovementSprint = PlayerMovement{12.0, 1080.0}
+)
+
+/* ******** Player Movement Policy Enumeration ******** */
+
+type PlayerMovementPolicy int
+
+const (
+	// PolicyLazy avoids any unnecessary key action if the new movement state is already achieved,
+	// which may cause less latency but also less robustness.
+	PolicyLazy PlayerMovementPolicy = 0
+	// PolicyDefault balances between [PolicyLazy] and [PolicyActive] policy.
+	PolicyDefault PlayerMovementPolicy = 1
+	// PolicyActive performs extra key actions to actively ensure the new movement state is achieved,
+	// which may cause more latency but also more robustness.
+	PolicyActive PlayerMovementPolicy = 2
 )

--- a/agent/go-service/pkg/control/adaptor_adb.go
+++ b/agent/go-service/pkg/control/adaptor_adb.go
@@ -133,7 +133,6 @@ func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement, policy 
 				if aca.pm.speed >= MovementSprint.speed {
 					// Set to "stop" temporarily to terminate the "sprint" state, then set to "run"
 					aca.TouchUp(joystickContact, defaultTouchActionDelayMillis)
-					joystickRunForward()
 				} else {
 					// Already in "run", do nothing else
 				}

--- a/agent/go-service/pkg/control/adaptor_adb.go
+++ b/agent/go-service/pkg/control/adaptor_adb.go
@@ -78,8 +78,28 @@ func (aca *ADBControlAdaptor) GetPlayerMovement() PlayerMovement {
 	return aca.pm
 }
 
-func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
+func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement, policy PlayerMovementPolicy) {
+	joystickRunForward := func() {
+		aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+	}
+	joystickWalkForward := func() {
+		aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_WALK_DY, 0)
+	}
+	joystickStopForward := func() {
+		aca.TouchUp(joystickContact, defaultTouchActionDelayMillis)
+	}
+
 	if movement.Equals(aca.pm) {
+		if policy >= PolicyActive {
+			// Actively ensure moving state
+			if movement.speed >= MovementRun.speed {
+				joystickRunForward()
+			} else if movement.speed > MovementStop.speed {
+				joystickWalkForward()
+			} else {
+				joystickStopForward()
+			}
+		}
 		return
 	}
 
@@ -90,7 +110,7 @@ func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
 
 	if movement.speed <= MovementStop.speed {
 		// Stop moving forward
-		aca.TouchUp(joystickContact, defaultTouchActionDelayMillis)
+		joystickStopForward()
 	} else {
 		if aca.lastMotionIsWalk {
 			if movement.speed >= MovementSprint.speed {
@@ -99,7 +119,7 @@ func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
 				aca.lastMotionIsWalk = false
 			} else if movement.speed >= MovementRun.speed {
 				// Set to "run"
-				aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+				joystickRunForward()
 				aca.lastMotionIsWalk = false
 			} else {
 				// Already in "walk", do nothing
@@ -107,21 +127,21 @@ func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
 		} else {
 			if movement.speed < MovementRun.speed {
 				// Set to "walk"
-				aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_WALK_DY, 0)
+				joystickWalkForward()
 				aca.lastMotionIsWalk = true
 			} else if movement.speed < MovementSprint.speed {
 				if aca.pm.speed >= MovementSprint.speed {
 					// Set to "stop" temporarily to terminate the "sprint" state, then set to "run"
 					aca.TouchUp(joystickContact, defaultTouchActionDelayMillis)
-					aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+					joystickRunForward()
 				} else {
 					// Already in "run", do nothing else
 				}
-				aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+				joystickRunForward()
 			} else {
 				// Set to "sprint"
 				aca.TouchClick(sprintButtonContact, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
-				aca.TouchDown(joystickContact, JOYSTICK_CENTER_X, JOYSTICK_CENTER_Y+JOYSTICK_RUN_DY, 0)
+				joystickRunForward()
 			}
 		}
 	}
@@ -130,17 +150,6 @@ func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
 
 func (aca *ADBControlAdaptor) PlayerJump() {
 	aca.TouchClick(jumpButtonContact, JUMP_BUTTON_X, JUMP_BUTTON_Y, defaultTouchActionDelayMillis*4, 0)
-}
-
-func (aca *ADBControlAdaptor) PlayerSprint() {
-	aca.TouchClick(sprintButtonContact, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
-	aca.pm = MovementSprint
-	aca.lastMotionIsWalk = false
-}
-
-func (aca *ADBControlAdaptor) PlayerStop() {
-	aca.TouchUp(joystickContact, defaultTouchActionDelayMillis)
-	aca.pm = MovementStop
 }
 
 func (aca *ADBControlAdaptor) AggressivelyResetCamera() {

--- a/agent/go-service/pkg/control/adaptor_adb.go
+++ b/agent/go-service/pkg/control/adaptor_adb.go
@@ -119,7 +119,9 @@ func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement, policy 
 				aca.lastMotionIsWalk = false
 			} else if movement.speed >= MovementRun.speed {
 				// Set to "run"
-				joystickRunForward()
+				if policy >= PolicyDefault {
+					joystickRunForward()
+				}
 				aca.lastMotionIsWalk = false
 			} else {
 				// Already in "walk", do nothing
@@ -130,17 +132,21 @@ func (aca *ADBControlAdaptor) SetPlayerMovement(movement PlayerMovement, policy 
 				joystickWalkForward()
 				aca.lastMotionIsWalk = true
 			} else if movement.speed < MovementSprint.speed {
-				if aca.pm.speed >= MovementSprint.speed {
-					// Set to "stop" temporarily to terminate the "sprint" state, then set to "run"
-					aca.TouchUp(joystickContact, defaultTouchActionDelayMillis)
-				} else {
-					// Already in "run", do nothing else
+				if policy >= PolicyDefault {
+					if aca.pm.speed >= MovementSprint.speed {
+						// Set to "stop" temporarily to terminate the "sprint" state, then set to "run"
+						aca.TouchUp(joystickContact, defaultTouchActionDelayMillis)
+					} else {
+						// Already in "run", do nothing else
+					}
+					joystickRunForward()
 				}
-				joystickRunForward()
 			} else {
 				// Set to "sprint"
 				aca.TouchClick(sprintButtonContact, SPRINT_BUTTON_X, SPRINT_BUTTON_Y, defaultTouchActionDelayMillis, 0)
-				joystickRunForward()
+				if policy >= PolicyDefault {
+					joystickRunForward()
+				}
 			}
 		}
 	}

--- a/agent/go-service/pkg/control/adaptor_desktop.go
+++ b/agent/go-service/pkg/control/adaptor_desktop.go
@@ -95,8 +95,16 @@ func (dca *desktopControlAdaptor) GetPlayerMovement() PlayerMovement {
 	return dca.pm
 }
 
-func (dca *desktopControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
+func (dca *desktopControlAdaptor) SetPlayerMovement(movement PlayerMovement, policy PlayerMovementPolicy) {
 	if movement.Equals(dca.pm) {
+		if policy >= PolicyActive {
+			// Actively ensure moving state
+			if movement.speed > MovementStop.speed {
+				dca.KeyDown(dca.keys.W, defaultDesktopKeyActionDelayMillis/4)
+			} else {
+				dca.KeyUp(dca.keys.W, defaultDesktopKeyActionDelayMillis/4)
+			}
+		}
 		return
 	}
 
@@ -134,25 +142,16 @@ func (dca *desktopControlAdaptor) SetPlayerMovement(movement PlayerMovement) {
 				dca.KeyType(dca.keys.Shift, defaultDesktopKeyActionDelayMillis)
 			}
 		}
-		// Ensure moving forward
-		dca.KeyDown(dca.keys.W, defaultDesktopKeyActionDelayMillis/4)
+		if policy >= PolicyDefault {
+			// Ensure moving forward
+			dca.KeyDown(dca.keys.W, defaultDesktopKeyActionDelayMillis/4)
+		}
 	}
 	dca.pm = movement
 }
 
 func (dca *desktopControlAdaptor) PlayerJump() {
 	dca.KeyType(dca.keys.Space, defaultDesktopKeyActionDelayMillis*4)
-}
-
-func (dca *desktopControlAdaptor) PlayerSprint() {
-	dca.KeyType(dca.keys.Shift, defaultDesktopKeyActionDelayMillis)
-	dca.pm = MovementSprint
-	dca.lastMotionIsWalk = false
-}
-
-func (dca *desktopControlAdaptor) PlayerStop() {
-	dca.KeyUp(dca.keys.W, defaultDesktopKeyActionDelayMillis)
-	dca.pm = MovementStop
 }
 
 func (dca *desktopControlAdaptor) AggressivelyResetCamera() {


### PR DESCRIPTION
## 概要

**由于 Cpp 寻路没有预复位。** 特设这个 PR 来闭环 Go 寻路的走路复位。

## Summary by Sourcery

引入可配置的玩家移动策略，并确保在导航完成或停止后统一重置移动状态。

新功能：
- 添加 `PlayerMovementPolicy` 枚举，用于控制输入动作在多大程度上强制执行移动状态。
- 扩展 `SetPlayerMovement`，使其在 ADB 和桌面控制适配器中都接受一个策略参数，从而支持惰性（lazy）、默认（default）或主动（active）的执行策略。
- 添加 `doPlayerStop` 辅助函数，用于在导航结束以及紧急停止或任务停止场景下执行多步骤的移动重置序列。

错误修复：
- 当角色可能卡住，或者精细接近（fine-approach）或旋转调整需要保持一致移动时，确保移动状态被主动强化。

增强改进：
- 优化导航流程，使其使用移动策略而不是直接调用 `PlayerStop`，从而提升 Go 导航与底层控制适配器之间的健壮性和一致性。
- 从 `ControlAdaptor` 接口及其实现中移除已冗余的 `PlayerSprint` 和 `PlayerStop` 方法，改为统一使用带策略的 `SetPlayerMovement`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable player movement policies and ensure consistent movement reset after navigation completes or stops.

New Features:
- Add PlayerMovementPolicy enumeration to control how aggressively input actions enforce movement state.
- Extend SetPlayerMovement to accept a policy parameter for both ADB and desktop control adaptors, enabling lazy, default, or active enforcement strategies.
- Add doPlayerStop helper to perform a multi-step movement reset sequence at the end of navigation and during emergency or task-stop scenarios.

Bug Fixes:
- Ensure movement state is actively reinforced when the character may be stuck or when fine-approach or rotation adjustments require consistent movement.

Enhancements:
- Refine navigation flow to use movement policies instead of direct PlayerStop calls, improving robustness and consistency between Go navigation and underlying control adaptors.
- Remove now-redundant PlayerSprint and PlayerStop methods from the ControlAdaptor interface and its implementations in favor of the unified SetPlayerMovement with policy.

</details>