### PR TITLE
fix(DeliveryJobs): 将进入任务拆分成每个仓储节点单独的任务

### DIFF
--- a/assets/resource/pipeline/DeliveryJobs/TransferJob.json
+++ b/assets/resource/pipeline/DeliveryJobs/TransferJob.json
@@ -1,6 +1,7 @@
 {
     // 转交任务的流程
-    // 进入送货任务 -> 点击转交任务 -> 确认转交任务 -> 回到本地仓储界面
+    // “进入送货任务”步骤已拆分到各地区 pipeline 的 DeliveryJobsEnter*DeliveryJob 节点中
+    // 本文件仅负责：点击转交任务 -> 确认转交任务 -> 回到本地仓储界面
     "DeliveryJobsClickTransferJob": {
         "desc": "单击转交任务",
         "recognition": "OCR",

--- a/assets/resource/pipeline/DeliveryJobs/TransferJob.json
+++ b/assets/resource/pipeline/DeliveryJobs/TransferJob.json
@@ -1,30 +1,6 @@
 {
     // 转交任务的流程
     // 进入送货任务 -> 点击转交任务 -> 确认转交任务 -> 回到本地仓储界面
-    "DeliveryJobsEnterDeliveryJob": {
-        "desc": "进入送货任务",
-        "recognition": "OCR",
-        "roi": [
-            79,
-            550,
-            985,
-            89
-        ],
-        "expected": [
-            "查看任务",
-            "查看任務",
-            "(?i)Check\\s*Mission",
-            "任務確認",
-            "임무 확인"
-        ],
-        "pre_delay": 0,
-        "action": "Click",
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
-            "DeliveryJobsClickTransferJob"
-        ]
-    },
     "DeliveryJobsClickTransferJob": {
         "desc": "单击转交任务",
         "recognition": "OCR",

--- a/assets/resource/pipeline/DeliveryJobs/ValleyIV.json
+++ b/assets/resource/pipeline/DeliveryJobs/ValleyIV.json
@@ -16,12 +16,128 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "[JumpBack]DeliveryJobsEnterDeliveryJob",
+            "[JumpBack]DeliveryJobsEnterOriginiumScienceParkDeliveryJob",
+            "[JumpBack]DeliveryJobsEnterOriginLodespringDeliveryJob",
+            "[JumpBack]DeliveryJobsEnterPowerPlateauDeliveryJob",
             "[JumpBack]DeliveryJobsEnterOriginiumScienceParkCargo",
             "[JumpBack]DeliveryJobsEnterOriginLodespringCargo",
             "[JumpBack]DeliveryJobsEnterPowerPlateauCargo",
             "DeliveryJobsLoop",
             "[JumpBack]SceneEnterMenuRegionalDevelopment"
+        ]
+    },
+    "DeliveryJobsCheckOriginiumScienceParkDeliveryJob": {
+        "desc": "检查源石研究园的送货任务按钮",
+        "recognition": "OCR",
+        "roi": "DeliveryJobsCheckLocalDepotNodeOriginiumScienceParkText",
+        "roi_offset": [
+            -39,
+            286,
+            220,
+            62
+        ],
+        "expected": [
+            "查看任务",
+            "查看任務",
+            "(?i)Check\\s*Mission",
+            "任務確認",
+            "임무 확인"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "DeliveryJobsCheckOriginLodespringDeliveryJob": {
+        "desc": "检查矿脉源区的送货任务按钮",
+        "recognition": "OCR",
+        "roi": "DeliveryJobsCheckLocalDepotNodeOriginLodespringText",
+        "roi_offset": [
+            -39,
+            286,
+            220,
+            62
+        ],
+        "expected": [
+            "查看任务",
+            "查看任務",
+            "(?i)Check\\s*Mission",
+            "任務確認",
+            "임무 확인"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "DeliveryJobsCheckPowerPlateauDeliveryJob": {
+        "desc": "检查供能高地的送货任务按钮",
+        "recognition": "OCR",
+        "roi": "DeliveryJobsCheckLocalDepotNodePowerPlateauText",
+        "roi_offset": [
+            -39,
+            286,
+            220,
+            62
+        ],
+        "expected": [
+            "查看任务",
+            "查看任務",
+            "(?i)Check\\s*Mission",
+            "任務確認",
+            "임무 확인"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "DeliveryJobsEnterOriginiumScienceParkDeliveryJob": {
+        "desc": "源石研究园：进入送货任务",
+        "max_hit": 1,
+        "recognition": "And",
+        "all_of": [
+            "DeliveryJobsCheckLocalDepotNodeOriginiumScienceParkText",
+            "DeliveryJobsCheckOriginiumScienceParkDeliveryJob"
+        ],
+        "box_index": 1,
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "DeliveryJobsClickTransferJob"
+        ]
+    },
+    "DeliveryJobsEnterOriginLodespringDeliveryJob": {
+        "desc": "矿脉源区：进入送货任务",
+        "max_hit": 1,
+        "recognition": "And",
+        "all_of": [
+            "DeliveryJobsCheckLocalDepotNodeOriginLodespringText",
+            "DeliveryJobsCheckOriginLodespringDeliveryJob"
+        ],
+        "box_index": 1,
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "DeliveryJobsClickTransferJob"
+        ]
+    },
+    "DeliveryJobsEnterPowerPlateauDeliveryJob": {
+        "desc": "供能高地：进入送货任务",
+        "max_hit": 1,
+        "recognition": "And",
+        "all_of": [
+            "DeliveryJobsCheckLocalDepotNodePowerPlateauText",
+            "DeliveryJobsCheckPowerPlateauDeliveryJob"
+        ],
+        "box_index": 1,
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "DeliveryJobsClickTransferJob"
         ]
     },
     "DeliveryJobsInValleyIVLocalDepotNode": {

--- a/assets/resource/pipeline/DeliveryJobs/Wuling.json
+++ b/assets/resource/pipeline/DeliveryJobs/Wuling.json
@@ -16,10 +16,48 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "[JumpBack]DeliveryJobsEnterDeliveryJob",
+            "[JumpBack]DeliveryJobsEnterWulingCityDeliveryJob",
             "[JumpBack]DeliveryJobsEnterWulingCityCargo",
             "DeliveryJobsLoop",
             "[JumpBack]SceneEnterMenuRegionalDevelopment"
+        ]
+    },
+    "DeliveryJobsCheckWulingCityDeliveryJob": {
+        "desc": "检查武陵城区的送货任务按钮",
+        "recognition": "OCR",
+        "roi": "DeliveryJobsCheckLocalDepotNodeWulingCityText",
+        "roi_offset": [
+            -39,
+            286,
+            220,
+            62
+        ],
+        "expected": [
+            "查看任务",
+            "查看任務",
+            "(?i)Check\\s*Mission",
+            "任務確認",
+            "임무 확인"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "DeliveryJobsEnterWulingCityDeliveryJob": {
+        "desc": "武陵城区：进入送货任务",
+        "max_hit": 1,
+        "recognition": "And",
+        "all_of": [
+            "DeliveryJobsCheckLocalDepotNodeWulingCityText",
+            "DeliveryJobsCheckWulingCityDeliveryJob"
+        ],
+        "box_index": 1,
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "DeliveryJobsClickTransferJob"
         ]
     },
     "DeliveryJobsInWulingLocalDepotNode": {

--- a/assets/tasks/DeliveryJobs.json
+++ b/assets/tasks/DeliveryJobs.json
@@ -319,8 +319,17 @@
                 {
                     "name": "Yes",
                     "pipeline_override": {
-                        // 确保不会转交任务
-                        "DeliveryJobsConfirmTaskTransfer": {
+                        // 确保不会进入送货任务，从而避免点击转交按钮
+                        "DeliveryJobsEnterOriginiumScienceParkDeliveryJob": {
+                            "enabled": false
+                        },
+                        "DeliveryJobsEnterOriginLodespringDeliveryJob": {
+                            "enabled": false
+                        },
+                        "DeliveryJobsEnterPowerPlateauDeliveryJob": {
+                            "enabled": false
+                        },
+                        "DeliveryJobsEnterWulingCityDeliveryJob": {
                             "enabled": false
                         },
                         // 回到大世界后直接停止任务，不继续后续流程
@@ -345,7 +354,17 @@
                 {
                     "name": "Yes",
                     "pipeline_override": {
-                        "DeliveryJobsConfirmTaskTransfer": {
+                        // 确保不会进入送货任务，从而避免点击转交按钮
+                        "DeliveryJobsEnterOriginiumScienceParkDeliveryJob": {
+                            "enabled": false
+                        },
+                        "DeliveryJobsEnterOriginLodespringDeliveryJob": {
+                            "enabled": false
+                        },
+                        "DeliveryJobsEnterPowerPlateauDeliveryJob": {
+                            "enabled": false
+                        },
+                        "DeliveryJobsEnterWulingCityDeliveryJob": {
                             "enabled": false
                         },
                         "DeliveryJobsInCargoRedistributionBid": {

--- a/assets/tasks/DeliveryJobs.json
+++ b/assets/tasks/DeliveryJobs.json
@@ -320,7 +320,7 @@
                     "name": "Yes",
                     "pipeline_override": {
                         // 确保不会转交任务
-                        "DeliveryJobsEnterDeliveryJob": {
+                        "DeliveryJobsConfirmTaskTransfer": {
                             "enabled": false
                         },
                         // 回到大世界后直接停止任务，不继续后续流程
@@ -345,7 +345,7 @@
                 {
                     "name": "Yes",
                     "pipeline_override": {
-                        "DeliveryJobsEnterDeliveryJob": {
+                        "DeliveryJobsConfirmTaskTransfer": {
                             "enabled": false
                         },
                         "DeliveryJobsInCargoRedistributionBid": {

--- a/tests/DeliveryJobs/test_transfer_job.json
+++ b/tests/DeliveryJobs/test_transfer_job.json
@@ -10,7 +10,7 @@
     "cases": [
         {
             "image": "四号谷地_地区建设_仓储节点_未就绪_查看任务_货物装箱.png",
-            "hits": ["DeliveryJobsEnterDeliveryJob"]
+            "hits": ["DeliveryJobsEnterOriginLodespringDeliveryJob"]
         },
         {
             "image": "四号谷地_地区建设_仓储节点_送货任务_转交运送委托.png",


### PR DESCRIPTION
每个仓储节点的任务只允许进入一次，来避免网络干扰。

fixed #1789
fixed #2407

## Summary by Sourcery

将入库配送任务按仓库节点拆分为独立任务，并更新相关的流水线和测试。

Enhancements:
- 调整配送任务流水线，以按单个仓库节点建模入库任务。
- 更新配送任务定义以支持新的按节点划分的任务结构。

Tests:
- 修改转运任务测试，以反映新的按节点划分的入库任务行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split incoming delivery jobs into separate tasks per warehouse node and update related pipelines and tests.

Enhancements:
- Adjust delivery job pipelines to model incoming tasks per individual warehouse node.
- Update delivery job task definitions to support the new per-node task structure.

Tests:
- Revise transfer job tests to reflect the new per-node incoming task behavior.

</details>