### PR TITLE
feat(基建任务): 会客室增加线索未溢出也送线索功能

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -214,6 +214,8 @@
     "option.ClueStockLimit.description": "Calculated per clue type. If a single clue type exceeds this amount, that clue will be sent automatically.",
     "option.ClueSetting.label": "Clue Settings",
     "option.ClueSetting.description": "Enable to customize clue rules. When disabled, the default behavior keeps up to 2 of each clue type and sends at most 3 clues.",
+    "option.ClueSendForce.labe1": "Send Clues Even Without Overflow",
+    "option.ClueSendForce.description": "When enabled, clues will still be gifted even if they are not overflowing. Intended for transferring clues from alternate accounts to a main account. Disabled by default and generally not recommended.",
     "option.SelectToGrow.label": "Growth Target",
     "option.SelectToGrow.description": "Will automatically plant the selected target.",
     "option.SelectToGrow.cases.DoNothing.label": "Do Nothing",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -210,6 +210,8 @@
     "option.ClueStockLimit.description": "手掛かりの種類ごとに計算します。特定の手掛かりがこの数を超えた場合、その種類を自動で贈ります。",
     "option.ClueSetting.label": "手掛かり設定",
     "option.ClueSetting.description": "有効にすると手掛かり処理ルールを変更できます。無効時は既定動作として、各種類を 2 個まで残し、最大 3 件まで贈ります。",
+    "option.ClueSendForce.labe1": "手がかりが上限未満でも送信",
+    "option.ClueSendForce.description": "有効にすると、手がかりが上限を超えていない場合でも送信されます。サブアカウントからメインアカウントへ手がかりを送る用途向けです。デフォルトでは無効で、通常は有効化を推奨しません。",
     "option.SelectToGrow.label": "栽培対象",
     "option.SelectToGrow.description": "有効にすると、が選択した対象を自動で栽培します。",
     "option.SelectToGrow.cases.DoNothing.label": "栽培しない",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -210,6 +210,8 @@
     "option.ClueStockLimit.description": "단서 종류별로 계산합니다. 특정 종류의 단서가 이 수량을 넘으면 해당 종류를 자동으로 선물합니다.",
     "option.ClueSetting.label": "단서 설정",
     "option.ClueSetting.description": "활성화하면 단서 처리 규칙을 변경할 수 있습니다. 비활성화 시 기본 동작으로 각 종류를 최대 2개까지 남기고, 최대 3개까지 선물합니다.",
+    "option.ClueSendForce.labe1": "초과되지 않아도 단서 보내기",
+    "option.ClueSendForce.description": "활성화하면 단서가 넘치지 않은 상태에서도 단서를 보냅니다. 부계정에서 본계정으로 단서를 보내는 용도로 사용됩니다. 기본적으로 비활성화되어 있으며 일반적으로 권장되지 않습니다.",
     "option.SelectToGrow.label": "재배 대상",
     "option.SelectToGrow.description": "활성화 시 가 선택한 대상을 자동으로 재배합니다.",
     "option.SelectToGrow.cases.DoNothing.label": "재배하지 않음",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -214,6 +214,8 @@
     "option.ClueStockLimit.description": "按单种线索库存计算；当某一种线索数量超过设定值时，会自动赠送该种线索。",
     "option.ClueSetting.label": "线索设置",
     "option.ClueSetting.description": "启用后可自定义线索规则；关闭时使用默认行为：每种线索最多保留 2 个，且最多赠送 3 次。",
+    "option.ClueSendForce.labe1": "未溢出也赠送线索",
+    "option.ClueSendForce.description": "启用后线索未溢出时也将赠送线索，用于小号向大号送线索，默认不建议开启。",
     "option.SelectToGrow.label": "种植目标",
     "option.SelectToGrow.description": "会自动种植对应目标",
     "option.SelectToGrow.cases.DoNothing.label": "不种植",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -214,6 +214,8 @@
     "option.ClueStockLimit.description": "按單種線索庫存計算；當某一種線索數量超過設定值時，會自動贈送該種線索。",
     "option.ClueSetting.label": "線索設定",
     "option.ClueSetting.description": "啟用後可自訂線索規則；關閉時使用預設行為：每種線索最多保留 2 個，且最多贈送 3 次。",
