### PR TITLE
feat: minicv模板匹配支持圆形模板并添加测试

### DIFF
--- a/agent/go-service/pkg/minicv/circle_utils.go
+++ b/agent/go-service/pkg/minicv/circle_utils.go
@@ -1,0 +1,77 @@
+package minicv
+
+import "math"
+
+// Circle defines a circle region in image coordinates.
+//
+// Note that X and Y are the center coordinates.
+// The circle includes all pixels whose centers are within the radius distance from (X, Y).
+// If Radius is 0, it includes only the pixel at (X, Y).
+type Circle struct {
+	X      int
+	Y      int
+	Radius int
+}
+
+// MinX returns the minimum X coordinate of the circle's bounding box.
+func (c Circle) MinX() int {
+	return c.X - c.Radius
+}
+
+// MinY returns the minimum Y coordinate of the circle's bounding box.
+func (c Circle) MinY() int {
+	return c.Y - c.Radius
+}
+
+// MaxX returns the maximum X coordinate of the circle's bounding box.
+func (c Circle) MaxX() int {
+	return c.X + c.Radius
+}
+
+// MaxY returns the maximum Y coordinate of the circle's bounding box.
+func (c Circle) MaxY() int {
+	return c.Y + c.Radius
+}
+
+// circleSpan stores a continuous [X0, X1] segment on a single row Y.
+type circleSpan struct {
+	Y  int
+	X0 int
+	X1 int
+}
+
+// buildCircleSpans computes the horizontal spans of pixels covered by a circle in an image of size w*h.
+func buildCircleSpans(w, h int, circle Circle) (spans []circleSpan, pixelCount int) {
+	if w <= 0 || h <= 0 || circle.Radius < 0 {
+		return nil, 0
+	}
+
+	yMin := max(0, circle.MinY())
+	yMax := min(h-1, circle.MaxY())
+	if yMin > yMax {
+		return nil, 0
+	}
+
+	spans = make([]circleSpan, 0, yMax-yMin+1)
+	pixelCount = 0
+
+	r2 := circle.Radius * circle.Radius
+
+	for y := yMin; y <= yMax; y++ {
+		dy := y - circle.Y
+		dx2 := r2 - dy*dy
+		if dx2 < 0 {
+			continue
+		}
+		dx := int(math.Sqrt(float64(dx2)))
+		x0 := max(0, circle.X-dx)
+		x1 := min(w-1, circle.X+dx)
+		if x0 > x1 {
+			continue
+		}
+		spans = append(spans, circleSpan{Y: y, X0: x0, X1: x1})
+		pixelCount += x1 - x0 + 1
+	}
+
+	return spans, pixelCount
+}

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	_ "image/png"
+	"math"
 	"os"
 	"sync"
 )
@@ -133,6 +134,72 @@ func ComputeNCC(img *image.RGBA, imgIntArr IntegralArray, tpl *image.RGBA, tplSt
 	return (float64(dot) - count*imgStats.Mean*tplStats.Mean) / stdProd
 }
 
