### PR TITLE
rft: AutoStockpile 数据记录移至 debug/record/ElasticGoodsPrices.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -485,6 +485,3 @@ tests/maatools
 
 # oh-my-opencode
 .sisyphus/
-
-# AutoStockpile local data
-assets/data/AutoStockpile/daily_storage.json

--- a/agent/go-service/autostockpile/daily_storage.go
+++ b/agent/go-service/autostockpile/daily_storage.go
@@ -6,14 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"time"
 )
 
 const (
-	dailyStorageFileName     = "daily_storage.json"
+	dailyStorageFileName     = "ElasticGoodsPrices.json"
 	maxDailyStorageDateCount = 120
-	maaEndDataDirEnvVar      = "MAAEND_DATA_DIR"
 )
 
 var resolveDailyStoragePathFunc = resolveDailyStoragePath
@@ -68,50 +66,7 @@ func storeDailyGoodsPrices(enabled bool, now time.Time, loc *time.Location, regi
 }
 
 func resolveDailyStoragePath() string {
-	return filepath.Join(resolveDailyStorageDataDir(), "AutoStockpile", dailyStorageFileName)
-}
-
-func resolveDailyStorageDataDir() string {
-	if dir := strings.TrimSpace(os.Getenv(maaEndDataDirEnvVar)); dir != "" {
-		return filepath.Clean(dir)
-	}
-
-	if cwd, err := os.Getwd(); err == nil {
-		if dir := findExistingDataDirFromAncestors(cwd); dir != "" {
-			return dir
-		}
-	}
-
-	if exePath, err := os.Executable(); err == nil {
-		if dir := findExistingDataDirFromAncestors(filepath.Dir(exePath)); dir != "" {
-			return dir
-		}
-	}
-
-	if cwd, err := os.Getwd(); err == nil {
-		return filepath.Join(cwd, "data")
-	}
-	return "data"
-}
-
-func findExistingDataDirFromAncestors(start string) string {
-	base := filepath.Clean(start)
-	for {
-		for _, candidate := range []string{
-			filepath.Join(base, "data"),
-			filepath.Join(base, "assets", "data"),
-		} {
-			if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-				return candidate
-			}
-		}
-
-		parent := filepath.Dir(base)
-		if parent == base {
-			return ""
-		}
-		base = parent
-	}
+	return filepath.Join("debug", "record", dailyStorageFileName)
 }
 
 func upsertDailyStorageRecord(path string, record dailyStorageRecord) error {

--- a/docs/en_us/developers/README.md
+++ b/docs/en_us/developers/README.md
@@ -96,7 +96,7 @@ Defines format specifications for files written by MaaEnd, for reliable consumpt
 
 | Document                                                                                 | Description                                                   |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [AutoStockpile Daily Price Records](../protocol/autostockpile-daily-storage/protocol.md) | `daily_storage.json` format, path resolution, and write rules |
+| [AutoStockpile Daily Price Records](../protocol/autostockpile-daily-storage/protocol.md) | `ElasticGoodsPrices.json` format, path resolution, and write rules |
 
 ## Quick lookup
 

--- a/docs/en_us/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/en_us/developers/tasks/auto-stockpile-maintain.md
@@ -96,7 +96,7 @@ If you need different pricing behavior, update the Go defaults in code rather th
 
 ## Local Daily Goods-Price Storage
 
-When `AutoStockpileAllowDataUpload` is enabled, the Go Service writes the recognized goods prices to `data/AutoStockpile/daily_storage.json` after successful recognition. For file format and path resolution rules, see [AutoStockpile Local Daily Goods-Price Records — Third-Party Read Protocol](../../protocol/autostockpile-daily-storage/protocol.md).
+When `AutoStockpileAllowDataUpload` is enabled, the Go Service writes the recognized goods prices to `debug/record/ElasticGoodsPrices.json` after successful recognition. For file format and path resolution rules, see [AutoStockpile Local Daily Goods-Price Records — Third-Party Read Protocol](../../protocol/autostockpile-daily-storage/protocol.md).
 
 ## Threshold Resolution Mechanism
 

--- a/docs/en_us/protocol/autostockpile-daily-storage/daily_storage.schema.json
+++ b/docs/en_us/protocol/autostockpile-daily-storage/daily_storage.schema.json
@@ -86,7 +86,7 @@
     "$id": "https://raw.githubusercontent.com/MaaEnd/MaaEnd/main/docs/en_us/protocol/autostockpile-daily-storage/daily_storage.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Format definition for the daily_storage.json file written by the AutoStockpile task.",
+    "description": "Format definition for the ElasticGoodsPrices.json file written by the AutoStockpile task.",
     "properties": {
         "records": {
             "description": "Array of price records.",

--- a/docs/en_us/protocol/autostockpile-daily-storage/protocol.md
+++ b/docs/en_us/protocol/autostockpile-daily-storage/protocol.md
@@ -1,6 +1,6 @@
 # AutoStockpile Local Daily Goods-Price Records — Third-Party Read Protocol
 
-When the `AutoStockpileAllowDataUpload` option is enabled, the Go Service writes the per-round recognized goods prices to `data/AutoStockpile/daily_storage.json` after successful goods recognition and region/server-day resolution. This path is for local file records only and does not trigger remote uploads.
+When the `AutoStockpileAllowDataUpload` option is enabled, the Go Service writes the per-round recognized goods prices to `debug/record/ElasticGoodsPrices.json` after successful goods recognition and region/server-day resolution. This path is for local file records only and does not trigger remote uploads.
 
 This document defines the file format and path resolution rules for third-party tools (data analysis dashboards, web frontends, users) to read reliably.
 
@@ -63,7 +63,7 @@ A corresponding JSON Schema file is provided for third-party tools to validate t
 - **Do not contain** the old `captured_at_utc` field. This field is deprecated in files with `schema_version ≥ 2`.
 - A new record with the same `server_date + region + uid` **overwrites** the old record. Different `uid` values on the same server date and region are kept independently.
 - At most **120 distinct** `server_date` values are retained. When exceeded, the earliest date and all its region records are discarded.
-- Writes use a same-directory temporary file + rename **atomic write** process. Readers can safely read `daily_storage.json` at any time without seeing a partially written file.
+- Writes use a same-directory temporary file + rename **atomic write** process. Readers can safely read `ElasticGoodsPrices.json` at any time without seeing a partially written file.
 - Write failures only log a warning and continue AutoStockpile; the task is not aborted.
 
 ---
@@ -73,37 +73,21 @@ A corresponding JSON Schema file is provided for third-party tools to validate t
 ### Target File
 
 ```text
-{Data Directory}/AutoStockpile/daily_storage.json
+debug/record/ElasticGoodsPrices.json
 ```
 
-### Data Directory Resolution Priority
-
-Search in the following order, using the first path that satisfies the condition:
-
-1. **Environment variable `MAAEND_DATA_DIR`** — If set and non-empty, use it directly (after `filepath.Clean`).
-2. **Upward search from current working directory** — Starting from the current working directory, walk upward looking for an existing `data/` or `assets/data/` directory; use the first one found.
-3. **Upward search from executable directory** — Starting from `os.Executable()`'s directory, walk upward looking for an existing `data/` or `assets/data/` directory; use the first one found.
-4. **Fallback** — If none of the above found, use `<working directory>/data/`. The directory is created via `MkdirAll` if it does not exist.
-
-### Upward Search Algorithm
-
-When walking upward from the starting directory, check two candidate paths at each level (in order):
-
-1. `{base}/data/`
-2. `{base}/assets/data/`
-
-The first path that exists and is a directory is the result. If the search reaches the filesystem root without finding a match, an empty string is returned.
+The path is a fixed relative path from the MaaEnd working directory. No upward search or environment variable resolution is performed. The directory is created via `MkdirAll` if it does not exist.
 
 ### Atomic Write Process
 
-1. Create a temporary file in the same directory (naming pattern `.{daily_storage.json}.*.tmp`)
+1. Create a temporary file in the same directory (naming pattern `.{ElasticGoodsPrices.json}.*.tmp`)
 2. Write the complete JSON content
 3. `chmod` the file to `0644`
 4. `Sync` to flush to disk
 5. `Close` the file handle
 6. `os.Rename` to atomically replace the target file
 
-Readers can safely read `daily_storage.json` at any time and will never see a partially written file.
+Readers can safely read `ElasticGoodsPrices.json` at any time and will never see a partially written file.
 
 ### Write Failure Behavior
 

--- a/docs/zh_cn/developers/README.md
+++ b/docs/zh_cn/developers/README.md
@@ -96,7 +96,7 @@ flowchart TD
 
 | 文档                                                                              | 说明                                              |
 | --------------------------------------------------------------------------------- | ------------------------------------------------- |
-| [AutoStockpile 每日价格记录](../protocol/autostockpile-daily-storage/protocol.md) | `daily_storage.json` 文件格式、路径解析与写入规则 |
+| [AutoStockpile 每日价格记录](../protocol/autostockpile-daily-storage/protocol.md) | `ElasticGoodsPrices.json` 文件格式、路径解析与写入规则 |
 
 ## 快速跳转
 

--- a/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
@@ -96,7 +96,7 @@ assets/resource/image/AutoStockpile/Goods/{Region}/{BaseName}.Tier{N}.png
 
 ## 本地每日商品价格记录
 
-启用 `AutoStockpileAllowDataUpload` 后，Go Service 会在每轮商品识别成功后将商品价格写入 `data/AutoStockpile/daily_storage.json`。文件格式与路径解析规则见 [AutoStockpile 本地每日商品价格记录 — 第三方读取协议](../../protocol/autostockpile-daily-storage/protocol.md)。
+启用 `AutoStockpileAllowDataUpload` 后，Go Service 会在每轮商品识别成功后将商品价格写入 `debug/record/ElasticGoodsPrices.json`。文件格式与路径解析规则见 [AutoStockpile 本地每日商品价格记录 — 第三方读取协议](../../protocol/autostockpile-daily-storage/protocol.md)。
 
 ## 阈值解析机制
 

--- a/docs/zh_cn/protocol/autostockpile-daily-storage/daily_storage.schema.json
+++ b/docs/zh_cn/protocol/autostockpile-daily-storage/daily_storage.schema.json
@@ -86,7 +86,7 @@
     "$id": "https://raw.githubusercontent.com/MaaEnd/MaaEnd/main/docs/zh_cn/protocol/autostockpile-daily-storage/daily_storage.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "AutoStockpile 任务写入的 daily_storage.json 文件格式定义。",
+    "description": "AutoStockpile 任务写入的 ElasticGoodsPrices.json 文件格式定义。",
     "properties": {
         "records": {
             "description": "价格记录数组。",

--- a/docs/zh_cn/protocol/autostockpile-daily-storage/protocol.md
+++ b/docs/zh_cn/protocol/autostockpile-daily-storage/protocol.md
@@ -1,6 +1,6 @@
 # AutoStockpile 本地每日商品价格记录 — 第三方读取协议
 
-`AutoStockpile` 任务启用 `AutoStockpileAllowDataUpload` 后，Go Service 会在每轮商品识别成功、地区与服务器日解析完成后，将当轮识别到的商品价格写入 `data/AutoStockpile/daily_storage.json`。该路径只用于本地文件记录，不会触发远程上传。
+`AutoStockpile` 任务启用 `AutoStockpileAllowDataUpload` 后，Go Service 会在每轮商品识别成功、地区与服务器日解析完成后，将当轮识别到的商品价格写入 `debug/record/ElasticGoodsPrices.json`。该路径只用于本地文件记录，不会触发远程上传。
 
 本文档定义文件格式与路径解析规则，供第三方工具（数据分析面板、Web 前端、用户）可靠读取。
 
@@ -73,37 +73,21 @@
 ### 目标文件
 
 ```text
-{数据目录}/AutoStockpile/daily_storage.json
+debug/record/ElasticGoodsPrices.json
 ```
 
-### 数据目录解析优先级
-
-按以下顺序查找，使用第一个满足条件的路径：
-
-1. **环境变量 `MAAEND_DATA_DIR`**：若设置且非空，直接使用该值（经 `filepath.Clean` 处理）。
-2. **当前工作目录向上查找**：从当前工作目录开始，向上逐级查找已存在的 `data/` 或 `assets/data/` 目录，使用第一个找到的。
-3. **可执行文件目录向上查找**：从 `os.Executable()` 所在目录开始，向上逐级查找已存在的 `data/` 或 `assets/data/` 目录，使用第一个找到的。
-4. **回退**：若以上均未找到，使用 `<工作目录>/data/`。目录不存在时由 `MkdirAll` 创建。
-
-### 向上查找算法
-
-从起始目录向上遍历时，每级目录检查两个候选路径（按顺序）：
-
-1. `{base}/data/`
-2. `{base}/assets/data/`
-
-以第一个存在且为目录的路径作为结果。若遍历到文件系统根仍未找到，返回空字符串。
+路径为相对于 MaaEnd 工作目录的固定路径，不再进行向上查找或环境变量解析。目录不存在时由 `MkdirAll` 自动创建。
 
 ### 原子写入流程
 
-1. 在同一目录下创建临时文件（命名模式 `.{daily_storage.json}.*.tmp`）
+1. 在同一目录下创建临时文件（命名模式 `.{ElasticGoodsPrices.json}.*.tmp`）
 2. 写入完整 JSON 内容
 3. `chmod` 设置权限为 `0644`
 4. `Sync` 刷盘
 5. `Close` 关闭文件句柄
 6. `os.Rename` 原子替换目标文件
 
-读取方可安全地在任何时刻读取 `daily_storage.json`，不会读到部分写入的内容。
+读取方可安全地在任何时刻读取 `ElasticGoodsPrices.json`，不会读到部分写入的内容。
 
 ### 写入失败行为
 


### PR DESCRIPTION
- 移除环境变量解析和向上查找逻辑，改用固定路径 debug/record/
- 文件名 daily_storage.json → ElasticGoodsPrices.json