### PR TITLE
feat:单路线失败不中断任务

### DIFF
--- a/assets/resource/pipeline/AutoCollect.json
+++ b/assets/resource/pipeline/AutoCollect.json
@@ -1,16 +1,24 @@
 {
     "AutoCollectStart": {
         "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "AutoCollectRoute1Sub",
+                "AutoCollectRoute2Sub",
+                "AutoCollectRoute3Sub",
+                "AutoCollectRoute4Sub",
+                "AutoCollectRoute5Sub",
+                "AutoCollectRoute6Sub",
+                "AutoCollectRoute7Sub",
+                "AutoCollectRoute8Sub"
+            ],
+            "continue": true,
+            "strict": true
+        },
         "post_delay": 0,
         "next": [
-            "[JumpBack]AutoCollectRoute1Sub",
-            "[JumpBack]AutoCollectRoute2Sub",
-            "[JumpBack]AutoCollectRoute3Sub",
-            "[JumpBack]AutoCollectRoute4Sub",
-            "[JumpBack]AutoCollectRoute5Sub",
-            "[JumpBack]AutoCollectRoute6Sub",
-            "[JumpBack]AutoCollectRoute7Sub",
-            "[JumpBack]AutoCollectRoute8Sub",
             "AutoCollectEnd"
         ]
     },


### PR DESCRIPTION
最后还是会返还失败。不影响红任务

## Summary by Sourcery

更新 AutoCollect 流水线配置，以在单个路由失败时调整行为，从而在不中断整体任务执行的情况下继续运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update AutoCollect pipeline configuration to adjust behavior when a single route fails without interrupting the overall task execution.

</details>