### PR TITLE
fix: (AutoCollect)优化自动采集7，9，10

### DIFF
--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute10.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute10.json
@@ -100,27 +100,6 @@
             ]
         }
     },
-    "AutoCollectRoute10GotoFind1Sub": {
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "AutoCollectRoute10GotoFind1",
-                "AutoCollectRoute10GotoFind2",
-                "AutoCollectRoute10GotoFind3",
-                "AutoCollectRoute10GotoFind4",
-                "AutoCollectRoute10GotoFind5",
-                "AutoCollectRoute10GotoFind6",
-                "AutoCollectRoute10GotoFind7",
-                "AutoCollectRoute10GotoFind8"
-            ],
-            "continue": true,
-            "strict": true
-        },
-        "next": [
-            "AutoCollectRoute10GotoFindLine2Sub"
-        ]
-    },
     "AutoCollectRoute10GotoFind1": {
         "desc": "前往收集地1",
         "action": "Custom",
@@ -137,6 +116,9 @@
                     221.2
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind2"
         },
         "next": [
             "AutoCollectClickStart"
@@ -159,6 +141,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind3"
+        },
         "next": [
             "AutoCollectClickStart"
         ]
@@ -180,6 +165,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind4"
+        },
         "next": [
             "AutoCollectClickStart"
         ]
@@ -197,6 +185,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind5"
+        },
         "next": [
             "AutoCollectClickStart"
         ]
@@ -213,6 +204,9 @@
                     217.5
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind6"
         },
         "next": [
             "AutoCollectClickStart"
@@ -235,6 +229,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind7"
+        },
         "next": [
             "AutoCollectClickStart"
         ]
@@ -256,6 +253,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind8"
+        },
         "next": [
             "AutoCollectClickStart"
         ]
@@ -276,6 +276,9 @@
                     213.8
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFindLine2Sub"
         },
         "next": [
             "AutoCollectClickStart"
@@ -314,7 +317,7 @@
             ]
         },
         "next": [
-            "AutoCollectRoute10GotoFind11Sub"
+            "AutoCollectRoute10GotoFind11"
         ]
     },
     "AutoCollectRoute10GotoFindLine2": {
@@ -359,27 +362,6 @@
             ]
         }
     },
-    "AutoCollectRoute10GotoFind11Sub": {
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "AutoCollectRoute10GotoFind11",
-                "AutoCollectRoute10GotoFind12",
-                "AutoCollectRoute10GotoFind13",
-                "AutoCollectRoute10GotoFind14",
-                "AutoCollectRoute10GotoFind15",
-                "AutoCollectRoute10GotoFind16",
-                "AutoCollectRoute10GotoFind17",
-                "AutoCollectRoute10GotoFind18"
-            ],
-            "continue": true,
-            "strict": true
-        },
-        "next": [
-            "AutoCollectRoute10End"
-        ]
-    },
     "AutoCollectRoute10GotoFind11": {
         "desc": "前往收集地1",
         "action": "Custom",
@@ -396,6 +378,9 @@
                     225.0
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind12"
         },
         "next": [
             "AutoCollectClickStart"
@@ -418,6 +403,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind13"
+        },
         "next": [
             "AutoCollectClickStart"
         ]
@@ -438,6 +426,9 @@
                     226.3
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind14"
         },
         "next": [
             "AutoCollectClickStart"
@@ -460,6 +451,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind15"
+        },
         "next": [
             "AutoCollectClickStart"
         ]
@@ -480,6 +474,9 @@
                     223.8
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind16"
         },
         "next": [
             "AutoCollectClickStart"
@@ -502,6 +499,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind17"
+        },
         "next": [
             "AutoCollectClickStart"
         ]
@@ -523,6 +523,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10GotoFind18"
+        },
         "next": [
             "AutoCollectClickStart"
         ]
@@ -543,6 +546,9 @@
                     214.9
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectClickAfter": "AutoCollectRoute10End"
         },
         "next": [
             "AutoCollectClickStart"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute10.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute10.json
@@ -67,7 +67,7 @@
             ]
         },
         "next": [
-            "AutoCollectRoute10GotoFind1Sub"
+            "AutoCollectRoute10GotoFind1"
         ]
     },
     "AutoCollectRoute10GotoFindLine1": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute7.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute7.json
@@ -13,6 +13,17 @@
         "pre_delay": 0,
         "post_delay": 0
     },
