### PR TITLE
chore: 将 CodeLLDB 的环境变量键改为 Path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
             "cwd": "${workspaceFolder}/install",
             "windows": {
                 "env": {
-                    "PATH": "${workspaceFolder}/install/maafw;${env:PATH}"
+                    "Path": "${workspaceFolder}/install/maafw;${env:Path}"
                 }
             }
         }


### PR DESCRIPTION
## 变更说明
- 将 `.vscode/launch.json` 中 CodeLLDB 的 Windows 调试环境变量键从 `PATH` 改为 `Path`

## 原因
CodeLLDB 在 Windows 上启动调试时，会把 launch.json 中注入的环境变量与现有系统环境一并传给 LLDB。若这里使用 `PATH`，最终调试环境里可能同时出现 `PATH` 和 `Path` 两个键。

虽然 Windows 对环境变量名大小写不敏感，但这条启动链会同时保留这两个键，导致调试进程可能仍沿用原始的 `Path`，从而无法稳定把 `install/maafw` 加入 DLL 搜索路径，并以 `0xc0000135` 提前退出。

改为直接覆盖现有的 `Path` 后，调试环境里只保留一个有效键，可以稳定让 MaaFramework 相关 DLL 在 CodeLLDB 启动时被找到。

## Summary by Sourcery

杂务：
- 更新 `.vscode/launch.json`，将 CodeLLDB 在 Windows 下的调试环境变量设置为 `Path` 而不是 `PATH`，以便更可靠地发现 DLL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Update .vscode/launch.json to set the CodeLLDB Windows debug environment variable under Path rather than PATH so DLLs are reliably discoverable.

</details>