### PR TITLE
fix(AutoSkip): 修复只有Esc按钮的剧情场景无法跳过，调整节点优先级

### DIFF
--- a/assets/resource/pipeline/RealTimeTask/AutoSkip.json
+++ b/assets/resource/pipeline/RealTimeTask/AutoSkip.json
@@ -43,6 +43,18 @@
                         "threshold": 0.7 // 图片alpha值较低，难以匹配，阈值不能太高
                     }
                 ]
+            },
+            {
+                // 匹配右上角Esc图标（部分剧情只有Esc没有Auto）
+                "recognition": "TemplateMatch",
+                "roi": [
+                    1140,
+                    0,
+                    120,
+                    90
+                ],
+                "template": "RealTimeTask/AutoSkipEsc.png",
+                "threshold": 0.7
             }
         ],
         "pre_delay": 0,
@@ -59,26 +71,42 @@
         "pre_delay": 200,
         "post_delay": 0,
         "next": [
-            "RealTimeAutoSkipAll",
             "RealTimeAutoSkipChoose",
             "RealTimeAutoSkipNext",
+            "RealTimeAutoSkipAll",
             "RealTimeAutoSkipExit",
             "RealTimeAutoSkipEntry"
         ]
     },
     "RealTimeAutoSkipExit": {
-        "desc": "auto图标消失，退出剧情",
-        // 找右上角退出按钮
-        "recognition": "TemplateMatch",
-        "roi": [
-            1140,
-            0,
-            120,
-            90
+        "desc": "Auto和Esc图标均消失，退出剧情",
+        "recognition": "And",
+        "all_of": [
+            {
+                "recognition": "TemplateMatch",
+                "roi": [
+                    1140,
+                    0,
+                    120,
+                    90
+                ],
+                "template": "RealTimeTask/AutoSkipA.png",
+                "threshold": 0.7,
+                "inverse": true
+            },
+            {
+                "recognition": "TemplateMatch",
+                "roi": [
+                    1140,
+                    0,
+                    120,
+                    90
+                ],
+                "template": "RealTimeTask/AutoSkipEsc.png",
+                "threshold": 0.7,
+                "inverse": true
+            }
         ],
-        "template": "RealTimeTask/AutoSkipA.png",
-        "threshold": 0.7,
-        "inverse": true,
         "pre_delay": 0,
         "post_delay": 0,
         "focus": {


### PR DESCRIPTION
- 入口识别新增单独匹配 AutoSkipEsc.png，兼容只有Esc没有Auto的剧情
- 退出检测改为 Auto 和 Esc 均消失才判定退出
- 部分场景的选项存在“确认进入”的设计，将选项检测和下一步检测优先级提到跳过之前，避免同时存在时误跳过

fix #2316

## 由 Sourcery 提供的摘要

调整 AutoSkip 实时任务逻辑，以正确处理仅有 Esc 按钮的剧情场景，并优化与跳过相关的检测优先级。

错误修复：
- 允许在仅显示 Esc 按钮而没有 Auto 按钮的剧情场景中使用自动跳过。
- 防止在 Auto 和 Esc 指示仍存在时提前退出自动跳过。
- 当确认框或选项选择提示与跳过提示同时存在时，通过提高选项和下一步检测的优先级，避免出现意外跳过。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust AutoSkip real-time task logic to correctly handle story scenes with only an Esc button and refine skip-related detection priorities.

Bug Fixes:
- Allow auto-skip to work in story scenes that expose only an Esc button without an Auto button.
- Prevent premature exit from auto-skip until both Auto and Esc indicators have disappeared.
- Avoid unintended skipping when confirmation or option-selection prompts coexist with skip cues by prioritizing option and next-step detection.

</details>