+    "option.ClueSendForce.labe1": "未溢出時也贈送線索",
+    "option.ClueSendForce.description": "啟用後，即使線索未溢出也會贈送線索，用於小號向大號贈送線索。預設不建議開啟。",
     "option.SelectToGrow.label": "種植目標",
     "option.SelectToGrow.description": "會自動種植對應目標",
     "option.SelectToGrow.cases.DoNothing.label": "不種植",

--- a/assets/tasks/DijiangRewards.json
+++ b/assets/tasks/DijiangRewards.json
@@ -198,7 +198,8 @@
                     "name": "Yes",
                     "option": [
                         "ClueSend",
-                        "ClueStockLimit"
+                        "ClueStockLimit",
+                        "ClueSendForce"
                     ]
                 },
                 {
@@ -257,6 +258,35 @@
                 }
             ]
         },
+        "ClueSendForce": {
+            "type": "switch",
+            "label": "$option.ClueSendForce.labe1",
+            "description": "$option.ClueSendForce.description",
+            "default_case": "No",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "ReceptionRoomViewIn": {
+                            "next": [
+                                "[JumpBack]ReceptionRoomCollectClues",
+                                "[JumpBack]ReceptionRoomReceiveClues",
+                                "[JumpBack]ReceptionRoomSetClues",
+                                "[JumpBack]ReceptionRoomStartExchange",
+                                "[JumpBack]ReceptionRoomSendCluesEntry",
+                                "ReceptionRoomExit"
+                            ]
+                        },                        
+                        "ReceptionRoomSendCluesEntry": {
+                            "max_hit": 1
+                        }
+                    }
+                },
+                {
+                    "name": "No"
+                }
+            ]
+        },        
         "SelectToGrow": {
             "type": "select",
             "label": "$option.SelectToGrow.label",


### PR DESCRIPTION
为会客室线索操作添加“未溢出也赠送”的控制开关。允许用户在未满足默认线索溢出条件时，手动/主动触发线索赠送。

### New Features / 新功能
- **UI 配置项**: 在会客室/基建任务设置界面新增“未溢出也送线索”的开关（默认关闭）。

---

## 🎯 Background / 背景
> **Related Issue / 相关问题**:  MaaEnd/MaaEnd#2844 MaaEnd/MaaEnd#2996 MaaEnd/MaaEnd#3046

对于有多个游戏账号的玩家，有把次要账号的线索赠送给主要账号的需求，以便每天都能开启线索交流。
当前的会客室任务只有在线索真正溢出时，才触发线索赠送。不能及时的把次要账号的线索送出。

---

## ✨ Changes / 修改内容

### 1. 
- 修改 `assets/tasks/DijiangRewards.json`：
  - 接入新的条件判断。当检测到 UI 开关被激活，即使线索未处于溢出状态，也会强行将任务流导向线索赠送节点。
  - 确保该动作“仅执行一次”。

### 2. 
更新了以下文件，增加了对应的 UI 文本标签与 hover 提示（Tooltip）：
- `assets/locales/interface/zh_cn.json` (简体中文)
- `assets/locales/interface/zh_tw.json` (繁体中文)
- `assets/locales/interface/en_us.json` (English)
- `assets/locales/interface/ja_jp.json` (日本語)
- `assets/locales/interface/ko_kr.json` (한국어)

---

## 📸 Screenshots / 效果截图

<img width="1920" height="1080" alt="{3D232574-5295-4C4E-9A11-DA342FA8890F}" src="https://github.com/user-attachments/assets/230de202-880a-430d-9c9a-da6409f4c0c9" />

---

## Summary by Sourcery

为会客室线索赠送新增一个可配置选项，以便即使线索未溢出时也能进行赠送，并将其接入任务流程和 UI 文本资源。

新功能：
- 在会客室/基建任务设置中引入 “即使未溢出也发送线索” 开关，以支持主动线索赠送。

增强优化：
- 更新 DijiangRewards 任务逻辑，以遵循新开关的状态，在启用时将任务流程引导至线索赠送流程一次。
- 扩展本地化文件，为新增加的会客室线索赠送选项在所有受支持语言中添加标签和工具提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable option for reception room clue gifting to allow sending clues even when they are not overflowing, and wire it into the task flow and UI text resources.

New Features:
- Introduce a "send clues even when not overflowing" toggle in the reception room/infrastructure task settings to allow proactive clue gifting.

Enhancements:
- Update DijiangRewards task logic to respect the new toggle and route once to the clue-gifting flow when enabled.
- Extend localization files with labels and tooltips for the new reception room clue-gifting option across supported languages.

</details>