### PR TITLE
feat(AutoStockpile): 实现本地每日商品价格记录功能

### DIFF
--- a/agent/go-service/autostockpile/daily_storage.go
+++ b/agent/go-service/autostockpile/daily_storage.go
@@ -1,0 +1,242 @@
+package autostockpile
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	dailyStorageFileName     = "daily_storage.json"
+	maxDailyStorageDateCount = 60
+	maaEndDataDirEnvVar      = "MAAEND_DATA_DIR"
+)
+
+var resolveDailyStoragePathFunc = resolveDailyStoragePath
+
+type dailyStorageFile struct {
+	SchemaVersion int                  `json:"schema_version"`
+	Records       []dailyStorageRecord `json:"records"`
+}
+
+type dailyStorageRecord struct {
+	ServerDate string      `json:"server_date"`
+	Weekday    int         `json:"weekday"`
+	UTCTime    string      `json:"utc_time"`
+	Region     string      `json:"region"`
+	Goods      []GoodsItem `json:"goods"`
+}
+
+func serverDateInfo(now time.Time, loc *time.Location) (string, int) {
+	serverTime := adjustedServerTime(now, loc)
+	return serverTime.Format(time.DateOnly), maaWeekday(serverTime.Weekday())
+}
+
+func maaWeekday(weekday time.Weekday) int {
+	if weekday == time.Sunday {
+		return 7
+	}
+	return int(weekday)
+}
+
+func storeDailyGoodsPrices(enabled bool, now time.Time, loc *time.Location, region string, data RecognitionData) error {
+	if !enabled {
+		return nil
+	}
+
+	serverDate, weekday := serverDateInfo(now, loc)
+	record := dailyStorageRecord{
+		ServerDate: serverDate,
+		Weekday:    weekday,
+		UTCTime:    now.UTC().Format(time.RFC3339),
+		Region:     region,
+		Goods:      cloneGoodsItems(data.Goods),
+	}
+
+	path := resolveDailyStoragePathFunc()
+	return upsertDailyStorageRecord(path, record)
+}
+
+func resolveDailyStoragePath() string {
+	return filepath.Join(resolveDailyStorageDataDir(), "AutoStockpile", dailyStorageFileName)
+}
+
+func resolveDailyStorageDataDir() string {
+	if dir := strings.TrimSpace(os.Getenv(maaEndDataDirEnvVar)); dir != "" {
+		return filepath.Clean(dir)
+	}
+
+	if cwd, err := os.Getwd(); err == nil {
+		if dir := findExistingDataDirFromAncestors(cwd); dir != "" {
+			return dir
+		}
+	}
+
+	if exePath, err := os.Executable(); err == nil {
+		if dir := findExistingDataDirFromAncestors(filepath.Dir(exePath)); dir != "" {
+			return dir
+		}
+	}
+
+	if cwd, err := os.Getwd(); err == nil {
+		return filepath.Join(cwd, "data")
+	}
+	return "data"
+}
+
+func findExistingDataDirFromAncestors(start string) string {
+	base := filepath.Clean(start)
+	for {
+		for _, candidate := range []string{
+			filepath.Join(base, "data"),
+			filepath.Join(base, "assets", "data"),
+		} {
+			if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+				return candidate
+			}
+		}
+
+		parent := filepath.Dir(base)
+		if parent == base {
+			return ""
+		}
+		base = parent
+	}
+}
+
+func upsertDailyStorageRecord(path string, record dailyStorageRecord) error {
+	storage, err := readDailyStorageFile(path)
+	if err != nil {
+		return err
+	}
+
+	replaced := false
+	for i := range storage.Records {
+		if storage.Records[i].ServerDate == record.ServerDate && storage.Records[i].Region == record.Region {
+			storage.Records[i] = record
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		storage.Records = append(storage.Records, record)
+	}
+
+	storage.Records = retainRecentDailyStorageDates(storage.Records, maxDailyStorageDateCount)
+	storage.SchemaVersion = 1
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create daily storage dir: %w", err)
+	}
+
+	content, err := json.MarshalIndent(storage, "", "    ")
+	if err != nil {
+		return fmt.Errorf("marshal daily storage: %w", err)
+	}
+	content = append(content, '\n')
+	if err := writeFileAtomic(path, content, 0644); err != nil {
+		return fmt.Errorf("write daily storage: %w", err)
+	}
+
+	return nil
+}
+
+func writeFileAtomic(path string, content []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+
+	return nil
+}
+
+func readDailyStorageFile(path string) (dailyStorageFile, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return dailyStorageFile{}, nil
+		}
+		return dailyStorageFile{}, fmt.Errorf("read daily storage: %w", err)
+	}
+	if len(content) == 0 {
+		return dailyStorageFile{}, nil
+	}
+
+	var storage dailyStorageFile
+	if err := json.Unmarshal(content, &storage); err != nil {
+		return dailyStorageFile{}, fmt.Errorf("parse daily storage: %w", err)
+	}
+	return storage, nil
+}
+
+func retainRecentDailyStorageDates(records []dailyStorageRecord, maxDateCount int) []dailyStorageRecord {
+	if maxDateCount <= 0 || len(records) == 0 {
+		return nil
+	}
+
+	dates := make(map[string]struct{})
+	for _, record := range records {
+		dates[record.ServerDate] = struct{}{}
+	}
+	if len(dates) <= maxDateCount {
+		return records
+	}
+
+	sortedDates := make([]string, 0, len(dates))
+	for date := range dates {
+		sortedDates = append(sortedDates, date)
+	}
+	sort.Strings(sortedDates)
+	retained := make(map[string]struct{}, maxDateCount)
+	for _, date := range sortedDates[len(sortedDates)-maxDateCount:] {
+		retained[date] = struct{}{}
+	}
+
+	filtered := records[:0]
+	for _, record := range records {
+		if _, ok := retained[record.ServerDate]; ok {
+			filtered = append(filtered, record)
+		}
+	}
+	return filtered
+}
+
+func cloneGoodsItems(goods []GoodsItem) []GoodsItem {
+	if len(goods) == 0 {
+		return nil
+	}
+	cloned := make([]GoodsItem, len(goods))
+	copy(cloned, goods)
+	return cloned
+}

