### PR TITLE
refactor: 万能跳转传送pipeline整理

### DIFF
--- a/assets/resource/pipeline/Interface/SceneWuling.json
+++ b/assets/resource/pipeline/Interface/SceneWuling.json
@@ -30,7 +30,7 @@
         "desc": "从任意界面进入-景玉谷-生态实验站",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley0Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley0"
         },
         "post_delay": 0,
         "next": [
@@ -42,7 +42,7 @@
         "desc": "从任意界面进入-景玉谷-踩道大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley1Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley1"
         },
         "post_delay": 0,
         "next": [
@@ -54,7 +54,7 @@
         "desc": "从任意界面进入-景玉谷-聚宝窟外大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley2Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley2"
         },
         "post_delay": 0,
         "next": [
@@ -66,7 +66,7 @@
         "desc": "从任意界面进入-景玉谷-清波寨外寨大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley3Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley3"
         },
         "post_delay": 0,
         "next": [
@@ -95,7 +95,7 @@
         "desc": "从任意界面进入-景玉谷-天王坪大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley5Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley5"
         },
         "post_delay": 0,
         "next": [
@@ -107,7 +107,7 @@
         "desc": "从任意界面进入-景玉谷-驮鼻山大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley6Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley6"
         },
         "post_delay": 0,
         "next": [
@@ -119,7 +119,7 @@
         "desc": "从任意界面进入-景玉谷-迷踪林大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley7Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley7"
         },
         "post_delay": 0,
         "next": [
@@ -131,7 +131,7 @@
         "desc": "从任意界面进入-景玉谷-摘菱屿大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley8Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley8"
         },
         "post_delay": 0,
         "next": [
@@ -143,7 +143,7 @@
         "desc": "从任意界面进入-景玉谷-南山大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley9Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley9"
         },
         "post_delay": 0,
         "next": [
@@ -155,7 +155,7 @@
         "desc": "从任意界面进入-景玉谷-水泽涧大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley10Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley10"
         },
         "post_delay": 0,
         "next": [
@@ -184,7 +184,7 @@
         "desc": "从任意界面进入武陵-武陵城-观测站大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity0Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity0"
         },
         "post_delay": 0,
         "next": [
@@ -196,7 +196,7 @@
         "desc": "从任意界面进入武陵-武陵城-界石坪大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity1Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity1"
         },
         "post_delay": 0,
         "next": [
@@ -208,7 +208,7 @@
         "desc": "从任意界面进入武陵-武陵城-待修缮区大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity2Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity2"
         },
         "post_delay": 0,
         "next": [
@@ -220,7 +220,7 @@
         "desc": "从任意界面进入武陵-武陵城-方兴衢大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity3Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity3"
         },
         "post_delay": 0,
         "next": [
@@ -232,7 +232,7 @@
         "desc": "从任意界面进入武陵-武陵城-天师府学院大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity4Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity4"
         },
         "post_delay": 0,
         "next": [
@@ -244,7 +244,7 @@
         "desc": "从任意界面进入武陵-武陵城-天井院大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity5Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity5"
         },
         "post_delay": 0,
         "next": [
@@ -256,7 +256,7 @@
         "desc": "从任意界面进入武陵-武陵城-储备站左上大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity6Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity6"
         },
         "post_delay": 0,
         "next": [
@@ -268,7 +268,7 @@
         "desc": "从任意界面进入武陵-武陵城-三窟岗大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity7Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity7"
         },
         "post_delay": 0,
         "next": [
@@ -280,7 +280,7 @@
         "desc": "从任意界面进入武陵-武陵城-储备站右下大世界",
         "pre_delay": 0,
         "anchor": {
-            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity8Try0"
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity8"
         },
         "post_delay": 0,
         "next": [

--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -164,7 +164,7 @@
             "__ScenePrivateMapTeleportConfirmWithSwipeAnchorClear"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley0Try0": {
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley0": {
         "desc": "在地图界面找锚点 (景玉谷-生态实验站)",
         "recognition": "And",
         "all_of": [
@@ -191,7 +191,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley1Try0": {
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley1": {
         "desc": "在地图界面找锚点 (景玉谷-踩道)",
         "recognition": "And",
         "all_of": [
@@ -218,8 +218,8 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley2Try0": {
-        "desc": "在地图界面找锚点 (景玉谷-聚宝窟外大世界)",
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley2": {
+        "desc": "在地图界面找锚点 (景玉谷-聚宝窟外)",
         "recognition": "And",
         "all_of": [
             "InMapWulingJingyuValley"
@@ -245,8 +245,8 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley3Try0": {
-        "desc": "在地图界面找锚点 (景玉谷-清波寨外寨大世界)",
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley3": {
+        "desc": "在地图界面找锚点 (景玉谷-清波寨外寨)",
         "recognition": "And",
         "all_of": [
             "InMapWulingJingyuValley"
@@ -374,8 +374,8 @@
             "__ScenePrivateMapTeleportConfirmWithSwipeAnchorClear"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley4Try0": {
-        "desc": "在地图界面找锚点 (景玉谷-聚宝窟内),此锚点兼容性差",
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley4": {
+        "desc": "在地图界面找锚点 (景玉谷-聚宝窟内)，此锚点兼容性差已暂时弃用，目前采用传统模板匹配",
         "recognition": "And",
         "all_of": [
             "InMapWulingJingyuValley"
@@ -401,7 +401,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley5Try0": {
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley5": {
         "desc": "在地图界面找锚点 (景玉谷-天王坪)",
         "recognition": "And",
         "all_of": [
@@ -428,7 +428,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley6Try0": {
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley6": {
         "desc": "在地图界面找锚点 (景玉谷-驮鼻山)",
         "recognition": "And",
         "all_of": [
@@ -455,7 +455,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley7Try0": {
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley7": {
         "desc": "在地图界面找锚点 (景玉谷-迷踪林)",
         "recognition": "And",
         "all_of": [
@@ -482,7 +482,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley8Try0": {
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley8": {
         "desc": "在地图界面找锚点 (景玉谷-摘菱屿)",
         "recognition": "And",
         "all_of": [
@@ -509,7 +509,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley9Try0": {
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley9": {
         "desc": "在地图界面找锚点 (景玉谷-南山)",
         "recognition": "And",
         "all_of": [
@@ -536,7 +536,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley10Try0": {
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldWulingJingyuValley10": {
         "desc": "在地图界面找锚点 (景玉谷-水泽涧)",
         "recognition": "And",
         "all_of": [
@@ -562,7 +562,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity0Try0": {
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity0": {
         "desc": "在地图界面找锚点 (武陵城-观测站)",
         "recognition": "And",
         "all_of": [
@@ -589,7 +589,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity1Try0": {
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity1": {
         "desc": "在地图界面找锚点 (武陵城-界石坪)",
         "recognition": "And",
         "all_of": [
@@ -616,7 +616,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity2Try0": {
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity2": {
         "desc": "在地图界面找锚点 (武陵城-待修缮区)",
         "recognition": "And",
         "all_of": [
@@ -643,7 +643,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity3Try0": {
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity3": {
         "desc": "在地图界面找锚点 (武陵城-方兴衢)",
         "recognition": "And",
         "all_of": [
@@ -670,7 +670,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity4Try0": {
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity4": {
         "desc": "在地图界面找锚点 (武陵城-天师府学院)",
         "recognition": "And",
         "all_of": [
@@ -697,8 +697,8 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity5Try0": {
-        "desc": "在地图界面找锚点 (武陵城-天井院学院)",
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity5": {
+        "desc": "在地图界面找锚点 (武陵城-天井院)",
         "recognition": "And",
         "all_of": [
             "InMapWulingWulingCity"
@@ -724,7 +724,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity6Try0": {
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity6": {
         "desc": "在地图界面找锚点 (武陵城-储备站左上)",
         "recognition": "And",
         "all_of": [
@@ -751,7 +751,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity7Try0": {
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity7": {
         "desc": "在地图界面找锚点 (武陵城-三窟岗)",
         "recognition": "And",
         "all_of": [
@@ -778,7 +778,7 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity8Try0": {
+    "__ScenePrivateMapWulingWulingCityEnterWorldWulingWulingCity8": {
         "desc": "在地图界面找锚点 (武陵城-储备站右下)",
         "recognition": "And",
         "all_of": [

--- a/assets/resource/pipeline/SceneManager/SceneValleyIV.json
+++ b/assets/resource/pipeline/SceneManager/SceneValleyIV.json
@@ -639,7 +639,6 @@
         "post_delay": 0,
         "next": [
             "__ScenePrivateMapTeleportSuccess",
-            "[JumpBack]__ScenePrivateMapZoomOut",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     },

--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -1,16 +1,4 @@
 {
-    "__ScenePrivateMapAnyEnterMapWulingWulingCity": {
-        "desc": "在任意地图界面，进入武陵-武陵城地图",
-        "recognition": "And",
-        "all_of": [
-            "InMapAny"
-        ],
-        "next": [
-            "__ScenePrivateMapAnyEnterMapWulingWulingCitySuccess",
-            "__ScenePrivateMapOverviewEnterMapWulingWulingCity",
-            "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
-        ]
-    },
     "__ScenePrivateMapAnyEnterMapWulingJingyuValley": {
         "desc": "在任意地图界面，进入武陵-景玉谷地图",
         "recognition": "And",
@@ -20,6 +8,18 @@
         "next": [
             "__ScenePrivateMapAnyEnterMapWulingJingyuValleySuccess",
             "__ScenePrivateMapOverviewEnterMapWulingJingyuValley",
+            "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
+        ]
+    },
+    "__ScenePrivateMapAnyEnterMapWulingWulingCity": {
+        "desc": "在任意地图界面，进入武陵-武陵城地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny"
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingWulingCitySuccess",
+            "__ScenePrivateMapOverviewEnterMapWulingWulingCity",
             "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
         ]
     },
@@ -35,20 +35,20 @@
             "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
         ]
     },
-    "__ScenePrivateMapAnyEnterMapWulingWulingCitySuccess": {
-        "desc": "在地图界面，成功进入武陵-武陵城地图",
-        "recognition": "And",
-        "all_of": [
-            "InMapWulingWulingCity"
-        ],
-        "pre_delay": 0,
-        "post_delay": 0
-    },
     "__ScenePrivateMapAnyEnterMapWulingJingyuValleySuccess": {
         "desc": "在地图界面，成功进入武陵-景玉谷地图",
         "recognition": "And",
         "all_of": [
             "InMapWulingJingyuValley"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0
+    },
+    "__ScenePrivateMapAnyEnterMapWulingWulingCitySuccess": {
+        "desc": "在地图界面，成功进入武陵-武陵城地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingWulingCity"
         ],
         "pre_delay": 0,
         "post_delay": 0
@@ -84,29 +84,6 @@
         },
         "post_wait_freezes": 400
     },
-    "__ScenePrivateMapOverviewEnterMapWulingWulingCity": {
-        "desc": "在地图地总览界面，进入武陵-武陵城地图",
-        "recognition": {
-            "type": "TemplateMatch",
-            "param": {
-                "roi": [
-                    -450,
-                    -150,
-                    350,
-                    150
-                ],
-                "template": [
-                    "SceneManager/MapOverviewWulingChoose.png",
-                    "SceneManager/MapOverviewWulingNotChoose.png"
-                ],
-                "threshold": 0.9
-            }
-        },
-        "next": [
-            "[JumpBack]__ScenePrivateMapOverviewSwitchMapOverviewWuling",
-            "__ScenePrivateMapOverviewWulingEnterMapWulingWulingCity"
-        ]
-    },
     "__ScenePrivateMapOverviewEnterMapWulingJingyuValley": {
         "desc": "在地图地总览界面，进入武陵-景玉谷地图",
         "recognition": {
@@ -128,6 +105,29 @@
         "next": [
             "[JumpBack]__ScenePrivateMapOverviewSwitchMapOverviewWuling",
             "__ScenePrivateMapOverviewWulingEnterMapWulingJingyuValley"
+        ]
+    },
+    "__ScenePrivateMapOverviewEnterMapWulingWulingCity": {
+        "desc": "在地图地总览界面，进入武陵-武陵城地图",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    -450,
+                    -150,
+                    350,
+                    150
+                ],
+                "template": [
+                    "SceneManager/MapOverviewWulingChoose.png",
+                    "SceneManager/MapOverviewWulingNotChoose.png"
+                ],
+                "threshold": 0.9
+            }
+        },
+        "next": [
+            "[JumpBack]__ScenePrivateMapOverviewSwitchMapOverviewWuling",
+            "__ScenePrivateMapOverviewWulingEnterMapWulingWulingCity"
         ]
     },
     "__ScenePrivateMapOverviewEnterMapWulingQingboStockade": {
@@ -153,57 +153,8 @@
             "__ScenePrivateMapOverviewWulingEnterMapWulingQingboStockade"
         ]
     },
-    "__ScenePrivateMapOverviewWulingEnterMapWulingWulingCity": {
-        "desc": "在武陵总览界面，进入武陵-武陵城地图",
-        // "recognition": {
-        //     "type": "OCR",
-        //     "param": {
-        //         "roi": [
-        //             450,
-        //             0,
-        //             500,
-        //             250
-        //         ],
-        //         "expected": [
-        //             "武",
-        //             "陵",
-        //             "城",
-        //             "WULING",
-        //             "CITY"
-        //         ]
-        //     }
-        // },
-        "action": "Click",
-        "target": [
-            510,
-            140,
-            130,
-            80
-        ],
-        "next": [
-            "__ScenePrivateMapAnyEnterMapWulingWulingCitySuccess"
-        ]
-    },
     "__ScenePrivateMapOverviewWulingEnterMapWulingJingyuValley": {
         "desc": "在武陵总览界面，进入武陵-景玉谷地图",
-        // "recognition": {
-        //     "type": "OCR",
-        //     "param": {
-        //         "roi": [
-        //             450,
-        //             -400,
-        //             500,
-        //             400
-        //         ],
-        //         "expected": [
-        //             "景",
-        //             "玉",
-        //             "谷",
-        //             "JINGYU",
-        //             "VALLEY"
-        //         ]
-        //     }
-        // },
         "action": "Click",
         "target": [
             480,
@@ -213,6 +164,19 @@
         ],
         "next": [
             "__ScenePrivateMapAnyEnterMapWulingJingyuValleySuccess"
+        ]
+    },
+    "__ScenePrivateMapOverviewWulingEnterMapWulingWulingCity": {
+        "desc": "在武陵总览界面，进入武陵-武陵城地图",
+        "action": "Click",
+        "target": [
+            510,
+            140,
+            130,
+            80
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingWulingCitySuccess"
         ]
     },
     "__ScenePrivateMapOverviewWulingEnterMapWulingQingboStockade": {
@@ -228,11 +192,11 @@
             "__ScenePrivateMapAnyEnterMapWulingQingboStockadeSuccess"
         ]
     },
-    "__ScenePrivateMapWulingWulingCityEnterWorldAnchor": {
-        "desc": "在武陵-武陵城地图界面，进入[锚点]大世界",
+    "__ScenePrivateMapWulingJingyuValleyEnterWorldAnchor": {
+        "desc": "在武陵-景玉谷地图界面，进入[锚点]大世界",
         "recognition": "And",
         "all_of": [
-            "InMapWulingWulingCity"
+            "InMapWulingJingyuValley"
         ],
         "pre_delay": 0,
         "post_delay": 0,
@@ -245,11 +209,11 @@
             "[JumpBack][Anchor]__ScenePrivateMapSwipeToStepFinishAnchor"
         ]
     },
-    "__ScenePrivateMapWulingJingyuValleyEnterWorldAnchor": {
-        "desc": "在武陵-景玉谷地图界面，进入[锚点]大世界",
+    "__ScenePrivateMapWulingWulingCityEnterWorldAnchor": {
+        "desc": "在武陵-武陵城地图界面，进入[锚点]大世界",
         "recognition": "And",
         "all_of": [
-            "InMapWulingJingyuValley"
+            "InMapWulingWulingCity"
         ],
         "pre_delay": 0,
         "post_delay": 0,
@@ -285,7 +249,6 @@
         "post_delay": 0,
         "next": [
             "__ScenePrivateMapTeleportSuccess",
-            "[JumpBack]__ScenePrivateMapZoomOut",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     },
@@ -299,7 +262,6 @@
         "post_delay": 0,
         "next": [
             "__ScenePrivateMapTeleportSuccess",
-            "[JumpBack]__ScenePrivateMapZoomOut",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     }


### PR DESCRIPTION
## 概要

此 PR 整理了万能跳转的传送部分的部分 pipeline，主要包括：

1. 简化了部分含 `Try0` 后缀的节点名称；
2. 对于 `WorldAnchorWithPick` 类型的节点，移除了手动缩小地图的步骤，因为 MapTrackerBigMapPick 会自动处理缩放问题。
3. 调整了武陵区域的地区顺序为 `景玉谷->武陵城->清波寨`，使之符合官方的地区排序顺序。
4. 部分节点描述文本错误修正。

## Summary by Sourcery

优化武陵及相关场景的通用传送流水线，使其行为与顺序符合当前的设计预期。

增强内容：
- 重命名传送流水线节点，以简化并统一命名方式，尤其是带有 `Try0` 后缀的节点。
- 更新 `WorldAnchorWithPick` 传送节点，改为依赖自动大地图缩放，而非手动地图缩放步骤。
- 重新排序武陵区域条目为 `景玉谷->武陵城->清波寨`，以匹配官方的区域顺序。
- 修正传送相关流水线定义中不准确或具有误导性的描述文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the universal teleport pipelines for the Wuling and related scenes to align behavior and ordering with current design expectations.

Enhancements:
- Rename teleport pipeline nodes to simplify and standardize naming, especially those with `Try0` suffixes.
- Update `WorldAnchorWithPick` teleport nodes to rely on automatic big-map scaling instead of manual map zoom steps.
- Reorder Wuling region entries to `景玉谷->武陵城->清波寨` to match the official regional sequence.
- Correct inaccurate or misleading description texts in teleport-related pipeline definitions.

</details>