### PR TITLE
fix(EnvironmentMonitoring): 如果没有到达指定位置应该直接报错

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToAncientTreeFinalCheckStartPos",
-            "GoToAncientTreeStartPosFailed"
+            "GoToAncientTreeFinalCheckStartPos"
         ]
     },
     "GoToAncientTreeFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToAncientTreeMapTrackerMove"
         ]
-    },
-    "GoToAncientTreeStartPosFailed": {
-        "desc": "古树传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToAncientTreeMapTrackerMove": {
         "desc": "前往古树",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInBlightTide.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInBlightTide.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToBeaconDamagedInBlightTideFinalCheckStartPos",
-            "GoToBeaconDamagedInBlightTideStartPosFailed"
+            "GoToBeaconDamagedInBlightTideFinalCheckStartPos"
         ]
     },
     "GoToBeaconDamagedInBlightTideFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToBeaconDamagedInBlightTideMapTrackerMove"
         ]
-    },
-    "GoToBeaconDamagedInBlightTideStartPosFailed": {
-        "desc": "侵蚀潮中损坏的信标传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToBeaconDamagedInBlightTideMapTrackerMove": {
         "desc": "前往侵蚀潮中损坏的信标",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToCisternOriginiumSlugsFinalCheckStartPos",
-            "GoToCisternOriginiumSlugsStartPosFailed"
+            "GoToCisternOriginiumSlugsFinalCheckStartPos"
         ]
     },
     "GoToCisternOriginiumSlugsFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToCisternOriginiumSlugsMapTrackerMove"
         ]
-    },
-    "GoToCisternOriginiumSlugsStartPosFailed": {
-        "desc": "蓄水源石虫传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToCisternOriginiumSlugsMapTrackerMove": {
         "desc": "前往蓄水源石虫",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToCleansingJadeFinalCheckStartPos",
-            "GoToCleansingJadeStartPosFailed"
+            "GoToCleansingJadeFinalCheckStartPos"
         ]
     },
     "GoToCleansingJadeFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToCleansingJadeMapTrackerMove"
         ]
-    },
-    "GoToCleansingJadeStartPosFailed": {
-        "desc": "漱玉传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToCleansingJadeMapTrackerMove": {
         "desc": "前往漱玉",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToCollapsedTianshiPillarFinalCheckStartPos",
-            "GoToCollapsedTianshiPillarStartPosFailed"
+            "GoToCollapsedTianshiPillarFinalCheckStartPos"
         ]
     },
     "GoToCollapsedTianshiPillarFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToCollapsedTianshiPillarMapTrackerMove"
         ]
-    },
-    "GoToCollapsedTianshiPillarStartPosFailed": {
-        "desc": "倒塌的天师桩传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToCollapsedTianshiPillarMapTrackerMove": {
         "desc": "前往倒塌的天师桩",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToEcologyNearTheFieldLogisticsDepotFinalCheckStartPos",
-            "GoToEcologyNearTheFieldLogisticsDepotStartPosFailed"
+            "GoToEcologyNearTheFieldLogisticsDepotFinalCheckStartPos"
         ]
     },
     "GoToEcologyNearTheFieldLogisticsDepotFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove"
         ]
-    },
-    "GoToEcologyNearTheFieldLogisticsDepotStartPosFailed": {
-        "desc": "储备站周围的生态环境传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove": {
         "desc": "前往储备站周围的生态环境",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToEternalSunsetFinalCheckStartPos",
-            "GoToEternalSunsetStartPosFailed"
+            "GoToEternalSunsetFinalCheckStartPos"
         ]
     },
     "GoToEternalSunsetFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToEternalSunsetMapTrackerMove"
         ]
-    },
-    "GoToEternalSunsetStartPosFailed": {
-        "desc": "栖霞驻影传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToEternalSunsetMapTrackerMove": {
         "desc": "前往栖霞驻影",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToIndoorCropsFinalCheckStartPos",
-            "GoToIndoorCropsStartPosFailed"
+            "GoToIndoorCropsFinalCheckStartPos"
         ]
     },
     "GoToIndoorCropsFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToIndoorCropsMapTrackerMove"
         ]
