### PR TITLE
fix: 修复长时间挂机被踢无法执行任务问题

### DIFF
--- a/assets/resource/pipeline/Interface/Scene.json
+++ b/assets/resource/pipeline/Interface/Scene.json
@@ -12,6 +12,7 @@
             "[JumpBack]__ScenePrivateLogin",
             "[JumpBack]__ScenePrivateNoticeRewardsUpgrade",
             "[JumpBack]__ScenePrivateWorldSpaceExit",
+            "[JumpBack]__ScenePrivateLoggedOutConfirm",
             "[JumpBack]SceneWaitLoadingExit",
             "[JumpBack]__ScenePrivateAnyExit"
         ]

--- a/assets/resource/pipeline/SceneManager/SceneCommon.json
+++ b/assets/resource/pipeline/SceneManager/SceneCommon.json
@@ -13,6 +13,34 @@
         },
         "post_delay": 600
     },
+    "__ScenePrivateLoggedOutConfirm": {
+        "desc": "确认自动登出弹窗",
+        "recognition": "And",
+        "all_of": [
+            {
+                "recognition": "OCR",
+                "roi": [
+                    350,
+                    250,
+                    550,
+                    202
+                ],
+                "expected": [
+                    "自动登出",
+                    "自動登出",
+                    "Logged out",
+                    "自動的にロ",
+                    "장시간 활동"
+                ]
+            },
+            "YellowConfirmButtonType1"
+        ],
+        "box_index": 1,
+        "pre_wait_freezes": 100,
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0
+    },
     "__ScenePrivateNoticeRewardsUpgrade": {
         "desc": "检测到升级",
         "recognition": "OCR",


### PR DESCRIPTION
close #2719
close #386

## Summary by Sourcery

Bug Fixes:
- 通过调整与场景相关的流水线配置，解决了任务在长时间空闲后被踢出导致无法继续执行的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve issues where tasks could not be executed after being kicked due to long periods of idling by adjusting scene-related pipeline configuration.

</details>