### PR TITLE
docs: 添加autostockpile本地每日商品价格记录的第三方读取协议

### DIFF
--- a/docs/en_us/developers/README.md
+++ b/docs/en_us/developers/README.md
@@ -90,6 +90,14 @@ Only when you maintain the matching task.
 | [CreditShopping](./tasks/credit-shopping-maintain.md)               | Purchase priority, credit top-up linkage, refresh strategy, item extensions                  |
 | [EnvironmentMonitoring](./tasks/environment-monitoring-maintain.md) | Observation-point route data, `pipeline-generate` auto-generation, and onboarding new points |
 
+### Third-party protocol docs (`protocol/`)
+
+Defines format specifications for files written by MaaEnd, for reliable consumption by external tools (data dashboards, web frontends, etc.).
+
+| Document                                                                                 | Description                                                   |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [AutoStockpile Daily Price Records](../protocol/autostockpile-daily-storage/protocol.md) | `daily_storage.json` format, path resolution, and write rules |
+
 ## Quick lookup
 
 | I want to…                                            | Read this                                                                                                                                                       |

--- a/docs/en_us/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/en_us/developers/tasks/auto-stockpile-maintain.md
@@ -96,46 +96,7 @@ If you need different pricing behavior, update the Go defaults in code rather th
 
 ## Local Daily Goods-Price Storage
 
-When `AutoStockpileAllowDataUpload` is enabled, the Go Service writes the recognized goods-price table after successful recognition and after region/server-day resolution. The local file is:
-
-```text
-data/AutoStockpile/daily_storage.json
-```
-
-The writable data directory is resolved deterministically: first the `MAAEND_DATA_DIR` environment variable, then existing `data/` or `assets/data/` directories found from the current working directory and its ancestors, then the executable directory and its ancestors, and finally CWD-relative `data/` with `MkdirAll` creating the missing directory. This path is for local records only and does not trigger remote uploads.
-
-The JSON schema is fixed as:
-
-```json
-{
-    "schema_version": 2,
-    "records": [
-        {
-            "server_date": "2026-05-04",
-            "weekday": 1,
-            "utc_time": "2026-05-04T12:00:00Z",
-            "region": "Wuling",
-            "uid": "abc123def4567890",
-            "goods": [
-                {
-                    "id": "Wuling/WulingFrozenPears.Tier1",
-                    "name": "Wuling Frozen Pears",
-                    "tier": "Wuling.Tier1",
-                    "price": 1000
-                }
-            ]
-        }
-    ]
-}
-```
-
-Maintenance constraints:
-
-- `weekday` uses the server day, mapped from Monday `1` through Sunday `7`; the server day still uses the existing `04:00` boundary.
-- The same `server_date + region + uid` overwrites the previous record; different UIDs on the same server date are kept as separate records.
-- At most 120 distinct `server_date` values are retained; all region records under retained dates are preserved.
-- Records contain only `server_date`, `weekday`, `utc_time`, `region`, `uid`, and `goods`. Do not add `quota` or other extra user data, and do not restore the old `captured_at_utc` field.
-- Writes use a same-directory temporary file followed by rename for atomic replacement. Write failures are warning-only and AutoStockpile continues running.
+When `AutoStockpileAllowDataUpload` is enabled, the Go Service writes the recognized goods prices to `data/AutoStockpile/daily_storage.json` after successful recognition. For file format and path resolution rules, see [AutoStockpile Local Daily Goods-Price Records — Third-Party Read Protocol](../../protocol/autostockpile-daily-storage/protocol.md).
 
 ## Threshold Resolution Mechanism
 
@@ -273,6 +234,12 @@ File: `agent/go-service/autostockpile/strategy.go`
 
 - Add labels and descriptions for all new options in `assets/locales/interface/`.
 
+### 7. Update Storage Schema
+
+File: `docs/en_us/protocol/autostockpile-daily-storage/daily_storage.schema.json`
+
+- Add the new region identifier (e.g., `"NewRegion"`) to the `region` field's `enum` list so third-party tools can validate data from the new region against the Schema.
+
 ## Self-Checklist
 
 Ensure the following after any changes:
