### PR TITLE
fix(MapLocator): 修复 tracking 状态路径抖动问题

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -297,12 +297,13 @@ std::optional<MapPosition> MapLocator::Impl::tryTracking(
 
     std::chrono::duration<double> dt = now - motionTracker->getLastTime();
 
-    double trackScale = motionTracker->getLastPos()->scale;
-    if (trackScale <= 0.0) {
-        trackScale = 1.0;
+    double baseScale = motionTracker->getLastPos()->scale;
+    if (baseScale <= 0.0) {
+        baseScale = 1.0;
     }
 
-    cv::Rect searchRect = motionTracker->predictNextSearchRect(trackScale, tmplFeat.image.cols, tmplFeat.image.rows, now);
+    // 用最大候选 scale 来 size 搜索窗，确保所有尺度的模板都能装下；与 kTrackingScaleSteps 对齐
+    cv::Rect searchRect = motionTracker->predictNextSearchRect(baseScale + 0.04, tmplFeat.image.cols, tmplFeat.image.rows, now);
 
     cv::Rect mapBounds(0, 0, zoneMap.cols, zoneMap.rows);
     cv::Rect validRoi = searchRect & mapBounds;
@@ -320,19 +321,54 @@ std::optional<MapPosition> MapLocator::Impl::tryTracking(
 
     auto searchFeature = strategy->extractSearchFeature(searchRoiWithPad);
 
+    // 窄带多尺度匹配：先以 baseScale 尝试，分数足够则直接接受；
+    // 否则遍历邻近尺度取最优，并通过 kScaleHysteresisDelta 抑制尺度频繁切换
+    std::optional<MatchResultRaw> trackResult;
     cv::Mat scaledTempl, scaledWeightMask;
-    if (std::abs(trackScale - 1.0) > 0.001) {
-        cv::resize(tmplFeat.image, scaledTempl, cv::Size(), trackScale, trackScale, cv::INTER_LINEAR);
-        cv::resize(tmplFeat.mask, scaledWeightMask, cv::Size(), trackScale, trackScale, cv::INTER_NEAREST);
-    }
-    else {
-        scaledTempl = tmplFeat.image;
-        scaledWeightMask = tmplFeat.mask;
+    double trackScale = baseScale;
+    double baseScore = -1.0;
+    for (double delta : kTrackingScaleSteps) {
+        if (delta != 0.0 && trackResult && trackResult->score >= kFastTrackingPassScore) {
+            break;
+        }
+        const double s = baseScale + delta;
+        if (s <= 0.0) {
+            continue;
+        }
+
+        cv::Mat templ, mask;
+        if (std::abs(s - 1.0) > 0.001) {
+            cv::resize(tmplFeat.image, templ, cv::Size(), s, s, cv::INTER_LINEAR);
+            cv::resize(tmplFeat.mask, mask, cv::Size(), s, s, cv::INTER_NEAREST);
+        }
+        else {
+            templ = tmplFeat.image;
+            mask = tmplFeat.mask;
+        }
+        if (templ.cols > searchFeature.image.cols || templ.rows > searchFeature.image.rows || cv::countNonZero(mask) < 5) {
+            continue;
+        }
+
+        auto cand = CoreMatch(searchFeature.image, templ, mask, matchCfg.blurSize);
+        if (!cand) {
+            continue;
+        }
+
+        if (delta == 0.0) {
+            baseScore = cand->score;
+        }
+        const bool isBetter = !trackResult || cand->score > trackResult->score;
+        const bool overHysteresis = baseScore < 0.0 || delta == 0.0 || (cand->score - baseScore) >= kScaleHysteresisDelta;
+        if (isBetter && overHysteresis) {
+            trackResult = cand;
+            scaledTempl = std::move(templ);
+            scaledWeightMask = std::move(mask);
+            trackScale = s;
+        }
     }
 
-    auto trackResult = CoreMatch(searchFeature.image, scaledTempl, scaledWeightMask, matchCfg.blurSize);
     if (!trackResult) {
-        LogInfo << "tryTracking: CoreMatch returned nullopt.";
+        LogInfo << "tryTracking: multi-scale CoreMatch returned nullopt for all scales.";
         return std::nullopt;
     }
 
@@ -428,6 +464,20 @@ std::optional<MapPosition> MapLocator::Impl::tryTracking(
     }
 
     if (validation.isValid) {
+        // 坐标 outlier 拒绝：跳变距离超过阈值且分数不足以支撑大幅位移时，hold 上一帧而非接受
+        if (auto last = motionTracker->getLastPos(); last && trackResult->score < kTrackingOutlierMinScore) {
+            const double jumpDist = std::hypot(validation.absX - last->x, validation.absY - last->y);
+            if (jumpDist > kTrackingOutlierDistance) {
+                auto held = *last;
+                held.score = trackResult->score;
+                held.scale = trackScale;
+                held.isHeld = true;
+                motionTracker->hold(held, now);
+                LogInfo << "Tracking outlier rejected, holding last pos." << VAR(jumpDist) << VAR(trackResult->score) << VAR(trackScale);
+                return held;
+            }
+        }
+
         MapPosition pos;
         pos.zoneId = currentZoneId;
         pos.x = validation.absX;
@@ -925,7 +975,8 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
         const bool fallbackHeld = fallbackResult.has_value() && fallbackResult->isHeld;
         const double dist = std::hypot(rawPrimaryPos.x - rawFallbackPos.x, rawPrimaryPos.y - rawFallbackPos.y);
 
-        if (rawFallbackPos.score > 0.1 && dist <= 5.0) {
+        // 双策略互证：两者分数均需满足最低要求，且坐标差在容差内，才视为结果可信
+        if (rawPrimaryPos.score >= kDualVerifyMinScore && rawFallbackPos.score >= kDualVerifyMinScore && dist <= kDualVerifyMaxDistance) {
             LogInfo << "Dual-Mode Tracking Verified! Coords matched. Dist: " << dist;
 
             MapPosition verifiedPos = rawPrimaryPos;
@@ -1071,8 +1122,9 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearchWithFallback(
     const MapPosition& rawGlobalFallbackPos = fallbackAttempt.rawPos;
     const double dist = std::hypot(rawGlobalPrimaryPos.x - rawGlobalFallbackPos.x, rawGlobalPrimaryPos.y - rawGlobalFallbackPos.y);
 
-    // 双策略验证：正常图传和梯度图传独立得出的坐标若极度相近（误差<5像素），说明虽然个别策略信心不足，但互为佐证，此即确信坐标
-    if (rawGlobalPrimaryPos.score > 0.1 && rawGlobalFallbackPos.score > 0.1 && dist <= 5.0) {
+    // 双策略验证：正常图传和梯度图传独立得出的坐标若极度相近，且双方分数都过线，才视为互证。
+    if (rawGlobalPrimaryPos.score >= kDualGlobalVerifyMinScore && rawGlobalFallbackPos.score >= kDualGlobalVerifyMinScore
+        && dist <= kDualVerifyMaxDistance) {
         LogInfo << "Dual-Mode Global Search Verified! Dist: " << dist;
         globalResult = rawGlobalPrimaryPos;
         globalResult->score = std::max(rawGlobalPrimaryPos.score, rawGlobalFallbackPos.score);

--- a/agent/cpp-algo/source/MapLocator/MapTypes.h
+++ b/agent/cpp-algo/source/MapLocator/MapTypes.h
@@ -157,6 +157,25 @@ constexpr double kPositionConsensusRadius = 12.0; // 近点判定半径
 constexpr double kFarJumpRejectDistance = 80.0;   // global 跨帧跳变阈值
 constexpr double kHighConfidenceOverride = 0.85;  // 压倒分：远跳但此分以上直接 reseed
 
+// tracking 窄带多尺度搜索参数。第一项必须为 0.0（即 baseScale），
+// 循环时 baseScale 先跑，达到 kFastTrackingPassScore 则跳过后续尺度
+constexpr double kTrackingScaleSteps[] = { 0.0, -0.04, -0.02, 0.02, 0.04 };
+// baseScale 的单次匹配达到此分时直接接受，无需再尝试其他尺度
+constexpr double kFastTrackingPassScore = 0.75;
+// 非 baseScale 的候选须比 baseScale 高出此值才会替换，抑制小幅波动引起的尺度频繁切换
+constexpr double kScaleHysteresisDelta = 0.015;
+// tracking 接受结果的分数下限；低于此值无论 psr/delta 如何均判为 ambiguous，走 hold 路径
+constexpr double kTrackingHardScoreFloor = 0.60;
+// 低于此分数的帧不参与速度 EMA 更新，保持速度估计的稳定性
+constexpr double kVelocityUpdateMinScore = 0.70;
+// tracking 路径的 outlier 拒绝参数：坐标跳变超过此距离且分数低于 kTrackingOutlierMinScore 时 hold 上一帧
+constexpr double kTrackingOutlierDistance = 25.0;
+constexpr double kTrackingOutlierMinScore = 0.78;
+// dual-mode 互证要求：两个策略的分数均需达到阈值，且坐标距离在容差内
+constexpr double kDualVerifyMinScore = 0.45;
+constexpr double kDualVerifyMaxDistance = 4.0;
+constexpr double kDualGlobalVerifyMinScore = 0.50;
+
 inline bool IsPathHeatmapZone(const std::string& zoneId)
 {
     constexpr const char* kPathHeatmapZoneMarkers[] = { "OMVBase" };

--- a/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
+++ b/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
@@ -265,8 +265,10 @@ public:
         // 突变防御：若帧间换算速度超过限制，则认为是发生了传送或视角剧变，需打断追踪状态强制重搜
         v.isTeleported = currentSpeed > trackingCfg.maxNormalSpeed;
 
+        // 分数硬下限：低于 kTrackingHardScoreFloor 时无论 psr/delta 如何均判为 ambiguous，走 hold 路径
+        const bool belowHardFloor = trackResult.score < kTrackingHardScoreFloor;
         bool lowScore = trackResult.score < 0.80;
-        bool ambiguous = lowScore && (trackResult.psr < 6.0 || trackResult.delta < 0.02);
+        bool ambiguous = belowHardFloor || (lowScore && (trackResult.psr < 6.0 || trackResult.delta < 0.02));
         v.isScreenBlocked = trackResult.score < trackingCfg.screenBlockedThreshold;
 
         v.isValid = !v.isEdgeSnapped && !v.isTeleported && !v.isScreenBlocked && !ambiguous;

--- a/agent/cpp-algo/source/MapLocator/MotionTracker.cpp
+++ b/agent/cpp-algo/source/MapLocator/MotionTracker.cpp
@@ -17,8 +17,8 @@ void MotionTracker::update(const MapPosition& newPos, std::chrono::steady_clock:
     if (lastKnownPos.has_value() && lostTrackingCount == 0) {
         std::chrono::duration<double> dt = now - lastTime;
         double dtSec = dt.count();
-        // 16ms~maxDt: 正常帧间隔; 超出范围说明速度不可信
-        if (dtSec > 0.016 && dtSec < trackingCfg.maxDtForPrediction) {
+        // 仅在帧间隔合理且匹配分数达标时更新速度，保证速度估计的可靠性
+        if (dtSec > 0.016 && dtSec < trackingCfg.maxDtForPrediction && newPos.score >= kVelocityUpdateMinScore) {
             double rawVx = (newPos.x - lastKnownPos->x) / dtSec;
             double rawVy = (newPos.y - lastKnownPos->y) / dtSec;
             double alpha = trackingCfg.velocitySmoothingAlpha;


### PR DESCRIPTION
## Summary by Sourcery

通过稳定尺度估计、拒绝低置信度的离群跳变，并收紧双策略验证阈值，提高地图跟踪的鲁棒性。

Bug Fixes:
- 防止在模板匹配过程中由于频繁的小尺度振荡而导致的跟踪路径抖动。
- 在匹配置信度不足时，避免接受帧间位置的大幅跳变。

Enhancements:
- 引入带滞回机制的窄带多尺度跟踪，并基于基础尺度置信度进行提前退出。
- 在标准匹配策略中通过设置硬性得分下限，细化歧义与遮挡检测。
- 仅在帧间间隔合理且跟踪置信度充足的情况下更新运动速度，以提升预测稳定性。
- 使用可配置的得分与距离阈值，收紧双模式跟踪与全局搜索验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve map tracking robustness by stabilizing scale estimation, rejecting low-confidence outlier jumps, and tightening dual-strategy verification thresholds.

Bug Fixes:
- Prevent tracking path jitter caused by frequent small scale oscillations during template matching.
- Avoid accepting large inter-frame position jumps when match confidence is insufficient.

Enhancements:
- Introduce narrow-band multi-scale tracking with hysteresis and early-exit based on base-scale confidence.
- Refine ambiguity and blocking detection with a hard score floor in the standard match strategy.
- Gate motion velocity updates on both reasonable frame intervals and sufficient tracking confidence to improve prediction stability.
- Tighten dual-mode tracking and global-search verification using configurable score and distance thresholds.

</details>