### PR TITLE
fix: 修复subtask子任务失败视为成功问题

### DIFF
--- a/agent/go-service/common/subtask/action.go
+++ b/agent/go-service/common/subtask/action.go
@@ -62,12 +62,21 @@ func (a *SubTaskAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 			continue
 		}
 
-		if _, err := ctx.RunTask(taskName); err != nil {
+		detail, err := ctx.RunTask(taskName)
+
+		if err != nil || detail == nil {
 			log.Error().
 				Err(err).
 				Int("index", i).
 				Str("task", taskName).
 				Msg("SubTask failed to run sub task")
+			hasSubFailure = true
+			if !continueOnSubFailure {
+				break
+			}
+		}
+
+		if !detail.Status.Success() {
 			hasSubFailure = true
 			if !continueOnSubFailure {
 				break


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修复子任务执行逻辑：当子任务返回错误、`nil` 详情或非成功状态时，将父级操作标记为失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix subtask execution to mark the parent action as failed when a subtask returns an error, nil detail, or a non-success status.

</details>