@@ -281,6 +248,7 @@ Ensure the following after any changes:
 2. Template images are placed in `assets/resource/image/AutoStockpile/Goods/{Region}/`.
 3. When adding a tier, `tierBases` in `strategy.go` is updated with the new tier's base value.
 4. When adding a region, `Main.json`, `DecisionLoop.json` (especially `AutoStockpileDecision{Region}.action.param.custom_action_param.Region`), `assets/tasks/AutoStockpile.json`, `item_map.json`, `strategy.go`, and `locales/*.json` are all updated.
+5. When adding a region, the `region` field's `enum` list in `docs/en_us/protocol/autostockpile-daily-storage/daily_storage.schema.json` is updated.
 
 ## Common Pitfalls
 

--- a/docs/en_us/protocol/autostockpile-daily-storage/daily_storage.schema.json
+++ b/docs/en_us/protocol/autostockpile-daily-storage/daily_storage.schema.json
@@ -1,0 +1,110 @@
+{
+    "$defs": {
+        "goods_item": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "description": "Internal goods ID, format {Region}/{BaseName}.Tier{N}.",
+                    "pattern": "^[A-Z][a-zA-Z0-9]+/[^./]+\\.Tier[0-9]+$",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Chinese item name.",
+                    "type": "string"
+                },
+                "price": {
+                    "description": "Recognized price for this good in the current round (elastic goods unit price).",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "tier": {
+                    "description": "Value tier identifier, format {Region}.Tier{N}.",
+                    "pattern": "^[A-Z][a-zA-Z0-9]+\\.Tier[0-9]+$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "name",
+                "tier",
+                "price"
+            ],
+            "type": "object"
+        },
+        "record": {
+            "additionalProperties": false,
+            "properties": {
+                "goods": {
+                    "description": "Array of goods recognized in this round.",
+                    "items": {
+                        "$ref": "#/$defs/goods_item"
+                    },
+                    "type": "array"
+                },
+                "region": {
+                    "description": "Region identifier.",
+                    "enum": [
+                        "Wuling",
+                        "ValleyIV"
+                    ],
+                    "type": "string"
+                },
+                "server_date": {
+                    "description": "Server date in YYYY-MM-DD format. Calculated using the target timezone's 04:00 boundary (04:00 ~ next 03:59 belongs to the same server day).",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "Player identifier. Derived from in-game UID digits via SHA256 salted hash, first 16 hex characters. Irreversible.",
+                    "maxLength": 16,
+                    "minLength": 7,
+                    "type": "string"
+                },
+                "utc_time": {
+                    "description": "UTC time when the record was written, RFC 3339 format.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "weekday": {
+                    "description": "Weekday of the server date, 1=Monday through 7=Sunday.",
+                    "maximum": 7,
+                    "minimum": 1,
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "server_date",
+                "weekday",
+                "utc_time",
+                "region",
+                "uid",
+                "goods"
+            ],
+            "type": "object"
+        }
+    },
+    "$id": "https://raw.githubusercontent.com/MaaEnd/MaaEnd/main/docs/en_us/protocol/autostockpile-daily-storage/daily_storage.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "description": "Format definition for the daily_storage.json file written by the AutoStockpile task.",
+    "properties": {
+        "records": {
+            "description": "Array of price records.",
+            "items": {
+                "$ref": "#/$defs/record"
+            },
+            "type": "array"
+        },
+        "schema_version": {
+            "const": 2,
+            "description": "Schema version number, currently fixed at 2. Increments on protocol upgrades; only new fields are added, never removed or changed.",
+            "type": "integer"
+        }
+    },
+    "required": [
+        "schema_version",
+        "records"
+    ],
+    "title": "AutoStockpile Local Daily Goods-Price Records",
+    "type": "object"
+}

