### PR TITLE
fix: 抢委托 适配 1.2 版本

### DIFF
--- a/assets/resource/pipeline/SeizeEntrustTask.json
+++ b/assets/resource/pipeline/SeizeEntrustTask.json
@@ -96,9 +96,9 @@
                                     -20
                                 ],
                                 "expected": [
-                                    "7.98",
-                                    "798",
-                                    "79.8"
+                                    "11.9",
+                                    "119",
+                                    "1.19"
                                 ],
                                 "only_rec": true
                             }
@@ -170,9 +170,9 @@
                                     -20
                                 ],
                                 "expected": [
-                                    "7.98",
-                                    "798",
-                                    "79.8"
+                                    "11.9",
+                                    "119",
+                                    "1.19"
                                 ],
                                 "only_rec": true
                             }
@@ -207,7 +207,7 @@
             "SeizeEntrustTaskNews"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "找到武陵城7.98万订单！"
+            "Node.Recognition.Succeeded": "找到武陵城11.9万订单！"
         }
     },
     "SeizeEntrustTaskFoundListOfDeliveryJobsButton": {

--- a/assets/resource/pipeline/SeizeEntrustTask.json
+++ b/assets/resource/pipeline/SeizeEntrustTask.json
@@ -203,6 +203,9 @@
             "SeizeEntrustTaskCheckWulingFilter",
             "SeizeEntrustTaskOpenRegionFilter"
         ],
+        "on_error": [
+            "SeizeEntrustTaskStopTask2"
+        ],
         "focus": {
             "Node.Recognition.Succeeded": "进入运送委托列表"
         }

--- a/assets/resource/pipeline/SeizeEntrustTask.json
+++ b/assets/resource/pipeline/SeizeEntrustTask.json
@@ -200,10 +200,106 @@
             "param": {}
         },
         "next": [
-            "isSeizeEntrustTaskReady"
+            "SeizeEntrustTaskCheckWulingFilter",
+            "SeizeEntrustTaskOpenRegionFilter"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "进入运送委托列表"
+        }
+    },
+    "SeizeEntrustTaskCheckWulingFilter": {
+        "desc": "当前已是武陵筛选，直接进入调度",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    60,
+                    647,
+                    132,
+                    29
+                ],
+                "expected": [
+                    "武陵",
+                    "Wuling",
+                    "무릉"
+                ]
+            }
+        },
+        "next": [
+            "isSeizeEntrustTaskExistOldTask",
+            "isSeizeEntrustTaskExhausted",
+            "isSeizeEntrustTaskDestinationWulingCity"
+        ],
+        "on_error": [
+            "SeizeEntrustTaskStopTask2"
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "当前已是武陵筛选，直接进入抢单"
+        }
+    },
+    "SeizeEntrustTaskOpenRegionFilter": {
+        "desc": "非武陵筛选则点击展开地区筛选",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    60,
+                    647,
+                    132,
+                    29
+                ],
+                "expected": [
+                    "全部地区",
+                    "四号谷地"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "SeizeEntrustTaskSelectWuling"
+        ],
+        "on_error": [
+            "SeizeEntrustTaskStopTask2"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": "展开地区筛选"
+        }
+    },
+    "SeizeEntrustTaskSelectWuling": {
+        "desc": "在筛选列表中选择武陵",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    65,
+                    523,
+                    123,
+                    114
+                ],
+                "expected": [
+                    "武陵",
+                    "Wuling",
+                    "무릉"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "isSeizeEntrustTaskExistOldTask",
+            "isSeizeEntrustTaskExhausted",
+            "isSeizeEntrustTaskDestinationWulingCity"
+        ],
+        "on_error": [
+            "SeizeEntrustTaskStopTask2"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": "切换到武陵筛选"
         }
     },
     "SeizeEntrustTaskFoundTarget": {
@@ -521,38 +617,6 @@
         },
         "focus": {
             "Node.Recognition.Succeeded": "当前已有其他送货任务，请完成后再接取"
-        }
-    },
-    "isSeizeEntrustTaskReady": {
-        "desc": "判断有没有成功进入",
-        "recognition": {
-            "type": "OCR",
-            "param": {
-                "roi": [
-                    136,
-                    130,
-                    87,
-                    34
-                ],
-                "expected": [
-                    "委托人信息",
-                    "委託人資訊",
-                    "(?i)Client\\s*Info",
-                    "依頼主詳細"
-                ]
-            }
-        },
-        "timeout": 1500,
-        "next": [
-            "isSeizeEntrustTaskExistOldTask",
-            "isSeizeEntrustTaskExhausted",
-            "isSeizeEntrustTaskDestinationWulingCity"
-        ],
-        "on_error": [
-            "SeizeEntrustTaskStopTask2"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "进入抢武陵城委托任务"
         }
     },
     "isSeizeEntrustTaskSuccessful": {

--- a/assets/resource/pipeline/SeizeEntrustTask.json
+++ b/assets/resource/pipeline/SeizeEntrustTask.json
@@ -1,36 +1,4 @@
 {
-    "SeizeEntrustTaskBeforeSwipeDown": {
-        "desc": "直接滑到最底下",
-        "recognition": {
-            "type": "TemplateMatch",
-            "param": {
-                "roi": [
-                    1250,
-                    620,
-                    16,
-                    23
-                ],
-                "template": [
-                    "SeizeEntrustTask/InDown.png"
-                ]
-            }
-        },
-        "inverse": true,
-        "pre_delay": 0,
-        "action": {
-            "type": "Scroll",
-            "param": {
-                "target": [
-                    763,
-                    424,
-                    5,
-                    5
-                ],
-                "dy": -240
-            }
-        },
-        "post_delay": 0
-    },
     "SeizeEntrustTaskErrorTaskStop": {
         "recognition": {
             "type": "OCR",
@@ -97,8 +65,7 @@
                                 ],
                                 "expected": [
                                     "11.9",
-                                    "119",
-                                    "1.19"
+                                    "119"
                                 ],
                                 "only_rec": true
                             }
@@ -171,8 +138,7 @@
                                 ],
                                 "expected": [
                                     "11.9",
-                                    "119",
-                                    "1.19"
+                                    "119"
                                 ],
                                 "only_rec": true
                             }
