### PR TITLE
fix(EnvironmentMonitoring): 修正环境监测相关 JSON 文件中的拼写错误

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AnnularWaterfall.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AnnularWaterfall.json
@@ -309,7 +309,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "AnnularWaterfallAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/BambooWaterChimes.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/BambooWaterChimes.json
@@ -309,7 +309,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "BambooWaterChimesAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/CloudrestEcoSite.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/CloudrestEcoSite.json
@@ -296,7 +296,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "CloudrestEcoSiteAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
@@ -341,7 +341,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "FloraObservationPointAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
@@ -377,7 +377,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "HangingVinesAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/MysteriousCryptidGraffiti.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/MysteriousCryptidGraffiti.json
@@ -357,7 +357,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "MysteriousCryptidGraffitiAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -297,7 +297,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "PeachTreeAtBabblesSHomeAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Rainbow.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Rainbow.json
@@ -341,7 +341,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "RainbowAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
@@ -296,7 +296,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "SerenityGardenTianshiPillarAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/TreeOfTheOldCourtyard.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/TreeOfTheOldCourtyard.json
@@ -317,7 +317,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "TreeOfTheOldCourtyardAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WaterTemperatureController.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WaterTemperatureController.json
@@ -349,7 +349,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "WaterTemperatureControllerAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WitheredBranches.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WitheredBranches.json
@@ -301,7 +301,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "WitheredBranchesAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
@@ -361,7 +361,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "AncientTreeAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInTheBlightTide.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInTheBlightTide.json
@@ -337,7 +337,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "BeaconDamagedInTheBlightTideAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
@@ -313,7 +313,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "CisternOriginiumSlugsAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
@@ -297,7 +297,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "CleansingJadeAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
@@ -309,7 +309,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "CollapsedTianshiPillarAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
@@ -341,7 +341,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "EcologyNearTheFieldLogisticsDepotAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -301,7 +301,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "EternalSunsetAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
@@ -325,7 +325,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "IndoorCropsAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
@@ -301,7 +301,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "InflatedAndGlowingBugspittingLankybeastAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
@@ -309,7 +309,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "MiniShellbeastAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
@@ -301,7 +301,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "ObservantSableChestedFowlbeastAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/PierWaterwheel.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/PierWaterwheel.json
@@ -301,7 +301,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "PierWaterwheelAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
@@ -325,7 +325,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "RainbowFinAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
@@ -301,7 +301,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "VigorousCisternOriginiumSlugAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/Waterlamp.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/Waterlamp.json
@@ -297,7 +297,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "WaterlampAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/XiraniteNexus.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/XiraniteNexus.json
@@ -321,7 +321,7 @@
             ]
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
+            "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "XiraniteNexusAdjustCamera"
         },
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
@@ -109,7 +109,7 @@
         ],
         "action": "Click",
         "next": [
-            "[Anchor]EnvironmentMonitoringBactToTerminal"
+            "[Anchor]EnvironmentMonitoringBackToTerminal"
         ]
     },
     "EnvironmentMonitoringShutterButtonHighlighted": {
@@ -143,7 +143,7 @@
         ],
         "action": "Click",
         "next": [
-            "[Anchor]EnvironmentMonitoringBactToTerminal"
+            "[Anchor]EnvironmentMonitoringBackToTerminal"
         ]
     },
     "EnvironmentMonitoringSwipeScreenUp": {

--- a/docs/en_us/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/en_us/developers/tasks/environment-monitoring-maintain.md
@@ -66,19 +66,19 @@ The chain inside each observation-point `{Id}Job` (rendered from `template.jsonc
                            ├─ GoTo{Id}RecheckStartPos     (re-check position after teleport)
                            └─ GoTo{Id}ReEnterMap          (second teleport → FinalCheck)
                                 └─ GoTo{Id}MapTrackerMove
-                                     ├─ anchor: EnvironmentMonitoringBactToTerminal → ${GoToMonitoringTerminal}
+                                     ├─ anchor: EnvironmentMonitoringBackToTerminal → ${GoToMonitoringTerminal}
                                      ├─ anchor: EnvironmentMonitoringAdjustCamera   → ${Id}AdjustCamera
                                      └─ next:   EnvironmentMonitoringTakePhoto
 EnvironmentMonitoringTakePhoto        (enters photo mode → adjusts facing → takes photo)
-  └─ [Anchor]EnvironmentMonitoringBactToTerminal
+  └─ [Anchor]EnvironmentMonitoringBackToTerminal
        └─ EnvironmentMonitoringGoTo{Outskirts|MarkerStone}MonitoringTerminal
 ```
 
 > [!NOTE]
 >
-> The two `anchor` keys are hard-coded placeholder names in the template (`EnvironmentMonitoringBactToTerminal` spelling is intentionally preserved from history—do not correct it). At runtime they are replaced with:
+> The two `anchor` keys are hard-coded placeholder names in the template (`EnvironmentMonitoringBackToTerminal` spelling is intentionally preserved from history—do not correct it). At runtime they are replaced with:
 >
-> - `EnvironmentMonitoringBactToTerminal` → the `EnvironmentMonitoringGoTo{Station}` node for the terminal this observation point belongs to (returns to the correct terminal after shooting)
+> - `EnvironmentMonitoringBackToTerminal` → the `EnvironmentMonitoringGoTo{Station}` node for the terminal this observation point belongs to (returns to the correct terminal after shooting)
 > - `EnvironmentMonitoringAdjustCamera` → `{Id}AdjustCamera` (executes the camera-swipe direction for this observation point)
 
 ## Naming conventions
@@ -192,7 +192,7 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 The three phases "teleport → recheck → pathfind" for each observation point all depend on `agent/go-service/map-tracker/`:
 
 - `MapTrackerAssertLocation` (recognizer): determines whether the current minimap position is within the `MapTarget` rectangle.
-- `MapTrackerMove` (action): walks along `MapPath` to the target, with anchor-rewrite support for `EnvironmentMonitoringBactToTerminal` / `EnvironmentMonitoringAdjustCamera`.
+- `MapTrackerMove` (action): walks along `MapPath` to the target, with anchor-rewrite support for `EnvironmentMonitoringBackToTerminal` / `EnvironmentMonitoringAdjustCamera`.
 
 For detailed parameters and coordinate recording, see [map-tracker.md](../components/map-tracker.md) and [map-navigator.md](../components/map-navigator.md).
 
@@ -299,5 +299,5 @@ Before committing, at minimum verify:
 - **`EnterMap` references a non-existent Scene node**: The generator does not validate this; at runtime the task will loop indefinitely at `GoTo{Id}NotAtStartPos`.
 - **`MapPath` passes through locked areas / combat / interactables**: MapTracker does not handle combat or cutscenes; paths must only traverse freely walkable sections.
 - **New `Station` added but `Locations.json` / `EnvironmentMonitoringLoop.next` not updated**: the new terminal cannot be recognized or entered, so all its observation points are unreachable.
-- **`anchor` placeholder name spelling**: `EnvironmentMonitoringBactToTerminal` is the historical spelling (missing a `k`—intentional, not a bug). It must stay consistent with `[Anchor]EnvironmentMonitoringBactToTerminal` in `TakePhoto.json`. Do not "fix" it to `Back`.
+- **`anchor` placeholder name spelling**: `EnvironmentMonitoringBackToTerminal` is the historical spelling (missing a `k`—intentional, not a bug). It must stay consistent with `[Anchor]EnvironmentMonitoringBackToTerminal` in `TakePhoto.json`. Do not "fix" it to `Back`.
 - **"Passes generation ≠ passes runtime"**: `ROUTE_DEFAULTS` prevents generation-stage errors, but `EnterMap=SceneAnyEnterWorld` + `MapPath=[[0,0]]` will never reach the target at runtime. Before committing, manually verify that no placeholder entries remain in `ROUTE_CONFIG` (entries with `EnterMap` set to `SceneAnyEnterWorld` and no `// TODO:` comment should raise a flag).

--- a/docs/en_us/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/en_us/developers/tasks/environment-monitoring-maintain.md
@@ -76,7 +76,7 @@ EnvironmentMonitoringTakePhoto        (enters photo mode → adjusts facing → 
 
 > [!NOTE]
 >
-> The two `anchor` keys are hard-coded placeholder names in the template (`EnvironmentMonitoringBackToTerminal` spelling is intentionally preserved from history—do not correct it). At runtime they are replaced with:
+> The two `anchor` keys are hard-coded placeholder names in the template. At runtime they are replaced with:
 >
 > - `EnvironmentMonitoringBackToTerminal` → the `EnvironmentMonitoringGoTo{Station}` node for the terminal this observation point belongs to (returns to the correct terminal after shooting)
 > - `EnvironmentMonitoringAdjustCamera` → `{Id}AdjustCamera` (executes the camera-swipe direction for this observation point)
@@ -299,5 +299,5 @@ Before committing, at minimum verify:
 - **`EnterMap` references a non-existent Scene node**: The generator does not validate this; at runtime the task will loop indefinitely at `GoTo{Id}NotAtStartPos`.
 - **`MapPath` passes through locked areas / combat / interactables**: MapTracker does not handle combat or cutscenes; paths must only traverse freely walkable sections.
 - **New `Station` added but `Locations.json` / `EnvironmentMonitoringLoop.next` not updated**: the new terminal cannot be recognized or entered, so all its observation points are unreachable.
-- **`anchor` placeholder name spelling**: `EnvironmentMonitoringBackToTerminal` is the historical spelling (missing a `k`—intentional, not a bug). It must stay consistent with `[Anchor]EnvironmentMonitoringBackToTerminal` in `TakePhoto.json`. Do not "fix" it to `Back`.
+- **`anchor` key name consistency**: The `anchor` key `EnvironmentMonitoringBackToTerminal` in `template.jsonc` must stay exactly consistent with `[Anchor]EnvironmentMonitoringBackToTerminal` in `TakePhoto.json`; a mismatch silently disables the anchor mechanism.
 - **"Passes generation ≠ passes runtime"**: `ROUTE_DEFAULTS` prevents generation-stage errors, but `EnterMap=SceneAnyEnterWorld` + `MapPath=[[0,0]]` will never reach the target at runtime. Before committing, manually verify that no placeholder entries remain in `ROUTE_CONFIG` (entries with `EnterMap` set to `SceneAnyEnterWorld` and no `// TODO:` comment should raise a flag).

--- a/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
@@ -76,7 +76,7 @@ EnvironmentMonitoringTakePhoto       （进入拍照模式 → 朝向 → 拍照
 
 > [!NOTE]
 >
-> `anchor` 字段的两个 key 是模板里硬编码的占位符名（`EnvironmentMonitoringBackToTerminal` 拼写沿用历史，请勿改），运行时被替换为：
+> `anchor` 字段的两个 key 是模板里硬编码的占位符名，运行时被替换为：
 >
 > - `EnvironmentMonitoringBackToTerminal` → 当前观察点所属终端的 `EnvironmentMonitoringGoTo{Station}` 节点（拍完回到正确终端）
 > - `EnvironmentMonitoringAdjustCamera` → `{Id}AdjustCamera`（执行该观察点的摄像头滑动方向）
@@ -299,5 +299,5 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 - **`EnterMap` 写了不存在的 Scene 节点**：生成器不校验，运行时会卡在 `GoTo{Id}NotAtStartPos` 死循环。
 - **`MapPath` 经过未解锁区域 / 战斗 / 互动物**：MapTracker 不处理战斗与剧情，路径只能选纯通行段。
 - **`Station` 新增但 `Locations.json` / `EnvironmentMonitoringLoop.next` 没同步**：新终端无法被识别进入，所有观察点都跑不到。
-- **`anchor` 占位符名拼写**：`EnvironmentMonitoringBackToTerminal` 是历史拼写（少了一个 `k` 不影响功能），与模板和 `TakePhoto.json` 中的 `[Anchor]EnvironmentMonitoringBackToTerminal` 必须保持一致。不要好心改成 `Back`。
+- **`anchor` 占位符名一致性**：`template.jsonc` 中 `anchor` 的 key 名 `EnvironmentMonitoringBackToTerminal` 必须与 `TakePhoto.json` 中的 `[Anchor]EnvironmentMonitoringBackToTerminal` 保持完全一致，否则 anchor 机制失效。
 - **「占位值能跑通生成 ≠ 任务能跑通运行」**：`ROUTE_DEFAULTS` 让生成阶段不报错，但运行时 `EnterMap=SceneAnyEnterWorld` + `MapPath=[[0,0]]` 永远走不到目标。提交前请人工核对 `ROUTE_CONFIG` 中没有遗留占位条目（`EnterMap` 为 `SceneAnyEnterWorld` 且没有 `// TODO:` 注释时应引起注意）。

--- a/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
@@ -66,19 +66,19 @@ EnvironmentMonitoringMain
                            ├─ GoTo{Id}RecheckStartPos    （传送后复核）
                            └─ GoTo{Id}ReEnterMap         （二次传送 → FinalCheck）
                                 └─ GoTo{Id}MapTrackerMove
-                                     ├─ anchor: EnvironmentMonitoringBactToTerminal → ${GoToMonitoringTerminal}
+                                     ├─ anchor: EnvironmentMonitoringBackToTerminal → ${GoToMonitoringTerminal}
                                      ├─ anchor: EnvironmentMonitoringAdjustCamera   → ${Id}AdjustCamera
                                      └─ next:   EnvironmentMonitoringTakePhoto
 EnvironmentMonitoringTakePhoto       （进入拍照模式 → 朝向 → 拍照）
-  └─ [Anchor]EnvironmentMonitoringBactToTerminal
+  └─ [Anchor]EnvironmentMonitoringBackToTerminal
        └─ EnvironmentMonitoringGoTo{Outskirts|MarkerStone}MonitoringTerminal
 ```
 
 > [!NOTE]
 >
-> `anchor` 字段的两个 key 是模板里硬编码的占位符名（`EnvironmentMonitoringBactToTerminal` 拼写沿用历史，请勿改），运行时被替换为：
+> `anchor` 字段的两个 key 是模板里硬编码的占位符名（`EnvironmentMonitoringBackToTerminal` 拼写沿用历史，请勿改），运行时被替换为：
 >
-> - `EnvironmentMonitoringBactToTerminal` → 当前观察点所属终端的 `EnvironmentMonitoringGoTo{Station}` 节点（拍完回到正确终端）
+> - `EnvironmentMonitoringBackToTerminal` → 当前观察点所属终端的 `EnvironmentMonitoringGoTo{Station}` 节点（拍完回到正确终端）
 > - `EnvironmentMonitoringAdjustCamera` → `{Id}AdjustCamera`（执行该观察点的摄像头滑动方向）
 
 ## 命名规则
@@ -192,7 +192,7 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 观察点的「传送 → 复核 → 寻路」三段都依赖 `agent/go-service/map-tracker/`：
 
 - `MapTrackerAssertLocation`（识别）：根据当前小地图判断是否在 `MapTarget` 矩形内。
-- `MapTrackerMove`（动作）：沿 `MapPath` 路径走到目标点，过程中支持 anchor 机制改写 `EnvironmentMonitoringBactToTerminal` / `EnvironmentMonitoringAdjustCamera`。
+- `MapTrackerMove`（动作）：沿 `MapPath` 路径走到目标点，过程中支持 anchor 机制改写 `EnvironmentMonitoringBackToTerminal` / `EnvironmentMonitoringAdjustCamera`。
 
 详细参数与坐标录制方式见 [map-tracker.md](../components/map-tracker.md) 与 [map-navigator.md](../components/map-navigator.md)。
 
@@ -299,5 +299,5 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 - **`EnterMap` 写了不存在的 Scene 节点**：生成器不校验，运行时会卡在 `GoTo{Id}NotAtStartPos` 死循环。
 - **`MapPath` 经过未解锁区域 / 战斗 / 互动物**：MapTracker 不处理战斗与剧情，路径只能选纯通行段。
 - **`Station` 新增但 `Locations.json` / `EnvironmentMonitoringLoop.next` 没同步**：新终端无法被识别进入，所有观察点都跑不到。
-- **`anchor` 占位符名拼写**：`EnvironmentMonitoringBactToTerminal` 是历史拼写（少了一个 `k` 不影响功能），与模板和 `TakePhoto.json` 中的 `[Anchor]EnvironmentMonitoringBactToTerminal` 必须保持一致。不要好心改成 `Back`。
+- **`anchor` 占位符名拼写**：`EnvironmentMonitoringBackToTerminal` 是历史拼写（少了一个 `k` 不影响功能），与模板和 `TakePhoto.json` 中的 `[Anchor]EnvironmentMonitoringBackToTerminal` 必须保持一致。不要好心改成 `Back`。
 - **「占位值能跑通生成 ≠ 任务能跑通运行」**：`ROUTE_DEFAULTS` 让生成阶段不报错，但运行时 `EnterMap=SceneAnyEnterWorld` + `MapPath=[[0,0]]` 永远走不到目标。提交前请人工核对 `ROUTE_CONFIG` 中没有遗留占位条目（`EnterMap` 为 `SceneAnyEnterWorld` 且没有 `// TODO:` 注释时应引起注意）。

--- a/tools/pipeline-generate/EnvironmentMonitoring/template.jsonc
+++ b/tools/pipeline-generate/EnvironmentMonitoring/template.jsonc
@@ -260,7 +260,7 @@
             "path": "${MapPath}"
         },
         "anchor": {
-            "EnvironmentMonitoringBactToTerminal": "${GoToMonitoringTerminal}",
+            "EnvironmentMonitoringBackToTerminal": "${GoToMonitoringTerminal}",
             "EnvironmentMonitoringAdjustCamera": "${Id}AdjustCamera"
         },
         "next": [


### PR DESCRIPTION
## Summary by Sourcery

为环境监控任务修正锚点占位符命名，并使文档与更新后的标识符保持一致。

Bug Fixes:
- 修复环境监控 JSON 流水线与模板中 `EnvironmentMonitoringBackToTerminal` 锚点名称不一致的问题，以防止引用不匹配。

Documentation:
- 更新中英文环境监控维护文档，使用修正后的 `EnvironmentMonitoringBackToTerminal` 锚点名称和描述。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct anchor placeholder naming for environment monitoring tasks and align documentation with the updated identifier.

Bug Fixes:
- Fix inconsistent EnvironmentMonitoringBackToTerminal anchor name across environment monitoring JSON pipelines and template to prevent mismatched references.

Documentation:
- Update English and Chinese environment monitoring maintenance docs to use the corrected EnvironmentMonitoringBackToTerminal anchor name and description.

</details>