### PR TITLE
fix: 修复售卖弹性物资好友判断、拥有物资判断问题

### DIFF
--- a/agent/go-service/autosell/autosell.go
+++ b/agent/go-service/autosell/autosell.go
@@ -154,7 +154,12 @@ func (a *AutoSellItemExecuteItemTaskAction) Run(ctx *maa.Context, arg *maa.Custo
 			},
 			"AutoSellFriendsPricesExpected": map[string]any{
 				"custom_recognition_param": map[string]any{
-					"lowest_price": targetPrice,
+					"expression": "{AutoSellFriendsPriceRecognition} > " + strconv.Itoa(targetPrice),
+				},
+			},
+			"AutoSellFriendsPricesExpectedBuy": map[string]any{
+				"custom_recognition_param": map[string]any{
+					"expression": "{AutoSellFriendsPriceCurrentRecognition} > " + strconv.Itoa(targetPrice),
 				},
 			},
 			"AutoSellStockRedistributionItemFindTextRecognition": map[string]any{
@@ -176,64 +181,6 @@ func (a *AutoSellItemExecuteItemTaskAction) Run(ctx *maa.Context, arg *maa.Custo
 	return true
 }
 
-type AutoSellPriceCompareRecognition struct{}
-
-func (r *AutoSellPriceCompareRecognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa.CustomRecognitionResult, bool) {
-	if arg == nil || arg.Img == nil {
-		return nil, false
-	}
-
-	var params struct {
-		LowestPrice int `json:"lowest_price"`
-	}
-
-	if paramsErr := json.Unmarshal([]byte(arg.CustomRecognitionParam), &params); paramsErr != nil {
-		log.Error().Err(paramsErr).Str("component", "autosell").Str("step", "price_compare").Msg("parse params")
-		return nil, false
-	}
-	lowestPrice := params.LowestPrice
-
-	detail, recoErr := ctx.RunRecognition("AutoSellFriendsPriceRecognition", arg.Img)
-	if recoErr != nil || detail == nil {
-		log.Error().Err(recoErr).Str("component", "autosell").Str("step", "price_compare").Msg("run recognition")
-		return nil, false
-	}
-
-	if !detail.Hit || detail.CombinedResult == nil || len(detail.CombinedResult) < 2 {
-		log.Warn().Str("component", "autosell").Str("step", "price_compare").Msg("recognition miss")
-		return nil, false
-	}
-
-	var detailJson struct {
-		Best struct {
-			Text string `json:"text"`
-		} `json:"best"`
-	}
-	// Results.Best是空，暂时只能这样获取
-	if detailJsonErr := json.Unmarshal([]byte(detail.CombinedResult[1].DetailJson), &detailJson); detailJsonErr != nil {
-		log.Error().Err(detailJsonErr).Str("component", "autosell").Str("step", "price_compare").Msg("parse detail json")
-		return nil, false
-	}
-
-	ocrPrice, atoiErr := strconv.Atoi(detailJson.Best.Text)
-	if atoiErr != nil {
-		log.Error().Err(atoiErr).Str("component", "autosell").Str("step", "price_compare").Str("raw_text", detailJson.Best.Text).Msg("parse ocr price")
-		return nil, false
-	}
-
-	log.Info().Str("component", "autosell").Str("step", "price_compare").Int("ocr_price", ocrPrice).Int("lowest_price", lowestPrice).Msg("price compare")
-	if ocrPrice < lowestPrice {
-		maafocus.Print(ctx, i18n.T("autosell.price_compare_fail", ocrPrice, lowestPrice))
-		return nil, false
-	}
-
-	maafocus.Print(ctx, i18n.T("autosell.price_compare_ok", ocrPrice, lowestPrice))
-	return &maa.CustomRecognitionResult{
-		Box:    arg.Roi,
-		Detail: `{"custom": "fake result"}`,
-	}, true
-}
-
 // firstContainedKeyword 按 subs 顺序返回首个被 s 包含的关键词，无匹配则返回空串。
 func firstContainedKeyword(s string, subs []string) string {
 	for _, sub := range subs {
@@ -253,6 +200,5 @@ var (
 // Compile-time interface checks
 var (
 	_ maa.CustomRecognitionRunner = (*AutoSellScanItemRecognition)(nil)
-	_ maa.CustomRecognitionRunner = (*AutoSellPriceCompareRecognition)(nil)
 	_ maa.CustomActionRunner      = (*AutoSellItemExecuteItemTaskAction)(nil)
 )

--- a/agent/go-service/autosell/autosell.go
+++ b/agent/go-service/autosell/autosell.go
@@ -154,12 +154,12 @@ func (a *AutoSellItemExecuteItemTaskAction) Run(ctx *maa.Context, arg *maa.Custo
 			},
 			"AutoSellFriendsPricesExpected": map[string]any{
 				"custom_recognition_param": map[string]any{
-					"expression": "{AutoSellFriendsPriceRecognition} > " + strconv.Itoa(targetPrice),
+					"expression": "{AutoSellFriendsPriceRecognition} >= " + strconv.Itoa(targetPrice),
 				},
 			},
 			"AutoSellFriendsPricesExpectedBuy": map[string]any{
 				"custom_recognition_param": map[string]any{
-					"expression": "{AutoSellFriendsPriceCurrentRecognition} > " + strconv.Itoa(targetPrice),
+					"expression": "{AutoSellFriendsPriceCurrentRecognition} >= " + strconv.Itoa(targetPrice),
 				},
 			},
 			"AutoSellStockRedistributionItemFindTextRecognition": map[string]any{

--- a/agent/go-service/autosell/register.go
+++ b/agent/go-service/autosell/register.go
@@ -6,5 +6,4 @@ import "github.com/MaaXYZ/maa-framework-go/v4"
 func Register() {
 	maa.AgentServerRegisterCustomRecognition("AutoSellScanItemRecognition", &AutoSellScanItemRecognition{})
 	maa.AgentServerRegisterCustomAction("AutoSellItemExecuteItemTaskAction", &AutoSellItemExecuteItemTaskAction{})
-	maa.AgentServerRegisterCustomRecognition("AutoSellPriceCompareRecognition", &AutoSellPriceCompareRecognition{})
 }

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -12,8 +12,6 @@
     "visitfriends.can_growth_chamber": "assist Growth Chamber",
     "visitfriends.current_counts": "Assist count: %d, Clue exchange count: %d",
     "visitfriends.check_friend": "Checking friend %s",
-    "autosell.price_compare_ok": "Recognized highest price: %d, minimum selling price: %d, meets condition",
-    "autosell.price_compare_fail": "Recognized highest price: %d, minimum selling price: %d, does not meet condition",
     "autosell.check_item_price_moderate": "Checking price for %s; moderate price volatility",
     "autosell.check_item_price_large": "Checking price for %s; large price volatility",
     "autosell.check_item_price_massive": "Checking price for %s; extreme price volatility",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -12,8 +12,6 @@
     "visitfriends.can_growth_chamber": "成長室を支援",
     "visitfriends.current_counts": "支援回数: %d、手がかり交換回数: %d",
     "visitfriends.check_friend": "フレンドを確認中: %s",
-    "autosell.price_compare_ok": "認識した最高価格: %d、最低販売価格: %d、条件を満たします",
-    "autosell.price_compare_fail": "認識した最高価格: %d、最低販売価格: %d、条件を満たしません",
     "autosell.check_item_price_moderate": "物資 %s の価格を確認中（価格変動は中程度）",
     "autosell.check_item_price_large": "物資 %s の価格を確認中（価格変動は大きい）",
     "autosell.check_item_price_massive": "物資 %s の価格を確認中（価格変動は極大）",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -12,8 +12,6 @@
     "visitfriends.can_growth_chamber": "성장실 지원",
     "visitfriends.current_counts": "현재 지원 횟수: %d, 단서 교환 횟수: %d",
     "visitfriends.check_friend": "친구 확인 중: %s",
-    "autosell.price_compare_ok": "인식 최고 가격: %d, 최저 판매 가격: %d, 조건 충족",
-    "autosell.price_compare_fail": "인식 최고 가격: %d, 최저 판매 가격: %d, 조건 불충족",
     "autosell.check_item_price_moderate": "%s 물자 가격 확인 중, 가격 변동 보통",
     "autosell.check_item_price_large": "%s 물자 가격 확인 중, 가격 변동 큼",
     "autosell.check_item_price_massive": "%s 물자 가격 확인 중, 가격 변동 매우 큼",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -12,8 +12,6 @@
     "visitfriends.can_growth_chamber": "助力生长舱",
     "visitfriends.current_counts": "当前助力次数：%d，线索交换次数：%d",
     "visitfriends.check_friend": "检查好友 %s",
-    "autosell.price_compare_ok": "识别最高价格: %d，最低售卖价格: %d，符合条件",
-    "autosell.price_compare_fail": "识别最高价格: %d，最低售卖价格: %d，不符合条件",
     "autosell.check_item_price_moderate": "检查物资 %s 价格，该物资价格变动适中",
     "autosell.check_item_price_large": "检查物资 %s 价格，该物资价格变动较大",
     "autosell.check_item_price_massive": "检查物资 %s 价格，该物资价格变动极大",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -12,8 +12,6 @@
     "visitfriends.can_growth_chamber": "助力生長艙",
     "visitfriends.current_counts": "當前助力次數：%d，線索交換次數：%d",
     "visitfriends.check_friend": "檢查好友 %s",
-    "autosell.price_compare_ok": "識別最高價格: %d，最低售賣價格: %d，符合條件",
-    "autosell.price_compare_fail": "識別最高價格: %d，最低售賣價格: %d，不符合條件",
     "autosell.check_item_price_moderate": "檢查物資 %s 價格，該物資價格變動適中",
     "autosell.check_item_price_large": "檢查物資 %s 價格，該物資價格變動較大",
     "autosell.check_item_price_massive": "檢查物資 %s 價格，該物資價格變動極大",

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -318,6 +318,8 @@
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryModeratePriceVolatilityValue.label": "Minimum selling price (moderate volatility)",
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryLargePriceVolatilityValue.label": "Minimum selling price (large volatility)",
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryMassivePriceVolatilityValue.label": "Minimum selling price (extreme volatility)",
+    "task.AutoSell.focus.friends_prices_expected_above_threshold": "Current highest price > configured threshold",
+    "task.AutoSell.focus.friends_prices_expected_below_threshold": "Current highest price < configured threshold",
     "task.AutoStockpile.label": "📦 Auto Stockpile",
     "task.AutoStockpile.description": "Purchase elastic demand supplies, based on big data intelligent calculation to derive the best purchasing strategy.",
     "task.AutoStockpile.option.AutoStockpileServerTime.label": "Server Timezone",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -257,6 +257,8 @@
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryModeratePriceVolatilityValue.label": "価格変動が中程度の物資の最低販売価格",
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryLargePriceVolatilityValue.label": "価格変動が大きい物資の最低販売価格",
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryMassivePriceVolatilityValue.label": "価格変動が極大の物資の最低販売価格",
+    "task.AutoSell.focus.friends_prices_expected_above_threshold": "現在の最高価格 > 設定した閾値",
+    "task.AutoSell.focus.friends_prices_expected_below_threshold": "現在の最高価格 < 設定した閾値",
     "task.AutoStockpile.label": "📦 自動備蓄",
     "task.AutoStockpile.description": "弾性需要物資を購入し、ビッグデータによるインテリジェント計算で最適な購買戦略を導き出します。",
     "task.AutoStockpile.option.AutoStockpileServerTime.label": "サーバー時間帯",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -257,6 +257,8 @@
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryModeratePriceVolatilityValue.label": "가격 변동이 보통인 물자 최저 판매 가격",
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryLargePriceVolatilityValue.label": "가격 변동이 큰 물자 최저 판매 가격",
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryMassivePriceVolatilityValue.label": "가격 변동이 매우 큰 물자 최저 판매 가격",
+    "task.AutoSell.focus.friends_prices_expected_above_threshold": "현재 최고 가격 > 설정한 기준 가격",
+    "task.AutoSell.focus.friends_prices_expected_below_threshold": "현재 최고 가격 < 설정한 기준 가격",
     "task.AutoStockpile.label": "📦 자동 비축",
     "task.AutoStockpile.description": "탄력 수요 물자를 구매하며, 빅데이터 지능형 계산을 통해 최적의 구매 전략을 도출합니다.",
     "task.AutoStockpile.option.AutoStockpileServerTime.label": "서버 시간대",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -257,6 +257,8 @@
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryModeratePriceVolatilityValue.label": "价格变动适中物资最低售卖价格",
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryLargePriceVolatilityValue.label": "价格变动较大物资最低售卖价格",
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryMassivePriceVolatilityValue.label": "价格变动极大物资最低售卖价格",
+    "task.AutoSell.focus.friends_prices_expected_above_threshold": "当前最高价 > 设置阈值",
+    "task.AutoSell.focus.friends_prices_expected_below_threshold": "当前最高价 < 设置阈值",
     "task.AutoStockpile.label": "📦自动囤货",
     "task.AutoStockpile.description": "购买弹性需求物资，基于大数据智能计算得出最佳购买策略。",
     "task.AutoStockpile.option.AutoStockpileServerTime.label": "服务器时区",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -257,6 +257,8 @@
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryModeratePriceVolatilityValue.label": "價格變動適中物資最低售賣價格",
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryLargePriceVolatilityValue.label": "價格變動較大物資最低售賣價格",
     "option.AutoSellPricePerCategory.inputs.AutoSellPricePerCategoryMassivePriceVolatilityValue.label": "價格變動極大物資最低售賣價格",
+    "task.AutoSell.focus.friends_prices_expected_above_threshold": "目前最高價 > 設定閾值",
+    "task.AutoSell.focus.friends_prices_expected_below_threshold": "目前最高價 < 設定閾值",
     "task.AutoStockpile.label": "📦自動囤貨",
     "task.AutoStockpile.description": "購買彈性需求物資，基於大數據智能計算得出最佳購買策略。",
     "task.AutoStockpile.option.AutoStockpileServerTime.label": "伺服器時區",

--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -360,7 +360,7 @@
         "recognition": "Custom",
         "custom_recognition": "ExpressionRecognition",
         "custom_recognition_param": {
-            "expression": "{AutoSellFriendsPriceRecognition} > 3000 "
+            "expression": "{AutoSellFriendsPriceRecognition} >= 5000 "
         },
         "pre_delay": 0,
         "post_delay": 0,
@@ -415,7 +415,7 @@
         "recognition": "Custom",
         "custom_recognition": "ExpressionRecognition",
         "custom_recognition_param": {
-            "expression": "{AutoSellFriendsPriceCurrentRecognition} > 3000 "
+            "expression": "{AutoSellFriendsPriceCurrentRecognition} >= 5000 "
         },
         "pre_delay": 0,
         "post_delay": 0,

--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -358,9 +358,9 @@
     "AutoSellFriendsPricesExpected": {
         "desc": "价格符合预期",
         "recognition": "Custom",
-        "custom_recognition": "AutoSellPriceCompareRecognition",
+        "custom_recognition": "ExpressionRecognition",
         "custom_recognition_param": {
-            "lowest_price": 5000
+            "expression": "{AutoSellFriendsPriceRecognition} > 3000 "
         },
         "pre_delay": 0,
         "post_delay": 0,
@@ -368,7 +368,11 @@
         "next": [
             "AutoSellFriendsPricesExpectedBuy",
             "AutoSellFriendsPricesExpectedGoTo"
-        ]
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "$task.AutoSell.focus.friends_prices_expected_above_threshold",
+            "Node.Recognition.Failed": "$task.AutoSell.focus.friends_prices_expected_below_threshold"
+        }
     },
     "AutoSellFriendsPricesUnExpected": {
         "desc": "价格不符合预期",
@@ -408,10 +412,11 @@
     },
     "AutoSellFriendsPricesExpectedBuy": {
         "desc": "当前价格符合预期，在当前好友飞船上，可以直接购买",
-        "recognition": "And",
-        "all_of": [
-            "AutoSellFriendsPriceCurrentRecognition"
-        ],
+        "recognition": "Custom",
+        "custom_recognition": "ExpressionRecognition",
+        "custom_recognition_param": {
+            "expression": "{AutoSellFriendsPriceCurrentRecognition} > 3000 "
+        },
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/AutoSell/Recognition.json
+++ b/assets/resource/pipeline/AutoSell/Recognition.json
@@ -47,16 +47,17 @@
             10
         ],
         "lower": [
-            61,
-            60,
-            60
+            34,
+            34,
+            34
         ],
         "upper": [
-            81,
-            80,
-            80
+            54,
+            54,
+            54
         ],
-        "count": 20
+        "connected": true,
+        "count": 300
     },
     "AutoSellStockRedistributionItemGreenLineRecognition": {
         "desc": "识别物资调度界面中的绿线所在位置，用于定位item宽度",
@@ -127,7 +128,7 @@
             "AutoSell/SellTicketFriendValleyIV.png",
             "AutoSell/SellTicketFriendWuling.png"
         ],
-        "threshold": 0.9
+        "threshold": 0.8
     },
     "AutoSellFriendsPriceRecognition": {
         "desc": "识别好友列表里第一个最高价格",
@@ -148,22 +149,21 @@
                 ],
                 "only_rec": true
             }
-        ]
+        ],
+        "box_index": 1
     },
     "AutoSellFriendsPriceCurrentRecognition": {
-        "desc": "识别好友列表里第一个价格是否是当前",
+        "desc": "识别好友列表里当前价格是否符合预期",
         "recognition": "And",
         "all_of": [
-            "AutoSellFriendsPriceFirstTicketRecognition",
             {
                 "sub_name": "current_area",
                 "recognition": "ColorMatch",
-                "roi": "AutoSellFriendsPriceFirstTicketRecognition",
-                "roi_offset": [
-                    -200,
-                    -20,
-                    150,
-                    20
+                "roi": [
+                    540,
+                    230,
+                    200,
+                    355
                 ],
                 "lower": [
                     245,
@@ -176,20 +176,39 @@
                     10
                 ],
                 "connected": true,
-                "count": 100
+                "count": 150
+            },
+            {
+                "sub_name": "ticket_icon",
+                "recognition": "TemplateMatch",
+                "roi": "current_area",
+                "roi_offset": [
+                    0,
+                    -15,
+                    200,
+                    30
+                ],
+                "template": [
+                    "AutoSell/SellTicketFriendValleyIV.png",
+                    "AutoSell/SellTicketFriendWuling.png"
+                ],
+                "threshold": 0.9
             },
             {
                 "recognition": "OCR",
-                "roi": "current_area",
+                "roi": "ticket_icon",
+                "roi_offset": [
+                    30,
+                    0,
+                    32,
+                    0
+                ],
                 "expected": [
-                    "当前",
-                    "目前",
-                    "Current",
-                    "現在",
-                    "현재"
+                    "\\d"
                 ],
                 "only_rec": true
             }
-        ]
+        ],
+        "box_index": 2
     }
 }


