### PR TITLE
feat(map): MapTrackerBigMapPick加入随机分段滑动

### DIFF
--- a/agent/go-service/map-tracker/big_map_pick.go
+++ b/agent/go-service/map-tracker/big_map_pick.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"image"
 	"math"
+	"math/rand"
 	"regexp"
 	"sync"
 	"time"
@@ -141,9 +142,10 @@ func (a *MapTrackerBigMapPick) Run(ctx *maa.Context, arg *maa.CustomActionArg) b
 			Int("attempt", attempt).
 			Float64("targetInViewX", targetInViewX).
 			Float64("targetInViewY", targetInViewY).
-			Msg("Panning big-map toward target")
+			Msg("Big-map target is not in viewport, need to pan")
 
-		if !doDragViewport(ca, &inferRes.ViewPort, deltaInViewX, deltaInViewY, panFactor) {
+		segments := rand.Intn(4) + 2
+		if !doDragViewport(ca, &inferRes.ViewPort, deltaInViewX, deltaInViewY, panFactor, segments) {
 			continue
 		}
 	}
@@ -355,36 +357,36 @@ func doBigMapInferForMap(ctx *maa.Context, ctrl *maa.Controller, mapName string)
 	return &result, nil
 }
 
-func doDragViewport(ca control.ControlAdaptor, viewport *mt.BigMapViewport, deltaInViewX, deltaInViewY, panFactor float64) bool {
-	left := int(math.Round(viewport.Left))
-	top := int(math.Round(viewport.Top))
-	right := int(math.Round(viewport.Right))
-	bottom := int(math.Round(viewport.Bottom))
-
+func doDragViewport(ca control.ControlAdaptor, viewport *mt.BigMapViewport, deltaInViewX, deltaInViewY, panFactor float64, segments int) bool {
 	rawDragDx := -deltaInViewX * panFactor
 	rawDragDy := -deltaInViewY * panFactor
-	startX, startY := pickDragStartCorner(left, top, right, bottom, rawDragDx, rawDragDy)
 
-	dragDx := int(math.Round(rawDragDx))
-	dragDy := int(math.Round(rawDragDy))
+	minX, minY, maxX, maxY := viewport.GetIntegerRect()
 
-	if dragDx == 0 && math.Abs(rawDragDx) >= 1.0 {
-		if rawDragDx > 0 {
-			dragDx = 1
-		} else {
-			dragDx = -1
+	pickDragStartCorner := func(rawDragDx, rawDragDy float64) (int, int) {
+		startX := minX
+		if rawDragDx < 0 {
+			// Drag toward left, start from right
+			startX = maxX
 		}
-	}
-	if dragDy == 0 && math.Abs(rawDragDy) >= 1.0 {
-		if rawDragDy > 0 {
-			dragDy = 1
-		} else {
-			dragDy = -1
+
+		startY := minY
+		if rawDragDy < 0 {
+			// Drag toward top, start from bottom
+			startY = maxY
 		}
+
+		return startX, startY
 	}
 
-	endX := min(right-1, max(left, startX+dragDx))
-	endY := min(bottom-1, max(top, startY+dragDy))
+	startX, startY := pickDragStartCorner(rawDragDx, rawDragDy)
+
+	dragDx := int(math.Ceil(math.Abs(rawDragDx)) * math.Copysign(1, rawDragDx))
+	dragDy := int(math.Ceil(math.Abs(rawDragDy)) * math.Copysign(1, rawDragDy))
+
+	endX := max(minX, min(maxX, startX+dragDx))
+	endY := max(minY, min(maxY, startY+dragDy))
+
 	dragDx = endX - startX
 	dragDy = endY - startY
 
@@ -392,25 +394,25 @@ func doDragViewport(ca control.ControlAdaptor, viewport *mt.BigMapViewport, delt
 		return false
 	}
 
-	ca.Swipe(0, startX, startY, dragDx, dragDy, 100, 50)
+	segments = max(1, segments)
+
+	segDragDx := int(math.Round(float64(dragDx) / float64(segments)))
+	segDragDy := int(math.Round(float64(dragDy) / float64(segments)))
+	segDragDx = int(math.Ceil(math.Abs(float64(segDragDx)))) * int(math.Copysign(1, float64(segDragDx)))
+	segDragDy = int(math.Ceil(math.Abs(float64(segDragDy)))) * int(math.Copysign(1, float64(segDragDy)))
+
+	log.Info().
+		Int("segments", segments).
+		Int("startX", startX).
+		Int("startY", startY).
+		Int("dragDx", dragDx).
+		Int("dragDy", dragDy).
+		Msg("Panning big-map viewport")
+
+	for i := 0; i < segments; i++ {
+		segStartX := startX + i*segDragDx
+		segStartY := startY + i*segDragDy
+		ca.Swipe(0, segStartX, segStartY, segDragDx, segDragDy, 75, 25)
+	}
 	return true
-}
-
-func pickDragStartCorner(left, top, right, bottom int, rawDragDx, rawDragDy float64) (int, int) {
-	minX := left
-	maxX := right - 1
-	minY := top
-	maxY := bottom - 1
-
-	startX := minX
-	if rawDragDx < 0 {
-		startX = maxX
-	}
-
-	startY := minY
-	if rawDragDy < 0 {
-		startY = maxY
-	}
-
-	return startX, startY
 }

--- a/agent/go-service/map-tracker/big_map_pick.go
+++ b/agent/go-service/map-tracker/big_map_pick.go
@@ -361,6 +361,7 @@ func doDragViewport(ca control.ControlAdaptor, viewport *mt.BigMapViewport, delt
 	rawDragDx := -deltaInViewX * panFactor
 	rawDragDy := -deltaInViewY * panFactor
 
+	// Calculate start and end points of the full drag
 	minX, minY, maxX, maxY := viewport.GetIntegerRect()
 
 	pickDragStartCorner := func(rawDragDx, rawDragDy float64) (int, int) {
@@ -394,12 +395,13 @@ func doDragViewport(ca control.ControlAdaptor, viewport *mt.BigMapViewport, delt
 		return false
 	}
 
+	// Calculate and perform segmented drags
 	segments = max(1, segments)
 
-	segDragDx := int(math.Round(float64(dragDx) / float64(segments)))
-	segDragDy := int(math.Round(float64(dragDy) / float64(segments)))
-	segDragDx = int(math.Ceil(math.Abs(float64(segDragDx)))) * int(math.Copysign(1, float64(segDragDx)))
-	segDragDy = int(math.Ceil(math.Abs(float64(segDragDy)))) * int(math.Copysign(1, float64(segDragDy)))
+	baseSegDx := dragDx / segments
+	baseSegDy := dragDy / segments
+	remainDx := dragDx - baseSegDx*segments
+	remainDy := dragDy - baseSegDy*segments
 
 	log.Info().
 		Int("segments", segments).
@@ -409,10 +411,22 @@ func doDragViewport(ca control.ControlAdaptor, viewport *mt.BigMapViewport, delt
 		Int("dragDy", dragDy).
 		Msg("Panning big-map viewport")
 
+	curX, curY := startX, startY
 	for i := 0; i < segments; i++ {
-		segStartX := startX + i*segDragDx
-		segStartY := startY + i*segDragDy
-		ca.Swipe(0, segStartX, segStartY, segDragDx, segDragDy, 75, 25)
+		segDx, segDy := baseSegDx, baseSegDy
+		if i == segments-1 {
+			segDx += remainDx
+			segDy += remainDy
+		}
+
+		if segDx == 0 && segDy == 0 {
+			continue
+		}
+
+		ca.Swipe(0, curX, curY, segDx, segDy, 75, 25)
+		curX += segDx
+		curY += segDy
 	}
+
 	return true
 }

--- a/agent/go-service/map-tracker/internal/big_map_viewport.go
+++ b/agent/go-service/map-tracker/internal/big_map_viewport.go
@@ -34,6 +34,15 @@ func NewBigMapViewport(originMapX, originMapY, scale float64) *BigMapViewport {
 	}
 }
 
+// GetIntegerRect returns the viewport bounds as integers, suitable for pixel-based operations.
+func (bmv *BigMapViewport) GetIntegerRect() (left int, top int, right int, bottom int) {
+	left = int(math.Round(bmv.Left))
+	top = int(math.Round(bmv.Top))
+	right = int(math.Round(bmv.Right))
+	bottom = int(math.Round(bmv.Bottom))
+	return left, top, right, bottom
+}
+
 // GetScreenCoordOf converts map coordinates to screen coordinates based on the current viewport.
 func (bmv *BigMapViewport) GetScreenCoordOf(mapX, mapY float64) (float64, float64) {
 	viewX := bmv.Left + (mapX-bmv.OriginMapX)*bmv.Scale


### PR DESCRIPTION
## 概述

此 PR 修复了由于终末地本身的 Bug 导致的大地图无效拖动。

## 关联

详情参见 #2281。

Fix #2281

## Summary by Sourcery

通过引入分段滑动和视口辅助工具，提高大地图平移的可靠性。

Bug Fixes:
- 通过调整滑动行为，修复在某些游戏内地图状态下大地图拖动操作被忽略的问题。

Enhancements:
- 在平移大地图时引入随机化的分段拖动手势，以更好地匹配预期的输入行为。
- 在 `BigMapViewport` 上添加一个辅助工具，用于暴露整数型视口边界，以便进行像素级精确操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve big map panning reliability by introducing segmented swipes and viewport helpers.

Bug Fixes:
- Fix big map drag operations being ignored in certain in-game map states by adjusting swipe behavior.

Enhancements:
- Introduce randomized segmented drag gestures when panning the big map to better match expected input behavior.
- Add a helper on BigMapViewport to expose integer viewport bounds for pixel-precise operations.

</details>