### PR TITLE
chore: 修复setup_workspace没有安装webview2依赖库问题

### DIFF
--- a/tools/locals/setup_workspace/en_us.json
+++ b/tools/locals/setup_workspace/en_us.json
@@ -74,6 +74,7 @@
     "wrn_cpp_algo_dmg_detach_failed": "[WRN] Failed to detach dmg, please check manually: {error}",
     "inf_cpp_algo_install_complete": "[INF] cpp-algo installation complete",
     "err_cpp_algo_install_failed": "[ERR] cpp-algo installation failed: {error}",
+    "wrn_cpp_algo_companion_missing": "[WRN] Runtime dependency {name} not found in cpp-algo release package, cpp-algo may fail to start",
     "description": "MaaEnd build tool: Initialize and install dependencies",
     "arg_update": "Update dependencies if they already exist",
     "arg_ci": "CI mode: Do not generate local version file",

--- a/tools/locals/setup_workspace/zh_cn.json
+++ b/tools/locals/setup_workspace/zh_cn.json
@@ -74,6 +74,7 @@
     "wrn_cpp_algo_dmg_detach_failed": "[WRN] 卸载 dmg 失败，请手动检查: {error}",
     "inf_cpp_algo_install_complete": "[INF] cpp-algo 安装完成",
     "err_cpp_algo_install_failed": "[ERR] cpp-algo 安装失败: {error}",
+    "wrn_cpp_algo_companion_missing": "[WRN] 未在 cpp-algo 发布包中找到运行时依赖 {name}，可能导致 cpp-algo 无法启动",
     "description": "MaaEnd 构建工具：初始化并安装依赖项",
     "arg_update": "当依赖项已存在时，是否进行更新操作",
     "arg_ci": "CI 模式：不生成本地版本文件",

--- a/tools/setup_workspace.py
+++ b/tools/setup_workspace.py
@@ -104,6 +104,9 @@ except KeyError as e:
 
 MXU_DIST_NAME: str = "mxu.exe" if OS_KEYWORD == "win" else "mxu"
 CPP_ALGO_DIST_NAME: str = "cpp-algo.exe" if OS_KEYWORD == "win" else "cpp-algo"
+CPP_ALGO_COMPANION_FILES: tuple[str, ...] = (
+    ("WebView2Loader.dll",) if OS_KEYWORD == "win" else ()
+)
 ARCH_VARIANT_HINTS: dict[str, tuple[str, ...]] = {
     "x86_64": ("x86_64", "amd64", "x64"),
     "aarch64": ("aarch64", "arm64"),
@@ -836,6 +839,15 @@ def copy_cpp_algo_binary(src_path: Path, install_root: Path) -> None:
         pdb_target = agent_dir / f"{Path(CPP_ALGO_DIST_NAME).stem}.pdb"
         _replace_file_with_retry(pdb_src, pdb_target)
         print(Console.ok(t("inf_updated_file", name=pdb_target.name)))
+
+    for companion_name in CPP_ALGO_COMPANION_FILES:
+        companion_src = src_path.parent / companion_name
+        if not companion_src.exists():
+            print(Console.warn(t("wrn_cpp_algo_companion_missing", name=companion_name)))
+            continue
+        companion_target = agent_dir / companion_name
+        _replace_file_with_retry(companion_src, companion_target)
+        print(Console.ok(t("inf_updated_file", name=companion_target.name)))
 
 
 def install_cpp_algo(


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修复在 Windows 上安装 `cpp-algo` 可执行文件时，未正确安装 WebView2 loader DLL 的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix missing installation of the WebView2 loader DLL when setting up the cpp-algo binary on Windows.

</details>