### PR TITLE
feat(AutoStockpile): 每日价格记录增加UID标识

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -485,3 +485,6 @@ tests/maatools
 
 # oh-my-opencode
 .sisyphus/
+
+# AutoStockpile local data
+assets/data/AutoStockpile/daily_storage.json

--- a/agent/go-service/autostockpile/daily_storage.go
+++ b/agent/go-service/autostockpile/daily_storage.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	dailyStorageFileName     = "daily_storage.json"
-	maxDailyStorageDateCount = 60
+	maxDailyStorageDateCount = 120
 	maaEndDataDirEnvVar      = "MAAEND_DATA_DIR"
 )
 

--- a/agent/go-service/autostockpile/daily_storage.go
+++ b/agent/go-service/autostockpile/daily_storage.go
@@ -49,6 +49,10 @@ func storeDailyGoodsPrices(enabled bool, now time.Time, loc *time.Location, regi
 		return nil
 	}
 
+	if uid == "" {
+		uid = "unknown"
+	}
+
 	serverDate, weekday := serverDateInfo(now, loc)
 	record := dailyStorageRecord{
 		ServerDate: serverDate,
@@ -129,7 +133,7 @@ func upsertDailyStorageRecord(path string, record dailyStorageRecord) error {
 	}
 
 	storage.Records = retainRecentDailyStorageDates(storage.Records, maxDailyStorageDateCount)
-	storage.SchemaVersion = 1
+	storage.SchemaVersion = 2
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("create daily storage dir: %w", err)
 	}
@@ -199,6 +203,16 @@ func readDailyStorageFile(path string) (dailyStorageFile, error) {
 	if err := json.Unmarshal(content, &storage); err != nil {
 		return dailyStorageFile{}, fmt.Errorf("parse daily storage: %w", err)
 	}
+
+	// Migrate old records: if schema_version < 2, normalize empty UID to "unknown".
+	if storage.SchemaVersion < 2 {
+		for i := range storage.Records {
+			if storage.Records[i].UID == "" {
+				storage.Records[i].UID = "unknown"
+			}
+		}
+	}
+
 	return storage, nil
 }
 

--- a/agent/go-service/autostockpile/daily_storage.go
+++ b/agent/go-service/autostockpile/daily_storage.go
@@ -28,6 +28,7 @@ type dailyStorageRecord struct {
 	Weekday    int         `json:"weekday"`
 	UTCTime    string      `json:"utc_time"`
 	Region     string      `json:"region"`
+	UID        string      `json:"uid"`
 	Goods      []GoodsItem `json:"goods"`
 }
 
@@ -43,7 +44,7 @@ func maaWeekday(weekday time.Weekday) int {
 	return int(weekday)
 }
 
