### PR TITLE
perf: minicv模板匹配采用SIMD计算NCC以及并行策略优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build-*
 *.lo
 *.o
 *.obj
+.gocache
 
 # Precompiled Headers
 *.gch

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -6,6 +6,7 @@ import (
 	_ "image/png"
 	"math"
 	"os"
+	"runtime"
 	"sync"
 	"unsafe"
 )
@@ -82,6 +83,41 @@ func (i *TemplateLoader) Get() (*Template, error) {
 
 	// Return cached results
 	return i.template, i.templateErr
+}
+
+var matchTemplateWorkerPool struct {
+	once  sync.Once
+	tasks chan func()
+}
+
+func runMatchWorkers(workerCount int, fn func(workerID int)) {
+	if workerCount <= 1 {
+		fn(0)
+		return
+	}
+
+	matchTemplateWorkerPool.once.Do(func() {
+		poolSize := max(1, runtime.GOMAXPROCS(0))
+		matchTemplateWorkerPool.tasks = make(chan func(), poolSize*2)
+		for range poolSize {
+			go func() {
+				for task := range matchTemplateWorkerPool.tasks {
+					task()
+				}
+			}()
+		}
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for workerID := range workerCount {
+		id := workerID
+		matchTemplateWorkerPool.tasks <- func() {
+			defer wg.Done()
+			fn(id)
+		}
+	}
+	wg.Wait()
 }
 
 func subpixelOffset(neg, pos float64) float64 {
@@ -256,27 +292,23 @@ func MatchTemplateInArea(
 		s    float64
 	}
 
-	numWorkers, stepLen := 4, 3
-	resChan := make(chan result, numWorkers)
-
-	for i := range numWorkers {
-		go func(id int) {
-			lx, ly, lm := 0, 0, -1.0
-			for y := minY + id*stepLen; y <= maxY; y += numWorkers * stepLen {
-				for x := minX; x <= maxX; x += stepLen {
-					s := ComputeNCC(img, imgIntArr, tpl, tplStats, x, y)
-					if s > lm {
-						lm, lx, ly = s, x, y
-					}
+	numWorkers, stepLen := 8, 3
+	results := make([]result, numWorkers)
+	runMatchWorkers(numWorkers, func(id int) {
+		lx, ly, lm := 0, 0, -1.0
+		for y := minY + id*stepLen; y <= maxY; y += numWorkers * stepLen {
+			for x := minX; x <= maxX; x += stepLen {
+				s := ComputeNCC(img, imgIntArr, tpl, tplStats, x, y)
+				if s > lm {
+					lm, lx, ly = s, x, y
 				}
 			}
-			resChan <- result{lx, ly, lm}
-		}(i)
-	}
+		}
+		results[id] = result{lx, ly, lm}
+	})
 
 	bc := result{minX, minY, -1.0}
-	for range numWorkers {
-		r := <-resChan
+	for _, r := range results {
 		if r.s > bc.s {
 			bc = r
 		}
@@ -360,27 +392,23 @@ func MatchCircleTemplateInArea(
 		s float64
 	}
 
-	numWorkers, stepLen := 4, 3
-	resChan := make(chan result, numWorkers)
-
-	for i := range numWorkers {
-		go func(id int) {
-			lx, ly, lm := minX, minY, -1.0
-			for y := minY + id*stepLen; y <= maxY; y += numWorkers * stepLen {
-				for x := minX; x <= maxX; x += stepLen {
-					s := ComputeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, x, y)
-					if s > lm {
-						lm, lx, ly = s, x, y
-					}
+	numWorkers, stepLen := 8, 3
+	results := make([]result, numWorkers)
+	runMatchWorkers(numWorkers, func(id int) {
+		lx, ly, lm := minX, minY, -1.0
+		for y := minY + id*stepLen; y <= maxY; y += numWorkers * stepLen {
+			for x := minX; x <= maxX; x += stepLen {
+				s := ComputeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, x, y)
+				if s > lm {
+					lm, lx, ly = s, x, y
 				}
 			}
-			resChan <- result{lx, ly, lm}
-		}(i)
-	}
+		}
+		results[id] = result{lx, ly, lm}
+	})
 
 	bc := result{minX, minY, -1.0}
-	for range numWorkers {
-		r := <-resChan
+	for _, r := range results {
 		if r.s > bc.s {
 			bc = r
 		}
@@ -471,51 +499,47 @@ func MatchTemplateAnyScale(
 		}
 
 		workerCount := min(stepCount, 8)
-		resChan := make(chan result, stepCount)
+		results := make([]result, stepCount)
+		runMatchWorkers(workerCount, func(id int) {
+			for idx := id; idx < stepCount; idx += workerCount {
+				scale := minScale
+				if stepCount == 1 {
+					scale = (minScale + maxScale) * 0.5
+				} else {
+					scale = minScale + float64(idx)*stepLen
+				}
 
-		for workerID := range workerCount {
-			go func(id int) {
-				for idx := id; idx < stepCount; idx += workerCount {
-					scale := minScale
-					if stepCount == 1 {
-						scale = (minScale + maxScale) * 0.5
-					} else {
-						scale = minScale + float64(idx)*stepLen
-					}
+				if scale <= 0 {
+					results[idx] = result{idx: idx, scale: scale, score: -1.0, valid: false}
+					continue
+				}
 
-					if scale <= 0 {
-						resChan <- result{idx: idx, scale: scale, score: -1.0, valid: false}
-						continue
-					}
-
-					scaledTpl := ImageScale(tpl, scale)
-					scaledStats := GetImageStats(scaledTpl)
-					if scaledStats.Std < 1e-12 {
-						resChan <- result{
-							idx:   idx,
-							scale: scale,
-							score: -1.0,
-							valid: false,
-						}
-						continue
-					}
-
-					x, y, score := MatchTemplate(img, imgIntArr, scaledTpl, scaledStats)
-
-					resChan <- result{
+				scaledTpl := ImageScale(tpl, scale)
+				scaledStats := GetImageStats(scaledTpl)
+				if scaledStats.Std < 1e-12 {
+					results[idx] = result{
 						idx:   idx,
 						scale: scale,
-						x:     x,
-						y:     y,
-						score: score,
-						valid: true,
+						score: -1.0,
+						valid: false,
 					}
+					continue
 				}
-			}(workerID)
-		}
 
-		for range stepCount {
-			res := <-resChan
+				x, y, score := MatchTemplate(img, imgIntArr, scaledTpl, scaledStats)
+
+				results[idx] = result{
+					idx:   idx,
+					scale: scale,
+					x:     x,
+					y:     y,
+					score: score,
+					valid: true,
+				}
+			}
+		})
+
+		for _, res := range results {
 			if res.valid {
 				if res.score > iterBestScore {
 					iterBestScore = res.score

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"sync"
+	"unsafe"
 )
 
 // Template represents a preloaded template image along with its integral array and statistics for matching.
@@ -98,6 +99,13 @@ func subpixelOffset(neg, pos float64) float64 {
 	return min(1.0, max(-1.0, offset))
 }
 
+func dotRGBA3(imgPix, tplPix *uint8, pixels int) uint64 {
+	if pixels <= 0 {
+		return 0
+	}
+	return dotRGBA3Impl(unsafe.Pointer(imgPix), unsafe.Pointer(tplPix), pixels)
+}
+
 // ComputeNCC computes the normalized cross-correlation between a rectangle region in the haystack image
 // and a template image, using precomputed integral array for efficiency
 func ComputeNCC(img *image.RGBA, imgIntArr IntegralArray, tpl *image.RGBA, tplStats StatsResult, ox, oy int) float64 {
@@ -111,18 +119,12 @@ func ComputeNCC(img *image.RGBA, imgIntArr IntegralArray, tpl *image.RGBA, tplSt
 	tpx, ts := tpl.Pix, tpl.Stride
 
 	var dot uint64
-	iOffBase := oy*is + ox*4
-	for y := range th {
-		iOff := iOffBase
-		tOff := y * ts
-		for range tw {
-			dot += uint64(ipx[iOff]) * uint64(tpx[tOff])
-			dot += uint64(ipx[iOff+1]) * uint64(tpx[tOff+1])
-			dot += uint64(ipx[iOff+2]) * uint64(tpx[tOff+2])
-			iOff += 4
-			tOff += 4
-		}
-		iOffBase += is
+	iOff := oy*is + ox*4
+	tOff := 0
+	for range th {
+		dot += dotRGBA3(&ipx[iOff], &tpx[tOff], tw)
+		iOff += is
+		tOff += ts
 	}
 
 	count := float64(tw * th * 3)
@@ -174,16 +176,7 @@ func ComputeNCCInCircle(
 
 		iOff := (oy+ty)*is + (ox+x0)*4
 		tOff := ty*ts + x0*4
-
-		for x := x0; x <= x1; x++ {
-			ir, ig, ib := uint64(ipx[iOff]), uint64(ipx[iOff+1]), uint64(ipx[iOff+2])
-			tr, tg, tb := uint64(tpx[tOff]), uint64(tpx[tOff+1]), uint64(tpx[tOff+2])
-
-			dot += ir*tr + ig*tg + ib*tb
-
-			iOff += 4
-			tOff += 4
-		}
+		dot += dotRGBA3(&ipx[iOff], &tpx[tOff], width)
 	}
 
 	count := float64(pixelCount * 3)

--- a/agent/go-service/pkg/minicv/simd.go
+++ b/agent/go-service/pkg/minicv/simd.go
@@ -1,0 +1,20 @@
+//go:build !amd64 || purego
+
+package minicv
+
+import "unsafe"
+
+func dotRGBA3Impl(imgPix, tplPix unsafe.Pointer, pixels int) uint64 {
+	ipx := (*[1 << 30]byte)(imgPix)
+	tpx := (*[1 << 30]byte)(tplPix)
+
+	var dot uint64
+	off := 0
+	for range pixels {
+		dot += uint64(ipx[off]) * uint64(tpx[off])
+		dot += uint64(ipx[off+1]) * uint64(tpx[off+1])
+		dot += uint64(ipx[off+2]) * uint64(tpx[off+2])
+		off += 4
+	}
+	return dot
+}

--- a/agent/go-service/pkg/minicv/simd_amd64.go
+++ b/agent/go-service/pkg/minicv/simd_amd64.go
@@ -1,0 +1,12 @@
+//go:build amd64 && !purego
+
+package minicv
+
+import "unsafe"
+
+//go:noescape
+func dotRGBA3SIMD(imgPix, tplPix unsafe.Pointer, pixels int) uint64
+
+func dotRGBA3Impl(imgPix, tplPix unsafe.Pointer, pixels int) uint64 {
+	return dotRGBA3SIMD(imgPix, tplPix, pixels)
+}

--- a/agent/go-service/pkg/minicv/simd_amd64.s
+++ b/agent/go-service/pkg/minicv/simd_amd64.s
@@ -1,0 +1,85 @@
+//go:build amd64 && !purego
+
+#include "textflag.h"
+
+DATA ·rgba3Mask<>(SB)/8, $0x00FFFFFF00FFFFFF
+DATA ·rgba3Mask<>+8(SB)/8, $0x00FFFFFF00FFFFFF
+GLOBL ·rgba3Mask<>(SB), RODATA, $16
+
+TEXT ·dotRGBA3SIMD(SB), NOSPLIT, $16-32
+	MOVQ imgPix+0(FP), SI
+	MOVQ tplPix+8(FP), DI
+	MOVQ pixels+16(FP), CX
+
+	PXOR X0, X0
+	PXOR X5, X5
+	MOVOU ·rgba3Mask<>(SB), X7
+
+	CMPQ CX, $4
+	JLT tail
+
+loop4:
+	MOVOU (SI), X1
+	MOVOU (DI), X2
+	PAND X7, X1
+	PAND X7, X2
+
+	MOVOU X1, X3
+	PUNPCKLBW X0, X3
+	MOVOU X1, X4
+	PUNPCKHBW X0, X4
+
+	MOVOU X2, X8
+	PUNPCKLBW X0, X8
+	MOVOU X2, X9
+	PUNPCKHBW X0, X9
+
+	PMADDWL X8, X3
+	PMADDWL X9, X4
+	PADDD X3, X5
+	PADDD X4, X5
+
+	ADDQ $16, SI
+	ADDQ $16, DI
+	SUBQ $4, CX
+	CMPQ CX, $4
+	JGE loop4
+
+tail:
+	MOVOU X5, 0(SP)
+	MOVL 0(SP), AX
+	MOVL 4(SP), BX
+	ADDL BX, AX
+	MOVL 8(SP), BX
+	ADDL BX, AX
+	MOVL 12(SP), BX
+	ADDL BX, AX
+	MOVLQZX AX, AX
+
+	CMPQ CX, $0
+	JEQ done
+
+tailLoop:
+	MOVBLZX 0(SI), BX
+	MOVBLZX 0(DI), DX
+	IMULQ DX, BX
+	ADDQ BX, AX
+
+	MOVBLZX 1(SI), BX
+	MOVBLZX 1(DI), DX
+	IMULQ DX, BX
+	ADDQ BX, AX
+
+	MOVBLZX 2(SI), BX
+	MOVBLZX 2(DI), DX
+	IMULQ DX, BX
+	ADDQ BX, AX
+
+	ADDQ $4, SI
+	ADDQ $4, DI
+	DECQ CX
+	JNZ tailLoop
+
+done:
+	MOVQ AX, ret+24(FP)
+	RET


### PR DESCRIPTION
## 概要

此 PR 对 Go minicv 模块的模板匹配部分做了两项重要性能优化。

1. 将 NCC 计算时进行的点积运算使用 SIMD 进行了加速（仅适用于 amd64 构建）。
2. 为避免反复创建 goroutine 的开销，采用 worker 池进行管理。得益于此带来的并行倾向性受益，模板匹配部分的并行 worker 数从 4 增加到了 8。

## 测试

在 20 核心机器上进行测试：

Before:

```
goos: windows
goarch: amd64
pkg: github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv
cpu: 13th Gen Intel(R) Core(TM) i7-13650HX
BenchmarkMatchTemplate/tpl_32x32-20                  100          33860498 ns/op            1453 B/op          9 allocs/op
BenchmarkMatchTemplate/tpl_64x64-20                   31         111651519 ns/op            1399 B/op          9 allocs/op
BenchmarkMatchCircleTemplate/r23-20                   78          44734076 ns/op            2543 B/op         10 allocs/op
BenchmarkMatchCircleTemplate/r45-20                   20         167516725 ns/op            3884 B/op         10 allocs/op
PASS
```

After:

```
goos: windows
goarch: amd64
pkg: github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv
cpu: 13th Gen Intel(R) Core(TM) i7-13650HX
BenchmarkMatchTemplate/tpl_32x32-20                  609           5790200 ns/op             688 B/op         11 allocs/op
BenchmarkMatchTemplate/tpl_64x64-20                  211          17127674 ns/op             692 B/op         11 allocs/op
BenchmarkMatchCircleTemplate/r23-20                  351          10311555 ns/op            1873 B/op         12 allocs/op
BenchmarkMatchCircleTemplate/r45-20                  123          29009372 ns/op            3027 B/op         12 allocs/op
PASS
```

根据模板匹配方式的不同，速度方面提升到了原来的 **4.5~6.8 倍**，内存占用方面降低到了原来的 **47%~78%**。

## Summary by Sourcery

优化 Go agent 中 minicv 模板匹配的性能和并行度。

增强点：
- 为 amd64 引入使用 SIMD 加速的 RGB 点积实现，用于 NCC，并在其他构建上提供纯 Go 的回退实现。
- 重构 NCC 计算逻辑，在矩形和圆形模板匹配路径中统一使用共享的 RGB 点积辅助函数。
- 用可复用的 worker pool 替代临时创建的 goroutine 方式处理模板匹配任务，并将并发 worker 数量从 4 提升到 8。
- 调整多尺度模板匹配逻辑，使用基于共享 worker pool 的并行执行模式，替代以往每次调用时临时创建 goroutine 的方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize minicv template matching performance and parallelism in the Go agent.

Enhancements:
- Introduce SIMD-accelerated RGB dot product implementation for NCC on amd64 with a pure Go fallback on other builds.
- Refactor NCC computation to use the shared RGB dot product helper in both rectangular and circular template matching paths.
- Replace ad-hoc goroutine creation with a reusable worker pool for template matching tasks and increase worker concurrency from 4 to 8.
- Adjust multi-scale template matching to use the shared worker-pool-based parallel execution pattern instead of per-call goroutine spawning.

</details>