### PR TITLE
feat: 念念家的桃树

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -306,7 +306,7 @@
     },
     "PeachTreeAtBabblesSHomeAdjustCamera": {
         "desc": "念念家的桃树任务中调整朝向",
-        "max_hit": 2,
+        "max_hit": 1,
         "next": [
             "EnvironmentMonitoringSwipeScreenRight"
         ]

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -157,7 +157,8 @@
             "InPeachTreeAtBabblesSHomeMission"
         ],
         "next": [
-            "TrackPeachTreeAtBabblesSHome"
+            "TrackPeachTreeAtBabblesSHome",
+            "GoToPeachTreeAtBabblesSHome"
         ]
     },
     "TrackPeachTreeAtBabblesSHome": {
@@ -169,7 +170,7 @@
         ],
         "action": "Click",
         "next": [
-            "PeachTreeAtBabblesSHomeNotAdapted"
+            "GoToPeachTreeAtBabblesSHome"
         ]
     },
     "PeachTreeAtBabblesSHomeNotAdapted": {
@@ -199,12 +200,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "^map\\d+_lv\\d+$",
+                    "map_name": "map02_lv004_tier_328",
                     "target": [
-                        0,
-                        0,
-                        1,
-                        1
+                        514,
+                        666,
+                        15,
+                        15
                     ]
                 }
             ]
@@ -219,7 +220,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneAnyEnterWorld"
+                "SceneEnterWorldWulingMarkerStone4"
             ]
         },
         "next": [
@@ -234,12 +235,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "^map\\d+_lv\\d+$",
+                    "map_name": "map02_lv004_tier_328",
                     "target": [
-                        0,
-                        0,
-                        1,
-                        1
+                        514,
+                        666,
+                        15,
+                        15
                     ]
                 }
             ]
@@ -254,7 +255,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneAnyEnterWorld"
+                "SceneEnterWorldWulingMarkerStone4"
             ]
         },
         "next": [
@@ -268,12 +269,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "^map\\d+_lv\\d+$",
+                    "map_name": "map02_lv004_tier_328",
                     "target": [
-                        0,
-                        0,
-                        1,
-                        1
+                        514,
+                        666,
+                        15,
+                        15
                     ]
                 }
             ]
@@ -287,11 +288,11 @@
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {
-            "map_name": "^map\\d+_lv\\d+$",
+            "map_name": "map02_lv004_tier_328",
             "path": [
                 [
-                    0,
-                    0
+                    520.3,
+                    672.8
                 ]
             ]
         },
@@ -307,7 +308,7 @@
         "desc": "念念家的桃树任务中调整朝向",
         "max_hit": 2,
         "next": [
-            "EnvironmentMonitoringSwipeScreenUp"
+            "EnvironmentMonitoringSwipeScreenRight"
         ]
     }
 }

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.mjs
@@ -419,11 +419,11 @@ export const ROUTE_CONFIG = [
     {
         Id: "PeachTreeAtBabblesSHome",
         Name: "念念家的桃树",
-        EnterMap: "SceneAnyEnterWorld",
-        MapName: "^map\\d+_lv\\d+$",
-        MapTarget: [0, 0, 1, 1],
-        MapPath: [[0, 0]],
-        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
+        EnterMap: "SceneEnterWorldWulingMarkerStone4",
+        MapName: "map02_lv004_tier_328",
+        MapTarget: [514, 666, 15, 15],
+        MapPath: [[520.3, 672.8]],
+        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenRight",
     },
     {
         Id: "WaterTemperatureController",

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.mjs
@@ -424,6 +424,7 @@ export const ROUTE_CONFIG = [
         MapTarget: [514, 666, 15, 15],
         MapPath: [[520.3, 672.8]],
         CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenRight",
+        CameraMaxHit: 1,
     },
     {
         Id: "WaterTemperatureController",


### PR DESCRIPTION
## Summary by Sourcery

将环境监测路线正确连接到彩虹和念念家的桃树这两个地点对应的五菱传送点。

New Features:
- 为念念家的桃树路线新增具体的地图位置和镜头滑动配置。

Enhancements:
- 将彩虹路线更新为使用特定的栖云窟五菱传送点标记，而不是通用的世界入口。
- 将念念家的桃树路线与彩虹对齐，使用相同的五菱传送点标记和地图层级。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Wire up environment monitoring routes to the correct Wuling teleport point for the Rainbow and念念家的桃树 locations.

New Features:
- Add concrete map location and camera swipe configuration for the 念念家的桃树 route.

Enhancements:
- Update the Rainbow route to use the specific栖云窟 Wuling teleport marker instead of the generic world entry.
- Align 念念家的桃树 route with the same specific Wuling teleport marker and map tier as Rainbow.

</details>

## Summary by Sourcery

增强内容：
- 将“念念家的桃树”路线从通用世界入口切换为精确指向“栖云窟·武陵”的传送点标记，并设置了精确的地图目标、路径和滑动方向。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Switch 念念家的桃树 route from a generic world entry to a specific栖云窟 Wuling teleport marker with precise map target, path, and swipe direction.

</details>