### PR TITLE
fix(MapLocator): 修复Assert在冷启动状态误判失败

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <string_view>
@@ -299,7 +300,7 @@ bool TryLocateOnMinimap(
 
     const MaaImageBuffer* actual_image = image;
     ScopedImageBuffer captured_image;
-    if (MaaImageBufferIsEmpty(actual_image)) {
+    if (actual_image == nullptr || MaaImageBufferIsEmpty(actual_image)) {
         auto controller = MaaTaskerGetController(MaaContextGetTasker(context));
         const MaaCtrlId screencap_id = MaaControllerPostScreencap(controller);
         MaaControllerWait(controller, screencap_id);
@@ -310,7 +311,7 @@ bool TryLocateOnMinimap(
         actual_image = captured_image.Get();
     }
 
-    if (MaaImageBufferIsEmpty(actual_image)) {
+    if (actual_image == nullptr || MaaImageBufferIsEmpty(actual_image)) {
         LogError << "MapLocateRecognition: Image buffer is empty";
         return false;
     }
@@ -423,9 +424,22 @@ MaaBool MAA_CALL MapLocateAssertLocationRun(
         return MAA_FALSE;
     }
 
+    const LocateOptions options = BuildAssertLocateOptions(param);
     LocateResult result;
-    if (!TryLocateOnMinimap(context, image, BuildAssertLocateOptions(param), &result)) {
-        return MAA_FALSE;
+    constexpr auto cold_start_retry_delay = std::chrono::milliseconds(300);
+    for (int attempt = 0; attempt < kColdStartConsensusFrames; ++attempt) {
+        const MaaImageBuffer* attempt_image = attempt == 0 ? image : nullptr;
+        if (!TryLocateOnMinimap(context, attempt_image, options, &result)) {
+            return MAA_FALSE;
+        }
+        const bool is_cold_start_collecting =
+            result.status == LocateStatus::TrackingLost && result.debugMessage == "Cold-start collecting.";
+        if (!is_cold_start_collecting || attempt + 1 >= kColdStartConsensusFrames) {
+            break;
+        }
+
+        LogInfo << "MapLocateAssertLocation cold-start pending" << VAR(attempt) << VAR(param.zone_id);
+        std::this_thread::sleep_for(cold_start_retry_delay);
     }
 
     const bool matched = result.status == LocateStatus::Success && result.position.has_value()

--- a/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
@@ -428,12 +428,13 @@ MaaBool MAA_CALL MapLocateAssertLocationRun(
     LocateResult result;
     constexpr auto cold_start_retry_delay = std::chrono::milliseconds(300);
     for (int attempt = 0; attempt < kColdStartConsensusFrames; ++attempt) {
+        // Cold-start consensus needs distinct frames; reuse would only confirm the same screenshot.
         const MaaImageBuffer* attempt_image = attempt == 0 ? image : nullptr;
         if (!TryLocateOnMinimap(context, attempt_image, options, &result)) {
             return MAA_FALSE;
         }
         const bool is_cold_start_collecting =
-            result.status == LocateStatus::TrackingLost && result.debugMessage == "Cold-start collecting.";
+            result.status == LocateStatus::TrackingLost && result.debugMessage == kColdStartCollectingMessage;
         if (!is_cold_start_collecting || attempt + 1 >= kColdStartConsensusFrames) {
             break;
         }

--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -1344,7 +1344,7 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
         if (!IsTightCluster(coldStartBuffer, kPositionConsensusRadius)) {
             LogInfo << "Cold-start: collecting." << VAR(coldStartBuffer.size()) << VAR(globalResult->x) << VAR(globalResult->y)
                     << VAR(globalResult->score);
-            return LocateResult { .status = LocateStatus::TrackingLost, .debugMessage = "Cold-start collecting." };
+            return LocateResult { .status = LocateStatus::TrackingLost, .debugMessage = kColdStartCollectingMessage };
         }
         LogInfo << "Cold-start: consensus." << VAR(globalResult->x) << VAR(globalResult->y) << VAR(globalResult->score);
     }

--- a/agent/cpp-algo/source/MapLocator/MapTypes.h
+++ b/agent/cpp-algo/source/MapLocator/MapTypes.h
@@ -153,9 +153,11 @@ constexpr double MobileSearchRadius = 50.0;
 
 // global 跨帧跳变保护 + 冷启动 burn-in
 constexpr int kColdStartConsensusFrames = 3;      // 冷启动需要的一致帧数
+static_assert(kColdStartConsensusFrames >= 1, "Cold-start consensus needs at least one frame.");
 constexpr double kPositionConsensusRadius = 12.0; // 近点判定半径
 constexpr double kFarJumpRejectDistance = 80.0;   // global 跨帧跳变阈值
 constexpr double kHighConfidenceOverride = 0.85;  // 压倒分：远跳但此分以上直接 reseed
+constexpr const char* kColdStartCollectingMessage = "Cold-start collecting.";
 
 // tracking 窄带多尺度搜索参数。第一项必须为 0.0（即 baseScale），
 // 循环时 baseScale 先跑，达到 kFastTrackingPassScore 则跳过后续尺度


### PR DESCRIPTION
## Summary by Sourcery

在冷启动小地图追踪过程中，提高地图位置断言的健壮性。

错误修复（Bug Fixes）:
- 处理在捕获小地图截图时出现的空图像缓冲区，以避免在冷启动时产生错误的断言失败和崩溃。

增强（Enhancements）:
- 在冷启动数据采集期间，对小地图位置断言在多个帧上进行重试，并加入短暂延时，以减少误检。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve map location assertion robustness during cold-start minimap tracking.

Bug Fixes:
- Handle null image buffers when capturing minimap screenshots to avoid false assertion failures and crashes on cold start.

Enhancements:
- Retry minimap location assertions across multiple frames during cold-start collection with small delays to reduce mis-detections.

</details>