### PR TITLE
fix: 修复重复识别到升级奖励界面

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneCommon.json
+++ b/assets/resource/pipeline/SceneManager/SceneCommon.json
@@ -53,8 +53,7 @@
         ],
         "pre_wait_freezes": 200,
         "pre_delay": 0,
-        "action": "Click",
-        "post_delay": 0
+        "action": "Click"
     },
     "__ScenePrivateCloseADBExit": {
         "desc": "关闭ADB控制器的退出游戏界面",


### PR DESCRIPTION
关闭后期望界面可能是大世界等动态界面因此不使用wait_freezes

## Summary by Sourcery

Bug Fixes:
- 通过更改场景关闭行为的处理方式，而不再依赖 `wait_freezes`，防止重复识别升级奖励界面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent repeated recognition of the upgrade reward screen by changing how the scene close behavior is handled without relying on wait_freezes.

</details>