### PR TITLE
fix(DailyRewards): 活跃度检测超时前恢复意外界面

### DIFF
--- a/assets/resource/pipeline/DailyRewards/Tasks.json
+++ b/assets/resource/pipeline/DailyRewards/Tasks.json
@@ -220,7 +220,17 @@
             "DailyTaskAssemble",
             "DailyTaskLevelUpOperator",
             "DailyTaskScrollFinished",
-            "[JumpBack]DailyTaskScrollDown"
+            "[JumpBack]DailyTaskScrollDown",
+            "DailyTaskRecoveryNavigate"
+        ]
+    },
+    "DailyTaskRecoveryNavigate": {
+        "desc": "不在日常任务界面时，回到起点重试",
+        "max_hit": 1,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "[JumpBack]DailyTaskStart"
         ]
     },
     "DailyTaskUpgradeWeapon": {


### PR DESCRIPTION
启动任务时在 Windows 下出现 Panic（大量 **"mxu"** 刷屏日志），原因是 Go 工具链 (v1.25.6) 与 purego 库 (v0.10.0) 在回调/GC 栈扫描方面存在兼容性冲突。
_修改go.md中的go版本及purego版本，_
**将 Go 版本降级至 1.24，purego 降级至 v0.9.1，以符合上游依赖要求。**

Closes #2871

## Summary by Sourcery

改进内容：
- 更新 DailyRewards 流水线任务定义，以优化行为和状态处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update DailyRewards pipeline task definitions to refine behavior and state handling.

</details>