### PR TITLE
fix(Baker): 修复会话列表筛选刷新方式适配 1.2 版本

### DIFF
--- a/assets/resource/pipeline/BAKER.json
+++ b/assets/resource/pipeline/BAKER.json
@@ -143,7 +143,7 @@
         ]
     },
     "BakerRefreshFilter": {
-        "desc": "刷新 Baker 联系人的循环流程, 点击筛选框之后直接点击保存可以省一步",
+        "desc": "刷新 Baker 联系人的循环流程, 打开筛选框后反选未读再重新勾选",
         "recognition": "OCR",
         "roi": [
             17,
@@ -158,7 +158,69 @@
         "action": "Click",
         "post_wait_freezes": 1,
         "next": [
-            "BakerSaveFilter"
+            "BakerDeselectUnread"
+        ]
+    },
+    "BakerDeselectUnread": {
+        "desc": "刷新筛选流程: 反选已选中的未读选项",
+        "recognition": "OCR",
+        "roi": [
+            219,
+            296,
+            153,
+            220
+        ],
+        "expected": [
+            "未读",
+            "未讀",
+            "(?i)Unread",
+            "未読"
+        ],
+        "action": "Click",
+        "post_wait_freezes": 1,
+        "next": [
+            "BakerSaveFilterRefresh"
+        ]
+    },
+    "BakerSaveFilterRefresh": {
+        "desc": "刷新筛选流程: 保存反选后的筛选(全部显示)",
+        "recognition": "OCR",
+        "roi": [
+            903,
+            448,
+            247,
+            170
+        ],
+        "expected": [
+            "保存",
+            "儲存",
+            "(?i)Save"
+        ],
+        "action": "Click",
+        "post_wait_freezes": 1,
+        "next": [
+            "BakerReopenFilter"
+        ]
+    },
+    "BakerReopenFilter": {
+        "desc": "刷新筛选流程: 重新打开筛选列表以重新选择未读",
+        "recognition": "OCR",
+        "roi": [
+            17,
+            603,
+            190,
+            103
+        ],
+        "expected": [
+            "全部显示",
+            "全部顯示",
+            "(?i)Show\\s*All",
+            "すべて"
+        ],
+        "action": "Click",
+        "post_wait_freezes": 1,
+        "next": [
+            "BakerFilterUnread"
         ]
     },
     "BakerResetFilter": {

--- a/assets/resource_adb/pipeline/BAKER.json
+++ b/assets/resource_adb/pipeline/BAKER.json
@@ -70,6 +70,27 @@
             "BakerSaveFilter"
         ]
     },
+    "BakerDeselectUnread": {
+        "desc": "刷新筛选流程: 反选已选中的未读选项",
+        "recognition": "OCR",
+        "roi": [
+            97,
+            287,
+            379,
+            270
+        ],
+        "expected": [
+            "未读",
+            "未讀",
+            "(?i)Unread",
+            "未読"
+        ],
+        "action": "Click",
+        "post_wait_freezes": 1,
+        "next": [
+            "BakerSaveFilterRefresh"
+        ]
+    },
     "BakerExpend": {
         "desc": "会话信息流程: 检测 Baker 联系人是否可以下拉,展开选项之后进行后续点击流程",
         "recognition": "TemplateMatch",


### PR DESCRIPTION
游戏新版本更新后，直接点击筛选保存无法刷新会话列表。
改为反选未读→保存(全部显示)→重新勾选未读→保存的方式刷新。

## Summary by Sourcery

错误修复：
- 通过更新 Baker 流水线配置中未读筛选器切换的顺序，修复了在保存筛选条件时会话列表不刷新的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix session list not refreshing when saving filters by updating the unread filter toggling sequence in the Baker pipeline configuration.

</details>