### PR TITLE
fix: 修复升级武器筛选流程无限循环

### DIFF
--- a/assets/resource/pipeline/Weapon.json
+++ b/assets/resource/pipeline/Weapon.json
@@ -2,6 +2,18 @@
     "WeaponUpgradeStart": {
         "desc": "升级武器任务入口",
         "pre_delay": 0,
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "ClearHitCount",
+                "custom_action_param": {
+                    "nodes": [
+                        "WeaponUpgradeSwitchLowLevel",
+                        "WeaponUpgradeSwitchAscending"
+                    ]
+                }
+            }
+        },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -181,6 +193,7 @@
     },
     "WeaponUpgradeSwitchLowLevel": {
         "desc": "识别品质，切换到等级分类",
+        "max_hit": 5,
         "recognition": {
             "type": "OCR",
             "param": {
@@ -201,6 +214,15 @@
         "action": {
             "type": "Click"
         },
+        "post_wait_freezes": {
+            "time": 500,
+            "target": [
+                0,
+                -200,
+                400,
+                200
+            ]
+        },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -208,7 +230,7 @@
         ]
     },
     "WeaponUpgradeClickLevelSort": {
-        "desc": "识别武器等级",
+        "desc": "在下拉菜单中识别武器等级并选择",
         "recognition": {
             "type": "OCR",
             "param": {
@@ -226,13 +248,21 @@
                 ]
             }
         },
-        "pre_wait_freezes": 100,
+        "pre_wait_freezes": {
+            "time": 300,
+            "target": [
+                16,
+                561,
+                375,
+                133
+            ]
+        },
         "pre_delay": 0,
         "action": {
             "type": "Click"
         },
         "post_wait_freezes": {
-            "time": 100,
+            "time": 300,
             "target": [
                 0,
                 -300,
@@ -245,6 +275,7 @@
     },
     "WeaponUpgradeSwitchAscending": {
         "desc": "识别到降序，变成升序",
+        "max_hit": 5,
         "recognition": {
             "type": "OCR",
             "param": {


### PR DESCRIPTION
## 问题

`📅日常奖励领取` 的 `升级武器` 子任务在武器筛选界面无限循环，持续约 40 分钟直到用户手动停止。

close #2312

## 根因

`WeaponUpgradeSwitchLowLevel` 点击"品质"打开排序下拉菜单后，`WeaponUpgradeClickLevelSort` 立即对同一 ROI 做 OCR，但此时下拉菜单动画尚未完成，"武器等级"文本不可见。识别失败后 JumpBack 回到 `WeaponUpgradeSetFilter`，"品质"标签仍然可见，循环再次触发。

日志中此循环执行了 **4416 次**，`WeaponUpgradeSelectLowLevelWeapons` **0 次**被触发。

## 修复方式

- `WeaponUpgradeSwitchLowLevel`：添加 `post_wait_freezes`（500ms）等待下拉菜单动画完成
- `WeaponUpgradeClickLevelSort`：增强 `pre_wait_freezes`（100ms → 300ms，带目标区域检测）确保下拉菜单渲染稳定后再扫描
- `WeaponUpgradeSwitchLowLevel` / `WeaponUpgradeSwitchAscending`：添加 `max_hit: 5` 作为安全兜底
- `WeaponUpgradeStart`：添加 `ClearHitCount` 在每次进入时重置筛选节点的命中计数器

## Summary by Sourcery

通过稳定下拉菜单交互并为过滤步骤添加安全限制，防止武器升级过滤管线中出现无限循环。

Bug Fixes:
- 修复在每日奖励流程中执行武器升级子任务时，由于下拉菜单 OCR 识别不稳定而导致的无限循环问题。

Enhancements:
- 为武器升级过滤节点添加等待逻辑和点击次数（命中计数）保护措施，以确保可靠的下拉菜单检测并防止无限重试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent infinite looping in the weapon upgrade filter pipeline by stabilizing the dropdown interaction and adding safety limits to filter steps.

Bug Fixes:
- Resolve an infinite loop when performing the weapon upgrade subtask in the daily rewards flow due to unstable dropdown OCR recognition.

Enhancements:
- Add waits and hit-count safeguards to weapon upgrade filter nodes to ensure reliable dropdown detection and prevent runaway retries.

</details>