### PR TITLE
fix: 修复协议空间选择队伍死循环

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -74,6 +74,7 @@
     },
     "ProtocolSpaceTeamChoose": {
         "desc": "选择协议空间队伍",
+        "max_hit": 1,
         "recognition": "And",
         "all_of": [
             "ProtocolSpaceTeamChooseTextRecognition",


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 解决在 ProtocolSpace InSpace 场景配置中选择团队时出现的无限循环问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve an infinite loop when selecting teams in the ProtocolSpace InSpace scene configuration.

</details>