### PR TITLE
ci: add fill_interface.py to compute resource hash and version

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -179,10 +179,12 @@ jobs:
             fi
           fi
 
-          # 更新 interface.json 中的版本号
-          echo "Update interface version to ${{ needs.meta.outputs.tag }}"
-          sed -E '/^[[:space:]]*\/\//d' install/interface.json | jq --indent 4 --arg version "${{ needs.meta.outputs.tag }}" '.version=$version' > install/interface.json.tmp
-          mv install/interface.json.tmp install/interface.json
+          # 更新 interface.json（版本号 + 资源 hash）
+          echo "Update interface.json: version=${{ needs.meta.outputs.tag }}, compute resource hashes"
+          python -m pip install maafw
+          python tools/fill_interface.py \
+            --version "${{ needs.meta.outputs.tag }}" \
+            --interface install/interface.json
 
           cat install/interface.json
 

--- a/tools/fill_interface.py
+++ b/tools/fill_interface.py
@@ -1,0 +1,96 @@
+"""
+Fill resource.hash and version into interface.json.
+
+Usage (in CI):
+    python -m pip install maafw
+    python tools/fill_interface.py \
+        --version v2.0.0 \
+        --interface install/interface.json
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def strip_jsonc_comments(text: str) -> str:
+    """Remove single-line // comments (outside strings) from JSONC text."""
+    return re.sub(r"^\s*//.*$", "", text, flags=re.MULTILINE)
+
+
+def load_jsonc(path: Path) -> dict:
+    raw = path.read_text(encoding="utf-8")
+    cleaned = strip_jsonc_comments(raw)
+    return json.loads(cleaned)
+
+
+def save_json(path: Path, data: dict) -> None:
+    text = json.dumps(data, indent=4, ensure_ascii=False) + "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def log(msg: str) -> None:
+    sys.stdout.buffer.write((msg + "\n").encode("utf-8"))
+    sys.stdout.buffer.flush()
+
+
+def compute_resource_hashes(
+    interface_data: dict,
+    base_dir: Path,
+    maafw_lib_dir: Path | None,
+) -> None:
+    from maa.library import Library
+    from maa.resource import Resource
+
+    if maafw_lib_dir:
+        Library.open(maafw_lib_dir)
+
+    for res_item in interface_data.get("resource", []):
+        paths = res_item.get("path", [])
+        if not paths:
+            continue
+
+        resource = Resource()
+        for p in paths:
+            clean = re.sub(r"^\.[\\/]", "", p)
+            full_path = base_dir / clean
+            if not full_path.exists():
+                log(f"  ERROR: resource path does not exist: {full_path}")
+                sys.exit(1)
+            job = resource.post_bundle(str(full_path))
+            job.wait()
+
+        h = resource.hash
+        res_item["hash"] = h
+        log(f"  {res_item['name']}: hash = {h}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fill interface.json with version and resource hashes")
+    parser.add_argument("--version", required=True, help="Version tag to set")
+    parser.add_argument("--maafw-lib-dir", help="Path to MaaFramework shared libraries (optional; uses pip-installed library if omitted)")
+    parser.add_argument("--interface", required=True, help="Path to interface.json to modify")
+    args = parser.parse_args()
+
+    interface_path = Path(args.interface)
+    maafw_lib_dir = Path(args.maafw_lib_dir) if args.maafw_lib_dir else None
+    base_dir = interface_path.parent
+
+    log(f"Loading {interface_path}")
+    data = load_jsonc(interface_path)
+
+    log(f"Setting version = {args.version}")
+    data["version"] = args.version
+
+    log("Computing resource hashes...")
+    compute_resource_hashes(data, base_dir, maafw_lib_dir)
+
+    log(f"Writing {interface_path}")
+    save_json(interface_path, data)
+    log("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add \	ools/fill_interface.py\: uses MaaFW Python binding to compute \esource.hash\ for each resource entry in interface.json, and fills in the \ersion\ field
- Replace the old \sed | jq\ one-liner in \install.yml\ with the new script
- Handles JSONC comment lines (\//\) in interface.json
- Requires \pip install maafw\ in CI (added to the Install step)

Depends on:
- MaaFW docs: https://github.com/MaaXYZ/MaaFramework/pull/1284
- MXU impl: https://github.com/MistEO/MXU/pull/182

## Test plan
- [ ] Dry run the workflow to verify \ill_interface.py\ runs without errors
- [ ] Verify the output interface.json has \hash\ fields in resource entries
- [ ] Verify the \ersion\ field is correctly set
- [ ] macOS DMG \mirrorchyan_rid\ patching still works (unchanged jq step)

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

更新 CI 工作流，通过专用的 Python 脚本为 `interface.json` 填充版本信息并计算资源哈希值。

新功能：
- 引入 `tools/fill_interface.py`，用于解析 `interface.json`（支持带 JSONC 注释），设置 `version` 字段，并使用 MaaFramework 绑定为每个资源条目计算哈希值。

改进：
- 在安装工作流中，用新的基于 Python 的 `interface.json` 填充步骤替代之前的 `sed + jq` 步骤，同时完成资源哈希值的计算。

构建：
- 确保在执行新的 `interface.json` 填充步骤之前，安装工作流会先安装 `maafw` Python 包。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI workflow to populate interface.json with version and computed resource hashes using a dedicated Python script.

New Features:
- Introduce tools/fill_interface.py to parse interface.json (with JSONC comments), set the version field, and compute hash values for each resource entry using MaaFramework bindings.

Enhancements:
- Replace the previous sed+jq step in the install workflow with the new Python-based interface.json filler that also calculates resource hashes.

Build:
- Ensure the install workflow installs the maafw Python package before running the new interface.json filling step.

</details>