### PR TITLE
fix: 前台模式窗口前置

### DIFF
--- a/agent/go-service/register.go
+++ b/agent/go-service/register.go
@@ -23,6 +23,7 @@ import (
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/scenemanager"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/taskersink/aspectratio"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/taskersink/cursormove"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/taskersink/foregroundwindow"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/taskersink/hdrcheck"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/taskersink/processcheck"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/visitfriends"
@@ -38,6 +39,7 @@ func registerAll() {
 	hdrcheck.Register()
 	processcheck.Register()
 	cursormove.Register()
+	foregroundwindow.Register()
 
 	// General Custom
 	subtask.Register()

--- a/agent/go-service/taskersink/foregroundwindow/sink.go
+++ b/agent/go-service/taskersink/foregroundwindow/sink.go
@@ -1,0 +1,59 @@
+package foregroundwindow
+
+import (
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+// ForegroundWindowSink 会在 Win32-Front 任务启动前尽力将游戏窗口置前。
+type ForegroundWindowSink struct {
+	activated bool
+}
+
+var _ maa.TaskerEventSink = &ForegroundWindowSink{}
+
+// Register 注册前台窗口 tasker sink。
+func Register() {
+	maa.AgentServerAddTaskerSink(&ForegroundWindowSink{})
+}
+
+// OnTaskerTask 会在 Win32-Front 任务启动时尝试前置游戏窗口。
+func (s *ForegroundWindowSink) OnTaskerTask(_ *maa.Tasker, event maa.EventStatus, detail maa.TaskerTaskDetail) {
+	switch event {
+	case maa.EventStatusStarting:
+		if s.activated {
+			return
+		}
+		if detail.Entry == "MaaTaskerPostStop" {
+			return
+		}
+		ctrl := pienv.GetController()
+		if ctrl == nil || ctrl.Win32 == nil {
+			return
+		}
+		if pienv.ControllerName() != "Win32-Front" {
+			return
+		}
+
+		if err := activateForegroundWindow(ctrl.Win32.WindowRegex, ctrl.Win32.ClassRegex); err != nil {
+			log.Warn().
+				Err(err).
+				Str("component", "foregroundwindow").
+				Str("controller", pienv.ControllerName()).
+				Uint64("task_id", detail.TaskID).
+				Str("entry", detail.Entry).
+				Msg("failed to activate window")
+			return
+		}
+		s.activated = true
+		log.Info().
+			Str("component", "foregroundwindow").
+			Str("controller", pienv.ControllerName()).
+			Uint64("task_id", detail.TaskID).
+			Str("entry", detail.Entry).
+			Msg("foreground window activated")
+	case maa.EventStatusSucceeded, maa.EventStatusFailed:
+		s.activated = false
+	}
+}

--- a/agent/go-service/taskersink/foregroundwindow/window_other.go
+++ b/agent/go-service/taskersink/foregroundwindow/window_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package foregroundwindow
+
+// activateForegroundWindow 在非 Windows 平台下为空操作。
+func activateForegroundWindow(_ string, _ string) error {
+	return nil
+}

--- a/agent/go-service/taskersink/foregroundwindow/window_windows.go
+++ b/agent/go-service/taskersink/foregroundwindow/window_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package foregroundwindow
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	foregroundWindowUser32 = windows.NewLazySystemDLL("user32.dll")
+	procFindWindowExW      = foregroundWindowUser32.NewProc("FindWindowExW")
+	procShowWindow         = foregroundWindowUser32.NewProc("ShowWindow")
+	procSetForegroundW     = foregroundWindowUser32.NewProc("SetForegroundWindow")
+)
+
+const swRestore = 9
+
+// activateForegroundWindow 会尽力恢复并单次前置当前配置的游戏窗口。
+// 为了保持实现最小化，这里有意忽略 classRegex 参数。
+func activateForegroundWindow(title string, _ string) error {
+	hwnd, err := findWindowByTitle(title)
+	if err != nil {
+		return err
+	}
+
+	procShowWindow.Call(uintptr(hwnd), swRestore)
+	if ret, _, _ := procSetForegroundW.Call(uintptr(hwnd)); ret == 0 {
+		return fmt.Errorf("SetForegroundWindow failed")
+	}
+	return nil
+}
+
+func findWindowByTitle(title string) (windows.HWND, error) {
+	hwnd, _, _ := procFindWindowExW.Call(
+		0,
+		0,
+		0,
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(title))),
+	)
+	if hwnd == 0 {
+		return 0, fmt.Errorf("window not found: %s", title)
+	}
+	return windows.HWND(hwnd), nil
+}


