### PR TITLE
fix: 修复送礼可以在通用、后台模式启动任务

### DIFF
--- a/assets/tasks/GiftOperator.json
+++ b/assets/tasks/GiftOperator.json
@@ -11,6 +11,10 @@
             ],
             "group": [
                 "dijiang_ship"
+            ],
+            "controller": [
+                "Win32-Front",
+                "Wlroots"
             ]
         }
     ],


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 更正礼物操作任务的设置，使其不再以通用模式或后台模式启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct gift operation task settings so it no longer starts in generic or background modes.

</details>