### PR TITLE
fix(BetterSliding): 使用多段end，让滑块飞一会儿

### DIFF
--- a/agent/go-service/bettersliding/overrides.go
+++ b/agent/go-service/bettersliding/overrides.go
@@ -29,7 +29,10 @@ func buildMainInitializationOverride(end []int, quantityBox []int, quantityFilte
 		nodeBetterSlidingSwipeToMax: map[string]any{
 			"action": map[string]any{
 				"param": map[string]any{
-					"end": append([]int(nil), end...),
+					"end": []any{
+						nodeBetterSlidingFindStart,
+						append([]int(nil), end...),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
再不行真没招了（

close #2384
close #2349
close #2238

## Summary by Sourcery

Bug Fixes:
- 确保 BetterSliding 的“滑动到最大”操作在应用配置的结束坐标之前，先找到起始位置，从而改进滑动行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the BetterSliding swipe-to-max action first finds the start position before applying the configured end coordinates to improve sliding behavior.

</details>