### PR TITLE
docs(BetterSliding): 调整仅滑动模式在文档中的位置

### DIFF
--- a/docs/en_us/developers/components/better-sliding.md
+++ b/docs/en_us/developers/components/better-sliding.md
@@ -125,6 +125,47 @@ In a business Pipeline, call it like a normal `Custom` action. The example below
 }
 ```
 
+## Swipe-Only Mode
+
+If you only need to drag the slider to its maximum position without reading any quantity or fine-tuning, you can use **swipe-only mode**.
+
+Swipe-only mode is activated automatically when `custom_action_param` is **empty**, or when it contains **only `Direction` and/or `SwipeButton`**.
+
+In this mode, `BetterSliding` performs the `SwipeToMax` drag and returns success immediately, skipping OCR, proportional clicking, and fine-tuning entirely. `SwipeButton` is still respected — you can supply a custom slider template path even in swipe-only mode, while `Direction` specifies which side corresponds to the maximum value.
+
+Minimal example:
+
+```json
+"SomeTaskSwipeToMax": {
+    "action": {
+        "type": "Custom",
+        "param": {
+            "custom_action": "BetterSliding",
+            "custom_action_param": {
+                "Direction": "right"
+            }
+        }
+    }
+}
+```
+
+With a custom slider template:
+
+```json
+"SomeTaskSwipeToMax": {
+    "action": {
+        "type": "Custom",
+        "param": {
+            "custom_action": "BetterSliding",
+            "custom_action_param": {
+                "Direction": "right",
+                "SwipeButton": "MyFeature/MySlider.png"
+            }
+        }
+    }
+}
+```
+
 ## Parameter description
 
 `BetterSliding` parameters can be divided into two groups:
@@ -220,47 +261,6 @@ Supported formats:
 If `[x, y]` is passed, it will be automatically normalized to `[x, y, 1, 1]` internally.
 
 Also note that after JSON deserialization on the Go side, these arrays may appear as `[]float64` or `[]any`. The current implementation normalizes them into integer arrays automatically. However, if the length is neither `2` nor `4`, the action fails immediately.
-
-## Swipe-Only Mode
-
-If you only need to drag the slider to its maximum position without reading any quantity or fine-tuning, you can use **swipe-only mode**.
-
-Swipe-only mode is activated automatically when `custom_action_param` is **empty**, or when it contains **only `Direction` and/or `SwipeButton`**.
-
-In this mode, `BetterSliding` performs the `SwipeToMax` drag and returns success immediately, skipping OCR, proportional clicking, and fine-tuning entirely. `SwipeButton` is still respected — you can supply a custom slider template path even in swipe-only mode, while `Direction` specifies which side corresponds to the maximum value.
-
-Minimal example:
-
-```json
-"SomeTaskSwipeToMax": {
-    "action": {
-        "type": "Custom",
-        "param": {
-            "custom_action": "BetterSliding",
-            "custom_action_param": {
-                "Direction": "right"
-            }
-        }
-    }
-}
-```
-
-With a custom slider template:
-
-```json
-"SomeTaskSwipeToMax": {
-    "action": {
-        "type": "Custom",
-        "param": {
-            "custom_action": "BetterSliding",
-            "custom_action_param": {
-                "Direction": "right",
-                "SwipeButton": "MyFeature/MySlider.png"
-            }
-        }
-    }
-}
-```
 
 ## Attach Parameters
 

--- a/docs/en_us/developers/components/better-sliding.md
+++ b/docs/en_us/developers/components/better-sliding.md
@@ -129,9 +129,11 @@ In a business Pipeline, call it like a normal `Custom` action. The example below
 
 If you only need to drag the slider to its maximum position without reading any quantity or fine-tuning, you can use **swipe-only mode**.
 
-Swipe-only mode is activated automatically when `custom_action_param` is **empty**, or when it contains **only `Direction` and/or `SwipeButton`**.
+Swipe-only mode is activated automatically when `custom_action_param` contains **only `Direction` (required)** and an optional `SwipeButton`, with **no other parameters** present.
 
-In this mode, `BetterSliding` performs the `SwipeToMax` drag and returns success immediately, skipping OCR, proportional clicking, and fine-tuning entirely. `SwipeButton` is still respected — you can supply a custom slider template path even in swipe-only mode, while `Direction` specifies which side corresponds to the maximum value.
+In this mode, `BetterSliding` performs the `SwipeToMax` drag and returns success immediately, skipping OCR, proportional clicking, and fine-tuning entirely. `Direction` is required and specifies which side corresponds to the maximum value, while `SwipeButton` is still respected — you can supply a custom slider template path even in swipe-only mode.
+
+> **Note:** In external call mode, `attach.Target`, `attach.TargetType`, `attach.TargetReverse`, and `attach.FinishAfterPreciseClick` are merged into `custom_action_param` **before** swipe-only mode is evaluated. If `attach` supplies `Target`, `TargetType`, or `TargetReverse`, the action will not enter swipe-only mode even when `custom_action_param` itself contains only `Direction` and optional `SwipeButton`. `FinishAfterPreciseClick` is also merged, but it does **not** affect swipe-only mode detection.
 
 Minimal example:
 

--- a/docs/zh_cn/developers/components/better-sliding.md
+++ b/docs/zh_cn/developers/components/better-sliding.md
@@ -129,9 +129,11 @@ clickY = startY + (endY - startY) * numerator / denominator
 
 如果你只需要将滑块拖到最大位置，而不需要读取数量或进行微调，可以使用**仅滑动模式**。
 
-仅滑动模式在 `custom_action_param` **不传任何参数**，或**仅传入 `Direction` 和/或 `SwipeButton`** 时自动激活。
+仅滑动模式在 `custom_action_param` 中**仅传入 `Direction`（必填）**，以及**可选传入 `SwipeButton`**，且**不包含其他参数**时自动激活。
 
-在此模式下，`BetterSliding` 执行 `SwipeToMax` 拖动后立即返回成功，跳过 OCR、比例点击和微调。`SwipeButton` 仍然有效——你可以在仅滑动模式下提供自定义滑块模板路径；`Direction` 则用于指定"最大值所在方向"。
+在此模式下，`BetterSliding` 执行 `SwipeToMax` 拖动后立即返回成功，跳过 OCR、比例点击和微调。`Direction` 用于指定"最大值所在方向"，为必填项；`SwipeButton` 仍然有效——你可以在仅滑动模式下提供自定义滑块模板路径。
+
+> **注意**：在对外调用模式下，`attach` 中的 `Target`、`TargetType`、`TargetReverse`、`FinishAfterPreciseClick` 会在仅滑动模式判定**之前**合并进 `custom_action_param`。因此，如果 `attach` 中存在 `Target`、`TargetType` 或 `TargetReverse`，即使 `custom_action_param` 本身只传了 `Direction`（以及可选的 `SwipeButton`），也不会进入仅滑动模式。`FinishAfterPreciseClick` 会参与合并，但**不会影响**仅滑动模式判定。
 
 最小示例：
 

--- a/docs/zh_cn/developers/components/better-sliding.md
+++ b/docs/zh_cn/developers/components/better-sliding.md
@@ -125,6 +125,47 @@ clickY = startY + (endY - startY) * numerator / denominator
 }
 ```
 
