### PR TITLE
feat: 新增环境监测-首墩检测终端-安思园的天师桩

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
@@ -157,7 +157,8 @@
             "InSerenityGardenTianshiPillarMission"
         ],
         "next": [
-            "TrackSerenityGardenTianshiPillar"
+            "TrackSerenityGardenTianshiPillar",
+            "GoToSerenityGardenTianshiPillar"
         ]
     },
     "TrackSerenityGardenTianshiPillar": {
@@ -169,7 +170,7 @@
         ],
         "action": "Click",
         "next": [
-            "SerenityGardenTianshiPillarNotAdapted"
+            "GoToSerenityGardenTianshiPillar"
         ]
     },
     "SerenityGardenTianshiPillarNotAdapted": {
@@ -199,12 +200,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "^map\\d+_lv\\d+$",
+                    "map_name": "map02_lv004",
                     "target": [
-                        0,
-                        0,
-                        1,
-                        1
+                        402.4,
+                        313.4,
+                        20.8,
+                        17.4
                     ]
                 }
             ]
@@ -219,7 +220,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneAnyEnterWorld"
+                "SceneEnterWorldWulingMarkerStone2"
             ]
         },
         "next": [
@@ -234,12 +235,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "^map\\d+_lv\\d+$",
+                    "map_name": "map02_lv004",
                     "target": [
-                        0,
-                        0,
-                        1,
-                        1
+                        402.4,
+                        313.4,
+                        20.8,
+                        17.4
                     ]
                 }
             ]
@@ -254,7 +255,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneAnyEnterWorld"
+                "SceneEnterWorldWulingMarkerStone2"
             ]
         },
         "next": [
@@ -268,12 +269,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "^map\\d+_lv\\d+$",
+                    "map_name": "map02_lv004",
                     "target": [
-                        0,
-                        0,
-                        1,
-                        1
+                        402.4,
+                        313.4,
+                        20.8,
+                        17.4
                     ]
                 }
             ]
@@ -287,11 +288,39 @@
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {
-            "map_name": "^map\\d+_lv\\d+$",
+            "map_name": "map02_lv004",
             "path": [
                 [
-                    0,
-                    0
+                    418.8,
+                    322.3
+                ],
+                [
+                    418.8,
+                    328.5
+                ],
+                [
+                    415,
+                    328.5
+                ],
+                [
+                    415,
+                    322.2
+                ],
+                [
+                    323.8,
+                    322.2
+                ],
+                [
+                    325,
+                    378.6
+                ],
+                [
+                    324.9,
+                    404.7
+                ],
+                [
+                    295.1,
+                    404.7
                 ]
             ]
         },

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.mjs
@@ -428,10 +428,19 @@ export const ROUTE_CONFIG = [
     },
     {
         Name: "安思园的天师桩",
-        EnterMap: "SceneAnyEnterWorld",
-        MapName: "^map\\d+_lv\\d+$",
-        MapTarget: [0, 0, 1, 1],
-        MapPath: [[0, 0]],
+        EnterMap: "SceneEnterWorldWulingMarkerStone2",
+        MapName: "map02_lv004",
+        MapTarget: [402.4, 313.4, 20.8, 17.4],
+        MapPath: [
+            [418.8, 322.3],
+            [418.8, 328.5],
+            [415.0, 328.5],
+            [415.0, 322.2],
+            [323.8, 322.2],
+            [325.0, 378.6],
+            [324.9, 404.7],
+            [295.1, 404.7],
+        ],
         CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
     },
 ];


### PR DESCRIPTION
新增了安思园天师桩的路线配置，用于终末地环境监测。
路线坐标已测试可用，可正常运行。

## Summary by Sourcery

新功能：
- 为“Serenity Garden Tianshi Pillar”环境监测路线配置特定的地图条目、目标区域和移动路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Configure a specific map entry, target region, and movement path for the Serenity Garden Tianshi Pillar environment monitoring route.

</details>