### PR TITLE
feat(MapLocator): 重新引入亚像素精度定位

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include <filesystem>
 #include <string_view>
 #include <thread>
@@ -39,8 +40,8 @@ struct LocateOutput
     int status = 0;
     std::string message;
     std::string mapName;
-    int x = 0;
-    int y = 0;
+    double x = 0.0;
+    double y = 0.0;
     double rot = 0.0;
     double locConf = 0.0;
     int latencyMs = 0;
@@ -66,8 +67,8 @@ struct MapLocateAssertLocationOutput
     bool inTarget = false;
     std::string message;
     std::string zoneId;
-    int x = 0;
-    int y = 0;
+    double x = 0.0;
+    double y = 0.0;
     double rot = 0.0;
     double locConf = 0.0;
     int latencyMs = 0;
@@ -156,8 +157,8 @@ LocateOutput BuildLocateOutput(const LocateResult& result)
 
     const auto& pos = result.position.value();
     output.mapName = pos.zoneId;
-    output.x = static_cast<int>(pos.x);
-    output.y = static_cast<int>(pos.y);
+    output.x = pos.x;
+    output.y = pos.y;
     output.rot = pos.angle;
     output.locConf = pos.score;
     output.latencyMs = static_cast<int>(pos.latencyMs);
@@ -181,8 +182,8 @@ MapLocateAssertLocationOutput BuildAssertLocationOutput(
     }
 
     const auto& pos = result.position.value();
-    output.x = static_cast<int>(pos.x);
-    output.y = static_cast<int>(pos.y);
+    output.x = pos.x;
+    output.y = pos.y;
     output.rot = pos.angle;
     output.locConf = pos.score;
     output.latencyMs = static_cast<int>(pos.latencyMs);
@@ -192,8 +193,8 @@ MapLocateAssertLocationOutput BuildAssertLocationOutput(
 MaaRect MakePointBox(const MapPosition& position)
 {
     return {
-        static_cast<int>(position.x),
-        static_cast<int>(position.y),
+        static_cast<int>(std::lround(position.x)),
+        static_cast<int>(std::lround(position.y)),
         1,
         1,
     };

--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include <exception>
 #include <filesystem>
 #include <format>
@@ -92,6 +93,18 @@ bool IsTightCluster(const std::vector<MapPosition>& buf, double radius)
     });
 }
 
+double QuantizeToHundredth(double value)
+{
+    return std::round(value * 100.0) / 100.0;
+}
+
+MapPosition QuantizePosition(MapPosition position)
+{
+    position.x = QuantizeToHundredth(position.x);
+    position.y = QuantizeToHundredth(position.y);
+    return position;
+}
+
 } // namespace
 
 class MapLocator::Impl
@@ -149,6 +162,8 @@ private:
         const YoloCoarseResult& coarse) const;
     std::optional<MapPosition>
         tryGlobalSearchWithFallback(const cv::Mat& minimap, const std::string& targetZoneId, const SearchConstraint& constraint);
+    MapPosition stabilizePosition(const MapPosition& raw);
+    MapPosition acceptPosition(const MapPosition& raw, TimePoint now);
     void drainBackgroundGlobalSearchTasks();
 
     void loadAvailableZones(const std::string& root);
@@ -167,6 +182,7 @@ private:
     std::chrono::steady_clock::time_point lastYoloCheckTime;
 
     std::vector<MapPosition> coldStartBuffer;
+    std::optional<MapPosition> stablePosition;
 
     TrackingConfig trackingCfg;
     MatchConfig matchCfg;
@@ -272,6 +288,36 @@ void MapLocator::Impl::drainBackgroundGlobalSearchTasks()
     backgroundGlobalSearchTasks.clear();
 }
 
