### PR TITLE
fix(AutoEssence): 重命名安思园为首墩

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -7,7 +7,7 @@
     "global.region.PowerPlateau": "Power Plateau",
     "global.region.WulingCity": "Wuling City",
     "global.region.QingboStockade": "Qingbo Stockade",
-    "global.region.SerenityGarden": "Serenity Garden",
+    "global.region.MarkerStone": "Marker Stone",
     "item.XiraniteGourd": "Xiranite Gourd",
     "item.XiraniteJadeGourd": "Xiranite Jade Gourd",
     "task.DeliveryJobs.AcceptJobOnly": "Accept-jobs-only mode is enabled. The subsequent transfer flow has been stopped. Please complete the delivery and run the task again.",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -7,7 +7,7 @@
     "global.region.PowerPlateau": "エネルギー高地",
     "global.region.WulingCity": "武陵城内",
     "global.region.QingboStockade": "清波寨",
-    "global.region.SerenityGarden": "安思園",
+    "global.region.MarkerStone": "首墩",
     "item.XiraniteGourd": "息壌ひょうたん",
     "item.XiraniteJadeGourd": "息壌玉ひょうたん",
     "task.DeliveryJobs.AcceptJobOnly": "依頼受注のみモードが有効です。以降の転送フローを停止しました。配達を完了してから、もう一度タスクを実行してください。",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -7,7 +7,7 @@
     "global.region.PowerPlateau": "에너지 공급 고지",
     "global.region.WulingCity": "무릉성 도심",
     "global.region.QingboStockade": "청파채",
-    "global.region.SerenityGarden": "안사원",
+    "global.region.MarkerStone": "마커 스톤",
     "item.XiraniteGourd": "식양 호리병",
     "item.XiraniteJadeGourd": "식양 옥 호리병",
     "task.DeliveryJobs.AcceptJobOnly": "임무 수락 전용 모드가 활성화되었습니다. 이후 전달 절차를 중지합니다. 배송을 완료한 뒤 작업을 다시 실행해 주세요.",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -7,7 +7,7 @@
     "global.region.PowerPlateau": "供能高地",
     "global.region.WulingCity": "武陵城区",
     "global.region.QingboStockade": "清波寨",
-    "global.region.SerenityGarden": "安思园",
+    "global.region.MarkerStone": "首墩",
     "item.XiraniteGourd": "息壤葫芦",
     "item.XiraniteJadeGourd": "息壤玉葫芦",
     "task.DeliveryJobs.AcceptJobOnly": "已开启仅接取任务模式，停止后续转交流程，请完成送货后再次运行任务",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -7,7 +7,7 @@
     "global.region.PowerPlateau": "供能高地",
     "global.region.WulingCity": "武陵城區",
     "global.region.QingboStockade": "清波寨",
-    "global.region.SerenityGarden": "安思園",
+    "global.region.MarkerStone": "首墩",
     "item.XiraniteGourd": "息壤葫蘆",
     "item.XiraniteJadeGourd": "息壤玉葫蘆",
     "task.DeliveryJobs.AcceptJobOnly": "已開啟僅接取任務模式，停止後續轉交流程，請完成送貨後再次執行任務",

--- a/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
+++ b/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
@@ -62,7 +62,7 @@
             "VFPowerPlateauLocationAssertion",
             "WLWulingCityLocationAssertion",
             "WLQingboStockadeLocationAssertion",
-            "WLSerenityGardenLocationAssertion",
+            "WLMarkerStoneLocationAssertion",
             // 如果上述所有地区都没有命中，则无事发生
             "AutoEssenceLocationSetupFailed"
         ],
@@ -89,7 +89,7 @@
             "VFPowerPlateauLocationAssertion",
             "WLWulingCityLocationAssertion",
             "WLQingboStockadeLocationAssertion",
-            "WLSerenityGardenLocationAssertion",
+            "WLMarkerStoneLocationAssertion",
             // 如果上述所有地区都没有命中，则自动导航到指定的某个淤积点
             "AutoEssenceSpecifiedLocation"
         ],
@@ -711,9 +711,9 @@
             "param": {
                 "roi": [
                     400,
-                    220,
+                    210,
                     200,
-                    180
+                    210
                 ],
                 "template": "AutoEssence/SpDialog.png"
             }
@@ -726,9 +726,9 @@
             "param": {
                 "roi": [
                     1030,
-                    150,
-                    140,
-                    140
+                    90,
+                    245,
+                    200
                 ],
                 "template": "AutoEssence/SpDialogCloseButton.png"
             }

