### PR TITLE
fix: 修复选择再次培养的情况下可能会被兜底任务拦截

### DIFF
--- a/assets/tasks/DijiangRewards.json
+++ b/assets/tasks/DijiangRewards.json
@@ -281,6 +281,9 @@
                         },
                         "GrowthChamberGrowAgain": {
                             "enabled": true
+                        },
+                        "GrowthChamberFakeTrue": {
+                            "enabled": false
                         }
                     }
                 },


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 防止重复的修炼选择被后备的 DijiangRewards 任务错误拦截。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent repeated cultivation choices from being incorrectly intercepted by fallback DijiangRewards tasks.

</details>
- 调整 DijiangRewards 任务逻辑，使得重复的“培养”选择不再被后备任务错误地阻止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 防止重复的修炼选择被后备的 DijiangRewards 任务错误拦截。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent repeated cultivation choices from being incorrectly intercepted by fallback DijiangRewards tasks.

</details>

</details>