### PR TITLE
fix(MapNavigator): 修复在 Seize 输入模式下仍尝试开启 mouse_lock_follow

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.cpp
+++ b/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.cpp
@@ -5,7 +5,7 @@
 
 #include <MaaUtils/Logger.h>
 
-#include "../../controller_info_utils.h"
+#include "MapNavigator/controller_info_utils.h"
 #include "../../navi_config.h"
 #include "desktop_input_backend.h"
 
@@ -24,8 +24,13 @@ constexpr int32_t kDesktopDefaultTouchPressure = 0;
 
 bool IsMouseLockFollowSupported(MaaController* ctrl)
 {
+#ifdef _WIN32
     MaaWin32InputMethod method = MaaWin32InputMethod_None;
     return TryGetWin32MouseInputMethod(ctrl, &method) && IsMessageInputMethod(method);
+#else
+    (void)ctrl;
+    return false;
+#endif
 }
 
 bool TrySetMouseLockFollow(MaaController* ctrl, bool enabled)

--- a/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.cpp
+++ b/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.cpp
@@ -22,13 +22,6 @@ constexpr int32_t kDesktopHoverTouchContactId = 0;
 constexpr int32_t kDesktopPrimaryTouchContactId = 1;
 constexpr int32_t kDesktopDefaultTouchPressure = 0;
 
