### PR TITLE
rft: 提取 AutoStockpile 的 Levenshtein 模糊匹配为公共工具函数

### DIFF
--- a/agent/go-service/autostockpile/itemmap.go
+++ b/agent/go-service/autostockpile/itemmap.go
@@ -99,23 +99,16 @@ func MatchGoodsName(ocrText string, itemMap *ItemMap, maxDistance int) (id strin
 		return "", "", false
 	}
 
-	// 对候选名称排序，确保距离相同时的 tie-break 是确定性的。
-	names := make([]string, 0, len(itemMap.NameToID))
-	for n := range itemMap.NameToID {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-
 	bestDistance := maxDistance + 1
 	bestName := ""
 	bestID := ""
 
-	for _, candidateName := range names {
+	for candidateName, candidateID := range itemMap.NameToID {
 		dist := levenshtein.Distance(ocrText, candidateName)
-		if dist <= maxDistance && dist < bestDistance {
+		if dist <= maxDistance && (dist < bestDistance || dist == bestDistance && candidateName < bestName) {
 			bestDistance = dist
 			bestName = candidateName
-			bestID = itemMap.NameToID[candidateName]
+			bestID = candidateID
 		}
 	}
 

--- a/agent/go-service/autostockpile/itemmap.go
+++ b/agent/go-service/autostockpile/itemmap.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/MaaXYZ/MaaEnd/agent/go-service/autostockpile/levenshtein"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/levenshtein"
 )
 
 //go:embed item_map.json
@@ -99,16 +99,23 @@ func MatchGoodsName(ocrText string, itemMap *ItemMap, maxDistance int) (id strin
 		return "", "", false
 	}
 
+	// 对候选名称排序，确保距离相同时的 tie-break 是确定性的。
+	names := make([]string, 0, len(itemMap.NameToID))
+	for n := range itemMap.NameToID {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
 	bestDistance := maxDistance + 1
 	bestName := ""
 	bestID := ""
 
-	for candidateName, candidateID := range itemMap.NameToID {
+	for _, candidateName := range names {
 		dist := levenshtein.Distance(ocrText, candidateName)
 		if dist <= maxDistance && dist < bestDistance {
 			bestDistance = dist
 			bestName = candidateName
-			bestID = candidateID
+			bestID = itemMap.NameToID[candidateName]
 		}
 	}
 

--- a/agent/go-service/pkg/levenshtein/levenshtein.go
+++ b/agent/go-service/pkg/levenshtein/levenshtein.go
@@ -1,5 +1,7 @@
 package levenshtein
 
+// Distance 计算两个字符串之间的 Levenshtein 编辑距离。
+// 支持多字节字符（rune 级别比较）。
 func Distance(a, b string) int {
 	runesA := []rune(a)
 	runesB := []rune(b)
@@ -34,17 +36,4 @@ func Distance(a, b string) int {
 	}
 
 	return prev[lenB]
-}
-
-func min(a, b, c int) int {
-	if a < b {
-		if a < c {
-			return a
-		}
-		return c
-	}
-	if b < c {
-		return b
-	}
-	return c
 }


### PR DESCRIPTION
Close #2832

## Summary by Sourcery

将 Levenshtein 距离逻辑提取到共享包中，并使 AutoStockpile 的名称匹配具有确定性。

增强内容：
- 将 Levenshtein 距离的实现从 AutoStockpile 模块移动到可复用的 `pkg/levenshtein` 工具包中。
- 在进行模糊匹配之前，对候选物品名称进行排序，以确保在货物名称匹配时的并列情况具有确定性的决策结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract Levenshtein distance logic into a shared package and make AutoStockpile name matching deterministic.

Enhancements:
- Move the Levenshtein distance implementation from the AutoStockpile module into a reusable pkg/levenshtein utility.
- Sort candidate item names before fuzzy matching to ensure deterministic tie-breaking in goods name matching.

</details>