### PR TITLE
fix: 修复余烬莱万汀重击识别为闪避问题

### DIFF
--- a/assets/resource/pipeline/AutoFight/Recognition.json
+++ b/assets/resource/pipeline/AutoFight/Recognition.json
@@ -290,7 +290,7 @@
     "__AutoFightRecognitionScreen": {
         "desc": "使用onnx模型整体识别",
         "recognition": "NeuralNetworkDetect",
-        "model": "AutoFight/autofightv7.onnx"
+        "model": "AutoFight/autofightv8.onnx"
     },
     "__AutoFightRecognitionEnemyInScreen": {
         "desc": "识别敌人是否在屏幕内",


### PR DESCRIPTION
close #2205

## Summary by Sourcery

错误修复：
- 修正技能识别逻辑，使 Embers Laiwanting 的蓄力攻击能够被正确识别，而不再在自动战斗逻辑中被误判为闪避。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct skill recognition so Embers Laiwanting’s charged attack is identified properly instead of being treated as a dodge in auto-fight logic.

</details>