### PR TITLE
fix(go-service): 降级 purego 至 v0.9.1 修复 agent 启动时崩溃

### DIFF
--- a/agent/go-service/go.mod
+++ b/agent/go-service/go.mod
@@ -28,3 +28,5 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	golang.org/x/arch v0.25.0 // indirect
 )
+
+replace github.com/ebitengine/purego => github.com/ebitengine/purego v0.9.1 // indirect; pinned for maa-framework-go compatibility

--- a/agent/go-service/go.sum
+++ b/agent/go-service/go.sum
@@ -12,8 +12,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
-github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.9.1 h1:a/k2f2HQU3Pi399RPW1MOaZyhKJL9w/xFpKAg4q1s0A=
+github.com/ebitengine/purego v0.9.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=


### PR DESCRIPTION
- close https://github.com/MaaEnd/MaaEnd/issues/2480
- close https://github.com/MaaEnd/MaaEnd/issues/2440
- close https://github.com/MaaEnd/MaaEnd/issues/2760
## Summary by Sourcery

将 go-service agent 的 purego 依赖固定到一个与 maa-framework-go 兼容的特定版本

Chores:
- 在 go.mod 中使用 `replace` 指令为 purego 模块记录并固定版本，以确保与 maa-framework-go 的兼容性。

## Summary by Sourcery

杂务：
- 在 `go.mod` 中记录并固定 `github.com/ebitengine/purego` 的版本为 `v0.9.1`，以确保与 `maa-framework-go` 的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Record and pin github.com/ebitengine/purego to version v0.9.1 in go.mod to ensure compatibility with maa-framework-go.

</details>