### PR TITLE
fix: 临时修复自动战斗检测退出战斗失败问题，释放终结技改为长按

### DIFF
--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -230,7 +230,7 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 
 		if time.Since(lastLevelShowCheck) >= 5*time.Second {
 			lastLevelShowCheck = time.Now()
-			if inFightSpace && getCharactorLevelShow(ctx, img) {
+			if getCharactorLevelShow(ctx, img) {
 				log.Info().Str("component", "AutoFight").Msg("character level show detected, exiting fight")
 				maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
 				saveExitImage(img, "character_level_show")

--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -22,7 +22,12 @@ var screenAnalyzer = NewScreenAnalyzer()
 func getCharactorLevelShow(ctx *maa.Context, img image.Image) bool {
 	detail, err := ctx.RunRecognition("__AutoFightRecognitionCharactorLevelShow", img)
 	if err != nil || detail == nil {
-		log.Error().Err(err).Msg("Failed to run recognition for combo notice")
+		log.Error().
+			Err(err).
+			Str("component", "AutoFight").
+			Str("step", "getCharactorLevelShow").
+			Str("recognition", "__AutoFightRecognitionCharactorLevelShow").
+			Msg("failed to run recognition for character level show")
 		return false
 	}
 	return detail.Hit

--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -19,6 +19,15 @@ import (
 
 var screenAnalyzer = NewScreenAnalyzer()
 
+func getCharactorLevelShow(ctx *maa.Context, img image.Image) bool {
+	detail, err := ctx.RunRecognition("__AutoFightRecognitionCharactorLevelShow", img)
+	if err != nil || detail == nil {
+		log.Error().Err(err).Msg("Failed to run recognition for combo notice")
+		return false
+	}
+	return detail.Hit
+}
+
 type AutoFightEntryRecognition struct{}
 
 func (r *AutoFightEntryRecognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa.CustomRecognitionResult, bool) {
@@ -149,6 +158,7 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 	log.Debug().Str("component", "AutoFight").Str("step", "parse params").Interface("params", params).Msg("parsed action attach parameters")
 	var pauseStart time.Time
 	var facingOnlyStart time.Time
+	var lastLevelShowCheck time.Time
 	characterCount := -1
 	skillCycleIndex := 1
 
@@ -211,6 +221,17 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 			saveExitImage(img, "character_level")
 			result = true
 			break
+		}
+
+		if time.Since(lastLevelShowCheck) >= 5*time.Second {
+			lastLevelShowCheck = time.Now()
+			if inFightSpace && getCharactorLevelShow(ctx, img) {
+				log.Info().Str("component", "AutoFight").Msg("character level show detected, exiting fight")
+				maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
+				saveExitImage(img, "character_level_show")
+				result = true
+				break
+			}
 		}
 		// CharacterLevel小概率识别不到，comboEmpty大概率不显示了依然命中，双重保险
 		// if len(comboFull) == 0 && len(comboEmpty) == 0 {
@@ -393,9 +414,9 @@ func drainActionQueue(ctx *maa.Context, characterCount int) {
 				continue
 			}
 			op := fa.operator + characterCount - 4
-			ctx.RunAction("__AutoFightActionEndSkillAltKeyDown", maa.Rect{600, 320, 80, 80}, "", nil)
+			// ctx.RunAction("__AutoFightActionEndSkillAltKeyDown", maa.Rect{600, 320, 80, 80}, "", nil)
 			ctx.RunAction(fmt.Sprintf("__AutoFightActionEndSkillOperators%d", op), maa.Rect{600, 320, 80, 80}, "", nil)
-			ctx.RunAction("__AutoFightActionEndSkillAltKeyUp", maa.Rect{600, 320, 80, 80}, "", nil)
+			// ctx.RunAction("__AutoFightActionEndSkillAltKeyUp", maa.Rect{600, 320, 80, 80}, "", nil)
 		case ActionLockTarget:
 			ctx.RunAction("__AutoFightActionLockTarget", maa.Rect{600, 320, 80, 80}, "", nil)
 		case ActionDodge:

--- a/assets/resource/pipeline/AutoFight/Action.json
+++ b/assets/resource/pipeline/AutoFight/Action.json
@@ -127,26 +127,29 @@
         "post_delay": 0
     },
     "__AutoFightActionEndSkillOperators1": {
-        "pre_delay": 200,
-        "action": "ClickKey",
+        "pre_delay": 0,
+        "action": "LongPressKey",
+        "duration": 1500,
         "key": 49, // 1键
-        "post_delay": 200,
+        "post_delay": 0,
         "focus": {
             "Node.Action.Succeeded": "触发干员1终结技"
         }
     },
     "__AutoFightActionEndSkillOperators2": {
-        "pre_delay": 200,
-        "action": "ClickKey",
+        "pre_delay": 0,
+        "action": "LongPressKey",
+        "duration": 1500,
         "key": 50, // 2键
-        "post_delay": 200,
+        "post_delay": 0,
         "focus": {
             "Node.Action.Succeeded": "触发干员2终结技"
         }
     },
     "__AutoFightActionEndSkillOperators3": {
         "pre_delay": 0,
-        "action": "ClickKey",
+        "action": "LongPressKey",
+        "duration": 1500,
         "key": 51, // 3键
         "post_delay": 0,
         "focus": {
@@ -155,7 +158,8 @@
     },
     "__AutoFightActionEndSkillOperators4": {
         "pre_delay": 0,
-        "action": "ClickKey",
+        "action": "LongPressKey",
+        "duration": 1500,
         "key": 52, // 4键
         "post_delay": 0,
         "focus": {


### PR DESCRIPTION
close #2432
#2335
close #2307
close #2292

## 由 Sourcery 提供的摘要

改进自动战斗的战斗结束检测，并调整终极技能触发行为。

错误修复：
- 增加对角色等级显示的周期性检查，以更可靠地检测并退出自动战斗中已结束的战斗。

功能增强：
- 修改终结技能的激活方式，仅使用干员特定的操作，移除辅助按键序列。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve auto-fight end-of-battle detection and adjust ultimate skill trigger behavior.

Bug Fixes:
- Add a periodic check for the character level display to more reliably detect and exit completed battles in auto-fight.

Enhancements:
- Change end-skill activation to use only the operator-specific action, removing the auxiliary key press sequence.

</details>