+    "AutoCollectRoute7Wait10sec": {
+        "desc": "等待10s完成收集",
+        "pre_delay": 0,
+        "post_delay": 10000,
+        "next": [
+            "AutoCollectRoute7End"
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "等待10s完成收集"
+        }
+    },
     "AutoCollectError": {
         "pre_delay": 0,
         "post_delay": 0,
@@ -1017,7 +1028,7 @@
             ]
         },
         "anchor": {
-            "AutoCollectDigAfter": "AutoCollectRoute7End"
+            "AutoCollectDigAfter": "AutoCollectRoute7Wait10sec"
         },
         "next": [
             "AutoCollectDigStart"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute9.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute9.json
@@ -78,7 +78,7 @@
             ]
         },
         "next": [
-            "AutoCollectRoute9GotoFind1Sub"
+            "AutoCollectRoute9GotoFind1"
         ]
     },
     "AutoCollectRoute9GotoFindLine1": {
@@ -139,27 +139,6 @@
             ]
         }
     },
-    "AutoCollectRoute9GotoFind1Sub": {
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "AutoCollectRoute9GotoFind1",
-                "AutoCollectRoute9GotoFind2",
-                "AutoCollectRoute9GotoFind3",
-                "AutoCollectRoute9GotoFind4",
-                "AutoCollectRoute9GotoFind5",
-                "AutoCollectRoute9GotoFind6",
-                "AutoCollectRoute9GotoFind7",
-                "AutoCollectRoute9GotoFind8"
-            ],
-            "continue": true,
-            "strict": true
-        },
-        "next": [
-            "AutoCollectRoute9Wait10sec"
-        ]
-    },
     "AutoCollectRoute9GotoFind1": {
         "desc": "前往收集地1",
         "action": "Custom",
@@ -176,6 +155,9 @@
                     908.8
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectDigAfter": "AutoCollectRoute9GotoFind2"
         },
         "next": [
             "AutoCollectDigStart"
@@ -198,6 +180,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectDigAfter": "AutoCollectRoute9GotoFind3"
+        },
         "next": [
             "AutoCollectDigStart"
         ]
@@ -218,6 +203,9 @@
                     908.8
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectDigAfter": "AutoCollectRoute9GotoFind4"
         },
         "next": [
             "AutoCollectDigStart"
@@ -240,6 +228,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectDigAfter": "AutoCollectRoute9GotoFind5"
+        },
         "next": [
             "AutoCollectDigStart"
         ]
@@ -260,6 +251,9 @@
                     911.3
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectDigAfter": "AutoCollectRoute9GotoFind6"
         },
         "next": [
             "AutoCollectDigStart"
@@ -282,6 +276,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectDigAfter": "AutoCollectRoute9GotoFind7"
+        },
         "next": [
             "AutoCollectDigStart"
         ]
@@ -303,6 +300,9 @@
                 ]
             ]
         },
+        "anchor": {
+            "AutoCollectDigAfter": "AutoCollectRoute9GotoFind8"
+        },
         "next": [
             "AutoCollectDigStart"
         ]
@@ -323,6 +323,9 @@
                     915.0
                 ]
             ]
+        },
+        "anchor": {
+            "AutoCollectDigAfter": "AutoCollectRoute9Wait10sec"
         },
         "next": [
             "AutoCollectDigStart"


### PR DESCRIPTION
主要是优化，其次添加线路7武陵石段在末尾等待10s，让队友收集完整

## Summary by Sourcery

优化自动收集路线 7、9 和 10，并调整路线 7 末尾的计时行为。

改进内容：
- 调整路线 7、9 和 10 的自动收集路径，以提升收集效率和行为表现。
- 在路线 7 的“雾林石”阶段末尾增加 10 秒等待时间，以便队友完成收集。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize auto-collect routes 7, 9, and 10 and adjust timing behavior at the end of route 7.

Enhancements:
- Tune the auto-collect paths for routes 7, 9, and 10 to improve collection efficiency and behavior.
- Add a 10-second wait at the end of route 7’s Wuling Stone segment to allow teammates to finish collecting.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化自动收集路线 7、9 和 10，并调整路线 7 末尾的计时行为。

改进内容：
- 调整路线 7、9 和 10 的自动收集路径，以提升收集效率和行为表现。
- 在路线 7 的“雾林石”阶段末尾增加 10 秒等待时间，以便队友完成收集。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize auto-collect routes 7, 9, and 10 and adjust timing behavior at the end of route 7.

Enhancements:
- Tune the auto-collect paths for routes 7, 9, and 10 to improve collection efficiency and behavior.
- Add a 10-second wait at the end of route 7’s Wuling Stone segment to allow teammates to finish collecting.

</details>

</details>