### PR TITLE
fix(EnvironmentMonitoring): 修正小壳兽的路径

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
@@ -291,20 +291,16 @@
             "map_name": "map02_lv002",
             "path": [
                 [
-                    240.3,
-                    703.6
+                    239.8,
+                    704.8
                 ],
                 [
-                    214.6,
-                    703.7
+                    214.7,
+                    706.1
                 ],
                 [
-                    214,
-                    708.3
-                ],
-                [
-                    182.8,
-                    707.9
+                    216.1,
+                    702.7
                 ]
             ]
         },
@@ -320,7 +316,7 @@
         "desc": "小壳兽任务中调整朝向",
         "max_hit": 2,
         "next": [
-            "EnvironmentMonitoringSwipeScreenLeft"
+            "EnvironmentMonitoringSwipeScreenDown"
         ]
     }
 }

--- a/docs/en_us/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/en_us/developers/tasks/environment-monitoring-maintain.md
@@ -12,26 +12,26 @@ The core characteristic of environment monitoring is **"data-driven + template b
 
 The core maintenance points for environment monitoring are:
 
-| Module                  | Path                                                                     | Purpose                                                                                                                                |
-| ----------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Task entry              | `assets/tasks/EnvironmentMonitoring.json`                                | Interface task definition (no configurable options; controller = Win32-Front / Wlroots / ADB)                                          |
-| Main-flow Pipeline      | `assets/resource/pipeline/EnvironmentMonitoring.json`                    | Top-level entry node `EnvironmentMonitoringMain`, loops over the two monitoring terminals                                              |
-| Terminal groups (gen.)  | `assets/resource/pipeline/EnvironmentMonitoring/Terminals.json`          | Entry nodes for Outskirts / MarkerStone terminals and their observation-point `next` lists (**generated**)                             |
-| Terminal navigation     | `assets/resource/pipeline/EnvironmentMonitoring/Locations.json`          | `EnvironmentMonitoringGoTo*` and `Select*` nodes that navigate from the main menu into the respective terminal                         |
-| Photo-taking flow       | `assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json`          | Enters photo mode, adjusts camera facing, identifies the shutter button, returns to the terminal after completion                      |
-| Camera swipe            | `assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json`          | `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` four-direction facing adjustment                                                |
-| Shared buttons          | `assets/resource/pipeline/EnvironmentMonitoring/Button.json`             | Environment-monitoring-specific shared buttons such as `TrackMissionButton`                                                            |
-| Observation-point nodes | `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json`     | **One JSON per observation point**, rendered from the template (**generated**)                                                         |
-| Point template          | `tools/pipeline-generate/EnvironmentMonitoring/template.jsonc`           | Single-observation-point Pipeline template (text recognition, accept/go-to, teleport, pathfinding, photo)                              |
-| Terminal template       | `tools/pipeline-generate/EnvironmentMonitoring/terminals-template.jsonc` | Terminal-group node template                                                                                                           |
-| Route / coordinate data | `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs`               | `ROUTE_CONFIG`: teleport target, map name, path, camera-swipe direction for each observation point                                     |
-| Terminal list data      | `tools/pipeline-generate/EnvironmentMonitoring/terminals-data.mjs`       | Terminal ID list; chains each observation-point Job node into the corresponding terminal's `next`                                      |
-| Game data snapshot      | `tools/pipeline-generate/EnvironmentMonitoring/kite_station.json`        | Official terminal/commission data from `zmdmap` (multi-language names, `shotTargetName`)                                               |
-| Generator config        | `tools/pipeline-generate/EnvironmentMonitoring/config.json`              | Per-point output config: `outputPattern: "${Station}/${Id}.json"`                                                                      |
-| Terminal gen. config    | `tools/pipeline-generate/EnvironmentMonitoring/terminals-config.json`    | Merged terminal output config: `outputFile: "Terminals.json"`                                                                          |
-| Locale strings          | `assets/locales/interface/*.json`                                        | `task.EnvironmentMonitoring.*` label / description (task level; observation-point names use OCR)                                       |
-| MapTracker dependency   | `agent/go-service/map-tracker/`                                          | `MapTrackerMove`, `MapTrackerAssertLocation` (see [map-tracker.md](../components/map-tracker.md))                                      |
-| SceneManager dependency | `assets/resource/pipeline/SceneManager/`, `Interface/`                   | `SceneEnterWorldWuling*`, `SceneEnterMenuRegionalDevelopmentWulingEnvironmentMonitoring` (see [scene-manager.md](../scene-manager.md)) |
+| Module                  | Path                                                                     | Purpose                                                                                                                                          |
+| ----------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Task entry              | `assets/tasks/EnvironmentMonitoring.json`                                | Interface task definition (no configurable options; controller = Win32-Front / Wlroots / ADB)                                                    |
+| Main-flow Pipeline      | `assets/resource/pipeline/EnvironmentMonitoring.json`                    | Top-level entry node `EnvironmentMonitoringMain`, loops over the two monitoring terminals                                                        |
+| Terminal groups (gen.)  | `assets/resource/pipeline/EnvironmentMonitoring/Terminals.json`          | Entry nodes for Outskirts / MarkerStone terminals and their observation-point `next` lists (**generated**)                                       |
+| Terminal navigation     | `assets/resource/pipeline/EnvironmentMonitoring/Locations.json`          | `EnvironmentMonitoringGoTo*` and `Select*` nodes that navigate from the main menu into the respective terminal                                   |
+| Photo-taking flow       | `assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json`          | Enters photo mode, adjusts camera facing, identifies the shutter button, returns to the terminal after completion                                |
+| Camera swipe            | `assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json`          | `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` four-direction facing adjustment                                                          |
+| Shared buttons          | `assets/resource/pipeline/EnvironmentMonitoring/Button.json`             | Environment-monitoring-specific shared buttons such as `TrackMissionButton`                                                                      |
+| Observation-point nodes | `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json`     | **One JSON per observation point**, rendered from the template (**generated**); `Id` is generated by `data.mjs` and normally not written by hand |
+| Point template          | `tools/pipeline-generate/EnvironmentMonitoring/template.jsonc`           | Single-observation-point Pipeline template (text recognition, accept/go-to, teleport, pathfinding, photo)                                        |
+| Terminal template       | `tools/pipeline-generate/EnvironmentMonitoring/terminals-template.jsonc` | Terminal-group node template                                                                                                                     |
+| Route / coordinate data | `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs`               | `ROUTE_CONFIG`: route overrides matched by the observation point's Chinese `Name` (teleport target, map name, path, camera-swipe direction)      |
+| Terminal list data      | `tools/pipeline-generate/EnvironmentMonitoring/terminals-data.mjs`       | Builds each terminal's `next` list from `data.mjs` rows and the automatically derived terminal list                                              |
+| Game data snapshot      | `tools/pipeline-generate/EnvironmentMonitoring/kite_station.json`        | Official terminal/commission data from `zmdmap` (multi-language names, `shotTargetName`)                                                         |
+| Generator config        | `tools/pipeline-generate/EnvironmentMonitoring/config.json`              | Per-point output config: `outputPattern: "${Station}/${Id}.json"`                                                                                |
+| Terminal gen. config    | `tools/pipeline-generate/EnvironmentMonitoring/terminals-config.json`    | Merged terminal output config: `outputFile: "Terminals.json"`                                                                                    |
+| Locale strings          | `assets/locales/interface/*.json`                                        | `task.EnvironmentMonitoring.*` label / description (task level; observation-point names use OCR)                                                 |
+| MapTracker dependency   | `agent/go-service/map-tracker/`                                          | `MapTrackerMove`, `MapTrackerAssertLocation` (see [map-tracker.md](../components/map-tracker.md))                                                |
+| SceneManager dependency | `assets/resource/pipeline/SceneManager/`, `Interface/`                   | `SceneEnterWorldWuling*`, `SceneEnterMenuRegionalDevelopmentWulingEnvironmentMonitoring` (see [scene-manager.md](../scene-manager.md))           |
 
 ## Main flow
 
