### PR TITLE
ci: 临时指定v5.10.2版本,等maafw修复后revert

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -60,12 +60,12 @@ jobs:
           echo is_release=$is_release | tee -a $GITHUB_OUTPUT
           echo is_prerelease=$is_prerelease | tee -a $GITHUB_OUTPUT
 
-      - id: maafw-latest-release
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          repository: MaaXYZ/MaaFramework
-          excludes: "draft"
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # - id: maafw-latest-release
+      #   uses: pozetroninc/github-action-get-latest-release@master
+      #   with:
+      #     repository: MaaXYZ/MaaFramework
+      #     excludes: "draft"
+      #     token: ${{ secrets.GITHUB_TOKEN }}
 
       - id: mxu-latest-release
         uses: pozetroninc/github-action-get-latest-release@master
@@ -78,7 +78,7 @@ jobs:
       tag: ${{ steps.set_tag.outputs.tag }}
       is_release: ${{ steps.set_tag.outputs.is_release }}
       is_prerelease: ${{ steps.set_tag.outputs.is_prerelease }}
-      maafw_version: ${{ steps.maafw-latest-release.outputs.release }}
+      maafw_version: "v5.10.2"
       mxu_version: ${{ steps.mxu-latest-release.outputs.release }}
 
   build_and_install:


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 注释掉在安装 GitHub Actions 工作流中查询最新 MaaFramework 版本的步骤，并将 `maafw_version` 固定为 `v5.10.2`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Comment out the step that queries the latest MaaFramework release in the install GitHub Actions workflow and hardcode maafw_version to v5.10.2.

</details>