### PR TITLE
refactor: (测试)不应在c:\temp下拉屎

### DIFF
--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -11,7 +11,22 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+func initTempEnv() {
+	temp := os.Getenv("TEMP")
+	if temp == "" {
+		temp = os.Getenv("TMP")
+	}
+	if temp == "" {
+		temp = os.TempDir()
+	}
+	if temp != "" {
+		os.Setenv("TEMP", temp)
+		os.Setenv("TMP", temp)
+	}
+}
+
 func main() {
+	initTempEnv()
 	logFile, err := initLogger()
 	if err != nil {
 		log.Fatal().


### PR DESCRIPTION
socket存放应初始化到指定目录或者环境变量的temp中，而不是回退到
"C:\Temp\maafw-agent-80918d2e-c05c-4e75-b72a-c28f8fb53fb8.sock"
"C:\Temp\maafw-agent-e3f313a9-b609-4ba3-9fbb-3732972905dc.sock"

## Summary by Sourcery

确保 Go 代理在启动前初始化其临时目录环境，使运行时生成的工件使用已配置的临时路径，而不是回退到硬编码的位置。

Bug Fixes:
- 通过在进程启动时规范化 TEMP/TMP，防止套接字文件和其他临时工件被创建在硬编码的 `C:\Temp` 路径下。

Enhancements:
- 在服务启动时，基于现有配置或系统默认临时目录，集中初始化 TEMP/TMP 环境变量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the Go agent initializes its temporary directory environment before startup so runtime artifacts use the configured temp path instead of falling back to a hardcoded location.

Bug Fixes:
- Prevent socket files and other temp artifacts from being created under a hardcoded C:\Temp path by normalizing TEMP/TMP at process start.

Enhancements:
- Add centralized initialization of TEMP/TMP environment variables based on existing configuration or the system default temp directory at service startup.

</details>