### PR TITLE
fix: 修复月卡登录死循环

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneLogin.json
+++ b/assets/resource/pipeline/SceneManager/SceneLogin.json
@@ -96,44 +96,99 @@
             "type": "Click"
         }
     },
-    "__ScenePrivateLoginMonthlyPassConfirm": {
-        "desc": "领取月卡，无法跳过必须领取",
+    "__ScenePrivateLoginMonthlyPassTitle": {
+        "desc": "登录月卡弹窗：标题区 OCR，用于与领取区分组合识别（点击框使用领取区）",
         "recognition": {
             "type": "OCR",
             "param": {
                 "roi": [
-                    400,
-                    180,
-                    500,
-                    362
+                    360,
+                    150,
+                    560,
+                    220
                 ],
                 "expected": [
+                    "今日焕新月卡奖励",
+                    "今日煥新月卡獎勵",
+                    "今日月卡奖励",
+                    "今日月卡獎勵",
+                    "(?i)Daily\\s*Monthly\\s*Pass\\s*Rewards",
+                    "(?i)Daily\\s*Renewed\\s*Monthly\\s*Pass\\s*Rewards",
                     "月卡剩余天数",
                     "月卡剩餘天數",
                     "(?i)Monthly\\s*Pass\\s*Day\\s*\\(\\s*s\\s*\\)\\s*Left",
                     "月パス残り",
-                    "今日月卡奖励",
-                    "今日月卡獎勵",
-                    "(?i)Daily\\s*Monthly\\s*Pass\\s*Rewards",
                     "本日報酬",
                     "月卡奖励$",
                     "月卡獎勵$"
                 ]
             }
         },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "__ScenePrivateLoginMonthlyPassClaimLine": {
+        "desc": "登录月卡弹窗：「点击领取」一行，点击目标取此识别框（避免点在标题文本框中心）",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    280,
+                    400,
+                    720,
+                    240
+                ],
+                "expected": [
+                    "点击领取今日焕新月卡奖励",
+                    "點擊領取今日煥新月卡獎勵",
+                    "点击领取",
+                    "點擊領取",
+                    "领取",
+                    "領取",
+                    "(?i)Tap\\s*to\\s*[Cc]laim",
+                    "(?i)[Cc]laim",
+                    "タップして受け取る",
+                    "本日の報酬を受け取る"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "__ScenePrivateLoginMonthlyPassConfirm": {
+        "desc": "领取月卡：标题+领取行同时命中后才点击（点击框为领取行，识别→点击→由父节点 next 再验）",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "__ScenePrivateLoginMonthlyPassTitle",
+                    "__ScenePrivateLoginMonthlyPassClaimLine"
+                ],
+                "box_index": 1
+            }
+        },
         "pre_delay": 1000, // 3d移动，pre_wait_freeze不生效
         "action": {
             "type": "Click"
-        }
+        },
+        "post_delay": 0,
+        "rate_limit": 0
     },
     "__ScenePrivateLoginCloseDialog": {
-        "desc": "关闭所有待领取的弹窗，此功能目的是进入游戏，奖励领取统一在单独任务中处理",
+        "desc": "兜底按 ESC 关闭阻塞弹窗；有 max_hit 上限，避免月卡等节点未命中时无限 ESC",
+        "max_hit": 8,
+        "recognition": "DirectHit",
+        "pre_delay": 0,
         "action": {
             "type": "ClickKey",
             "param": {
                 "key": 27 // ESC
             }
-        }
+        },
+        "post_delay": 0,
+        "rate_limit": 0
     },
     "__ScenePrivateLoginSuccess": {
         "desc": "进入大世界成功",

--- a/assets/resource/pipeline/VisitFriends/Exectue.json
+++ b/assets/resource/pipeline/VisitFriends/Exectue.json
@@ -459,7 +459,7 @@
         ]
     },
     "VisitFriendsMenuTerminalExitToWorldShip": {
-        "desc": "从好友菜单返回世界界面",
+        "desc": "从好友菜单返回世界界面；点击后先尝试进入世界船，若仍在访客终端则自循环重试（缓解 ADB 等场景下点击未生效）",
         "recognition": "And",
         "all_of": [
             {
@@ -485,9 +485,19 @@
         "pre_wait_freezes": 400,
         "pre_delay": 0,
         "action": "Click",
+        "post_wait_freezes": {
+            "time": 350,
+            "target": [
+                0,
+                0,
+                0,
+                0
+            ]
+        },
         "post_delay": 0,
         "next": [
-            "VisitFriendsWorldShipExitToMenuFriends"
+            "VisitFriendsWorldShipExitToMenuFriends",
+            "VisitFriendsMenuTerminalExitToWorldShip"
         ]
     },
     "VisitFriendsWorldShipExitToMenuFriends": {


### PR DESCRIPTION
## Summary

- **月卡登录死循环** (#2353, #2350)：原 `__ScenePrivateLoginMonthlyPassConfirm` OCR 命中标题后点击落在标题区域而非「点击领取」按钮，且 `__ScenePrivateLoginCloseDialog` 无条件 DirectHit+ESC 无上限，形成 4 万+次迭代的死循环
  - 拆为标题区 + 领取行两个子节点，用 And + box_index:1 组合识别，确保点击落在领取行
  - CloseDialog 加 max_hit: 8 上限，阻断无限 ESC 循环

## Test Plan

- [x] 月卡账号登录，验证弹窗正确领取并关闭
- [x] 无月卡账号登录，验证 CloseDialog 在 max_hit 内正常退出

Closes #2353

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

修复登录月卡弹窗处理逻辑，并提高好友拜访退出流程的稳定性。

Bug 修复：
- 通过修正点击目标并限制弹窗关闭尝试次数，解决处理月卡登录弹窗时出现的无限循环问题。
- 通过在退出流程中加入重试机制和稳定性等待，防止在退出好友拜访终端时出现卡死。

功能改进：
- 调整登录场景和“拜访好友”流程，使 UI 自动化流程对短暂的 UI 状态变化更具韧性与容错能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix login monthly pass dialog handling and improve friend visit exit robustness.

Bug Fixes:
- Resolve infinite loop when handling the monthly pass login dialog by correcting click targeting and limiting dialog close attempts.
- Prevent stalls when exiting the friend visit terminal by adding retry behavior and stability waits in the exit pipeline.

Enhancements:
- Adjust login scene and visit-friends pipelines to make UI automation flows more resilient to transient UI states.

</details>