### PR TITLE
fix(自动采集): 修复因复位导致的跳崖

### DIFF
--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute2.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute2.json
@@ -123,6 +123,7 @@
                 "custom_action_param": {
                     "map_name": "map02_lv002",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             530.1,
@@ -148,6 +149,7 @@
                 "custom_action_param": {
                     "map_name": "map02_lv002",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             528.8,
@@ -173,6 +175,7 @@
                 "custom_action_param": {
                     "map_name": "map02_lv002",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             531.2,
@@ -198,6 +201,7 @@
                 "custom_action_param": {
                     "map_name": "map02_lv002",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             531.3,
@@ -223,6 +227,7 @@
                 "custom_action_param": {
                     "map_name": "map02_lv002",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             532.5,
@@ -248,6 +253,7 @@
                 "custom_action_param": {
                     "map_name": "map02_lv002",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             530.1,
@@ -273,6 +279,7 @@
                 "custom_action_param": {
                     "map_name": "map02_lv002",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             525.1,
@@ -298,6 +305,7 @@
                 "custom_action_param": {
                     "map_name": "map02_lv002",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             523.8,

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute4.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute4.json
@@ -179,6 +179,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv007",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             482.2,
@@ -204,6 +205,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv007",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             481.0,
@@ -229,6 +231,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv007",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             477.2,
@@ -254,6 +257,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv007",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             476.0,
@@ -279,6 +283,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv007",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             473.5,
@@ -304,6 +309,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv007",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             476.0,
@@ -329,6 +335,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv007",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             478.5,

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute5.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute5.json
@@ -123,6 +123,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv001",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             487.2,
@@ -148,6 +149,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv001",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             486.0,
@@ -173,6 +175,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv001",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             487.2,
@@ -198,6 +201,7 @@
                 "custom_action_param": {
                     "map_name": "map01_lv001",
                     "fine_approach": "AllTargets",
+                    "no_ensure_initial_movement_state": true,
                     "path": [
                         [
                             479.9,


### PR DESCRIPTION
fix #2734

## Summary by Sourcery

Bug Fixes:
- 修正路线 2、4 和 5 的自动收集路由数据，以避免由重置引起的坠崖行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct auto-collect routing data for routes 2, 4, and 5 to avoid cliff-fall behavior caused by resets.

</details>