+// computeNCCInCircle computes masked NCC at the given top-left corner using circle spans.
+func computeNCCInCircle(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplCircleStats StatsResult,
+	spans []circleSpan,
+	pixelCount int,
+	ox, oy int,
+) float64 {
+	if pixelCount <= 0 || tplCircleStats.Std < 1e-12 {
+		return 0.0
+	}
+
+	iw, ih := img.Rect.Dx(), img.Rect.Dy()
+	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
+	if ox < 0 || oy < 0 || ox+tw > iw || oy+th > ih {
+		return 0.0
+	}
+
+	ipx, is := img.Pix, img.Stride
+	tpx, ts := tpl.Pix, tpl.Stride
+
+	var dot uint64
+	var sumI float64
+	var sumI2 float64
+
+	for _, sp := range spans {
+		ty := sp.Y
+		x0 := sp.X0
+		x1 := sp.X1
+		width := x1 - x0 + 1
+
+		rowSum, rowSumSq := imgIntArr.GetRowRangeIntegral(oy+ty, ox+x0, width)
+		sumI += rowSum
+		sumI2 += rowSumSq
+
+		iOff := (oy+ty)*is + (ox+x0)*4
+		tOff := ty*ts + x0*4
+
+		for x := x0; x <= x1; x++ {
+			ir, ig, ib := uint64(ipx[iOff]), uint64(ipx[iOff+1]), uint64(ipx[iOff+2])
+			tr, tg, tb := uint64(tpx[tOff]), uint64(tpx[tOff+1]), uint64(tpx[tOff+2])
+
+			dot += ir*tr + ig*tg + ib*tb
+
+			iOff += 4
+			tOff += 4
+		}
+	}
+
+	count := float64(pixelCount * 3)
+	imgMean := sumI / count
+	imgVar := sumI2 - count*imgMean*imgMean
+	if imgVar < 1e-12 {
+		return 0.0
+	}
+	imgStd := math.Sqrt(imgVar)
+	stdProd := imgStd * tplCircleStats.Std
+	if stdProd < 1e-12 {
+		return 0.0
+	}
+
+	return (float64(dot) - count*imgMean*tplCircleStats.Mean) / stdProd
+}
+
 // MatchTemplate performs template matching on the whole image,
 // returns (x, y, val) of the best match, where x and y are subpixel-accurate coordinates.
 func MatchTemplate(
@@ -141,8 +208,27 @@ func MatchTemplate(
 	tpl *image.RGBA,
 	tplStats StatsResult,
 ) (x, y, val float64) {
+	if img == nil || tpl == nil {
+		return 0, 0, 0
+	}
 	iw, ih := img.Rect.Dx(), img.Rect.Dy()
 	return MatchTemplateInArea(img, imgIntArr, tpl, tplStats, [4]int{0, 0, iw, ih})
+}
+
+// MatchCircleTemplate matches a circular region inside the template on the whole image.
+// Returns (x, y, val) of the best match, where (x, y) is the top-left corner with subpixel accuracy.
+func MatchCircleTemplate(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplCircleStats StatsResult,
+	tplCirclePolar Circle,
+) (x, y, val float64) {
+	if img == nil || tpl == nil {
+		return 0, 0, 0
+	}
+	iw, ih := img.Rect.Dx(), img.Rect.Dy()
+	return MatchCircleTemplateInArea(img, imgIntArr, tpl, tplCircleStats, tplCirclePolar, [4]int{0, 0, iw, ih})
 }
 
 // MatchTemplateInArea performs template matching such that the center of the template
@@ -155,6 +241,10 @@ func MatchTemplateInArea(
 	tplStats StatsResult,
 	rect [4]int,
 ) (x, y, val float64) {
+	if img == nil || tpl == nil {
+		return 0, 0, 0
+	}
+
 	ax, ay, aw, ah := rect[0], rect[1], rect[2], rect[3]
 	iw, ih := img.Rect.Dx(), img.Rect.Dy()
 	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
@@ -224,6 +314,108 @@ func MatchTemplateInArea(
 	if fx+1 <= maxX {
 		rightNCC = ComputeNCC(img, imgIntArr, tpl, tplStats, fx+1, fy)
 	}
+
+	subX := float64(fx) + subpixelOffset(leftNCC, rightNCC)
+	subY := float64(fy) + subpixelOffset(upNCC, downNCC)
+
+	return subX, subY, fm
+}
+
+// MatchCircleTemplateInArea matches a circular region inside the template in a rectangular search area.
+// tplCirclePolar is the template-space circle and rect is the image-space area (x, y, w, h)
+// where the template center is constrained to remain.
+// Returns (x, y, val) where (x, y) is top-left with subpixel accuracy.
+func MatchCircleTemplateInArea(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplCircleStats StatsResult,
+	tplCirclePolar Circle,
+	rect [4]int,
+) (x, y, val float64) {
+	if img == nil || tpl == nil {
+		return 0, 0, 0
+	}
+
+	iw, ih := img.Rect.Dx(), img.Rect.Dy()
+	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
+	if tw <= 0 || th <= 0 || iw < tw || ih < th {
+		return 0, 0, 0
+	}
+
+	spans, pixelCount := buildCircleSpans(tw, th, tplCirclePolar)
+	if pixelCount == 0 {
+		return 0, 0, 0
+	}
+	if tplCircleStats.Std < 1e-12 {
+		return 0, 0, 0
+	}
+
+	ax, ay, aw, ah := rect[0], rect[1], rect[2], rect[3]
+	minX := max(0, ax-tw/2)
+	maxX := min(iw-tw, ax+aw-tw/2)
+	minY := max(0, ay-th/2)
+	maxY := min(ih-th, ay+ah-th/2)
+	if minX > maxX || minY > maxY {
+		return 0, 0, 0
+	}
+
+	type result struct {
+		x int
+		y int
+		s float64
+	}
+
+	numWorkers, stepLen := 4, 3
+	resChan := make(chan result, numWorkers)
+
+	for i := range numWorkers {
+		go func(id int) {
+			lx, ly, lm := minX, minY, -1.0
+			for y := minY + id*stepLen; y <= maxY; y += numWorkers * stepLen {
+				for x := minX; x <= maxX; x += stepLen {
+					s := computeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, x, y)
+					if s > lm {
+						lm, lx, ly = s, x, y
+					}
+				}
+			}
+			resChan <- result{lx, ly, lm}
+		}(i)
+	}
+
+	bc := result{minX, minY, -1.0}
+	for range numWorkers {
+		r := <-resChan
+		if r.s > bc.s {
+			bc = r
+		}
+	}
+	if bc.s < 0 {
+		return 0, 0, 0
+	}
+
+	fm, fx, fy := bc.s, bc.x, bc.y
+	for y := max(minY, bc.y-stepLen+1); y <= min(maxY, bc.y+stepLen-1); y++ {
+		for x := max(minX, bc.x-stepLen+1); x <= min(maxX, bc.x+stepLen-1); x++ {
+			s := computeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, x, y)
+			if s > fm {
+				fm, fx, fy = s, x, y
+			}
+		}
+	}
+
+	evalOr := func(tx, ty int, fallback float64) float64 {
+		if tx < minX || tx > maxX || ty < minY || ty > maxY {
+			return fallback
+		}
+		return computeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, tx, ty)
+	}
+
+	upNCC := evalOr(fx, fy-1, fm)
+	downNCC := evalOr(fx, fy+1, fm)
+	leftNCC := evalOr(fx-1, fy, fm)
+	rightNCC := evalOr(fx+1, fy, fm)
 
 	subX := float64(fx) + subpixelOffset(leftNCC, rightNCC)
 	subY := float64(fy) + subpixelOffset(upNCC, downNCC)

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -134,8 +134,9 @@ func ComputeNCC(img *image.RGBA, imgIntArr IntegralArray, tpl *image.RGBA, tplSt
 	return (float64(dot) - count*imgStats.Mean*tplStats.Mean) / stdProd
 }
 
