### PR TITLE
fix: 抢委托 刷新后任务失败

### DIFF
--- a/assets/resource/pipeline/SeizeEntrustTask.json
+++ b/assets/resource/pipeline/SeizeEntrustTask.json
@@ -380,7 +380,7 @@
                 ],
                 "expected": [
                     "^刷新",
-                    "^(?i)Refresh"
+                    "^Refresh"
                 ]
             }
         },

--- a/assets/resource/pipeline/SeizeEntrustTask.json
+++ b/assets/resource/pipeline/SeizeEntrustTask.json
@@ -379,9 +379,8 @@
                     34
                 ],
                 "expected": [
-                    "刷新",
-                    "更新",
-                    "(?i)Refresh"
+                    "^刷新",
+                    "^(?i)Refresh"
                 ]
             }
         },
@@ -389,35 +388,7 @@
             "type": "Click",
             "param": {}
         },
-        "post_delay": 1500,
-        "next": [
-            "SeizeEntrustTaskNewsStatus1"
-        ]
-    },
-    "SeizeEntrustTaskNewsStatus1": {
-        "desc": "等待刷新完成",
-        "recognition": {
-            "type": "OCR",
-            "param": {
-                "roi": [
-                    1006,
-                    525,
-                    244,
-                    121
-                ],
-                "expected": [
-                    "接取运送委托",
-                    "接取運送委託",
-                    "(?i)Accept\\s*Delivery\\s*Job",
-                    "配達依頼を受ける",
-                    "填充至起送",
-                    "填充到起送",
-                    "(?i)Delivery",
-                    "最低容量",
-                    "Accept"
-                ]
-            }
-        }
+        "post_delay": 1500
     },
     "SeizeEntrustTaskStopTask": {
         "action": {


### PR DESCRIPTION
fix #2277

## Summary by Sourcery

错误修复：
- 通过更新其流水线配置，解决页面刷新后“seize entrust”任务执行失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve seize entrust task failing after page refresh by updating its pipeline configuration.

</details>