### PR TITLE
fix(MapNavigator): 修复超时检测不生效的问题

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -364,7 +364,6 @@ bool NavigationStateMachine::TickNavigate()
 
         if (recovery_status == RecoveryStatus::RequestRejoin) {
             motion_controller_->SetForwardState(false);
-            runtime_state_.ResetNavigationAssistState();
             CaptureCurrentPosition(true);
 
             size_t best_idx = 0;
@@ -387,7 +386,10 @@ bool NavigationStateMachine::TickNavigate()
 
             session_->ApplyRejoinSlice(slice_start, *position_);
             session_->ResetProgress();
-            runtime_state_.BeginNavigation(std::chrono::steady_clock::now());
+            runtime_state_.route.Reset();
+            runtime_state_.semantic.ResetTransient();
+            runtime_state_.flow.navigate_started_at = std::chrono::steady_clock::now();
+            runtime_state_.flow.last_auto_sprint_time = {};
 
             utils::SleepFor(kStopWaitMs);
 


### PR DESCRIPTION
- resolve #2642

## Summary by Sourcery

Bug Fixes:
- 通过正确重置路由、语义和计时状态，修复在重新加入后导航超时及相关流程逻辑未生效的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix navigation timeout and related flow logic not taking effect after rejoin by properly resetting route, semantic, and timing state.

</details>