### PR TITLE
fix(MapLocator): 使用更好的 dual 策略 fallback 处理

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -1019,6 +1019,9 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
     if (options.force_global_search) {
         return std::nullopt;
     }
+    if (!motionTracker) {
+        return std::nullopt;
+    }
 
     refreshAsyncYoloState(minimap, now);
 
@@ -1055,6 +1058,7 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
         auto fallbackTmpl = fallbackStrategy->extractTemplateFeature(minimap);
 
         MapPosition rawFallbackPos {};
+        // fallback 只作为 dual 互证的第二路信号；试算后立即恢复状态，避免两策略不一致时单独推进或 hold tracker
         auto savedMotionTracker = *motionTracker;
         const auto savedStablePosition = stablePosition;
         tryTracking(fallbackTmpl, fallbackStrategy.get(), now, options, &rawFallbackPos);

--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -1040,23 +1040,26 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
     auto trackingResult = tryTracking(trackingTmpl, primaryStrategy.get(), now, options, &rawPrimaryPos);
     const bool trackingHeld = trackingResult.has_value() && trackingResult->isHeld;
 
-    if (trackingResult) {
+    if (trackingResult && !trackingHeld) {
         return LocateResult {
             .status = LocateStatus::Success,
             .position = trackingResult,
-            .debugMessage = trackingHeld ? "Tracking Hold" : "Tracking Success",
+            .debugMessage = "Tracking Success",
         };
     }
 
-    const bool shouldTryDualTracking = !isPathHeatmapZone && rawPrimaryPos.score > 0.1 && !trackingResult;
+    const bool shouldTryDualTracking = !isPathHeatmapZone && rawPrimaryPos.score > 0.1 && (!trackingResult || trackingHeld);
     if (shouldTryDualTracking) {
         auto fallbackStrategy =
             MatchStrategyFactory::create(currentZoneId, trackingCfg, matchCfg, baseImgCfg, tierImgCfg, MatchMode::ForcePathHeatmap);
         auto fallbackTmpl = fallbackStrategy->extractTemplateFeature(minimap);
 
         MapPosition rawFallbackPos {};
-        auto fallbackResult = tryTracking(fallbackTmpl, fallbackStrategy.get(), now, options, &rawFallbackPos);
-        const bool fallbackHeld = fallbackResult.has_value() && fallbackResult->isHeld;
+        auto savedMotionTracker = *motionTracker;
+        const auto savedStablePosition = stablePosition;
+        tryTracking(fallbackTmpl, fallbackStrategy.get(), now, options, &rawFallbackPos);
+        *motionTracker = savedMotionTracker;
+        stablePosition = savedStablePosition;
         const double dist = std::hypot(rawPrimaryPos.x - rawFallbackPos.x, rawPrimaryPos.y - rawFallbackPos.y);
 
         // 双策略互证：两者分数均需满足最低要求，且坐标差在容差内，才视为结果可信
@@ -1073,14 +1076,15 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
                 .debugMessage = "Dual-Mode Tracking Success",
             };
         }
-
-        if (fallbackResult && !fallbackHeld) {
-            LogInfo << "Dual-Mode Tracking: accepted fallback strategy result independently. Dist was " << dist;
-            return LocateResult { .status = LocateStatus::Success, .position = fallbackResult, .debugMessage = "Tracking Success" };
-        }
+        LogInfo << "Dual-Mode Tracking rejected" << VAR(rawPrimaryPos.score) << VAR(rawPrimaryPos.x) << VAR(rawPrimaryPos.y)
+                << VAR(rawFallbackPos.score) << VAR(rawFallbackPos.x) << VAR(rawFallbackPos.y) << VAR(dist);
     }
 
-    return std::nullopt;
+    if (!trackingHeld) {
+        return std::nullopt;
+    }
+
+    return LocateResult { .status = LocateStatus::Success, .position = trackingResult, .debugMessage = "Tracking Hold" };
 }
 
 SearchConstraint MapLocator::Impl::buildSearchConstraint(


### PR DESCRIPTION
## 由 Sourcery 提供的总结

调整 `MapLocator` 中的追踪与双策略回退逻辑，更加保守地接受回退结果，并在双模式检查过程中保留追踪器状态。

Bug 修复：
- 确保仅在追踪结果未被“保持”（non-held）的情况下才返回主追踪成功状态，并在调试信息中正确报告。
- 在运行双策略校验时，通过保存并恢复运动追踪器和稳定位置的状态，避免对其进行修改。
- 当双策略校验失败时，不再单独接受回退追踪结果，而是仅将其用于交叉验证和日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tracking and dual-strategy fallback logic in MapLocator to more conservatively accept fallback results and preserve tracker state during dual-mode checks.

Bug Fixes:
- Ensure primary tracking success is only returned for non-held tracking results and correctly reported in debug messages.
- Avoid mutating motion tracker and stable position when running dual-strategy verification by saving and restoring their state.
- Stop independently accepting fallback tracking results when dual-strategy verification fails, instead only using them for cross-validation and logging.

</details>