-// computeNCCInCircle computes masked NCC at the given top-left corner using circle spans.
-func computeNCCInCircle(
+// ComputeNCCInCircle computes masked normalized cross-correlation at the given top-left corner using circle spans.
+// See [ComputeNCC] for the unmasked version.
+func ComputeNCCInCircle(
 	img *image.RGBA,
 	imgIntArr IntegralArray,
 	tpl *image.RGBA,
@@ -374,7 +375,7 @@ func MatchCircleTemplateInArea(
 			lx, ly, lm := minX, minY, -1.0
 			for y := minY + id*stepLen; y <= maxY; y += numWorkers * stepLen {
 				for x := minX; x <= maxX; x += stepLen {
-					s := computeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, x, y)
+					s := ComputeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, x, y)
 					if s > lm {
 						lm, lx, ly = s, x, y
 					}
@@ -398,7 +399,7 @@ func MatchCircleTemplateInArea(
 	fm, fx, fy := bc.s, bc.x, bc.y
 	for y := max(minY, bc.y-stepLen+1); y <= min(maxY, bc.y+stepLen-1); y++ {
 		for x := max(minX, bc.x-stepLen+1); x <= min(maxX, bc.x+stepLen-1); x++ {
-			s := computeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, x, y)
+			s := ComputeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, x, y)
 			if s > fm {
 				fm, fx, fy = s, x, y
 			}
@@ -409,7 +410,7 @@ func MatchCircleTemplateInArea(
 		if tx < minX || tx > maxX || ty < minY || ty > maxY {
 			return fallback
 		}
-		return computeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, tx, ty)
+		return ComputeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, tx, ty)
 	}
 
 	upNCC := evalOr(fx, fy-1, fm)

--- a/agent/go-service/pkg/minicv/match_template_test.go
+++ b/agent/go-service/pkg/minicv/match_template_test.go
@@ -3,6 +3,8 @@ package minicv
 
 import (
 	"image"
+	"image/color"
+	"math"
 	"testing"
 )
 
@@ -14,6 +16,207 @@ func cropAsTemplate(src *image.RGBA, x, y, w, h int) *image.RGBA {
 		copy(tpl.Pix[dstOff:dstOff+w*4], src.Pix[srcOff:srcOff+w*4])
 	}
 	return tpl
+}
+
+func generateMatchTestImage(w, h int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		off := y * img.Stride
+		for x := range w {
+			r := uint8((x*x*3 + y*17 + (x*y)%251) & 0xFF)
+			g := uint8((x*29 + y*y*5 + (x^y)*7) & 0xFF)
+			b := uint8((((x * 11) ^ (y * 23)) + x*y*13) & 0xFF)
+			img.Pix[off] = r
+			img.Pix[off+1] = g
+			img.Pix[off+2] = b
+			img.Pix[off+3] = 255
+			off += 4
+		}
+	}
+
+	ImageDrawLine(img, 37, 29, 1217, 681, color.RGBA{R: 255, G: 64, B: 32, A: 255}, 3)
+	ImageDrawLine(img, 120, 690, 1260, 18, color.RGBA{R: 32, G: 220, B: 255, A: 255}, 2)
+	ImageDrawFilledCircle(img, 640, 360, 41, color.RGBA{R: 250, G: 220, B: 40, A: 255})
+	ImageDrawFilledCircle(img, 72, 76, 23, color.RGBA{R: 40, G: 240, B: 110, A: 255})
+	ImageDrawFilledCircle(img, 1196, 644, 19, color.RGBA{R: 220, G: 60, B: 220, A: 255})
+
+	return img
+}
+
+func decorateTargetArea(img *image.RGBA, x, y, w, h int) {
+	cx := x + w/2
+	cy := y + h/2
+
+	ImageDrawLine(img, x+3, y+5, x+w-4, y+h-6, color.RGBA{R: 255, G: 16, B: 16, A: 255}, 3)
+	ImageDrawLine(img, x+w-5, y+4, x+4, y+h-5, color.RGBA{R: 16, G: 255, B: 48, A: 255}, 2)
+	ImageDrawLine(img, x+w/2, y+2, x+w/2, y+h-3, color.RGBA{R: 32, G: 96, B: 255, A: 255}, 2)
+	ImageDrawFilledCircle(img, cx, cy, min(w, h)/5, color.RGBA{R: 255, G: 220, B: 0, A: 255})
+	ImageDrawFilledCircle(img, x+w/3, y+h/3, max(3, min(w, h)/10), color.RGBA{R: 0, G: 220, B: 255, A: 255})
+}
+
+func assertMatchNear(t *testing.T, gotX, gotY float64, wantX, wantY int) {
+	t.Helper()
+	if math.Abs(gotX-float64(wantX)) > 0.1 || math.Abs(gotY-float64(wantY)) > 0.1 {
+		t.Fatalf("unexpected match position: got=(%.3f, %.3f), want=(%d, %d)", gotX, gotY, wantX, wantY)
+	}
+}
+
+func assertZeroMatch(t *testing.T, gotX, gotY, gotScore float64) {
+	t.Helper()
+	if gotX != 0 || gotY != 0 || gotScore != 0 {
+		t.Fatalf("unexpected non-zero match result: got=(%.3f, %.3f, %.3f), want=(0, 0, 0)", gotX, gotY, gotScore)
+	}
+}
+
+func TestMatchTemplateNilInputs(t *testing.T) {
+	img := generateMatchTestImage(128, 128)
+	imgIntArr := GetIntegralArray(img)
+	tpl := cropAsTemplate(img, 16, 16, 32, 32)
+	tplStats := GetImageStats(tpl)
+
+	testCases := []struct {
+		name string
+		run  func() (float64, float64, float64)
+	}{
+		{
+			name: "whole_image_nil_img",
+			run: func() (float64, float64, float64) {
+				return MatchTemplate(nil, imgIntArr, tpl, tplStats)
+			},
+		},
+		{
+			name: "whole_image_nil_tpl",
+			run: func() (float64, float64, float64) {
+				return MatchTemplate(img, imgIntArr, nil, tplStats)
+			},
+		},
+		{
+			name: "in_area_nil_img",
+			run: func() (float64, float64, float64) {
+				return MatchTemplateInArea(nil, imgIntArr, tpl, tplStats, [4]int{0, 0, 128, 128})
+			},
+		},
+		{
+			name: "in_area_nil_tpl",
+			run: func() (float64, float64, float64) {
+				return MatchTemplateInArea(img, imgIntArr, nil, tplStats, [4]int{0, 0, 128, 128})
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			x, y, score := tc.run()
+			assertZeroMatch(t, x, y, score)
+		})
+	}
+}
+
+func TestMatchTemplate(t *testing.T) {
+	testCases := []struct {
+		name string
+		tplX int
+		tplY int
+		tplW int
+		tplH int
+	}{
+		{name: "center", tplX: 608, tplY: 328, tplW: 64, tplH: 64},
+		{name: "near_edge", tplX: 9, tplY: 14, tplW: 64, tplH: 64},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			img := generateMatchTestImage(1280, 720)
+			decorateTargetArea(img, tc.tplX, tc.tplY, tc.tplW, tc.tplH)
+			imgIntArr := GetIntegralArray(img)
+			tpl := cropAsTemplate(img, tc.tplX, tc.tplY, tc.tplW, tc.tplH)
+			tplStats := GetImageStats(tpl)
+
+			x, y, score := MatchTemplate(img, imgIntArr, tpl, tplStats)
+
+			assertMatchNear(t, x, y, tc.tplX, tc.tplY)
+			if score < 0.9999 {
+				t.Fatalf("unexpected match score: got=%.6f, want>=0.9999", score)
+			}
+		})
+	}
+}
+
+func TestMatchCircleTemplateNilInputs(t *testing.T) {
+	img := generateMatchTestImage(128, 128)
+	imgIntArr := GetIntegralArray(img)
+	tpl := cropAsTemplate(img, 16, 16, 48, 48)
+	polar := Circle{X: 24, Y: 24, Radius: 12}
+	tplCircleStats := GetImageCircleStats(tpl, polar)
+
+	testCases := []struct {
+		name string
+		run  func() (float64, float64, float64)
+	}{
+		{
+			name: "whole_image_nil_img",
+			run: func() (float64, float64, float64) {
+				return MatchCircleTemplate(nil, imgIntArr, tpl, tplCircleStats, polar)
+			},
+		},
+		{
+			name: "whole_image_nil_tpl",
+			run: func() (float64, float64, float64) {
+				return MatchCircleTemplate(img, imgIntArr, nil, tplCircleStats, polar)
+			},
+		},
+		{
+			name: "in_area_nil_img",
+			run: func() (float64, float64, float64) {
+				return MatchCircleTemplateInArea(nil, imgIntArr, tpl, tplCircleStats, polar, [4]int{0, 0, 128, 128})
+			},
+		},
+		{
+			name: "in_area_nil_tpl",
+			run: func() (float64, float64, float64) {
+				return MatchCircleTemplateInArea(img, imgIntArr, nil, tplCircleStats, polar, [4]int{0, 0, 128, 128})
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			x, y, score := tc.run()
+			assertZeroMatch(t, x, y, score)
+		})
+	}
+}
+
+func TestMatchCircleTemplate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		tplX        int
+		tplY        int
+		tplW        int
+		tplH        int
+		polarRadius int
+	}{
+		{name: "center", tplX: 592, tplY: 312, tplW: 96, tplH: 96, polarRadius: 23},
+		{name: "near_edge", tplX: 12, tplY: 18, tplW: 96, tplH: 96, polarRadius: 23},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			img := generateMatchTestImage(1280, 720)
+			decorateTargetArea(img, tc.tplX, tc.tplY, tc.tplW, tc.tplH)
+			imgIntArr := GetIntegralArray(img)
+			tpl := cropAsTemplate(img, tc.tplX, tc.tplY, tc.tplW, tc.tplH)
+			polar := Circle{X: tc.tplW / 2, Y: tc.tplH / 2, Radius: tc.polarRadius}
+			tplCircleStats := GetImageCircleStats(tpl, polar)
+
+			x, y, score := MatchCircleTemplate(img, imgIntArr, tpl, tplCircleStats, polar)
+
+			assertMatchNear(t, x, y, tc.tplX, tc.tplY)
+			if score < 0.9999 {
+				t.Fatalf("unexpected circle match score: got=%.6f, want>=0.9999", score)
+			}
+		})
+	}
 }
 
 func BenchmarkMatchTemplate(b *testing.B) {
@@ -41,6 +244,53 @@ func BenchmarkMatchTemplate(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				_, _, _ = MatchTemplate(img, imgIntArr, tpl, tplStats)
+			}
+		})
+	}
+}
+
+func BenchmarkMatchCircleTemplate(b *testing.B) {
+	img := generateBenchmarkImage(1280, 720)
+	imgIntArr := GetIntegralArray(img)
+
+	benchmarks := []struct {
+		name        string
+		tplW        int
+		tplH        int
+		tplX        int
+		tplY        int
+		polarRadius int
+	}{
+		{
+			name:        "r23",
+			tplW:        128,
+			tplH:        128,
+			tplX:        420,
+			tplY:        260,
+			polarRadius: 23,
+		},
+		{
+			name:        "r45",
+			tplW:        128,
+			tplH:        128,
+			tplX:        420,
+			tplY:        260,
+			polarRadius: 45,
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			tpl := cropAsTemplate(img, bm.tplX, bm.tplY, bm.tplW, bm.tplH)
+
+			polar := Circle{X: bm.tplW / 2, Y: bm.tplH / 2, Radius: bm.polarRadius}
+			tplCircleStats := GetImageCircleStats(tpl, polar)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, _, _ = MatchCircleTemplate(img, imgIntArr, tpl, tplCircleStats, polar)
 			}
 		})
 	}

