### PR TITLE
feat: go-service 崩溃时将堆栈及 stderr 保存至 debug 目录

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,10 @@
             "args": [
                 "{AGENT_ID}"
             ],
-            "cwd": "${workspaceFolder}/install"
+            "cwd": "${workspaceFolder}/install",
+            "env": {
+                "GOTRACEBACK": "crash"
+            }
         },
         {
             "name": "launch-cpp-agent",

--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/bytedance/sonic"
 	"github.com/rs/zerolog/log"
-	"golang.org/x/sys/windows"
 )
 
 func main() {
@@ -39,14 +38,7 @@ func main() {
 		}
 	}()
 
-	// Redirect stderr to file so Go runtime crash output is preserved
-	if stderrFile, err := os.OpenFile(
-		filepath.Join(".", "debug", "go-service.stderr.log"),
-		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644,
-	); err == nil {
-		windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(stderrFile.Fd()))
-		os.Stderr = stderrFile
-	}
+	redirectStderr()
 
 	log.Info().
 		Str("version", Version).

--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -15,7 +15,9 @@ import (
 )
 
 func main() {
-	os.Setenv("GOTRACEBACK", "crash")
+	if _, ok := os.LookupEnv("GOTRACEBACK"); !ok {
+		debug.SetTraceback("crash")
+	}
 	debug.SetPanicOnFault(true)
 
 	logFile, err := initLogger()
@@ -29,10 +31,17 @@ func main() {
 	defer func() {
 		if r := recover(); r != nil {
 			buf := make([]byte, 64<<10)
-			n := runtime.Stack(buf, true)
+			for {
+				n := runtime.Stack(buf, true)
+				if n < len(buf) {
+					buf = buf[:n]
+					break
+				}
+				buf = make([]byte, 2*len(buf))
+			}
 			log.Error().
 				Interface("panic", r).
-				Str("stack", string(buf[:n])).
+				Str("stack", string(buf)).
 				Msg("FATAL: go-service panicked")
 			logFile.Sync()
 			panic(r)

--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime/debug"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
@@ -10,9 +11,13 @@ import (
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/bytedance/sonic"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/windows"
 )
 
 func main() {
+	os.Setenv("GOTRACEBACK", "crash")
+	debug.SetPanicOnFault(true)
+
 	logFile, err := initLogger()
 	if err != nil {
 		log.Fatal().
@@ -20,6 +25,28 @@ func main() {
 			Msg("Failed to initialize logger")
 	}
 	defer logFile.Close()
+
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			log.Error().
+				Interface("panic", r).
+				Str("stack", string(stack)).
+				Msg("FATAL: go-service panicked")
+			logFile.Sync()
+			logFile.Close()
+			os.Exit(1)
+		}
+	}()
+
+	// Redirect stderr to file so Go runtime crash output is preserved
+	if stderrFile, err := os.OpenFile(
+		filepath.Join(".", "debug", "go-service.stderr.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644,
+	); err == nil {
+		windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(stderrFile.Fd()))
+		os.Stderr = stderrFile
+	}
 
 	log.Info().
 		Str("version", Version).

--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
@@ -27,13 +28,13 @@ func main() {
 
 	defer func() {
 		if r := recover(); r != nil {
-			stack := debug.Stack()
+			buf := make([]byte, 64<<10)
+			n := runtime.Stack(buf, true)
 			log.Error().
 				Interface("panic", r).
-				Str("stack", string(stack)).
+				Str("stack", string(buf[:n])).
 				Msg("FATAL: go-service panicked")
 			logFile.Sync()
-			logFile.Close()
 			os.Exit(1)
 		}
 	}()

--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -43,7 +43,11 @@ func main() {
 				Interface("panic", r).
 				Str("stack", string(buf)).
 				Msg("FATAL: go-service panicked")
-			logFile.Sync()
+			if err := logFile.Sync(); err != nil {
+				log.Error().
+					Err(err).
+					Msg("FATAL: failed to sync log file")
+			}
 			panic(r)
 		}
 	}()

--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -35,11 +35,15 @@ func main() {
 				Str("stack", string(buf[:n])).
 				Msg("FATAL: go-service panicked")
 			logFile.Sync()
-			os.Exit(1)
+			panic(r)
 		}
 	}()
 
-	redirectStderr()
+	if err := redirectStderr(); err != nil {
+		log.Warn().
+			Err(err).
+			Msg("Failed to redirect stderr to file")
+	}
 
 	log.Info().
 		Str("version", Version).

--- a/agent/go-service/stderr_other.go
+++ b/agent/go-service/stderr_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func redirectStderr() {}

--- a/agent/go-service/stderr_other.go
+++ b/agent/go-service/stderr_other.go
@@ -2,4 +2,4 @@
 
 package main
 
-func redirectStderr() {}
+func redirectStderr() error { return nil }

--- a/agent/go-service/stderr_windows.go
+++ b/agent/go-service/stderr_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package main
 
 import (

--- a/agent/go-service/stderr_windows.go
+++ b/agent/go-service/stderr_windows.go
@@ -21,7 +21,10 @@ func redirectStderr() error {
 	if err != nil {
 		return fmt.Errorf("open stderr log: %w", err)
 	}
-	windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(stderrFile.Fd()))
+	if err := windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(stderrFile.Fd())); err != nil {
+		stderrFile.Close()
+		return fmt.Errorf("set stderr handle: %w", err)
+	}
 	os.Stderr = stderrFile
 	return nil
 }

--- a/agent/go-service/stderr_windows.go
+++ b/agent/go-service/stderr_windows.go
@@ -8,8 +8,11 @@ import (
 )
 
 func redirectStderr() {
+	debugDir := filepath.Join(".", "debug")
+	os.MkdirAll(debugDir, 0755)
+
 	stderrFile, err := os.OpenFile(
-		filepath.Join(".", "debug", "go-service.stderr.log"),
+		filepath.Join(debugDir, "go-service.stderr.log"),
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644,
 	)
 	if err != nil {

--- a/agent/go-service/stderr_windows.go
+++ b/agent/go-service/stderr_windows.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func redirectStderr() {
+	stderrFile, err := os.OpenFile(
+		filepath.Join(".", "debug", "go-service.stderr.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644,
+	)
+	if err != nil {
+		return
+	}
+	windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(stderrFile.Fd()))
+	os.Stderr = stderrFile
+}

--- a/agent/go-service/stderr_windows.go
+++ b/agent/go-service/stderr_windows.go
@@ -1,23 +1,27 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"golang.org/x/sys/windows"
 )
 
-func redirectStderr() {
+func redirectStderr() error {
 	debugDir := filepath.Join(".", "debug")
-	os.MkdirAll(debugDir, 0755)
+	if err := os.MkdirAll(debugDir, 0755); err != nil {
+		return fmt.Errorf("mkdir debug: %w", err)
+	}
 
 	stderrFile, err := os.OpenFile(
 		filepath.Join(debugDir, "go-service.stderr.log"),
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644,
 	)
 	if err != nil {
-		return
+		return fmt.Errorf("open stderr log: %w", err)
 	}
 	windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(stderrFile.Fd()))
 	os.Stderr = stderrFile
+	return nil
 }


### PR DESCRIPTION
看看记录点堆栈能不能帮助解决 
- #2871 
## Summary by Sourcery

通过配置运行时时崩溃行为并将 stderr 重定向到调试日志文件，捕获 go-service 的崩溃诊断信息。

新功能：
- 在 go-service 中添加运行时配置和 panic 恢复机制，以在崩溃时记录堆栈跟踪信息。
- 将 go-service 的 stderr 输出持久化到专用的调试日志文件，以便进行事后分析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Capture go-service crash diagnostics by configuring runtime crash behavior and redirecting stderr to a debug log file.

New Features:
- Add runtime configuration and panic recovery in go-service to record stack traces on crashes.
- Persist go-service stderr output to a dedicated debug log file for post-mortem analysis.

</details>

## Summary by Sourcery

改进 go-service 的崩溃诊断和 stderr 处理，以便更轻松地进行事后分析。

新功能：
- 在 `go-service` 发生 panic 时记录详细的堆栈跟踪，以帮助崩溃调查。
- 在 Windows 上将 `go-service` 的 stderr 输出持久化到调试目录下的专用日志文件中。

增强：
- 配置 Go 运行时的崩溃行为，并启用 panic-on-fault，以提供更有信息量的故障信号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve go-service crash diagnostics and stderr handling for easier post-mortem analysis.

New Features:
- Record detailed stack traces when go-service panics to aid crash investigation.
- Persist go-service stderr output to a dedicated log file under a debug directory on Windows.

Enhancements:
- Configure Go runtime crash behavior and enable panic-on-fault for more informative failure signals.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 go-service 的崩溃诊断和 stderr 处理，以便更轻松地进行事后分析。

新功能：
- 在 `go-service` 发生 panic 时记录详细的堆栈跟踪，以帮助崩溃调查。
- 在 Windows 上将 `go-service` 的 stderr 输出持久化到调试目录下的专用日志文件中。

增强：
- 配置 Go 运行时的崩溃行为，并启用 panic-on-fault，以提供更有信息量的故障信号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve go-service crash diagnostics and stderr handling for easier post-mortem analysis.

New Features:
- Record detailed stack traces when go-service panics to aid crash investigation.
- Persist go-service stderr output to a dedicated log file under a debug directory on Windows.

Enhancements:
- Configure Go runtime crash behavior and enable panic-on-fault for more informative failure signals.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 go-service 的崩溃诊断和 stderr 处理，以便更轻松地进行事后分析。

新功能：
- 在 `go-service` 发生 panic 时记录详细的堆栈跟踪，以帮助崩溃调查。
- 在 Windows 上将 `go-service` 的 stderr 输出持久化到调试目录下的专用日志文件中。

增强：
- 配置 Go 运行时的崩溃行为，并启用 panic-on-fault，以提供更有信息量的故障信号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve go-service crash diagnostics and stderr handling for easier post-mortem analysis.

New Features:
- Record detailed stack traces when go-service panics to aid crash investigation.
- Persist go-service stderr output to a dedicated log file under a debug directory on Windows.

Enhancements:
- Configure Go runtime crash behavior and enable panic-on-fault for more informative failure signals.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 go-service 的崩溃诊断和 stderr 处理，以便更轻松地进行事后分析。

新功能：
- 在 `go-service` 发生 panic 时记录详细的堆栈跟踪，以帮助崩溃调查。
- 在 Windows 上将 `go-service` 的 stderr 输出持久化到调试目录下的专用日志文件中。

增强：
- 配置 Go 运行时的崩溃行为，并启用 panic-on-fault，以提供更有信息量的故障信号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve go-service crash diagnostics and stderr handling for easier post-mortem analysis.

New Features:
- Record detailed stack traces when go-service panics to aid crash investigation.
- Persist go-service stderr output to a dedicated log file under a debug directory on Windows.

Enhancements:
- Configure Go runtime crash behavior and enable panic-on-fault for more informative failure signals.

</details>

</details>

</details>