### PR TITLE
rft: 库存转移改用编辑距离模糊 OCR

### DIFF
--- a/agent/go-service/itemtransfer/action.go
+++ b/agent/go-service/itemtransfer/action.go
@@ -122,7 +122,7 @@ func (a *ItemTransferFallbackAction) Run(ctx *maa.Context, arg *maa.CustomAction
 
 	// Case 2.2 + Step 3: binary search among visible grid cells
 	if targetIdx >= 0 && len(categoryOrder) > 0 {
-		result := binarySearchOnPage(ctx, tasker, ctrl, items, categoryOrder, targetIdx, itemInfo.Name)
+		result := binarySearchOnPage(ctx, tasker, ctrl, items, categoryOrder, targetIdx, itemInfo.Name, params.MaxDistance)
 		if result != nil {
 			return ctrlClick(ctrl, result.CenterX, result.CenterY)
 		}
@@ -353,14 +353,14 @@ func matchesAnyTarget(names []string, targetName string) bool {
 
 // resolveOCRIndex finds the first OCR text that exists in categoryOrder
 // and returns its name and index. Falls back to fuzzy matching.
-func resolveOCRIndex(names []string, categoryOrder []string) (string, int) {
+func resolveOCRIndex(names []string, categoryOrder []string, maxDistance int) (string, int) {
 	for _, n := range names {
 		if i := indexOf(categoryOrder, n); i >= 0 {
 			return n, i
 		}
 	}
 	for _, n := range names {
-		if i := fuzzyIndexOf(categoryOrder, n); i >= 0 {
+		if i := fuzzyIndexOf(categoryOrder, n, maxDistance); i >= 0 {
 			return n, i
 		}
 	}
@@ -385,7 +385,7 @@ func cleanOCRNoise(s string) string {
 // Always starts from cell 0 (top-left) to establish a baseline, then
 // converges forward via binary search on the remaining range.
 // Returns the target item if found, or nil when the range is exhausted.
-func binarySearchOnPage(ctx *maa.Context, tasker *maa.Tasker, ctrl *maa.Controller, items []gridItem, categoryOrder []string, targetIdx int, targetName string) *gridItem {
+func binarySearchOnPage(ctx *maa.Context, tasker *maa.Tasker, ctrl *maa.Controller, items []gridItem, categoryOrder []string, targetIdx int, targetName string, maxDistance int) *gridItem {
 	if len(items) == 0 {
 		return nil
 	}
@@ -406,7 +406,7 @@ func binarySearchOnPage(ctx *maa.Context, tasker *maa.Tasker, ctrl *maa.Controll
 	}
 
 	if len(names) > 0 {
-		name, ocrIdx := resolveOCRIndex(names, categoryOrder)
+		name, ocrIdx := resolveOCRIndex(names, categoryOrder, maxDistance)
 		if ocrIdx >= 0 && ocrIdx > targetIdx {
 			log.Info().Str("component", componentName).
 				Str("ocr_name", name).Int("ocr_idx", ocrIdx).Int("target_idx", targetIdx).
@@ -441,7 +441,7 @@ func binarySearchOnPage(ctx *maa.Context, tasker *maa.Tasker, ctrl *maa.Controll
 			return item
 		}
 
-		name, ocrIdx := resolveOCRIndex(names, categoryOrder)
+		name, ocrIdx := resolveOCRIndex(names, categoryOrder, maxDistance)
 		if ocrIdx < 0 {
 			consecutiveMisses++
 			if consecutiveMisses >= maxConsecutiveCategoryMisses {
@@ -539,16 +539,18 @@ func indexOf(order []string, name string) int {
 }
 
 // fuzzyIndexOf 在有序候选列表中查找与 name 编辑距离最小的项。
-// maxDistance 硬编码为 1；如需调整请修改此常量。
-func fuzzyIndexOf(order []string, name string) int {
-	const maxDistance = 1 // 硬编码：允许最多 1 个字符差异
+// maxDistance 由调用方通过 custom_action_param.max_distance 指定。
+func fuzzyIndexOf(order []string, name string, maxDistance int) int {
 	name = strings.TrimSpace(name)
-	if name == "" {
+	if name == "" || maxDistance <= 0 {
 		return -1
 	}
 	bestIdx := -1
 	bestDist := maxDistance + 1
 	for i, n := range order {
+		if d := len(n) - len(name); d > maxDistance || d < -maxDistance {
+			continue
+		}
 		dist := levenshtein.Distance(name, n)
 		if dist <= maxDistance && dist < bestDist {
 			bestDist = dist

--- a/agent/go-service/itemtransfer/action.go
+++ b/agent/go-service/itemtransfer/action.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/levenshtein"
 	"github.com/rs/zerolog/log"
 )
 
@@ -537,20 +538,21 @@ func indexOf(order []string, name string) int {
 	return -1
 }
 
+// fuzzyIndexOf 在有序候选列表中查找与 name 编辑距离最小的项。
+// maxDistance 硬编码为 1；如需调整请修改此常量。
 func fuzzyIndexOf(order []string, name string) int {
+	const maxDistance = 1 // 硬编码：允许最多 1 个字符差异
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return -1
 	}
 	bestIdx := -1
-	bestDist := len(name) + 1
+	bestDist := maxDistance + 1
 	for i, n := range order {
-		if strings.Contains(n, name) || strings.Contains(name, n) {
-			d := abs(len(n) - len(name))
-			if d < bestDist {
-				bestDist = d
-				bestIdx = i
-			}
+		dist := levenshtein.Distance(name, n)
+		if dist <= maxDistance && dist < bestDist {
+			bestDist = dist
+			bestIdx = i
 		}
 	}
 	return bestIdx
@@ -566,11 +568,4 @@ func reversed(s []string) []string {
 		out[i], out[j] = out[j], out[i]
 	}
 	return out
-}
-
-func abs(x int) int {
-	if x < 0 {
-		return -x
-	}
-	return x
 }

--- a/agent/go-service/itemtransfer/ocr_action.go
+++ b/agent/go-service/itemtransfer/ocr_action.go
@@ -20,6 +20,7 @@ type ocrActionParams struct {
 	ItemName   string `json:"item_name"`
 	Descending bool   `json:"descending"`
 	Side       string `json:"side"`
+	MaxDistance int    `json:"max_distance"`
 }
 
 func (a *ItemTransferOCRAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
@@ -120,7 +121,7 @@ func (a *ItemTransferOCRAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) 
 		items = buildSyntheticGrid(side, cols)
 	}
 
-	result := binarySearchOnPage(ctx, tasker, ctrl, items, categoryOrder, targetIdx, params.ItemName)
+	result := binarySearchOnPage(ctx, tasker, ctrl, items, categoryOrder, targetIdx, params.ItemName, params.MaxDistance)
 	if result != nil {
 		return ctrlClick(ctrl, result.CenterX, result.CenterY)
 	}

--- a/agent/go-service/itemtransfer/types.go
+++ b/agent/go-service/itemtransfer/types.go
@@ -22,6 +22,7 @@ type fallbackParams struct {
 	TargetClass int    `json:"target_class"`
 	Descending  bool   `json:"descending"`
 	Side        string `json:"side"`
+	MaxDistance  int    `json:"max_distance"`
 }
 
 type gridItem struct {

--- a/assets/resource/pipeline/ItemTransfer.json
+++ b/assets/resource/pipeline/ItemTransfer.json
@@ -741,7 +741,8 @@
         "custom_action": "ItemTransferOCRAction",
         "custom_action_param": {
             "item_name": "",
-            "side": "repo"
+            "side": "repo",
+            "max_distance": 1
         },
         "next": [
             "ItemTransferSwitchRepoToDestination"
@@ -753,7 +754,8 @@
         "custom_action": "ItemTransferOCRAction",
         "custom_action_param": {
             "item_name": "",
-            "side": "bag"
+            "side": "bag",
+            "max_distance": 1
         },
         "next": [
             "ItemTransferCheckIfFull",
@@ -767,7 +769,8 @@
         "custom_action": "ItemTransferOCRAction",
         "custom_action_param": {
             "item_name": "",
-            "side": "bag"
+            "side": "bag",
+            "max_distance": 1
         },
         "focus": {
             "Node.Action.Succeeded": "$task.ItemTransfer.bag_return_completed"
@@ -779,7 +782,8 @@
         "custom_action": "ItemTransferFallbackAction",
         "custom_action_param": {
             "target_class": 0,
-            "side": "repo"
+            "side": "repo",
+            "max_distance": 1
         },
         "next": [
             "ItemTransferSwitchRepoToDestination"
@@ -791,7 +795,8 @@
         "custom_action": "ItemTransferFallbackAction",
         "custom_action_param": {
             "target_class": 0,
-            "side": "bag"
+            "side": "bag",
+            "max_distance": 1
         },
         "next": [
             "ItemTransferCheckIfFull",
@@ -805,7 +810,8 @@
         "custom_action": "ItemTransferFallbackAction",
         "custom_action_param": {
             "target_class": 0,
-            "side": "bag"
+            "side": "bag",
+            "max_distance": 1
         },
         "focus": {
             "Node.Action.Succeeded": "$task.ItemTransfer.bag_return_completed"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- 将用于物品名称查找的“子串/长度差”模糊匹配替换为 Levenshtein 距离匹配，并将匹配限制在较小的编辑距离范围内。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace substring/length-difference fuzzy match with Levenshtein distance for item name lookup, limiting matches to a small edit distance.

</details>