### PR TITLE
fix(AutoStockpile): 寻回失散的ClampTargetToMax

### DIFF
--- a/assets/resource/pipeline/AutoStockpile/Purchase.json
+++ b/assets/resource/pipeline/AutoStockpile/Purchase.json
@@ -102,7 +102,8 @@
                             255
                         ],
                         "method": 40
-                    }
+                    },
+                    "ClampTargetToMax": true
                 }
             }
         },


### PR DESCRIPTION
close #2218

## Summary by Sourcery

错误修复：
- 通过在 AutoStockpile 的流水线配置中重新引入 `ClampTargetToMax` 设置，修复其购买行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix AutoStockpile purchase behavior by reintroducing the ClampTargetToMax setting in its pipeline configuration.

</details>