### PR DESCRIPTION
## 说明
fix #2184 
事实上bot的分析有误，复现表明这个BUG应该是在v2.4.0与v2.5.0-beta.1之间引入的。
这并不是MAFW的问题，测试时采用了相同的MAFW版本（5.9.0-alpha4）

我（让GPT分析了5个commit）高度怀疑 5404a4f7e7534936e2eb857d4accab088a68263d 引入了这一回归。因其修改了进入流程
但是继续改Pipeline显然是不稳定的，因此简单加入前台模式下，在开始任务时强制前置一次窗口的流程。

为 `Win32-Front` 增加一个任务启动前的前台窗口置前步骤。

在前台模式下，如果用户是外部手动启动游戏，再打开 MaaEnd 点击开始，游戏窗口有时虽然已经存在，但并没有真正处于可交互的前台状态。此时前台模式下的首个点击/按键可能会打空，用户感知为“没有正确拉起窗口”或“卡在初始界面”。

本 PR 在任务开始前，对 `Endfield` 窗口执行一次 best-effort 的前置操作，尽量降低这种情况出现的概率。

## 改动内容

- 注册新的 `foregroundwindow` tasker sink
- 仅在 `Win32-Front` 下生效
- 跳过 `MaaTaskerPostStop`
- Windows 下在任务启动时：
  - 查找标题为 `Endfield` 的目标窗口
  - 调用 `ShowWindow(SW_RESTORE)` 恢复窗口
  - 调用 `SetForegroundWindow` 尝试置前
- 非 Windows 平台保持 no-op

## 设计取舍

这次实现刻意保持最小化：

- 只尝试一次
- 不做窗口枚举
- 不做线程附着
- 不做轮询确认
- 不修改具体任务 Pipeline

## 预期效果

当用户外部启动游戏后再打开 MaaEnd，并使用 `Win32-Front` 点击开始时，框架会先尝试将 `Endfield` 窗口恢复并置前，再进入具体任务逻辑，从而降低前台模式首个输入打空的概率。

## 背景

这个问题的用户感知与“点击启动后没有正确拉起游戏窗口，界面停留在初始状态”一致。

结合历史排查，回归范围可以收敛到 `v2.4.0` 到 `v2.5.0-beta.1` 之间；其中 `5404a4f7 feat: 用识别公告界面代替原来的硬编码 (#1691)` 将登录阶段从较粗放的 `ESC` 兜底改成了更依赖准确前台点击的公告关闭识别，使得原本前台状态不稳定的问题更容易被用户感知为“启动后卡住”。

因此这次修复不去改具体登录节点，而是在前台任务启动前统一补一次窗口前置，优先降低前台状态不稳定带来的影响。

## 说明

- 这是 best-effort 行为，Windows 仍可能因为系统前台策略拒绝置前
- 若置前失败，仅记录 warning，不阻断后续任务流程

## 测试情况

- 代码编译通过
- 当前环境完成 Windows 实机验证，可正确置前

## Summary by Sourcery

错误修复：
- 缓解在 Win32-Front 前台模式下，由于 Endfield 窗口实际上并未处于交互式前台状态而导致第一次输入丢失的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Mitigate cases where the first input in Win32-Front foreground mode is lost because the Endfield window is not actually in the interactive foreground state.

</details>