### PR TITLE
feat(EnvironmentMonitoring): routes.json 支持可选 Heading 字段

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AnnularWaterfall.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AnnularWaterfall.json
@@ -324,6 +324,15 @@
             "EnvironmentMonitoringAdjustCamera": "AnnularWaterfallAdjustCamera"
         },
         "next": [
+            "AnnularWaterfallAdjustHeading"
+        ]
+    },
+    "AnnularWaterfallAdjustHeading": {
+        "desc": "环形瀑布任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/BambooWaterChimes.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/BambooWaterChimes.json
@@ -324,6 +324,15 @@
             "EnvironmentMonitoringAdjustCamera": "BambooWaterChimesAdjustCamera"
         },
         "next": [
+            "BambooWaterChimesAdjustHeading"
+        ]
+    },
+    "BambooWaterChimesAdjustHeading": {
+        "desc": "水竹铃任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/CloudrestEcoSite.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/CloudrestEcoSite.json
@@ -388,6 +388,15 @@
             "EnvironmentMonitoringAdjustCamera": "CloudrestEcoSiteAdjustCamera"
         },
         "next": [
+            "CloudrestEcoSiteAdjustHeading"
+        ]
+    },
+    "CloudrestEcoSiteAdjustHeading": {
+        "desc": "栖云生态点任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
@@ -384,6 +384,15 @@
             "EnvironmentMonitoringAdjustCamera": "FloraObservationPointAdjustCamera"
         },
         "next": [
+            "FloraObservationPointAdjustHeading"
+        ]
+    },
+    "FloraObservationPointAdjustHeading": {
+        "desc": "植物观察点任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
@@ -392,6 +392,15 @@
             "EnvironmentMonitoringAdjustCamera": "HangingVinesAdjustCamera"
         },
         "next": [
+            "HangingVinesAdjustHeading"
+        ]
+    },
+    "HangingVinesAdjustHeading": {
+        "desc": "垂藤任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/MysteriousCryptidGraffiti.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/MysteriousCryptidGraffiti.json
@@ -372,6 +372,15 @@
             "EnvironmentMonitoringAdjustCamera": "MysteriousCryptidGraffitiAdjustCamera"
         },
         "next": [
+            "MysteriousCryptidGraffitiAdjustHeading"
+        ]
+    },
+    "MysteriousCryptidGraffitiAdjustHeading": {
+        "desc": "谜之生物的涂鸦任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -312,6 +312,15 @@
             "EnvironmentMonitoringAdjustCamera": "PeachTreeAtBabblesSHomeAdjustCamera"
         },
         "next": [
+            "PeachTreeAtBabblesSHomeAdjustHeading"
+        ]
+    },
+    "PeachTreeAtBabblesSHomeAdjustHeading": {
+        "desc": "念念家的桃树任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -316,8 +316,18 @@
         ]
     },
     "PeachTreeAtBabblesSHomeAdjustHeading": {
-        "desc": "念念家的桃树任务无需调整角色朝向",
+        "desc": "念念家的桃树任务中调整角色朝向",
         "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "HEADING",
+                    "angle": 90
+                }
+            ]
+        },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Rainbow.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Rainbow.json
@@ -356,6 +356,15 @@
             "EnvironmentMonitoringAdjustCamera": "RainbowAdjustCamera"
         },
         "next": [
+            "RainbowAdjustHeading"
+        ]
+    },
+    "RainbowAdjustHeading": {
+        "desc": "彩虹任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
@@ -340,6 +340,15 @@
             "EnvironmentMonitoringAdjustCamera": "SerenityGardenTianshiPillarAdjustCamera"
         },
         "next": [
+            "SerenityGardenTianshiPillarAdjustHeading"
+        ]
+    },
+    "SerenityGardenTianshiPillarAdjustHeading": {
+        "desc": "安思园的天师桩任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/TreeOfTheOldCourtyard.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/TreeOfTheOldCourtyard.json
@@ -336,6 +336,15 @@
             "EnvironmentMonitoringAdjustCamera": "TreeOfTheOldCourtyardAdjustCamera"
         },
         "next": [
+            "TreeOfTheOldCourtyardAdjustHeading"
+        ]
+    },
+    "TreeOfTheOldCourtyardAdjustHeading": {
+        "desc": "旧庭树任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WaterTemperatureController.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WaterTemperatureController.json
@@ -364,6 +364,15 @@
             "EnvironmentMonitoringAdjustCamera": "WaterTemperatureControllerAdjustCamera"
         },
         "next": [
+            "WaterTemperatureControllerAdjustHeading"
+        ]
+    },
+    "WaterTemperatureControllerAdjustHeading": {
+        "desc": "净水温控装置任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WitheredBranches.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WitheredBranches.json
@@ -316,6 +316,15 @@
             "EnvironmentMonitoringAdjustCamera": "WitheredBranchesAdjustCamera"
         },
         "next": [
+            "WitheredBranchesAdjustHeading"
+        ]
+    },
+    "WitheredBranchesAdjustHeading": {
+        "desc": "枯枝任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
@@ -376,6 +376,15 @@
             "EnvironmentMonitoringAdjustCamera": "AncientTreeAdjustCamera"
         },
         "next": [
+            "AncientTreeAdjustHeading"
+        ]
+    },
+    "AncientTreeAdjustHeading": {
+        "desc": "古树任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInTheBlightTide.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInTheBlightTide.json
@@ -352,6 +352,15 @@
             "EnvironmentMonitoringAdjustCamera": "BeaconDamagedInTheBlightTideAdjustCamera"
         },
         "next": [
+            "BeaconDamagedInTheBlightTideAdjustHeading"
+        ]
+    },
+    "BeaconDamagedInTheBlightTideAdjustHeading": {
+        "desc": "侵蚀潮中损坏的信标任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
@@ -328,6 +328,15 @@
             "EnvironmentMonitoringAdjustCamera": "CisternOriginiumSlugsAdjustCamera"
         },
         "next": [
+            "CisternOriginiumSlugsAdjustHeading"
+        ]
+    },
+    "CisternOriginiumSlugsAdjustHeading": {
+        "desc": "蓄水源石虫任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
@@ -312,6 +312,15 @@
             "EnvironmentMonitoringAdjustCamera": "CleansingJadeAdjustCamera"
         },
         "next": [
+            "CleansingJadeAdjustHeading"
+        ]
+    },
+    "CleansingJadeAdjustHeading": {
+        "desc": "漱玉任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
@@ -324,6 +324,15 @@
             "EnvironmentMonitoringAdjustCamera": "CollapsedTianshiPillarAdjustCamera"
         },
         "next": [
+            "CollapsedTianshiPillarAdjustHeading"
+        ]
+    },
+    "CollapsedTianshiPillarAdjustHeading": {
+        "desc": "倒塌的天师桩任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
@@ -356,6 +356,15 @@
             "EnvironmentMonitoringAdjustCamera": "EcologyNearTheFieldLogisticsDepotAdjustCamera"
         },
         "next": [
+            "EcologyNearTheFieldLogisticsDepotAdjustHeading"
+        ]
+    },
+    "EcologyNearTheFieldLogisticsDepotAdjustHeading": {
+        "desc": "储备站周围的生态环境任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -316,6 +316,15 @@
             "EnvironmentMonitoringAdjustCamera": "EternalSunsetAdjustCamera"
         },
         "next": [
+            "EternalSunsetAdjustHeading"
+        ]
+    },
+    "EternalSunsetAdjustHeading": {
+        "desc": "栖霞驻影任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
@@ -340,6 +340,15 @@
             "EnvironmentMonitoringAdjustCamera": "IndoorCropsAdjustCamera"
         },
         "next": [
+            "IndoorCropsAdjustHeading"
+        ]
+    },
+    "IndoorCropsAdjustHeading": {
+        "desc": "室内作物任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
@@ -316,6 +316,15 @@
             "EnvironmentMonitoringAdjustCamera": "InflatedAndGlowingBugspittingLankybeastAdjustCamera"
         },
         "next": [
+            "InflatedAndGlowingBugspittingLankybeastAdjustHeading"
+        ]
+    },
+    "InflatedAndGlowingBugspittingLankybeastAdjustHeading": {
+        "desc": "肚子鼓气后发光的吐虫长股兽任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
@@ -320,6 +320,15 @@
             "EnvironmentMonitoringAdjustCamera": "MiniShellbeastAdjustCamera"
         },
         "next": [
+            "MiniShellbeastAdjustHeading"
+        ]
+    },
+    "MiniShellbeastAdjustHeading": {
+        "desc": "小壳兽任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
@@ -316,6 +316,15 @@
             "EnvironmentMonitoringAdjustCamera": "ObservantSableChestedFowlbeastAdjustCamera"
         },
         "next": [
+            "ObservantSableChestedFowlbeastAdjustHeading"
+        ]
+    },
+    "ObservantSableChestedFowlbeastAdjustHeading": {
+        "desc": "东张西望的黑腹雉羽兽任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/PierWaterwheel.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/PierWaterwheel.json
@@ -316,6 +316,15 @@
             "EnvironmentMonitoringAdjustCamera": "PierWaterwheelAdjustCamera"
         },
         "next": [
+            "PierWaterwheelAdjustHeading"
+        ]
+    },
+    "PierWaterwheelAdjustHeading": {
+        "desc": "码头水车任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
@@ -340,6 +340,15 @@
             "EnvironmentMonitoringAdjustCamera": "RainbowFinAdjustCamera"
         },
         "next": [
+            "RainbowFinAdjustHeading"
+        ]
+    },
+    "RainbowFinAdjustHeading": {
+        "desc": "七彩鳞任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
@@ -316,6 +316,15 @@
             "EnvironmentMonitoringAdjustCamera": "VigorousCisternOriginiumSlugAdjustCamera"
         },
         "next": [
+            "VigorousCisternOriginiumSlugAdjustHeading"
+        ]
+    },
+    "VigorousCisternOriginiumSlugAdjustHeading": {
+        "desc": "充满活力的蓄水源石虫任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/Waterlamp.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/Waterlamp.json
@@ -312,6 +312,15 @@
             "EnvironmentMonitoringAdjustCamera": "WaterlampAdjustCamera"
         },
         "next": [
+            "WaterlampAdjustHeading"
+        ]
+    },
+    "WaterlampAdjustHeading": {
+        "desc": "水灯虫任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/XiraniteNexus.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/XiraniteNexus.json
@@ -336,6 +336,15 @@
             "EnvironmentMonitoringAdjustCamera": "XiraniteNexusAdjustCamera"
         },
         "next": [
+            "XiraniteNexusAdjustHeading"
+        ]
+    },
+    "XiraniteNexusAdjustHeading": {
+        "desc": "枢壤仪任务无需调整角色朝向",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/tools/pipeline-generate/EnvironmentMonitoring/README.md
+++ b/tools/pipeline-generate/EnvironmentMonitoring/README.md
@@ -42,9 +42,13 @@ npx @joebao/maa-pipeline-generate --config terminals-config.json
         // 用 tools/MapNavigator/ 的 GUI 工具录制。
     "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenUp",
         // 摄像头朝向调整方向，四选一：Up / Down / Left / Right。
-    "CameraMaxHit": 2
+    "CameraMaxHit": 2,
         // 可选；调整摄像头时的最大滑屏命中次数，默认值见 routes.mjs 的 ROUTE_DEFAULTS。
         // 拍照目标较难对准时可适当调大。
+    "Heading": 90
+        // 可选；到达拍照点后、进入拍照模式前，先用 MapNavigator 的 HEADING 动作把
+        // 角色朝向旋转到该角度（度数，与 MapNavigator 角度约定一致）。未配置时不调整。
+        // 仅影响角色朝向（决定进入拍照模式时的初始视角），与摄像头滑屏（CameraSwipeDirection）相互独立。
     // "Id": "ExistingObservationPoint"
     //     可选；默认从 kite_station.json 的 name["en-US"] 自动转换。
     //     只有需要锁定旧节点名/输出文件名（${Station}/${Id}.json）时才显式指定，新增观察点通常不要加。

--- a/tools/pipeline-generate/EnvironmentMonitoring/data.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/data.mjs
@@ -198,7 +198,15 @@ function buildRow(mission, usedIds) {
     const CameraMaxHit = override?.CameraMaxHit ?? ROUTE_DEFAULTS.CameraMaxHit;
     // Heading 是可选朝向（角度），未配置时不调整角色朝向，AdjustHeading 节点退化为透传。
     const HeadingRaw = override?.Heading;
-    const HasHeading = typeof HeadingRaw === "number" && Number.isFinite(HeadingRaw);
+    const isHeadingNumber = typeof HeadingRaw === "number" && Number.isFinite(HeadingRaw);
+    const isHeadingInRange = isHeadingNumber && HeadingRaw >= 0 && HeadingRaw < 360;
+    if (isHeadingNumber && !isHeadingInRange) {
+        console.warn(
+            `[EnvironmentMonitoring] 任务 ${sanitizeDisplayName(missionName)} (${mission.missionId}) Heading 值 ${HeadingRaw} 超出合法范围 [0, 360)，已自动归一化为 ${((HeadingRaw % 360) + 360) % 360}。`,
+        );
+    }
+    const HasHeading = isHeadingNumber;
+    const Heading = HasHeading ? ((HeadingRaw % 360) + 360) % 360 : undefined;
 
     if (override != null && missingFields.length > 0) {
         console.warn(
@@ -239,7 +247,7 @@ function buildRow(mission, usedIds) {
                   path: [
                       {
                           action: "HEADING",
-                          angle: HeadingRaw,
+                          angle: Heading,
                       },
                   ],
               },

--- a/tools/pipeline-generate/EnvironmentMonitoring/data.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/data.mjs
@@ -196,6 +196,9 @@ function buildRow(mission, usedIds) {
     }
     const {EnterMap, MapName, MapTarget, MapPath, CameraSwipeDirection} = resolved;
     const CameraMaxHit = override?.CameraMaxHit ?? ROUTE_DEFAULTS.CameraMaxHit;
+    // Heading 是可选朝向（角度），未配置时不调整角色朝向，AdjustHeading 节点退化为透传。
+    const HeadingRaw = override?.Heading;
+    const HasHeading = typeof HeadingRaw === "number" && Number.isFinite(HeadingRaw);
 
     if (override != null && missingFields.length > 0) {
         console.warn(
@@ -224,6 +227,35 @@ function buildRow(mission, usedIds) {
     ];
     const AfterTrackedNext = isAdapted ? [`GoTo${Id}`] : [`${Id}NotAdapted`];
 
+    // 朝向节点：配置了 Heading 时调用 MapNavigateAction 的 HEADING 旋转角色，
+    // 否则退化为透传节点（仅承担 next 桥接）。模板里以 "${AdjustHeadingNodeBody}" 整体注入。
+    const AdjustHeadingNodeBody = HasHeading
+        ? {
+              desc: `${sanitizeDisplayName(missionName)}任务中调整角色朝向`,
+              action: "Custom",
+              custom_action: "MapNavigateAction",
+              custom_action_param: {
+                  map_name: MapName,
+                  path: [
+                      {
+                          action: "HEADING",
+                          angle: HeadingRaw,
+                      },
+                  ],
+              },
+              pre_delay: 0,
+              post_delay: 0,
+              rate_limit: 0,
+              next: ["EnvironmentMonitoringTakePhoto"],
+          }
+        : {
+              desc: `${sanitizeDisplayName(missionName)}任务无需调整角色朝向`,
+              pre_delay: 0,
+              post_delay: 0,
+              rate_limit: 0,
+              next: ["EnvironmentMonitoringTakePhoto"],
+          };
+
     return {
         Station,
         Id,
@@ -239,6 +271,7 @@ function buildRow(mission, usedIds) {
         InExpectedText: buildExpectedFromLocaleMap(mission.shotTargetName),
         TrackOrGoToNext,
         AfterTrackedNext,
+        AdjustHeadingNodeBody,
     };
 }
 

--- a/tools/pipeline-generate/EnvironmentMonitoring/data.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/data.mjs
@@ -232,10 +232,10 @@ function buildRow(mission, usedIds) {
     const AdjustHeadingNodeBody = HasHeading
         ? {
               desc: `${sanitizeDisplayName(missionName)}任务中调整角色朝向`,
+              pre_delay: 0,
               action: "Custom",
               custom_action: "MapNavigateAction",
               custom_action_param: {
-                  map_name: MapName,
                   path: [
                       {
                           action: "HEADING",
@@ -243,7 +243,6 @@ function buildRow(mission, usedIds) {
                       },
                   ],
               },
-              pre_delay: 0,
               post_delay: 0,
               rate_limit: 0,
               next: ["EnvironmentMonitoringTakePhoto"],

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -421,7 +421,8 @@
         "MapTarget": [514, 666, 15, 15],
         "MapPath": [[520.3, 672.8]],
         "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenRight",
-        "CameraMaxHit": 1
+        "CameraMaxHit": 1,
+        "Heading": 90
     },
     {
         "Name": "净水温控装置",

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.mjs
@@ -26,4 +26,5 @@ export const ROUTE_DEFAULTS = {
     ],
     CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
     CameraMaxHit: 2,
+    Heading: null,
 };

--- a/tools/pipeline-generate/EnvironmentMonitoring/template.jsonc
+++ b/tools/pipeline-generate/EnvironmentMonitoring/template.jsonc
@@ -273,9 +273,10 @@
             "EnvironmentMonitoringAdjustCamera": "${Id}AdjustCamera"
         },
         "next": [
-            "EnvironmentMonitoringTakePhoto"
+            "${Id}AdjustHeading"
         ]
     },
+    "${Id}AdjustHeading": "${AdjustHeadingNodeBody}",
     "${Id}AdjustCamera": {
         "desc": "${Name}任务中调整朝向",
         "max_hit": "${CameraMaxHit}",

--- a/tools/schema/environment_monitoring_routes.schema.json
+++ b/tools/schema/environment_monitoring_routes.schema.json
@@ -83,6 +83,12 @@
                 "description": "调整摄像头时的最大滑屏命中次数。可选；默认值见 routes.mjs 的 ROUTE_DEFAULTS（当前为 2）。拍照目标较难对准时可适当调大。",
                 "minimum": 1
             },
+            "Heading": {
+                "type": "number",
+                "description": "可选；到达拍照点后、进入拍照模式前，先用 MapNavigator 的 HEADING 动作把角色朝向旋转到该角度（度数，与 MapNavigator 角度约定一致）。未配置时不调整角色朝向。仅影响角色朝向，与摄像头滑屏（CameraSwipeDirection）相互独立。",
+                "minimum": 0,
+                "exclusiveMaximum": 360
+            },
             "Id": {
                 "type": "string",
                 "pattern": "^[A-Za-z][A-Za-z0-9]*$",


### PR DESCRIPTION
到达拍照点后、进入拍照模式前，使用 MapNavigator 的 HEADING 动作把角色朝向旋转到指定角度；未配置时该节点退化为透传， 保持原有行为。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

为 EnvironmentMonitoring 路由添加可选的朝向（heading）支持，使角色在进入拍照模式前可以旋转到指定角度，同时在未配置该选项时保持现有行为不变。

新功能：
- 允许在 EnvironmentMonitoring 的 `routes.json` 条目中指定可选的 `Heading` 角度，在拍照前通过 `MapNavigateAction` 旋转角色。

文档：
- 扩展 EnvironmentMonitoring 配置的 README，记录新的可选字段 `Heading`，以及它与相机滑动（camera swipe）设置之间的行为关系。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional heading support to EnvironmentMonitoring routes to rotate the character to a specified angle before entering photo mode while preserving existing behavior when not configured.

New Features:
- Allow EnvironmentMonitoring routes.json entries to specify an optional Heading angle that rotates the character via MapNavigateAction before taking a photo.

Documentation:
- Extend EnvironmentMonitoring configuration README to document the new optional Heading field and its behavior relative to camera swipe settings.

</details>