--- a/docs/en_us/protocol/autostockpile-daily-storage/protocol.md
+++ b/docs/en_us/protocol/autostockpile-daily-storage/protocol.md
@@ -1,0 +1,145 @@
+# AutoStockpile Local Daily Goods-Price Records — Third-Party Read Protocol
+
+When the `AutoStockpileAllowDataUpload` option is enabled, the Go Service writes the per-round recognized goods prices to `data/AutoStockpile/daily_storage.json` after successful goods recognition and region/server-day resolution. This path is for local file records only and does not trigger remote uploads.
+
+This document defines the file format and path resolution rules for third-party tools (data analysis dashboards, web frontends, users) to read reliably.
+
+---
+
+## JSON Schema
+
+The top-level file structure is fixed as:
+
+```json
+{
+    "schema_version": 2,
+    "records": [
+        {
+            "server_date": "2026-05-04",
+            "weekday": 1,
+            "utc_time": "2026-05-04T12:00:00Z",
+            "region": "Wuling",
+            "uid": "abc123def4567890",
+            "goods": [
+                {
+                    "id": "Wuling/WulingFrozenPears.Tier1",
+                    "name": "Wuling Frozen Pears",
+                    "tier": "Wuling.Tier1",
+                    "price": 1000
+                }
+            ]
+        }
+    ]
+}
+```
+
+A corresponding JSON Schema file is provided for third-party tools to validate the data format:
+[daily_storage.schema.json](./daily_storage.schema.json)
+
+### Top-level Fields
+
+- `schema_version: int` — Schema version number, currently fixed at `2`. Increments on protocol upgrades; only new fields are added, never removed or changed.
+- `records: array` — Array of price records; see below for elements.
+
+### `records[]` Fields
+
+- `server_date: string` — Server date in `YYYY-MM-DD` format. Calculated using the target timezone's `04:00` boundary (`04:00 ~ next 03:59` belongs to the same server day).
+- `weekday: int` — Weekday of the server date, `1`=Monday through `7`=Sunday.
+- `utc_time: string` — UTC time when the record was written, RFC 3339 format (e.g., `2026-05-04T12:00:00Z`).
+- `region: string` — Region identifier. Current possible values: `Wuling`, `ValleyIV` (Valley IV).
+- `uid: string` — Player identifier. Derived from the in-game UID digits via SHA256 salted hash, taking the first 16 hex characters. Irreversible. Falls back to `"unknown"` when no valid UID is available.
+- `goods: array` — Array of goods recognized in this round; see below for elements.
+
+### `goods[]` Fields
+
+- `id: string` — Internal goods ID, format `{Region}/{BaseName}.Tier{N}`, e.g. `Wuling/WulingFrozenPears.Tier1`.
+- `name: string` — Chinese item name, e.g. "武陵冻梨".
+- `tier: string` — Value tier identifier, format `{Region}.Tier{N}`, e.g. `Wuling.Tier1`.
+- `price: int` — Recognized price for this good in the current round (elastic goods unit price).
+
+### Read/Write Constraints
+
+- Records contain only `server_date`, `weekday`, `utc_time`, `region`, `uid`, and `goods`. They **do not** contain `quota` or other extra user data. Third parties must not assume additional fields exist.
+- **Do not contain** the old `captured_at_utc` field. This field is deprecated in files with `schema_version ≥ 2`.
+- A new record with the same `server_date + region + uid` **overwrites** the old record. Different `uid` values on the same server date and region are kept independently.
+- At most **120 distinct** `server_date` values are retained. When exceeded, the earliest date and all its region records are discarded.
+- Writes use a same-directory temporary file + rename **atomic write** process. Readers can safely read `daily_storage.json` at any time without seeing a partially written file.
+- Write failures only log a warning and continue AutoStockpile; the task is not aborted.
+
+---
+
+## Path Resolution
+
+### Target File
+
+```text
+{Data Directory}/AutoStockpile/daily_storage.json
+```
+
+### Data Directory Resolution Priority
+
+Search in the following order, using the first path that satisfies the condition:
+
+1. **Environment variable `MAAEND_DATA_DIR`** — If set and non-empty, use it directly (after `filepath.Clean`).
+2. **Upward search from current working directory** — Starting from the current working directory, walk upward looking for an existing `data/` or `assets/data/` directory; use the first one found.
+3. **Upward search from executable directory** — Starting from `os.Executable()`'s directory, walk upward looking for an existing `data/` or `assets/data/` directory; use the first one found.
+4. **Fallback** — If none of the above found, use `<working directory>/data/`. The directory is created via `MkdirAll` if it does not exist.
+
+### Upward Search Algorithm
+
+When walking upward from the starting directory, check two candidate paths at each level (in order):
+
+1. `{base}/data/`
+2. `{base}/assets/data/`
+
+The first path that exists and is a directory is the result. If the search reaches the filesystem root without finding a match, an empty string is returned.
+
+### Atomic Write Process
+
+1. Create a temporary file in the same directory (naming pattern `.{daily_storage.json}.*.tmp`)
+2. Write the complete JSON content
+3. `chmod` the file to `0644`
+4. `Sync` to flush to disk
+5. `Close` the file handle
+6. `os.Rename` to atomically replace the target file
+
+Readers can safely read `daily_storage.json` at any time and will never see a partially written file.
+
+### Write Failure Behavior
+
+- Write failures only log at **warning level**
+- AutoStockpile task flow is not aborted
+- No retry is attempted
+
+---
+
+## UID Hash Algorithm
+
+For third parties needing to verify or compare UIDs, the algorithm is:
+
+1. Extract all consecutive digit segments from the in-game UID OCR result
+2. Concatenate all digit segments into a single string (e.g., `"123456789"`)
+3. Compute `SHA256(digit_string + "AutoStockpile")`
+4. Take the first 16 characters of the hex digest as the final UID
+
+When no valid digits can be extracted, the UID is `"unknown"`.
+
+> This hash is an **irreversible salted digest** — the original in-game UID cannot be reversed from the UID in the file.
+
+---
+
+## Server Day Calculation
+
+- **Default timezone**: `UTC+8`
+- **Day boundary**: `04:00` (i.e., each day from `04:00 ~ next 03:59` belongs to the same server day)
+- **Weekday mapping**: Go standard library `time.Weekday` mapped as `1` (Monday) through `7` (Sunday)
+
+Users can override the timezone offset via the `AutoStockpileServerTime` task option. Current option mappings: CN/Asia `UTC+8`, US/EU `UTC-5`.
+
+---
+
+## Version Compatibility
+
+- The `schema_version` field allows users to read it first and decide their parsing strategy.
+- Version increments only add new fields; existing field semantics are never changed.
+- Records with `schema_version: 1` may have an empty `uid`; the Go Service normalizes empty `uid` to `"unknown"` when reading back before rewriting. Third-party readers should also tolerate empty `uid`.

