### PR TITLE
fix: 修复协议空间领取奖励页面无法判断理智不足问题

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -443,7 +443,7 @@
         "roi": [
             680,
             530,
-            90,
+            110,
             35
         ],
         "expected": [
@@ -489,6 +489,7 @@
         ],
         "action": "Click",
         "next": [
+            "ProtocolSpaceRewardSanityLow",
             "ProtocolSpaceRewardClaim"
         ],
         "focus": {


### PR DESCRIPTION
close #2501

## Summary by Sourcery

Bug Fixes:
- 在协议空间奖励领取页面上正确检测并处理不足的理智值，防止无效的奖励领取操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correctly detect and handle insufficient sanity on the Protocol Space reward claim page to prevent invalid reward claims.

</details>