+## 仅滑动模式
+
+如果你只需要将滑块拖到最大位置，而不需要读取数量或进行微调，可以使用**仅滑动模式**。
+
+仅滑动模式在 `custom_action_param` **不传任何参数**，或**仅传入 `Direction` 和/或 `SwipeButton`** 时自动激活。
+
+在此模式下，`BetterSliding` 执行 `SwipeToMax` 拖动后立即返回成功，跳过 OCR、比例点击和微调。`SwipeButton` 仍然有效——你可以在仅滑动模式下提供自定义滑块模板路径；`Direction` 则用于指定"最大值所在方向"。
+
+最小示例：
+
+```json
+"SomeTaskSwipeToMax": {
+    "action": {
+        "type": "Custom",
+        "param": {
+            "custom_action": "BetterSliding",
+            "custom_action_param": {
+                "Direction": "right"
+            }
+        }
+    }
+}
+```
+
+使用自定义滑块模板：
+
+```json
+"SomeTaskSwipeToMax": {
+    "action": {
+        "type": "Custom",
+        "param": {
+            "custom_action": "BetterSliding",
+            "custom_action_param": {
+                "Direction": "right",
+                "SwipeButton": "MyFeature/MySlider.png"
+            }
+        }
+    }
+}
+```
+
 ## 参数说明
 
 `BetterSliding` 的参数可以分成两类：
@@ -220,47 +261,6 @@ clickY = startY + (endY - startY) * numerator / denominator
 如果传入 `[x, y]`，内部会自动补成 `[x, y, 1, 1]`。
 
 另外，实际从 JSON 反序列化进入 Go 后，这类数组可能表现为 `[]float64` 或 `[]any`，当前实现会自动归一化为整数数组；但如果长度既不是 `2` 也不是 `4`，动作会直接报错返回失败。
-
-## 仅滑动模式
-
-如果你只需要将滑块拖到最大位置，而不需要读取数量或进行微调，可以使用**仅滑动模式**。
-
-仅滑动模式在 `custom_action_param` **不传任何参数**，或**仅传入 `Direction` 和/或 `SwipeButton`** 时自动激活。
-
-在此模式下，`BetterSliding` 执行 `SwipeToMax` 拖动后立即返回成功，跳过 OCR、比例点击和微调。`SwipeButton` 仍然有效——你可以在仅滑动模式下提供自定义滑块模板路径；`Direction` 则用于指定"最大值所在方向"。
-
-最小示例：
-
-```json
-"SomeTaskSwipeToMax": {
-    "action": {
-        "type": "Custom",
-        "param": {
-            "custom_action": "BetterSliding",
-            "custom_action_param": {
-                "Direction": "right"
-            }
-        }
-    }
-}
-```
-
-使用自定义滑块模板：
-
-```json
-"SomeTaskSwipeToMax": {
-    "action": {
-        "type": "Custom",
-        "param": {
-            "custom_action": "BetterSliding",
-            "custom_action_param": {
-                "Direction": "right",
-                "SwipeButton": "MyFeature/MySlider.png"
-            }
-        }
-    }
-}
-```
 
 ## 附加参数
 


### PR DESCRIPTION
## Summary by Sourcery

重新整理 BetterSliding 的文档结构，在使用指南中更早介绍「仅滑动模式」，并移除重复内容。

文档：
- 在英文和中文文档中，将 BetterSliding 的「仅滑动模式」章节移动到参数说明之前，以提升该特性的可发现性。
- 通过移除后文重复的章节，消除中英文文档中关于「仅滑动模式」的重复内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reorganize BetterSliding documentation to surface swipe-only mode earlier in the usage guide and remove duplicated sections.

Documentation:
- Move the swipe-only mode section for BetterSliding above the parameter description in both English and Chinese docs to improve feature discoverability.
- Deduplicate swipe-only mode documentation content by removing the later repeated section in both language versions.

</details>