### PR TITLE
fix: 修复售卖弹性物资查找好友循环问题

### DIFF
--- a/assets/resource/pipeline/AutoSell/Recognition.json
+++ b/assets/resource/pipeline/AutoSell/Recognition.json
@@ -12,7 +12,7 @@
             "AutoSell/SellTicketItemValleyIV.png",
             "AutoSell/SellTicketItemWuling.png"
         ],
-        "threshold": 0.9
+        "threshold": 0.8
     },
     "AutoSellStockRedistributionItemNameAreaRecognition": {
         "desc": "识别物资调度界面中的item",


### PR DESCRIPTION
close #3083
close #3098
## Summary by Sourcery

Bug Fixes:
- 通过调整识别管线（Recognition pipeline）的配置，修复在自动出售弹性物品时搜索好友会进入无限循环的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve an infinite loop when searching friends during auto-selling of elastic items by adjusting the Recognition pipeline configuration.

</details>