--- a/agent/go-service/pkg/minicv/match_template_test.go
+++ b/agent/go-service/pkg/minicv/match_template_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Harry Huang
+package minicv
+
+import (
+	"image"
+	"testing"
+)
+
+func cropAsTemplate(src *image.RGBA, x, y, w, h int) *image.RGBA {
+	tpl := image.NewRGBA(image.Rect(0, 0, w, h))
+	for row := range h {
+		srcOff := (y+row)*src.Stride + x*4
+		dstOff := row * tpl.Stride
+		copy(tpl.Pix[dstOff:dstOff+w*4], src.Pix[srcOff:srcOff+w*4])
+	}
+	return tpl
+}
+
+func BenchmarkMatchTemplate(b *testing.B) {
+	img := generateBenchmarkImage(1280, 720)
+	imgIntArr := GetIntegralArray(img)
+
+	benchmarks := []struct {
+		name string
+		tplW int
+		tplH int
+		tplX int
+		tplY int
+	}{
+		{name: "tpl_32x32", tplW: 32, tplH: 32, tplX: 160, tplY: 120},
+		{name: "tpl_64x64", tplW: 64, tplH: 64, tplX: 480, tplY: 240},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			tpl := cropAsTemplate(img, bm.tplX, bm.tplY, bm.tplW, bm.tplH)
+			tplStats := GetImageStats(tpl)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, _, _ = MatchTemplate(img, imgIntArr, tpl, tplStats)
+			}
+		})
+	}
+}

