### PR TITLE
fix: 再次尝试修复协议空间领取奖励点不上问题

### DIFF
--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -307,7 +307,7 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 			len(comboFull) == 0 {
 			log.Info().Str("component", "AutoFight").Msg("exiting fight")
 			maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
-			saveExitImage(img, "character_level")
+			// saveExitImage(img, "character_level")
 			result = true
 			break
 		}
@@ -317,7 +317,7 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 			if getCharactorLevelShow(ctx, img) {
 				log.Info().Str("component", "AutoFight").Msg("character level show detected, exiting fight")
 				maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
-				saveExitImage(img, "character_level_show")
+				// saveExitImage(img, "character_level_show")
 				result = true
 				break
 			}

--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -469,6 +469,8 @@
                 ]
             }
         ],
+        "pre_delay": 0,
+        "post_delay": 0,
         "box_index": 1,
         "action": "Custom",
         "custom_action": "AutoAltClickAction",


### PR DESCRIPTION
#2770

## Summary by Sourcery

错误修复：
- 修复了在自动战斗期间，由于多余的退出截图处理导致协议空间奖励领取卡住的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent protocol space reward claiming from getting stuck due to extraneous exit screenshot handling during autofight.

</details>