-func storeDailyGoodsPrices(enabled bool, now time.Time, loc *time.Location, region string, data RecognitionData) error {
+func storeDailyGoodsPrices(enabled bool, now time.Time, loc *time.Location, region string, uid string, data RecognitionData) error {
 	if !enabled {
 		return nil
 	}
@@ -54,6 +55,7 @@ func storeDailyGoodsPrices(enabled bool, now time.Time, loc *time.Location, regi
 		Weekday:    weekday,
 		UTCTime:    now.UTC().Format(time.RFC3339),
 		Region:     region,
+		UID:        uid,
 		Goods:      cloneGoodsItems(data.Goods),
 	}
 
@@ -116,7 +118,7 @@ func upsertDailyStorageRecord(path string, record dailyStorageRecord) error {
 
 	replaced := false
 	for i := range storage.Records {
-		if storage.Records[i].ServerDate == record.ServerDate && storage.Records[i].Region == record.Region {
+		if storage.Records[i].ServerDate == record.ServerDate && storage.Records[i].Region == record.Region && storage.Records[i].UID == record.UID {
 			storage.Records[i] = record
 			replaced = true
 			break

--- a/agent/go-service/autostockpile/register.go
+++ b/agent/go-service/autostockpile/register.go
@@ -14,6 +14,7 @@ func Register() {
 			Msg("failed to init item map during registration, OCR name matching may be disabled")
 	}
 
+	maa.AgentServerRegisterCustomAction("AutoStockpile.CaptureUid", &CaptureUidAction{})
 	maa.AgentServerRegisterCustomAction(autoStockpileSelectItemActionName, &SelectItemAction{})
 	maa.AgentServerRegisterCustomAction(autoStockpileReconcileDecisionActionName, &ReconcileDecisionAction{})
 	maa.AgentServerRegisterCustomRecognition(autoStockpileRecognitionName, &ItemValueChangeRecognition{})

--- a/agent/go-service/autostockpile/selector.go
+++ b/agent/go-service/autostockpile/selector.go
@@ -101,7 +101,7 @@ func (a *SelectItemAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 
 	serverNow := time.Now()
 	serverDate, serverWeekday := serverDateInfo(serverNow, serverLocation)
-	if err := storeDailyGoodsPrices(attach.AllowDataUpload, serverNow, serverLocation, region, *data); err != nil {
+	if err := storeDailyGoodsPrices(attach.AllowDataUpload, serverNow, serverLocation, region, getCapturedUid(), *data); err != nil {
 		log.Warn().
 			Err(err).
 			Str("component", "autostockpile").

--- a/agent/go-service/autostockpile/uid.go
+++ b/agent/go-service/autostockpile/uid.go
@@ -1,0 +1,85 @@
+package autostockpile
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"sync"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+var _ maa.CustomActionRunner = &CaptureUidAction{}
+
+var (
+	capturedUid   string
+	capturedUidMu sync.Mutex
+)
+
+// CaptureUidAction 从 AutoStockpileGetUid 节点的 OCR 识别结果中提取玩家 UID，
+// 数字部分加盐哈希后存储，供后续数据保存使用。
+type CaptureUidAction struct{}
+
+func (a *CaptureUidAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	uid := extractAndHashUid(arg.RecognitionDetail)
+
+	capturedUidMu.Lock()
+	capturedUid = uid
+	capturedUidMu.Unlock()
+
+	log.Info().
+		Str("component", autoStockpileComponent).
+		Str("uid", uid).
+		Msg("captured uid")
+
+	return true
+}
+
+var uidDigitRe = regexp.MustCompile(`\d+`)
+
+// extractAndHashUid 从 OCR 识别结果的 best 文本中提取连续数字，
+// 使用 SHA256 加盐 "AutoStockpile" 后取前 16 位十六进制。
+// 无法提取有效数字时返回 "unknown"。
+func extractAndHashUid(detail *maa.RecognitionDetail) string {
+	ocrTexts := ocrTextCandidates(detail, ocrTextPolicyBestOnly)
+	if len(ocrTexts) == 0 {
+		log.Warn().
+			Str("component", autoStockpileComponent).
+			Msg("no OCR text found in recognition detail")
+		return "unknown"
+	}
+
+	bestText := ocrTexts[0]
+	digits := uidDigitRe.FindAllString(bestText, -1)
+	if len(digits) == 0 {
+		log.Warn().
+			Str("component", autoStockpileComponent).
+			Str("ocr_text", bestText).
+			Msg("no digits found in OCR result")
+		return "unknown"
+	}
+
+	numericPart := ""
+	for _, d := range digits {
+		numericPart += d
+	}
+
+	hash := sha256.Sum256([]byte(numericPart + "AutoStockpile"))
+	uid := fmt.Sprintf("%x", hash)[:16]
+
+	log.Debug().
+		Str("component", autoStockpileComponent).
+		Str("numeric_part", numericPart).
+		Str("uid", uid).
+		Msg("uid extracted and hashed")
+
+	return uid
+}
+
+// getCapturedUid 返回最近一次采集的 UID（线程安全）。
+func getCapturedUid() string {
+	capturedUidMu.Lock()
+	defer capturedUidMu.Unlock()
+	return capturedUid
+}

--- a/agent/go-service/autostockpile/uid.go
+++ b/agent/go-service/autostockpile/uid.go
@@ -22,6 +22,20 @@ var (
 type CaptureUidAction struct{}
 
 func (a *CaptureUidAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	if arg == nil {
+		log.Error().
+			Str("component", autoStockpileComponent).
+			Msg("custom action arg is nil")
+		return false
+	}
+
+	if arg.RecognitionDetail == nil {
+		log.Error().
+			Str("component", autoStockpileComponent).
+			Msg("recognition detail is nil")
+		return false
+	}
+
 	uid := extractAndHashUid(arg.RecognitionDetail)
 
 	capturedUidMu.Lock()
@@ -70,7 +84,6 @@ func extractAndHashUid(detail *maa.RecognitionDetail) string {
 
 	log.Debug().
 		Str("component", autoStockpileComponent).
-		Str("numeric_part", numericPart).
 		Str("uid", uid).
 		Msg("uid extracted and hashed")
 

--- a/assets/resource/pipeline/AutoStockpile/Main.json
+++ b/assets/resource/pipeline/AutoStockpile/Main.json
@@ -5,9 +5,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "[JumpBack]AutoStockpileElasticValleyIV",
-            "[JumpBack]AutoStockpileElasticWuling",
-            "AutoStockpileDone"
+            "AutoStockpileGetUid"
         ]
     },
     "AutoStockpileElasticValleyIV": {
@@ -70,5 +68,30 @@
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0
+    },
+    "AutoStockpileGetUid": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    60,
+                    690,
+                    120,
+                    25
+                ],
+                "order_by": "Length"
+            }
+        },
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "AutoStockpile.CaptureUid"
+            }
+        },
+        "next": [
+            "[JumpBack]AutoStockpileElasticValleyIV",
+            "[JumpBack]AutoStockpileElasticWuling",
+            "AutoStockpileDone"
+        ]
     }
 }

--- a/docs/en_us/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/en_us/developers/tasks/auto-stockpile-maintain.md
@@ -108,13 +108,14 @@ The JSON schema is fixed as:
 
 ```json
 {
-    "schema_version": 1,
+    "schema_version": 2,
     "records": [
         {
             "server_date": "2026-05-04",
             "weekday": 1,
             "utc_time": "2026-05-04T12:00:00Z",
             "region": "Wuling",
+            "uid": "abc123def4567890",
             "goods": [
                 {
                     "id": "Wuling/WulingFrozenPears.Tier1",
@@ -131,9 +132,9 @@ The JSON schema is fixed as:
 Maintenance constraints:
 
 - `weekday` uses the server day, mapped from Monday `1` through Sunday `7`; the server day still uses the existing `04:00` boundary.
-- The same `server_date + region` overwrites the previous record; different regions on the same server date are kept as separate records.
+- The same `server_date + region + uid` overwrites the previous record; different UIDs on the same server date are kept as separate records.
 - At most 120 distinct `server_date` values are retained; all region records under retained dates are preserved.
-- Records contain only `server_date`, `weekday`, `utc_time`, `region`, and `goods`. Do not add `quota` or other extra user data, and do not restore the old `captured_at_utc` field.
+- Records contain only `server_date`, `weekday`, `utc_time`, `region`, `uid`, and `goods`. Do not add `quota` or other extra user data, and do not restore the old `captured_at_utc` field.
 - Writes use a same-directory temporary file followed by rename for atomic replacement. Write failures are warning-only and AutoStockpile continues running.
 
 ## Threshold Resolution Mechanism

--- a/docs/en_us/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/en_us/developers/tasks/auto-stockpile-maintain.md
@@ -132,7 +132,7 @@ Maintenance constraints:
 
 - `weekday` uses the server day, mapped from Monday `1` through Sunday `7`; the server day still uses the existing `04:00` boundary.
 - The same `server_date + region` overwrites the previous record; different regions on the same server date are kept as separate records.
-- At most 60 distinct `server_date` values are retained; all region records under retained dates are preserved.
+- At most 120 distinct `server_date` values are retained; all region records under retained dates are preserved.
 - Records contain only `server_date`, `weekday`, `utc_time`, `region`, and `goods`. Do not add `quota` or other extra user data, and do not restore the old `captured_at_utc` field.
 - Writes use a same-directory temporary file followed by rename for atomic replacement. Write failures are warning-only and AutoStockpile continues running.
 

--- a/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
@@ -108,13 +108,14 @@ JSON schema 固定为：
 
 ```json
 {
-    "schema_version": 1,
+    "schema_version": 2,
     "records": [
         {
             "server_date": "2026-05-04",
             "weekday": 1,
             "utc_time": "2026-05-04T12:00:00Z",
             "region": "Wuling",
+            "uid": "abc123def4567890",
             "goods": [
                 {
                     "id": "Wuling/WulingFrozenPears.Tier1",
@@ -131,9 +132,9 @@ JSON schema 固定为：
 维护约束：
 
 - `weekday` 使用服务器日，映射为周一 `1` 到周日 `7`；服务器日仍按现有 `04:00` 边界计算。
-- 同一个 `server_date + region` 会覆盖旧记录；同一服务器日的不同 `region` 会作为独立记录保留。
+- 同一个 `server_date + region + uid` 会覆盖旧记录；同一服务器日同一地区的不同 `uid` 会作为独立记录保留。
 - 最多保留 120 个不同的 `server_date`；被保留日期下的所有地区记录都会保留。
-- 记录只包含 `server_date`、`weekday`、`utc_time`、`region` 和 `goods`，不得加入 `quota` 或其他额外用户数据，也不得恢复旧字段 `captured_at_utc`。
+- 记录只包含 `server_date`、`weekday`、`utc_time`、`region`、`uid` 和 `goods`，不得加入 `quota` 或其他额外用户数据，也不得恢复旧字段 `captured_at_utc`。
 - 写入使用同目录临时文件和 rename 的原子写流程；写入失败只记录 warning 并继续 AutoStockpile，不会中止任务。
 
 ## 阈值解析机制

--- a/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
@@ -132,7 +132,7 @@ JSON schema 固定为：
 
 - `weekday` 使用服务器日，映射为周一 `1` 到周日 `7`；服务器日仍按现有 `04:00` 边界计算。
 - 同一个 `server_date + region` 会覆盖旧记录；同一服务器日的不同 `region` 会作为独立记录保留。
-- 最多保留 60 个不同的 `server_date`；被保留日期下的所有地区记录都会保留。
+- 最多保留 120 个不同的 `server_date`；被保留日期下的所有地区记录都会保留。
 - 记录只包含 `server_date`、`weekday`、`utc_time`、`region` 和 `goods`，不得加入 `quota` 或其他额外用户数据，也不得恢复旧字段 `captured_at_utc`。
 - 写入使用同目录临时文件和 rename 的原子写流程；写入失败只记录 warning 并继续 AutoStockpile，不会中止任务。
 


### PR DESCRIPTION
## 由 Sourcery 提供的总结

记录带有哈希用户标识符的每日 AutoStockpile 价格数据，并扩展历史保留窗口。

新功能：
- 在每日 AutoStockpile 价格记录中增加每用户的 UID 字段，该字段由 OCR 派生，并与区域和商品信息一同存储。
- 新增 `CaptureUid` 自定义动作，从 OCR 识别结果中提取、哈希并缓存玩家 UID，以便后续在数据存储中使用。

改进：
- 将 `daily_storage` 中保留的 `server_date` 最大条目数从 60 提升到 120，并更新相应代码和开发者文档。
- 在向 `daily_storage` 进行 upsert 时，将具有相同 `server_date`、`region` 和 `UID` 的记录视为同一条记录，从而在同一日期和区域下实现按用户区分的数据存储。

文档：
- 更新英文和中文的 AutoStockpile 维护文档，以反映 `daily_storage` 记录新的 120 天保留上限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 AutoStockpile 每日价格记录添加按用户的 UID 跟踪，并扩展历史保留窗口。

新功能：
- 在每日 AutoStockpile 价格记录中，伴随 region 和 goods 一起记录经过哈希处理的按用户 UID
- 引入 CaptureUid 自定义动作，从 OCR 结果中提取、哈希并缓存玩家 UID，以便后续用于数据存储

增强：
- 将 retained daily_storage 的 server_date 窗口从 60 个不同日期增加到 120 个不同日期，并在 upsert 时将具有相同 server_date、region 和 UID 的记录视为同一条目

文档：
- 更新英文和中文的 AutoStockpile 维护文档，以反映 120 天的 daily_storage 保留限制以及扩展后的记录模式(schema)

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-user UID tracking to AutoStockpile daily price records and extend the historical retention window.

New Features:
- Record a hashed per-user UID alongside region and goods in daily AutoStockpile price records
- Introduce a CaptureUid custom action to extract, hash, and cache player UIDs from OCR results for later data storage use

Enhancements:
- Increase the retained daily_storage server_date window from 60 to 120 distinct days and treat records with the same server_date, region, and UID as the same entry during upsert

Documentation:
- Update English and Chinese AutoStockpile maintenance docs to reflect the 120-day daily_storage retention limit and the expanded record schema

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 AutoStockpile 每日价格记录添加按用户的 UID 跟踪，并扩展历史保留窗口。

新功能：
- 在每日 AutoStockpile 价格记录中，伴随 region 和 goods 一起记录经过哈希处理的按用户 UID
- 引入 CaptureUid 自定义动作，从 OCR 结果中提取、哈希并缓存玩家 UID，以便后续用于数据存储

增强：
- 将 retained daily_storage 的 server_date 窗口从 60 个不同日期增加到 120 个不同日期，并在 upsert 时将具有相同 server_date、region 和 UID 的记录视为同一条目

文档：
- 更新英文和中文的 AutoStockpile 维护文档，以反映 120 天的 daily_storage 保留限制以及扩展后的记录模式(schema)

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-user UID tracking to AutoStockpile daily price records and extend the historical retention window.

New Features:
- Record a hashed per-user UID alongside region and goods in daily AutoStockpile price records
- Introduce a CaptureUid custom action to extract, hash, and cache player UIDs from OCR results for later data storage use

Enhancements:
- Increase the retained daily_storage server_date window from 60 to 120 distinct days and treat records with the same server_date, region, and UID as the same entry during upsert

Documentation:
- Update English and Chinese AutoStockpile maintenance docs to reflect the 120-day daily_storage retention limit and the expanded record schema

</details>

</details>

</details>