### PR TITLE
fix: 回复理智增加优先级，按照时间顺序

### DIFF
--- a/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
@@ -50,7 +50,7 @@
                 "template": "Valuables/EmergencySpBooster.png",
                 "green_mask": true,
                 "threshold": 0.84,
-                "order_by": "Score"
+                "order_by": "Vertical"
             }
         },
         "action": "Click",
@@ -98,7 +98,7 @@
                 "template": "Valuables/EmergencySpBoosterExpireSoon.png",
                 "green_mask": true,
                 "threshold": 0.84,
-                "order_by": "Score"
+                "order_by": "Vertical"
             }
         }
     },


### PR DESCRIPTION
fix #3073 
加了个vertical order，应该可以解决时间在前面的自动先选。

## Summary by Sourcery

Bug Fixes:
- 确保在自动选择理智恢复道具时，遵循时间顺序而不是任意的优先级。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure auto-selection of sanity recovery items respects chronological order rather than arbitrary priority.

</details>