### PR TITLE
fix(BetterSliidng): 添加wait_freezes等待画面更新

### DIFF
--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmSwipeToTarget.json
@@ -154,10 +154,12 @@
         "desc": "判断是否在大世界",
         "recognition": {
             "type": "Or",
-            "param": {"any_of": [
+            "param": {
+                "any_of": [
                     "_AutoEcoFarmInWorldFactory",
                     "_AutoEcoFarmInWorldExplore"
-                ]}
+                ]
+            }
         },
         "next": [
             "_AutoEcoFarmJumpBack"

--- a/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
+++ b/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
@@ -24,7 +24,9 @@
     "AutoEssenceBackToWorld": {
         "desc": "开始任务前万能跳转回大世界",
         "max_hit": 1,
-        "next": ["SceneAnyEnterWorld"]
+        "next": [
+            "SceneAnyEnterWorld"
+        ]
     },
     "AutoEssenceTryRechallengeFromBattleResult": {
         "desc": "再来一次",
@@ -405,7 +407,9 @@
                     134,
                     94
                 ],
-                "expected": ["领取奖励"]
+                "expected": [
+                    "领取奖励"
+                ]
             }
         }
     },

--- a/assets/resource/pipeline/BetterSliding/Main.json
+++ b/assets/resource/pipeline/BetterSliding/Main.json
@@ -236,6 +236,7 @@
                 ]
             }
         },
+        "post_wait_freezes": 200,
         "post_delay": 0
     },
     "BetterSlidingGetMaxQuantity": {

--- a/assets/resource/pipeline/LevelUpOperator.json
+++ b/assets/resource/pipeline/LevelUpOperator.json
@@ -424,7 +424,9 @@
                     90,
                     70
                 ],
-                "template": ["LevelUpOperator/OperatorSelected.png"],
+                "template": [
+                    "LevelUpOperator/OperatorSelected.png"
+                ],
                 "green_mask": true,
                 "threshold": 0.9
             }


### PR DESCRIPTION
close #2773

## Summary by Sourcery

为多个自动化流水线添加屏幕冻结等待机制，以提升 BetterSliding 的稳定性和同步性。

Bug 修复：
- 确保 BetterSliding 交互在继续执行前会等待屏幕更新，以减少竞争条件和误滑动。

增强内容：
- 使 AutoEcoFarm、AutoEssence 和干员升级（operator level-up）等流水线与新的“等待屏幕冻结”行为保持一致，从而获得更可靠的自动化流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add screen-freeze waits to multiple automation pipelines to improve BetterSliding stability and synchronization.

Bug Fixes:
- Ensure BetterSliding interactions wait for screen updates before proceeding to reduce race conditions and mis-swipes.

Enhancements:
- Align AutoEcoFarm, AutoEssence, and operator level-up pipelines with the new wait-for-freeze behavior for more reliable automation flows.

</details>