### PR TITLE
fix(MapNavigator): 修复 COLLECT/DIG 节点起步时连续消费多个点导致永久卡死

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/semantic_nodes.cpp
+++ b/agent/cpp-algo/source/MapNavigator/semantic_nodes.cpp
@@ -486,8 +486,8 @@ Result HandleArrivalSemantic(const Context& ctx, const Waypoint& waypoint, doubl
 
         ctx.session->NoteCanonicalFinalGoalConsumed(arrived_absolute_node_idx, *ctx.position, completed_reason);
         ctx.session->AdvanceToNextWaypoint(waypoint.action, completed_reason);
-        ctx.session->ResetProgress();
-        ctx.runtime_state->route.ResetTracking();
+        ctx.runtime_state->OnWaypointAdvance();
+        ctx.runtime_state->route.Reset();
 
         if (!ctx.session->HasCurrentWaypoint()) {
             ctx.session->NoteRouteTailConsumed(*ctx.position, "route_tail_consumed");


### PR DESCRIPTION
- fix #2747

## Summary by Sourcery

Bug Fixes:
- 修复了一个死锁问题：在启动 COLLECT/DIG 节点时，可能会消耗多个点数，并在航点推进后导致导航永久卡住。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix a deadlock where starting COLLECT/DIG nodes could consume multiple points and leave navigation permanently stuck after waypoint advancement.

</details>