### PR TITLE
fix(map): 避免寻路热路径每帧分配 controller wrapper 导致句柄失效

### DIFF
--- a/agent/go-service/common/charactercontroller/controller.go
+++ b/agent/go-service/common/charactercontroller/controller.go
@@ -70,7 +70,13 @@ func (a *CharacterControllerRelativeMoveAction) Run(ctx *maa.Context, arg *maa.C
 
 	scaledDX := int32(dx)
 	scaledDY := int32(dy)
-	controlType, _ := control.GetCachedControlType(ctx.GetTasker().GetController())
+	// Use the process-wide fast lane to avoid allocating a controller wrapper
+	// per call: this action runs in tight per-frame loops on movement paths.
+	// See MaaXYZ/maa-framework-go#41 and MaaEnd #2901 for the failure mode.
+	controlType := control.GetLastSeenControlType()
+	if controlType == "" {
+		controlType, _ = control.GetControlType(ctx.GetTasker().GetController())
+	}
 	if controlType == control.CONTROL_TYPE_WLROOTS {
 		scaledDX = int32(math.Round(float64(dx) * control.WlrootsRelativeMoveScale))
 		scaledDY = int32(math.Round(float64(dy) * control.WlrootsRelativeMoveScale))

--- a/agent/go-service/maptracker/default/infer.go
+++ b/agent/go-service/maptracker/default/infer.go
@@ -85,7 +85,16 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 		return nil, false
 	}
 
-	ctrlType, _ := control.GetCachedControlType(ctx.GetTasker().GetController())
+	// Avoid GetCachedControlType here: it requires a *maa.Controller argument,
+	// which would force ctx.GetTasker().GetController() to allocate a fresh
+	// wrapper on every recognition frame. That wrapper's finalizer can release
+	// the underlying C handle (MaaXYZ/maa-framework-go#41) and invalidate the
+	// long-lived ctrl that MapTrackerMove.Run caches, manifesting as
+	// `controller_id=""` / `controller not found` mid-navigation (#2901).
+	ctrlType := control.GetLastSeenControlType()
+	if ctrlType == "" {
+		ctrlType, _ = control.GetControlType(ctx.GetTasker().GetController())
+	}
 
 	// Compile regex
 	mapNameRegex, err := regexp.Compile(param.MapNameRegex)

--- a/agent/go-service/pkg/control/utils.go
+++ b/agent/go-service/pkg/control/utils.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
@@ -27,6 +28,14 @@ type controllerCacheEntry struct {
 
 var controllerCache sync.Map
 
+// lastSeenControlType is the most recently observed control type across any
+// controller. Exists as a hot-path fast lane: callers like MapTrackerInfer run
+// per frame and must avoid resolving a controller wrapper just to look up the
+// type, because each ctx.GetTasker().GetController() allocates a new Go
+// wrapper whose finalizer can release the underlying C handle and invalidate
+// long-lived wrappers held elsewhere (see MaaXYZ/maa-framework-go#41).
+var lastSeenControlType atomic.Value
+
 func loadControllerCache(ctrl *maa.Controller) (controllerCacheEntry, bool) {
 	if ctrl == nil {
 		return controllerCacheEntry{}, false
@@ -44,6 +53,22 @@ func storeControllerCache(ctrl *maa.Controller, entry controllerCacheEntry) {
 		return
 	}
 	controllerCache.Store(ctrl, entry)
+	if entry.ControlType != "" {
+		lastSeenControlType.Store(entry.ControlType)
+	}
+}
+
+// GetLastSeenControlType returns the most recently observed control type in
+// this process, or "" if no controller has been resolved yet. Hot paths
+// should prefer this over GetCachedControlType to avoid the side effect of
+// allocating a fresh controller wrapper just for a cache lookup.
+func GetLastSeenControlType() string {
+	if v := lastSeenControlType.Load(); v != nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
 }
 
 // InvalidateControllerCache clears cached metadata for a specific controller


### PR DESCRIPTION
## 触发现象

`v2.10.0-beta.6` 起,Win32 控制器下跑寻路相关任务(`MapTrackerMove`)时,寻路会在第一轮推理后卡死,maafw.log 出现 `controller_id=""` / `controller not found`。详见 #2901。

## 因果链

- **触发点**:#2859 在 "API 风格统一" 时,把 `maptracker/default/infer.go` 和 `common/charactercontroller/controller.go` 里查控制器类型的调用从「读包级 `CachedControlType` 字符串、空时才取 controller」改成了「每次先 `ctx.GetTasker().GetController()` 再查 sync.Map」,把"冷启动一次"的开销变成了"寻路热路径每帧调用一次"。
- **根因**:MaaXYZ/maa-framework-go#41 —— `GetController()` 每次返回新的 `*maa.Controller` Go wrapper,新 wrapper 被 GC 时 finalizer 会释放底层 C handle。
- **受害者**:`MapTrackerMove.Run()` 在循环开头长期缓存 `ctrl`,这个 ctrl 在第二轮推理前就被前面 wrapper 的 finalizer 弄废,后续 `PostScreencap()` 全部失败。
- `aspectratio` 自己的事件回调里调用 `GetController()` 频率低,不触雷;只有 `infer.go`(每帧推理)和 `charactercontroller`(走路时高频调用)真正出事。

## 修复点

- `pkg/control/utils.go`:新增进程级 `GetLastSeenControlType()` 快速通道,使用 `atomic.Value` 存储。所有进入 sync.Map 的 type 在 `storeControllerCache` 内部同步到这个 atomic 变量,热路径无须传 ctrl 即可读取。
- `maptracker/default/infer.go` 和 `charactercontroller/controller.go`:热路径改为先读 `GetLastSeenControlType()`,只在冷启动 \`\"\"\` 时才走 `GetControlType(ctrl)`(与 #2859 之前的旧逻辑等价)。
- `aspectratio` 那套 sync.Map per-instance HWND 缓存保留不动 —— 它是低频事件回调,且确实需要 per-instance HWND,功能没毛病。

## 测试

- [x] \`go build ./...\` 通过
- [x] \`go vet ./pkg/control/... ./maptracker/default/... ./common/charactercontroller/...\` 通过
- [x] **需要复现者验证**:#2901 报告的 \`EnvironmentMonitoring → 码头水车\` 流程不再卡死;一并验证基质刷取 / 自动采集等其他依赖 MapTrackerMove 的任务不受影响

## 留下的 TODO

- \`MapTrackerMove.Run()\` 长期缓存 \`ctrl\` 的模式本身是脆弱的,等 MaaXYZ/maa-framework-go#41 修了之后,应改成每轮 \`doInfer\` 重新获取或在 stopping 检测时重绑,作为根本性的健壮化。当前 PR 只做最小止血。

Closes #2901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在热点路径中避免每帧分配控制器包装器，以防止在地图追踪和角色移动过程中控制器句柄失效。

Bug 修复：
- 修复由于重复分配控制器包装器导致控制器句柄失效，从而引起的 MapTracker 推断和移动任务卡死问题。

增强功能：
- 引入进程级的“最后一次看到的控制类型”缓存，使热点路径可以在不为每帧创建新控制器包装器的情况下读取控制器类型。
- 更新地图追踪推断逻辑和角色控制器移动逻辑，以复用缓存的控制类型，并仅在冷启动时解析控制器元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Avoid per-frame controller wrapper allocations in hot paths to prevent controller handle invalidation during map tracking and character movement.

Bug Fixes:
- Fix MapTracker inference and movement tasks freezing due to invalidated controller handles caused by repeated controller wrapper allocations.

Enhancements:
- Introduce a process-wide last-seen control type cache to let hot paths read controller types without resolving a new controller wrapper each frame.
- Update map tracker inference and character controller movement logic to reuse the cached control type and only resolve controller metadata on cold start.

</details>