### PR TITLE
fix: 修复偶现月卡领取失败问题

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneLogin.json
+++ b/assets/resource/pipeline/SceneManager/SceneLogin.json
@@ -98,6 +98,7 @@
     },
     "__ScenePrivateLoginMonthlyPassConfirm": {
         "desc": "领取月卡，无法跳过必须领取",
+        "max_hit": 1, // 3d移动不好判断什么时候结束，因此只点一次防止影响到下一层弹窗
         "recognition": {
             "type": "OCR",
             "param": {
@@ -125,6 +126,7 @@
     },
     "__ScenePrivateLoginPristineMonthlyPassConfirm": {
         "desc": "领取焕新月卡，无法跳过必须领取",
+        "max_hit": 1, // 3d移动不好判断什么时候结束，因此只点一次防止影响到下一层弹窗
         "recognition": {
             "type": "OCR",
             "param": {


### PR DESCRIPTION
close #2508

## Summary by Sourcery

Bug Fixes:
- 修复了一个间歇性问题：登录时可能会导致月卡奖励领取失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix an intermittent issue where the monthly card reward could fail to be claimed on login.

</details>