### PR TITLE
fix: 修复在画面不稳定时点击关闭按钮失效,补上漏掉的控制器

### DIFF
--- a/assets/resource/pipeline/BatchUseDetector/main.json
+++ b/assets/resource/pipeline/BatchUseDetector/main.json
@@ -39,13 +39,13 @@
         ]
     },
     "BatchUseDetectorFindNoItem": {
-        "desc": "没有找到或无法使用选择的探物器/罗盘",
+        "desc": "没有找到选择的探物器/罗盘",
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "FalseAction",
         "post_delay": 0,
         "focus": {
-            "Node.Recognition.Succeeded": "没有找到或无法使用选择的探物器/罗盘"
+            "Node.Recognition.Succeeded": "没有找到选择的探物器/罗盘"
         }
     },
     "BatchUseDetectorClickWhiteConfirmButton": {
@@ -74,9 +74,13 @@
             }
         },
         "action": "Click",
+        "timeout": 5000,
         "next": [
             "BatchUseDetectorBacktoValuablesTab"
-        ]
+        ],
+        "focus": {
+            "Node.PipelineNode.Failed": "当前无法使用探物器/罗盘"
+        }
     },
     "BatchUseDetectorBacktoValuablesTab": {
         "desc": "返回珍贵物品页，返回上一级",
@@ -85,6 +89,17 @@
             "CloseButtonType1",
             "InMapAny"
         ],
+        "pre_wait_freezes": {
+            "time": 100,
+            "target": [
+                0,
+                0,
+                0,
+                0
+            ],
+            "timeout": 3000,
+            "threshold": 0.98
+        }, //这里识别到后得等画面稳定后才可以正常点击
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 0,

--- a/assets/tasks/BatchUseDetector.json
+++ b/assets/tasks/BatchUseDetector.json
@@ -12,6 +12,7 @@
             ],
             "controller": [
                 "Win32-Window",
+                "Win32-Window-Background",
                 "Win32-Front",
                 "Wlroots"
             ],


### PR DESCRIPTION
- fix https://github.com/MaaEnd/MaaEnd/issues/2971

## Summary by Sourcery

修复 BatchUseDetector pipeline 和 task 定义，以便在屏幕不稳定时关闭按钮仍能正常工作。

Bug 修复：
- 通过纠正 BatchUseDetector 配置，解决在屏幕不稳定情况下关闭按钮可能变得无响应的问题。

增强：
- 为 BatchUseDetector pipeline/task 添加之前缺失的 controller 配置，以确保其行为正确。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix BatchUseDetector pipeline and task definitions so the close button works correctly when the screen is unstable.

Bug Fixes:
- Resolve an issue where the close button could become unresponsive in unstable screen conditions by correcting the BatchUseDetector configuration.

Enhancements:
- Add the previously missing controller configuration for the BatchUseDetector pipeline/task to ensure proper behavior.

</details>