### PR TITLE
fix(MapLocator): align navigator tracking

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -541,6 +541,7 @@ std::optional<MapPosition> MapLocator::Impl::tryTracking(
                 held.scale = trackScale;
                 held.isHeld = true;
                 motionTracker->hold(held, now);
+                motionTracker->markLost();
                 LogInfo << "Tracking outlier rejected, holding last pos." << VAR(jumpDist) << VAR(trackResult->score) << VAR(trackScale);
                 return held;
             }
@@ -1039,8 +1040,12 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
     auto trackingResult = tryTracking(trackingTmpl, primaryStrategy.get(), now, options, &rawPrimaryPos);
     const bool trackingHeld = trackingResult.has_value() && trackingResult->isHeld;
 
-    if (trackingResult && !trackingHeld) {
-        return LocateResult { .status = LocateStatus::Success, .position = trackingResult, .debugMessage = "Tracking Success" };
+    if (trackingResult) {
+        return LocateResult {
+            .status = LocateStatus::Success,
+            .position = trackingResult,
+            .debugMessage = trackingHeld ? "Tracking Hold" : "Tracking Success",
+        };
     }
 
     const bool shouldTryDualTracking = !isPathHeatmapZone && rawPrimaryPos.score > 0.1 && (!trackingResult || trackingHeld);
@@ -1075,11 +1080,7 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
         }
     }
 
-    if (!trackingHeld) {
-        return std::nullopt;
-    }
-
-    return LocateResult { .status = LocateStatus::Success, .position = trackingResult, .debugMessage = "Tracking Hold" };
+    return std::nullopt;
 }
 
 SearchConstraint MapLocator::Impl::buildSearchConstraint(

--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -1048,7 +1048,7 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
         };
     }
 
-    const bool shouldTryDualTracking = !isPathHeatmapZone && rawPrimaryPos.score > 0.1 && (!trackingResult || trackingHeld);
+    const bool shouldTryDualTracking = !isPathHeatmapZone && rawPrimaryPos.score > 0.1 && !trackingResult;
     if (shouldTryDualTracking) {
         auto fallbackStrategy =
             MatchStrategyFactory::create(currentZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg, MatchMode::ForcePathHeatmap);

--- a/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
+++ b/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
@@ -406,9 +406,11 @@ public:
         v.isTeleported = currentSpeed > trackingCfg.maxNormalSpeed;
 
         // 追踪态高分豁免
-        bool accept = (trackResult.score >= 0.85) || (trackResult.score >= 0.42 && trackResult.delta >= 0.04 && trackResult.psr >= 3.8)
+        bool accept = (trackResult.score >= 0.85) || (trackResult.score >= 0.70 && trackResult.delta >= 0.25 && trackResult.psr >= 2.0)
+                      || (trackResult.score >= 0.42 && trackResult.delta >= 0.04 && trackResult.psr >= 3.8)
                       || (trackResult.score >= 0.40 && trackResult.delta >= 0.05 && trackResult.psr >= 3.8);
-        bool hold = trackResult.score >= 0.35 && trackResult.psr >= 4.0;
+        bool hold = (trackResult.score >= 0.70 && trackResult.delta >= 0.25 && trackResult.psr >= 2.0)
+                    || (trackResult.score >= 0.35 && trackResult.psr >= 4.0);
 
         bool ambiguous = !accept;
         v.isScreenBlocked = !accept && !hold;

--- a/agent/cpp-algo/source/MapLocator/MotionTracker.cpp
+++ b/agent/cpp-algo/source/MapLocator/MotionTracker.cpp
@@ -42,7 +42,6 @@ void MotionTracker::hold(const MapPosition& oldPos, std::chrono::steady_clock::t
 {
     lastKnownPos = oldPos;
     lastTime = now;
-    lostTrackingCount++;
 }
 
 void MotionTracker::markLost(int increment)


### PR DESCRIPTION
- fix #3018

## Summary by Sourcery

调整地图跟踪行为，以更好地匹配导航器的跟踪状态和阈值。

Bug Fixes（错误修复）:
- 当在保持最后位置的情况下拒绝跟踪离群值时，确保运动跟踪被标记为已丢失。
- 对于正常跟踪和跟踪保持状态，统一返回跟踪定位结果，而不是将保持状态视为单独的成功路径。

Enhancements（增强改进）:
- 调整路径热力图的跟踪接受和保持阈值，以优化跟踪的稳定性和响应性。

Chores（日常维护）:
- 在运动跟踪器中仅仅保持最后已知位置时，不再增加丢失跟踪计数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust map tracking behavior to better align navigator tracking status and thresholds.

Bug Fixes:
- Ensure motion tracking is marked lost when rejecting tracking outliers while holding the last position.
- Return tracking locate results consistently for both normal tracking and tracking hold states instead of treating hold as a separate success path.

Enhancements:
- Tune path heatmap tracking acceptance and hold thresholds to refine tracking stability and responsiveness.

Chores:
- Stop incrementing lost tracking count when simply holding the last known position in the motion tracker.

</details>