-constexpr MaaWin32InputMethod kMessageInputMethodMask =
-    MaaWin32InputMethod_SendMessage | MaaWin32InputMethod_PostMessage | MaaWin32InputMethod_SendMessageWithCursorPos
-    | MaaWin32InputMethod_PostMessageWithCursorPos | MaaWin32InputMethod_SendMessageWithWindowPos
-    | MaaWin32InputMethod_PostMessageWithWindowPos;
-
-bool IsMessageInputMethod(MaaWin32InputMethod method) { return (method & kMessageInputMethodMask) != 0; }
-
 bool IsMouseLockFollowSupported(MaaController* ctrl)
 {
     MaaWin32InputMethod method = MaaWin32InputMethod_None;

--- a/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.cpp
+++ b/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.cpp
@@ -5,6 +5,7 @@
 
 #include <MaaUtils/Logger.h>
 
+#include "../../controller_info_utils.h"
 #include "../../navi_config.h"
 #include "desktop_input_backend.h"
 
@@ -20,6 +21,19 @@ constexpr int32_t kDesktopDefaultHoverAnchorY = kDesktopReferenceFrameHeight / 2
 constexpr int32_t kDesktopHoverTouchContactId = 0;
 constexpr int32_t kDesktopPrimaryTouchContactId = 1;
 constexpr int32_t kDesktopDefaultTouchPressure = 0;
+
+constexpr MaaWin32InputMethod kMessageInputMethodMask =
+    MaaWin32InputMethod_SendMessage | MaaWin32InputMethod_PostMessage | MaaWin32InputMethod_SendMessageWithCursorPos
+    | MaaWin32InputMethod_PostMessageWithCursorPos | MaaWin32InputMethod_SendMessageWithWindowPos
+    | MaaWin32InputMethod_PostMessageWithWindowPos;
+
+bool IsMessageInputMethod(MaaWin32InputMethod method) { return (method & kMessageInputMethodMask) != 0; }
+
+bool IsMouseLockFollowSupported(MaaController* ctrl)
+{
+    MaaWin32InputMethod method = MaaWin32InputMethod_None;
+    return TryGetWin32MouseInputMethod(ctrl, &method) && IsMessageInputMethod(method);
+}
 
 bool TrySetMouseLockFollow(MaaController* ctrl, bool enabled)
 {
@@ -81,8 +95,13 @@ DesktopInputBackend::DesktopInputBackend(
         return;
     }
 
-    mouse_lock_follow_enabled_ = TrySetMouseLockFollow(ctrl_, true);
-    LogInfo << backend_name_ << " backend mouse lock follow." << VAR(controller_type_) << VAR(mouse_lock_follow_enabled_);
+    if (IsMouseLockFollowSupported(ctrl_)) {
+        mouse_lock_follow_enabled_ = TrySetMouseLockFollow(ctrl_, true);
+        LogInfo << backend_name_ << " backend mouse lock follow." << VAR(controller_type_) << VAR(mouse_lock_follow_enabled_);
+    }
+    else {
+        LogInfo << backend_name_ << " backend mouse lock follow skipped." << VAR(controller_type_);
+    }
 
     const std::vector<int32_t> managed_keys {
         key_codes_.move_forward, key_codes_.move_left, key_codes_.move_backward,

--- a/agent/cpp-algo/source/MapNavigator/Backend/backend.cpp
+++ b/agent/cpp-algo/source/MapNavigator/Backend/backend.cpp
@@ -1,10 +1,9 @@
 #include <utility>
 
-#include <MaaFramework/Utility/MaaBuffer.h>
 #include <MaaUtils/Logger.h>
-#include <meojson/json.hpp>
 
 #include "../../MapLocator/MapLocateAction.h"
+#include "../controller_info_utils.h"
 #include "../controller_type_utils.h"
 #include "Adb/adb_input_backend.h"
 #include "Desktop/desktop_input_backend.h"
@@ -13,37 +12,6 @@
 
 namespace mapnavigator
 {
-
-namespace
-{
-
-std::string DetectControllerType(MaaController* ctrl)
-{
-    if (ctrl == nullptr) {
-        return {};
-    }
-
-    MaaStringBuffer* buffer = MaaStringBufferCreate();
-    if (buffer == nullptr) {
-        return {};
-    }
-
-    std::string controller_type;
-    if (MaaControllerGetInfo(ctrl, buffer) && !MaaStringBufferIsEmpty(buffer)) {
-        const char* raw = MaaStringBufferGet(buffer);
-        if (raw != nullptr && raw[0] != '\0') {
-            const auto info = json::parse(raw).value_or(json::object {});
-            if (info.contains("type") && info.at("type").is_string()) {
-                controller_type = info.at("type").as_string();
-            }
-        }
-    }
-
-    MaaStringBufferDestroy(buffer);
-    return controller_type;
-}
-
-} // namespace
 
 std::unique_ptr<IInputBackend> CreateInputBackend(MaaController* ctrl)
 {

--- a/agent/cpp-algo/source/MapNavigator/Backend/backend.cpp
+++ b/agent/cpp-algo/source/MapNavigator/Backend/backend.cpp
@@ -3,7 +3,7 @@
 #include <MaaUtils/Logger.h>
 
 #include "../../MapLocator/MapLocateAction.h"
-#include "../controller_info_utils.h"
+#include "MapNavigator/controller_info_utils.h"
 #include "../controller_type_utils.h"
 #include "Adb/adb_input_backend.h"
 #include "Desktop/desktop_input_backend.h"

--- a/agent/cpp-algo/source/MapNavigator/controller_info_utils.cpp
+++ b/agent/cpp-algo/source/MapNavigator/controller_info_utils.cpp
@@ -1,0 +1,82 @@
+#include "controller_info_utils.h"
+
+#include <optional>
+
+#include <MaaFramework/Utility/MaaBuffer.h>
+#include <meojson/json.hpp>
+
+namespace mapnavigator
+{
+
+namespace
+{
+
+struct ControllerInfo
+{
+    std::string type;
+    std::optional<int> mouse_method;
+
+    MEO_JSONIZATION(MEO_OPT type, MEO_OPT mouse_method)
+};
+
+ControllerInfo ParseControllerInfo(MaaController* controller)
+{
+    if (controller == nullptr) {
+        return {};
+    }
+
+    MaaStringBuffer* buffer = MaaStringBufferCreate();
+    if (buffer == nullptr) {
+        return {};
+    }
+
+    if (!MaaControllerGetInfo(controller, buffer)) {
+        MaaStringBufferDestroy(buffer);
+        return {};
+    }
+
+    const char* raw = MaaStringBufferGet(buffer);
+    ControllerInfo info = json::parse(raw).value().as<ControllerInfo>();
+    MaaStringBufferDestroy(buffer);
+    return info;
+}
+
+} // namespace
+
+std::string DetectControllerType(MaaController* controller)
+{
+    const auto info = ParseControllerInfo(controller);
+    return info.type;
+}
+
+bool TryGetWin32MouseInputMethod(MaaController* controller, MaaWin32InputMethod* out_method)
+{
+    if (out_method == nullptr) {
+        return false;
+    }
+
+    const auto info = ParseControllerInfo(controller);
+    if (!info.mouse_method.has_value()) {
+        return false;
+    }
+
+    *out_method = static_cast<MaaWin32InputMethod>(info.mouse_method.value());
+    return true;
+}
+
+bool IsMessageInputMethod(MaaWin32InputMethod method)
+{
+    switch (method) {
+    case MaaWin32InputMethod_SendMessage:
+    case MaaWin32InputMethod_PostMessage:
+    case MaaWin32InputMethod_SendMessageWithCursorPos:
+    case MaaWin32InputMethod_PostMessageWithCursorPos:
+    case MaaWin32InputMethod_SendMessageWithWindowPos:
+    case MaaWin32InputMethod_PostMessageWithWindowPos:
+        return true;
+    default:
+        return false;
+    }
+}
+
+} // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/controller_info_utils.h
+++ b/agent/cpp-algo/source/MapNavigator/controller_info_utils.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+#include <MaaFramework/MaaAPI.h>
+
+namespace mapnavigator
+{
+
+std::string DetectControllerType(MaaController* controller);
+
+bool TryGetWin32MouseInputMethod(MaaController* controller, MaaWin32InputMethod* out_method);
+bool IsMessageInputMethod(MaaWin32InputMethod method);
+
+} // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/position_provider.cpp
+++ b/agent/cpp-algo/source/MapNavigator/position_provider.cpp
@@ -1,7 +1,7 @@
 #include <chrono>
 
 #include "../utils.h"
-#include "controller_info_utils.h"
+#include "MapNavigator/controller_info_utils.h"
 #include "controller_type_utils.h"
 #include "navi_math.h"
 #include "position_provider.h"

--- a/agent/cpp-algo/source/MapNavigator/position_provider.cpp
+++ b/agent/cpp-algo/source/MapNavigator/position_provider.cpp
@@ -1,9 +1,7 @@
 #include <chrono>
 
-#include <MaaFramework/Utility/MaaBuffer.h>
-#include <meojson/json.hpp>
-
 #include "../utils.h"
+#include "controller_info_utils.h"
 #include "controller_type_utils.h"
 #include "navi_math.h"
 #include "position_provider.h"
@@ -62,32 +60,6 @@ public:
 private:
     MaaImageBuffer* buffer_;
 };
-
-std::string DetectControllerType(MaaController* controller)
-{
-    if (controller == nullptr) {
-        return {};
-    }
-
-    MaaStringBuffer* buffer = MaaStringBufferCreate();
-    if (buffer == nullptr) {
-        return {};
-    }
-
-    std::string controller_type;
-    if (MaaControllerGetInfo(controller, buffer) && !MaaStringBufferIsEmpty(buffer)) {
-        const char* raw = MaaStringBufferGet(buffer);
-        if (raw != nullptr && raw[0] != '\0') {
-            const auto info = json::parse(raw).value_or(json::object {});
-            if (info.contains("type") && info.at("type").is_string()) {
-                controller_type = info.at("type").as_string();
-            }
-        }
-    }
-
-    MaaStringBufferDestroy(buffer);
-    return controller_type;
-}
 
 } // namespace
 


### PR DESCRIPTION
- resolve #2565

## Summary by Sourcery

确保 MapNavigator 只在控制器支持的情况下启用桌面鼠标锁定跟随功能，并集中管理控制器信息辅助方法。

Bug 修复：
- 在尝试启用鼠标锁定跟随之前，先检查控制器的 Win32 输入方式，防止在 Seize 或其他不支持的输入模式下启用该功能。

增强功能：
- 将控制器类型检测和控制器信息处理重构为共享工具，由后端和位置提供者共同使用。
- 改进桌面后端日志记录，以指示何时启用了鼠标锁定跟随，或在何种情况下被明确跳过。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure MapNavigator only enables desktop mouse lock follow when supported by the controller and centralize controller info helpers.

Bug Fixes:
- Prevent attempting to enable mouse lock follow in Seize or other unsupported input modes by checking the controller's Win32 input method first.

Enhancements:
- Refactor controller type detection and controller info handling into shared utilities used by backend and position provider.
- Improve desktop backend logging to indicate when mouse lock follow is enabled or explicitly skipped.

</details>