### PR TITLE
feat:自动采集增加前后一键存放背包

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -661,6 +661,7 @@
     "task.AutoArtificing.label": "⚒️ Auto Refining",
     "task.AutoCollect.description": "Automatically collect wild resources (the game must stay in the foreground; do not move the mouse).\nNote: if crops have not fully grown, they may grow randomly, which can lead to incomplete collection.\nDue to recognition accuracy limits, even when fully grown some may not be collected.",
     "task.AutoCollect.label": "🧺 Auto Collect",
+    "task.AutoCollect.option.AutoCollectStashBackpackSubTask.label": "Stash backpack before and after task",
     "option.AutoCollectRoutes.label": "Collect Routes",
     "option.AutoCollectRoute1.label": "Collect Route 1: Wuling City - Blighted Yuhua Leaf",
     "option.AutoCollectRoute2.label": "Collect Route 2: Wuling City - False Aggela",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -661,6 +661,7 @@
     "task.AutoArtificing.label": "⚒️自動精錬",
     "task.AutoCollect.description": "フィールド資源を自動採集します（ゲームを常に前面に表示し、マウスを動かさないでください）。\n注意：作物が完全に成長していない場合、作物がランダムに成長し、採集漏れが発生することがあります。\n認識精度の制限により、成長済みでも一部採集できない場合があります。",
     "task.AutoCollect.label": "🧺自動収集",
+    "task.AutoCollect.option.AutoCollectStashBackpackSubTask.label": "タスク前後にバックパックを収納",
     "option.AutoCollectRoutes.label": "採集ルート",
     "option.AutoCollectRoute1.label": "採集ルート1：武陵城内-侵蝕玉華葉",
     "option.AutoCollectRoute2.label": "採集ルート2：武陵城内-岩アンゲロス葉",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -661,6 +661,7 @@
     "task.AutoArtificing.label": "⚒️자동 정련",
     "task.AutoCollect.description": "야외 자원을 자동 수집합니다(게임을 계속 전면에 유지하고 마우스를 움직이지 마세요).\n참고: 작물이 완전히 자라기 전에 랜덤 성장으로 인해 수집이 누락될 수 있습니다.\n인식 정확도의 한계로 인해 완전히 자라도 일부는 수집되지 않을 수 있습니다.",
     "task.AutoCollect.label": "🧺자동 수집",
+    "task.AutoCollect.option.AutoCollectStashBackpackSubTask.label": "태스크 전후 배낭 보관",
     "option.AutoCollectRoutes.label": "채집 경로",
     "option.AutoCollectRoute1.label": "채집 경로 1: 무릉성 도심-침식된 유화 잎",
     "option.AutoCollectRoute2.label": "채집 경로 2: 무릉성 도심-바위아겔로스 잎",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -661,6 +661,7 @@
     "task.AutoArtificing.label": "⚒️自动精锻",
     "task.AutoCollect.description": "自动采集野外资源（需一直保持前台，不要乱动鼠标）\n 注意，作物没有完全生长齐的时候作物会随机生长，会导致收集不齐的情况。\n 受限于识别精度即使齐了也会有个别无法收集",
     "task.AutoCollect.label": "🧺自动采集",
+    "task.AutoCollect.option.AutoCollectStashBackpackSubTask.label": "任务前后存放背包",
     "option.AutoCollectRoutes.label": "采集线路",
     "option.AutoCollectRoute1.label": "线路1：武陵城-受蚀玉华叶",
     "option.AutoCollectRoute2.label": "线路2：武陵城-岩天使叶",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -476,6 +476,7 @@
     "task.AutoArtificing.label": "⚒️自動精鍛",
     "task.AutoCollect.description": "自動採集野外資源（需一直保持前台，不要亂動滑鼠）\n注意，作物沒有完全生長齊的時候作物會隨機生長，會導致收集不齊的情況。\n受限於識別精度即使齊了也會有個別無法收集",
     "task.AutoCollect.label": "🧺自動採集",
+    "task.AutoCollect.option.AutoCollectStashBackpackSubTask.label": "任務前後存放背包",
     "option.AutoCollectRoutes.label": "採集路線",
     "option.AutoCollectRoute1.label": "採集路線1：武陵城區-受蝕玉華葉",
     "option.AutoCollectRoute2.label": "採集路線2：武陵城區-岩天使葉",

--- a/assets/resource/pipeline/AutoCollect.json
+++ b/assets/resource/pipeline/AutoCollect.json
@@ -24,6 +24,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
+                "StashBackpackSubTask",
                 "AutoCollectRoute1Sub",
                 "AutoCollectRoute2Sub",
                 "AutoCollectRoute3Sub",
@@ -37,7 +38,9 @@
                 "AutoCollectRoute11Sub",
                 "AutoCollectRoute12Sub",
                 "AutoCollectRoute13Sub",
-                "AutoCollectRoute14Sub"
+                "AutoCollectRoute14Sub",
+                "AutoCollectResetStashBackpackHitCount",
+                "StashBackpackSubTask"
             ],
             "continue": true,
             "strict": true
