### PR TITLE
ci: 添加 check-submodule 工作流

### DIFF
--- a/.github/workflows/check-submodule.yml
+++ b/.github/workflows/check-submodule.yml
@@ -1,0 +1,86 @@
+name: check-submodule
+
+on:
+  push:
+    branches:
+      - "v2"
+    paths:
+      - "agent/cpp-algo/MaaUtils"
+      - "assets/resource/model"
+      - "tests/MaaEndTestset"
+
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - "agent/cpp-algo/MaaUtils"
+      - "assets/resource/model"
+      - "tests/MaaEndTestset"
+
+  workflow_dispatch:
+
+jobs:
+  check-submodule:
+    runs-on: ubuntu-latest
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PUSH_COMMIT_MSG: ${{ github.event.head_commit.message }}
+      PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PUSH_BEFORE: ${{ github.event.before }}
+      PUSH_AFTER: ${{ github.event.after }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate submodule update naming
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE="$PR_BASE_SHA"
+            HEAD_SHA="$PR_HEAD_SHA"
+            TITLE="$PR_TITLE"
+            SOURCE="PR title"
+          else
+            BASE="$PUSH_BEFORE"
+            HEAD_SHA="$PUSH_AFTER"
+            TITLE="$PUSH_COMMIT_MSG"
+            SOURCE="commit title"
+          fi
+
+          # Skip if base is all zeros (e.g. new branch with no prior commits)
+          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "::notice::New branch, skipping submodule check"
+            exit 0
+          fi
+
+          echo "Diff range: $BASE .. $HEAD_SHA"
+
+          SUBMODULE_PATHS=$(git config --file .gitmodules --get-regexp path | awk '{print $2}')
+          echo "Registered submodules:"
+          echo "$SUBMODULE_PATHS"
+
+          CHANGED_FILES=$(git diff --name-only "$BASE" "$HEAD_SHA")
+
+          HAS_CHANGE=0
+          for path in $SUBMODULE_PATHS; do
+            if echo "$CHANGED_FILES" | grep -Fxq "$path"; then
+              echo "Submodule updated: $path"
+              HAS_CHANGE=1
+            fi
+          done
+
+          if [ "$HAS_CHANGE" -eq 0 ]; then
+            echo "No submodule changes detected, check passed."
+            exit 0
+          fi
+
+          echo "Checking $SOURCE: $TITLE"
+
+          if echo "$TITLE" | grep -qiE "(submodule|子模块)"; then
+            echo "::notice::$SOURCE contains 'submodule' or '子模块', check passed."
+          else
+            echo "::error::Submodule updated but $SOURCE does not contain 'submodule' or '子模块'. Please include the keyword in the title."
+            exit 1
+          fi

--- a/.github/workflows/check-submodule.yml
+++ b/.github/workflows/check-submodule.yml
@@ -25,7 +25,6 @@ jobs:
     env:
       EVENT_NAME: ${{ github.event_name }}
       PR_TITLE: ${{ github.event.pull_request.title }}
-      PUSH_COMMIT_MSG: ${{ github.event.head_commit.message }}
       PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PUSH_BEFORE: ${{ github.event.before }}
@@ -37,6 +36,11 @@ jobs:
 
       - name: Validate submodule update naming
         run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "::notice::Manual trigger, skipping submodule check"
+            exit 0
+          fi
+
           if [ "$EVENT_NAME" = "pull_request" ]; then
             BASE="$PR_BASE_SHA"
             HEAD_SHA="$PR_HEAD_SHA"
@@ -45,8 +49,8 @@ jobs:
           else
             BASE="$PUSH_BEFORE"
             HEAD_SHA="$PUSH_AFTER"
-            TITLE="$PUSH_COMMIT_MSG"
-            SOURCE="commit title"
+            TITLE=$(git log --format="%s" "$BASE..$HEAD_SHA")
+            SOURCE="commit titles"
           fi
 
           # Skip if base is all zeros (e.g. new branch with no prior commits)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,11 +7,10 @@ on:
     paths:
       - ".github/workflows/check.yml"
       - "assets/**"
+      - "!assets/resource/model"
       - "tools/schema/**"
       - "package.json"
       - "maatools.config.mts"
-    paths-ignore:
-      - "assets/resource/model"
 
   pull_request:
     branches:
@@ -19,11 +18,10 @@ on:
     paths:
       - ".github/workflows/check.yml"
       - "assets/**"
+      - "!assets/resource/model"
       - "tools/schema/**"
       - "package.json"
       - "maatools.config.mts"
-    paths-ignore:
-      - "assets/resource/model"
 
   workflow_dispatch:
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,8 @@ on:
       - "tools/schema/**"
       - "package.json"
       - "maatools.config.mts"
+    paths-ignore:
+      - "assets/resource/model"
 
   pull_request:
     branches:
@@ -20,6 +22,8 @@ on:
       - "tools/schema/**"
       - "package.json"
       - "maatools.config.mts"
+    paths-ignore:
+      - "assets/resource/model"
 
   workflow_dispatch:
 


### PR DESCRIPTION
## 正文

引入一个 check-submodule 工作流,子模块更新时检查标题含不含有(submodule|子模块)

## ci 运行记录

https://github.com/MaaEnd/MaaEnd/actions/runs/26288736971/job/77382964236?pr=3102
https://github.com/MaaEnd/MaaEnd/actions/runs/26288479996/job/77382234756?pr=3102

## 由 Sourcery 提供的总结

添加专门的 CI 工作流，用于验证与子模块相关的更改，并确保它们的提交或 PR 标题包含适当的关键词。

CI：
- 在现有的检查工作流触发条件中排除模型资源路径。
- 引入一个 check-submodule 工作流，当特定子模块或资源路径发生更改时，在相关分支上运行，并强制检查标题中是否包含子模块相关关键词。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a dedicated CI workflow to validate submodule-related changes and ensure their commit or PR titles include appropriate keywords.

CI:
- Exclude model asset path from the existing check workflow triggers.
- Introduce a check-submodule workflow that runs on relevant branches when specific submodule or asset paths change and enforces submodule keyword presence in titles.

</details>

## Summary by Sourcery

引入专门的 CI 工作流，用于验证与子模块相关的更改，并调整现有检查，将模型资源从通用工作流触发条件中排除。

CI：
- 从通用检查工作流的触发路径中排除模型资源路径，使其更改不再运行主检查工作流。
- 新增 `check-submodule` 工作流，在特定的子模块和资源路径发生变化时触发，并强制在提交或 PR 标题中包含与子模块相关的关键词。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated CI workflow to validate submodule-related changes and adjust existing checks to exclude model resources from the general workflow triggers.

CI:
- Exclude the model resource path from the general check workflow triggers so its changes no longer run the main check workflow.
- Add a check-submodule workflow that triggers on specific submodule and resource paths and enforces submodule-related keywords in commit or PR titles.

</details>

CI：
- 将模型资源路径从现有的一般检查工作流触发器中排除，这样对此路径的更改将不再运行主检查。
- 引入一个 `check-submodule` 工作流，当推送或拉取请求触及特定子模块或资源路径时触发，并验证其提交或 PR 标题中是否包含与子模块相关的关键词。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入专门的 CI 工作流，用于验证与子模块相关的更改，并调整现有检查，将模型资源从通用工作流触发条件中排除。

CI：
- 从通用检查工作流的触发路径中排除模型资源路径，使其更改不再运行主检查工作流。
- 新增 `check-submodule` 工作流，在特定的子模块和资源路径发生变化时触发，并强制在提交或 PR 标题中包含与子模块相关的关键词。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated CI workflow to validate submodule-related changes and adjust existing checks to exclude model resources from the general workflow triggers.

CI:
- Exclude the model resource path from the general check workflow triggers so its changes no longer run the main check workflow.
- Add a check-submodule workflow that triggers on specific submodule and resource paths and enforces submodule-related keywords in commit or PR titles.

</details>

</details>

CI：
- 将模型资源路径从现有的检查工作流触发条件中排除，这样在这些路径变更时将不再运行通用检查。
- 引入一个 `check-submodule` 工作流：当特定子模块或资源路径在相关分支上发生变更时触发，并验证提交或 PR 标题中是否包含与子模块相关的关键词。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入专门的 CI 工作流，用于验证与子模块相关的更改，并调整现有检查，将模型资源从通用工作流触发条件中排除。

CI：
- 从通用检查工作流的触发路径中排除模型资源路径，使其更改不再运行主检查工作流。
- 新增 `check-submodule` 工作流，在特定的子模块和资源路径发生变化时触发，并强制在提交或 PR 标题中包含与子模块相关的关键词。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated CI workflow to validate submodule-related changes and adjust existing checks to exclude model resources from the general workflow triggers.

CI:
- Exclude the model resource path from the general check workflow triggers so its changes no longer run the main check workflow.
- Add a check-submodule workflow that triggers on specific submodule and resource paths and enforces submodule-related keywords in commit or PR titles.

</details>

CI：
- 将模型资源路径从现有的一般检查工作流触发器中排除，这样对此路径的更改将不再运行主检查。
- 引入一个 `check-submodule` 工作流，当推送或拉取请求触及特定子模块或资源路径时触发，并验证其提交或 PR 标题中是否包含与子模块相关的关键词。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入专门的 CI 工作流，用于验证与子模块相关的更改，并调整现有检查，将模型资源从通用工作流触发条件中排除。

CI：
- 从通用检查工作流的触发路径中排除模型资源路径，使其更改不再运行主检查工作流。
- 新增 `check-submodule` 工作流，在特定的子模块和资源路径发生变化时触发，并强制在提交或 PR 标题中包含与子模块相关的关键词。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated CI workflow to validate submodule-related changes and adjust existing checks to exclude model resources from the general workflow triggers.

CI:
- Exclude the model resource path from the general check workflow triggers so its changes no longer run the main check workflow.
- Add a check-submodule workflow that triggers on specific submodule and resource paths and enforces submodule-related keywords in commit or PR titles.

</details>

</details>

</details>