### PR TITLE
fix: 更新确认赠送礼物按钮类型为 YellowConfirmButtonType2

### DIFF
--- a/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
@@ -128,7 +128,7 @@
             "type": "And",
             "param": {
                 "all_of": [
-                    "YellowConfirmButtonType1"
+                    "YellowConfirmButtonType2"
                 ]
             }
         },


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 调整礼物流程配置中的确认礼物按钮类型，改为使用 YellowConfirmButtonType2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust confirmation gift button type in gift flow configuration to use YellowConfirmButtonType2.

</details>