@@ -326,7 +292,7 @@
             "type": "Click",
             "param": {}
         },
-        "post_delay": 5000,
+        "post_delay": 3000,
         "next": [
             "SeizeEntrustTaskNewsStatus1"
         ]
@@ -426,7 +392,7 @@
         }
     },
     "isSeizeEntrustTaskDestinationWulingCity": {
-        "desc": "滑到底后才会执行调度器，然后等待委托列表静止后再进入调度",
+        "desc": "等待委托列表静止后再进入调度",
         "pre_wait_freezes": {
             "time": 2000,
             "target": [
@@ -580,7 +546,6 @@
         "next": [
             "isSeizeEntrustTaskExistOldTask",
             "isSeizeEntrustTaskExhausted",
-            "[JumpBack]SeizeEntrustTaskBeforeSwipeDown",
             "isSeizeEntrustTaskDestinationWulingCity"
         ],
         "on_error": [

--- a/assets/resource/pipeline/SeizeEntrustTask.json
+++ b/assets/resource/pipeline/SeizeEntrustTask.json
@@ -292,7 +292,7 @@
             "type": "Click",
             "param": {}
         },
-        "post_delay": 3000,
+        "post_delay": 1500,
         "next": [
             "SeizeEntrustTaskNewsStatus1"
         ]
@@ -542,7 +542,7 @@
                 ]
             }
         },
-        "timeout": 3000,
+        "timeout": 1500,
         "next": [
             "isSeizeEntrustTaskExistOldTask",
             "isSeizeEntrustTaskExhausted",


### PR DESCRIPTION
## 由 Sourcery 提供的总结

增强内容：
- 调整 SeizeEntrustTask 流水线配置，以使用在 1.2 版本中引入的更新阈值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust SeizeEntrustTask pipeline configuration to use the updated threshold values introduced in version 1.2.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

增强内容：
- 调整 SeizeEntrustTask 流水线配置，以使用在 1.2 版本中引入的更新阈值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust SeizeEntrustTask pipeline configuration to use the updated threshold values introduced in version 1.2.

</details>

</details>
- 调整 SeizeEntrustTask 流水线资源，以使用更新后的抢占委托阈值。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

增强内容：
- 调整 SeizeEntrustTask 流水线配置，以使用在 1.2 版本中引入的更新阈值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust SeizeEntrustTask pipeline configuration to use the updated threshold values introduced in version 1.2.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

增强内容：
- 调整 SeizeEntrustTask 流水线配置，以使用在 1.2 版本中引入的更新阈值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust SeizeEntrustTask pipeline configuration to use the updated threshold values introduced in version 1.2.

</details>

</details>

</details>