### PR TITLE
refactor(map): 重构MapTracker的InferState状态机

### DIFF
--- a/agent/go-service/maptracker/default/infer.go
+++ b/agent/go-service/maptracker/default/infer.go
@@ -133,7 +133,7 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 	if internalLocHit {
 		if globalInferState.IsCloseToConvinced(loc) {
 			// This hit is close to the currently convinced location
-			globalInferState.UpdateConvincedFromHit(loc)
+			globalInferState.SetConvinced(*loc)
 			finalLoc = loc
 
 		} else if globalInferState.IsCloseToPending(loc) {

--- a/agent/go-service/maptracker/default/infer.go
+++ b/agent/go-service/maptracker/default/infer.go
@@ -28,7 +28,7 @@ type MapTrackerInferResult struct {
 	RotConf     float64 `json:"rotConf"`     // Rotation confidence
 	LocTimeMs   int64   `json:"locTimeMs"`   // Location inference time in ms
 	RotTimeMs   int64   `json:"rotTimeMs"`   // Rotation inference time in ms
-	InferMode   string  `json:"inferMode"`   // Inference mode ("FullSearchHit", "FastSearchHit", "VirtualHit")
+	InferMode   string  `json:"inferMode"`   // Inference mode ("FullSearchHit", "FastSearchHit")
 	InferTimeMs int64   `json:"inferTimeMs"` // Total inference time in ms
 }
 
@@ -76,7 +76,6 @@ type InferLocationHitMode string
 const (
 	FULL_SEARCH_HIT InferLocationHitMode = "FullSearchHit"
 	FAST_SEARCH_HIT InferLocationHitMode = "FastSearchHit"
-	VIRTUAL_HIT     InferLocationHitMode = "VirtualHit"
 )
 
 // Time-series empirical optimization configuration
@@ -230,26 +229,6 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 				globalInferState.pending = emptyLocationRawResult
 				globalInferState.pendingHitCount = 0
 				finalLoc = &globalInferState.convinced
-			}
-		}
-	}
-
-	if finalLoc == nil {
-		if globalInferState.convinced.mapName != "" && nowMs-globalInferState.convincedLastHitTime < CONVINCED_VALID_TIME_MS {
-			// This is a temporary miss, but we can generate a virtual result
-			dt := nowMs - globalInferState.convincedLastHitTime
-			sx := globalInferState.convincedMoveSpeed * math.Cos(globalInferState.convincedMoveDirection)
-			sy := globalInferState.convincedMoveSpeed * math.Sin(globalInferState.convincedMoveDirection)
-			vx := roundTo1Decimal(globalInferState.convinced.x + sx*float64(dt))
-			vy := roundTo1Decimal(globalInferState.convinced.y + sy*float64(dt))
-
-			finalLoc = &InferLocationRawResult{
-				mapName:       globalInferState.convinced.mapName,
-				x:             vx,
-				y:             vy,
-				conf:          0,
-				source:        VIRTUAL_HIT,
-				elapsedTimeMs: 0,
 			}
 		}
 	}

--- a/agent/go-service/maptracker/default/infer.go
+++ b/agent/go-service/maptracker/default/infer.go
@@ -56,54 +56,23 @@ type MapTrackerInfer struct {
 	scaledScale  float64
 }
 
-type InferState struct {
-	convinced              InferLocationRawResult
-	convincedLastHitTime   int64
-	convincedMoveDirection float64
-	convincedMoveSpeed     float64
-
-	pending             InferLocationRawResult
-	pendingFirstHitTime int64
-	pendingHitCount     int
-
-	mu sync.Mutex
-}
-
-var globalInferState InferState
-
-type InferLocationHitMode string
-
-const (
-	FULL_SEARCH_HIT InferLocationHitMode = "FullSearchHit"
-	FAST_SEARCH_HIT InferLocationHitMode = "FastSearchHit"
-)
-
-// Time-series empirical optimization configuration
-const (
-	PENDING_TAKEOVER_TIME_MS         = 1000
-	PENDING_TAKEOVER_COUNT_THRESHOLD = 3
-	CONVINCED_DISTANCE_THRESHOLD     = 20
-	CONVINCED_VALID_TIME_MS          = 2000
-)
-
+// InferLocationRawResult represents the raw result of location inference
 type InferLocationRawResult struct {
-	mapName       string
-	x             float64
-	y             float64
-	conf          float64
-	source        InferLocationHitMode
-	elapsedTimeMs int64
+	MapName       string
+	X             float64
+	Y             float64
+	Conf          float64
+	Source        InferLocationHitMode
+	ElapsedTimeMs int64
 }
