### PR TITLE
chore: 注释客户端无法加载的readme图片

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD033 MD041 -->
-<p align="center">
+<!-- <p align="center">
   <img alt="Do not discuss MAA on Skland" src="docs/img/NoSkland.png" width="280" />
-</p>
+</p> -->
 
 <h1 align="center">Do not discuss MAA on Skland</h1>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD033 MD041 -->
-<p align="center">
+<!-- <p align="center">
   <img alt="不要去森空岛讨论MAA" src="docs/img/NoSkland.png" width="280" />
-</p>
+</p> -->
 
 <p align="center"><strong>不要去森空岛讨论MAA!!!!!</strong></p>
 


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 通过将 README 头部图片的 HTML 块包裹在注释中来隐藏它们，这样在无法加载这些图片的客户端中就不会再渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Hide the README header images by wrapping their HTML blocks in comments so they no longer render in clients that cannot load them.

</details>