### PR TITLE
fix: 修复自动采集关闭分支后任务误判失败问题

### DIFF
--- a/assets/resource/pipeline/AutoCollect.json
+++ b/assets/resource/pipeline/AutoCollect.json
@@ -48,123 +48,93 @@
         "post_delay": 0
     },
     "AutoCollectRoute1Sub": {
-        "enabled": false,
         "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "AutoCollectRoute1Start"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "$option.AutoCollectRoute1.label"
-        }
+            "AutoCollectRoute1Start",
+            "EmptyNode"
+        ]
     },
     "AutoCollectRoute2Sub": {
-        "enabled": false,
         "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "AutoCollectRoute2Start"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "$option.AutoCollectRoute2.label"
-        }
+            "AutoCollectRoute2Start",
+            "EmptyNode"
+        ]
     },
     "AutoCollectRoute3Sub": {
-        "enabled": false,
         "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "AutoCollectRoute3Start"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "$option.AutoCollectRoute3.label"
-        }
+            "AutoCollectRoute3Start",
+            "EmptyNode"
+        ]
     },
     "AutoCollectRoute4Sub": {
-        "enabled": false,
         "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "AutoCollectRoute4Start"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "$option.AutoCollectRoute4.label"
-        }
+            "AutoCollectRoute4Start",
+            "EmptyNode"
+        ]
     },
     "AutoCollectRoute5Sub": {
-        "enabled": false,
         "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "AutoCollectRoute5Start"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "$option.AutoCollectRoute5.label"
-        }
+            "AutoCollectRoute5Start",
+            "EmptyNode"
+        ]
     },
     "AutoCollectRoute6Sub": {
-        "enabled": false,
         "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "AutoCollectRoute6Start"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "$option.AutoCollectRoute6.label"
-        }
+            "AutoCollectRoute6Start",
+            "EmptyNode"
+        ]
     },
     "AutoCollectRoute7Sub": {
-        "enabled": false,
         "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "AutoCollectRoute7Start"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "$option.AutoCollectRoute7.label"
-        }
+            "AutoCollectRoute7Start",
+            "EmptyNode"
+        ]
     },
     "AutoCollectRoute8Sub": {
-        "enabled": false,
         "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "AutoCollectRoute8Start"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "$option.AutoCollectRoute8.label"
-        }
+            "AutoCollectRoute8Start",
+            "EmptyNode"
+        ]
     },
     "AutoCollectRoute9Sub": {
-        "enabled": false,
         "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "AutoCollectRoute9Start"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "$option.AutoCollectRoute9.label"
-        }
+            "AutoCollectRoute9Start",
+            "EmptyNode"
+        ]
     },
     "AutoCollectRoute10Sub": {
-        "enabled": false,
         "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "AutoCollectRoute10Start"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "$option.AutoCollectRoute10.label"
-        }
+            "AutoCollectRoute10Start",
+            "EmptyNode"
+        ]
     }
 }

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute1.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute1.json
@@ -1,11 +1,12 @@
 {
     "AutoCollectRoute1Start": {
+        "enabled": false,
         "next": [
             "AutoCollectRoute1AssertLocation",
             "[JumpBack]SceneEnterWorldWulingWulingCity5"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "开始路线1"
+            "Node.Recognition.Succeeded": "$option.AutoCollectRoute1.label"
         }
     },
     "AutoCollectRoute1End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute10.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute10.json
@@ -1,12 +1,13 @@
 {
     "AutoCollectRoute10Start": {
         "desc": "共两个重红柱状菌采集点",
+        "enabled": false,
         "next": [
             "AutoCollectRoute10AssertLocation1",
             "[JumpBack]SceneEnterWorldWulingJingyuValley1"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "开始路线10"
+            "Node.Recognition.Succeeded": "$option.AutoCollectRoute10.label"
         }
     },
     "AutoCollectRoute10End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute2.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute2.json
@@ -1,11 +1,12 @@
 {
     "AutoCollectRoute2Start": {
+        "enabled": false,
         "next": [
             "AutoCollectRoute2AssertLocation",
             "[JumpBack]SceneEnterWorldWulingWulingCity2"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "开始路线2"
+            "Node.Recognition.Succeeded": "$option.AutoCollectRoute2.label"
         }
     },
     "AutoCollectRoute2End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute3.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute3.json
@@ -1,11 +1,12 @@
 {
     "AutoCollectRoute3Start": {
+        "enabled": false,
         "next": [
             "AutoCollectRoute3AssertLocation",
             "[JumpBack]SceneEnterWorldWulingWulingCity7"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "开始路线3"
+            "Node.Recognition.Succeeded": "$option.AutoCollectRoute3.label"
         }
     },
     "AutoCollectRoute3End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute4.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute4.json
@@ -1,11 +1,12 @@
 {
     "AutoCollectRoute4Start": {
+        "enabled": false,
         "next": [
             "AutoCollectRoute4AssertLocation",
             "[JumpBack]SceneEnterWorldValleyIVPowerPlateau3"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "开始路线4"
+            "Node.Recognition.Succeeded": "$option.AutoCollectRoute4.label"
         }
     },
     "AutoCollectRoute4End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute5.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute5.json
@@ -1,11 +1,12 @@
 {
     "AutoCollectRoute5Start": {
+        "enabled": false,
         "next": [
             "AutoCollectRoute5AssertLocation",
             "[JumpBack]SceneEnterWorldValleyIVTheHub2"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "开始路线5"
+            "Node.Recognition.Succeeded": "$option.AutoCollectRoute5.label"
         }
     },
     "AutoCollectRoute5End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute6.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute6.json
@@ -1,11 +1,12 @@
 {
     "AutoCollectRoute6Start": {
+        "enabled": false,
         "next": [
             "AutoCollectRoute6AssertLocation",
             "[JumpBack]SceneEnterWorldValleyIVTheHub2"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "开始路线6"
+            "Node.Recognition.Succeeded": "$option.AutoCollectRoute6.label"
         }
     },
     "AutoCollectRoute6End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute7.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute7.json
@@ -1,12 +1,13 @@
 {
     "AutoCollectRoute7Start": {
         "desc": "本路线包含两个收集点，血菌和武陵石",
+        "enabled": false,
         "next": [
             "AutoCollectRoute7AssertLocation1",
             "[JumpBack]SceneEnterWorldWulingWulingCity1"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "开始路线7"
+            "Node.Recognition.Succeeded": "$option.AutoCollectRoute7.label"
         }
     },
     "AutoCollectRoute7End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute8.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute8.json
@@ -1,11 +1,12 @@
 {
     "AutoCollectRoute8Start": {
+        "enabled": false,
         "next": [
             "AutoCollectRoute8AssertLocation1",
             "[JumpBack]SceneEnterWorldWulingWulingCity7"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "开始路线8"
+            "Node.Recognition.Succeeded": "$option.AutoCollectRoute8.label"
         }
     },
     "AutoCollectRoute8End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute9.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute9.json
@@ -1,12 +1,13 @@
 {
     "AutoCollectRoute9Start": {
         "desc": "燎石",
+        "enabled": false,
         "next": [
             "AutoCollectRoute9AssertLocation1",
             "[JumpBack]SceneEnterWorldWulingWulingCity7"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "开始路线9"
+            "Node.Recognition.Succeeded": "$option.AutoCollectRoute9.label"
         }
     },
     "AutoCollectRoute9End": {

--- a/assets/tasks/AutoCollect.json
+++ b/assets/tasks/AutoCollect.json
@@ -131,7 +131,7 @@
                     "name": "Route1",
                     "label": "$option.AutoCollectRoute1.label",
                     "pipeline_override": {
-                        "AutoCollectRoute1Sub": {
+                        "AutoCollectRoute1Start": {
                             "enabled": true
                         }
                     }
@@ -140,7 +140,7 @@
                     "name": "Route2",
                     "label": "$option.AutoCollectRoute2.label",
                     "pipeline_override": {
-                        "AutoCollectRoute2Sub": {
+                        "AutoCollectRoute2Start": {
                             "enabled": true
                         }
                     }
@@ -149,7 +149,7 @@
                     "name": "Route3",
                     "label": "$option.AutoCollectRoute3.label",
                     "pipeline_override": {
-                        "AutoCollectRoute3Sub": {
+                        "AutoCollectRoute3Start": {
                             "enabled": true
                         }
                     }
@@ -158,7 +158,7 @@
                     "name": "Route4",
                     "label": "$option.AutoCollectRoute4.label",
                     "pipeline_override": {
-                        "AutoCollectRoute4Sub": {
+                        "AutoCollectRoute4Start": {
                             "enabled": true
                         }
                     }
@@ -167,7 +167,7 @@
                     "name": "Route5",
                     "label": "$option.AutoCollectRoute5.label",
                     "pipeline_override": {
-                        "AutoCollectRoute5Sub": {
+                        "AutoCollectRoute5Start": {
                             "enabled": true
                         }
                     }
@@ -176,7 +176,7 @@
                     "name": "Route6",
                     "label": "$option.AutoCollectRoute6.label",
                     "pipeline_override": {
-                        "AutoCollectRoute6Sub": {
+                        "AutoCollectRoute6Start": {
                             "enabled": true
                         }
                     }
@@ -185,7 +185,7 @@
                     "name": "Route7",
                     "label": "$option.AutoCollectRoute7.label",
                     "pipeline_override": {
-                        "AutoCollectRoute7Sub": {
+                        "AutoCollectRoute7Start": {
                             "enabled": true
                         }
                     }
@@ -194,7 +194,7 @@
                     "name": "Route8",
                     "label": "$option.AutoCollectRoute8.label",
                     "pipeline_override": {
-                        "AutoCollectRoute8Sub": {
+                        "AutoCollectRoute8Start": {
                             "enabled": true
                         }
                     }
@@ -203,7 +203,7 @@
                     "name": "Route9",
                     "label": "$option.AutoCollectRoute9.label",
                     "pipeline_override": {
-                        "AutoCollectRoute9Sub": {
+                        "AutoCollectRoute9Start": {
                             "enabled": true
                         }
                     }
@@ -212,7 +212,7 @@
                     "name": "Route10",
                     "label": "$option.AutoCollectRoute10.label",
                     "pipeline_override": {
-                        "AutoCollectRoute10Sub": {
+                        "AutoCollectRoute10Start": {
                             "enabled": true
                         }
                     }


### PR DESCRIPTION
close #2796 
改subtask有点危险，就没改了
<img width="910" height="805" alt="image" src="https://github.com/user-attachments/assets/6114136f-b3fd-4544-ad03-0f9041f2c62a" />

## Summary by Sourcery

Bug Fixes:
- 通过更新流水线和路由配置 JSON，防止在自动收集分支关闭后，自动收集任务被错误地标记为失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent auto-collect tasks from being incorrectly marked as failed after the auto-collect branch is closed by updating pipeline and route configuration JSONs.

</details>