### PR TITLE
fix(AutoEcoFarm): 拍照模式稳定性优化与错误分支整理

### DIFF
--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
@@ -325,7 +325,7 @@
             ]
         },
         "next": [
-            "[JumpBack]AutoEcoFarmEnterCameraModeKeyDownR",
+            "[JumpBack]_AutoEcoFarmEnterCameraModeKeyDownR",
             "_AutoEcoFarmWaitForTeammate"
         ]
     },

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
@@ -1,5 +1,5 @@
 {
-    "AutoEcoFarmEnterCameraModeKeyDownR": {
+    "_AutoEcoFarmEnterCameraModeKeyDownR": {
         "desc": "通过长按R进入拍照模式",
         "recognition": "And",
         "all_of": [
@@ -17,11 +17,11 @@
             ]
         },
         "next": [
-            "AutoEcoFarmEnterCameraModeChooseCamera",
-            "AutoEcoFarmEnterCameraModeFailKeyUp"
+            "_AutoEcoFarmEnterCameraModeChooseCamera",
+            "_AutoEcoFarmEnterCameraModeFailKeyUp"
         ]
     },
-    "AutoEcoFarmEnterCameraModeFailKeyUp": {
+    "_AutoEcoFarmEnterCameraModeFailKeyUp": {
         "desc": "未出现选相机界面时松开R（next 兜底，不用 on_error），再 JumpBack",
         "pre_delay": 0,
         "action": "KeyUp",
@@ -78,7 +78,7 @@
             "_AutoEcoFarmJumpBack"
         ]
     },
-    "AutoEcoFarmEnterCameraModeChooseCamera": {
+    "_AutoEcoFarmEnterCameraModeChooseCamera": {
         "desc": "进入拍照模式，选择拍照",
         "recognition": {
             "type": "TemplateMatch",
@@ -105,20 +105,20 @@
             ]
         },
         "next": [
-            "AutoEcoFarmEnterCameraModeKeyUpR"
+            "_AutoEcoFarmEnterCameraModeKeyUpR"
         ]
     },
-    "AutoEcoFarmEnterCameraModeKeyUpR": {
+    "_AutoEcoFarmEnterCameraModeKeyUpR": {
         "desc": "松开R解除占用",
         "action": "KeyUp",
         "key": 82, // R 0x52
         "next": [
-            "AutoEcoFarmClickPhotoScene",
+            "_AutoEcoFarmClickPhotoScene",
             "_AutoEcoFarmPhotoModeFailJumpBackKeyUpR"
         ]
     },
     "_AutoEcoFarmPhotoModeFailJumpBackKeyUpR": {
-        "desc": "拍照模式：AutoEcoFarmEnterCameraModeKeyUpR 之后未命中 AutoEcoFarmClickPhotoScene，仅 JumpBack",
+        "desc": "拍照模式：_AutoEcoFarmEnterCameraModeKeyUpR 之后未命中 _AutoEcoFarmClickPhotoScene，仅 JumpBack",
         "recognition": "DirectHit",
         "pre_delay": 0,
         "post_delay": 0,
@@ -131,12 +131,12 @@
         }
     },
     ///////点击画面部分
-    "AutoEcoFarmClickPhotoScene": {
+    "_AutoEcoFarmClickPhotoScene": {
         "desc": "打开画面菜单（没打开的话）",
         "recognition": "And",
         "all_of": [
-            "AutoEcoFarmPhotoScene",
-            "AutoEcoFarmPhotoSceneIsWhite"
+            "_AutoEcoFarmPhotoScene",
+            "_AutoEcoFarmPhotoSceneIsWhite"
         ],
         "action": "Click",
         "post_wait_freezes": {
@@ -154,7 +154,7 @@
         ]
     },
     "_AutoEcoFarmPhotoModeFailJumpBackClickPhotoScene": {
-        "desc": "拍照模式：AutoEcoFarmClickPhotoScene 之后未命中 _AutoEcoFarmHideFactoryFacilities，仅 JumpBack",
+        "desc": "拍照模式：_AutoEcoFarmClickPhotoScene 之后未命中 _AutoEcoFarmHideFactoryFacilities，仅 JumpBack",
         "recognition": "DirectHit",
         "pre_delay": 0,
         "post_delay": 0,
@@ -166,7 +166,7 @@
             "Node.Recognition.Succeeded": "未识别到关闭显示工业设备，任务继续"
         }
     },
-    "AutoEcoFarmPhotoScene": {
+    "_AutoEcoFarmPhotoScene": {
         "desc": "[识别节点]拍照模式画面按钮",
         "recognition": "TemplateMatch",
         "roi": [
@@ -180,7 +180,7 @@
         "order_by": "Score",
         "action": "Click"
     },
-    "AutoEcoFarmPhotoSceneIsWhite": {
+    "_AutoEcoFarmPhotoSceneIsWhite": {
         "desc": "[识别节点]拍照模式画面按钮白色",
         "recognition": {
             "type": "ColorMatch",

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
@@ -27,7 +27,7 @@
         "action": "KeyUp",
         "key": 82, // R 0x52
         "post_wait_freezes": {
-            "time": 400,
+            "time": 500,
             "target": [
                 1065,
                 551,
@@ -63,7 +63,7 @@
             }
         },
         "post_wait_freezes": {
-            "time": 200,
+            "time": 500,
             "target": [
                 12,
                 9,
@@ -93,7 +93,7 @@
         },
         "action": "Click",
         "post_wait_freezes": {
-            "time": 200,
+            "time": 500,
             "target": [
                 53,
                 7,
@@ -123,7 +123,7 @@
         ],
         "action": "Click",
         "post_wait_freezes": {
-            "time": 200,
+            "time": 500,
             "target": [
                 265,
                 216,

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
@@ -38,7 +38,10 @@
         "post_delay": 0,
         "next": [
             "_AutoEcoFarmJumpBack"
-        ]
+        ],
+        "focus": {
+            "Node.Action.Starting": "未识别到选相机界面，任务继续"
+        }
     },
     "_AutoEcoFarmExitCameraMode": {
         "desc": "按右键退出拍照模式",
@@ -110,8 +113,22 @@
         "action": "KeyUp",
         "key": 82, // R 0x52
         "next": [
-            "AutoEcoFarmClickPhotoScene"
+            "AutoEcoFarmClickPhotoScene",
+            "_AutoEcoFarmPhotoModeFailJumpBackKeyUpR"
         ]
+    },
+    "_AutoEcoFarmPhotoModeFailJumpBackKeyUpR": {
+        "desc": "拍照模式：AutoEcoFarmEnterCameraModeKeyUpR 之后未命中 AutoEcoFarmClickPhotoScene，仅 JumpBack",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "_AutoEcoFarmJumpBack"
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "未识别到画面菜单，任务继续"
+        }
     },
     ///////点击画面部分
     "AutoEcoFarmClickPhotoScene": {
@@ -132,8 +149,22 @@
             ]
         },
         "next": [
-            "_AutoEcoFarmHideFactoryFacilities"
+            "_AutoEcoFarmHideFactoryFacilities",
+            "_AutoEcoFarmPhotoModeFailJumpBackClickPhotoScene"
         ]
+    },
+    "_AutoEcoFarmPhotoModeFailJumpBackClickPhotoScene": {
+        "desc": "拍照模式：AutoEcoFarmClickPhotoScene 之后未命中 _AutoEcoFarmHideFactoryFacilities，仅 JumpBack",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "_AutoEcoFarmJumpBack"
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "未识别到关闭显示工业设备，任务继续"
+        }
     },
     "AutoEcoFarmPhotoScene": {
         "desc": "[识别节点]拍照模式画面按钮",

--- a/assets/resource_wlroots/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
+++ b/assets/resource_wlroots/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
@@ -116,7 +116,7 @@
             ]
         },
         "next": [
-            "[JumpBack]AutoEcoFarmEnterCameraModeKeyDownR",
+            "[JumpBack]_AutoEcoFarmEnterCameraModeKeyDownR",
             "_AutoEcoFarmWaitForTeammate"
         ]
     },

--- a/assets/resource_wlroots/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
+++ b/assets/resource_wlroots/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
@@ -1,5 +1,5 @@
 {
-    "AutoEcoFarmEnterCameraModeKeyDownR": {
+    "_AutoEcoFarmEnterCameraModeKeyDownR": {
         "desc": "通过长按R进入拍照模式",
         "recognition": "And",
         "all_of": [
@@ -17,11 +17,11 @@
             ]
         },
         "next": [
-            "AutoEcoFarmEnterCameraModeChooseCamera",
-            "AutoEcoFarmEnterCameraModeFailKeyUp"
+            "_AutoEcoFarmEnterCameraModeChooseCamera",
+            "_AutoEcoFarmEnterCameraModeFailKeyUp"
         ]
     },
-    "AutoEcoFarmEnterCameraModeFailKeyUp": {
+    "_AutoEcoFarmEnterCameraModeFailKeyUp": {
         "desc": "未出现选相机界面时松开R（next 兜底，不用 on_error），再 JumpBack",
         "pre_delay": 0,
         "action": "KeyUp",
@@ -40,12 +40,12 @@
             "_AutoEcoFarmJumpBack"
         ]
     },
-    "AutoEcoFarmEnterCameraModeKeyUpR": {
+    "_AutoEcoFarmEnterCameraModeKeyUpR": {
         "desc": "松开R解除占用",
         "action": "KeyUp",
         "key": 19,
         "next": [
-            "AutoEcoFarmClickPhotoScene"
+            "_AutoEcoFarmClickPhotoScene"
         ]
     }
 }


### PR DESCRIPTION
1、增大各步 post_wait_freezes 的静止等待，减少动画未停稳就进入下一步导致的识别抖动。
2、在 KeyUpR → 打开画面菜单、ClickPhotoScene → 关闭「显示工业设备」两条主链路上，为识别未命中增加 独立 JumpBack 错误节点（不额外松 R），便于日志区分来源。
3、将仍缺 _ 前缀的内部节点补全为 _AutoEcoFarm…（任务出入口 AutoEcoFarmMain / AutoEcoFarmExit / AutoEcoFarmExitErr 不变）。

## Summary by Sourcery

改进 AutoEcoFarm 照片模式流水线的稳定性和错误处理。

错误修复：
- 通过在执行下一步动作前增加步骤完成后的空闲等待时间，减少 AutoEcoFarm 照片模式中的识别抖动。

增强改进：
- 在关键的 AutoEcoFarm 照片模式交互路径上添加专用的 JumpBack 错误节点，以便在日志中更好地区分故障来源。
- 统一内部 AutoEcoFarm 节点命名，在 MoveAndWork 和 PhotoMode 流水线中使用一致的 `_AutoEcoFarm*` 前缀，同时保持对外公开的入口/出口节点名称不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the stability and error handling of the AutoEcoFarm photo mode pipeline.

Bug Fixes:
- Reduce recognition jitter in AutoEcoFarm photo mode by increasing post-step idle waits before proceeding to the next action.

Enhancements:
- Add dedicated JumpBack error nodes on key AutoEcoFarm photo mode interaction paths to better distinguish failure sources in logs.
- Normalize internal AutoEcoFarm node naming with a consistent _AutoEcoFarm* prefix across MoveAndWork and PhotoMode pipelines, keeping public entry/exit nodes unchanged.

</details>