### PR TITLE
feat: 全屏模式分辨率不符合时，提示切换到窗口化

### DIFF
--- a/agent/go-service/pkg/gamesetting/gamesetting_other.go
+++ b/agent/go-service/pkg/gamesetting/gamesetting_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package gamesetting
+
+import "errors"
+
+var ErrUnsupported = errors.New("gamesetting: only supported on windows")
+
+func GetVideoFullScreen() (uint32, error) {
+	return 0, ErrUnsupported
+}
+
+func SetVideoFullScreen(_ uint32) error {
+	return ErrUnsupported
+}

--- a/agent/go-service/pkg/gamesetting/gamesetting_windows.go
+++ b/agent/go-service/pkg/gamesetting/gamesetting_windows.go
@@ -1,0 +1,85 @@
+//go:build windows
+
+package gamesetting
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const registryPath = `Software\Hypergryph\Endfield`
+
+const valuePrefixVideoFullScreen = `video_full_screen_h`
+
+var ErrUnsupported = errors.New("gamesetting: only supported on windows")
+
+func GetVideoFullScreen() (uint32, error) {
+	return getDWord(valuePrefixVideoFullScreen)
+}
+
+func SetVideoFullScreen(value uint32) error {
+	return setDWord(valuePrefixVideoFullScreen, value)
+}
+
+func getDWord(prefix string) (uint32, error) {
+	k, err := registry.OpenKey(registry.CURRENT_USER, registryPath, registry.QUERY_VALUE)
+	if err != nil {
+		return 0, fmt.Errorf("gamesetting: open %q failed: %w", registryPath, err)
+	}
+	defer k.Close()
+
+	name, err := findValueNameByPrefix(k, prefix)
+	if err != nil {
+		return 0, err
+	}
+
+	val, _, err := k.GetIntegerValue(name)
+	if err != nil {
+		return 0, fmt.Errorf("gamesetting: read value %q failed: %w", name, err)
+	}
+	return uint32(val), nil
+}
+
+func setDWord(prefix string, value uint32) error {
+	k, err := registry.OpenKey(registry.CURRENT_USER, registryPath, registry.QUERY_VALUE|registry.SET_VALUE)
+	if err != nil {
+		return fmt.Errorf("gamesetting: open %q failed: %w", registryPath, err)
+	}
+	defer k.Close()
+
+	name, err := findValueNameByPrefix(k, prefix)
+	if err != nil {
+		return err
+	}
+
+	if err := k.SetDWordValue(name, value); err != nil {
+		return fmt.Errorf("gamesetting: write value %q failed: %w", name, err)
+	}
+	return nil
+}
+
+func findValueNameByPrefix(k registry.Key, prefix string) (string, error) {
+	names, err := k.ReadValueNames(-1)
+	if err != nil {
+		return "", fmt.Errorf("gamesetting: enumerate values under %q failed: %w", registryPath, err)
+	}
+
+	var matches []string
+	for _, n := range names {
+		if strings.HasPrefix(n, prefix) {
+			matches = append(matches, n)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("gamesetting: no value with prefix %q under HKCU\\%s", prefix, registryPath)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("gamesetting: ambiguous prefix %q under HKCU\\%s, matched %v", prefix, registryPath, matches)
+	}
+}

--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/control"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/gamesetting"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
@@ -113,7 +114,7 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 	}
 
 	if isADBController {
-		requirement := exactResolutionRequirement()
+		requirement := i18n.T("tasker.aspect_ratio_warning.requirement_exact", targetWidth, targetHeight)
 		log.Debug().
 			Uint64("task_id", detail.TaskID).
 			Str("entry", detail.Entry).
@@ -161,14 +162,12 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		return
 	}
 
-	requirement := aspectRatioRequirement()
 	log.Debug().
 		Uint64("task_id", detail.TaskID).
 		Str("entry", detail.Entry).
 		Str("controller_name", pienv.ControllerName()).
 		Str("controller_type", controlType).
 		Str("requirement", "aspect_ratio").
-		Str("target_resolution", requirement).
 		Str("mode", "aspect_ratio_only").
 		Int32("width", width).
 		Int32("height", height).
@@ -183,7 +182,6 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 			Str("controller_name", pienv.ControllerName()).
 			Str("controller_type", controlType).
 			Str("requirement", "aspect_ratio").
-			Str("target_resolution", requirement).
 			Bool("stop_task", true).
 			Int32("width", width).
 			Int32("height", height).
@@ -191,7 +189,12 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 			Float64("target_ratio", targetRatio).
 			Str("mode", "aspect_ratio_only").
 			Msg("resolution check failed")
-		c.stopWithWarning(tasker, controllerDisplay, int(width), int(height), requirement)
+		fullScreen, _ := gamesetting.GetVideoFullScreen()
+		if fullScreen == 1 {
+			c.stopWithWarning(tasker, controllerDisplay, int(width), int(height), i18n.T("tasker.aspect_ratio_warning.full_screen_illegal"))
+		} else {
+			c.stopWithWarning(tasker, controllerDisplay, int(width), int(height), i18n.T("tasker.aspect_ratio_warning.requirement_ratio"))
+		}
 		return
 	}
 
