### PR TITLE
fix: 修复颜色检测误判

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneImageCheck.json
+++ b/assets/resource/pipeline/SceneManager/SceneImageCheck.json
@@ -75,7 +75,7 @@
         "rate_limit": 0,
         "next": [
             "__SceneImageCheckAICPlanColorSuccess",
-            "__SceneImageCheckAICPlanColorFailedScreenShot"
+            "__SceneImageCheckAICPlanColorFailedFinish"
         ]
     },
     "__SceneImageCheckAICPlanColorSuccess": {
@@ -98,17 +98,7 @@
             58
         ],
         "connected": true,
-        "count": 1500
-    },
-    "__SceneImageCheckAICPlanColorFailedScreenShot": {
-        "desc": "检查颜色失败并截图",
-        "pre_delay": 0,
-        "action": "Screencap",
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
-            "__SceneImageCheckAICPlanColorFailedFinish"
-        ]
+        "count": 1000
     },
     "__SceneImageCheckAICPlanColorFailedFinish": {
         "desc": "检查颜色失败",

--- a/assets/resource/pipeline/SceneManager/SceneImageCheck.json
+++ b/assets/resource/pipeline/SceneManager/SceneImageCheck.json
@@ -98,7 +98,7 @@
             58
         ],
         "connected": true,
-        "count": 1000
+        "count": 800
     },
     "__SceneImageCheckAICPlanColorFailedFinish": {
         "desc": "检查颜色失败",


### PR DESCRIPTION
close #2890

## Summary by Sourcery

错误修复：
- 调整图像检查设置，以减少在场景图像中错误检测颜色的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust image checking settings to reduce incorrect color detection in scene images.

</details>