--- a/agent/go-service/pkg/minicv/stats_utils.go
+++ b/agent/go-service/pkg/minicv/stats_utils.go
@@ -14,9 +14,11 @@ type StatsResult struct {
 
 // IntegralArray stores precomputed sums for O(1) area statistics
 type IntegralArray struct {
-	Sum   []float64
-	SumSq []float64
-	W, H  int
+	Sum      []float64
+	SumSq    []float64
+	RowSum   []float64
+	RowSumSq []float64
+	W, H     int
 }
 
 // GetImageStats computes the mean and standard deviation of pixel values in an image
@@ -46,12 +48,50 @@ func GetImageStats(img *image.RGBA) StatsResult {
 	return StatsResult{mean, math.Sqrt(variance)}
 }
 
+// GetImageCircleStats computes mean and unnormalized std of RGB values inside a circle.
+// circle is (cx, cy, radius) in image coordinates.
+func GetImageCircleStats(img *image.RGBA, circle Circle) StatsResult {
+	if img == nil {
+		return StatsResult{}
+	}
+
+	w, h := img.Rect.Dx(), img.Rect.Dy()
+	spans, pixelCount := buildCircleSpans(w, h, circle)
+	if pixelCount == 0 {
+		return StatsResult{}
+	}
+
+	ipx, is := img.Pix, img.Stride
+	var sum int
+	var sumSq int
+
+	for _, sp := range spans {
+		off := sp.Y*is + sp.X0*4
+		for x := sp.X0; x <= sp.X1; x++ {
+			r, g, b := int(ipx[off]), int(ipx[off+1]), int(ipx[off+2])
+			sum += r + g + b
+			sumSq += r*r + g*g + b*b
+			off += 4
+		}
+	}
+
+	count := float64(pixelCount * 3)
+	mean := float64(sum) / count
+	variance := float64(sumSq) - count*(mean*mean)
+	if variance < 1e-12 {
+		return StatsResult{Mean: mean, Std: 0}
+	}
+	return StatsResult{Mean: mean, Std: math.Sqrt(variance)}
+}
+
 // GetIntegralArray computes the integral array for an image
 func GetIntegralArray(img *image.RGBA) IntegralArray {
 	w, h := img.Rect.Dx(), img.Rect.Dy()
 
 	sumArr := make([]float64, (w+1)*(h+1))
 	sumSqArr := make([]float64, (w+1)*(h+1))
+	rowSumArr := make([]float64, h*(w+1))
+	rowSumSqArr := make([]float64, h*(w+1))
 	stride := w + 1
 
 	ipx, is := img.Pix, img.Stride
@@ -67,10 +107,20 @@ func GetIntegralArray(img *image.RGBA) IntegralArray {
 			idx := (y+1)*stride + (x + 1)
 			sumArr[idx] = sumArr[y*stride+(x+1)] + float64(sumRow)
 			sumSqArr[idx] = sumSqArr[y*stride+(x+1)] + float64(sumSqRow)
+			rowIdx := y*stride + (x + 1)
+			rowSumArr[rowIdx] = float64(sumRow)
+			rowSumSqArr[rowIdx] = float64(sumSqRow)
 			off += 4
 		}
 	}
-	return IntegralArray{Sum: sumArr, SumSq: sumSqArr, W: w, H: h}
+	return IntegralArray{
+		Sum:      sumArr,
+		SumSq:    sumSqArr,
+		RowSum:   rowSumArr,
+		RowSumSq: rowSumSqArr,
+		W:        w,
+		H:        h,
+	}
 }
 
 // GetAreaIntegral returns (sum, sumSq) for a given rectangle area using the integral array
