### PR TITLE
feat(MapNavigator): 支持后台寻路

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.cpp
+++ b/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include <MaaUtils/Logger.h>
 
@@ -19,6 +20,21 @@ constexpr int32_t kDesktopDefaultHoverAnchorY = kDesktopReferenceFrameHeight / 2
 constexpr int32_t kDesktopHoverTouchContactId = 0;
 constexpr int32_t kDesktopPrimaryTouchContactId = 1;
 constexpr int32_t kDesktopDefaultTouchPressure = 0;
+
+bool TrySetMouseLockFollow(MaaController* ctrl, bool enabled)
+{
+    return ctrl != nullptr && MaaControllerSetOption(ctrl, MaaCtrlOption_MouseLockFollow, &enabled, sizeof(enabled));
+}
+
+bool TrySetBackgroundManagedKeys(MaaController* ctrl, const std::vector<int32_t>& keycodes)
+{
+    return ctrl != nullptr
+           && MaaControllerSetOption(
+               ctrl,
+               MaaCtrlOption_BackgroundManagedKeys,
+               keycodes.empty() ? nullptr : const_cast<int32_t*>(keycodes.data()),
+               static_cast<MaaOptionValueSize>(sizeof(int32_t) * keycodes.size()));
+}
 
 double ComputeDefaultTurnUnitsPerDegree(MaaController* ctrl, const std::string& backend_name)
 {
@@ -62,6 +78,27 @@ DesktopInputBackend::DesktopInputBackend(
 {
     if (ctrl_ == nullptr) {
         unsupported_reason_ = "controller handle is null";
+        return;
+    }
+
+    mouse_lock_follow_enabled_ = TrySetMouseLockFollow(ctrl_, true);
+    LogInfo << backend_name_ << " backend mouse lock follow." << VAR(controller_type_) << VAR(mouse_lock_follow_enabled_);
+
+    const std::vector<int32_t> managed_keys {
+        key_codes_.move_forward, key_codes_.move_left, key_codes_.move_backward, key_codes_.move_right,
+        key_codes_.interact,     key_codes_.jump,
+    };
+    background_managed_keys_enabled_ = TrySetBackgroundManagedKeys(ctrl_, managed_keys);
+    LogInfo << backend_name_ << " backend background managed keys." << VAR(controller_type_) << VAR(background_managed_keys_enabled_);
+}
+
+DesktopInputBackend::~DesktopInputBackend()
+{
+    if (mouse_lock_follow_enabled_ && !TrySetMouseLockFollow(ctrl_, false)) {
+        LogWarn << backend_name_ << " backend: failed to disable mouse lock follow." << VAR(controller_type_);
+    }
+    if (background_managed_keys_enabled_ && !TrySetBackgroundManagedKeys(ctrl_, {})) {
+        LogWarn << backend_name_ << " backend: failed to clear background managed keys." << VAR(controller_type_);
     }
 }
 

--- a/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.h
+++ b/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.h
@@ -22,6 +22,7 @@ class DesktopInputBackend : public IInputBackend
 {
 public:
     DesktopInputBackend(MaaController* ctrl, std::string controller_type, std::string backend_name, DesktopKeyCodes key_codes);
+    ~DesktopInputBackend() override;
 
     MaaController* GetCtrl() const override;
     const std::string& controller_type() const override;
@@ -61,6 +62,8 @@ private:
     std::string unsupported_reason_;
     DesktopKeyCodes key_codes_ {};
     double default_turn_units_per_degree_ = 0.0;
+    bool mouse_lock_follow_enabled_ = false;
+    bool background_managed_keys_enabled_ = false;
     int hover_x_ = 0;
     int hover_y_ = 0;
     bool hover_inited_ = false;

--- a/agent/cpp-algo/source/MapNavigator/Backend/WlRoots/wlroots_input_backend.cpp
+++ b/agent/cpp-algo/source/MapNavigator/Backend/WlRoots/wlroots_input_backend.cpp
@@ -35,8 +35,6 @@ public:
 
     void TriggerSprintSync() override
     {
-        // 准则：wlroots 在 3D 界面下不发送绝对坐标。
-        // 混用相对移动和绝对坐标会导致视角跳变
         MaaControllerWait(GetCtrl(), MaaControllerPostKeyDown(GetCtrl(), kVkShift));
         SleepIfNeeded(kActionSprintPressMs);
         MaaControllerWait(GetCtrl(), MaaControllerPostKeyUp(GetCtrl(), kVkShift));


### PR DESCRIPTION
利用上游 MaaXYZ/MaaFramework#1231 及 MaaXYZ/MaaFramework#1232 引入的 `MaaCtrlOption_MouseLockFollow` `MaaCtrlOption_BackgroundManagedKeys` 让寻路模块在「电脑端-默认 / 电脑端-后台」控制器下也能正常生效

Draft：等待上游发版

## Summary by Sourcery

通过配置控制器鼠标锁定和托管按键选项，并在关闭时进行清理，使桌面版 MapNavigator 能够在后台控制模式下正常工作。

New Features:
- 为桌面版 MapNavigator 后端配置“鼠标锁定跟随”和“后台托管移动按键”，从而使其能够在默认和后台桌面控制器下正常运行。

Enhancements:
- 在桌面输入后端中，为控制器鼠标锁定和后台托管按键选项添加生命周期管理，包括日志记录以及在销毁时进行清理。
- 从 wlroots 输入后端的冲刺触发实现中移除过时的内联注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable desktop MapNavigator to work correctly with background control modes by configuring controller mouse-lock and managed-key options and cleaning them up on shutdown.

New Features:
- Configure mouse lock follow and background-managed movement keys for the desktop MapNavigator backend so it functions under default and background desktop controllers.

Enhancements:
- Add lifecycle management for controller mouse-lock and background-managed key options in the desktop input backend, including logging and cleanup on destruction.
- Remove outdated inline comments from the wlroots input backend sprint trigger implementation.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过配置控制器鼠标锁定和托管按键选项，并在关闭时进行清理，使桌面版 MapNavigator 能够在后台控制模式下正常工作。

New Features:
- 为桌面版 MapNavigator 后端配置“鼠标锁定跟随”和“后台托管移动按键”，从而使其能够在默认和后台桌面控制器下正常运行。

Enhancements:
- 在桌面输入后端中，为控制器鼠标锁定和后台托管按键选项添加生命周期管理，包括日志记录以及在销毁时进行清理。
- 从 wlroots 输入后端的冲刺触发实现中移除过时的内联注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable desktop MapNavigator to work correctly with background control modes by configuring controller mouse-lock and managed-key options and cleaning them up on shutdown.

New Features:
- Configure mouse lock follow and background-managed movement keys for the desktop MapNavigator backend so it functions under default and background desktop controllers.

Enhancements:
- Add lifecycle management for controller mouse-lock and background-managed key options in the desktop input backend, including logging and cleanup on destruction.
- Remove outdated inline comments from the wlroots input backend sprint trigger implementation.

</details>

</details>