### PR TITLE
fix: 修复SIMD潜在溢出和并行策略潜在死锁

### DIFF
--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -500,54 +500,54 @@ func MatchTemplateAnyScale(
 
 		workerCount := min(stepCount, 8)
 		results := make([]result, stepCount)
-		runMatchWorkers(workerCount, func(id int) {
-			for idx := id; idx < stepCount; idx += workerCount {
-				scale := minScale
-				if stepCount == 1 {
-					scale = (minScale + maxScale) * 0.5
-				} else {
-					scale = minScale + float64(idx)*stepLen
-				}
 
-				if scale <= 0 {
-					results[idx] = result{idx: idx, scale: scale, score: -1.0, valid: false}
-					continue
-				}
+		var wg sync.WaitGroup
+		wg.Add(workerCount)
+		for workerID := range workerCount {
+			go func(id int) {
+				defer wg.Done()
 
-				scaledTpl := ImageScale(tpl, scale)
-				scaledStats := GetImageStats(scaledTpl)
-				if scaledStats.Std < 1e-12 {
+				for idx := id; idx < stepCount; idx += workerCount {
+					scale := minScale
+					if stepCount == 1 {
+						scale = (minScale + maxScale) * 0.5
+					} else {
+						scale = minScale + float64(idx)*stepLen
+					}
+
+					if scale <= 0 {
+						results[idx] = result{idx: idx, scale: scale, score: -1.0, valid: false}
+						continue
+					}
+
+					scaledTpl := ImageScale(tpl, scale)
+					scaledStats := GetImageStats(scaledTpl)
+					if scaledStats.Std < 1e-12 {
+						results[idx] = result{idx: idx, scale: scale, score: -1.0, valid: false}
+						continue
+					}
+
+					x, y, score := MatchTemplate(img, imgIntArr, scaledTpl, scaledStats)
 					results[idx] = result{
 						idx:   idx,
 						scale: scale,
-						score: -1.0,
-						valid: false,
+						x:     x,
+						y:     y,
+						score: score,
+						valid: true,
 					}
-					continue
 				}
-
-				x, y, score := MatchTemplate(img, imgIntArr, scaledTpl, scaledStats)
-
-				results[idx] = result{
-					idx:   idx,
-					scale: scale,
-					x:     x,
-					y:     y,
-					score: score,
-					valid: true,
-				}
-			}
-		})
+			}(workerID)
+		}
+		wg.Wait()
 
 		for _, res := range results {
-			if res.valid {
-				if res.score > iterBestScore {
-					iterBestScore = res.score
-					iterBestX = res.x
-					iterBestY = res.y
-					iterBestScale = res.scale
-					iterBestIdx = res.idx
-				}
+			if res.valid && res.score > iterBestScore {
+				iterBestScore = res.score
+				iterBestX = res.x
+				iterBestY = res.y
+				iterBestScale = res.scale
+				iterBestIdx = res.idx
 			}
 		}
 

--- a/agent/go-service/pkg/minicv/simd_amd64.s
+++ b/agent/go-service/pkg/minicv/simd_amd64.s
@@ -11,12 +11,27 @@ TEXT ·dotRGBA3SIMD(SB), NOSPLIT, $16-32
 	MOVQ tplPix+8(FP), DI
 	MOVQ pixels+16(FP), CX
 
+	XORQ AX, AX
 	PXOR X0, X0
-	PXOR X5, X5
 	MOVOU ·rgba3Mask<>(SB), X7
 
-	CMPQ CX, $4
-	JLT tail
+chunkLoop:
+	CMPQ CX, $0
+	JEQ done
+
+	// Keep each SIMD chunk within the range where the 32-bit PADDD accumulators
+	// and the final 32-bit horizontal reduction cannot overflow.
+	MOVQ CX, R8
+	CMPQ R8, $16384
+	JLE chunkReady
+	MOVQ $16384, R8
+
+chunkReady:
+	MOVQ R8, R9
+	PXOR X5, X5
+
+	CMPQ R9, $4
+	JLT reduceChunk
 
 loop4:
 	MOVOU (SI), X1
@@ -41,23 +56,26 @@ loop4:
 
 	ADDQ $16, SI
 	ADDQ $16, DI
-	SUBQ $4, CX
-	CMPQ CX, $4
+	SUBQ $4, R9
+	CMPQ R9, $4
 	JGE loop4
 
-tail:
+reduceChunk:
+	// Reduce the chunk-local SIMD accumulators to a scalar before moving on to
+	// the next chunk so the running total stays in 64-bit AX.
 	MOVOU X5, 0(SP)
-	MOVL 0(SP), AX
+	MOVL 0(SP), R10
 	MOVL 4(SP), BX
-	ADDL BX, AX
+	ADDL BX, R10
 	MOVL 8(SP), BX
-	ADDL BX, AX
+	ADDL BX, R10
 	MOVL 12(SP), BX
-	ADDL BX, AX
-	MOVLQZX AX, AX
+	ADDL BX, R10
+	MOVLQZX R10, R10
+	ADDQ R10, AX
 
-	CMPQ CX, $0
-	JEQ done
+	CMPQ R9, $0
+	JEQ nextChunk
 
 tailLoop:
 	MOVBLZX 0(SI), BX
@@ -77,8 +95,12 @@ tailLoop:
 
 	ADDQ $4, SI
 	ADDQ $4, DI
-	DECQ CX
+	DECQ R9
 	JNZ tailLoop
+
+nextChunk:
+	SUBQ R8, CX
+	JMP chunkLoop
 
 done:
 	MOVQ AX, ret+24(FP)

--- a/agent/go-service/pkg/minicv/simd_test.go
+++ b/agent/go-service/pkg/minicv/simd_test.go
@@ -1,0 +1,40 @@
+package minicv
+
+import "testing"
+
+func dotRGBA3Reference(imgPix, tplPix []byte, pixels int) uint64 {
+	var dot uint64
+	off := 0
+	for range pixels {
+		dot += uint64(imgPix[off]) * uint64(tplPix[off])
+		dot += uint64(imgPix[off+1]) * uint64(tplPix[off+1])
+		dot += uint64(imgPix[off+2]) * uint64(tplPix[off+2])
+		off += 4
+	}
+	return dot
+}
+
+func TestDotRGBA3WideRow(t *testing.T) {
+	const pixels = 50000
+
+	imgPix := make([]byte, pixels*4)
+	tplPix := make([]byte, pixels*4)
+	for i := range pixels {
+		off := i * 4
+		imgPix[off] = byte((i*17 + 11) & 0xFF)
+		imgPix[off+1] = byte((i*31 + 7) & 0xFF)
+		imgPix[off+2] = byte((i*47 + 3) & 0xFF)
+		imgPix[off+3] = 255
+
+		tplPix[off] = byte((i*19 + 5) & 0xFF)
+		tplPix[off+1] = byte((i*23 + 13) & 0xFF)
+		tplPix[off+2] = byte((i*29 + 17) & 0xFF)
+		tplPix[off+3] = 255
+	}
+
+	got := dotRGBA3(&imgPix[0], &tplPix[0], pixels)
+	want := dotRGBA3Reference(imgPix, tplPix, pixels)
+	if got != want {
+		t.Fatalf("unexpected dot product: got=%d want=%d", got, want)
+	}
+}


### PR DESCRIPTION
## 概要

此 PR 是为了解决 #2411 引入的 edge case。

1. SIMD 可能存在数值溢出问题，现在改为分块计算。
2. 并行策略可能存在死锁问题，已把相关调用进行修改。

## 由 Sourcery 总结

修复 SIMD 点积中的数值溢出问题，并调整模板匹配的并行化策略以避免死锁风险。

错误修复：
- 通过对计算进行分块并使用 64 位累加器，防止 SIMD RGBA3 点积中 32 位累加器可能出现的溢出问题。
- 将模板匹配的缩放搜索修改为使用基于 WaitGroup 的 worker 模式，以避免并行策略中潜在的死锁。

测试：
- 为宽行上的 SIMD RGBA3 点积新增正确性测试，用于防止溢出并防止回归。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix numeric overflow in SIMD dot product and adjust template matching parallelization to avoid deadlock risks.

Bug Fixes:
- Prevent potential 32-bit accumulator overflow in the SIMD RGBA3 dot product by chunking the computation and accumulating in 64-bit.
- Change the template matching scale search to use a WaitGroup-based worker pattern to avoid potential deadlocks in the parallel strategy.

Tests:
- Add a correctness test for the SIMD RGBA3 dot product on a wide row to guard against overflow and regression.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 总结

修复 SIMD 点积中的数值溢出问题，并调整模板匹配的并行化策略以避免死锁风险。

错误修复：
- 通过对计算进行分块并使用 64 位累加器，防止 SIMD RGBA3 点积中 32 位累加器可能出现的溢出问题。
- 将模板匹配的缩放搜索修改为使用基于 WaitGroup 的 worker 模式，以避免并行策略中潜在的死锁。

测试：
- 为宽行上的 SIMD RGBA3 点积新增正确性测试，用于防止溢出并防止回归。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix numeric overflow in SIMD dot product and adjust template matching parallelization to avoid deadlock risks.

Bug Fixes:
- Prevent potential 32-bit accumulator overflow in the SIMD RGBA3 dot product by chunking the computation and accumulating in 64-bit.
- Change the template matching scale search to use a WaitGroup-based worker pattern to avoid potential deadlocks in the parallel strategy.

Tests:
- Add a correctness test for the SIMD RGBA3 dot product on a wide row to guard against overflow and regression.

</details>

</details>