### PR TITLE
fix(AutoSell): 修复售卖弹性物资好友遍历死循环

### DIFF
--- a/agent/go-service/autosell/autosell.go
+++ b/agent/go-service/autosell/autosell.go
@@ -108,7 +108,6 @@ func (a *AutoSellItemExecuteItemTaskAction) Run(ctx *maa.Context, arg *maa.Custo
 
 	hasError := false
 	for _, name := range names {
-		// 翻译有缘再写
 		targetPrice := 9999
 		targetName := "unknown"
 		if k := firstContainedKeyword(name, moderatePriceKeywords); k != "" {
@@ -133,7 +132,7 @@ func (a *AutoSellItemExecuteItemTaskAction) Run(ctx *maa.Context, arg *maa.Custo
 			continue
 		}
 
-		override := map[string]any{
+		baseOverride := map[string]any{
 			"AutoSellStockRedistributionItemOpenPrepareRegionalDevelopmentValleyIV": map[string]any{
 				"enabled": param.Region == "ValleyIV",
 			},
@@ -147,10 +146,12 @@ func (a *AutoSellItemExecuteItemTaskAction) Run(ctx *maa.Context, arg *maa.Custo
 				"enabled": param.Region == "Wuling",
 			},
 			"AutoSellStockRedistributionItemOpenPrepareFriendsFailedToValleyIV": map[string]any{
-				"enabled": param.Region == "ValleyIV",
+				"enabled":   param.Region == "ValleyIV",
+				"max_hit":   1,
 			},
 			"AutoSellStockRedistributionItemOpenPrepareFriendsFailedToWuling": map[string]any{
-				"enabled": param.Region == "Wuling",
+				"enabled":   param.Region == "Wuling",
+				"max_hit":   1,
 			},
 			"AutoSellFriendsPricesExpected": map[string]any{
 				"custom_recognition_param": map[string]any{
@@ -167,11 +168,49 @@ func (a *AutoSellItemExecuteItemTaskAction) Run(ctx *maa.Context, arg *maa.Custo
 			},
 		}
 
-		detail, err := ctx.RunTask("AutoSellStockRedistributionItemOpenPrepare", override)
-		if detail == nil || err != nil {
-			log.Error().Err(err).Str("component", "autosell").Str("step", "execute_sell").Str("item_name", name).Msg("run prepare task")
-			hasError = true
+		sold := false
+		for friendIdx := 0; friendIdx < 20 && !sold; friendIdx++ {
+			override := make(map[string]any, len(baseOverride)+1)
+			for k, v := range baseOverride {
+				override[k] = v
+			}
+			if friendIdx > 0 {
+				yOffset := friendIdx * 145
+				override["AutoSellFriendsPriceFirstTicketRecognition"] = map[string]any{
+					"roi_offset": []int{0, yOffset, 0, 0},
+				}
+				maafocus.Print(ctx, i18n.T("autosell.try_next_friend", name, friendIdx+1))
+			}
+
+			detail, err := ctx.RunTask("AutoSellStockRedistributionItemOpenPrepare", override)
+			if detail == nil || err != nil {
+				log.Error().Err(err).Str("component", "autosell").Str("step", "execute_sell").Str("item_name", name).Int("friend_idx", friendIdx).Msg("run prepare task")
+				hasError = true
+				break
+			}
+
+			if detail.Status.Success() {
+				sold = true
+				maafocus.Print(ctx, i18n.T("autosell.sell_success", name))
+			} else {
+				log.Info().
+					Str("component", "autosell").
+					Str("step", "execute_sell").
+					Str("item_name", name).
+					Int("friend_idx", friendIdx).
+					Msg("current friend does not have target item, try next")
+			}
+		}
+
+		if hasError {
 			break
+		}
+		if !sold {
+			log.Warn().
+				Str("component", "autosell").
+				Str("step", "execute_sell").
+				Str("item_name", name).
+				Msg("no friends have the target item")
 		}
 	}
 	if hasError {

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -17,6 +17,8 @@
     "autosell.check_item_price_massive": "Checking price for %s; extreme price volatility",
     "autosell.check_item_price_unknown": "Checking price for %s; unknown price volatility",
     "autosell.scan_item_owned": "Elastic demand supplies owned: %s",
+    "autosell.sell_success": "Supplies %s sold successfully",
+    "autosell.try_next_friend": "Supplies %s: current friend has no stock, try friend #%d",
     "autostockpile.recognition_done": "Recognition complete, %d items found",
     "autostockpile.no_qualifying_product": "No qualifying items found (%s)",
     "autostockpile.hit_but_skip": "Item matched but not purchasing (%s)",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -17,6 +17,8 @@
     "autosell.check_item_price_massive": "物資 %s の価格を確認中（価格変動は極大）",
     "autosell.check_item_price_unknown": "物資 %s の価格を確認中（価格変動は不明）",
     "autosell.scan_item_owned": "所持している弾性需要物資：%s",
+    "autosell.sell_success": "物資 %s 販売成功",
+    "autosell.try_next_friend": "物資 %s：現在のフレンドに在庫なし、%d番目のフレンドを試します",
     "autostockpile.recognition_done": "認識完了。商品を%d件検出しました",
     "autostockpile.no_qualifying_product": "条件を満たす商品がありません (%s)",
     "autostockpile.hit_but_skip": "商品に一致しましたが、最終的に購入しません（%s）",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -17,6 +17,8 @@
     "autosell.check_item_price_massive": "%s 물자 가격 확인 중, 가격 변동 매우 큼",
     "autosell.check_item_price_unknown": "%s 물자 가격 확인 중, 가격 변동 알 수 없음",
     "autosell.scan_item_owned": "보유한 탄력 수요 물자: %s",
+    "autosell.sell_success": "물자 %s 판매 성공",
+    "autosell.try_next_friend": "물자 %s: 현재 친구에게 재고 없음, %d번째 친구 시도",
     "autostockpile.recognition_done": "인식 완료, 총 %d개의 상품을 인식했습니다",
     "autostockpile.no_qualifying_product": "조건에 맞는 상품을 찾지 못했습니다 (%s)",
     "autostockpile.hit_but_skip": "상품이 일치했지만 최종적으로 구매하지 않습니다 (%s)",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -17,6 +17,8 @@
     "autosell.check_item_price_massive": "检查物资 %s 价格，该物资价格变动极大",
     "autosell.check_item_price_unknown": "检查物资 %s 价格，该物资价格变动未知",
     "autosell.scan_item_owned": "拥有弹性需求物资：%s",
+    "autosell.sell_success": "物资 %s 售卖成功",
+    "autosell.try_next_friend": "物资 %s：当前好友无货，尝试第 %d 位好友",
     "autostockpile.recognition_done": "识别完成，共识别到 %d 个商品",
     "autostockpile.no_qualifying_product": "未找到符合条件的商品 (%s)",
     "autostockpile.hit_but_skip": "已命中商品，但最终不购买（%s）",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -17,6 +17,8 @@
     "autosell.check_item_price_massive": "檢查物資 %s 價格，該物資價格變動極大",
     "autosell.check_item_price_unknown": "檢查物資 %s 價格，該物資價格變動未知",
     "autosell.scan_item_owned": "擁有彈性需求物資：%s",
+    "autosell.sell_success": "物資 %s 售賣成功",
+    "autosell.try_next_friend": "物資 %s：目前好友無貨，嘗試第 %d 位好友",
     "autostockpile.recognition_done": "識別完成，共識別到 %d 個商品",
     "autostockpile.no_qualifying_product": "未找到符合條件的商品 (%s)",
     "autostockpile.hit_but_skip": "已命中商品，但最終不購買（%s）",

--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -156,6 +156,7 @@
     },
     "AutoSellStockRedistributionItemOpenPrepareFriendsFailedToValleyIV": {
         "desc": "当前在好友界面，回到地区建设界面，切换地区到四号谷地",
+        "max_hit": 1,
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "SubTask",
@@ -176,6 +177,7 @@
     },
     "AutoSellStockRedistributionItemOpenPrepareFriendsFailedToWuling": {
         "desc": "当前在好友界面，回到地区建设界面，切换地区到武陵",
+        "max_hit": 1,
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "SubTask",


### PR DESCRIPTION
通过设置max_hit:1，来实现每个好友只查看一次，防止RunTask死循环

## Summary by Sourcery

通过为每个好友限制尝试次数并在有界的候选集合中迭代，防止 AutoSell 好友遍历发生无限循环。

Bug Fixes:
- 通过对好友命中次数和尝试次数设定上限，防止在为弹性商品寻找可出售好友时，AutoSell 的库存再分配进入 RunTask 循环。

Enhancements:
- 在 AutoSell 中为逐个好友的重试流程添加有界逻辑，并在寻找可出售物品时加入带上下文的日志和聚焦提示信息。
- 更新本地化条目和 AutoSell 物品流水线定义，以支持新的好友遍历和消息行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent AutoSell friend traversal from looping indefinitely by limiting attempts per friend and iterating through a bounded set of candidates.

Bug Fixes:
- Stop AutoSell stock redistribution from entering a RunTask loop when searching friends for elastic goods to sell by capping friend hits and attempts.

Enhancements:
- Add bounded friend-by-friend retry logic with contextual logging and focus messages when searching for a sellable item in AutoSell.
- Update localization entries and AutoSell item pipeline definitions to support the new friend traversal and messaging behavior.

</details>