### PR TITLE
fix(go-service): 新增 KillProcess action，修复游戏关闭后结束自身时序问题

### DIFF
--- a/agent/go-service/common/killproc/action.go
+++ b/agent/go-service/common/killproc/action.go
@@ -1,0 +1,122 @@
+package killproc
+
+import (
+	"encoding/json"
+	"time"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+// Compile-time interface check
+var _ maa.CustomActionRunner = &KillProcAction{}
+
+type killProcParam struct {
+	// ProcessName 是要结束的进程名称（如 "Endfield.exe"），为空时不杀进程。
+	ProcessName string `json:"process_name"`
+	// PostStop 若为 true，则在动作成功返回后向 Tasker 发送异步停止信号。
+	// 这是针对 MXU __MXU_KILLPROC__ kill_self=true 时序 bug 的 MaaEnd 侧绕过方案：
+	// MXU 的实现在自定义动作回调内同步调用 MaaTaskerPostStop，导致动作结果来不及
+	// 提交，出现 PipelineTask bad next / completed=false。
+	// 本实现先返回 true，再在 goroutine 中延迟调用 PostStop，避免该竞态。
+	PostStop bool `json:"post_stop"`
+}
+
+// KillProcAction 结束指定进程，并可选地在动作返回后向 Tasker 发送停止信号。
+// 注册名称：KillProcess
+// 参数示例：
+//
+//	{"process_name": "Endfield.exe", "post_stop": true}
+//	{"process_name": "Endfield.exe"}   // 仅杀进程，不停止 Tasker
+//	{"post_stop": true}               // 仅停止 Tasker，不杀进程
+type KillProcAction struct{}
+
+// Run kills the specified process and optionally posts a stop signal to the tasker.
+func (a *KillProcAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	if arg == nil {
+		log.Error().Msg("KillProcess got nil custom action arg")
+		return false
+	}
+
+	var params killProcParam
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+		log.Error().
+			Err(err).
+			Str("param", arg.CustomActionParam).
+			Msg("KillProcess failed to parse custom_action_param")
+		return false
+	}
+
+	if params.ProcessName == "" && !params.PostStop {
+		log.Error().Msg("KillProcess requires at least one of: process_name, post_stop")
+		return false
+	}
+
+	// 先同步结束进程
+	if params.ProcessName != "" {
+		if !killByName(params.ProcessName) {
+			return false
+		}
+	}
+
+	// 在动作返回后异步请求 Tasker 停止，避免在回调栈内调用 PostStop 导致
+	// 动作结果无法提交（MXU kill_self 时序 bug 的根因）。
+	if params.PostStop {
+		tasker := ctx.GetTasker()
+		go func() {
+			// 短暂延迟，确保本次动作的返回值已被 MaaFramework 提交
+			time.Sleep(300 * time.Millisecond)
+			log.Info().Msg("KillProcess: posting tasker stop signal")
+			tasker.PostStop()
+		}()
+	}
+
+	return true
+}
+
+// killByName kills all processes whose name exactly matches the given string.
+// Returns true if at least one process was killed, or if no matching process was found
+// (idempotent: process already gone is treated as success).
+// Returns false only on enumeration or kill errors.
+func killByName(name string) bool {
+	procs, err := process.Processes()
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("process", name).
+			Msg("KillProcess failed to enumerate processes")
+		return false
+	}
+
+	killedAny := false
+	for _, p := range procs {
+		pName, err := p.Name()
+		if err != nil {
+			continue
+		}
+		if pName != name {
+			continue
+		}
+		if err := p.Kill(); err != nil {
+			log.Error().
+				Err(err).
+				Str("process", name).
+				Int32("pid", p.Pid).
+				Msg("KillProcess failed to kill process")
+			return false
+		}
+		log.Info().
+			Str("process", name).
+			Int32("pid", p.Pid).
+			Msg("KillProcess killed process")
+		killedAny = true
+	}
+
+	if !killedAny {
+		log.Warn().
+			Str("process", name).
+			Msg("KillProcess: process not found (already gone), treating as success")
+	}
+	return true
+}

--- a/agent/go-service/common/killproc/register.go
+++ b/agent/go-service/common/killproc/register.go
@@ -1,0 +1,8 @@
+package killproc
+
+import maa "github.com/MaaXYZ/maa-framework-go/v4"
+
+// Register registers the KillProcess custom action.
+func Register() {
+	maa.AgentServerRegisterCustomAction("KillProcess", &KillProcAction{})
+}

--- a/agent/go-service/register.go
+++ b/agent/go-service/register.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/charactercontroller"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/clearhitcount"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/expressionrecognition"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/killproc"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/pipelineoverride"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/subtask"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/dailyrewards"
@@ -49,6 +50,7 @@ func registerAll() {
 	attachregex.Register()
 	autoaltclick.Register()
 	charactercontroller.Register()
+	killproc.Register()
 
 	// Business Custom
 	autosell.Register()


### PR DESCRIPTION
#2355
在"全套日常"任务链末尾，先结束 Endfield.exe，再触发"结束自身"时，
MXU 的 __MXU_KILLPROC__ kill_self=true 实现在自定义动作回调内同步调用 MaaTaskerPostStop，导致动作结果来不及提交，约 20 秒后出现
PipelineTask bad next / completed=false，任务失败。

解决方案（MaaEnd 侧绕过）：
新增 common/killproc 包，注册自定义 Action "KillProcess"。
当 post_stop=true 时，先返回 true，再在独立 goroutine 中延迟
300ms 调用 tasker.PostStop()，避免在回调栈内触发竞态。

用法示例（Pipeline）：
  "custom_action": "KillProcess"
  "custom_action_param": {"process_name": "Endfield.exe", "post_stop": true}

## Summary by Sourcery

添加自定义的 KillProcess 动作，用于安全地终止 Endfield 游戏进程，然后异步停止 tasker，从而避免在游戏退出后 Maa 自行结束时出现的时序问题。

新功能：
- 引入自定义动作 KillProcess，可终止指定进程，并可选地在完成后请求 tasker 停止。

缺陷修复：
- 通过在单独的 goroutine 中延后发送停止信号，避免在 KillProcess 自定义动作中同步调用 tasker 停止导致任务失败的问题。

增强：
- 在 agent 服务中注册新的 KillProcess 自定义动作，使其可用于流水线配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a custom KillProcess action to safely terminate the Endfield game process and then asynchronously stop the tasker to avoid timing issues when Maa ends itself after the game exits.

New Features:
- Introduce a KillProcess custom action that can terminate a specified process and optionally request the tasker to stop after completion.

Bug Fixes:
- Prevent task failure caused by synchronous tasker stop calls during the KillProcess custom action by deferring the stop signal in a separate goroutine.

Enhancements:
- Register the new KillProcess custom action in the agent service so it is available for pipeline configurations.

</details>