### PR TITLE
fix:修复选择角色时仍会选择200信赖指的角色

### DIFF
--- a/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
@@ -328,7 +328,7 @@
                     -2
                 ],
                 "expected": [
-                    "^(?:199|1[0-9]{2}|[1-9][0-9]?|0)"
+                    "^((?!200).)*$"
                 ],
                 "only_rec": true,
                 "order_by": "Vertical"
@@ -340,12 +340,12 @@
         "recognition": {
             "type": "ColorMatch",
             "param": {
-                "roi": "GiftOperatorTrustIcon",
+                "roi": "GiftOperatorTrustValue",
                 "roi_offset": [
-                    36,
-                    -85,
-                    4,
-                    5
+                    27,
+                    -84,
+                    -24,
+                    0
                 ],
                 "method": 40,
                 "lower": [
@@ -429,10 +429,10 @@
             "type": "Click",
             "param": {
                 "target_offset": [
-                    8,
-                    8,
-                    -16,
-                    -16
+                    -30,
+                    50,
+                    0,
+                    0
                 ]
             }
         },
@@ -457,10 +457,10 @@
             "type": "Click",
             "param": {
                 "target_offset": [
-                    8,
-                    8,
-                    -16,
-                    -16
+                    -30,
+                    50,
+                    0,
+                    0
                 ]
             }
         },
@@ -485,10 +485,10 @@
             "type": "Click",
             "param": {
                 "target_offset": [
-                    8,
-                    8,
-                    -16,
-                    -16
+                    -30,
+                    50,
+                    0,
+                    0
                 ]
             }
         },

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorMain.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorMain.json
@@ -26,7 +26,7 @@
             }
         },
         "anchor": {
-            "GiftOperatorMoveModeAnchor": "GiftOperatorShiftToRunRecorded"
+            "GiftOperatorMoveModeAnchor": "GiftOperatorShiftToRunMapTracker"
         },
         "next": [
             "[Anchor]GiftOperatorMoveModeAnchor"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 防止在 GiftOperator 流程中选择角色时，错误地选中信用度为 200 的角色。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent 200-trust characters from being incorrectly selected when choosing a role in the GiftOperator flow.

</details>
- 调整 GiftOperator 联系人管道配置，以便在选择角色时不再错误地选择 200-trust 字符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 防止在 GiftOperator 流程中选择角色时，错误地选中信用度为 200 的角色。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent 200-trust characters from being incorrectly selected when choosing a role in the GiftOperator flow.

</details>

</details>