### PR TITLE
fix(SellProduct): 等待页面稳定再单击

### DIFF
--- a/assets/resource/pipeline/SellProduct/SellCore.json
+++ b/assets/resource/pipeline/SellProduct/SellCore.json
@@ -283,7 +283,15 @@
                 ]
             }
         ],
-        "pre_wait_freezes": 80,
+        "pre_wait_freezes": {
+            "time": 200,
+            "target": [
+                357,
+                283,
+                577,
+                163
+            ]
+        },
         "pre_delay": 0,
         "action": "Click",
         "anchor": {


### PR DESCRIPTION
fix #2409
fix #2293

## Summary by Sourcery

Bug Fixes:
- 调整 SellCore 流水线的时机和条件，在触发点击操作之前等待页面稳定，以解决问题 #2409 和 #2293。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust SellCore pipeline timing/conditions to wait for page stability before triggering click actions, addressing issues #2409 and #2293.

</details>