### PR TITLE
fix: 修复 ExpressionRecognition 对非 And 节点不必要地调用 GetNodeJSON 导致信用购物选项2/3失效

### DIFF
--- a/agent/go-service/common/expressionrecognition/recognition.go
+++ b/agent/go-service/common/expressionrecognition/recognition.go
@@ -1,6 +1,7 @@
 package expressionrecognition
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"go/ast"
@@ -25,7 +26,9 @@ type Params struct {
 }
 
 type nodeDefinition struct {
-	Recognition recognitionDefinition `json:"recognition"`
+	Recognition json.RawMessage   `json:"recognition"`
+	AllOf       []json.RawMessage `json:"all_of"`
+	BoxIndex    *int              `json:"box_index"`
 }
 
 type recognitionDefinition struct {
@@ -293,28 +296,66 @@ func resolveAndNodeBoxIndex(raw string) (int, bool, error) {
 		return 0, false, fmt.Errorf("unmarshal node json: %w", err)
 	}
 
-	recognitionType := strings.TrimSpace(node.Recognition.Type)
-	if recognitionType == "" {
-		recognitionType = strings.TrimSpace(node.Recognition.Recognition)
+	// Handle missing/null recognition (e.g. DirectHit nodes where recognition is optional)
+	if len(node.Recognition) == 0 || bytes.Equal(node.Recognition, []byte("null")) {
+		return 0, false, nil
 	}
+
+	// Determine recognition type from either shorthand string or full object format.
+	recognitionType := ""
+	switch node.Recognition[0] {
+	case '"': // shorthand format: "recognition": "OCR"
+		var recognitionStr string
+		if err := json.Unmarshal(node.Recognition, &recognitionStr); err != nil {
+			return 0, false, fmt.Errorf("unmarshal recognition string: %w", err)
+		}
+		recognitionType = strings.TrimSpace(recognitionStr)
+	case '{': // full format: "recognition": {"type": "And", "param": {...}}
+		var recognition recognitionDefinition
+		if err := json.Unmarshal(node.Recognition, &recognition); err != nil {
+			return 0, false, fmt.Errorf("unmarshal recognition definition: %w", err)
+		}
+		recognitionType = strings.TrimSpace(recognition.Type)
+		if recognitionType == "" {
+			recognitionType = strings.TrimSpace(recognition.Recognition)
+		}
+	default:
+		return 0, false, nil
+	}
+
 	if recognitionType != "And" {
 		return 0, false, nil
 	}
 
-	allOf := node.Recognition.AllOf
+	// Collect all_of and box_index from multiple possible locations,
+	// in order of precedence: recognition.param > recognition-level > node top-level.
+	allOf := node.AllOf
 	boxIndex := 0
+	if node.BoxIndex != nil {
+		boxIndex = *node.BoxIndex
+	}
 
-	if len(node.Recognition.Param) > 0 {
-		var param andRecognitionParam
-		if err := json.Unmarshal(node.Recognition.Param, &param); err != nil {
-			return 0, true, fmt.Errorf("unmarshal and param: %w", err)
+	// Try to extract from full-format recognition object
+	if node.Recognition[0] == '{' {
+		var recognition recognitionDefinition
+		_ = json.Unmarshal(node.Recognition, &recognition)
+		if len(recognition.Param) > 0 {
+			var param andRecognitionParam
+			if err := json.Unmarshal(recognition.Param, &param); err != nil {
+				return 0, true, fmt.Errorf("unmarshal and param: %w", err)
+			}
+			allOf = param.AllOf
+			if param.BoxIndex != nil {
+				boxIndex = *param.BoxIndex
+			}
+		} else {
+			if len(recognition.AllOf) > 0 {
+				allOf = recognition.AllOf
+			}
+			if recognition.BoxIndex != nil {
+				boxIndex = *recognition.BoxIndex
+			}
 		}
-		allOf = param.AllOf
-		if param.BoxIndex != nil {
-			boxIndex = *param.BoxIndex
-		}
-	} else if node.Recognition.BoxIndex != nil {
-		boxIndex = *node.Recognition.BoxIndex
 	}
 
 	if len(allOf) == 0 {

--- a/agent/go-service/common/expressionrecognition/recognition.go
+++ b/agent/go-service/common/expressionrecognition/recognition.go
@@ -223,6 +223,12 @@ func extractRecognitionNumberFromNode(ctx *maa.Context, nodeName string, detail 
 		return 0, fmt.Errorf("recognition detail is empty")
 	}
 
+	// Non-And nodes have no CombinedResult; extract the number directly.
+	if len(detail.CombinedResult) == 0 {
+		return extractRecognitionNumber(detail)
+	}
+
+	// And nodes: look up box_index from the node definition to select the right sub-result.
 	raw, err := ctx.GetNodeJSON(nodeName)
 	if err != nil {
 		return 0, fmt.Errorf("get node %s json: %w", nodeName, err)
@@ -252,6 +258,12 @@ func extractRecognitionBoxFromNode(ctx *maa.Context, nodeName string, detail *ma
 		return maa.Rect{}, fmt.Errorf("recognition detail is empty")
 	}
 
+	// Non-And nodes have no CombinedResult; use the box directly.
+	if len(detail.CombinedResult) == 0 {
+		return detail.Box, nil
+	}
+
+	// And nodes: look up box_index from the node definition to select the right sub-result.
 	raw, err := ctx.GetNodeJSON(nodeName)
 	if err != nil {
 		return maa.Rect{}, fmt.Errorf("get node %s json: %w", nodeName, err)

--- a/agent/go-service/common/expressionrecognition/recognition_test.go
+++ b/agent/go-service/common/expressionrecognition/recognition_test.go
@@ -122,6 +122,44 @@ func TestResolveAndNodeBoxIndex(t *testing.T) {
 			wantIsAndNode: false,
 		},
 		{
+			name:          "shorthand string recognition is not and node",
+			raw:           `{"recognition": "OCR", "expected": "^\\d+$"}`,
+			wantIsAndNode: false,
+		},
+		{
+			name:          "shorthand TemplateMatch is not and node",
+			raw:           `{"recognition": "TemplateMatch", "template": "foo.png"}`,
+			wantIsAndNode: false,
+		},
+		{
+			name:          "shorthand And recognition returns error without all_of",
+			raw:           `{"recognition": "And"}`,
+			wantIsAndNode: true,
+			wantErr:       true,
+		},
+		{
+			name:          "shorthand And with top-level all_of and box_index",
+			raw:           `{"recognition": "And", "all_of": ["NodeA", "NodeB"], "box_index": 1}`,
+			wantBoxIndex:  1,
+			wantIsAndNode: true,
+		},
+		{
+			name:          "shorthand And with top-level all_of only defaults to box_index 0",
+			raw:           `{"recognition": "And", "all_of": ["NodeA"]}`,
+			wantBoxIndex:  0,
+			wantIsAndNode: true,
+		},
+		{
+			name:          "missing recognition treated as non-and node",
+			raw:           `{"foo": "bar"}`,
+			wantIsAndNode: false,
+		},
+		{
+			name:          "null recognition treated as non-and node",
+			raw:           `{"recognition": null}`,
+			wantIsAndNode: false,
+		},
+		{
 			name: "and node rejects out of range index",
 			raw: `{
 				"recognition": {
@@ -132,13 +170,17 @@ func TestResolveAndNodeBoxIndex(t *testing.T) {
 					}
 				}
 			}`,
-			wantErr: true,
+			wantIsAndNode: true,
+			wantErr:       true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotBoxIndex, gotIsAndNode, err := resolveAndNodeBoxIndex(tc.raw)
+			if gotIsAndNode != tc.wantIsAndNode {
+				t.Fatalf("resolveAndNodeBoxIndex() isAndNode = %v, want %v", gotIsAndNode, tc.wantIsAndNode)
+			}
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -147,9 +189,6 @@ func TestResolveAndNodeBoxIndex(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
-			}
-			if gotIsAndNode != tc.wantIsAndNode {
-				t.Fatalf("resolveAndNodeBoxIndex() isAndNode = %v, want %v", gotIsAndNode, tc.wantIsAndNode)
 			}
 			if gotBoxIndex != tc.wantBoxIndex {
 				t.Fatalf("resolveAndNodeBoxIndex() boxIndex = %d, want %d", gotBoxIndex, tc.wantBoxIndex)


### PR DESCRIPTION
resolveAndNodeBoxIndex 将 nodeDefinition.Recognition 定义为结构体类型， 当 GetNodeJSON 返回简写格式（如 "recognition": "OCR"）时 json.Unmarshal 会失败，导致所有 ExpressionRecognition 表达式求值失败。

这会使 Priority2/3 的信用点门槛检查永远返回 false，阻断所有购买。

修复方式：将 Recognition 字段改为 json.RawMessage，先尝试解析为字符串（简写格式），再尝试解析为对象（完整格式）。

## Summary by Sourcery

在 ExpressionRecognition 中正确处理简写和完整的识别配置，从而使非 And 节点以及 And 节点的框选在不破坏信用检查的前提下正常工作。

Bug 修复：
- 修复对简写字符串识别值的解析，防止 ExpressionRecognition 评估失败并阻塞优先级 2/3 的信用检查。
- 避免对非 And 识别节点调用节点 JSON 解析，从而直接使用它们的数值结果和框选结果。

增强功能：
- 在节点级和识别级同时支持识别元数据，包括对 And 节点的 `all_of` 和 `box_index` 优先级处理。

测试：
- 扩展 `resolveAndNodeBoxIndex` 测试，涵盖简写识别字符串、缺失/为空的识别配置，以及更多 And 节点错误和成功场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle shorthand and full recognition configurations correctly in ExpressionRecognition so non-And nodes and And-node box selection work without breaking credit checks.

Bug Fixes:
- Fix parsing of shorthand string recognition values to prevent ExpressionRecognition evaluation from failing and blocking priority 2/3 credit checks.
- Avoid calling node JSON resolution for non-And recognition nodes so their numeric and box results are taken directly.

Enhancements:
- Support recognition metadata at both node and recognition levels, including all_of and box_index precedence for And nodes.

Tests:
- Extend resolveAndNodeBoxIndex tests to cover shorthand recognition strings, missing/null recognition, and additional And-node error and success scenarios.

</details>

Bug 修复：
- 修复了简写字符串识别值解析失败的问题，该问题会导致所有 And 节点的 `ExpressionRecognition` 评估在优先级 2/3 信用检查时全部失败。

测试：
- 添加涵盖简写字符串识别值的测试，以确保非 And 节点能够被正确忽略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 ExpressionRecognition 中正确处理简写和完整的识别配置，从而使非 And 节点以及 And 节点的框选在不破坏信用检查的前提下正常工作。

Bug 修复：
- 修复对简写字符串识别值的解析，防止 ExpressionRecognition 评估失败并阻塞优先级 2/3 的信用检查。
- 避免对非 And 识别节点调用节点 JSON 解析，从而直接使用它们的数值结果和框选结果。

增强功能：
- 在节点级和识别级同时支持识别元数据，包括对 And 节点的 `all_of` 和 `box_index` 优先级处理。

测试：
- 扩展 `resolveAndNodeBoxIndex` 测试，涵盖简写识别字符串、缺失/为空的识别配置，以及更多 And 节点错误和成功场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle shorthand and full recognition configurations correctly in ExpressionRecognition so non-And nodes and And-node box selection work without breaking credit checks.

Bug Fixes:
- Fix parsing of shorthand string recognition values to prevent ExpressionRecognition evaluation from failing and blocking priority 2/3 credit checks.
- Avoid calling node JSON resolution for non-And recognition nodes so their numeric and box results are taken directly.

Enhancements:
- Support recognition metadata at both node and recognition levels, including all_of and box_index precedence for And nodes.

Tests:
- Extend resolveAndNodeBoxIndex tests to cover shorthand recognition strings, missing/null recognition, and additional And-node error and success scenarios.

</details>

</details>