@@ -49,6 +52,20 @@
     },
     "AutoCollectEnd": {
         "pre_delay": 0,
+        "post_delay": 0
+    },
+    "AutoCollectResetStashBackpackHitCount": {
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "ClearHitCount",
+        "custom_action_param": {
+            "nodes": [
+                "StashBackpackMain",
+                "StashBackpackStashQuick",
+                "StashBackpackUsableItemsLimited"
+            ],
+            "strict": true
+        },
         "post_delay": 0
     },
     "AutoCollectRoute1Sub": {

--- a/assets/resource/pipeline/AutoCollect.json
+++ b/assets/resource/pipeline/AutoCollect.json
@@ -39,7 +39,6 @@
                 "AutoCollectRoute12Sub",
                 "AutoCollectRoute13Sub",
                 "AutoCollectRoute14Sub",
-                "AutoCollectResetStashBackpackHitCount",
                 "StashBackpackSubTask"
             ],
             "continue": true,
@@ -52,20 +51,6 @@
     },
     "AutoCollectEnd": {
         "pre_delay": 0,
-        "post_delay": 0
-    },
-    "AutoCollectResetStashBackpackHitCount": {
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "ClearHitCount",
-        "custom_action_param": {
-            "nodes": [
-                "StashBackpackMain",
-                "StashBackpackStashQuick",
-                "StashBackpackUsableItemsLimited"
-            ],
-            "strict": true
-        },
         "post_delay": 0
     },
     "AutoCollectRoute1Sub": {

--- a/assets/resource/pipeline/StashBackpack.json
+++ b/assets/resource/pipeline/StashBackpack.json
@@ -11,7 +11,6 @@
     },
     "StashBackpackMain": {
         "desc": "任务入口",
-        "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,
@@ -27,18 +26,30 @@
             "InBackpack"
         ],
         "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "StashBackpackStashQuickSubTask",
+                "StashBackpackUsableItemsLimitedSubTask"
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "StashBackpackStashQuickSubTask": {
+        "desc": "一键存放被子任务入口",
+        "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "[JumpBack]StashBackpackStashQuick",
-            "[JumpBack]StashBackpackUsableItemsLimited",
+            "StashBackpackStashQuick",
             "EmptyNode"
         ]
     },
     "StashBackpackStashQuick": {
         "desc": "一键存放",
         "enabled": false,
-        "max_hit": 1,
         "recognition": "TemplateMatch",
         "roi": [
             871,
@@ -56,10 +67,19 @@
         "post_delay": 0,
         "rate_limit": 0
     },
+    "StashBackpackUsableItemsLimitedSubTask": {
+        "desc": "少量可用物品存放被子任务入口",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "StashBackpackUsableItemsLimited",
+            "EmptyNode"
+        ]
+    },
     "StashBackpackUsableItemsLimited": {
         "desc": "少量可用物品存放",
         "enabled": false,
-        "max_hit": 1,
         "recognition": "TemplateMatch",
         "roi": [
             1023,

--- a/assets/resource/pipeline/StashBackpack.json
+++ b/assets/resource/pipeline/StashBackpack.json
@@ -68,7 +68,7 @@
         "rate_limit": 0
     },
     "StashBackpackUsableItemsLimitedSubTask": {
-        "desc": "少量可用物品存放被子任务入口",
+        "desc": "少量可用物品存放背包任务入口",
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/StashBackpack.json
+++ b/assets/resource/pipeline/StashBackpack.json
@@ -38,7 +38,7 @@
         "rate_limit": 0
     },
     "StashBackpackStashQuickSubTask": {
-        "desc": "一键存放被子任务入口",
+        "desc": "一键存放背包任务入口",
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/tasks/AutoCollect.json
+++ b/assets/tasks/AutoCollect.json
@@ -11,7 +11,8 @@
             ],
             "option": [
                 "AutoCollectSchedule",
-                "AutoCollectRoutes"
+                "AutoCollectRoutes",
+                "AutoCollectStashBackpackSubTask"
             ],
             "group": [
                 "open_world"
@@ -106,6 +107,32 @@
                             "attach": {
                                 "sunday": true
                             }
+                        }
+                    }
+                }
+            ]
+        },
+        "AutoCollectStashBackpackSubTask": {
+            "type": "switch",
+            "label": "$task.AutoCollect.option.AutoCollectStashBackpackSubTask.label",
+            "default_case": "Yes",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "StashBackpackMain": {
+                            "enabled": true
+                        }
+                    },
+                    "option": [
+                        "StashBackpackType"
+                    ]
+                },
+                {
+                    "name": "No",
+                    "pipeline_override": {
+                        "StashBackpackMain": {
+                            "enabled": false
                         }
                     }
                 }


### PR DESCRIPTION
## Summary by Sourcery

为自动采集流程添加对“一键存储”采集前后物品的支持。

新功能：
- 在 AutoCollect 流水线和任务定义中，新增配置，用于在采集前和采集后将物品一键自动存入背包。

文档：
- 更新英文和中文 UI 本地化文案，以支持新的自动采集“一键存入背包”选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for one-click storing collected items before and after auto-collection flows.

New Features:
- Introduce configuration for automatic pre- and post-collection one-click storage into the backpack in the AutoCollect pipeline and task definitions.

Documentation:
- Update English and Chinese UI localization strings for the new auto-collection one-click backpack storage options.

</details>