@@ -82,6 +132,16 @@ func (ia *IntegralArray) GetAreaIntegral(x, y, w, h int) (float64, float64) {
 
 	sum := ia.Sum[idx22] - ia.Sum[idx12] - ia.Sum[idx21] + ia.Sum[idx11]
 	sumSq := ia.SumSq[idx22] - ia.SumSq[idx12] - ia.SumSq[idx21] + ia.SumSq[idx11]
+	return sum, sumSq
+}
+
+// GetRowRangeIntegral returns (sum, sumSq) for a single-row interval [x, x+w).
+func (ia *IntegralArray) GetRowRangeIntegral(y, x, w int) (float64, float64) {
+	stride := ia.W + 1
+	rowBase := y * stride
+	x2 := x + w
+	sum := ia.RowSum[rowBase+x2] - ia.RowSum[rowBase+x]
+	sumSq := ia.RowSumSq[rowBase+x2] - ia.RowSumSq[rowBase+x]
 	return sum, sumSq
 }
 

--- a/agent/go-service/pkg/minicv/stats_utils.go
+++ b/agent/go-service/pkg/minicv/stats_utils.go
@@ -24,13 +24,13 @@ func GetImageStats(img *image.RGBA) StatsResult {
 	w, h := img.Rect.Dx(), img.Rect.Dy()
 	ipx, is := img.Pix, img.Stride
 
-	sum := 0.0
-	sumSq := 0.0
+	var sum int
+	var sumSq int
 
 	for y := range h {
 		off := y * is
 		for range w {
-			r, g, b := float64(ipx[off]), float64(ipx[off+1]), float64(ipx[off+2])
+			r, g, b := int(ipx[off]), int(ipx[off+1]), int(ipx[off+2])
 			sum += r + g + b
 			sumSq += r*r + g*g + b*b
 			off += 4
@@ -38,8 +38,8 @@ func GetImageStats(img *image.RGBA) StatsResult {
 	}
 
 	count := float64(w * h * 3)
-	mean := sum / count
-	variance := sumSq - count*(mean*mean)
+	mean := float64(sum) / count
+	variance := float64(sumSq) - count*(mean*mean)
 	if variance < 1e-12 {
 		return StatsResult{Mean: mean, Std: 0}
 	}
@@ -57,16 +57,16 @@ func GetIntegralArray(img *image.RGBA) IntegralArray {
 	ipx, is := img.Pix, img.Stride
 
 	for y := range h {
-		var sumRow, sumSqRow float64
+		var sumRow, sumSqRow int
 		off := y * is
 		for x := range w {
-			r, g, b := float64(ipx[off]), float64(ipx[off+1]), float64(ipx[off+2])
+			r, g, b := int(ipx[off]), int(ipx[off+1]), int(ipx[off+2])
 			sumRow += r + g + b
 			sumSqRow += r*r + g*g + b*b
 
 			idx := (y+1)*stride + (x + 1)
-			sumArr[idx] = sumArr[y*stride+(x+1)] + sumRow
-			sumSqArr[idx] = sumSqArr[y*stride+(x+1)] + sumSqRow
+			sumArr[idx] = sumArr[y*stride+(x+1)] + float64(sumRow)
+			sumSqArr[idx] = sumSqArr[y*stride+(x+1)] + float64(sumSqRow)
 			off += 4
 		}
 	}

--- a/agent/go-service/pkg/minicv/stats_utils.go
+++ b/agent/go-service/pkg/minicv/stats_utils.go
@@ -14,10 +14,10 @@ type StatsResult struct {
 
 // IntegralArray stores precomputed sums for O(1) area statistics
 type IntegralArray struct {
-	Sum      []float64
-	SumSq    []float64
-	RowSum   []float64
-	RowSumSq []float64
+	Sum      []uint64
+	SumSq    []uint64
+	RowSum   []uint64
+	RowSumSq []uint64
 	W, H     int
 }
 
@@ -26,13 +26,13 @@ func GetImageStats(img *image.RGBA) StatsResult {
 	w, h := img.Rect.Dx(), img.Rect.Dy()
 	ipx, is := img.Pix, img.Stride
 
-	var sum int
-	var sumSq int
+	var sum uint64
+	var sumSq uint64
 
 	for y := range h {
 		off := y * is
 		for range w {
-			r, g, b := int(ipx[off]), int(ipx[off+1]), int(ipx[off+2])
+			r, g, b := uint64(ipx[off]), uint64(ipx[off+1]), uint64(ipx[off+2])
 			sum += r + g + b
 			sumSq += r*r + g*g + b*b
 			off += 4
@@ -62,13 +62,13 @@ func GetImageCircleStats(img *image.RGBA, circle Circle) StatsResult {
 	}
 
 	ipx, is := img.Pix, img.Stride
-	var sum int
-	var sumSq int
+	var sum uint64
+	var sumSq uint64
 
 	for _, sp := range spans {
 		off := sp.Y*is + sp.X0*4
 		for x := sp.X0; x <= sp.X1; x++ {
-			r, g, b := int(ipx[off]), int(ipx[off+1]), int(ipx[off+2])
+			r, g, b := uint64(ipx[off]), uint64(ipx[off+1]), uint64(ipx[off+2])
 			sum += r + g + b
 			sumSq += r*r + g*g + b*b
 			off += 4
@@ -88,28 +88,28 @@ func GetImageCircleStats(img *image.RGBA, circle Circle) StatsResult {
 func GetIntegralArray(img *image.RGBA) IntegralArray {
 	w, h := img.Rect.Dx(), img.Rect.Dy()
 
-	sumArr := make([]float64, (w+1)*(h+1))
-	sumSqArr := make([]float64, (w+1)*(h+1))
-	rowSumArr := make([]float64, h*(w+1))
-	rowSumSqArr := make([]float64, h*(w+1))
+	sumArr := make([]uint64, (w+1)*(h+1))
+	sumSqArr := make([]uint64, (w+1)*(h+1))
+	rowSumArr := make([]uint64, h*(w+1))
+	rowSumSqArr := make([]uint64, h*(w+1))
 	stride := w + 1
 
 	ipx, is := img.Pix, img.Stride
 
 	for y := range h {
-		var sumRow, sumSqRow int
+		var sumRow, sumSqRow uint64
 		off := y * is
 		for x := range w {
-			r, g, b := int(ipx[off]), int(ipx[off+1]), int(ipx[off+2])
+			r, g, b := uint64(ipx[off]), uint64(ipx[off+1]), uint64(ipx[off+2])
 			sumRow += r + g + b
 			sumSqRow += r*r + g*g + b*b
 
 			idx := (y+1)*stride + (x + 1)
-			sumArr[idx] = sumArr[y*stride+(x+1)] + float64(sumRow)
-			sumSqArr[idx] = sumSqArr[y*stride+(x+1)] + float64(sumSqRow)
+			sumArr[idx] = sumArr[y*stride+(x+1)] + sumRow
+			sumSqArr[idx] = sumSqArr[y*stride+(x+1)] + sumSqRow
 			rowIdx := y*stride + (x + 1)
-			rowSumArr[rowIdx] = float64(sumRow)
-			rowSumSqArr[rowIdx] = float64(sumSqRow)
+			rowSumArr[rowIdx] = sumRow
+			rowSumSqArr[rowIdx] = sumSqRow
 			off += 4
 		}
 	}
@@ -132,7 +132,7 @@ func (ia *IntegralArray) GetAreaIntegral(x, y, w, h int) (float64, float64) {
 
 	sum := ia.Sum[idx22] - ia.Sum[idx12] - ia.Sum[idx21] + ia.Sum[idx11]
 	sumSq := ia.SumSq[idx22] - ia.SumSq[idx12] - ia.SumSq[idx21] + ia.SumSq[idx11]
-	return sum, sumSq
+	return float64(sum), float64(sumSq)
 }
 
 // GetRowRangeIntegral returns (sum, sumSq) for a single-row interval [x, x+w).
@@ -142,7 +142,7 @@ func (ia *IntegralArray) GetRowRangeIntegral(y, x, w int) (float64, float64) {
 	x2 := x + w
 	sum := ia.RowSum[rowBase+x2] - ia.RowSum[rowBase+x]
 	sumSq := ia.RowSumSq[rowBase+x2] - ia.RowSumSq[rowBase+x]
-	return sum, sumSq
+	return float64(sum), float64(sumSq)
 }
 
 // GetAreaStats returns the mean and standard deviation (unnormalized) for a given rectangle area using the integral array

--- a/agent/go-service/pkg/minicv/stats_utils_test.go
+++ b/agent/go-service/pkg/minicv/stats_utils_test.go
@@ -45,6 +45,29 @@ func BenchmarkGetImageStats(b *testing.B) {
 	}
 }
 
+func BenchmarkGetImageStatsInCircle(b *testing.B) {
+	img := generateBenchmarkImage(1280, 720)
+
+	benchmarks := []struct {
+		name   string
+		circle Circle
+	}{
+		{name: "720p_r23", circle: Circle{X: 640, Y: 360, Radius: 23}},
+		{name: "720p_r45", circle: Circle{X: 640, Y: 360, Radius: 45}},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_ = GetImageCircleStats(img, bm.circle)
+			}
+		})
+	}
+}
+
 func BenchmarkGetIntegralArray(b *testing.B) {
 	benchmarks := []struct {
 		name string

--- a/agent/go-service/pkg/minicv/stats_utils_test.go
+++ b/agent/go-service/pkg/minicv/stats_utils_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Harry Huang
+package minicv
+
+import (
+	"image"
+	"testing"
+)
+
+// generateBenchmarkImage creates a deterministic RGBA image for performance tests.
+func generateBenchmarkImage(w, h int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		off := y * img.Stride
+		for x := range w {
+			img.Pix[off] = uint8((x*31 + y*17) & 0xFF)
+			img.Pix[off+1] = uint8((x*13 + y*29) & 0xFF)
+			img.Pix[off+2] = uint8((x*7 + y*19) & 0xFF)
+			img.Pix[off+3] = 255
+			off += 4
+		}
+	}
+	return img
+}
+
+func BenchmarkGetImageStats(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		w    int
+		h    int
+	}{
+		{name: "720p", w: 1280, h: 720},
+		{name: "1080p", w: 1920, h: 1080},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			img := generateBenchmarkImage(bm.w, bm.h)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_ = GetImageStats(img)
+			}
+		})
+	}
+}
+
+func BenchmarkGetIntegralArray(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		w    int
+		h    int
+	}{
+		{name: "720p", w: 1280, h: 720},
+		{name: "1080p", w: 1920, h: 1080},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			img := generateBenchmarkImage(bm.w, bm.h)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_ = GetIntegralArray(img)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

此 PR 向 Go minicv 包中增加了对圆形模板的模板匹配支持、为模板匹配添加了一般测试和性能测试、略微优化了模板匹配性能。

圆形模板后续可能用于扩大 MapTrackerInfer 的感受野，在该场景下：若一圆形模板，其几何上恰好是某方形模板的外接圆，则对于它的模板匹配，耗时是该方形模板的 1.5~2 倍。

## Summary by Sourcery

为 minicv 包添加圆形模板匹配支持，并扩展统计工具以处理圆形区域以及更快速的积分计算。

新功能：
- 支持在整幅图像以及受限区域内，对模板中的圆形区域进行匹配。
- 提供圆形几何工具以及针对光栅化圆形区域的跨度（span）生成能力。

改进：
- 通过使用整数累加器和逐行积分缓冲区来优化模板匹配和统计计算，并对 `nil` 输入进行防御式处理。

测试：
- 添加针对矩形和圆形模板匹配的单元测试，包括 `nil` 输入场景以及靠近图像边缘时的正确性验证。
- 添加针对模板匹配、圆形模板匹配、图像统计计算（矩形与圆形）以及积分数组生成的基准测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add circular template matching support to the minicv package and extend statistics utilities to handle circular regions and faster integral computations.

New Features:
- Support matching circular regions within templates over an image and within constrained areas.
- Provide circle geometry utilities and span generation for rasterized circular regions.

Enhancements:
- Optimize template matching and statistics computation by using integer accumulators and per-row integral buffers, and by handling nil inputs defensively.

Tests:
- Add unit tests for rectangular and circular template matching, including nil-input cases and correctness near image edges.
- Add benchmarks for template matching, circular template matching, image statistics computation (rectangular and circular), and integral array generation.

</details>