--- a/docs/en_us/protocol/autostockpile-daily-storage/protocol.md
+++ b/docs/en_us/protocol/autostockpile-daily-storage/protocol.md
@@ -23,7 +23,7 @@ The top-level file structure is fixed as:
             "goods": [
                 {
                     "id": "Wuling/WulingFrozenPears.Tier1",
-                    "name": "Wuling Frozen Pears",
+                    "name": "武陵冻梨",
                     "tier": "Wuling.Tier1",
                     "price": 1000
                 }

--- a/docs/zh_cn/developers/README.md
+++ b/docs/zh_cn/developers/README.md
@@ -90,6 +90,14 @@ flowchart TD
 | [CreditShopping 信用点商店](./tasks/credit-shopping-maintain.md)             | 购买优先级、补信用联动、刷新策略与商品扩展                 |
 | [EnvironmentMonitoring 环境监测](./tasks/environment-monitoring-maintain.md) | 观察点路线数据、`pipeline-generate` 自动生成与新点接入流程 |
 
+### 第三方协议文档（`protocol/`）
+
+定义 MaaEnd 写入文件的格式规范，供外部工具（数据分析面板、Web 前端等）可靠读取。
+
+| 文档                                                                              | 说明                                              |
+| --------------------------------------------------------------------------------- | ------------------------------------------------- |
+| [AutoStockpile 每日价格记录](../protocol/autostockpile-daily-storage/protocol.md) | `daily_storage.json` 文件格式、路径解析与写入规则 |
+
 ## 快速跳转
 
 | 我想做什么               | 该看哪里                                                                                                                                                        |

--- a/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
@@ -251,6 +251,7 @@ assets/resource/image/AutoStockpile/Goods/{Region}/{BaseName}.Tier{N}.png
 2. 模板图是否放在 `assets/resource/image/AutoStockpile/Goods/{Region}/` 下。
 3. 新增档位时，`agent/go-service/autostockpile/strategy.go` 的 `tierBases` 是否补充了对应基础值。
 4. 新增地区时，`Main.json`、`DecisionLoop.json`（尤其是 `AutoStockpileDecision{Region}.action.param.custom_action_param.Region`）、`assets/tasks/AutoStockpile.json`、`item_map.json`、`strategy.go`、`assets/locales/interface/*.json` 是否同步修改。
+5. 新增地区时，`docs/zh_cn/protocol/autostockpile-daily-storage/daily_storage.schema.json` 中 `region` 字段的 `enum` 列表是否加入了新地区标识。
 
 ## 常见坑
 

--- a/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
@@ -96,46 +96,7 @@ assets/resource/image/AutoStockpile/Goods/{Region}/{BaseName}.Tier{N}.png
 
 ## 本地每日商品价格记录
 
-启用 `AutoStockpileAllowDataUpload` 后，Go Service 会在每轮商品识别成功、地区与服务器日解析完成后，将当轮识别到的商品价格写入本地文件：
-
-```text
-data/AutoStockpile/daily_storage.json
-```
-
-写入目标按可写数据目录解析：优先使用环境变量 `MAAEND_DATA_DIR` 指定的数据目录，其次从当前工作目录及其父目录、可执行文件目录及其父目录中查找已存在的 `data/` 或 `assets/data/`，最后回退到当前工作目录下的 `data/` 并由 `MkdirAll` 创建。该路径只用于本地文件记录，不会触发远程上传。
-
-JSON schema 固定为：
-
-```json
-{
-    "schema_version": 2,
-    "records": [
-        {
-            "server_date": "2026-05-04",
-            "weekday": 1,
-            "utc_time": "2026-05-04T12:00:00Z",
-            "region": "Wuling",
-            "uid": "abc123def4567890",
-            "goods": [
-                {
-                    "id": "Wuling/WulingFrozenPears.Tier1",
-                    "name": "武陵冻梨",
-                    "tier": "Wuling.Tier1",
-                    "price": 1000
-                }
-            ]
-        }
-    ]
-}
-```
-
-维护约束：
-
-- `weekday` 使用服务器日，映射为周一 `1` 到周日 `7`；服务器日仍按现有 `04:00` 边界计算。
-- 同一个 `server_date + region + uid` 会覆盖旧记录；同一服务器日同一地区的不同 `uid` 会作为独立记录保留。
-- 最多保留 120 个不同的 `server_date`；被保留日期下的所有地区记录都会保留。
-- 记录只包含 `server_date`、`weekday`、`utc_time`、`region`、`uid` 和 `goods`，不得加入 `quota` 或其他额外用户数据，也不得恢复旧字段 `captured_at_utc`。
-- 写入使用同目录临时文件和 rename 的原子写流程；写入失败只记录 warning 并继续 AutoStockpile，不会中止任务。
+启用 `AutoStockpileAllowDataUpload` 后，Go Service 会在每轮商品识别成功后将商品价格写入 `data/AutoStockpile/daily_storage.json`。文件格式与路径解析规则见 [AutoStockpile 本地每日商品价格记录 — 第三方读取协议](../../protocol/autostockpile-daily-storage/protocol.md)。
 
 ## 阈值解析机制
 
@@ -275,6 +236,12 @@ assets/resource/image/AutoStockpile/Goods/{Region}/{BaseName}.Tier{N}.png
 ### 6. 国际化
 
 - 在 `assets/locales/interface/` 下补齐所有新增选项的 label 和 description。
+
+### 7. 更新价格记录 Schema
+
+文件：`docs/zh_cn/protocol/autostockpile-daily-storage/daily_storage.schema.json`
+
+- 在 `region` 字段的 `enum` 列表中加入新地区标识（如 `"NewRegion"`），确保第三方工具能通过 Schema 校验新增地区的数据。
 
 ## 自检清单
 

--- a/docs/zh_cn/protocol/autostockpile-daily-storage/daily_storage.schema.json
+++ b/docs/zh_cn/protocol/autostockpile-daily-storage/daily_storage.schema.json
@@ -1,0 +1,110 @@
+{
+    "$defs": {
+        "goods_item": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "description": "商品内部 ID，格式 {Region}/{BaseName}.Tier{N}。",
+                    "pattern": "^[A-Z][a-zA-Z0-9]+/[^./]+\\.Tier[0-9]+$",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "商品中文名称。",
+                    "type": "string"
+                },
+                "price": {
+                    "description": "商品当轮识别到的价格（弹性需求物资单价）。",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "tier": {
+                    "description": "价值变动幅度标识，格式 {Region}.Tier{N}。",
+                    "pattern": "^[A-Z][a-zA-Z0-9]+\\.Tier[0-9]+$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "name",
+                "tier",
+                "price"
+            ],
+            "type": "object"
+        },
+        "record": {
+            "additionalProperties": false,
+            "properties": {
+                "goods": {
+                    "description": "本轮识别到的商品数组。",
+                    "items": {
+                        "$ref": "#/$defs/goods_item"
+                    },
+                    "type": "array"
+                },
+                "region": {
+                    "description": "地区标识。",
+                    "enum": [
+                        "Wuling",
+                        "ValleyIV"
+                    ],
+                    "type": "string"
+                },
+                "server_date": {
+                    "description": "服务器日期，格式 YYYY-MM-DD。按目标时区 04:00 边界计算（04:00 ~ 次日 03:59 属同一服务器日）。",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "玩家标识。由游戏内 UID 数字部分经 SHA256 加盐哈希后取前 16 位十六进制。不可逆。",
+                    "maxLength": 16,
+                    "minLength": 7,
+                    "type": "string"
+                },
+                "utc_time": {
+                    "description": "记录写入时的 UTC 时间，RFC 3339 格式。",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "weekday": {
+                    "description": "服务器日对应的星期，1=周一 ~ 7=周日。",
+                    "maximum": 7,
+                    "minimum": 1,
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "server_date",
+                "weekday",
+                "utc_time",
+                "region",
+                "uid",
+                "goods"
+            ],
+            "type": "object"
+        }
+    },
+    "$id": "https://raw.githubusercontent.com/MaaEnd/MaaEnd/main/docs/zh_cn/protocol/autostockpile-daily-storage/daily_storage.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "description": "AutoStockpile 任务写入的 daily_storage.json 文件格式定义。",
+    "properties": {
+        "records": {
+            "description": "价格记录数组。",
+            "items": {
+                "$ref": "#/$defs/record"
+            },
+            "type": "array"
+        },
+        "schema_version": {
+            "const": 2,
+            "description": "Schema 版本号，当前固定为 2。协议升级时递增，只加字段不删不改旧字段。",
+            "type": "integer"
+        }
+    },
+    "required": [
+        "schema_version",
+        "records"
+    ],
+    "title": "AutoStockpile 本地每日商品价格记录",
+    "type": "object"
+}

--- a/docs/zh_cn/protocol/autostockpile-daily-storage/protocol.md
+++ b/docs/zh_cn/protocol/autostockpile-daily-storage/protocol.md
@@ -1,0 +1,145 @@
+# AutoStockpile 本地每日商品价格记录 — 第三方读取协议
+
+`AutoStockpile` 任务启用 `AutoStockpileAllowDataUpload` 后，Go Service 会在每轮商品识别成功、地区与服务器日解析完成后，将当轮识别到的商品价格写入 `data/AutoStockpile/daily_storage.json`。该路径只用于本地文件记录，不会触发远程上传。
+
+本文档定义文件格式与路径解析规则，供第三方工具（数据分析面板、Web 前端、用户）可靠读取。
+
+---
+
+## JSON Schema
+
+文件顶层结构固定为：
+
+```json
+{
+    "schema_version": 2,
+    "records": [
+        {
+            "server_date": "2026-05-04",
+            "weekday": 1,
+            "utc_time": "2026-05-04T12:00:00Z",
+            "region": "Wuling",
+            "uid": "abc123def4567890",
+            "goods": [
+                {
+                    "id": "Wuling/WulingFrozenPears.Tier1",
+                    "name": "武陵冻梨",
+                    "tier": "Wuling.Tier1",
+                    "price": 1000
+                }
+            ]
+        }
+    ]
+}
+```
+
+我们提供了相对应的 JSON Schema 文件，供第三方工具验证数据格式:
+[daily_storage.schema.json](./daily_storage.schema.json)
+
+### 顶层字段
+
+- `schema_version: int`：Schema 版本号，当前固定为 `2`。协议升级时递增，只加字段不删不改旧字段。
+- `records: array`：价格记录数组，元素见下。
+
+### `records[]` 字段
+
+- `server_date: string`：服务器日期，格式 `YYYY-MM-DD`。按目标时区 `04:00` 边界计算（`04:00 ~ 次日 03:59` 属同一服务器日）。
+- `weekday: int`：服务器日对应的星期，`1`=周一 ~ `7`=周日。
+- `utc_time: string`：记录写入时的 UTC 时间，RFC 3339 格式（如 `2026-05-04T12:00:00Z`）。
+- `region: string`：地区标识。当前可能值：`Wuling`（武陵）、`ValleyIV`（四号谷地）。
+- `uid: string`：玩家标识。由游戏内 UID 数字部分经 SHA256 加盐哈希后取前 16 位十六进制。不可逆。无有效 UID 时回退为 `"unknown"`。
+- `goods: array`：本轮识别到的商品数组，元素见下。
+
+### `goods[]` 字段
+
+- `id: string`：商品内部 ID，格式 `{Region}/{BaseName}.Tier{N}`，如 `Wuling/WulingFrozenPears.Tier1`。
+- `name: string`：商品中文名称，如"武陵冻梨"。
+- `tier: string`：价值变动幅度标识，格式 `{Region}.Tier{N}`，如 `Wuling.Tier1`。
+- `price: int`：商品当轮识别到的价格（弹性需求物资单价）。
+
+### 读写约束
+
+- 记录只包含 `server_date`、`weekday`、`utc_time`、`region`、`uid` 和 `goods`，**不包含** `quota` 或其他额外用户数据。第三方不得假设其他字段存在。
+- **不包含旧字段** `captured_at_utc`。`schema_version ≥ 2` 的文件中该字段已废弃。
+- 同一 `server_date + region + uid` 的新记录会**覆盖**旧记录。不同 `uid` 在同一天同一地区的记录独立保留。
+- 最多保留 **120 个不同的** `server_date`。超出时丢弃最早的日期及其所有地区记录。
+- 写入使用同目录临时文件 + rename 的**原子写**流程。读取方在任何时刻读取都不会读到半截文件。
+- 写入失败只记录 warning 日志并继续 AutoStockpile，不会中止任务。
+
+---
+
+## 路径解析
+
+### 目标文件
+
+```text
+{数据目录}/AutoStockpile/daily_storage.json
+```
+
+### 数据目录解析优先级
+
+按以下顺序查找，使用第一个满足条件的路径：
+
+1. **环境变量 `MAAEND_DATA_DIR`**：若设置且非空，直接使用该值（经 `filepath.Clean` 处理）。
+2. **当前工作目录向上查找**：从当前工作目录开始，向上逐级查找已存在的 `data/` 或 `assets/data/` 目录，使用第一个找到的。
+3. **可执行文件目录向上查找**：从 `os.Executable()` 所在目录开始，向上逐级查找已存在的 `data/` 或 `assets/data/` 目录，使用第一个找到的。
+4. **回退**：若以上均未找到，使用 `<工作目录>/data/`。目录不存在时由 `MkdirAll` 创建。
+
+### 向上查找算法
+
+从起始目录向上遍历时，每级目录检查两个候选路径（按顺序）：
+
+1. `{base}/data/`
+2. `{base}/assets/data/`
+
+以第一个存在且为目录的路径作为结果。若遍历到文件系统根仍未找到，返回空字符串。
+
+### 原子写入流程
+
+1. 在同一目录下创建临时文件（命名模式 `.{daily_storage.json}.*.tmp`）
+2. 写入完整 JSON 内容
+3. `chmod` 设置权限为 `0644`
+4. `Sync` 刷盘
+5. `Close` 关闭文件句柄
+6. `os.Rename` 原子替换目标文件
+
+读取方可安全地在任何时刻读取 `daily_storage.json`，不会读到部分写入的内容。
+
+### 写入失败行为
+
+- 写入失败只记录 **warning 级别日志**
+- 不会中止 AutoStockpile 任务流程
+- 不会重试
+
+---
+
+## UID 哈希算法
+
+第三方如需验证或比对 UID，算法如下：
+
+1. 从游戏内 UID 的 OCR 结果中提取所有连续数字片段
+2. 将所有数字片段拼接为一个字符串（如 `"123456789"`）
+3. 计算 `SHA256(数字字符串 + "AutoStockpile")`
+4. 取十六进制摘要的前 16 个字符作为最终 UID
+
+无法提取有效数字时，UID 为 `"unknown"`。
+
+> 该哈希为**不可逆加盐摘要**，无法从文件中的 UID 反推游戏内原始 UID。
+
+---
+
+## 服务器日计算
+
+- **默认时区**：`UTC+8`
+- **日边界**：`04:00`（即每天 `04:00 ~ 次日 03:59` 属于同一服务器日）
+- **weekday 映射**：Go 标准库 `time.Weekday` 映射为 `1`（周一）到 `7`（周日）
+
+用户可通过 `AutoStockpileServerTime` 任务选项覆盖时区偏移。当前选项映射为：国服/亚服 `UTC+8`、美服/欧服 `UTC-5`。
+
+---
+
+## 版本兼容性
+
+- `schema_version` 字段供用户先读取以决定解析策略。
+- 版本递增时只增加新字段，不修改已有字段语义。
+- `schema_version: 1` 的记录中 `uid` 可能为空字符串；Go Service 在读取后会自动将空 `uid` 规范化为 `"unknown"` 再写回。第三方读取时也应该兼容空 `uid`。


### PR DESCRIPTION
- close https://github.com/MaaEnd/MaaEnd/issues/1005
## Summary by Sourcery

将 AutoStockpile 本地每日商品价格存储格式文档化，作为一个独立的第三方读取协议，并将其集成到开发者文档中。

增强功能：
- 为 AutoStockpile 每日存储新增英文和中文的 JSON Schema 定义文件，以便外部工具能够验证记录的数据，包括可扩展的 `region` 枚举。

文档：
- 新增独立的英文和中文协议文档，描述 `daily_storage.json` 的模式(schema)、路径解析、UID 哈希、服务器日规则以及写入语义，供第三方使用方参考。
- 简化 AutoStockpile 维护文档，将内联的格式细节替换为指向新的中英文协议文档的链接。
- 在开发者 README 中新增英文/中文部分，介绍新的 `protocol/` 文档区域，并链接到 AutoStockpile 每日价格记录协议。
- 记录说明：当添加新的 region 时，维护者必须同时更新 AutoStockpile 每日存储 JSON Schema 文件中的 `region` 枚举列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the AutoStockpile local daily goods-price storage format as a dedicated third-party read protocol and integrate it into developer docs.

Enhancements:
- Add English and Chinese JSON Schema definition files for AutoStockpile daily storage so external tools can validate recorded data, including an extensible `region` enum.

Documentation:
- Introduce dedicated English and Chinese protocol documents describing `daily_storage.json` schema, path resolution, UID hashing, server-day rules, and write semantics for third-party consumers.
- Simplify the AutoStockpile maintenance docs by replacing inline format details with links to the new protocol documentation in both English and Chinese.
- Add developer README sections (EN/ZH) describing the new `protocol/` documentation area and linking to the AutoStockpile daily price records protocol.
- Document that when adding a region, maintainers must also update the `region` enum list in the AutoStockpile daily storage JSON Schema files.

</details>

## Summary by Sourcery

将 AutoStockpile 每日本地价格存储格式文档化，作为第三方读取协议对外发布，并集成到开发者文档中。

New Features:
- 为 AutoStockpile 每日商品价格记录引入专用的第三方读取协议，内容包括文件格式、路径解析、UID 哈希规则、服务器日规则以及写入语义。

Enhancements:
- 为 AutoStockpile 每日存储文件提供 JSON Schema 定义（中/英文），以便外部工具进行数据校验，并包含可扩展的地区枚举。
- 增加维护指引，当引入新地区时，确保 AutoStockpile 每日存储 Schema 能保持同步更新。

Documentation:
- 在 `protocol/` 目录下新增英文和中文协议文档，说明 `daily_storage.json` 的格式及其面向第三方消费者的使用方式。
- 简化现有 AutoStockpile 维护文档，将内联的存储格式细节替换为对新协议文档的引用。
- 扩展开发者 README（中/英文），新增一个章节列出所有第三方协议文档，其中包括 AutoStockpile 每日价格记录协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the AutoStockpile daily local price storage format as a third-party read protocol and integrate it into the developer documentation.

New Features:
- Introduce a dedicated third-party read protocol for AutoStockpile daily goods-price records, including file format, path resolution, UID hashing, server-day rules, and write semantics.

Enhancements:
- Provide JSON Schema definitions (EN/ZH) for the AutoStockpile daily storage file so external tools can validate data, including an extensible region enum.
- Add maintenance guidance to keep the AutoStockpile daily storage Schema in sync when new regions are introduced.

Documentation:
- Add English and Chinese protocol documents under `protocol/` describing the `daily_storage.json` format and usage for third-party consumers.
- Simplify existing AutoStockpile maintenance docs by replacing inline storage format details with references to the new protocol documentation.
- Extend the developer README (EN/ZH) with a new section listing third-party protocol documents, including the AutoStockpile daily price records protocol.

</details>