### PR TITLE
fix(EnvironmentMonitoring): 修复肚子鼓气后发光的吐虫长股兽和七彩鳞任务

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
@@ -194,12 +194,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "map02_lv001",
+                    "map_name": "map02_lv002",
                     "target": [
-                        280,
-                        580,
-                        15,
-                        15
+                        416.7,
+                        844.3,
+                        11.4,
+                        10.6
                     ]
                 }
             ]
@@ -214,7 +214,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneEnterWorldWulingJingyuValley7"
+                "SceneEnterWorldWulingWulingCity7"
             ]
         },
         "next": [
@@ -229,12 +229,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "map02_lv001",
+                    "map_name": "map02_lv002",
                     "target": [
-                        280,
-                        580,
-                        15,
-                        15
+                        416.7,
+                        844.3,
+                        11.4,
+                        10.6
                     ]
                 }
             ]
@@ -249,7 +249,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneEnterWorldWulingJingyuValley7"
+                "SceneEnterWorldWulingWulingCity7"
             ]
         },
         "next": [
@@ -264,12 +264,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "map02_lv001",
+                    "map_name": "map02_lv002",
                     "target": [
-                        280,
-                        580,
-                        15,
-                        15
+                        416.7,
+                        844.3,
+                        11.4,
+                        10.6
                     ]
                 }
             ]
@@ -286,31 +286,15 @@
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {
-            "map_name": "map02_lv001",
+            "map_name": "map02_lv002",
             "path": [
                 [
-                    290.5,
-                    585.0
+                    425.0,
+                    851.2
                 ],
                 [
-                    300.4,
-                    575.0
-                ],
-                [
-                    303.0,
-                    562.5
-                ],
-                [
-                    303.7,
-                    548.6
-                ],
-                [
-                    297.9,
-                    545.0
-                ],
-                [
-                    287.9,
-                    546.3
+                    436.3,
+                    842.5
                 ]
             ]
         },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
@@ -334,7 +334,7 @@
         "desc": "七彩鳞任务中调整朝向",
         "max_hit": 2,
         "next": [
-            "EnvironmentMonitoringSwipeScreenLeft"
+            "EnvironmentMonitoringSwipeScreenDown"
         ]
     }
 }

--- a/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/data.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/data.json
@@ -214,16 +214,12 @@
                 "腹が膨らんで光る虫吐き長脚獣",
                 "배를 부풀려 빛을 내는 버그스피팅 랭키비스트"
             ],
-            "EnterMap": "SceneEnterWorldWulingJingyuValley7",
-            "MapName": "map02_lv001",
-            "MapTarget": [280, 580, 15, 15],
+            "EnterMap": "SceneEnterWorldWulingWulingCity7",
+            "MapName": "map02_lv002",
+            "MapTarget": [416.7, 844.3, 11.4, 10.6],
             "MapPath": [
-                [290.5, 585.0],
-                [300.4, 575.0],
-                [303.0, 562.5],
-                [303.7, 548.6],
-                [297.9, 545.0],
-                [287.9, 546.3]
+                [425.0, 851.2],
+                [436.3, 842.5]
             ],
             "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenUp"
         },

--- a/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/data.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/data.json
@@ -267,7 +267,7 @@
                 [194, 765],
                 [205, 755]
             ],
-            "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenLeft"
+            "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenDown"
         },
         {
             "Id": "VigorousCisternOriginiumSlug",


### PR DESCRIPTION
肚子鼓气后发光的吐虫长股兽使用新路径。

fixed #2228
fixed #2213
fixed #2018

## 由 Sourcery 提供的总结

使用更新后的配置路径修复特定“Outskirts Monitoring Terminal”任务的环境监控设置。

错误修复：
- 在 InflatedAndGlowingBugspittingLankybeast 目标膨胀发光后，修正其监控配置。
- 修复 RainbowFin 目标的配置，使相关任务按预期运行。

增强功能：
- 更新 Outskirts Monitoring Terminal 的流水线数据，使其与新的资源配置保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix environment monitoring setup for specific Outskirts Monitoring Terminal tasks using updated configuration paths.

Bug Fixes:
- Correct the monitoring configuration for the InflatedAndGlowingBugspittingLankybeast objective after it inflates and glows.
- Fix the configuration for the RainbowFin objective so the related task behaves as intended.

Enhancements:
- Update Outskirts Monitoring Terminal pipeline data to align with the new resource configurations.

</details>