### PR TITLE
chore: update maa-framework-go to v4.0.0-beta.17

### DIFF
--- a/agent/go-service/common/charactercontroller/controller.go
+++ b/agent/go-service/common/charactercontroller/controller.go
@@ -70,13 +70,7 @@ func (a *CharacterControllerRelativeMoveAction) Run(ctx *maa.Context, arg *maa.C
 
 	scaledDX := int32(dx)
 	scaledDY := int32(dy)
-	// Use the process-wide fast lane to avoid allocating a controller wrapper
-	// per call: this action runs in tight per-frame loops on movement paths.
-	// See MaaXYZ/maa-framework-go#41 and MaaEnd #2901 for the failure mode.
-	controlType := control.GetLastSeenControlType()
-	if controlType == "" {
-		controlType, _ = control.GetControlType(ctx.GetTasker().GetController())
-	}
+	controlType, _ := control.GetControlType(ctx.GetTasker().GetController())
 	if controlType == control.CONTROL_TYPE_WLROOTS {
 		scaledDX = int32(math.Round(float64(dx) * control.WlrootsRelativeMoveScale))
 		scaledDY = int32(math.Round(float64(dy) * control.WlrootsRelativeMoveScale))

--- a/agent/go-service/go.mod
+++ b/agent/go-service/go.mod
@@ -3,7 +3,7 @@ module github.com/MaaXYZ/MaaEnd/agent/go-service
 go 1.25.6
 
 require (
-	github.com/MaaXYZ/maa-framework-go/v4 v4.0.0-beta.14
+	github.com/MaaXYZ/maa-framework-go/v4 v4.0.0-beta.17
 	github.com/bytedance/sonic v1.15.0
 	github.com/rs/zerolog v1.34.0
 	github.com/shirou/gopsutil/v4 v4.26.2

--- a/agent/go-service/go.sum
+++ b/agent/go-service/go.sum
@@ -1,5 +1,5 @@
-github.com/MaaXYZ/maa-framework-go/v4 v4.0.0-beta.14 h1:7DHibysUOWuAXy9R6BDc9o+ZMjyb2UJh4BF38X9n83E=
-github.com/MaaXYZ/maa-framework-go/v4 v4.0.0-beta.14/go.mod h1:kDxaU/NZDmLRfxnZtn+UnVWw9Egv0i0yQgnjz7ho6Oo=
+github.com/MaaXYZ/maa-framework-go/v4 v4.0.0-beta.17 h1:3pwYC16TPtof9hRyw1Pap2182Kc9AK0ecAAcNur240Y=
+github.com/MaaXYZ/maa-framework-go/v4 v4.0.0-beta.17/go.mod h1:kDxaU/NZDmLRfxnZtn+UnVWw9Egv0i0yQgnjz7ho6Oo=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=

--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -84,11 +84,7 @@ func main() {
 	// Wait for the server to finish
 	maa.AgentServerJoin()
 
-	// Agent loop has exited — mirror the C++ Win32 controller's destructor
-	// cleanup by restoring any window state we changed during the session.
-	// Must run before AgentServerShutDown so the controller (if still alive)
-	// can still service us; SendAltEnter / SetWindowPos themselves only need
-	// the HWND and call user32 directly, so this works even after teardown.
+	// Restoring any window state we changed during the session.
 	aspectratio.Cleanup()
 
 	// Shutdown

--- a/agent/go-service/maptracker/default/infer.go
+++ b/agent/go-service/maptracker/default/infer.go
@@ -85,16 +85,7 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 		return nil, false
 	}
 
-	// Avoid GetCachedControlType here: it requires a *maa.Controller argument,
-	// which would force ctx.GetTasker().GetController() to allocate a fresh
-	// wrapper on every recognition frame. That wrapper's finalizer can release
-	// the underlying C handle (MaaXYZ/maa-framework-go#41) and invalidate the
-	// long-lived ctrl that MapTrackerMove.Run caches, manifesting as
-	// `controller_id=""` / `controller not found` mid-navigation (#2901).
-	ctrlType := control.GetLastSeenControlType()
-	if ctrlType == "" {
-		ctrlType, _ = control.GetControlType(ctx.GetTasker().GetController())
-	}
+	ctrlType, _ := control.GetControlType(ctx.GetTasker().GetController())
 
 	// Compile regex
 	mapNameRegex, err := regexp.Compile(param.MapNameRegex)

--- a/agent/go-service/pkg/control/utils.go
+++ b/agent/go-service/pkg/control/utils.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
-	"github.com/rs/zerolog/log"
 )
 
 /* ******** Controller Type ******** */
@@ -34,7 +33,6 @@ func GetControlType(ctrl *maa.Controller) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	log.Info().Str("controllerInfo", infoStr).Msg("Fetched controller info")
 	if infoStr == "" {
 		return "", fmt.Errorf("empty controller info")
 	}

--- a/agent/go-service/pkg/control/utils.go
+++ b/agent/go-service/pkg/control/utils.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"sync"
-	"sync/atomic"
 
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
@@ -21,70 +19,13 @@ const (
 	CONTROL_TYPE_ADB     = "adb"
 )
 
-type controllerCacheEntry struct {
-	ControlType string
-	Win32HWnd   uintptr
-}
-
-var controllerCache sync.Map
-
-// lastSeenControlType is the most recently observed control type across any
-// controller. Exists as a hot-path fast lane: callers like MapTrackerInfer run
-// per frame and must avoid resolving a controller wrapper just to look up the
-// type, because each ctx.GetTasker().GetController() allocates a new Go
-// wrapper whose finalizer can release the underlying C handle and invalidate
-// long-lived wrappers held elsewhere (see MaaXYZ/maa-framework-go#41).
-var lastSeenControlType atomic.Value
-
-func loadControllerCache(ctrl *maa.Controller) (controllerCacheEntry, bool) {
-	if ctrl == nil {
-		return controllerCacheEntry{}, false
-	}
-	v, ok := controllerCache.Load(ctrl)
-	if !ok {
-		return controllerCacheEntry{}, false
-	}
-	entry, ok := v.(controllerCacheEntry)
-	return entry, ok
-}
-
-func storeControllerCache(ctrl *maa.Controller, entry controllerCacheEntry) {
-	if ctrl == nil {
-		return
-	}
-	controllerCache.Store(ctrl, entry)
-	if entry.ControlType != "" {
-		lastSeenControlType.Store(entry.ControlType)
-	}
-}
-
-// GetLastSeenControlType returns the most recently observed control type in
-// this process, or "" if no controller has been resolved yet. Hot paths
-// should prefer this over GetCachedControlType to avoid the side effect of
-// allocating a fresh controller wrapper just for a cache lookup.
-func GetLastSeenControlType() string {
-	if v := lastSeenControlType.Load(); v != nil {
-		if s, ok := v.(string); ok {
-			return s
-		}
-	}
-	return ""
-}
-
-// InvalidateControllerCache clears cached metadata for a specific controller
-// instance. Cache scope is controller-lifetime, not process-lifetime.
-func InvalidateControllerCache(ctrl *maa.Controller) {
-	if ctrl == nil {
-		return
-	}
-	controllerCache.Delete(ctrl)
+type maaControllerInfoDto struct {
+	Type string `json:"type"`
+	HWnd uint64 `json:"hwnd"`
 }
 
 // GetControlType retrieves the control type of the given controller by parsing its info string.
 func GetControlType(ctrl *maa.Controller) (string, error) {
-	if entry, ok := loadControllerCache(ctrl); ok && entry.ControlType != "" {
-		return entry.ControlType, nil
-	}
 	if ctrl == nil {
 		return "", fmt.Errorf("nil controller")
 	}
@@ -98,24 +39,16 @@ func GetControlType(ctrl *maa.Controller) (string, error) {
 		return "", fmt.Errorf("empty controller info")
 	}
 
-	type maaControllerInfo struct {
-		Type string `json:"type"`
-		HWnd uint64 `json:"hwnd"`
-	}
-
-	var info maaControllerInfo
+	var info maaControllerInfoDto
 	if err := json.Unmarshal([]byte(infoStr), &info); err != nil {
 		// Fallback
 		if strings.Contains(infoStr, CONTROL_TYPE_WIN32) {
-			storeControllerCache(ctrl, controllerCacheEntry{ControlType: CONTROL_TYPE_WIN32})
 			return CONTROL_TYPE_WIN32, nil
 		}
 		if strings.Contains(infoStr, CONTROL_TYPE_WLROOTS) {
-			storeControllerCache(ctrl, controllerCacheEntry{ControlType: CONTROL_TYPE_WLROOTS})
 			return CONTROL_TYPE_WLROOTS, nil
 		}
 		if strings.Contains(infoStr, CONTROL_TYPE_ADB) {
-			storeControllerCache(ctrl, controllerCacheEntry{ControlType: CONTROL_TYPE_ADB})
 			return CONTROL_TYPE_ADB, nil
 		}
 		return "", fmt.Errorf("failed to parse controller info via JSON: %w, and fallback parsing also failed", err)
@@ -125,40 +58,21 @@ func GetControlType(ctrl *maa.Controller) (string, error) {
 	}
 
 	if info.Type == CONTROL_TYPE_WIN32 {
-		storeControllerCache(ctrl, controllerCacheEntry{
-			ControlType: CONTROL_TYPE_WIN32,
-			Win32HWnd:   uintptr(info.HWnd),
-		})
 		return CONTROL_TYPE_WIN32, nil
 	}
 	if info.Type == CONTROL_TYPE_WLROOTS {
-		storeControllerCache(ctrl, controllerCacheEntry{ControlType: CONTROL_TYPE_WLROOTS})
 		return CONTROL_TYPE_WLROOTS, nil
 	}
 	if info.Type == CONTROL_TYPE_ADB {
-		storeControllerCache(ctrl, controllerCacheEntry{ControlType: CONTROL_TYPE_ADB})
 		return CONTROL_TYPE_ADB, nil
 	}
 	return "", fmt.Errorf("unsupported controller type: %s", info.Type)
 }
 
-// GetCachedControlType returns controller type cached for a specific
-// controller instance when available, otherwise falls back to GetControlType.
-func GetCachedControlType(ctrl *maa.Controller) (string, error) {
-	if entry, ok := loadControllerCache(ctrl); ok && entry.ControlType != "" {
-		return entry.ControlType, nil
-	}
-	return GetControlType(ctrl)
-}
-
 // GetWin32HWnd returns the HWND that a Win32 controller is attached to.
-// Prefers controller-scoped cached metadata; otherwise parses ctrl.GetInfo()
-// directly. See MaaFramework's Win32ControlUnitMgr::get_info, which serializes
-// `{"type":"win32","hwnd":<uint64>,...}`.
+//
+// See MaaFramework's Win32ControlUnitMgr::get_info, which serializes `{"type":"win32","hwnd":<uint64>,...}`.
 func GetWin32HWnd(ctrl *maa.Controller) (uintptr, error) {
-	if entry, ok := loadControllerCache(ctrl); ok && entry.Win32HWnd != 0 {
-		return entry.Win32HWnd, nil
-	}
 	if ctrl == nil {
 		return 0, fmt.Errorf("nil controller")
 	}
@@ -169,10 +83,8 @@ func GetWin32HWnd(ctrl *maa.Controller) (uintptr, error) {
 	if infoStr == "" {
 		return 0, fmt.Errorf("empty controller info")
 	}
-	var info struct {
-		Type string `json:"type"`
-		HWnd uint64 `json:"hwnd"`
-	}
+
+	var info maaControllerInfoDto
 	if err := json.Unmarshal([]byte(infoStr), &info); err != nil {
 		return 0, fmt.Errorf("failed to parse controller info: %w", err)
 	}
@@ -182,10 +94,6 @@ func GetWin32HWnd(ctrl *maa.Controller) (uintptr, error) {
 	if info.HWnd == 0 {
 		return 0, fmt.Errorf("controller info has no hwnd field or hwnd is zero")
 	}
-	storeControllerCache(ctrl, controllerCacheEntry{
-		ControlType: CONTROL_TYPE_WIN32,
-		Win32HWnd:   uintptr(info.HWnd),
-	})
 	return uintptr(info.HWnd), nil
 }
 

--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -462,11 +462,6 @@ func resolveControllerType(controller *maa.Controller) (string, string, error) {
 	if controlType := normalizeControllerType(pienv.ControllerType()); controlType != "" {
 		return controlType, "pi_env", nil
 	}
-	if controlType, err := control.GetControlType(controller); err == nil {
-		if normalized := normalizeControllerType(controlType); normalized != "" {
-			return normalized, "cache", nil
-		}
-	}
 
 	controlType, err := control.GetControlType(controller)
 	if err != nil {

--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -462,7 +462,7 @@ func resolveControllerType(controller *maa.Controller) (string, string, error) {
 	if controlType := normalizeControllerType(pienv.ControllerType()); controlType != "" {
 		return controlType, "pi_env", nil
 	}
-	if controlType, err := control.GetCachedControlType(controller); err == nil {
+	if controlType, err := control.GetControlType(controller); err == nil {
 		if normalized := normalizeControllerType(controlType); normalized != "" {
 			return normalized, "cache", nil
 		}


### PR DESCRIPTION
## 概述

此 PR 将 Go 依赖项 maa-framework-go 升级到了 v4.0.0-beta.17 版本。

得益于此次升级带来的 bug 修复，此 PR 移除了 pkg/control 中对 Controller 实例的缓存行为。

## 关联

此 PR 是 #2901 的最终解决方案。

有关上游修复的详细信息，参见 https://github.com/MaaXYZ/maa-framework-go/issues/41 。

## Summary by Sourcery

将 Go agent 更新为使用 maa-framework-go v4.0.0-beta.17，并移除已不再需要的控制器元数据缓存，从而简化控制器类型和 HWND 的解析流程。

增强功能：
- 移除进程级和按控制器维度的控制器类型及 HWND 缓存，改为直接从 maa-framework-go 解析控制器信息。
- 通过共享的 DTO 结构体统一控制器信息 JSON 解析逻辑，该结构体同时用于控制类型和 Win32 HWND 的辅助方法。
- 在地图追踪器和角色控制器逻辑中，通过直接调用 `GetControlType` 简化控制器类型解析，并移除“最近一次记录”的快速路径逻辑。
- 明确并精简纵横比清理和控制器类型解析的代码路径，使其与更新后的控制器工具保持一致。

构建：
- 在 Go agent 模块中，将 `maa-framework-go/v4` 依赖版本从 `v4.0.0-beta.14` 升级到 `v4.0.0-beta.17`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Go agent to use maa-framework-go v4.0.0-beta.17 and remove now-unnecessary controller metadata caching, simplifying controller type and HWND resolution.

Enhancements:
- Remove process-wide and per-controller caching of controller type and HWND in favor of directly parsing controller info from maa-framework-go.
- Unify controller info JSON parsing via a shared DTO struct used by both control type and Win32 HWND helpers.
- Simplify controller type resolution in map tracker and character controller logic by calling GetControlType directly and dropping last-seen fast-path logic.
- Clarify and shorten aspect ratio cleanup and controller type resolution code paths to match the updated controller utilities.

Build:
- Bump maa-framework-go/v4 dependency from v4.0.0-beta.14 to v4.0.0-beta.17 in the Go agent module.

</details>