### PR TITLE
fix: 修复基建线索交流结束的延迟弹窗偶尔无法被命中

### DIFF
--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -25,7 +25,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            //"ReceptionRoomClueExchangeWait",
+            "ReceptionRoomClueExchangeWait",
             "ReceptionRoomViewWait"
         ]
     },
@@ -149,7 +149,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            // "ReceptionRoomClueExchangeWait",
+            "ReceptionRoomClueExchangeWait",
             "ReceptionRoomViewIn"
         ],
         "focus": {

--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -36,7 +36,7 @@
             "param": {
                 "any_of": [
                     "ReceptionRoomExchangeEnd1"
-                    // "ReceptionRoomExchangeEnd2"
+                    // "ReceptionRoomExchangeEnd2" //原本识别到信用点增加也会判断命中情报交流结束,为了防止误伤先关闭
                 ]
             }
         },

--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -25,7 +25,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "ReceptionRoomClueExchangeWait",
+            //"ReceptionRoomClueExchangeWait",
             "ReceptionRoomViewWait"
         ]
     },
@@ -35,8 +35,8 @@
             "type": "Or",
             "param": {
                 "any_of": [
-                    "ReceptionRoomExchangeEnd1",
-                    "ReceptionRoomExchangeEnd2"
+                    "ReceptionRoomExchangeEnd1"
+                    // "ReceptionRoomExchangeEnd2"
                 ]
             }
         },
@@ -46,10 +46,10 @@
         "rate_limit": 0,
         "next": [
             "ReceptionRoomClueExchangeConfirm"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "命中线索交流结束界面" //测试输出
-        }
+        ]
+        //"focus": {
+        //    "Node.Recognition.Succeeded": "命中线索交流结束界面" //测试输出
+        //}
     },
     "ReceptionRoomExchangeEnd2": {
         "desc": "[会客室·线索] 识别到信用点增加,且在会客室界面，确认情报交流结束",
@@ -149,7 +149,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "ReceptionRoomClueExchangeWait",
+            // "ReceptionRoomClueExchangeWait",
             "ReceptionRoomViewIn"
         ],
         "focus": {
@@ -213,6 +213,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "ReceptionRoomClueExchangeWait",
             "ReceptionRoomSendCluesClueCollectionOpen"
         ]
     },
@@ -387,6 +388,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "ReceptionRoomClueExchangeWait",
             "SceneNoticeRewardsConfirm"
         ]
     },
@@ -411,6 +413,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "ReceptionRoomClueExchangeWait",
             "ReceptionRoomReceiveCluesOpen"
         ]
     },
@@ -887,6 +890,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "ReceptionRoomClueExchangeWait",
             "ReceptionRoomSetCluesChooseClues"
         ]
     },
@@ -1083,6 +1087,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "ReceptionRoomClueExchangeWait",
             "InDijiangControlNexus"
         ]
     }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 解决在 ReceptionRoom 流程中，基础设施线索的对话结束延迟弹窗未能被正确触发而导致的间歇性失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve intermittent failures where the end-of-conversation delayed popup for infrastructure clues was not being correctly triggered in the ReceptionRoom flow.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 解决在 ReceptionRoom 流程中，基础设施线索的对话结束延迟弹窗未能被正确触发而导致的间歇性失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve intermittent failures where the end-of-conversation delayed popup for infrastructure clues was not being correctly triggered in the ReceptionRoom flow.

</details>

</details>