### PR TITLE
fix: 修复输出带换行前端日志时的处理逻辑

### DIFF
--- a/agent/go-service/map-tracker/infer.go
+++ b/agent/go-service/map-tracker/infer.go
@@ -271,7 +271,7 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 	if !finalHit {
 		log.Info().Bool("finalLocHit", finalLoc != nil).Bool("finalRotHit", finalRot != nil).Msg("Map tracking inference did not hit")
 		if param.Print {
-			maafocus.PrintLargeContent(i18n.RenderHTML("maptracker.inference_failed", nil))
+			maafocus.PrintLargeContentTrimNewline(i18n.RenderHTML("maptracker.inference_failed", nil))
 		}
 
 		// Return as not hit
@@ -311,7 +311,7 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 		Float64("RotConf", result.RotConf).
 		Msg("Map tracking inference completed")
 	if param.Print {
-		maafocus.PrintLargeContent(
+		maafocus.PrintLargeContentTrimNewline(
 			i18n.RenderHTML("maptracker.inference_finished", map[string]any{
 				"X":       finalLoc.x,
 				"Y":       finalLoc.y,

--- a/agent/go-service/map-tracker/move.go
+++ b/agent/go-service/map-tracker/move.go
@@ -159,7 +159,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		if initResult, err := doInfer(ctx, ctrl, param); err == nil && initResult != nil {
 			initRot = calcTargetRotation(initResult.X, initResult.Y, targetX, targetY)
 			if !param.NoPrint {
-				maafocus.PrintLargeContent(
+				maafocus.PrintLargeContentTrimNewline(
 					a.buildNavigationMovingHTML(param, i, initResult.X, initResult.Y, targetX, targetY),
 				)
 			}
@@ -386,7 +386,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		if finalInfer, err := doInfer(ctx, ctrl, param); err == nil && finalInfer != nil {
 			finishedX, finishedY = finalInfer.X, finalInfer.Y
 		}
-		maafocus.PrintLargeContent(
+		maafocus.PrintLargeContentTrimNewline(
 			a.buildNavigationFinishedHTML(param, finishedX, finishedY),
 		)
 	}
@@ -494,7 +494,7 @@ func doPlayerStop(ca control.ControlAdaptor) {
 func doEmergencyStop(ca control.ControlAdaptor, noPrint bool) {
 	log.Warn().Msg("Emergency stop triggered")
 	if !noPrint {
-		maafocus.PrintLargeContent(i18n.RenderHTML("maptracker.emergency_stop", nil))
+		maafocus.PrintLargeContentTrimNewline(i18n.RenderHTML("maptracker.emergency_stop", nil))
 	}
 	doPlayerStop(ca)
 }

--- a/agent/go-service/pkg/maafocus/maafocus.go
+++ b/agent/go-service/pkg/maafocus/maafocus.go
@@ -4,6 +4,7 @@ package maafocus
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
@@ -44,11 +45,22 @@ func Print(ctx *maa.Context, content string) {
 	}
 }
 
-// PrintLargeContent sends payload to [fmt.Println] for large content.
+// PrintLargeContent sends payload to [fmt.Println] as an alternative to the [Print] function.
+// So that the content will not be recorded into Maa's log system in order to reduce Maa's log size.
 //
-// Instead of [Print], this function will not record the content into Maa's log system.
-//
-// Note that this function does not require a context argument.
+// If the content contains newlines, consider using [PrintLargeContentTrimNewline]
+// to avoid client parsing issues.
 func PrintLargeContent(content string) {
+	fmt.Println(content)
+}
+
+// PrintLargeContentTrimNewline sends payload to [fmt.Println]
+// and replaces all newlines and continuous blanks with a single space.
+//
+// This function is useful when printing HTML content.
+func PrintLargeContentTrimNewline(content string) {
+	content = strings.ReplaceAll(content, "\r", " ")
+	content = strings.ReplaceAll(content, "\n", " ")
+	content = strings.Join(strings.Fields(content), " ")
 	fmt.Println(content)
 }

--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -209,7 +209,7 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 }
 
 func (c *AspectRatioChecker) stopWithWarning(tasker *maa.Tasker, controllerDisplay string, width, height int, requirement string) {
-	maafocus.PrintLargeContent(
+	maafocus.PrintLargeContentTrimNewline(
 		i18n.RenderHTML("tasker.aspect_ratio_warning", buildWarningData(controllerDisplay, width, height, requirement)),
 	)
 	tasker.PostStop()

--- a/agent/go-service/taskersink/processcheck/checker.go
+++ b/agent/go-service/taskersink/processcheck/checker.go
@@ -53,7 +53,7 @@ func (c *ProcessChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventStatus,
 
 	names := strings.Join(found, ", ")
 
-	maafocus.PrintLargeContent(
+	maafocus.PrintLargeContentTrimNewline(
 		i18n.RenderHTML("tasker.process_warning", map[string]any{"ProcessNames": names}),
 	)
 


### PR DESCRIPTION
## 概要

此 PR 向 maafocus 包补充了 PrintLargeContentTrimNewline 函数，以便将打印载荷清除换行符，避免客户端前端解析时进行拆分。

## 关联

此 PR 的问题是从 #2452 引入的，将修复 #2481 。

Fix #2481

## Summary by Sourcery

添加一个会裁剪末尾换行符的大内容打印辅助函数变体，并在基于 HTML 的前端日志中使用它，以避免与换行符相关的客户端解析问题。

New Features:
- 引入 `PrintLargeContentTrimNewline` 辅助函数，用于打印大体积负载数据，在绕过 Maa 日志系统的同时对空白符进行规范化处理。

Bug Fixes:
- 规范从地图追踪和任务检查器打印出的 HTML 日志中的换行符和多余空白符，防止前端在解析日志时错误地把一条消息拆分成多条。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a newline-trimming variant of the large-content print helper and use it for HTML-based frontend logs to avoid newline-related client parsing issues.

New Features:
- Introduce PrintLargeContentTrimNewline helper to print large payloads with normalized whitespace while bypassing Maa's log system.

Bug Fixes:
- Normalize newlines and excessive whitespace in HTML logs printed from map tracking and tasker checkers to prevent frontend log parsing from splitting messages incorrectly.

</details>