### PR TITLE
fix: 修复焕新月卡无法领取问题

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneLogin.json
+++ b/assets/resource/pipeline/SceneManager/SceneLogin.json
@@ -47,7 +47,7 @@
         "next": [
             "[JumpBack]SceneWaitLoadingExit",
             "[JumpBack]__ScenePrivateLoginMonthlyPassConfirm",
-            "[JumpBack]CloseRewardsButton",
+            "[JumpBack]__ScenePrivateLoginPristineMonthlyPassConfirm",
             "__ScenePrivateLoginSuccess",
             "[JumpBack]__ScenePrivateLoginCloseDialog"
         ]
@@ -125,6 +125,34 @@
         "action": {
             "type": "Click"
         }
+    },
+    "__ScenePrivateLoginPristineMonthlyPassConfirm": {
+        "desc": "领取焕新月卡，无法跳过必须领取",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    850,
+                    180,
+                    250,
+                    150
+                ],
+                "expected": [
+                    "焕新月卡赠礼",
+                    "煥新月卡贈禮",
+                    "Pristine Monthly Pass Tribute",
+                    "月パス特典",
+                    "리뉴얼 월정액 선물"
+                ]
+            }
+        },
+        "pre_wait_freezes": 200,
+        "action": {
+            "type": "Click"
+        },
+        "next": [
+            "SceneNoticeRewardsConfirm"
+        ]
     },
     "__ScenePrivateLoginCloseDialog": {
         "desc": "关闭所有待领取的弹窗，此功能目的是进入游戏，奖励领取统一在单独任务中处理",

--- a/assets/resource/pipeline/SceneManager/SceneLogin.json
+++ b/assets/resource/pipeline/SceneManager/SceneLogin.json
@@ -131,7 +131,7 @@
                 "roi": [
                     850,
                     180,
-                    250,
+                    300,
                     150
                 ],
                 "expected": [
@@ -158,6 +158,15 @@
             "param": {
                 "key": 27 // ESC
             }
+        },
+        "post_wait_freezes": {
+            "target": [
+                0,
+                0,
+                100,
+                100
+            ],
+            "time": 600
         }
     },
     "__ScenePrivateLoginSuccess": {

--- a/assets/resource/pipeline/SceneManager/SceneLogin.json
+++ b/assets/resource/pipeline/SceneManager/SceneLogin.json
@@ -114,10 +114,7 @@
                     "月パス残り",
                     "今日月卡奖励",
                     "今日月卡獎勵",
-                    "(?i)Daily\\s*Monthly\\s*Pass\\s*Rewards",
-                    "本日報酬",
-                    "月卡奖励$",
-                    "月卡獎勵$"
+                    "(?i)Daily\\s*Monthly\\s*Pass\\s*Rewards"
                 ]
             }
         },


### PR DESCRIPTION
拆分普通月卡和焕新月卡pipeline处理逻辑，避免逻辑糅杂
close #2257
close #2350
close #2353
close #2429
close #2438

## Summary by Sourcery

将普通月卡和续费月卡的登录流程处理进行分离，以解决奖励领取问题并降低逻辑耦合度。

Bug Fixes:
- 修复在特定条件下无法领取续费月卡奖励的情况。

Enhancements:
- 在登录流程中解耦普通月卡与续费月卡的处理，以简化流程并提升可维护性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate the login pipeline handling for standard and renewal monthly cards to resolve reward claim issues and reduce logic coupling.

Bug Fixes:
- Fix cases where renewal monthly card rewards could not be claimed under certain conditions.

Enhancements:
- Decouple standard and renewal monthly card processing in the login flow to simplify the pipeline and improve maintainability.

</details>

Bug 修复：
- 修复在某些条件下续费月卡奖励无法领取的问题。

增强项：
- 在登录流程中解耦普通月卡和续费月卡的处理，以减少逻辑耦合并提升可维护性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将普通月卡和续费月卡的登录流程处理进行分离，以解决奖励领取问题并降低逻辑耦合度。

Bug Fixes:
- 修复在特定条件下无法领取续费月卡奖励的情况。

Enhancements:
- 在登录流程中解耦普通月卡与续费月卡的处理，以简化流程并提升可维护性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate the login pipeline handling for standard and renewal monthly cards to resolve reward claim issues and reduce logic coupling.

Bug Fixes:
- Fix cases where renewal monthly card rewards could not be claimed under certain conditions.

Enhancements:
- Decouple standard and renewal monthly card processing in the login flow to simplify the pipeline and improve maintainability.

</details>

</details>