### PR TITLE
fix: 修复协议空间重开时没有检测体力剩余问题

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -561,6 +561,7 @@
             "time": 200
         },
         "next": [
+            "ProtocolSpaceRewardClaimSuccessSanityLow",
             "ProtocolSpaceRewardClaimSuccessContinue",
             "ProtocolSpaceRewardClaimSuccessFinish"
         ]
@@ -578,6 +579,38 @@
         ],
         "focus": {
             "Node.Action.Succeeded": "继续行动"
+        }
+    },
+    "ProtocolSpaceRewardClaimSuccessSanityLow": {
+        "desc": "使用理智消耗许可时理智不足",
+        "recognition": "OCR",
+        "roi": [
+            330,
+            -180,
+            300,
+            180
+        ],
+        "expected": [
+            "\\d"
+        ],
+        "color_filter": "ProtocolSpaceRewardSanityLowFilter",
+        "next": [
+            "ProtocolSpaceRewardClaimSuccessSanityLowFinish"
+        ]
+    },
+    "ProtocolSpaceRewardClaimSuccessSanityLowFinish": {
+        "desc": "协议空间奖励界面，结束任务",
+        "recognition": "And",
+        "all_of": [
+            "CancelButton"
+        ],
+        "action": "Click",
+        "next": [
+            "ProtocolSpaceOperationExitToWorld",
+            "[JumpBack]SceneAnyEnterWorld"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": "理智不足，结束任务"
         }
     },
     "ProtocolSpaceRewardClaimSuccessFinish": {


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 在空间内流水线配置中重新打开 ProtocolSpace 会话时，确保对剩余耐力值进行校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure stamina remaining is validated when reopening a ProtocolSpace session in the in-space pipeline configuration.

</details>