### PR TITLE
chore: 添加  pipeline 生成命令

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,6 +29,26 @@
                 "instanceLimit": 1
             },
             "problemMatcher": []
+        },
+        {
+            "label": "Generate: EnvironmentMonitoring",
+            "type": "shell",
+            "command": "pnpm generate:EnvironmentMonitoring",
+            "runOptions": {
+                "instanceLimit": 1
+            },
+            "problemMatcher": [],
+            "group": "build"
+        },
+        {
+            "label": "Generate: SellProduct",
+            "type": "shell",
+            "command": "pnpm generate:SellProduct",
+            "runOptions": {
+                "instanceLimit": 1
+            },
+            "problemMatcher": [],
+            "group": "build"
         }
     ]
 }

--- a/assets/resource/pipeline/SellProduct/Outposts/CardiacRemediationStation.json
+++ b/assets/resource/pipeline/SellProduct/Outposts/CardiacRemediationStation.json
@@ -79,7 +79,6 @@
         "expected": [
             "心脏修缮站",
             "心臟修繕站",
-            "(?i)Cardiac\\s*Remediation\\s*Station",
             "心臓修復施設",
             "(?i)^Cardiac\\s*Remediation\\s*Station$"
         ],
@@ -97,16 +96,9 @@
             331,
             127
         ],
-        "roi_offset": [
-            0,
-            0,
-            359,
-            0
-        ],
         "expected": [
             "心脏修缮站",
             "心臟修繕站",
-            "(?i)Cardiac\\s*Remediation\\s*Station",
             "心臓修復施設",
             "(?i)^Cardiac\\s*Remediation\\s*Station$"
         ],

--- a/docs/en_us/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/en_us/developers/tasks/environment-monitoring-maintain.md
@@ -173,11 +173,10 @@ When a new Station appears, **the generator side (`routes.mjs` + `data.mjs`) req
 ### Run commands
 
 ```bash
-# Install dependency (first time only)
-npm i -g @joebao/maa-pipeline-generate
-# Or as a one-off: npx @joebao/maa-pipeline-generate
+# Recommended: run from the repository root
+pnpm generate:EnvironmentMonitoring
 
-# Run in the tools/pipeline-generate/EnvironmentMonitoring/ directory:
+# Equivalent to running in tools/pipeline-generate/EnvironmentMonitoring/:
 
 # 1) Render all observation-point Pipelines
 npx @joebao/maa-pipeline-generate
@@ -261,6 +260,10 @@ Use the GUI tool described in [map-navigator.md](../components/map-navigator.md)
 ### 5. Regenerate the Pipeline
 
 ```bash
+# Run from the repository root
+pnpm generate:EnvironmentMonitoring
+
+# Or run the generator commands individually
 cd tools/pipeline-generate/EnvironmentMonitoring
 npx @joebao/maa-pipeline-generate
 npx @joebao/maa-pipeline-generate --config terminals-config.json
@@ -278,7 +281,7 @@ Here, `{Id}` is the generated node ID. In normal maintenance, just inspect the g
 Adjusting only the route/facing (no change to the English name):
 
 1. Edit `ROUTE_CONFIG[i]` in `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs`.
-2. Regenerate (only `npx @joebao/maa-pipeline-generate` is needed; re-generating `Terminals.json` is unnecessary when the terminal list is unchanged).
+2. Regenerate. In the common case, run `pnpm generate:EnvironmentMonitoring` from the repository root; if you know the terminal list is unchanged, you can instead run only `npx @joebao/maa-pipeline-generate` in `tools/pipeline-generate/EnvironmentMonitoring/`, without re-generating `Terminals.json`.
 3. Commit `routes.mjs` together with the regenerated `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json`.
 
 If the observation point's official English name changes, the generated `Id` / file name changes too. In most cases, regenerating is enough; if you want to keep the old node and file name:

