### PR TITLE
chore: remove redundant map_name in AutoCollect routes

### DIFF
--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute1.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute1.json
@@ -44,7 +44,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -177,7 +176,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -206,7 +204,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -235,7 +232,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -264,7 +260,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -293,7 +288,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -322,7 +316,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -351,7 +344,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute3.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute3.json
@@ -44,7 +44,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -153,7 +152,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -182,7 +180,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -211,7 +208,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -240,7 +236,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -269,7 +264,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -298,7 +292,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",
@@ -327,7 +320,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map02_lv002",
                     "path": [
                         {
                             "action": "ZONE",

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute6.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute6.json
@@ -37,7 +37,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map01_lv001",
                     "path": [
                         {
                             "action": "ZONE",
@@ -234,7 +233,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map01_lv001",
                     "path": [
                         {
                             "action": "ZONE",
@@ -299,7 +297,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map01_lv001",
                     "path": [
                         {
                             "action": "ZONE",
@@ -340,7 +337,6 @@
             "param": {
                 "custom_action": "MapNavigateAction",
                 "custom_action_param": {
-                    "map_name": "map01_lv001",
                     "path": [
                         {
                             "action": "ZONE",


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 通过从路由配置文件中移除未使用的 `map_name` 字段，简化 AutoCollect 路由的 JSON 定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Simplify AutoCollect route JSON definitions by removing the unused map_name field from route configuration files.

</details>