--- a/agent/go-service/autostockpile/options.go
+++ b/agent/go-service/autostockpile/options.go
@@ -9,7 +9,8 @@ import (
 )
 
 type serverTimeAttach struct {
-	ServerTime *int `json:"server_time"`
+	ServerTime      *int `json:"server_time"`
+	AllowDataUpload bool `json:"allow_data_upload"`
 }
 
 const (
@@ -28,28 +29,31 @@ func validateServerTimeOffset(offset *int) error {
 	return nil
 }
 
-func loadServerTimeOffsetFromAttach(ctx *maa.Context, nodeName string) (*int, error) {
+func loadAutoStockpileAttach(ctx *maa.Context, nodeName string) (serverTimeAttach, error) {
 	if ctx == nil {
-		return nil, fmt.Errorf("context is nil")
+		return serverTimeAttach{}, fmt.Errorf("context is nil")
 	}
 	if strings.TrimSpace(nodeName) == "" {
-		return nil, fmt.Errorf("node name is empty")
+		return serverTimeAttach{}, fmt.Errorf("node name is empty")
 	}
 
 	raw, err := ctx.GetNodeJSON(nodeName)
 	if err != nil {
-		return nil, fmt.Errorf("get node %s json: %w", nodeName, err)
+		return serverTimeAttach{}, fmt.Errorf("get node %s json: %w", nodeName, err)
 	}
+	return parseAutoStockpileAttach(raw, nodeName)
+}
 
+func parseAutoStockpileAttach(raw string, nodeName string) (serverTimeAttach, error) {
 	var wrapper struct {
 		Attach serverTimeAttach `json:"attach"`
 	}
 	if err := json.Unmarshal([]byte(raw), &wrapper); err != nil {
-		return nil, fmt.Errorf("unmarshal %s attach: %w", nodeName, err)
+		return serverTimeAttach{}, fmt.Errorf("unmarshal %s attach: %w", nodeName, err)
 	}
 	if err := validateServerTimeOffset(wrapper.Attach.ServerTime); err != nil {
-		return nil, fmt.Errorf("validate %s attach: %w", nodeName, err)
+		return serverTimeAttach{}, fmt.Errorf("validate %s attach: %w", nodeName, err)
 	}
 
-	return wrapper.Attach.ServerTime, nil
+	return wrapper.Attach, nil
 }

--- a/agent/go-service/autostockpile/selector.go
+++ b/agent/go-service/autostockpile/selector.go
@@ -3,6 +3,7 @@ package autostockpile
 import (
 	"encoding/json"
 	"sort"
+	"time"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
@@ -83,10 +84,11 @@ func (a *SelectItemAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 		Str("region", region).
 		Msg("selector region resolved")
 
-	serverTimeOffset, err := loadServerTimeOffsetFromAttach(ctx, attachNodeName)
+	attach, err := loadAutoStockpileAttach(ctx, attachNodeName)
 	if err != nil {
 		return stopTaskWithFocus(ctx, AbortReasonSelectionConfigInvalidFatal, err)
 	}
+	serverTimeOffset := attach.ServerTime
 	applyWeekdayAdjustment := serverTimeOffset != nil
 	serverLocation := locationFromUTCOffset(serverTimeOffset)
 
@@ -94,7 +96,20 @@ func (a *SelectItemAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 		Str("component", "autostockpile").
 		Str("region", region).
 		Str("server_location", serverLocation.String()).
+		Bool("allow_data_upload", attach.AllowDataUpload).
 		Msg("selector server time resolved")
+
+	serverNow := time.Now()
+	serverDate, serverWeekday := serverDateInfo(serverNow, serverLocation)
+	if err := storeDailyGoodsPrices(attach.AllowDataUpload, serverNow, serverLocation, region, *data); err != nil {
+		log.Warn().
+			Err(err).
+			Str("component", "autostockpile").
+			Str("server_date", serverDate).
+			Int("weekday", serverWeekday).
+			Str("region", region).
+			Msg("failed to store daily goods prices")
+	}
 
 	cfg, err := buildSelectionConfig(region, serverLocation, applyWeekdayAdjustment)
 	if err != nil {

--- a/agent/go-service/autostockpile/server_day.go
+++ b/agent/go-service/autostockpile/server_day.go
@@ -22,6 +22,10 @@ func locationFromUTCOffset(offset *int) *time.Location {
 }
 
 func resolveServerWeekday(now time.Time, loc *time.Location) time.Weekday {
+	return adjustedServerTime(now, loc).Weekday()
+}
+
+func adjustedServerTime(now time.Time, loc *time.Location) time.Time {
 	if loc == nil {
 		loc = defaultServerLocation
 	}
@@ -31,5 +35,5 @@ func resolveServerWeekday(now time.Time, loc *time.Location) time.Weekday {
 		serverTime = serverTime.AddDate(0, 0, -1)
 	}
 
-	return serverTime.Weekday()
+	return serverTime
 }

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -283,6 +283,8 @@
     "task.AutoStockpile.option.AutoStockpileWuling.description": "Wuling stockpile purchase settings",
     "task.AutoStockpile.option.AutoStockpileElasticValleyIV.label": "Valley IV",
     "task.AutoStockpile.option.AutoStockpileElasticWuling.label": "Wuling",
+    "task.AutoStockpile.option.AutoStockpileAllowDataUpload.label": "Allow Data Upload",
+    "task.AutoStockpile.option.AutoStockpileAllowDataUpload.description": "Anonymously upload data to study the patterns of elastic resource price fluctuations. Related video: [BV1zgRAByECH](https://www.bilibili.com/video/BV1zgRAByECH)",
     "task.CreditShopping.label": "🛍️ Credit Shopping",
     "task.CreditShopping.description": "Purchase items from the Credit Exchange",
     "option.CreditShoppingPriority1.label": "Purchase Item Option 1",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -242,6 +242,8 @@
     "task.AutoStockpile.option.AutoStockpileWuling.description": "武陵の物資購入設定",
     "task.AutoStockpile.option.AutoStockpileElasticValleyIV.label": "第4谷地",
     "task.AutoStockpile.option.AutoStockpileElasticWuling.label": "武陵",
+    "task.AutoStockpile.option.AutoStockpileAllowDataUpload.label": "データ報告を許可",
+    "task.AutoStockpile.option.AutoStockpileAllowDataUpload.description": "弾性物資の価格変動の法則を研究するため、匿名でデータをアップロードします。関連動画: [BV1zgRAByECH](https://www.bilibili.com/video/BV1zgRAByECH)",
     "task.CreditShopping.label": "🛍️ クレジットショッピング",
     "task.CreditShopping.description": "クレジット取引所でアイテムを購入します",
     "option.CreditShoppingPriority1.label": "購入アイテム設定1",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -242,6 +242,8 @@
     "task.AutoStockpile.option.AutoStockpileWuling.description": "무릉 물자 구매 설정",
     "task.AutoStockpile.option.AutoStockpileElasticValleyIV.label": "제4 계곡",
     "task.AutoStockpile.option.AutoStockpileElasticWuling.label": "무릉",
+    "task.AutoStockpile.option.AutoStockpileAllowDataUpload.label": "데이터 업로드 허용",
+    "task.AutoStockpile.option.AutoStockpileAllowDataUpload.description": "탄력적 물자 가격 변동의 패턴을 연구하기 위해 익명으로 데이터를 업로드합니다. 관련 영상: [BV1zgRAByECH](https://www.bilibili.com/video/BV1zgRAByECH)",
     "task.CreditShopping.label": "🛍️ 크레딧 쇼핑",
     "task.CreditShopping.description": "크레딧 거래소에서 아이템을 구매합니다.",
     "option.CreditShoppingPriority1.label": "구매 물품 옵션 1",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -242,6 +242,8 @@
     "task.AutoStockpile.option.AutoStockpileWuling.description": "武陵物资购买配置",
     "task.AutoStockpile.option.AutoStockpileElasticValleyIV.label": "四号谷地",
     "task.AutoStockpile.option.AutoStockpileElasticWuling.label": "武陵",
+    "task.AutoStockpile.option.AutoStockpileAllowDataUpload.label": "允许上报数据",
+    "task.AutoStockpile.option.AutoStockpileAllowDataUpload.description": "匿名上传数据，用于研究弹性物资价格变动的规律，相关视频 [BV1zgRAByECH](https://www.bilibili.com/video/BV1zgRAByECH)",
     "task.CreditShopping.label": "🛍️信用点购物",
     "task.CreditShopping.description": "在信用交易所购买物品",
     "option.CreditShoppingPriority1.label": "购买物品选项1",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -242,6 +242,8 @@
     "task.AutoStockpile.option.AutoStockpileWuling.description": "武陵物資購買配置",
     "task.AutoStockpile.option.AutoStockpileElasticValleyIV.label": "四號谷地",
     "task.AutoStockpile.option.AutoStockpileElasticWuling.label": "武陵",
+    "task.AutoStockpile.option.AutoStockpileAllowDataUpload.label": "允許上報數據",
+    "task.AutoStockpile.option.AutoStockpileAllowDataUpload.description": "匿名上傳數據，用於研究彈性物資價格變動的規律，相關影片 [BV1zgRAByECH](https://www.bilibili.com/video/BV1zgRAByECH)",
     "task.CreditShopping.label": "🛍️信用點購物",
     "task.CreditShopping.description": "在信用交易所購買物品",
     "option.CreditShoppingPriority1.label": "購買物品選項1",

--- a/assets/tasks/AutoStockpile.json
+++ b/assets/tasks/AutoStockpile.json
@@ -118,10 +118,24 @@
             "default_case": "Yes",
             "cases": [
                 {
-                    "name": "Yes"
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "AutoStockpileAttach": {
+                            "attach": {
+                                "allow_data_upload": true
+                            }
+                        }
+                    }
                 },
                 {
-                    "name": "No"
+                    "name": "No",
+                    "pipeline_override": {
+                        "AutoStockpileAttach": {
+                            "attach": {
+                                "allow_data_upload": false
+                            }
+                        }
+                    }
                 }
             ]
         }

--- a/assets/tasks/AutoStockpile.json
+++ b/assets/tasks/AutoStockpile.json
@@ -16,6 +16,7 @@
             ],
             "option": [
                 "AutoStockpileServerTime",
+                "AutoStockpileAllowDataUpload",
                 "AutoStockpileElasticValleyIV",
                 "AutoStockpileElasticWuling"
             ]
@@ -104,6 +105,20 @@
                             "enabled": true
                         }
                     }
+                },
+                {
+                    "name": "No"
+                }
+            ]
+        },
+        "AutoStockpileAllowDataUpload": {
+            "type": "switch",
+            "label": "$task.AutoStockpile.option.AutoStockpileAllowDataUpload.label",
+            "description": "$task.AutoStockpile.option.AutoStockpileAllowDataUpload.description",
+            "default_case": "Yes",
+            "cases": [
+                {
+                    "name": "Yes"
                 },
                 {
                     "name": "No"

--- a/docs/en_us/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/en_us/developers/tasks/auto-stockpile-maintain.md
@@ -76,21 +76,65 @@ Current regions and tiers supported in the repository:
 
 ### Current Task Options
 
-The current `assets/tasks/AutoStockpile.json` exposes one server-time selector and two region toggles:
+The current `assets/tasks/AutoStockpile.json` exposes one server-time selector, one local data-recording toggle, and two region toggles:
 
 | Task option                    | Purpose                                                                                    |
 | ------------------------------ | ------------------------------------------------------------------------------------------ |
 | `AutoStockpileServerTime`      | Selects the server timezone by writing an integer UTC hour offset to `AutoStockpileAttach` |
+| `AutoStockpileAllowDataUpload` | Writes the local data-recording switch to `AutoStockpileAttach`                            |
 | `AutoStockpileElasticValleyIV` | Enables the Valley IV region node via `pipeline_override.enabled`                          |
 | `AutoStockpileElasticWuling`   | Enables the Wuling region node via `pipeline_override.enabled`                             |
 
-The region toggles do not write to `attach`. `AutoStockpileServerTime` writes `server_time` to `AutoStockpileAttach.attach` through `pipeline_override`, and the Go Service reads it at runtime. The current built-in behaviors are:
+The region toggles do not write to `attach`. `AutoStockpileServerTime` writes `server_time` to `AutoStockpileAttach.attach` through `pipeline_override`; `AutoStockpileAllowDataUpload` writes `AutoStockpileAttach.attach.allow_data_upload`, where `Yes` is `true` and `No` is `false`. The Go Service reads both fields at runtime. The current built-in behaviors are:
 
 - **Overflow threshold bypass**: `selector.go` enables threshold bypass automatically only when recognition reports overflow (`Quota.Overflow > 0`); there is no user-facing or attach-based switch.
 - **Price thresholds**: `buildSelectionConfig()` in `strategy.go` computes per-region defaults from the `region_base + tier_base + weekday_adjustment` formula. The default server timezone is `UTC+8`, and the server-day boundary is `04:00`. `AutoStockpileServerTime` can override the weekday calculation by writing an integer UTC hour offset to `AutoStockpileAttach.attach.server_time`. If unset, the runtime still falls back to `UTC+8`.
+- **Local goods-price records**: Enabled only when `AutoStockpileAttach.attach.allow_data_upload = true`. The current implementation writes local JSON only and does not include any remote upload or network behavior.
 - **Reserve stock bill**: Not implemented as a runtime decision input. The recognition payload only carries quota and goods data, and the downstream decision flow does not consume any reserve-stock-bill state.
 
-If you need different pricing behavior, update the Go defaults in code rather than expanding manual `attach` overrides. The current AutoStockpile flow only reads an attach-based override for `server_time`, which affects weekday calculation only; it still does not read attach-based price-limit, overflow-handling, or reserve-stock-bill settings.
+If you need different pricing behavior, update the Go defaults in code rather than expanding manual `attach` overrides. The current AutoStockpile flow only reads attach-based `server_time` and `allow_data_upload`; `server_time` affects weekday calculation only, and `allow_data_upload` only controls whether local records are written. It still does not read attach-based price-limit, overflow-handling, or reserve-stock-bill settings.
+
+## Local Daily Goods-Price Storage
+
+When `AutoStockpileAllowDataUpload` is enabled, the Go Service writes the recognized goods-price table after successful recognition and after region/server-day resolution. The local file is:
+
+```text
+data/AutoStockpile/daily_storage.json
+```
+
+The writable data directory is resolved deterministically: first the `MAAEND_DATA_DIR` environment variable, then existing `data/` or `assets/data/` directories found from the current working directory and its ancestors, then the executable directory and its ancestors, and finally CWD-relative `data/` with `MkdirAll` creating the missing directory. This path is for local records only and does not trigger remote uploads.
+
+The JSON schema is fixed as:
+
+```json
+{
+    "schema_version": 1,
+    "records": [
+        {
+            "server_date": "2026-05-04",
+            "weekday": 1,
+            "utc_time": "2026-05-04T12:00:00Z",
+            "region": "Wuling",
+            "goods": [
+                {
+                    "id": "Wuling/WulingFrozenPears.Tier1",
+                    "name": "Wuling Frozen Pears",
+                    "tier": "Wuling.Tier1",
+                    "price": 1000
+                }
+            ]
+        }
+    ]
+}
+```
+
+Maintenance constraints:
+
+- `weekday` uses the server day, mapped from Monday `1` through Sunday `7`; the server day still uses the existing `04:00` boundary.
+- The same `server_date + region` overwrites the previous record; different regions on the same server date are kept as separate records.
+- At most 60 distinct `server_date` values are retained; all region records under retained dates are preserved.
+- Records contain only `server_date`, `weekday`, `utc_time`, `region`, and `goods`. Do not add `quota` or other extra user data, and do not restore the old `captured_at_utc` field.
+- Writes use a same-directory temporary file followed by rename for atomic replacement. Write failures are warning-only and AutoStockpile continues running.
 
 ## Threshold Resolution Mechanism
 

--- a/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
@@ -76,21 +76,65 @@ assets/resource/image/AutoStockpile/Goods/{Region}/{BaseName}.Tier{N}.png
 
 ### 当前任务选项
 
-当前 `assets/tasks/AutoStockpile.json` 中，任务选项包含 1 个服务器时区选项和 2 个地区开关：
+当前 `assets/tasks/AutoStockpile.json` 中，任务选项包含 1 个服务器时区选项、1 个本地数据记录开关和 2 个地区开关：
 
 | 任务选项                       | 作用                                                                      |
 | ------------------------------ | ------------------------------------------------------------------------- |
 | `AutoStockpileServerTime`      | 通过 `pipeline_override` 向 `AutoStockpileAttach` 写入服务器 UTC 小时偏移 |
+| `AutoStockpileAllowDataUpload` | 通过 `pipeline_override` 向 `AutoStockpileAttach` 写入本地数据记录开关    |
 | `AutoStockpileElasticValleyIV` | 通过 `pipeline_override.enabled` 启用四号谷地节点                         |
 | `AutoStockpileElasticWuling`   | 通过 `pipeline_override.enabled` 启用武陵节点                             |
 
-地区开关不写入 `attach`。`AutoStockpileServerTime` 会通过 `pipeline_override` 将 `server_time` 写入 `AutoStockpileAttach.attach`，并由 Go Service 在运行时读取。当前内建行为如下：
+地区开关不写入 `attach`。`AutoStockpileServerTime` 会通过 `pipeline_override` 将 `server_time` 写入 `AutoStockpileAttach.attach`；`AutoStockpileAllowDataUpload` 会写入 `AutoStockpileAttach.attach.allow_data_upload`，`Yes` 为 `true`、`No` 为 `false`。这两个字段均由 Go Service 在运行时读取。当前内建行为如下：
 
 - **溢出时放宽阈值**：仅当识别结果中的 `Quota.Overflow > 0` 时，`selector.go` 才会自动放宽阈值；当前没有用户配置项，也没有 attach 覆盖入口。
 - **价格阈值**：默认值由 `strategy.go` 中的 `buildSelectionConfig()` 按 `region_base + tier_base + weekday_adjustment` 公式生成。默认服务器时区为 `UTC+8`，服务器日边界为 `04:00`。`AutoStockpileServerTime` 可通过写入 `AutoStockpileAttach.attach.server_time` 覆盖 weekday 计算；未设置时仍回退到 `UTC+8`。
+- **本地商品价格记录**：仅当 `AutoStockpileAttach.attach.allow_data_upload = true` 时启用。当前实现只写本地 JSON，不包含任何远程上传或网络行为。
 - **保留调度券**：当前未作为运行时决策输入实现。识别结果只传递配额与商品数据，下游决策流程也不会消费任何保留调度券状态。
 
-如果需要调整价格策略，请直接修改 Go 代码中的默认值，而不是扩展手动 `attach` 覆盖。当前 AutoStockpile 流程只读取基于 attach 的 `server_time` 覆盖，且该字段仅影响 weekday 计算；价格阈值、溢出开关和保留调度券配置仍不会从 attach 读取。
+如果需要调整价格策略，请直接修改 Go 代码中的默认值，而不是扩展手动 `attach` 覆盖。当前 AutoStockpile 流程只读取基于 attach 的 `server_time` 与 `allow_data_upload`；其中 `server_time` 仅影响 weekday 计算，`allow_data_upload` 仅影响本地记录是否写入。价格阈值、溢出开关和保留调度券配置仍不会从 attach 读取。
+
+## 本地每日商品价格记录
+
+启用 `AutoStockpileAllowDataUpload` 后，Go Service 会在每轮商品识别成功、地区与服务器日解析完成后，将当轮识别到的商品价格写入本地文件：
+
+```text
+data/AutoStockpile/daily_storage.json
+```
+
+写入目标按可写数据目录解析：优先使用环境变量 `MAAEND_DATA_DIR` 指定的数据目录，其次从当前工作目录及其父目录、可执行文件目录及其父目录中查找已存在的 `data/` 或 `assets/data/`，最后回退到当前工作目录下的 `data/` 并由 `MkdirAll` 创建。该路径只用于本地文件记录，不会触发远程上传。
+
+JSON schema 固定为：
+
+```json
+{
+    "schema_version": 1,
+    "records": [
+        {
+            "server_date": "2026-05-04",
+            "weekday": 1,
+            "utc_time": "2026-05-04T12:00:00Z",
+            "region": "Wuling",
+            "goods": [
+                {
+                    "id": "Wuling/WulingFrozenPears.Tier1",
+                    "name": "武陵冻梨",
+                    "tier": "Wuling.Tier1",
+                    "price": 1000
+                }
+            ]
+        }
+    ]
+}
+```
+
+维护约束：
+
+- `weekday` 使用服务器日，映射为周一 `1` 到周日 `7`；服务器日仍按现有 `04:00` 边界计算。
+- 同一个 `server_date + region` 会覆盖旧记录；同一服务器日的不同 `region` 会作为独立记录保留。
+- 最多保留 60 个不同的 `server_date`；被保留日期下的所有地区记录都会保留。
+- 记录只包含 `server_date`、`weekday`、`utc_time`、`region` 和 `goods`，不得加入 `quota` 或其他额外用户数据，也不得恢复旧字段 `captured_at_utc`。
+- 写入使用同目录临时文件和 rename 的原子写流程；写入失败只记录 warning 并继续 AutoStockpile，不会中止任务。
 
 ## 阈值解析机制
 


### PR DESCRIPTION
## Summary by Sourcery

为 AutoStockpile 流程新增可选的本地每日商品价格记录功能，通过新的 attach 选项进行控制，并将识别出的价格持久化到轮转 JSON 存储中。

New Features:
- 引入 AutoStockpile 的 attach 标志，用于启用或禁用本地每日商品价格记录。
- 将识别出的商品价格按服务器日期和地区写入本地 JSON 文件，使用固定的模式并受保留期限限制。

Enhancements:
- 扩展 AutoStockpile 的 attach 解析和服务器时间处理逻辑，以同时携带服务器时区和数据记录配置。
- 在英文和中文开发者指南中记录新的本地数据记录开关、文件格式以及保留规则。

Documentation:
- 在 en_us 和 zh_cn 开发者文档中描述 AutoStockpile 的本地数据记录选项，以及每日商品价格的存储格式与约束。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional local daily goods-price recording to the AutoStockpile flow, controlled by a new attach option, and persist recognized prices to a rotating JSON store.

New Features:
- Introduce an AutoStockpile attach flag to enable or disable local daily goods-price recording.
- Persist recognized goods prices per server date and region into a local JSON file with a fixed schema and retention limits.

Enhancements:
- Extend AutoStockpile attach parsing and server-time handling to carry both server timezone and data-recording configuration.
- Document the new local data-recording toggle, file format, and retention rules in both English and Chinese developer guides.

Documentation:
- Describe the AutoStockpile local data-recording option and daily goods-price storage format and constraints in en_us and zh_cn developer documentation.

</details>