### PR TITLE
fix: 修复前台模式颜色检查误判导致任务失败问题

### DIFF
--- a/assets/resource/pipeline/Interface/MouseMoveReset.json
+++ b/assets/resource/pipeline/Interface/MouseMoveReset.json
@@ -12,7 +12,7 @@
         "anchor": {
             "MouseMoveResetAnchor": ""
         },
-        "post_delay": 0,
+        "post_delay": 200,
         "rate_limit": 0
     }
 }

--- a/assets/resource/pipeline/SceneManager/SceneImageCheck.json
+++ b/assets/resource/pipeline/SceneManager/SceneImageCheck.json
@@ -28,9 +28,13 @@
         ],
         "pre_wait_freezes": 120,
         "pre_delay": 0,
+        "anchor": {
+            "MouseMoveResetAnchor": "MouseMoveReset"
+        },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "[JumpBack][Anchor]MouseMoveResetAnchor",
             "[JumpBack]__SceneCheckOSD",
             "[JumpBack]__SceneImageCheckAICPlanColor",
             "__SceneImageCheckFinishSave"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复前景色检查配置不正确的问题，该问题可能会导致场景图像检查中的任务失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect foreground color check configuration that could cause tasks to fail in scene image checks.

</details>