### PR TITLE
fix: 修复超大HTML导致的日志文件过大问题和任务链停止问题

### DIFF
--- a/agent/go-service/map-tracker/infer.go
+++ b/agent/go-service/map-tracker/infer.go
@@ -271,7 +271,7 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 	if !finalHit {
 		log.Info().Bool("finalLocHit", finalLoc != nil).Bool("finalRotHit", finalRot != nil).Msg("Map tracking inference did not hit")
 		if param.Print {
-			maafocus.Print(ctx, i18n.RenderHTML("maptracker.inference_failed", nil))
+			maafocus.PrintLargeContent(i18n.RenderHTML("maptracker.inference_failed", nil))
 		}
 
 		// Return as not hit
@@ -311,8 +311,7 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 		Float64("RotConf", result.RotConf).
 		Msg("Map tracking inference completed")
 	if param.Print {
-		maafocus.Print(
-			ctx,
+		maafocus.PrintLargeContent(
 			i18n.RenderHTML("maptracker.inference_finished", map[string]any{
 				"X":       finalLoc.x,
 				"Y":       finalLoc.y,

--- a/agent/go-service/map-tracker/move.go
+++ b/agent/go-service/map-tracker/move.go
@@ -159,8 +159,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		if initResult, err := doInfer(ctx, ctrl, param); err == nil && initResult != nil {
 			initRot = calcTargetRotation(initResult.X, initResult.Y, targetX, targetY)
 			if !param.NoPrint {
-				maafocus.Print(
-					ca.Ctx(),
+				maafocus.PrintLargeContent(
 					a.buildNavigationMovingHTML(param, i, initResult.X, initResult.Y, targetX, targetY),
 				)
 			}
@@ -387,8 +386,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		if finalInfer, err := doInfer(ctx, ctrl, param); err == nil && finalInfer != nil {
 			finishedX, finishedY = finalInfer.X, finalInfer.Y
 		}
-		maafocus.Print(
-			ca.Ctx(),
+		maafocus.PrintLargeContent(
 			a.buildNavigationFinishedHTML(param, finishedX, finishedY),
 		)
 	}
@@ -496,7 +494,7 @@ func doPlayerStop(ca control.ControlAdaptor) {
 func doEmergencyStop(ca control.ControlAdaptor, noPrint bool) {
 	log.Warn().Msg("Emergency stop triggered")
 	if !noPrint {
-		maafocus.Print(ca.Ctx(), i18n.RenderHTML("maptracker.emergency_stop", nil))
+		maafocus.PrintLargeContent(i18n.RenderHTML("maptracker.emergency_stop", nil))
 	}
 	doPlayerStop(ca)
 }

--- a/agent/go-service/map-tracker/move.go
+++ b/agent/go-service/map-tracker/move.go
@@ -499,7 +499,6 @@ func doEmergencyStop(ca control.ControlAdaptor, noPrint bool) {
 		maafocus.Print(ca.Ctx(), i18n.RenderHTML("maptracker.emergency_stop", nil))
 	}
 	doPlayerStop(ca)
-	ca.Ctx().GetTasker().PostStop()
 }
 
 func doInfer(ctx *maa.Context, ctrl *maa.Controller, param *MapTrackerMoveParam) (*MapTrackerInferResult, error) {

--- a/agent/go-service/pkg/maafocus/maafocus.go
+++ b/agent/go-service/pkg/maafocus/maafocus.go
@@ -9,8 +9,13 @@ import (
 
 const nodeName = "_GO_SERVICE_FOCUS_"
 
-// Print sends focus payload on node action starting event.
+// Print sends focus payload on node action starting event,
+// so that the client can make the payload visible to users.
+//
 // The actual UI rendering is handled by client side.
+//
+// If the content is too large, consider using [PrintLargeContent]
+// to avoid potential performance issues.
 func Print(ctx *maa.Context, content string) {
 	if ctx == nil {
 		log.Warn().
@@ -34,4 +39,13 @@ func Print(ctx *maa.Context, content string) {
 			Str("event", "node_action_starting").
 			Msg("failed to send focus")
 	}
+}
+
+// PrintLargeContent sends payload to stdout for large content.
+//
+// Instead of [Print], this function will not record the content into Maa's log system.
+//
+// Note that this function does not require a context argument.
+func PrintLargeContent(content string) {
+	println(content)
 }

--- a/agent/go-service/pkg/maafocus/maafocus.go
+++ b/agent/go-service/pkg/maafocus/maafocus.go
@@ -3,6 +3,8 @@
 package maafocus
 
 import (
+	"fmt"
+
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -13,6 +15,7 @@ const nodeName = "_GO_SERVICE_FOCUS_"
 // so that the client can make the payload visible to users.
 //
 // The actual UI rendering is handled by client side.
+// See https://maafw.com/en/docs/3.1-PipelineProtocol#node-notifications
 //
 // If the content is too large, consider using [PrintLargeContent]
 // to avoid potential performance issues.
@@ -41,11 +44,11 @@ func Print(ctx *maa.Context, content string) {
 	}
 }
 
-// PrintLargeContent sends payload to stdout for large content.
+// PrintLargeContent sends payload to [fmt.Println] for large content.
 //
 // Instead of [Print], this function will not record the content into Maa's log system.
 //
 // Note that this function does not require a context argument.
 func PrintLargeContent(content string) {
-	println(content)
+	fmt.Println(content)
 }

--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/control"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
@@ -208,8 +209,9 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 }
 
 func (c *AspectRatioChecker) stopWithWarning(tasker *maa.Tasker, controllerDisplay string, width, height int, requirement string) {
-	content := i18n.RenderHTML("tasker.aspect_ratio_warning", buildWarningData(controllerDisplay, width, height, requirement))
-	fmt.Println(content)
+	maafocus.PrintLargeContent(
+		i18n.RenderHTML("tasker.aspect_ratio_warning", buildWarningData(controllerDisplay, width, height, requirement)),
+	)
 	tasker.PostStop()
 }
 

--- a/agent/go-service/taskersink/hdrcheck/checker.go
+++ b/agent/go-service/taskersink/hdrcheck/checker.go
@@ -39,7 +39,7 @@ func (c *HDRChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventStatus, det
 		log.Warn().Msg("HDR is enabled! This may cause issues with image recognition.")
 
 		// Print warning message (HTML formatted for MXU display)
-		// fmt.Println(i18n.RenderHTML("tasker.hdr_warning", nil))
+		// maafocus.PrintLargeContent(i18n.RenderHTML("tasker.hdr_warning", nil))
 
 		// Mark as warned to avoid repeated warnings
 		c.warned = true

--- a/agent/go-service/taskersink/processcheck/checker.go
+++ b/agent/go-service/taskersink/processcheck/checker.go
@@ -1,10 +1,10 @@
 package processcheck
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/v4/process"
@@ -52,7 +52,10 @@ func (c *ProcessChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventStatus,
 		Msg("Blacklisted processes detected!")
 
 	names := strings.Join(found, ", ")
-	fmt.Println(i18n.RenderHTML("tasker.process_warning", map[string]any{"ProcessNames": names}))
+
+	maafocus.PrintLargeContent(
+		i18n.RenderHTML("tasker.process_warning", map[string]any{"ProcessNames": names}),
+	)
 
 	c.warned = true
 }


### PR DESCRIPTION
## 概要

此 PR 解决了两个 Go Agent 的使用方面的问题：

1. 打印超大 HTML 文本到 focus 导致 MaaFW 日志文件过大的问题——现在采用直接 stdout 解决，向 maafocus pkg 引入了 PrintLargeContent 函数并进行若干调用处迁移。
2. MapTrackerMove 节点的急停特性会直接停止整个任务链条的问题——现在仅返回 false 结果。

## 关联

上述两个问题都是为了修复 #2254 。

Fix #2254

## Summary by Sourcery

为大型 HTML 内容引入专用的焦点打印路径，并调整 map-tracker 的紧急停止行为，以避免停止整个任务链。

New Features:
- 在 `maafocus` 包中新增 `PrintLargeContent` 辅助方法，用于将大型 HTML 负载输出到 stdout，而不在 Maa 日志中记录。

Bug Fixes:
- 通过移除自动调用 `PostStop`，防止 MapTracker 紧急停止时终止整个任务链。
- 避免将非常大的 HTML 焦点负载打印进日志系统而导致 Maa 日志体积过度增长。

Enhancements:
- 将各种基于 HTML 的警告和状态消息（地图跟踪导航、推理结果、纵横比与进程检查等）通过新的大型内容打印辅助方法进行处理，以获得更合适的处理方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated focus printing path for large HTML content and adjust map-tracker emergency-stop behavior to avoid stopping entire task chains.

New Features:
- Add a PrintLargeContent helper in the maafocus package to output large HTML payloads to stdout without recording them in Maa logs.

Bug Fixes:
- Prevent MapTracker emergency stops from terminating the entire task chain by removing the automatic PostStop call.
- Avoid excessive Maa log growth caused by printing very large HTML focus payloads into the logging system.

Enhancements:
- Route various HTML-based warnings and status messages (map tracker navigation, inference results, aspect-ratio and process checks) through the new large-content printing helper for more appropriate handling.

</details>