@@ -201,16 +204,15 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		Str("controller_name", pienv.ControllerName()).
 		Str("controller_type", controlType).
 		Str("requirement", "aspect_ratio").
-		Str("target_resolution", requirement).
 		Int32("width", width).
 		Int32("height", height).
 		Str("mode", "aspect_ratio_only").
 		Msg("resolution check passed")
 }
 
-func (c *AspectRatioChecker) stopWithWarning(tasker *maa.Tasker, controllerDisplay string, width, height int, requirement string) {
+func (c *AspectRatioChecker) stopWithWarning(tasker *maa.Tasker, controllerDisplay string, width, height int, followUpLines ...string) {
 	maafocus.PrintLargeContentTrimNewline(
-		i18n.RenderHTML("tasker.aspect_ratio_warning", buildWarningData(controllerDisplay, width, height, requirement)),
+		i18n.RenderHTML("tasker.aspect_ratio_warning", buildWarningData(controllerDisplay, width, height, followUpLines...)),
 	)
 	tasker.PostStop()
 }
@@ -260,11 +262,17 @@ func calculateAspectRatio(width, height int) float64 {
 	return h / w
 }
 
-func buildWarningData(controllerDisplay string, width, height int, requirement string) map[string]any {
+func buildWarningData(controllerDisplay string, width, height int, followUpLines ...string) map[string]any {
+	lines := make([]string, 0, len(followUpLines))
+	for _, line := range followUpLines {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
 	return map[string]any{
 		"ControllerType":    controllerDisplay,
 		"CurrentResolution": fmt.Sprintf("%dx%d", width, height),
-		"Requirement":       requirement,
+		"FollowUpLines":     lines,
 	}
 }
 
@@ -306,12 +314,4 @@ func normalizeControllerType(controllerType string) string {
 	default:
 		return ""
 	}
-}
-
-func exactResolutionRequirement() string {
-	return i18n.T("tasker.aspect_ratio_warning.requirement_exact", targetWidth, targetHeight)
-}
-
-func aspectRatioRequirement() string {
-	return i18n.T("tasker.aspect_ratio_warning.requirement_ratio")
 }

--- a/assets/locales/go-service/HTML/aspect-ratio-warning.html
+++ b/assets/locales/go-service/HTML/aspect-ratio-warning.html
@@ -4,8 +4,14 @@
 <br/><span style="color: #faad14; font-size: 1.4em; font-weight: bold;">{{t "desc"}}</span>
 <br/><span style="font-size: 1.25em; color: #ffd666; font-weight: bold;">{{t "controller_label"}} {{.ControllerType}}</span>
 <br/><span style="font-size: 1.25em; color: #ffd666; font-weight: bold;">{{t "current_resolution"}} {{.CurrentResolution}}</span>
-<br/><span style="font-size: 1.25em; color: #00bfff; font-weight: bold;">{{t "requirement_label"}} {{.Requirement}}</span>
-<br/><span style="font-size: 1.1em; color: #00bfff;">{{t "requirement_ratio_note"}}</span>
+{{if .FollowUpLines}}
+<br/><span style="font-size: 1.25em; color: #00bfff; font-weight: bold;">{{t "requirement_label"}}</span>
+{{range .FollowUpLines}}
+<br/><span style="font-size: 1.15em; color: #00bfff;">{{escapeHTML .}}</span>
+{{end}}
+{{else}}
+<br/><span style="font-size: 1.25em; color: #00bfff; font-weight: bold;">{{t "requirement_label"}} -</span>
+{{end}}
 {{else}}
 <span style="color: #ff0000; font-size: 1.8em; font-weight: 900;">{{t "title"}}</span>
 <br/><span style="color: #ff4500; font-size: 1.6em; font-weight: 800;">{{t "stopped"}}</span>

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -126,7 +126,7 @@
     "tasker.aspect_ratio_warning.requirement_label": "Required:",
     "tasker.aspect_ratio_warning.requirement_exact": "Exact %dx%d; other 16:9 resolutions such as 1920x1080 are not accepted",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 aspect ratio; for example 3840x2160, 2560x1440, 1920x1080, 1280x720",
-    "tasker.aspect_ratio_warning.requirement_ratio_note": "Fullscreen mode only supports 16:9 monitors; in windowed mode, you can manually set the resolution to 16:9.",
+    "tasker.aspect_ratio_warning.full_screen_illegal": "Windowed mode; fullscreen requires a physical 16:9 monitor, which your current display does not meet.",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",
     "maptracker.emergency_stop.desc": "Navigation aborted.",
     "maptracker.emergency_stop.cause_header": " Possible causes:",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -126,7 +126,7 @@
     "tasker.aspect_ratio_warning.requirement_label": "必要条件：",
     "tasker.aspect_ratio_warning.requirement_exact": "正確に %dx%d。1920x1080 など他の 16:9 解像度でも通りません",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比率。例: 3840x2160、2560x1440、1920x1080、1280x720",
-    "tasker.aspect_ratio_warning.requirement_ratio_note": "フルスクリーンモードは16:9モニターのみサポート。ウィンドウモードでは手動で解像度を16:9に設定できます。",
+    "tasker.aspect_ratio_warning.full_screen_illegal": "ウィンドウモード；全画面モードでは物理的に 16:9 のディスプレイが必要ですが、現在のディスプレイは条件を満たしません。",
     "maptracker.emergency_stop.title": "🚨 緊急停止",
     "maptracker.emergency_stop.desc": "ナビゲーションを中止しました。",
     "maptracker.emergency_stop.cause_header": "考えられる原因：",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -126,7 +126,7 @@
     "tasker.aspect_ratio_warning.requirement_label": "요구 사항:",
     "tasker.aspect_ratio_warning.requirement_exact": "정확히 %dx%d여야 하며, 1920x1080 같은 다른 16:9 해상도도 허용되지 않습니다",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 비율; 예: 3840x2160, 2560x1440, 1920x1080, 1280x720",
-    "tasker.aspect_ratio_warning.requirement_ratio_note": "전체 화면 모드는 16:9 모니터만 지원합니다. 창 모드에서는 해상도를 수동으로 16:9로 설정할 수 있습니다.",
+    "tasker.aspect_ratio_warning.full_screen_illegal": "창 모드; 전체 화면 모드는 물리적으로 16:9 해상도 모니터가 필요하며 현재 디스플레이는 조건에 맞지 않습니다.",
     "maptracker.emergency_stop.title": "🚨 긴급 정지",
     "maptracker.emergency_stop.desc": "길찾기가 중단되었습니다.",
     "maptracker.emergency_stop.cause_header": "가능한 원인:",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -126,7 +126,7 @@
     "tasker.aspect_ratio_warning.requirement_label": "目标要求：",
     "tasker.aspect_ratio_warning.requirement_exact": "精确 %dx%d；1920x1080 等 16:9 分辨率也不通过",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例；例如 3840x2160、2560x1440、1920x1080、1280x720",
-    "tasker.aspect_ratio_warning.requirement_ratio_note": "全屏模式仅支持16:9显示器；窗口化模式下可将分辨率手动设为16:9。",
+    "tasker.aspect_ratio_warning.full_screen_illegal": "窗口模式；全屏模式需使用物理分辨率16:9的显示器，当前显示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",
     "maptracker.emergency_stop.desc": "寻路已中止。",
     "maptracker.emergency_stop.cause_header": "可能原因：",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -126,7 +126,7 @@
     "tasker.aspect_ratio_warning.requirement_label": "目標要求：",
     "tasker.aspect_ratio_warning.requirement_exact": "精確 %dx%d；1920x1080 等其他 16:9 解析度也不通過",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例；例如 3840x2160、2560x1440、1920x1080、1280x720",
-    "tasker.aspect_ratio_warning.requirement_ratio_note": "全螢幕模式僅支援16:9顯示器；視窗化模式下可將解析度手動設為16:9。",
+    "tasker.aspect_ratio_warning.full_screen_illegal": "視窗模式；全螢幕模式需使用物理解析度 16:9 的顯示器，目前顯示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",
     "maptracker.emergency_stop.desc": "尋路已中止。",
     "maptracker.emergency_stop.cause_header": "可能原因：",


### PR DESCRIPTION
## Summary by Sourcery

更新纵横比警告行为，以根据全屏设置调整指引内容，并支持更丰富的本地化后续消息。

新功能：
- 通过新的 `gamesetting` 包在 Windows 上检测游戏的全屏设置，该包可读取和写入基于注册表的视频选项。
- 在全屏运行与其他模式下展示不同的纵横比警告指引，包括在分辨率不兼容时建议退出全屏模式的提示信息。

增强：
- 优化纵横比警告的 HTML 模板和数据模型，以支持多行本地化后续文本，而不是单一的需求字符串。
- 简化纵横比检查器的日志记录和警告构造，移除硬编码的需求辅助函数，改为直接使用 i18n 消息。

文档：
- 扩展所有支持语言中的纵横比警告本地化文案，以涵盖新的全屏及纵横比相关指引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update aspect-ratio warning behavior to tailor guidance based on full-screen settings and support richer localized follow-up messages.

New Features:
- Detect the game full-screen setting on Windows via a new gamesetting package that reads and writes registry-based video options.
- Show different aspect-ratio warning guidance when running in full-screen versus other modes, including messaging that suggests switching out of full-screen when the resolution is incompatible.

Enhancements:
- Refine the aspect-ratio warning HTML template and data model to support multiple localized follow-up lines instead of a single requirement string.
- Simplify aspect-ratio checker logging and warning construction by removing hard-coded requirement helpers in favor of direct i18n messages.

Documentation:
- Extend localized aspect-ratio warning texts in all supported languages to cover the new full-screen and aspect-ratio guidance.

</details>