### PR TITLE
fix(maatools): 改用标准 ESM 路径推导并稳定 .mts 类型检查

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="node" />
+
+declare global {
+  interface ImportMeta {
+    readonly dirname: string
+  }
+}
+
+export {}

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,9 +1,0 @@
-/// <reference types="node" />
-
-declare global {
-  interface ImportMeta {
-    readonly dirname: string
-  }
-}
-
-export {}

--- a/maatools.config.mts
+++ b/maatools.config.mts
@@ -1,10 +1,14 @@
 import type { FullConfig } from '@nekosu/maa-tools'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { fetchCases } from './tests/scripts/loader.mts'
 import parserConfig from './tools/parser'
 
+const cwd = dirname(fileURLToPath(import.meta.url))
+
 const config: FullConfig = {
-  cwd: import.meta.dirname,
+  cwd,
 
   maaVersion: 'latest',
   maaStdoutLevel: 'Error',

--- a/maatools.config.mts
+++ b/maatools.config.mts
@@ -4,7 +4,7 @@ import { fetchCases } from './tests/scripts/loader.mts'
 import parserConfig from './tools/parser'
 
 const config: FullConfig = {
-  cwd: (import.meta as ImportMeta & { dirname: string }).dirname,
+  cwd: import.meta.dirname,
 
   maaVersion: 'latest',
   maaStdoutLevel: 'Error',

--- a/maatools.config.mts
+++ b/maatools.config.mts
@@ -4,7 +4,7 @@ import { fetchCases } from './tests/scripts/loader.mts'
 import parserConfig from './tools/parser'
 
 const config: FullConfig = {
-  cwd: import.meta.dirname,
+  cwd: (import.meta as ImportMeta & { dirname: string }).dirname,
 
   maaVersion: 'latest',
   maaStdoutLevel: 'Error',

--- a/tests/scripts/loader.mts
+++ b/tests/scripts/loader.mts
@@ -1,5 +1,6 @@
 import { TestCases } from '@nekosu/maa-tools'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 type MatrixValue = string | string[]
 type Rect = [number, number, number, number]
@@ -125,7 +126,7 @@ export async function fetchCases(): Promise<TestCases[]> {
     // 'PlayCover': '',
   }
 
-  const testsRoot = path.resolve(import.meta.dirname, '..')
+  const testsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
   const [
     allTestCases,
     failPaths,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "allowImportingTsExtensions": true,
+        "noEmit": true,
+        "types": [
+            "node"
+        ],
+        "skipLibCheck": true
+    },
+    "include": [
+        "maatools.config.mts",
+        "tests/scripts/**/*.mts",
+        "global.d.ts"
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     },
     "include": [
         "maatools.config.mts",
-        "tests/scripts/**/*.mts",
-        "global.d.ts"
+        "tests/scripts/**/*.mts"
     ]
 }


### PR DESCRIPTION
## 由 Sourcery 总结

错误修复：
- 修复在 maatools 配置中将 `import.meta.dirname` 赋值给 `cwd` 字段时出现的 TypeScript 类型错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

稳定 maatools 的 ESM 路径处理，并为 `.mts` 配置和测试文件提供 TypeScript 支持。

错误修复：
- 通过改用基于 `import.meta.url` 的标准 ESM 路径解析，修复了在 maatools 配置和测试加载器中错误使用 `import.meta.dirname` 的问题。

增强内容：
- 引入项目级的 `tsconfig.json`，启用 Node 类型定义，并为 `.mts` 配置和测试文件配置 TypeScript。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize maatools ESM path handling and TypeScript support for .mts config and test files.

Bug Fixes:
- Fix incorrect use of import.meta.dirname in maatools config and test loader by switching to standard ESM path resolution based on import.meta.url.

Enhancements:
- Introduce a project-level tsconfig.json enabling Node type definitions and configuring TypeScript for .mts config and test files.

</details>

Bug 修复：
- 解决在 maatools 配置中将 `import.meta.dirname` 赋值给 `cwd` 字段时出现的 TypeScript 类型错误。

改进：
- 新增项目级 `tsconfig.json`，启用 Node 类型定义，并为 `.mts` 配置和测试文件进行相应配置。
- 声明一个全局的 ImportMeta 接口扩展，为基于模块的脚本暴露 `dirname` 属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

稳定 maatools 的 ESM 路径处理，并为 `.mts` 配置和测试文件提供 TypeScript 支持。

错误修复：
- 通过改用基于 `import.meta.url` 的标准 ESM 路径解析，修复了在 maatools 配置和测试加载器中错误使用 `import.meta.dirname` 的问题。

增强内容：
- 引入项目级的 `tsconfig.json`，启用 Node 类型定义，并为 `.mts` 配置和测试文件配置 TypeScript。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize maatools ESM path handling and TypeScript support for .mts config and test files.

Bug Fixes:
- Fix incorrect use of import.meta.dirname in maatools config and test loader by switching to standard ESM path resolution based on import.meta.url.

Enhancements:
- Introduce a project-level tsconfig.json enabling Node type definitions and configuring TypeScript for .mts config and test files.

</details>

</details>

</details>