### PR TITLE
fix: 修复环境监测死循环

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring.json
@@ -10,7 +10,7 @@
         "desc": "环境监测循环",
         "recognition": "And",
         "all_of": [
-            "EnvironmentMonitoringCheckOutskirtsMonitoringTerminalText"
+            "EnvironmentMonitoringCheckMonitoringTerminalText"
         ],
         "next": [
             "[JumpBack]OutskirtsMonitoringTerminal",

--- a/assets/resource/pipeline/SceneManager/SceneRegionalDevelopment.json
+++ b/assets/resource/pipeline/SceneManager/SceneRegionalDevelopment.json
@@ -418,7 +418,7 @@
         "desc": "在武陵地区建设界面，进入环境监测界面成功",
         "recognition": "And",
         "all_of": [
-            "EnvironmentMonitoringCheckOutskirtsMonitoringTerminalText"
+            "EnvironmentMonitoringCheckMonitoringTerminalText"
         ],
         "pre_wait_freezes": {
             "time": 80,


### PR DESCRIPTION
## Summary

- \EnvironmentMonitoringLoop\ 和 \__ScenePrivateAnyEnterMenuRegionalDevelopmentWulingEnvironmentMonitoringSuccess\ 的识别条件从特定 tab 文本（\EnvironmentMonitoringCheckOutskirtsMonitoringTerminalText\ = 城郊监测终端）改为页面级标题（\EnvironmentMonitoringCheckMonitoringTerminalText\ = 环境监测终端）
- 无论当前选中城郊还是首墩 tab，都能正确识别当前在监测终端页面，避免误走 JumpBack 导航链导致死循环

## Root Cause

原 \EnvironmentMonitoringLoop\ 的 \ll_of\ 只检查「城郊监测终端」OCR 文本。当画面在首墩 tab 或非监测终端页面时，OCR 不匹配 → 走 \[JumpBack]SceneEnterMenuRegionalDevelopmentWulingEnvironmentMonitoring\（DirectHit，无条件成功）→ 内部导航条件不满足 → 回退是 DoNothing → 反复振荡。

同样的问题影响 \SceneRegionalDevelopment.json\ 中的导航成功判定节点。

Closes #2430, Closes #2422

Made with [Cursor](https://cursor.com)

## 由 Sourcery 撰写的总结

更新环境监控场景检测逻辑，从依赖特定标签页名称改为依赖页面级标题，以防止导航循环。

错误修复：
- 修复当当前标签页不是外围监控终端时，`EnvironmentMonitoringLoop` 中出现的无限导航循环问题。
- 更正区域开发场景中的环境监控成功检测逻辑，使监控终端页面能够在任意标签选中状态下被识别。

功能增强：
- 在 `EnvironmentMonitoring` 和 `SceneRegionalDevelopment` 流水线中统一环境监控终端识别逻辑，改为使用一致的页面级标题检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update environment monitoring scene detection to rely on page-level titles instead of specific tab labels to prevent navigation loops.

Bug Fixes:
- Fix infinite navigation loop in EnvironmentMonitoringLoop when the current tab is not the outskirts monitoring terminal.
- Correct environment monitoring success detection in regional development scenes so monitoring terminal pages are recognized regardless of selected tab.

Enhancements:
- Align environment monitoring terminal recognition logic across EnvironmentMonitoring and SceneRegionalDevelopment pipelines to use consistent page-level title checks.

</details>