### PR TITLE
fix: 修复购买稳定物资数量验证器在遇到个位数1时识别错误

### DIFF
--- a/assets/resource/pipeline/AutoStockStaple/General/GoodsCountValidate.json
+++ b/assets/resource/pipeline/AutoStockStaple/General/GoodsCountValidate.json
@@ -18,6 +18,12 @@
             "type": "OCR",
             "param": {
                 "roi": "AutoStockStapleGoodsCountValidateColor",
+                "roi_offset": [
+                    -2,
+                    -2,
+                    4,
+                    4
+                ],
                 "expected": [
                     "\\d+"
                 ],


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修正主食商品数量校验器中，对个位数为 1 的购买数量识别错误的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct misidentification of purchase quantities whose unit digit is 1 in the staple goods count validator.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 修正主食商品数量校验器中，对个位数为 1 的购买数量识别错误的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct misidentification of purchase quantities whose unit digit is 1 in the staple goods count validator.

</details>

</details>