### PR DESCRIPTION
close #2830
close #2819 
close #2804

## Summary by Sourcery

调整自动出售好友价格和物品拥有状态的校验逻辑，使其依赖基于表达式的识别结果，并移除已过时的自定义价格比较识别器。

Bug 修复：
- 修复在出售可变材料时，对好友物品定价判断错误的问题，改为直接基于识别结果进行表达式比较。
- 修复在自动出售可变材料时，对玩家是否拥有该物品的判断错误问题。

增强优化：
- 通过移除现已不再需要的 `AutoSellPriceCompareRecognition` 处理器及其相关注册逻辑，简化自动出售流程。
- 将自动出售的识别和流水线配置调整为使用新的价格相关识别条目，以获取期望好友价格和当前好友价格。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust autosell friend price and ownership checks to rely on expression-based recognition and remove the obsolete custom price comparison recognizer.

Bug Fixes:
- Fix incorrect friend-item pricing judgment when selling flexible materials by using direct expression-based comparisons on recognition results.
- Fix incorrect detection of whether the player owns an item during autosell of flexible materials.

Enhancements:
- Simplify the autosell pipeline by removing the now-unnecessary AutoSellPriceCompareRecognition handler and associated registration.
- Align autosell recognition and pipeline configuration to use the new price-related recognition entries for expected and current friend prices.

</details>