--- a/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
@@ -173,11 +173,10 @@ MysteriousCryptidGraffiti         → 谜之生物的涂鸦
 ### 运行命令
 
 ```bash
-# 安装依赖（首次）
-npm i -g @joebao/maa-pipeline-generate
-# 或一次性：npx @joebao/maa-pipeline-generate
+# 推荐：在仓库根目录运行
+pnpm generate:EnvironmentMonitoring
 
-# 在 tools/pipeline-generate/EnvironmentMonitoring/ 目录下运行：
+# 等价于在 tools/pipeline-generate/EnvironmentMonitoring/ 目录下运行：
 
 # 1) 渲染所有观察点 Pipeline
 npx @joebao/maa-pipeline-generate
@@ -261,6 +260,10 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 ### 5. 重新生成 Pipeline
 
 ```bash
+# 在仓库根目录运行
+pnpm generate:EnvironmentMonitoring
+
+# 或在生成器目录分别执行
 cd tools/pipeline-generate/EnvironmentMonitoring
 npx @joebao/maa-pipeline-generate
 npx @joebao/maa-pipeline-generate --config terminals-config.json
@@ -278,7 +281,7 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
 只调整路线/朝向（不变更英文名）：
 
 1. 改 `tools/pipeline-generate/EnvironmentMonitoring/routes.mjs` 的 `ROUTE_CONFIG[i]`。
-2. 重新生成（仅需跑 `npx @joebao/maa-pipeline-generate`，终端列表未变化无需重新生成 `Terminals.json`）。
+2. 重新生成。常规情况下可直接在仓库根目录运行 `pnpm generate:EnvironmentMonitoring`；如果确认终端列表未变化，也可以只在 `tools/pipeline-generate/EnvironmentMonitoring/` 目录运行 `npx @joebao/maa-pipeline-generate`，无需重新生成 `Terminals.json`。
 3. 提交 `routes.mjs` 与重生成的 `assets/resource/pipeline/EnvironmentMonitoring/{Station}/{Id}.json`。
 
 如果观察点的官方英文名变了，生成出的 `Id` / 文件名也会跟着变。多数情况下重新生成即可；如果希望保留旧节点名和文件名：

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
         "format:go": "cd agent/go-service && go fmt ./...",
         "format:all": "pnpm format && pnpm format:go",
         "check": "maa-tools check",
