### PR TITLE
fix: 修复添加已保存蓝图任务失败问题

### DIFF
--- a/assets/resource/pipeline/ImportBluePrints.json
+++ b/assets/resource/pipeline/ImportBluePrints.json
@@ -170,11 +170,7 @@
                 "expected": [
                     "存至共享蓝图",
                     "存至共享藍圖",
-                    "(?i)Save\\s*to\\s*Shared\\s*Blueprints",
-                    "保存",
-                    "儲存",
-                    "(?i)Save",
-                    "Save to Shared"
+                    "(?i)Save\\s*to\\s*Shared\\s*Blueprints"
                 ]
             }
         },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 调整 `ImportBluePrints` 流水线配置，修复从已保存的蓝图中添加任务时出现的失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust ImportBluePrints pipeline configuration to fix failures when adding tasks from saved blueprints.

</details>