### PR TITLE
更新"task.SeizeEntrustTask.description"文本描述至11.9w武陵券（多个语种

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -545,7 +545,7 @@
     "task.AndroidOpenGame.label": "🎮 Launch Game (Android)",
     "task.AndroidOpenGame.description": "Launch the game on Android. Please open the emulator manually first.",
     "task.SeizeEntrustTask.label": "🌆Accept Commission",
-    "task.SeizeEntrustTask.description": "Only accept orders in Master Zhuang's territory～🌆 Only take Wuling orders of 79,800 ~ ",
+    "task.SeizeEntrustTask.description": "Only accept orders in Master Zhuang's territory～🌆 Only take Wuling orders of 119,000 ~ ",
     "task.SeizeEntrustTaskisGoDepotNodeWorld.label": "Teleport to Depot Node Anchor",
     "task.SeizeEntrustTaskisGoDepotNodeWorld.description": "When enabled, automatically teleports to the anchor point near the depot node after seizing an order.",
     "task.SeizeEntrustTaskisWalkingToDepotNode.label": "Walk to Depot Node",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -383,7 +383,7 @@
     "task.AndroidOpenGame.label": "🎮 ゲーム起動（Android）",
     "task.AndroidOpenGame.description": "Androidでゲームを起動します。事前にエミュレーターを手動で起動してください。",
     "task.SeizeEntrustTask.label": "🌆受注依頼",
-    "task.SeizeEntrustTask.description": "荘天師の勢力圏でのみ受注～🌆 7 万 9800 円の武陵注文のみ対応～",
+    "task.SeizeEntrustTask.description": "荘天師の勢力圏でのみ受注～🌆 11 万 9000 円の武陵注文のみ対応～",
     "task.SeizeEntrustTaskisGoDepotNodeWorld.label": "倉庫ノード近くのアンカーへ転送",
     "task.SeizeEntrustTaskisGoDepotNodeWorld.description": "有効にすると、受注完了後に倉庫ノード近くのアンカーへ自動転送します。",
     "task.SeizeEntrustTaskisWalkingToDepotNode.label": "倉庫ノードまで歩行",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -383,7 +383,7 @@
     "task.AndroidOpenGame.label": "🎮 게임 실행 (Android)",
     "task.AndroidOpenGame.description": "Android에서 게임을 실행합니다. 먼저 에뮬레이터를 수동으로 실행해 주세요.",
     "task.SeizeEntrustTask.label": "🌆의뢰 수락",
-    "task.SeizeEntrustTask.description": "장천사 영역에서만 주문 수락～🌆 7만9800원의 무릉 주문만 받습니다～",
+    "task.SeizeEntrustTask.description": "장천사 영역에서만 주문 수락～🌆 11만9000원의 무릉 주문만 받습니다～",
     "task.SeizeEntrustTaskisGoDepotNodeWorld.label": "창고 노드 앵커로 텔레포트",
     "task.SeizeEntrustTaskisGoDepotNodeWorld.description": "활성화하면 주문 접수 후 창고 노드 근처 앵커로 자동 텔레포트합니다.",
     "task.SeizeEntrustTaskisWalkingToDepotNode.label": "창고 노드까지 걷기",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -504,7 +504,7 @@
     "task.AndroidOpenGame.label": "🎮打开游戏",
     "task.AndroidOpenGame.description": "安卓端打开游戏，需先手动打开模拟器",
     "task.SeizeEntrustTask.label": "🌆抢委托",
-    "task.SeizeEntrustTask.description": "庄天师的地盘才接单～🌆只接7.98万的武陵订单~",
+    "task.SeizeEntrustTask.description": "庄天师的地盘才接单～🌆只接11.9万的武陵订单~",
     "task.SeizeEntrustTaskisGoDepotNodeWorld.label": "传送至仓储节点锚点",
     "task.SeizeEntrustTaskisGoDepotNodeWorld.description": "开启后将抢完单将自动传送到仓储节点上面的锚点",
     "task.SeizeEntrustTaskisWalkingToDepotNode.label": "走到仓储节点",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -383,7 +383,7 @@
     "task.AndroidOpenGame.label": "🎮打開遊戲",
     "task.AndroidOpenGame.description": "安卓端打開遊戲，需先手動打開模擬器",
     "task.SeizeEntrustTask.label": "🌆搶委託",
-    "task.SeizeEntrustTask.description": "莊天師的地盤才接單～🌆只接 7.98 萬的武陵訂單～",
+    "task.SeizeEntrustTask.description": "莊天師的地盤才接單～🌆只接 11.9 萬的武陵訂單～",
     "task.SeizeEntrustTaskisGoDepotNodeWorld.label": "傳送至倉儲節點錨點",
     "task.SeizeEntrustTaskisGoDepotNodeWorld.description": "開啟後將搶完單後自動傳送到倉儲節點上面的錨點",
     "task.SeizeEntrustTaskisWalkingToDepotNode.label": "走到倉儲節點",


### PR DESCRIPTION
如题

## Summary by Sourcery

增强内容：
- 更新“Seize Entrust”任务描述文案在英文、日文、韩文、简体中文和繁体中文本地化文件中的内容，以反映新的 11.9w 五菱优惠券数值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refresh the Seize Entrust task description copy in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese localization files to reflect the new 11.9w Wuling coupon value.

</details>