@@ -59,7 +59,9 @@ The chain inside each observation-point `{Id}Job` (rendered from `template.jsonc
   └─ GoTo{Id}Mission                  (commission already accepted → click go-to)
        └─ {Id}TrackOrGoTo
             ├─ Track{Id}              (if "Start Tracking" button present → click it)
-            └─ GoTo{Id}              (SubTask: SceneAnyEnterWorld → back to open world)
+            │    ├─ {Id}NotAdapted    (route not adapted → show notice and finish this point)
+            │    └─ GoTo{Id}          (route adapted → continue to the location)
+            └─ GoTo{Id}               (route adapted and no tracking click needed → SubTask: SceneAnyEnterWorld)
                  ├─ GoTo{Id}StartPos  (MapTrackerAssertLocation confirms position → MapTrackerMove)
                  └─ GoTo{Id}NotAtStartPos
                       └─ SubTask: ${EnterMap}             (teleport)
@@ -83,9 +85,9 @@ EnvironmentMonitoringTakePhoto        (enters photo mode → adjusts facing → 
 
 ## Naming conventions
 
-### Observation-point ID (`Id`)
+### Observation-point node ID (`Id`, generated)
 
-`ROUTE_CONFIG[*].Id` in `routes.mjs`; serves as the prefix for all generated node names:
+`Id` is a generated field assembled by `data.mjs`; it serves as the prefix for all generated observation-point node names and output files:
 
 ```text
 {PascalCase English name}
@@ -99,11 +101,13 @@ EcologyNearTheFieldLogisticsDepot → 储备站周围的生态环境
 MysteriousCryptidGraffiti         → 谜之生物的涂鸦
 ```
 
-`Id` is derived by default from the `name["en-US"]` of the corresponding task in `kite_station.json`, PascalCase'd via `buildDefaultId()` / `toPascalCase()` in `data.mjs`. **When an explicit `Id` is provided in `ROUTE_CONFIG`, that value takes precedence**—this is the only way to decouple `Id` from the game's official English name.
+By default, `Id` is derived from the corresponding task's `name["en-US"]` in `kite_station.json`, PascalCase'd via `buildDefaultId()` / `toPascalCase()` in `data.mjs`. If the English name is missing, it falls back to `missionId` / `entrustIdx`; if duplicates occur, `ensureUniqueId()` appends a suffix automatically.
+
+When maintaining `ROUTE_CONFIG`, you **normally do not need to write `Id`**. `ROUTE_CONFIG` is matched by the Chinese `Name`; `Id` is only an internal generation field for node names and file names. Write an explicit `Id` only when you intentionally need to pin an old node name, typically when the game's official English name changed but you want to keep the old generated file name and avoid noisy renames.
 
 > [!IMPORTANT]
 >
-> Do not use `Id` as display text. Display text comes from `Name` (Chinese) or OCR; `Id` is only used for constructing node names and file names (`outputPattern: "${Station}/${Id}.json"`). `Id` must be a valid identifier (only `[A-Za-z0-9]`) and must match the `[JumpBack]{Id}Job` entries in the `next` list exactly.
+> Do not use `Id` as display text, and do not add it by default for new observation points. Display text comes from `Name` (Chinese) or OCR; `Id` is only used for constructing node names and file names (`outputPattern: "${Station}/${Id}.json"`). If you do write `Id` manually, keep it identifier-like (`[A-Za-z0-9]` only).
 
 ### Terminal group (`Station`)
 
@@ -140,8 +144,8 @@ When a new Station appears, **the generator side (`routes.mjs` + `data.mjs`) req
 | Field                               | Source                                                                                                                                          |
 | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Station`                           | English terminal name from `kite_station.json` (PascalCase)                                                                                     |
-| `Id`                                | `ROUTE_CONFIG[*].Id` if provided; otherwise official English name PascalCase'd                                                                  |
-| `Name`                              | `name["zh-CN"]` from `kite_station.json`, special characters stripped                                                                           |
+| `Id`                                | Generated from the official English name by default; overridden only when `ROUTE_CONFIG[*].Id` is explicitly provided                           |
+| `Name`                              | `name["zh-CN"]` from `kite_station.json`, special characters stripped; `ROUTE_CONFIG` is also matched by this Chinese name                      |
 | `GoToMonitoringTerminal`            | Determined by `Station`                                                                                                                         |
 | `EnterMap`                          | `ROUTE_CONFIG[*].EnterMap`; **must be an existing SceneManager node name**                                                                      |
 | `MapName` / `MapTarget` / `MapPath` | `ROUTE_CONFIG[*]`; maps to `MapTrackerMove` / `MapTrackerAssertLocation` parameters                                                             |
@@ -149,6 +153,7 @@ When a new Station appears, **the generator side (`routes.mjs` + `data.mjs`) req
 | `CameraMaxHit`                      | `ROUTE_CONFIG[*].CameraMaxHit`; defaults to `ROUTE_DEFAULTS.CameraMaxHit` (`2`); corresponds to the max-hit count for `${Id}AdjustCamera` swipe |
 | `ExpectedText`                      | Expanded automatically from `mission.name` multi-language map in `kite_station.json` (5 languages, English converted to a flexible regex)       |
 | `InExpectedText`                    | Expanded from `mission.shotTargetName` in `kite_station.json`                                                                                   |
+| `TrackOrGoToNext` / `TrackNext`     | Decided automatically by `data.mjs`: adapted points continue to photo-taking, while unadapted points only accept and track                      |
 
 ### Terminal groups: `terminals-config.json`
 
@@ -183,7 +188,7 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 
 > [!NOTE]
 >
-> If an observation point is missing fields at render time, `data.mjs` falls back to `ROUTE_DEFAULTS` (`SceneAnyEnterWorld` + placeholder coordinates) and emits a `console.warn`. **Pipelines rendered with placeholder values pass lint but cannot reach the observation point at runtime.** After adding a new point, always confirm that all `ROUTE_CONFIG` fields are filled in to avoid leaving placeholder entries behind.
+> If an observation point has no `ROUTE_CONFIG`, or if its route fields still equal `ROUTE_DEFAULTS` (`SceneAnyEnterWorld` + placeholder coordinates), `data.mjs` emits a `console.warn` and treats the point as **not adapted**. The point still gets a generated Pipeline, but at runtime it only accepts and tracks the mission, then stops at `${Id}NotAdapted`; placeholder teleport/pathfinding is not executed.
 
 ## Key dependencies
 
@@ -200,7 +205,7 @@ For detailed parameters and coordinate recording, see [map-tracker.md](../compon
 
 The `EnterMap` field must be an existing teleport node name in SceneManager, e.g. `SceneEnterWorldWulingJingyuValley7`. If a new observation point is in a yet-unsupported teleport location, the corresponding `SceneEnterWorld*` and scene-recognition nodes must first be added under `assets/resource/pipeline/SceneManager/` and `assets/resource/pipeline/Interface/` (see [scene-manager.md](../scene-manager.md)).
 
-Special fallback: `SceneAnyEnterWorld` means "skip teleport, return to the current world directly." When no suitable teleport exists for an observation point (e.g. the "Rainbow" point that lacks a Qingyun Cave teleport in this branch), `SceneAnyEnterWorld` can be used temporarily combined with a precise `MapTarget` / `MapPath` so the character walks there; mark it with a `// TODO:` comment in `routes.mjs`.
+`SceneAnyEnterWorld` is currently only the unadapted placeholder value. `data.mjs` treats any point with `EnterMap === ROUTE_DEFAULTS.EnterMap` as not adapted, so even if `MapTarget` / `MapPath` are filled in, the route and photo flow will not run. To fully automate a point, `EnterMap` must be a real `SceneEnterWorld*` teleport node. If no usable teleport exists yet, leave the point without a `ROUTE_CONFIG` entry and let it use the degraded "accept and track only" flow for now.
 
 ### Main menu entry
 
@@ -218,20 +223,19 @@ New observation points generally come from game updates, reflected as additional
 
 Replace `tools/pipeline-generate/EnvironmentMonitoring/kite_station.json` with the latest version (source: `zmdmap`).
 
-### 2. Identify missing entries
+### 2. Check route adaptation status
 
-Compare `entrustTasks` in `kite_station.json` against entries in `ROUTE_CONFIG` and confirm:
+Compare `entrustTasks` in `kite_station.json` against entries in `ROUTE_CONFIG` and confirm each observation point's status. Matching is done by normalized Chinese `Name`, not by `Id`:
 
-- **Missing config**: the observation point is absent from `ROUTE_CONFIG` entirely → proceed to step 3.
-- **Placeholder pending completion**: the entry exists in `ROUTE_CONFIG` but `EnterMap` / `MapPath` etc. are still default values → proceed to step 4.
+- **Not adapted**: the observation point has no `ROUTE_CONFIG`, or still uses `ROUTE_DEFAULTS` placeholder fields → after generation, it only accepts and tracks.
+- **Ready to adapt**: the observation point should automatically travel and take the photo → proceed to step 3 and fill real route data.
 
-### 3. Add an entry to `ROUTE_CONFIG`
+### 3. Add or complete an entry in `ROUTE_CONFIG`
 
 In `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs` → `ROUTE_CONFIG`:
 
 ```javascript
 {
-    Id: "MyNewObservationPoint",         // PascalCase; used as node prefix and file name
     Name: "我的新观察点",                 // must match zh-CN name in kite_station.json (after stripping special characters)
     EnterMap: "SceneEnterWorldWulingXxx",// existing teleport node in SceneManager
     MapName: "map02_lv001",              // MapTracker minimap identifier
@@ -239,12 +243,13 @@ In `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs` → `ROUTE_CONFIG`
     MapPath: [[x1, y1], [x2, y2], ...],  // pathfinding route (minimap coordinates)
     CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp", // facing-adjustment direction
     // CameraMaxHit: 2,  // optional; max swipe count, default 2; increase if the target is hard to frame
+    // Id: "ExistingObservationPoint", // optional; only pin old node/file names when needed, usually omit for new points
 }
 ```
 
 > [!IMPORTANT]
 >
-> `Name` is the matching key used internally by `data.mjs`'s `normalizeMissionName()`; it is compared against `mission.name["zh-CN"]` in `kite_station.json` with symbols stripped and lowercased. If the match fails, the override in `ROUTE_CONFIG` will not take effect and the default values will be used as fallback.
+> `Name` is the matching key used internally by `data.mjs`'s `normalizeMissionName()`; it is compared against `mission.name["zh-CN"]` in `kite_station.json` with symbols stripped and lowercased. If the match fails, the override in `ROUTE_CONFIG` will not take effect and the point is treated as not adapted. `Id` is not the matching key, so do not add it by default for new observation points.
 
 ### 4. Record coordinates and path
 
@@ -266,6 +271,8 @@ Verify the two categories of generated files:
 - `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json`
 - `assets/resource/pipeline/EnvironmentMonitoring/Terminals.json` (`{Station}MonitoringTerminalLoop.next` contains `[JumpBack]{Id}Job`)
 
+Here, `{Id}` is the generated node ID. In normal maintenance, just inspect the generated file name; you do not need to precompute it in `routes.mjs`.
+
 ## Modifying an existing observation-point route
 
 Adjusting only the route/facing (no change to the English name):
@@ -274,9 +281,9 @@ Adjusting only the route/facing (no change to the English name):
 2. Regenerate (only `npx @joebao/maa-pipeline-generate` is needed; re-generating `Terminals.json` is unnecessary when the terminal list is unchanged).
 3. Commit `routes.mjs` together with the regenerated `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json`.
 
-If the observation point's official English name changes and causes the `Id` to drift:
+If the observation point's official English name changes, the generated `Id` / file name changes too. In most cases, regenerating is enough; if you want to keep the old node and file name:
 
-1. Explicitly add `Id: "ExistingId"` in `ROUTE_CONFIG` to pin the old ID (prevents all `[JumpBack]{Id}Job` entries in `next` chains from breaking).
+1. Explicitly add `Id: "ExistingId"` in `ROUTE_CONFIG` to pin the old ID (prevents generated files and `[JumpBack]{Id}Job` chains from being renamed together).
 2. Regenerate.
 
 ## Pre-submit checklist
@@ -284,20 +291,22 @@ If the observation point's official English name changes and causes the `Id` to 
 Before committing, at minimum verify:
 
 1. New/modified entries in `ROUTE_CONFIG` in `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs` have all required fields.
-2. `EnterMap`, `MapTarget`, `MapPath`, and `CameraSwipeDirection` in new `ROUTE_CONFIG` entries all hold real values (not `ROUTE_DEFAULTS` placeholders).
-3. The regenerated `Terminals.json` has `[JumpBack]{Id}Job` for every new point in both `{Station}MonitoringTerminalLoop.next` lists, ending with `EnvironmentMonitoringFinish`.
-4. The `Scene*` node referenced by `EnterMap` actually exists under `assets/resource/pipeline/SceneManager/` and `Interface/`.
-5. `CameraSwipeDirection` is one of `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}`.
-6. **No hand-edits** to `assets/resource/pipeline/EnvironmentMonitoring/{Station}/*.json` or `Terminals.json` (hand-edits are overwritten on the next generation run; if special nodes are truly needed, extend `template.jsonc` / `terminals-template.jsonc`).
-7. JSON files conform to `.prettierrc` formatting (the generator has `format: true`, but running `pnpm prettier --write` before committing is even safer).
+2. The `Name` of each new `ROUTE_CONFIG` entry matches `mission.name["zh-CN"]` in `kite_station.json`; do not add `Id` by default for new points.
+3. Adapted entries have real `EnterMap`, `MapTarget`, `MapPath`, and `CameraSwipeDirection` values (not `ROUTE_DEFAULTS` placeholders).
+4. The regenerated `Terminals.json` has `[JumpBack]{Id}Job` for every new point in each `{Station}MonitoringTerminalLoop.next` list, ending with `EnvironmentMonitoringFinish`.
+5. The `Scene*` node referenced by `EnterMap` actually exists under `assets/resource/pipeline/SceneManager/` and `Interface/`.
+6. `CameraSwipeDirection` is one of `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}`.
+7. **No hand-edits** to `assets/resource/pipeline/EnvironmentMonitoring/{Station}/*.json` or `Terminals.json` (hand-edits are overwritten on the next generation run; if special nodes are truly needed, extend `template.jsonc` / `terminals-template.jsonc`).
+8. JSON files conform to `.prettierrc` formatting (the generator has `format: true`, but running `pnpm prettier --write` before committing is even safer).
 
 ## Common pitfalls
 
 - **Hand-editing generated artifacts**: Directly editing `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json` or `Terminals.json` will lose changes on the next generation run. Edit source data and regenerate.
-- **`Name` does not match game text**: `ROUTE_CONFIG[i].Name` is only used internally in `data.mjs` to match `mission.name["zh-CN"]` in `kite_station.json`. It is not display text or an OCR expectation. A mismatch emits a `console.warn` and falls back to the placeholder.
-- **`Id` drifts from `kite_station.json` English name**: When the game renames an item in English, the auto-computed `Id` changes, invalidating old `[JumpBack]{Id}Job` entries in `Terminals.json`. Add `ROUTE_CONFIG[i].Id` explicitly to pin the old ID.
+- **`Name` does not match game text**: `ROUTE_CONFIG[i].Name` is only used internally in `data.mjs` to match `mission.name["zh-CN"]` in `kite_station.json`. It is not display text or an OCR expectation. A mismatch emits a `console.warn` and treats the point as not adapted (accept and track only).
+- **Treating `Id` as required**: new observation points normally should not write `Id`. Add `ROUTE_CONFIG[i].Id` only when you need to pin an old node/file name.
+- **`Id` drifts from `kite_station.json` English name**: When the game renames an item in English, the auto-computed `Id` changes, which can cause generated file renames or stale old files. Add `ROUTE_CONFIG[i].Id` explicitly if you want to keep the old name.
 - **`EnterMap` references a non-existent Scene node**: The generator does not validate this; at runtime the task will loop indefinitely at `GoTo{Id}NotAtStartPos`.
 - **`MapPath` passes through locked areas / combat / interactables**: MapTracker does not handle combat or cutscenes; paths must only traverse freely walkable sections.
 - **New `Station` added but `Locations.json` / `EnvironmentMonitoringLoop.next` not updated**: the new terminal cannot be recognized or entered, so all its observation points are unreachable.
 - **`anchor` key name consistency**: The `anchor` key `EnvironmentMonitoringBackToTerminal` in `template.jsonc` must stay exactly consistent with `[Anchor]EnvironmentMonitoringBackToTerminal` in `TakePhoto.json`; a mismatch silently disables the anchor mechanism.
-- **"Passes generation ≠ passes runtime"**: `ROUTE_DEFAULTS` prevents generation-stage errors, but `EnterMap=SceneAnyEnterWorld` + `MapPath=[[0,0]]` will never reach the target at runtime. Before committing, manually verify that no placeholder entries remain in `ROUTE_CONFIG` (entries with `EnterMap` set to `SceneAnyEnterWorld` and no `// TODO:` comment should raise a flag).
+- **"Generated successfully ≠ fully adapted"**: points without route config, or points still using `ROUTE_DEFAULTS`, are generated as a degraded flow. They only accept and track; they do not travel or take the photo. Full automation requires real `EnterMap`, `MapTarget`, `MapPath`, and `CameraSwipeDirection` values.

--- a/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
@@ -21,11 +21,11 @@
 | 拍照流程           | `assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json`          | 进入拍照模式、调整朝向、识别拍照按钮、达成目标后回到终端                                                                                 |
 | 摄像头滑动         | `assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json`          | `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` 四向调整朝向                                                                      |
 | 公共按钮           | `assets/resource/pipeline/EnvironmentMonitoring/Button.json`             | `TrackMissionButton` 等环境监测专用通用按钮                                                                                              |
-| 观察点节点（生成） | `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json`     | **每个观察点一份 JSON**，由模板渲染（**生成**）                                                                                          |
+| 观察点节点（生成） | `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json`     | **每个观察点一份 JSON**，由模板渲染（**生成**）；`Id` 由 `data.mjs` 自动生成，通常不用手写                                               |
 | 观察点模板         | `tools/pipeline-generate/EnvironmentMonitoring/template.jsonc`           | 单观察点 Pipeline 模板（识别文本、接取/前往、传送、寻路、拍照）                                                                          |
 | 终端模板           | `tools/pipeline-generate/EnvironmentMonitoring/terminals-template.jsonc` | 终端分组节点模板                                                                                                                         |
-| 路线/坐标数据      | `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs`               | `ROUTE_CONFIG`：每个观察点的传送点、地图、路径、摄像头滑动方向                                                                           |
-| 终端列表数据       | `tools/pipeline-generate/EnvironmentMonitoring/terminals-data.mjs`       | 终端 ID 列表，对每个观察点 Job 节点串成 `next`                                                                                           |
+| 路线/坐标数据      | `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs`               | `ROUTE_CONFIG`：按观察点中文 `Name` 匹配的路线覆盖（传送点、地图、路径、摄像头滑动方向）                                                 |
+| 终端列表数据       | `tools/pipeline-generate/EnvironmentMonitoring/terminals-data.mjs`       | 从 `data.mjs` 的行数据和自动派生的终端列表生成各终端 `next`                                                                              |
 | 游戏数据快照       | `tools/pipeline-generate/EnvironmentMonitoring/kite_station.json`        | 由 `zmdmap` 提供的官方监测终端/委托数据（多语言名称、`shotTargetName`）                                                                  |
 | 生成器配置         | `tools/pipeline-generate/EnvironmentMonitoring/config.json`              | 单观察点输出配置：`outputPattern: "${Station}/${Id}.json"`                                                                               |
 | 终端生成器配置     | `tools/pipeline-generate/EnvironmentMonitoring/terminals-config.json`    | 合并到单文件的终端输出配置：`outputFile: "Terminals.json"`                                                                               |
@@ -59,7 +59,9 @@ EnvironmentMonitoringMain
   └─ GoTo{Id}Mission                 （委托已接 → 点击前往）
        └─ {Id}TrackOrGoTo
             ├─ Track{Id}             （存在「开始追踪」按钮则点击）
-            └─ GoTo{Id}              （SubTask: SceneAnyEnterWorld 回大世界）
+            │    ├─ {Id}NotAdapted   （路线未适配 → 仅提示并结束该观察点）
+            │    └─ GoTo{Id}         （路线已适配 → 继续前往）
+            └─ GoTo{Id}              （路线已适配且无需点击追踪 → SubTask: SceneAnyEnterWorld 回大世界）
                  ├─ GoTo{Id}StartPos （MapTrackerAssertLocation 已就位 → MapTrackerMove）
                  └─ GoTo{Id}NotAtStartPos
                       └─ SubTask: ${EnterMap}            （传送）
@@ -83,9 +85,9 @@ EnvironmentMonitoringTakePhoto       （进入拍照模式 → 朝向 → 拍照
 
 ## 命名规则
 
-### 观察点 ID（`Id`）
+### 观察点节点 ID（`Id`，自动生成）
 
-`routes.mjs` 里 `ROUTE_CONFIG[*].Id`，等价于生成出的所有节点名前缀：
+`Id` 是 `data.mjs` 装配出的生成字段，等价于所有观察点节点名和输出文件名的前缀：
 
 ```text
 {PascalCase 英文名}
@@ -99,11 +101,13 @@ EcologyNearTheFieldLogisticsDepot → 储备站周围的生态环境
 MysteriousCryptidGraffiti         → 谜之生物的涂鸦
 ```
 
-`Id` 默认从 `kite_station.json` 中该任务的 `name["en-US"]` 转 PascalCase 得到，规则在 `data.mjs` 的 `buildDefaultId()` / `toPascalCase()`。**当 `ROUTE_CONFIG` 中显式提供 `Id` 时以显式值为准**——这是 `Id` 与游戏官方英文名脱钩的唯一入口。
+默认情况下，`Id` 从 `kite_station.json` 中该任务的 `name["en-US"]` 转 PascalCase 得到，规则在 `data.mjs` 的 `buildDefaultId()` / `toPascalCase()`。如果英文名缺失，会回退到 `missionId` / `entrustIdx`；如果出现重复，`ensureUniqueId()` 会自动追加后缀。
+
+维护 `ROUTE_CONFIG` 时 **通常不需要写 `Id`**。`ROUTE_CONFIG` 的匹配键是中文 `Name`，`Id` 只是生成器内部用来拼节点名和文件名的字段。只有在需要主动锁定旧节点名时才显式写 `Id`，典型场景是游戏官方英文名变了，但希望继续沿用旧的生成文件名，避免产生无意义的大量重命名。
 
 > [!IMPORTANT]
 >
-> 不要把 `Id` 当作展示文案。展示文案走 `Name`（中文）或 OCR；`Id` 只用于拼接节点名、文件名（`outputPattern: "${Station}/${Id}.json"`）。`Id` 必须是合法的标识符（仅 `[A-Za-z0-9]`），且应与该观察点 `next` 列表里的 `[JumpBack]{Id}Job` 完全一致。
+> 不要把 `Id` 当作展示文案，也不要为了新增观察点默认加 `Id`。展示文案走 `Name`（中文）或 OCR；`Id` 只用于拼接节点名、文件名（`outputPattern: "${Station}/${Id}.json"`）。如果确实手写 `Id`，请保持合法标识符风格（仅 `[A-Za-z0-9]`）。
 
 ### 终端分组（`Station`）
 
@@ -140,8 +144,8 @@ MysteriousCryptidGraffiti         → 谜之生物的涂鸦
 | 字段                                | 来源                                                                                                                         |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `Station`                           | `kite_station.json` 的英文站名（PascalCase）                                                                                 |
-| `Id`                                | `ROUTE_CONFIG[*].Id` 优先；否则官方英文名 PascalCase                                                                         |
-| `Name`                              | `kite_station.json` 的 `name["zh-CN"]`，去掉特殊符号                                                                         |
+| `Id`                                | 默认由官方英文名 PascalCase 自动生成；仅当 `ROUTE_CONFIG[*].Id` 显式提供时覆盖                                               |
+| `Name`                              | `kite_station.json` 的 `name["zh-CN"]`，去掉特殊符号；`ROUTE_CONFIG` 也按这个中文名归并匹配                                  |
 | `GoToMonitoringTerminal`            | 由 `Station` 决定                                                                                                            |
 | `EnterMap`                          | `ROUTE_CONFIG[*].EnterMap`，**必须是 SceneManager 中存在的节点名**                                                           |
 | `MapName` / `MapTarget` / `MapPath` | `ROUTE_CONFIG[*]`，对应 `MapTrackerMove` / `MapTrackerAssertLocation` 参数                                                   |
@@ -149,6 +153,7 @@ MysteriousCryptidGraffiti         → 谜之生物的涂鸦
 | `CameraMaxHit`                      | `ROUTE_CONFIG[*].CameraMaxHit`，缺省用 `ROUTE_DEFAULTS.CameraMaxHit`（`2`）；对应 `${Id}AdjustCamera` 滑屏动作的最大命中次数 |
 | `ExpectedText`                      | 由 `kite_station.json` 的 `mission.name` 多语言 map 自动展开（5 语言，英文转柔性正则）                                       |
 | `InExpectedText`                    | 由 `kite_station.json` 的 `mission.shotTargetName` 自动展开                                                                  |
+| `TrackOrGoToNext` / `TrackNext`     | 由 `data.mjs` 根据路线是否完整自动决定：已适配则继续前往拍照，未适配则仅接取并追踪                                           |
 
 ### 终端分组：`terminals-config.json`
 
@@ -183,7 +188,7 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 
 > [!NOTE]
 >
-> `data.mjs` 在渲染时如果某观察点缺字段，会用 `ROUTE_DEFAULTS`（`SceneAnyEnterWorld` + 占位坐标）兜底，并 `console.warn`。**占位渲染出的 Pipeline 能跑过 lint，但运行时无法真正抵达观察点**。新增观察点后务必确认 `ROUTE_CONFIG` 字段已全部填写，避免遗留占位。
+> `data.mjs` 在渲染时如果某观察点没有 `ROUTE_CONFIG`，或路线字段仍等于 `ROUTE_DEFAULTS`（`SceneAnyEnterWorld` + 占位坐标），会 `console.warn` 并把该观察点视为 **未适配**。未适配观察点仍会生成 Pipeline，但运行时只会接取并追踪任务，然后在 `${Id}NotAdapted` 提示后结束，不会执行占位传送或占位寻路。
 
 ## 关键依赖
 
@@ -200,7 +205,7 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 
 `EnterMap` 字段必须填写 SceneManager 中已存在的传送节点名，例如 `SceneEnterWorldWulingJingyuValley7`。如果新增观察点位于尚未支持的传送点，需要先在 `assets/resource/pipeline/SceneManager/` 与 `assets/resource/pipeline/Interface/` 下补齐对应的 `SceneEnterWorld*` 与场景识别节点（参见 [scene-manager.md](../scene-manager.md)）。
 
-特殊兜底：`SceneAnyEnterWorld` 表示「不传送、直接回到当前世界」。当观察点本身没有合适的传送点（比如本分支里的「彩虹（缺少栖云窟传送点）」），可以临时填 `SceneAnyEnterWorld`，配合精确的 `MapTarget` / `MapPath` 让玩家跑过去；但要在 `routes.mjs` 注释 `// TODO:` 标记。
+`SceneAnyEnterWorld` 目前只作为未适配占位值使用。`data.mjs` 会把 `EnterMap === ROUTE_DEFAULTS.EnterMap` 的观察点判定为未适配，因此即使同时填写了 `MapTarget` / `MapPath`，也不会进入寻路和拍照流程。要让观察点完整自动化，`EnterMap` 必须改成真实的 `SceneEnterWorld*` 传送节点；暂时没有可用传送点时，可以先不加 `ROUTE_CONFIG` 条目，让它按“仅接取并追踪”的降级流程运行。
 
 ### 主菜单入口
 
@@ -218,20 +223,19 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 
 把最新的 `kite_station.json` 替换到 `tools/pipeline-generate/EnvironmentMonitoring/kite_station.json`（数据来源：`zmdmap`）。
 
-### 2. 检查缺失项
+### 2. 检查路线适配状态
 
-对比 `kite_station.json` 中的 `entrustTasks` 与 `ROUTE_CONFIG` 的条目，确认：
+对比 `kite_station.json` 中的 `entrustTasks` 与 `ROUTE_CONFIG` 的条目，确认每个观察点的状态。匹配方式是中文 `Name` 归一化匹配，而不是 `Id` 匹配：
 
-- **缺失配置**：`ROUTE_CONFIG` 完全没有该观察点 → 走步骤 3。
-- **占位待补全**：`ROUTE_CONFIG` 已加但 `EnterMap` / `MapPath` 等字段仍是默认值 → 走步骤 4。
+- **未适配**：`ROUTE_CONFIG` 没有该观察点，或仍使用 `ROUTE_DEFAULTS` 占位字段 → 生成后只会接取并追踪。
+- **准备适配**：需要让该观察点自动前往并拍照 → 走步骤 3，补齐真实路线。
 
-### 3. 在 `ROUTE_CONFIG` 中新增条目
+### 3. 在 `ROUTE_CONFIG` 中新增/补全条目
 
 `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs` → `ROUTE_CONFIG`：
 
 ```javascript
 {
-    Id: "MyNewObservationPoint",         // PascalCase，作为节点前缀和文件名
     Name: "我的新观察点",                 // 必须与 kite_station.json 中的 zh-CN 名（去掉特殊符号后）匹配
     EnterMap: "SceneEnterWorldWulingXxx",// SceneManager 中存在的传送节点
     MapName: "map02_lv001",              // MapTracker 的小地图标识
@@ -239,12 +243,13 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
     MapPath: [[x1, y1], [x2, y2], ...],  // 寻路路径（小地图坐标）
     CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp", // 朝向调整方向
     // CameraMaxHit: 2,  // 可选；滑屏最大命中次数，默认为 2；拍摄目标较难对准时可适当调大
+    // Id: "ExistingObservationPoint", // 可选；仅在需要锁定旧节点/文件名时填写，新增点通常不要加
 }
 ```
 
 > [!IMPORTANT]
 >
-> `Name` 是 `data.mjs` 内部 `normalizeMissionName()` 的匹配键，会与 `kite_station.json` 中的 `mission.name["zh-CN"]` 做去符号、小写对比。如果对不上，`ROUTE_CONFIG` 里的覆盖不会生效，会被默认值兜底。
+> `Name` 是 `data.mjs` 内部 `normalizeMissionName()` 的匹配键，会与 `kite_station.json` 中的 `mission.name["zh-CN"]` 做去符号、小写对比。如果对不上，`ROUTE_CONFIG` 里的覆盖不会生效，该观察点会按未适配处理。`Id` 不是匹配键，新增观察点时不要默认添加。
 
 ### 4. 录制坐标和路径
 
@@ -266,6 +271,8 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 - `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json`
 - `assets/resource/pipeline/EnvironmentMonitoring/Terminals.json`（`{Station}MonitoringTerminalLoop.next` 中包含 `[JumpBack]{Id}Job`）
 
+这里的 `{Id}` 是生成结果里的节点 ID。通常直接看生成出的文件名即可确认；维护 `routes.mjs` 时不需要提前手算。
+
 ## 修改已有观察点路线
 
 只调整路线/朝向（不变更英文名）：
@@ -274,9 +281,9 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 2. 重新生成（仅需跑 `npx @joebao/maa-pipeline-generate`，终端列表未变化无需重新生成 `Terminals.json`）。
 3. 提交 `routes.mjs` 与重生成的 `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json`。
 
-如果观察点的官方英文名变了导致 `Id` 漂移：
+如果观察点的官方英文名变了，生成出的 `Id` / 文件名也会跟着变。多数情况下重新生成即可；如果希望保留旧节点名和文件名：
 
-1. 在 `ROUTE_CONFIG` 中显式加 `Id: "ExistingId"` 锁定旧 ID（避免 `next` 链路里所有 `[JumpBack]{Id}Job` 都失效）。
+1. 在 `ROUTE_CONFIG` 中显式加 `Id: "ExistingId"` 锁定旧 ID（避免生成文件和 `[JumpBack]{Id}Job` 链路整体改名）。
 2. 重新生成。
 
 ## 自检清单
@@ -284,20 +291,22 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 提交前至少检查：
 
 1. `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs` 的 `ROUTE_CONFIG` 中新增/修改条目是否字段齐全。
-2. `ROUTE_CONFIG` 中新增条目的 `EnterMap`、`MapTarget`、`MapPath`、`CameraSwipeDirection` 均已填写真实值（非 `ROUTE_DEFAULTS` 占位）。
-3. 重生成的 `Terminals.json` 中两个 `{Station}MonitoringTerminalLoop.next` 包含全部新 `[JumpBack]{Id}Job`，并以 `EnvironmentMonitoringFinish` 收尾。
-4. `EnterMap` 引用的 `Scene*` 节点确实存在于 `assets/resource/pipeline/SceneManager/` 与 `Interface/` 中。
-5. `CameraSwipeDirection` 是 `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` 四者之一。
-6. **没有手改** `assets/resource/pipeline/EnvironmentMonitoring/{Station}/*.json` 或 `Terminals.json`（手改会被下次生成覆盖；如确需特殊节点，应在 `template.jsonc` / `terminals-template.jsonc` 中扩展）。
-7. JSON 文件遵循 `.prettierrc` 格式（生成器自带 `format: true`，但提交前 `pnpm prettier --write` 一遍更稳）。
+2. `ROUTE_CONFIG` 中新增条目的 `Name` 是否能匹配 `kite_station.json` 的 `mission.name["zh-CN"]`；不要为了新增点默认添加 `Id`。
+3. 已适配条目的 `EnterMap`、`MapTarget`、`MapPath`、`CameraSwipeDirection` 均已填写真实值（非 `ROUTE_DEFAULTS` 占位）。
+4. 重生成的 `Terminals.json` 中各 `{Station}MonitoringTerminalLoop.next` 包含全部新 `[JumpBack]{Id}Job`，并以 `EnvironmentMonitoringFinish` 收尾。
+5. `EnterMap` 引用的 `Scene*` 节点确实存在于 `assets/resource/pipeline/SceneManager/` 与 `Interface/` 中。
+6. `CameraSwipeDirection` 是 `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` 四者之一。
+7. **没有手改** `assets/resource/pipeline/EnvironmentMonitoring/{Station}/*.json` 或 `Terminals.json`（手改会被下次生成覆盖；如确需特殊节点，应在 `template.jsonc` / `terminals-template.jsonc` 中扩展）。
+8. JSON 文件遵循 `.prettierrc` 格式（生成器自带 `format: true`，但提交前 `pnpm prettier --write` 一遍更稳）。
 
 ## 常见坑
 
 - **手改生成产物**：直接编辑 `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json` 或 `Terminals.json`，下次重新生成时改动会丢。改源数据 + 重新生成才是正确做法。
-- **`Name` 与游戏文本对不上**：`ROUTE_CONFIG[i].Name` 只用于在 `data.mjs` 内部匹配 `kite_station.json` 的 `mission.name["zh-CN"]`，不是显示文本也不是 OCR 期望。匹配失败时 `console.warn` 提示，并使用占位值兜底。
-- **`Id` 与 `kite_station.json` 英文名漂移**：当游戏侧改英文名后，自动算出的 `Id` 会变，导致 `Terminals.json` 中旧的 `[JumpBack]{Id}Job` 失效。补 `ROUTE_CONFIG[i].Id` 显式锁定旧 ID 即可。
+- **`Name` 与游戏文本对不上**：`ROUTE_CONFIG[i].Name` 只用于在 `data.mjs` 内部匹配 `kite_station.json` 的 `mission.name["zh-CN"]`，不是显示文本也不是 OCR 期望。匹配失败时 `console.warn` 提示，并按未适配处理（仅接取并追踪）。
+- **把 `Id` 当必填字段**：新增观察点通常不要写 `Id`。只有需要锁定旧节点名/文件名时才补 `ROUTE_CONFIG[i].Id`。
+- **`Id` 与 `kite_station.json` 英文名漂移**：当游戏侧改英文名后，自动算出的 `Id` 会变，可能带来生成文件重命名或旧文件残留。若想保留旧名，补 `ROUTE_CONFIG[i].Id` 显式锁定即可。
 - **`EnterMap` 写了不存在的 Scene 节点**：生成器不校验，运行时会卡在 `GoTo{Id}NotAtStartPos` 死循环。
 - **`MapPath` 经过未解锁区域 / 战斗 / 互动物**：MapTracker 不处理战斗与剧情，路径只能选纯通行段。
 - **`Station` 新增但 `Locations.json` / `EnvironmentMonitoringLoop.next` 没同步**：新终端无法被识别进入，所有观察点都跑不到。
 - **`anchor` 占位符名一致性**：`template.jsonc` 中 `anchor` 的 key 名 `EnvironmentMonitoringBackToTerminal` 必须与 `TakePhoto.json` 中的 `[Anchor]EnvironmentMonitoringBackToTerminal` 保持完全一致，否则 anchor 机制失效。
-- **「占位值能跑通生成 ≠ 任务能跑通运行」**：`ROUTE_DEFAULTS` 让生成阶段不报错，但运行时 `EnterMap=SceneAnyEnterWorld` + `MapPath=[[0,0]]` 永远走不到目标。提交前请人工核对 `ROUTE_CONFIG` 中没有遗留占位条目（`EnterMap` 为 `SceneAnyEnterWorld` 且没有 `// TODO:` 注释时应引起注意）。
+- **「生成成功 ≠ 已完整适配」**：没有路线配置或仍使用 `ROUTE_DEFAULTS` 的观察点会生成成降级流程，只接取并追踪，不会前往拍照。完整自动化必须补真实的 `EnterMap`、`MapTarget`、`MapPath` 和 `CameraSwipeDirection`。

--- a/tools/pipeline-generate/EnvironmentMonitoring/README.md
+++ b/tools/pipeline-generate/EnvironmentMonitoring/README.md
@@ -12,7 +12,7 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 ## 新增/更新观察点
 
 1. **更新游戏数据**：将最新的 `kite_station.json` 替换到本目录（数据来源：`zmdmap`）。
-2. **补充路线配置**：在 `routes.mjs` 的 `ROUTE_CONFIG` 中新增或修改对应观察点的条目（传送点、地图名、寻路路径、摄像头朝向等）。若暂无数据，`ROUTE_DEFAULTS` 会自动兜底，但生成的 Pipeline **无法真正运行**。
+2. **补充路线配置**：在 `routes.mjs` 的 `ROUTE_CONFIG` 中新增或修改对应观察点的条目（传送点、地图名、寻路路径、摄像头朝向等）。若暂无数据，生成器会将该观察点标记为未适配，生成的 Pipeline 只会接取并追踪，不会前往拍照。
 3. **重新生成 Pipeline**：运行上方两条命令，分别生成观察点节点文件与终端分组文件。
 4. **提交**：将 `routes.mjs` 与 `assets/resource/pipeline/EnvironmentMonitoring/` 下重新生成的文件一并提交。
 
@@ -20,15 +20,13 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 
 ```javascript
 {
-    Id: "MyObservationPoint",
-        // PascalCase 英文名，作为节点前缀与输出文件名（${Station}/${Id}.json）。
-        // 默认从 kite_station.json 的 name["en-US"] 转换；有歧义或官方英文名变动时显式指定。
     Name: "我的观察点",
         // 用于匹配 kite_station.json 中对应 mission 的 name["zh-CN"]（去符号小写对比）。
-        // 匹配失败时 data.mjs 会 console.warn 并以 ROUTE_DEFAULTS 兜底。
+        // 匹配失败时 data.mjs 会 console.warn，并按未适配处理。
     EnterMap: "SceneEnterWorldWulingXxx",
         // 传送节点名，必须已在 assets/resource/pipeline/SceneManager/ 中存在。
-        // 无合适传送点时填 "SceneAnyEnterWorld"（直接回大世界），并附 // TODO: 注释。
+        // "SceneAnyEnterWorld" 是未适配占位值；填它会只接取并追踪，不会进入寻路/拍照。
+        // 暂无合适传送点时，建议先不加 ROUTE_CONFIG 条目，等传送节点补齐后再完整适配。
     MapName: "map02_lv001",
         // MapTracker 小地图标识，支持正则（如 "^map\\d+_lv\\d+$"）。
     MapTarget: [x, y, w, h],
@@ -41,6 +39,9 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
     CameraMaxHit: 2,
         // 可选；调整摄像头时的最大滑屏命中次数，默认值见 ROUTE_DEFAULTS。
         // 拍照目标较难对准时可适当调大。
+    // Id: "ExistingObservationPoint",
+    //     可选；默认从 kite_station.json 的 name["en-US"] 自动转换。
+    //     只有需要锁定旧节点名/输出文件名（${Station}/${Id}.json）时才显式指定，新增观察点通常不要加。
 }
 ```
 

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.mjs
@@ -227,12 +227,11 @@ export const ROUTE_CONFIG = [
         MapName: "map02_lv002",
         MapTarget: [238.6, 694.1, 15.2, 14.6],
         MapPath: [
-            [240.3, 703.6],
-            [214.6, 703.7],
-            [214.0, 708.3],
-            [182.8, 707.9]
+            [239.8, 704.8],
+            [214.7, 706.1],
+            [216.1, 702.7]
         ],
-        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenLeft",
+        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenDown",
     },
     {
         Name: "环形瀑布",


### PR DESCRIPTION
有时候二楼会没有小壳兽

顺便更新文档。

## Summary by Sourcery

更新 MiniShellbeast 的 EnvironmentMonitoring 路由配置，以纠正其路径和相机滑动方向，并调整相关的流水线资源。

Bug 修复：
- 修正 MiniShellbeast 的路由路径和相机滑动方向，确保其始终显示在二楼。

增强：
- 为郊区监控终端中的 MiniShellbeast 调整 EnvironmentMonitoring 流水线资源。

文档：
- 更新与 MiniShellbeast 路由和行为相关的 EnvironmentMonitoring 文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update EnvironmentMonitoring route configuration for the MiniShellbeast to correct its path and camera swipe direction, and adjust associated pipeline resources.

Bug Fixes:
- Correct MiniShellbeast route path and camera swipe direction to ensure it appears consistently on the second floor.

Enhancements:
- Adjust EnvironmentMonitoring pipeline resources for the MiniShellbeast in the outskirts monitoring terminal.

Documentation:
- Update EnvironmentMonitoring documentation related to the MiniShellbeast route and behavior.

</details>