### PR TITLE
fix: 修复在弹性物资售卖界面启动稳定物资购买时失败

### DIFF
--- a/assets/resource/pipeline/AutoStockStaple/Main.json
+++ b/assets/resource/pipeline/AutoStockStaple/Main.json
@@ -29,6 +29,26 @@
             "[JumpBack]SceneEnterMenuRegionalDevelopmentValleyIVStockRedistribution"
         ]
     },
+    "InStockStaple": {
+        "desc": "识别是否在稳定物资界面",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    0,
+                    0,
+                    247,
+                    122
+                ],
+                "expected": [
+                    "物资调度",
+                    "物資調度",
+                    "(?i)Stock\\s*Redistribution",
+                    "商品取引"
+                ]
+            }
+        }
+    },
     "AutoStockStapleWuling": {
         "desc": "自动囤货稳定需求物资武陵节点",
         "enabled": false,

--- a/assets/resource/pipeline/AutoStockStaple/ValleyIV.json
+++ b/assets/resource/pipeline/AutoStockStaple/ValleyIV.json
@@ -6,7 +6,8 @@
             "param": {
                 "all_of": [
                     "InValleyIVText",
-                    "InStapleColor"
+                    "InStapleColor",
+                    "InStockStaple"
                 ]
             }
         },

--- a/assets/resource/pipeline/AutoStockStaple/Wuling.json
+++ b/assets/resource/pipeline/AutoStockStaple/Wuling.json
@@ -6,7 +6,8 @@
             "param": {
                 "all_of": [
                     "InWulingText",
-                    "InStapleColor"
+                    "InStapleColor",
+                    "InStockStaple"
                 ]
             }
         },


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 解决在 Main、ValleyIV 和 Wuling AutoStockStaple 流水线中，通过弹性商品销售视图启动主食商品采购时出现的错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve errors preventing staple goods purchases from being started via the elastic goods selling view in the Main, ValleyIV, and Wuling AutoStockStaple pipelines.

</details>
- 解决了在某些 AutoStockStaple 流水线中，从弹性商品销售界面发起稳定商品购买时发生的失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 解决在 Main、ValleyIV 和 Wuling AutoStockStaple 流水线中，通过弹性商品销售视图启动主食商品采购时出现的错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve errors preventing staple goods purchases from being started via the elastic goods selling view in the Main, ValleyIV, and Wuling AutoStockStaple pipelines.

</details>

</details>