### PR TITLE
fix/优化了协议空间进入逻辑

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/Prepare.json
+++ b/assets/resource/pipeline/ProtocolSpace/Prepare.json
@@ -41,6 +41,7 @@
         "next": [
             "ProtocolSpacePrepareLock",
             "ProtocolSpaceNormalPrepareChooseReward",
+            "ProtocolSpaceExamineSanity",
             "ProtocolSpaceEnterSpace"
         ],
         "focus": {
@@ -137,6 +138,7 @@
         "threshold": 0.9,
         "action": "Click",
         "next": [
+            "ProtocolSpaceExamineSanity",
             "ProtocolSpaceEnterSpace"
         ]
     },
@@ -160,6 +162,7 @@
         "post_delay": 0,
         "next": [
             "ProtocolSpacePrepareLock",
+            "ProtocolSpaceExamineSanity",
             "ProtocolSpaceEnterSpace"
         ]
     },
@@ -179,6 +182,32 @@
         ],
         "focus": {
             "Node.Recognition.Succeeded": "协议空间未解锁"
+        }
+    },
+        "ProtocolSpaceExamineSanity":{
+        "desc":"检查理智是否满足最小需求",
+        "recognition": "ColorMatch",
+        "roi":[
+            990, 
+            650, 
+            25, 
+            20
+        ],
+        "lower": [
+            150,
+            30,
+            60
+        ],
+        "upper": [
+            250,
+            120,
+            210
+        ],
+        "pre_delay": 0,
+        "post_wait_freezes": 0,
+        "post_delay": 0,
+        "focus": {
+            "Node.Recognition.Succeeded": "理智不足，结束任务"
         }
     }
 }


### PR DESCRIPTION
现在在进入协议空间前会检查是否有足够刷取一次的理智，防止因理智不足导致卡死在领取界面。

## Summary by Sourcery

Bug Fixes:
- 为协议空间（Protocol Space）运行添加进入前的理智值检查，以避免在理智不足时卡在奖励领取界面无法继续。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a pre-entry sanity check for Protocol Space runs to avoid getting stuck on the reward collection screen when sanity is insufficient.

</details>