-    },
-    "GoToIndoorCropsStartPosFailed": {
-        "desc": "室内作物传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToIndoorCropsMapTrackerMove": {
         "desc": "前往室内作物",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToInflatedAndGlowingBugspittingLankybeastFinalCheckStartPos",
-            "GoToInflatedAndGlowingBugspittingLankybeastStartPosFailed"
+            "GoToInflatedAndGlowingBugspittingLankybeastFinalCheckStartPos"
         ]
     },
     "GoToInflatedAndGlowingBugspittingLankybeastFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove"
         ]
-    },
-    "GoToInflatedAndGlowingBugspittingLankybeastStartPosFailed": {
-        "desc": "肚子鼓气后发光的吐虫长股兽传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove": {
         "desc": "前往肚子鼓气后发光的吐虫长股兽",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToObservantSableChestedFowlbeastFinalCheckStartPos",
-            "GoToObservantSableChestedFowlbeastStartPosFailed"
+            "GoToObservantSableChestedFowlbeastFinalCheckStartPos"
         ]
     },
     "GoToObservantSableChestedFowlbeastFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToObservantSableChestedFowlbeastMapTrackerMove"
         ]
-    },
-    "GoToObservantSableChestedFowlbeastStartPosFailed": {
-        "desc": "东张西望的黑腹雉羽兽传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToObservantSableChestedFowlbeastMapTrackerMove": {
         "desc": "前往东张西望的黑腹雉羽兽",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToRainbowFinFinalCheckStartPos",
-            "GoToRainbowFinStartPosFailed"
+            "GoToRainbowFinFinalCheckStartPos"
         ]
     },
     "GoToRainbowFinFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToRainbowFinMapTrackerMove"
         ]
-    },
-    "GoToRainbowFinStartPosFailed": {
-        "desc": "七彩鳞传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToRainbowFinMapTrackerMove": {
         "desc": "前往七彩鳞",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
@@ -253,8 +253,7 @@
             ]
         },
         "next": [
-            "GoToVigorousCisternOriginiumSlugFinalCheckStartPos",
-            "GoToVigorousCisternOriginiumSlugStartPosFailed"
+            "GoToVigorousCisternOriginiumSlugFinalCheckStartPos"
         ]
     },
     "GoToVigorousCisternOriginiumSlugFinalCheckStartPos": {
@@ -277,9 +276,6 @@
         "next": [
             "GoToVigorousCisternOriginiumSlugMapTrackerMove"
         ]
-    },
-    "GoToVigorousCisternOriginiumSlugStartPosFailed": {
-        "desc": "充满活力的蓄水源石虫传送后仍未到达预期起点，结束当前子任务"
     },
     "GoToVigorousCisternOriginiumSlugMapTrackerMove": {
         "desc": "前往充满活力的蓄水源石虫",

--- a/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/template.jsonc
+++ b/tools/pipeline-generate/EnvironmentMonitoring/OutskirtsMonitoringTerminal/template.jsonc
@@ -231,8 +231,7 @@
             ]
         },
         "next": [
-            "GoTo${Id}FinalCheckStartPos",
-            "GoTo${Id}StartPosFailed"
+            "GoTo${Id}FinalCheckStartPos"
         ]
     },
     "GoTo${Id}FinalCheckStartPos": {
@@ -250,9 +249,6 @@
         "next": [
             "GoTo${Id}MapTrackerMove"
         ]
-    },
-    "GoTo${Id}StartPosFailed": {
-        "desc": "${Name}传送后仍未到达预期起点，结束当前子任务"
     },
     "GoTo${Id}MapTrackerMove": {
         "desc": "前往${Name}",


### PR DESCRIPTION
#2131 应该报错而不是成功。

## Summary by Sourcery

确保环境监控终端流水线在运行未到达指定位置时，将其视为失败而不是成功。

Bug Fixes:
- 修正环境监控任务，使其在被追踪实体未达到指定位置时正确报错。

Enhancements:
- 使所有郊区监控终端流水线定义及其模板与更新后的失败条件语义保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure environment monitoring terminal pipelines treat runs that do not reach the specified location as failures instead of successes.

Bug Fixes:
- Correct environment monitoring tasks so they error when the tracked entity does not reach its designated position.

Enhancements:
- Align all outskirts monitoring terminal pipeline definitions and their template with the updated failure condition semantics.

</details>