### PR TITLE
fix(生态农场):只有在盲走任务中预先追踪标记、修复进入大世界节点没有退出判定的bug

### DIFF
--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
@@ -507,8 +507,7 @@
         "all_of": ["_AutoEcoFarmInWorld"],
         "inverse": true,
         "next": [
-            "[JumpBack]SceneAnyEnterWorld",
-            "_AutoEcoFarmJumpBack"
+            "SceneAnyEnterWorld"
         ]
     }
 }

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
@@ -4,17 +4,7 @@
 {
     //通用出入口
     "_AutoEcoFarmFindFarmlandStart": {
-        "desc": "在地图上查找农田标记并追踪标记,如果大小地图中已经能看到则跳过自身",
-        "recognition": {
-            "type": "Or",
-            "param": {
-                "any_of": [
-                    "_AutoEcoFarmFindFamlandInWorld",
-                    "_AutoEcoFarmFindFamlandInMap"
-                ]
-            }
-        },
-        "inverse": true,
+        "desc": "在地图上查找农田标记并追踪标记",
         "next": [
             "_AutoEcoFarmFindFarmlandOpenMap"
         ]

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
@@ -1,17 +1,13 @@
 //这块代码的目的是通过追踪标记来识别农田，并点击追踪标记
 //节点从Start进入，开始前必须要在农田附近
-//节点从Exit离开，这里关联下一个阶段的节点
+//要使用subtask调用入口"_AutoEcoFarmFindFarmlandStart""，
+// 或者next里写上["识别子任务完成的节点",[JumpBack]_AutoEcoFarmFindFarmlandStart"]
 {
-    //通用出入口
+    //通用入口
     "_AutoEcoFarmFindFarmlandStart": {
         "desc": "在地图上查找农田标记并追踪标记",
         "next": [
             "_AutoEcoFarmFindFarmlandOpenMap"
-        ]
-    },
-    "_AutoEcoFarmFindFarmlandExit": {
-        "next": [
-            "_AutoEcoFarmReturnToWorld"
         ]
     },
     //内部节点
@@ -356,7 +352,7 @@
             "_AutoEcoFarmFarmlandStillVisibleRetry",
             "[JumpBack]_AutoEcoFarmMoveMouse",
             //识别不到农田的话不结束脚本，而是只结束该子任务，因为农田可能就在边上
-            "_AutoEcoFarmFindFarmlandExit"
+            "SceneAnyEnterWorld"
         ]
     },
     "_AutoEcoFarmFarmlandStillVisibleRetry": {
@@ -433,7 +429,7 @@
             }
         },
         "next": [
-            "_AutoEcoFarmFindFarmlandExit"
+            "SceneAnyEnterWorld"
         ]
     },
     "_AutoEcoFarmSetTarget": {
@@ -461,7 +457,7 @@
             "type": "Click"
         },
         "next": [
-            "_AutoEcoFarmFindFarmlandExit"
+            "SceneAnyEnterWorld"
         ]
     },
     "_AutoEcoFarmMutiSelection": {
@@ -490,14 +486,5 @@
         "action": {
             "type": "Click"
         }
-    },
-    "_AutoEcoFarmReturnToWorld": {
-        "desc": "返回大世界",
-        "recognition": "And",
-        "all_of": ["_AutoEcoFarmInWorld"],
-        "inverse": true,
-        "next": [
-            "SceneAnyEnterWorld"
-        ]
     }
 }

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmGotoFarm.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmGotoFarm.json
@@ -12,13 +12,18 @@
         ]
     },
     "_AutoEcoFarmGotoEcoFarmExit": {
+        "desc": "结束去农场任务，接下一个任务",
+        "pre_delay": 0,
         "action": "Custom",
-
         "custom_action": "SubTask",
-        "custom_action_param": {"sub": [
+        "custom_action_param": {
+            "sub": [
                 "_AutoEcoFarmFindFarmlandStart",
                 "_AutoEcoFarmSwipeToTargetInitFarmLand"
-            ]},
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "_AutoEcoFarmMoveAndWorkStart"
         ]

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmGotoFarm.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmGotoFarm.json
@@ -12,10 +12,14 @@
         ]
     },
     "_AutoEcoFarmGotoEcoFarmExit": {
+        "action": "Custom",
+
+        "custom_action": "SubTask",
+        "custom_action_param": {"sub": [
+                "_AutoEcoFarmFindFarmlandStart",
+                "_AutoEcoFarmSwipeToTargetInitFarmLand"
+            ]},
         "next": [
-            //到目的地后再次识别农田并靠近
-            "[JumpBack]_AutoEcoFarmFindFarmlandStart",
-            "[JumpBack]_AutoEcoFarmSwipeToTargetInitFarmLand",
             "_AutoEcoFarmMoveAndWorkStart"
         ]
     },

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
@@ -4,24 +4,8 @@
 {
     //入口节点模板
     "_AutoEcoFarmSwipeToTargetInitDefault": {
-        "desc": "设定并将视角拉向{默认}标记，如果标记已经在屏幕中央则跳过自身",
-        "max_hit": 20,
-        "recognition": {
-            "type": "TemplateMatch",
-            "param": {
-                "roi": [
-                    620,
-                    100,
-                    40,
-                    300
-                ],
-                "template": "AutoEcoFarm/AutoEcoFarmTarget.png",
-                "green_mask": true,
-                "threshold": 0.5,
-                "order_by": "Score"
-            }
-        },
-        "inverse": true,
+        "desc": "设定并将视角拉向{默认}标记",
+
         "action": {
             "type": "Custom",
             "param": {

--- a/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitValleyIV.json
+++ b/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitValleyIV.json
@@ -25,7 +25,6 @@
         },
         "next": [
             "[JumpBack][Anchor]_AutoEcoFarmTeleportToFarmAnchor",
-            "[JumpBack]_AutoEcoFarmFindFarmlandStart",
             "[Anchor]_AutoEcoFarmBlindWalkStartAnchor",
             "_AutoEcoFarmGotoEcoFarmStart"
         ]

--- a/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitValleyIV.json
+++ b/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitValleyIV.json
@@ -379,8 +379,18 @@
     "_AutoEcoFarmBlindWalkStartValleyIV": {
         "desc": "[ValleyIV版]关闭工业设备朝标记盲走一段距离，默认关闭",
         "enabled": false,
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "_AutoEcoFarmFindFarmlandStart",
+                "_AutoEcoFarmSwipeToTargetInitFarmLand"
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
         "next": [
-            "[JumpBack]_AutoEcoFarmSwipeToTargetInitFarmLand",
             "_AutoEcoFarmBlindWalkPhotoMode"
         ]
     }

--- a/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitWulin.json
+++ b/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitWulin.json
@@ -25,7 +25,6 @@
         },
         "next": [
             "[JumpBack][Anchor]_AutoEcoFarmTeleportToFarmAnchor",
-            "[JumpBack]_AutoEcoFarmFindFarmlandStart",
             "[Anchor]_AutoEcoFarmBlindWalkStartAnchor",
             "_AutoEcoFarmGotoEcoFarmStart"
         ]
@@ -286,6 +285,7 @@
         "desc": "[Wulin版]关闭工业设备朝标记盲走一段距离，默认关闭",
         "enabled": false,
         "next": [
+            "[JumpBack]_AutoEcoFarmFindFarmlandStart",
             "[JumpBack]_AutoEcoFarmSwipeToTargetInitFarmLand",
             "_AutoEcoFarmBlindWalkPhotoMode"
         ]

--- a/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitWulin.json
+++ b/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitWulin.json
@@ -284,9 +284,18 @@
     "_AutoEcoFarmBlindWalkStartWulin": {
         "desc": "[Wulin版]关闭工业设备朝标记盲走一段距离，默认关闭",
         "enabled": false,
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "_AutoEcoFarmFindFarmlandStart",
+                "_AutoEcoFarmSwipeToTargetInitFarmLand"
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
         "next": [
-            "[JumpBack]_AutoEcoFarmFindFarmlandStart",
-            "[JumpBack]_AutoEcoFarmSwipeToTargetInitFarmLand",
             "_AutoEcoFarmBlindWalkPhotoMode"
         ]
     }


### PR DESCRIPTION
1、只有在盲走任务中预先追踪标记，减少没必要的操作
2、修复进入大世界节点没有退出判定的bug
3、改用subtask来接通用任务，这样不会因为入口识别问题导致任务失败

## Summary by Sourcery

在生态农场流水线中限制生态农场的预追踪范围，并提升任务流程的健壮性。

Bug 修复：
- 确保在生态农场流程中进入开放世界节点时，能够正确检测并处理退出条件，避免出现卡死状态。

增强：
- 将生态农场流水线中标记点的预追踪限制为仅在盲走任务中进行，以避免不必要的操作。
- 在生态农场区域/通用节点中通过子任务连接通用任务，避免由于跨农田导航与初始化节点的进入识别问题而导致的失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict eco farm pre-tracking and improve task flow robustness in the eco farm pipelines.

Bug Fixes:
- Ensure entering the open-world node in the eco farm flow correctly detects and handles exit conditions to avoid stuck states.

Enhancements:
- Limit pre-tracking of markers to blind-walk tasks in the eco farm pipeline to avoid unnecessary operations.
- Connect generic tasks via subtasks in eco farm region/common nodes to avoid failures caused by entry recognition issues across farmland navigation and initialization nodes.

</details>