-
-var emptyLocationRawResult = InferLocationRawResult{"", 0, 0, 0.0, "", 0}
-
-var mapCoreNameRegexp = regexp.MustCompile(`^(.+?)(?:_tier_\w+)?$`)
 
 type InferRotationRawResult struct {
-	rot           int
-	conf          float64
-	elapsedTimeMs int64
+	Rot           int
+	Conf          float64
+	ElapsedTimeMs int64
 }
+
+var mapCoreNameRegexp = regexp.MustCompile(`^(.+?)(?:_tier_\w+)?$`)
 
 var MapTrackerInferRunner maa.CustomRecognitionRunner = &MapTrackerInfer{}
 
@@ -151,84 +120,42 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 	loc := <-ch
 
 	// Determine if recognition hit natively
-	internalLocHit := loc != nil && loc.conf > param.Threshold
-	internalRotHit := rot != nil && rot.conf > param.Threshold
+	internalLocHit := loc != nil && loc.Conf > param.Threshold
+	internalRotHit := rot != nil && rot.Conf > param.Threshold
 
 	// Final results (nil for now)
 	var finalLoc *InferLocationRawResult
 	var finalRot *InferRotationRawResult
 
-	globalInferState.mu.Lock()
+	globalInferState.Lock()
 	nowMs := time.Now().UnixMilli()
 
 	// Process internal location hit
 	if internalLocHit {
-		isCloseToConvinced := func() bool {
-			if !isMapNameCoreMatch(globalInferState.convinced.mapName, loc.mapName) {
-				return false
-			}
-			dx := globalInferState.convinced.x - loc.x
-			dy := globalInferState.convinced.y - loc.y
-			return math.Hypot(dx, dy) < CONVINCED_DISTANCE_THRESHOLD
-		}
-
-		isCloseToPending := func() bool {
-			if !isMapNameCoreMatch(globalInferState.pending.mapName, loc.mapName) {
-				return false
-			}
-			dx := globalInferState.pending.x - loc.x
-			dy := globalInferState.pending.y - loc.y
-			return math.Hypot(dx, dy) < CONVINCED_DISTANCE_THRESHOLD
-		}
-
-		if isCloseToConvinced() {
+		if globalInferState.IsCloseToConvinced(loc) {
 			// This hit is close to the currently convinced location
-			dt := nowMs - globalInferState.convincedLastHitTime
-			if dt > 0 {
-				dx := loc.x - globalInferState.convinced.x
-				dy := loc.y - globalInferState.convinced.y
-				dist := math.Hypot(dx, dy)
-				globalInferState.convincedMoveSpeed = dist / float64(dt)
-				globalInferState.convincedMoveDirection = math.Atan2(dy, dx)
-			}
-			globalInferState.convinced = *loc
-			globalInferState.convincedLastHitTime = nowMs
+			globalInferState.UpdateConvincedFromHit(loc, nowMs)
 			finalLoc = loc
 
-		} else if isCloseToPending() {
+		} else if globalInferState.IsCloseToPending(loc) {
 			// This hit is close to the pending location
-			globalInferState.pending.x = loc.x
-			globalInferState.pending.y = loc.y
-			globalInferState.pendingHitCount++
+			globalInferState.UpdatePending(loc.X, loc.Y)
 
-			if globalInferState.convinced.mapName == "" ||
-				nowMs-globalInferState.pendingFirstHitTime >= PENDING_TAKEOVER_TIME_MS ||
-				globalInferState.pendingHitCount >= PENDING_TAKEOVER_COUNT_THRESHOLD {
+			if globalInferState.ShouldTakeoverPending(nowMs) {
 				// Do takeover (replace convinced with pending)
-				globalInferState.convinced = globalInferState.pending
-				globalInferState.convincedLastHitTime = nowMs
-				globalInferState.convincedMoveSpeed = 0
-				globalInferState.convincedMoveDirection = 0
-				globalInferState.pending = emptyLocationRawResult
-				globalInferState.pendingHitCount = 0
-				finalLoc = &globalInferState.convinced
+				globalInferState.TakeoverPending(nowMs)
+				finalLoc = loc
 			}
 		} else {
 			// This hit is far from both convinced and pending locations
-			if nowMs-globalInferState.convincedLastHitTime < CONVINCED_VALID_TIME_MS {
+			if globalInferState.IsImmediateTrackLoss(nowMs) {
 				// It's an immediate track loss, start a new pending
-				globalInferState.pending = *loc
-				globalInferState.pendingFirstHitTime = nowMs
-				globalInferState.pendingHitCount = 1
+				globalInferState.SetPending(*loc, nowMs)
 			} else {
 				// It's a stale track loss, directly replace convinced with this new hit
-				globalInferState.convinced = *loc
-				globalInferState.convincedLastHitTime = nowMs
-				globalInferState.convincedMoveSpeed = 0
-				globalInferState.convincedMoveDirection = 0
-				globalInferState.pending = emptyLocationRawResult
-				globalInferState.pendingHitCount = 0
-				finalLoc = &globalInferState.convinced
+				globalInferState.SetConvinced(*loc, nowMs)
+				globalInferState.ResetPending()
+				finalLoc = loc
 			}
 		}
 	}
@@ -238,7 +165,7 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 		finalRot = rot
 	}
 
-	globalInferState.mu.Unlock()
+	globalInferState.Unlock()
 
 	finalHit := finalLoc != nil && finalRot != nil
 	finalElapsedTimeMs := time.Since(t0).Milliseconds()
@@ -255,15 +182,15 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 
 	// Build hit result
 	result := MapTrackerInferResult{
-		MapName:     finalLoc.mapName,
-		X:           finalLoc.x,
-		Y:           finalLoc.y,
-		Rot:         finalRot.rot,
-		LocConf:     finalLoc.conf,
-		RotConf:     finalRot.conf,
-		LocTimeMs:   finalLoc.elapsedTimeMs,
-		RotTimeMs:   finalRot.elapsedTimeMs,
-		InferMode:   string(finalLoc.source),
+		MapName:     finalLoc.MapName,
+		X:           finalLoc.X,
+		Y:           finalLoc.Y,
+		Rot:         finalRot.Rot,
+		LocConf:     finalLoc.Conf,
+		RotConf:     finalRot.Conf,
+		LocTimeMs:   finalLoc.ElapsedTimeMs,
+		RotTimeMs:   finalRot.ElapsedTimeMs,
+		InferMode:   string(finalLoc.Source),
 		InferTimeMs: finalElapsedTimeMs,
 	}
 
@@ -370,16 +297,14 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 	// Time-series empirical optimization
 	// If the user is in a stable state (convinced location updated recently, no pending drifts),
 	// try to match the convinced map around the convinced location first.
-	globalInferState.mu.Lock()
+	globalInferState.Lock()
 
-	stableConvincedMapName := globalInferState.convinced.mapName
-	stableLocX := globalInferState.convinced.x
-	stableLocY := globalInferState.convinced.y
-	isInTime := globalInferState.convinced.mapName != "" &&
-		(time.Now().UnixMilli()-globalInferState.convincedLastHitTime < CONVINCED_VALID_TIME_MS) &&
-		globalInferState.pendingHitCount == 0
+	stableConvincedMapName := globalInferState.convinced.MapName
+	stableLocX := globalInferState.convinced.X
+	stableLocY := globalInferState.convinced.Y
+	isInTime := globalInferState.IsConvincedValid(time.Now().UnixMilli())
 
-	globalInferState.mu.Unlock()
+	globalInferState.Unlock()
 
 	isStable := func() bool {
 		if !isInTime {
@@ -435,12 +360,12 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 				Msg("Internal fast search location inference completed")
 
 			return &InferLocationRawResult{
-				mapName:       fastBestMapName,
-				x:             fastBestX,
-				y:             fastBestY,
-				conf:          fastBestVal,
-				source:        FAST_SEARCH_HIT,
-				elapsedTimeMs: elapsedTimeMs,
+				MapName:       fastBestMapName,
+				X:             fastBestX,
+				Y:             fastBestY,
+				Conf:          fastBestVal,
+				Source:        FAST_SEARCH_HIT,
+				ElapsedTimeMs: elapsedTimeMs,
 			}
 		}
 	} else {
@@ -528,12 +453,12 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 		Msg("Internal location inference completed")
 
 	return &InferLocationRawResult{
-		mapName:       bestMapName,
-		x:             bestX,
-		y:             bestY,
-		conf:          bestVal,
-		source:        FULL_SEARCH_HIT,
-		elapsedTimeMs: time.Since(t0).Milliseconds(),
+		MapName:       bestMapName,
+		X:             bestX,
+		Y:             bestY,
+		Conf:          bestVal,
+		Source:        FULL_SEARCH_HIT,
+		ElapsedTimeMs: time.Since(t0).Milliseconds(),
 	}
 }
 
@@ -607,9 +532,9 @@ func (i *MapTrackerInfer) inferRotation(ctrlType string, screenImg *image.RGBA, 
 		Msg("Internal rotation inference completed")
 
 	return &InferRotationRawResult{
-		rot:           bestAngle,
-		conf:          maxVal,
-		elapsedTimeMs: time.Since(t0).Milliseconds(),
+		Rot:           bestAngle,
+		Conf:          maxVal,
+		ElapsedTimeMs: time.Since(t0).Milliseconds(),
 	}
 }
 

--- a/agent/go-service/maptracker/default/infer.go
+++ b/agent/go-service/maptracker/default/infer.go
@@ -128,32 +128,31 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 	var finalRot *InferRotationRawResult
 
 	globalInferState.Lock()
-	nowMs := time.Now().UnixMilli()
 
 	// Process internal location hit
 	if internalLocHit {
 		if globalInferState.IsCloseToConvinced(loc) {
 			// This hit is close to the currently convinced location
-			globalInferState.UpdateConvincedFromHit(loc, nowMs)
+			globalInferState.UpdateConvincedFromHit(loc)
 			finalLoc = loc
 
 		} else if globalInferState.IsCloseToPending(loc) {
 			// This hit is close to the pending location
 			globalInferState.UpdatePending(loc.X, loc.Y)
 
-			if globalInferState.ShouldTakeoverPending(nowMs) {
+			if globalInferState.ShouldTakeoverPending() {
 				// Do takeover (replace convinced with pending)
-				globalInferState.TakeoverPending(nowMs)
+				globalInferState.TakeoverPending()
 				finalLoc = loc
 			}
 		} else {
 			// This hit is far from both convinced and pending locations
-			if globalInferState.IsImmediateTrackLoss(nowMs) {
+			if globalInferState.IsImmediateTrackLoss() {
 				// It's an immediate track loss, start a new pending
-				globalInferState.SetPending(*loc, nowMs)
+				globalInferState.SetPending(*loc)
 			} else {
 				// It's a stale track loss, directly replace convinced with this new hit
-				globalInferState.SetConvinced(*loc, nowMs)
+				globalInferState.SetConvinced(*loc)
 				globalInferState.ResetPending()
 				finalLoc = loc
 			}
@@ -302,7 +301,7 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 	stableConvincedMapName := globalInferState.convinced.MapName
 	stableLocX := globalInferState.convinced.X
 	stableLocY := globalInferState.convinced.Y
-	isInTime := globalInferState.IsConvincedValid(time.Now().UnixMilli())
+	isInTime := globalInferState.IsConvincedValid()
 
 	globalInferState.Unlock()
 

--- a/agent/go-service/maptracker/default/infer_state.go
+++ b/agent/go-service/maptracker/default/infer_state.go
@@ -77,6 +77,7 @@ func (s *InferState) SetPending(loc InferLocationRawResult) {
 
 // UpdatePending updates the pending location and increments hit count
 func (s *InferState) UpdatePending(x, y float64) {
+	_ = s.getLockTime()
 	s.pending.X = x
 	s.pending.Y = y
 	s.pendingHitCount++
@@ -87,12 +88,12 @@ func (s *InferState) TakeoverPending() {
 	nowMs := s.getLockTime()
 	s.convinced = s.pending
 	s.convincedLastHitTime = nowMs
-	s.pending = emptyLocationRawResult
-	s.pendingHitCount = 0
+	s.ResetPending()
 }
 
 // ResetPending clears the pending state
 func (s *InferState) ResetPending() {
+	_ = s.getLockTime()
 	s.pending = emptyLocationRawResult
 	s.pendingFirstHitTime = 0
 	s.pendingHitCount = 0

--- a/agent/go-service/maptracker/default/infer_state.go
+++ b/agent/go-service/maptracker/default/infer_state.go
@@ -4,6 +4,7 @@ package maptrackerdefault
 import (
 	"math"
 	"sync"
+	"time"
 )
 
 // InferLocationHitMode represents the mode of location inference hit
@@ -35,29 +36,42 @@ type InferState struct {
 	pendingFirstHitTime int64
 	pendingHitCount     int
 
-	mu sync.Mutex
+	mu       sync.Mutex
+	lockTime int64
 }
 
 var globalInferState InferState
 
-// Lock acquires the state mutex
+// Lock acquires the state mutex and records the current time
 func (s *InferState) Lock() {
 	s.mu.Lock()
+	s.lockTime = time.Now().UnixMilli()
 }
 
-// Unlock releases the state mutex
+// Unlock releases the state mutex and clears the lock time
 func (s *InferState) Unlock() {
+	s.lockTime = 0
 	s.mu.Unlock()
 }
 
+// getLockTime returns the lock time, panics if not locked
+func (s *InferState) getLockTime() int64 {
+	if s.lockTime == 0 {
+		panic("InferState method called without holding Lock")
+	}
+	return s.lockTime
+}
+
 // SetConvinced sets the convinced state and updates last hit time
-func (s *InferState) SetConvinced(loc InferLocationRawResult, nowMs int64) {
+func (s *InferState) SetConvinced(loc InferLocationRawResult) {
+	nowMs := s.getLockTime()
 	s.convinced = loc
 	s.convincedLastHitTime = nowMs
 }
 
 // UpdateConvincedFromHit updates convinced state from a location hit
-func (s *InferState) UpdateConvincedFromHit(loc *InferLocationRawResult, nowMs int64) {
+func (s *InferState) UpdateConvincedFromHit(loc *InferLocationRawResult) {
+	nowMs := s.getLockTime()
 	dt := nowMs - s.convincedLastHitTime
 	if dt > 0 {
 		dx := loc.X - s.convinced.X
@@ -71,7 +85,8 @@ func (s *InferState) UpdateConvincedFromHit(loc *InferLocationRawResult, nowMs i
 }
 
 // SetPending sets the pending state and initializes hit count
-func (s *InferState) SetPending(loc InferLocationRawResult, nowMs int64) {
+func (s *InferState) SetPending(loc InferLocationRawResult) {
+	nowMs := s.getLockTime()
 	s.pending = loc
 	s.pendingFirstHitTime = nowMs
 	s.pendingHitCount = 1
@@ -85,7 +100,8 @@ func (s *InferState) UpdatePending(x, y float64) {
 }
 
 // TakeoverPending promotes pending to convinced state
-func (s *InferState) TakeoverPending(nowMs int64) {
+func (s *InferState) TakeoverPending() {
+	nowMs := s.getLockTime()
 	s.convinced = s.pending
 	s.convincedLastHitTime = nowMs
 	s.convincedMoveSpeed = 0
@@ -102,7 +118,8 @@ func (s *InferState) ResetPending() {
 }
 
 // IsConvincedValid checks if convinced state is still valid based on time
-func (s *InferState) IsConvincedValid(nowMs int64) bool {
+func (s *InferState) IsConvincedValid() bool {
+	nowMs := s.getLockTime()
 	return s.convinced.MapName != "" &&
 		(nowMs-s.convincedLastHitTime < CONVINCED_VALID_TIME_MS) &&
 		s.pendingHitCount == 0
@@ -129,13 +146,15 @@ func (s *InferState) IsCloseToPending(loc *InferLocationRawResult) bool {
 }
 
 // ShouldTakeoverPending checks if pending should be promoted to convinced
-func (s *InferState) ShouldTakeoverPending(nowMs int64) bool {
+func (s *InferState) ShouldTakeoverPending() bool {
+	nowMs := s.getLockTime()
 	return s.convinced.MapName == "" ||
 		nowMs-s.pendingFirstHitTime >= PENDING_TAKEOVER_TIME_MS ||
 		s.pendingHitCount >= PENDING_TAKEOVER_COUNT_THRESHOLD
 }
 
 // IsImmediateTrackLoss checks if this is an immediate track loss
-func (s *InferState) IsImmediateTrackLoss(nowMs int64) bool {
+func (s *InferState) IsImmediateTrackLoss() bool {
+	nowMs := s.getLockTime()
 	return nowMs-s.convincedLastHitTime < CONVINCED_VALID_TIME_MS
 }

--- a/agent/go-service/maptracker/default/infer_state.go
+++ b/agent/go-service/maptracker/default/infer_state.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Harry Huang
+package maptrackerdefault
+
+import (
+	"math"
+	"sync"
+)
+
+// InferLocationHitMode represents the mode of location inference hit
+type InferLocationHitMode string
+
+const (
+	FULL_SEARCH_HIT InferLocationHitMode = "FullSearchHit"
+	FAST_SEARCH_HIT InferLocationHitMode = "FastSearchHit"
+)
+
+// Time-series empirical optimization configuration
+const (
+	PENDING_TAKEOVER_TIME_MS         = 1000
+	PENDING_TAKEOVER_COUNT_THRESHOLD = 3
+	CONVINCED_DISTANCE_THRESHOLD     = 20
+	CONVINCED_VALID_TIME_MS          = 2000
+)
+
+var emptyLocationRawResult = InferLocationRawResult{}
+
+// InferState manages the state for map tracking inference
+type InferState struct {
+	convinced              InferLocationRawResult
+	convincedLastHitTime   int64
+	convincedMoveDirection float64
+	convincedMoveSpeed     float64
+
+	pending             InferLocationRawResult
+	pendingFirstHitTime int64
+	pendingHitCount     int
+
+	mu sync.Mutex
+}
+
+var globalInferState InferState
+
+// Lock acquires the state mutex
+func (s *InferState) Lock() {
+	s.mu.Lock()
+}
+
+// Unlock releases the state mutex
+func (s *InferState) Unlock() {
+	s.mu.Unlock()
+}
+
+// SetConvinced sets the convinced state and updates last hit time
+func (s *InferState) SetConvinced(loc InferLocationRawResult, nowMs int64) {
+	s.convinced = loc
+	s.convincedLastHitTime = nowMs
+}
+
+// UpdateConvincedFromHit updates convinced state from a location hit
+func (s *InferState) UpdateConvincedFromHit(loc *InferLocationRawResult, nowMs int64) {
+	dt := nowMs - s.convincedLastHitTime
+	if dt > 0 {
+		dx := loc.X - s.convinced.X
+		dy := loc.Y - s.convinced.Y
+		dist := math.Hypot(dx, dy)
+		s.convincedMoveSpeed = dist / float64(dt)
+		s.convincedMoveDirection = math.Atan2(dy, dx)
+	}
+	s.convinced = *loc
+	s.convincedLastHitTime = nowMs
+}
+
+// SetPending sets the pending state and initializes hit count
+func (s *InferState) SetPending(loc InferLocationRawResult, nowMs int64) {
+	s.pending = loc
+	s.pendingFirstHitTime = nowMs
+	s.pendingHitCount = 1
+}
+
+// UpdatePending updates the pending location and increments hit count
+func (s *InferState) UpdatePending(x, y float64) {
+	s.pending.X = x
+	s.pending.Y = y
+	s.pendingHitCount++
+}
+
+// TakeoverPending promotes pending to convinced state
+func (s *InferState) TakeoverPending(nowMs int64) {
+	s.convinced = s.pending
+	s.convincedLastHitTime = nowMs
+	s.convincedMoveSpeed = 0
+	s.convincedMoveDirection = 0
+	s.pending = emptyLocationRawResult
+	s.pendingHitCount = 0
+}
+
+// ResetPending clears the pending state
+func (s *InferState) ResetPending() {
+	s.pending = emptyLocationRawResult
+	s.pendingFirstHitTime = 0
+	s.pendingHitCount = 0
+}
+
+// IsConvincedValid checks if convinced state is still valid based on time
+func (s *InferState) IsConvincedValid(nowMs int64) bool {
+	return s.convinced.MapName != "" &&
+		(nowMs-s.convincedLastHitTime < CONVINCED_VALID_TIME_MS) &&
+		s.pendingHitCount == 0
+}
+
+// IsCloseToConvinced checks if a location is close to the convinced location
+func (s *InferState) IsCloseToConvinced(loc *InferLocationRawResult) bool {
+	if !isMapNameCoreMatch(s.convinced.MapName, loc.MapName) {
+		return false
+	}
+	dx := s.convinced.X - loc.X
+	dy := s.convinced.Y - loc.Y
+	return math.Hypot(dx, dy) < CONVINCED_DISTANCE_THRESHOLD
+}
+
+// IsCloseToPending checks if a location is close to the pending location
+func (s *InferState) IsCloseToPending(loc *InferLocationRawResult) bool {
+	if !isMapNameCoreMatch(s.pending.MapName, loc.MapName) {
+		return false
+	}
+	dx := s.pending.X - loc.X
+	dy := s.pending.Y - loc.Y
+	return math.Hypot(dx, dy) < CONVINCED_DISTANCE_THRESHOLD
+}
+
+// ShouldTakeoverPending checks if pending should be promoted to convinced
+func (s *InferState) ShouldTakeoverPending(nowMs int64) bool {
+	return s.convinced.MapName == "" ||
+		nowMs-s.pendingFirstHitTime >= PENDING_TAKEOVER_TIME_MS ||
+		s.pendingHitCount >= PENDING_TAKEOVER_COUNT_THRESHOLD
+}
+
+// IsImmediateTrackLoss checks if this is an immediate track loss
+func (s *InferState) IsImmediateTrackLoss(nowMs int64) bool {
+	return nowMs-s.convincedLastHitTime < CONVINCED_VALID_TIME_MS
+}

--- a/agent/go-service/maptracker/default/infer_state.go
+++ b/agent/go-service/maptracker/default/infer_state.go
@@ -27,10 +27,8 @@ var emptyLocationRawResult = InferLocationRawResult{}
 
 // InferState manages the state for map tracking inference
 type InferState struct {
-	convinced              InferLocationRawResult
-	convincedLastHitTime   int64
-	convincedMoveDirection float64
-	convincedMoveSpeed     float64
+	convinced            InferLocationRawResult
+	convincedLastHitTime int64
 
 	pending             InferLocationRawResult
 	pendingFirstHitTime int64
@@ -69,22 +67,7 @@ func (s *InferState) SetConvinced(loc InferLocationRawResult) {
 	s.convincedLastHitTime = nowMs
 }
 
-// UpdateConvincedFromHit updates convinced state from a location hit
-func (s *InferState) UpdateConvincedFromHit(loc *InferLocationRawResult) {
-	nowMs := s.getLockTime()
-	dt := nowMs - s.convincedLastHitTime
-	if dt > 0 {
-		dx := loc.X - s.convinced.X
-		dy := loc.Y - s.convinced.Y
-		dist := math.Hypot(dx, dy)
-		s.convincedMoveSpeed = dist / float64(dt)
-		s.convincedMoveDirection = math.Atan2(dy, dx)
-	}
-	s.convinced = *loc
-	s.convincedLastHitTime = nowMs
-}
-
-// SetPending sets the pending state and initializes hit count
+// SetPending sets the pending state and initializes hit count to 1
 func (s *InferState) SetPending(loc InferLocationRawResult) {
 	nowMs := s.getLockTime()
 	s.pending = loc
@@ -104,8 +87,6 @@ func (s *InferState) TakeoverPending() {
 	nowMs := s.getLockTime()
 	s.convinced = s.pending
 	s.convincedLastHitTime = nowMs
-	s.convincedMoveSpeed = 0
-	s.convincedMoveDirection = 0
 	s.pending = emptyLocationRawResult
 	s.pendingHitCount = 0
 }


### PR DESCRIPTION
## 概要

此 PR 将 InferState 状态机从 MapTrackerInfer 节点中提取到独立的文件中，并移除了一些不常使用的冗余设计（例如 VirtualHit 相关的逻辑）。此举旨在使得该节点的代码结构更加清晰。

## Summary by Sourcery

将 InferState 映射跟踪状态机提取到独立模块中，并通过移除 virtual-hit 处理来简化推断模式。

增强内容：
- 将推断状态管理重构为单独的 InferState 类型，并提供基于锁作用域的辅助方法，用于状态转换和有效性检查。
- 通过统一字段命名并集中化状态逻辑，简化 MapTracker 推断结果结构及其使用方式。
- 移除对 VirtualHit 推断模式及相关时间序列跟踪逻辑的支持，以精简位置推断行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract InferState map-tracking state machine into a dedicated module and simplify inference modes by dropping virtual-hit handling.

Enhancements:
- Refactor infer state management into a separate InferState type with explicit lock-scoped helper methods for state transitions and validity checks.
- Simplify MapTracker inference result structures and usage by standardizing field naming and centralizing state logic.
- Remove support for the VirtualHit inference mode and related time-series tracking logic to streamline location inference behavior.

</details>