### PR TITLE
fix: 修复一次把药全吃了

### DIFF
--- a/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
@@ -143,6 +143,9 @@
                 "threshold": 0.8
             }
         },
+        "anchor": {
+            "UseAllExpireSoonSpMedication": "AutoUseSpMedicationAdd"
+        },
         "next": [
             "AutoUseSpMedicationUseEmergencySpBooster"
         ]
@@ -219,7 +222,7 @@
         "action": "Click",
         "post_wait_freezes": 300,
         "next": [
-            "AutoUseSpMedicationAdd",
+            "[Anchor]UseAllExpireSoonSpMedication",
             "AutoUseSpMedicationQuickUse",
             "AutoUseSpMedicationQuickUseCancel"
         ]

--- a/assets/tasks/AutoUseSpMedication.json
+++ b/assets/tasks/AutoUseSpMedication.json
@@ -62,9 +62,6 @@
                             "next": [
                                 "AutoUseSpMedicationIfExpireSoon"
                             ]
-                        },
-                        "AutoUseSpMedicationChooseEmergencySanityBooster": {
-                            "enabled": false
                         }
                     }
                 },


### PR DESCRIPTION
fix #2495
## Summary by Sourcery

修复自动使用 SP 药物的逻辑，防止一次性消耗所有药品

Bug Fixes:
- 修正自动 SP 药物使用流水线，使其在一次使用时采用合适的剂量，而不是消耗所有可用物品

Enhancements:
- 调整 `AutoUseSpMedication` 任务和流水线配置，以实现更可控的药物消耗行为

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix automatic SP medication usage to prevent consuming all medicine at once

Bug Fixes:
- Correct automatic SP medication pipeline to use appropriate dosage instead of all available items in a single use

Enhancements:
- Adjust AutoUseSpMedication task and pipeline configuration for more controlled medication consumption behavior

</details>

## Summary by Sourcery

调整自动使用 SP 药物的逻辑，防止在一次动作中消耗所有药物。

Bug Fixes:
- 确保自动使用 SP 药物时，只消耗适当剂量，而不是一次性使用所有可用物品。

Enhancements:
- 更新 `AutoUseSpMedication` 任务和流水线配置，以提供更可控的药物消耗行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust automatic SP medication usage logic to prevent consuming all medicine in a single action.

Bug Fixes:
- Ensure automatic SP medication consumption uses an appropriate dose instead of all available items at once.

Enhancements:
- Update AutoUseSpMedication task and pipeline configuration to provide more controlled medication consumption behavior.

</details>