### PR TITLE
fix:干员升级任务卡死

### DIFF
--- a/assets/resource/pipeline/LevelUpOperator.json
+++ b/assets/resource/pipeline/LevelUpOperator.json
@@ -427,8 +427,7 @@
                 "template": [
                     "LevelUpOperator/OperatorSelected.png"
                 ],
-                "green_mask": true,
-                "threshold": 0.9
+                "green_mask": true
             }
         },
         "pre_delay": 0,
@@ -458,8 +457,7 @@
                                 "template": [
                                     "LevelUpOperator/OperatorSelected.png"
                                 ],
-                                "green_mask": true,
-                                "threshold": 0.9
+                                "green_mask": true
                             }
                         }
                     }


### PR DESCRIPTION
#2892

原因：UI更新导致管线识别失败卡死了任务处理流程

措施：降低了识别门槛（从0.9变为0.7）

## Summary by Sourcery

Bug Fixes:
- 放宽操作员升级流水线配置中的 UI 识别阈值，以避免此前会导致流水线检测失败、从而使任务流程挂起的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Relax UI recognition threshold in the operator level-up pipeline configuration to avoid pipeline detection failures that previously caused the task flow to hang.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 放宽操作员升级流水线配置中的 UI 识别阈值，以避免此前会导致流水线检测失败、从而使任务流程挂起的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Relax UI recognition threshold in the operator level-up pipeline configuration to avoid pipeline detection failures that previously caused the task flow to hang.

</details>

</details>