### PR TITLE
fix(AutoStockpile): 改用false返回结束，避免影响后续任务

### DIFF
--- a/agent/go-service/autostockpile/selector.go
+++ b/agent/go-service/autostockpile/selector.go
@@ -340,13 +340,6 @@ func stopTaskWithFocus(ctx *maa.Context, reason AbortReason, err error) bool {
 	maafocus.Print(ctx, i18n.RenderHTML("autostockpile.fatal_error", map[string]any{
 		"Reason": reasonText,
 	}))
-	if ctx == nil || ctx.GetTasker() == nil {
-		log.Error().
-			Str("component", "autostockpile").
-			Str("abort_reason", string(reason)).
-			Msg("tasker is unavailable for fatal stop")
-		return false
-	}
 	return false
 }
 

--- a/agent/go-service/autostockpile/selector.go
+++ b/agent/go-service/autostockpile/selector.go
@@ -347,8 +347,6 @@ func stopTaskWithFocus(ctx *maa.Context, reason AbortReason, err error) bool {
 			Msg("tasker is unavailable for fatal stop")
 		return false
 	}
-	// TODO 由于SubTask中的子Task错误时不能全部停止，此处使用PostStop强制停止，代价是会抛出一部分报错
-	ctx.GetTasker().PostStop()
 	return false
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 防止在停止具有焦点的任务时强制调用 PostStop，以避免对后续任务产生意外的副作用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent forced PostStop invocation when stopping tasks with focus to avoid unintended side effects on subsequent tasks.

</details>