### PR TITLE
fix:修复环境监测因OCR识别进入错误处理流程的问题

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/Terminals.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/Terminals.json
@@ -20,6 +20,7 @@
         ],
         "next": [
             "[JumpBack]BeaconDamagedInTheBlightTideJob",
+            "[JumpBack]VigorousCisternOriginiumSlugJob",
             "[JumpBack]CisternOriginiumSlugsJob",
             "[JumpBack]RainbowFinJob",
             "[JumpBack]IndoorCropsJob",
@@ -27,7 +28,6 @@
             "[JumpBack]CollapsedTianshiPillarJob",
             "[JumpBack]EternalSunsetJob",
             "[JumpBack]CleansingJadeJob",
-            "[JumpBack]VigorousCisternOriginiumSlugJob",
             "[JumpBack]InflatedAndGlowingBugspittingLankybeastJob",
             "[JumpBack]ObservantSableChestedFowlbeastJob",
             "[JumpBack]EcologyNearTheFieldLogisticsDepotJob",

--- a/tools/pipeline-generate/EnvironmentMonitoring/terminals-data.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/terminals-data.mjs
@@ -24,9 +24,31 @@ function buildTerminalName(terminalId) {
     return kiteStationData?.[terminalId]?.level?.name?.["zh-CN"] || terminalId;
 }
 
+// 当一个任务名是另一个任务名的子串时（如 "蓄水源石虫" ⊂ "充满活力的蓄水源石虫"），
+// 必须先尝试匹配更具体的版本，否则 OCR 会被短名吞掉。
+// 在保持 entrustIdx 原序的前提下，把更具体的任务上浮到其子串版本之前。
+function reorderBySpecificity(items) {
+    const arr = [...items];
+    let changed = true;
+    while (changed) {
+        changed = false;
+        outer: for (let i = 0; i < arr.length; i++) {
+            for (let j = i + 1; j < arr.length; j++) {
+                if (arr[i].Name !== arr[j].Name && arr[j].Name.includes(arr[i].Name)) {
+                    const [moved] = arr.splice(j, 1);
+                    arr.splice(i, 0, moved);
+                    changed = true;
+                    break outer;
+                }
+            }
+        }
+    }
+    return arr;
+}
+
 function buildTerminalNext(station) {
-    return rows
-        .filter((row) => row.Station === station)
+    const stationRows = rows.filter((row) => row.Station === station);
+    return reorderBySpecificity(stationRows)
         .map((row) => `[JumpBack]${row.Id}Job`)
         .concat("EnvironmentMonitoringFinish");
 }


### PR DESCRIPTION
fixed #2607


调整了next中充满活力的蓄水源石虫和蓄水源石虫的识别先后顺序以防止进入错误处理流程

## Summary by Sourcery

调整环境监控中针对特定敌人的识别优先级配置，以避免在 OCR 之后进入错误处理流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust recognition priority configuration for specific enemies in environment monitoring to avoid entering the error handling flow after OCR.

</details>