### PR TITLE
fix: 修复自动战斗结束后干员攻击动画位移导致识别失败

### DIFF
--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -482,6 +482,10 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 	if params.EnableAttack {
 		ctx.RunAction("__AutoFightActionAttackTouchUp", maa.Rect{600, 320, 80, 80}, "", nil)
 	}
+	if !ctx.GetTasker().Stopping() {
+		// 确保最后的攻击动作执行完毕，避免还在位移时进入下一个pipeline
+		time.Sleep(3 * time.Second)
+	}
 	return result
 }
 


### PR DESCRIPTION
close #2617

## Summary by Sourcery

Bug Fixes:
- 当自动战斗未停止时，在最后一次攻击动作后添加一个延迟，以防止由于干员仍在移动而导致的误识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a delay after the final attack action when auto-fight is not stopping to prevent misrecognition caused by ongoing operator movement.

</details>