+MapPosition MapLocator::Impl::stabilizePosition(const MapPosition& raw)
+{
+    if (raw.zoneId == "None") {
+        return raw;
+    }
+
+    if (!stablePosition.has_value() || stablePosition->zoneId != raw.zoneId) {
+        stablePosition = QuantizePosition(raw);
+        return *stablePosition;
+    }
+
+    const double dist = std::hypot(raw.x - stablePosition->x, raw.y - stablePosition->y);
+    if (raw.score >= kStableMinScore && (dist <= kStableDeadband || dist < kStableReleaseDist)) {
+        MapPosition out = raw;
+        out.x = stablePosition->x;
+        out.y = stablePosition->y;
+        return out;
+    }
+
+    stablePosition = QuantizePosition(raw);
+    return *stablePosition;
+}
+
+MapPosition MapLocator::Impl::acceptPosition(const MapPosition& raw, TimePoint now)
+{
+    MapPosition stable = stabilizePosition(raw);
+    motionTracker->update(stable, now);
+    return stable;
+}
+
 std::optional<MapPosition> MapLocator::Impl::tryTracking(
     const MatchFeature& tmplFeat,
     IMatchStrategy* strategy,
@@ -357,9 +403,21 @@ std::optional<MapPosition> MapLocator::Impl::tryTracking(
         if (delta == 0.0) {
             baseScore = cand->score;
         }
+        bool scaleChangeAllowed = baseScore < 0.0 || delta == 0.0;
+        if (!scaleChangeAllowed) {
+            scaleChangeAllowed = cand->score >= baseScore + kScaleHysteresisDelta;
+            if (scaleChangeAllowed) {
+                if (auto last = motionTracker->getLastPos()) {
+                    const double candAbsX = static_cast<double>(searchRect.x) + cand->loc.x + templ.cols / 2.0;
+                    const double candAbsY = static_cast<double>(searchRect.y) + cand->loc.y + templ.rows / 2.0;
+                    scaleChangeAllowed =
+                        std::hypot(candAbsX - last->x, candAbsY - last->y) < kScaleChangeMaxPositionDelta;
+                }
+            }
+        }
+
         const bool isBetter = !trackResult || cand->score > trackResult->score;
-        const bool overHysteresis = baseScore < 0.0 || delta == 0.0 || (cand->score - baseScore) >= kScaleHysteresisDelta;
-        if (isBetter && overHysteresis) {
+        if (isBetter && scaleChangeAllowed) {
             trackResult = cand;
             scaledTempl = std::move(templ);
             scaledWeightMask = std::move(mask);
@@ -410,7 +468,11 @@ std::optional<MapPosition> MapLocator::Impl::tryTracking(
         cv::Canny(templGray, templEdge, 100, 200);
         cv::bitwise_and(templEdge, scaledWeightMask, templEdge);
 
-        cv::Rect matchedRect(trackResult->loc.x, trackResult->loc.y, bgrTempl.cols, bgrTempl.rows);
+        cv::Rect matchedRect(
+            static_cast<int>(std::lround(trackResult->loc.x)),
+            static_cast<int>(std::lround(trackResult->loc.y)),
+            bgrTempl.cols,
+            bgrTempl.rows);
         matchedRect &= cv::Rect(0, 0, searchRoiWithPad.cols, searchRoiWithPad.rows);
 
         cv::Mat patchGray;
@@ -485,8 +547,7 @@ std::optional<MapPosition> MapLocator::Impl::tryTracking(
         pos.score = trackResult->score;
         pos.scale = trackScale;
         pos.isHeld = false;
-        motionTracker->update(pos, now);
-        return pos;
+        return acceptPosition(pos, now);
     }
 
     return std::nullopt;
@@ -735,7 +796,18 @@ std::optional<MapPosition> MapLocator::Impl::tryLegacyCoarseSearch(const SearchE
         return std::nullopt;
     }
 
-    std::sort(cands.begin(), cands.end(), [](auto& a, auto& b) { return a.score > b.score; });
+    std::stable_sort(cands.begin(), cands.end(), [](const auto& a, const auto& b) {
+        if (a.score != b.score) {
+            return a.score > b.score;
+        }
+        if (a.s != b.s) {
+            return a.s < b.s;
+        }
+        if (a.loc.y != b.loc.y) {
+            return a.loc.y < b.loc.y;
+        }
+        return a.loc.x < b.loc.x;
+    });
     if ((int)cands.size() > topK) {
         cands.resize(topK);
     }
@@ -912,6 +984,7 @@ void MapLocator::Impl::refreshAsyncYoloState(const cv::Mat& minimap, TimePoint n
             && predicted.zone_id != currentZoneId) {
             LogInfo << "Async YOLO detected zone change: " << currentZoneId << " -> " << predicted.zone_id;
             motionTracker->forceLost();
+            stablePosition.reset();
         }
     }
 
@@ -981,7 +1054,7 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
 
             MapPosition verifiedPos = rawPrimaryPos;
             verifiedPos.score = std::max(rawPrimaryPos.score, rawFallbackPos.score);
-            motionTracker->update(verifiedPos, now);
+            verifiedPos = acceptPosition(verifiedPos, now);
 
             return LocateResult {
                 .status = LocateStatus::Success,
@@ -1225,6 +1298,7 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
         motionTracker->markLost();
         if (motionTracker->getLostCount() > maxAllowedLost) {
             motionTracker->forceLost();
+            stablePosition.reset();
         }
         return LocateResult { .status = LocateStatus::TrackingLost, .debugMessage = "Global search failed." };
     }
@@ -1242,6 +1316,7 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
         if (motionTracker->getLostCount() > maxAllowedLost) {
             motionTracker->forceLost();
             coldStartBuffer.clear();
+            stablePosition.reset();
         }
         return LocateResult { .status = LocateStatus::TrackingLost, .debugMessage = "Far-jump rejected." };
     }
@@ -1261,6 +1336,7 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
     coldStartBuffer.clear();
 
     if (farJump || zoneChanged) {
+        stablePosition.reset();
         motionTracker->clearVelocity();
         if (farJump) {
             LogInfo << "Global Search: high-conf reseed." << VAR(jumpDist) << VAR(globalResult->score);
@@ -1269,8 +1345,8 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
 
     currentZoneId = globalResult->zoneId;
     globalResult->angle = inferredAngle;
-    motionTracker->update(*globalResult, now);
-    return LocateResult { .status = LocateStatus::Success, .position = globalResult, .debugMessage = "Global Search Success" };
+    MapPosition accepted = acceptPosition(*globalResult, now);
+    return LocateResult { .status = LocateStatus::Success, .position = accepted, .debugMessage = "Global Search Success" };
 }
 
 void MapLocator::Impl::resetTrackingState()
@@ -1281,6 +1357,7 @@ void MapLocator::Impl::resetTrackingState()
     }
     currentZoneId = "";
     coldStartBuffer.clear();
+    stablePosition.reset();
 }
 
 std::optional<MapPosition> MapLocator::Impl::getLastKnownPos() const

--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -300,7 +300,13 @@ MapPosition MapLocator::Impl::stabilizePosition(const MapPosition& raw)
     }
 
     const double dist = std::hypot(raw.x - stablePosition->x, raw.y - stablePosition->y);
-    if (raw.score >= kStableMinScore && (dist <= kStableDeadband || dist < kStableReleaseDist)) {
+    if (raw.score >= kStableMinScore && dist <= kStableDeadband) {
+        MapPosition out = raw;
+        out.x = stablePosition->x;
+        out.y = stablePosition->y;
+        return out;
+    }
+    if (raw.score >= kStableMinScore && dist < kStableReleaseDist) {
         MapPosition out = raw;
         out.x = stablePosition->x;
         out.y = stablePosition->y;

--- a/agent/cpp-algo/source/MapLocator/MapTypes.h
+++ b/agent/cpp-algo/source/MapLocator/MapTypes.h
@@ -163,11 +163,16 @@ constexpr double kTrackingScaleSteps[] = { 0.0, -0.04, -0.02, 0.02, 0.04 };
 // baseScale 的单次匹配达到此分时直接接受，无需再尝试其他尺度
 constexpr double kFastTrackingPassScore = 0.75;
 // 非 baseScale 的候选须比 baseScale 高出此值才会替换，抑制小幅波动引起的尺度频繁切换
-constexpr double kScaleHysteresisDelta = 0.015;
+constexpr double kScaleHysteresisDelta = 0.03;
+constexpr double kScaleChangeMaxPositionDelta = 2.0;
+constexpr double kStableDeadband = 0.15;
+constexpr double kStableReleaseDist = 0.40;
+constexpr double kStableMinScore = 0.80;
 // tracking 接受结果的分数下限；低于此值无论 psr/delta 如何均判为 ambiguous，走 hold 路径
 constexpr double kTrackingHardScoreFloor = 0.60;
 // 低于此分数的帧不参与速度 EMA 更新，保持速度估计的稳定性
 constexpr double kVelocityUpdateMinScore = 0.70;
+constexpr double kVelocityDeadband = 0.25;
 // tracking 路径的 outlier 拒绝参数：坐标跳变超过此距离且分数低于 kTrackingOutlierMinScore 时 hold 上一帧
 constexpr double kTrackingOutlierDistance = 25.0;
 constexpr double kTrackingOutlierMinScore = 0.78;

--- a/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
+++ b/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <cmath>
 #include <filesystem>
 
 #include <MaaUtils/Logger.h>
@@ -57,6 +59,32 @@ static cv::Mat ExtractPathHeatmapFeature(const cv::Mat& src)
     // 适度高斯模糊，为 NCC 优化器提供平滑的梯度下降盆地
     cv::GaussianBlur(feature, feature, cv::Size(5, 5), 0);
     return feature;
+}
+
+double RefinePeakOffset(float prev, float center, float next)
+{
+    const double denom = static_cast<double>(prev) - 2.0 * static_cast<double>(center) + static_cast<double>(next);
+    if (std::abs(denom) < 1e-12) {
+        return 0.0;
+    }
+
+    const double offset = 0.5 * (static_cast<double>(prev) - static_cast<double>(next)) / denom;
+    return std::clamp(offset, -0.5, 0.5);
+}
+
+cv::Point2d RefinePeakSubpixel(const cv::Mat& result, const cv::Point& maxLoc)
+{
+    cv::Point2d refined(static_cast<double>(maxLoc.x), static_cast<double>(maxLoc.y));
+    const float center = result.at<float>(maxLoc.y, maxLoc.x);
+
+    if (maxLoc.x > 0 && maxLoc.x + 1 < result.cols) {
+        refined.x += RefinePeakOffset(result.at<float>(maxLoc.y, maxLoc.x - 1), center, result.at<float>(maxLoc.y, maxLoc.x + 1));
+    }
+    if (maxLoc.y > 0 && maxLoc.y + 1 < result.rows) {
+        refined.y += RefinePeakOffset(result.at<float>(maxLoc.y - 1, maxLoc.x), center, result.at<float>(maxLoc.y + 1, maxLoc.x));
+    }
+
+    return refined;
 }
 
 std::optional<MatchResultRaw> CoreMatch(const cv::Mat& searchImgRaw, const cv::Mat& templRaw, const cv::Mat& weightMask, int blurSize)
@@ -150,7 +178,7 @@ std::optional<MatchResultRaw> CoreMatch(const cv::Mat& searchImgRaw, const cv::M
 
     MatchResultRaw out;
     out.score = maxVal;
-    out.loc = maxLoc;
+    out.loc = RefinePeakSubpixel(result, maxLoc);
     out.secondScore = secondVal;
     out.delta = maxVal - secondVal;
     out.psr = psr;

--- a/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
+++ b/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
@@ -12,7 +12,10 @@ namespace fs = std::filesystem;
 namespace maplocator
 {
 
-static cv::Mat ExtractPathHeatmapFeature(const cv::Mat& src)
+namespace
+{
+
+cv::Mat ExtractPathHeatmapFeature(const cv::Mat& src)
 {
     cv::Mat bgr, alpha;
     if (src.channels() == 4) {
@@ -74,6 +77,9 @@ double RefinePeakOffset(float prev, float center, float next)
 
 cv::Point2d RefinePeakSubpixel(const cv::Mat& result, const cv::Point& maxLoc)
 {
+    CV_Assert(result.type() == CV_32F);
+    CV_Assert(maxLoc.x >= 0 && maxLoc.x < result.cols && maxLoc.y >= 0 && maxLoc.y < result.rows);
+
     cv::Point2d refined(static_cast<double>(maxLoc.x), static_cast<double>(maxLoc.y));
     const float center = result.at<float>(maxLoc.y, maxLoc.x);
 
@@ -86,6 +92,8 @@ cv::Point2d RefinePeakSubpixel(const cv::Mat& result, const cv::Point& maxLoc)
 
     return refined;
 }
+
+} // namespace
 
 std::optional<MatchResultRaw> CoreMatch(const cv::Mat& searchImgRaw, const cv::Mat& templRaw, const cv::Mat& weightMask, int blurSize)
 {

--- a/agent/cpp-algo/source/MapLocator/MatchStrategy.h
+++ b/agent/cpp-algo/source/MapLocator/MatchStrategy.h
@@ -19,7 +19,7 @@ struct MatchFeature
 struct MatchResultRaw
 {
     double score = -1.0;
-    cv::Point loc { 0, 0 };
+    cv::Point2d loc { 0.0, 0.0 };
 
     // 置信度指标
     double secondScore = -1.0;

--- a/agent/cpp-algo/source/MapLocator/MotionTracker.cpp
+++ b/agent/cpp-algo/source/MapLocator/MotionTracker.cpp
@@ -1,5 +1,6 @@
 #include "MotionTracker.h"
 #include <algorithm>
+#include <cmath>
 
 namespace maplocator
 {
@@ -17,10 +18,16 @@ void MotionTracker::update(const MapPosition& newPos, std::chrono::steady_clock:
     if (lastKnownPos.has_value() && lostTrackingCount == 0) {
         std::chrono::duration<double> dt = now - lastTime;
         double dtSec = dt.count();
+        const double dx = newPos.x - lastKnownPos->x;
+        const double dy = newPos.y - lastKnownPos->y;
+        if (std::hypot(dx, dy) < kVelocityDeadband) {
+            velocityX = 0.0;
+            velocityY = 0.0;
+        }
         // 仅在帧间隔合理且匹配分数达标时更新速度，保证速度估计的可靠性
-        if (dtSec > 0.016 && dtSec < trackingCfg.maxDtForPrediction && newPos.score >= kVelocityUpdateMinScore) {
-            double rawVx = (newPos.x - lastKnownPos->x) / dtSec;
-            double rawVy = (newPos.y - lastKnownPos->y) / dtSec;
+        else if (dtSec > 0.016 && dtSec < trackingCfg.maxDtForPrediction && newPos.score >= kVelocityUpdateMinScore) {
+            double rawVx = dx / dtSec;
+            double rawVy = dy / dtSec;
             double alpha = trackingCfg.velocitySmoothingAlpha;
             velocityX = velocityX * (1.0 - alpha) + rawVx * alpha;
             velocityY = velocityY * (1.0 - alpha) + rawVy * alpha;


### PR DESCRIPTION
## Sourcery 总结

重新引入亚像素精度的地图位置追踪，并在收紧尺度变化与运动估计的同时稳定报告的位置。

新功能：
- 在模板匹配中支持亚像素峰值细化，以生成亚像素级的 `MapPosition` 坐标。
- 在 `locate` 和 `assert-location` 的输出中暴露双精度的位置值，避免截断为整数。

增强改进：
- 引入带有死区和滞回的量化稳定位置，在保留精细坐标的同时平滑小幅抖动。
- 通过将滞回与针对上一次跟踪位置的空间一致性检查相结合，收紧尺度变化的选择。
- 在对粗略搜索候选项排序时使用确定性并列打破策略，以提升结果的可复现性。
- 在创建需要整数像素的 `debug/rect` 输出时，对亚像素坐标进行四舍五入。
- 在区域变化、追踪丢失或重新播种（reseed）事件时重置稳定位置状态。
- 新增速度死区及相关阈值，以避免在极小运动下产生虚假的速度更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reintroduce subpixel-precision map location tracking and stabilize reported positions while tightening scale changes and motion estimates.

New Features:
- Support subpixel peak refinement in template matching to produce subpixel MapPosition coordinates.
- Expose double-precision position values in locate and assert-location outputs instead of truncating to integers.

Enhancements:
- Introduce quantized stable positions with deadband and hysteresis to smooth small jitters while preserving fine-grained coordinates.
- Tighten scale-change selection by combining hysteresis with a spatial consistency check against the last tracked position.
- Use deterministic tie-breaking when sorting coarse search candidates to improve reproducibility.
- Round subpixel coordinates when creating debug/rect outputs that require integer pixels.
- Reset stable-position state on zone changes, tracking loss, or reseed events.
- Add velocity deadband and related thresholds to avoid spurious velocity updates on minimal motion.

</details>