--- a/assets/resource/pipeline/AutoEssence/RegionNodes/WLMarkerStone.json
+++ b/assets/resource/pipeline/AutoEssence/RegionNodes/WLMarkerStone.json
@@ -1,15 +1,15 @@
 {
-    "WLSerenityGardenMoveToTriggerPointAuto": {
+    "WLMarkerStoneMoveToTriggerPointAuto": {
         "anchor": {
-            "AutoEssenceMoveToTriggerPoint": "WLSerenityGardenMoveToTriggerPoint",
-            "AutoEssenceWalkAround": "WLSerenityGardenWalkAround1"
+            "AutoEssenceMoveToTriggerPoint": "WLMarkerStoneMoveToTriggerPoint",
+            "AutoEssenceWalkAround": "WLMarkerStoneWalkAround1"
         },
         "next": [
-            "[JumpBack]WLSerenityGardenMaybeTeleport",
-            "WLSerenityGardenMoveToTriggerPoint"
+            "[JumpBack]WLMarkerStoneMaybeTeleport",
+            "WLMarkerStoneMoveToTriggerPoint"
         ]
     },
-    "WLSerenityGardenLocationAssertion": {
+    "WLMarkerStoneLocationAssertion": {
         "recognition": {
             "type": "Custom",
             "param": {
@@ -31,14 +31,14 @@
             }
         },
         "anchor": {
-            "AutoEssenceMoveToTriggerPoint": "WLSerenityGardenMoveToTriggerPoint",
-            "AutoEssenceWalkAround": "WLSerenityGardenWalkAround1"
+            "AutoEssenceMoveToTriggerPoint": "WLMarkerStoneMoveToTriggerPoint",
+            "AutoEssenceWalkAround": "WLMarkerStoneWalkAround1"
         },
         "focus": {
-            "Node.Action.Starting": "📍附近的能量淤积点：\n<p style=\"text-align: center\"><strong>安思园</strong></p>"
+            "Node.Action.Starting": "📍附近的能量淤积点：\n<p style=\"text-align: center\"><strong>首敦</strong></p>"
         }
     },
-    "WLSerenityGardenMaybeTeleport": {
+    "WLMarkerStoneMaybeTeleport": {
         "recognition": {
             "type": "Custom",
             "param": {
@@ -77,7 +77,7 @@
             "Node.Action.Starting": "✈️准备传送到最近锚点"
         }
     },
-    "WLSerenityGardenMoveToTriggerPoint": {
+    "WLMarkerStoneMoveToTriggerPoint": {
         "action": {
             "type": "Custom",
             "param": {
@@ -115,13 +115,13 @@
             }
         },
         "next": [
-            "WLSerenityGardenMoveToTriggerPointExact"
+            "WLMarkerStoneMoveToTriggerPointExact"
         ],
         "focus": {
             "Node.Action.Starting": "🚶正在前往激发点附近"
         }
     },
-    "WLSerenityGardenMoveToTriggerPointExact": {
+    "WLMarkerStoneMoveToTriggerPointExact": {
         "action": {
             "type": "Custom",
             "param": {
@@ -148,7 +148,7 @@
             "Node.Action.Starting": "🚶正在前往激发点"
         }
     },
-    "WLSerenityGardenWalkAround1": {
+    "WLMarkerStoneWalkAround1": {
         "action": {
             "type": "Custom",
             "param": {
@@ -173,13 +173,13 @@
         },
         "next": [
             "AutoEssenceCheckOngoing",
-            "WLSerenityGardenWalkAround2"
+            "WLMarkerStoneWalkAround2"
         ],
         "focus": {
             "Node.Action.Starting": "🚶正在散步中"
         }
     },
-    "WLSerenityGardenWalkAround2": {
+    "WLMarkerStoneWalkAround2": {
         "action": {
             "type": "Custom",
             "param": {
@@ -204,7 +204,7 @@
         },
         "next": [
             "AutoEssenceCheckOngoing",
-            "WLSerenityGardenWalkAround1"
+            "WLMarkerStoneWalkAround1"
         ],
         "focus": {
             "Node.Action.Starting": "🚶正在散步中"

--- a/assets/tasks/AutoEssence.json
+++ b/assets/tasks/AutoEssence.json
@@ -97,12 +97,12 @@
                     }
                 },
                 {
-                    "name": "WLSerenityGarden",
-                    "label": "$global.region.SerenityGarden",
+                    "name": "WLMarkerStone",
+                    "label": "$global.region.MarkerStone",
                     "pipeline_override": {
                         "AutoEssenceSpecifiedLocation": {
                             "next": [
-                                "WLSerenityGardenMoveToTriggerPointAuto"
+                                "WLMarkerStoneMoveToTriggerPointAuto"
                             ]
                         }
                     }


### PR DESCRIPTION
## 概要

此 PR 重命名了错误的淤积点地区名称“安思园”为“首墩”。

## Summary by Sourcery

将错误标记的 AutoEssence 区域名称从 An Siyuan 重命名为 Shoudun，并在数据和本地化资源中完成同步更新。

Bug Fixes:
- 在区域节点定义及相关资源中，将 AutoEssence 区域名称从 An Siyuan 更正为 Shoudun。

Enhancements:
- 使所有本地化字符串和 AutoEssence 流水线节点与更新后的 Shoudun 区域命名保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename an incorrectly labeled AutoEssence region from An Siyuan to Shoudun across data and localization assets.

Bug Fixes:
- Correct the AutoEssence region name from An Siyuan to Shoudun in region node definitions and associated resources.

Enhancements:
- Align all locale strings and AutoEssence pipeline nodes with the updated Shoudun region naming.

</details>