-        "test": "maa-tools test"
+        "test": "maa-tools test",
+        "generate:EnvironmentMonitoring": "cd tools/pipeline-generate/EnvironmentMonitoring && maa-pipeline-generate && maa-pipeline-generate --config terminals-config.json",
+        "generate:SellProduct": "cd tools/pipeline-generate/SellProduct && maa-pipeline-generate --config pipeline-config.json && maa-pipeline-generate --config task-config.json"
     },
     "devDependencies": {
+        "@joebao/maa-pipeline-generate": "^1.2.0",
         "@nekosu/maa-tools": "1.0.22",
         "@nekosu/prettier-plugin-maafw-sort": "1.0.4",
         "@types/node": "^24.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@joebao/maa-pipeline-generate':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@nekosu/maa-tools':
         specifier: 1.0.22
         version: 1.0.22
@@ -73,6 +76,11 @@ packages:
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
+
+  '@joebao/maa-pipeline-generate@1.2.0':
+    resolution: {integrity: sha512-Fg3oSUUgJc+w5wJDMUnDZNFhky2b+8ArSc0XsNKyyNeuGKh5a9VIWD+7nz8F99bCokpp1p8BJFKQ55pLbjGnKw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@nekosu/maa-locale@1.0.2':
     resolution: {integrity: sha512-h09IQIN6iKt3OmwiCD7O36QOkmfL8lFO4nAAj+cXOuQfXYbWv4kLDzApzfURhGezjpm4+9gPaksYY9xK9LLkOA==}
@@ -642,6 +650,11 @@ snapshots:
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
+
+  '@joebao/maa-pipeline-generate@1.2.0':
+    dependencies:
+      '@nekosu/maa-pipeline-manager': 1.0.10
+      jsonc-parser: 3.3.1
 
   '@nekosu/maa-locale@1.0.2': {}
 

--- a/tools/pipeline-generate/EnvironmentMonitoring/README.md
+++ b/tools/pipeline-generate/EnvironmentMonitoring/README.md
@@ -5,6 +5,10 @@
 ## 运行方式
 
 ```bash
+# 在仓库根目录运行
+pnpm generate:EnvironmentMonitoring
+
+# 等价于在当前目录运行
 npx @joebao/maa-pipeline-generate
 npx @joebao/maa-pipeline-generate --config terminals-config.json
 ```

--- a/tools/pipeline-generate/SellProduct/README.md
+++ b/tools/pipeline-generate/SellProduct/README.md
@@ -3,8 +3,12 @@
 据点数据: <https://assets.zmdmap.com/data/entity/1.2.4/settlement_trade.json>
 
 ```shell
-npx @joebao/maa-pipeline-generate --config task-config.json
+# 在仓库根目录运行
+pnpm generate:SellProduct
+
+# 等价于在当前目录运行
 npx @joebao/maa-pipeline-generate --config pipeline-config.json
+npx @joebao/maa-pipeline-generate --config task-config.json
 ```
 
 ## 致谢


### PR DESCRIPTION
## Summary by Sourcery

在仓库层面新增用于生成 EnvironmentMonitoring 和 SellProduct 流水线的命令，并在开发者指南和生成器 README 中补充相关用法说明。

Build：
- 定义 pnpm 脚本 `generate:EnvironmentMonitoring` 和 `generate:SellProduct`，对相应流水线的 `maa-pipeline-generate` 调用进行封装。

Documentation：
- 更新英文和中文的 Environment Monitoring 维护文档，推荐使用新的 `pnpm generate:EnvironmentMonitoring` 命令，而不是直接使用 `npx`。
- 更新 EnvironmentMonitoring 和 SellProduct 生成器的 README，说明如何从仓库根目录运行新的 `pnpm generate` 脚本。

Chores：
- 新增 `@joebao/maa-pipeline-generate` 为 devDependency，并相应刷新 lockfile 条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add repository-level commands for generating EnvironmentMonitoring and SellProduct pipelines and document their usage across developer guides and generator READMEs.

Build:
- Define pnpm scripts generate:EnvironmentMonitoring and generate:SellProduct that wrap maa-pipeline-generate invocations for the corresponding pipelines.

Documentation:
- Update English and Chinese Environment Monitoring maintenance docs to recommend the new pnpm generate:EnvironmentMonitoring command instead of direct npx usage.
- Update EnvironmentMonitoring and SellProduct generator READMEs to describe running the new pnpm generate scripts from the repository root.

Chores:
- Add @joebao/maa-pipeline-generate as a devDependency and refresh lockfile entries accordingly.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在仓库层面新增用于生成 EnvironmentMonitoring 和 SellProduct 流水线的命令，并在开发者指南和生成器 README 中补充相关用法说明。

Build：
- 定义 pnpm 脚本 `generate:EnvironmentMonitoring` 和 `generate:SellProduct`，对相应流水线的 `maa-pipeline-generate` 调用进行封装。

Documentation：
- 更新英文和中文的 Environment Monitoring 维护文档，推荐使用新的 `pnpm generate:EnvironmentMonitoring` 命令，而不是直接使用 `npx`。
- 更新 EnvironmentMonitoring 和 SellProduct 生成器的 README，说明如何从仓库根目录运行新的 `pnpm generate` 脚本。

Chores：
- 新增 `@joebao/maa-pipeline-generate` 为 devDependency，并相应刷新 lockfile 条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add repository-level commands for generating EnvironmentMonitoring and SellProduct pipelines and document their usage across developer guides and generator READMEs.

Build:
- Define pnpm scripts generate:EnvironmentMonitoring and generate:SellProduct that wrap maa-pipeline-generate invocations for the corresponding pipelines.

Documentation:
- Update English and Chinese Environment Monitoring maintenance docs to recommend the new pnpm generate:EnvironmentMonitoring command instead of direct npx usage.
- Update EnvironmentMonitoring and SellProduct generator READMEs to describe running the new pnpm generate scripts from the repository root.

Chores:
- Add @joebao/maa-pipeline-generate as a devDependency and refresh lockfile entries accordingly.

</details>

</details>