### PR TITLE
fix: 修复传送时点到当前区域信息

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneTeleportValleyIV.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportValleyIV.json
@@ -391,7 +391,7 @@
             100,
             100,
             1080,
-            520
+            420
         ],
         "template": [
             "SceneManager/ValleyIV/OriginiumSciencePark3Top.png"
@@ -523,7 +523,7 @@
             100,
             100,
             1080,
-            520
+            420
         ],
         "template": [
             "SceneManager/ValleyIV/OriginiumSciencePark4Top.png"
@@ -787,7 +787,7 @@
             100,
             100,
             1080,
-            520
+            420
         ],
         "template": [
             "SceneManager/ValleyIV/OriginLodespring1Top.png"
@@ -1084,7 +1084,7 @@
             100,
             100,
             1080,
-            520
+            420
         ],
         "template": [
             "SceneManager/ValleyIV/OriginLodespring4Top.png"
@@ -1282,7 +1282,7 @@
             100,
             100,
             1080,
-            520
+            420
         ],
         "template": [
             "SceneManager/ValleyIV/PowerPlateau1Top.png"
@@ -1381,7 +1381,7 @@
             100,
             100,
             1080,
-            520
+            420
         ],
         "template": [
             "SceneManager/ValleyIV/PowerPlateau2Top.png"
@@ -1480,7 +1480,7 @@
             100,
             100,
             1080,
-            520
+            420
         ],
         "template": [
             "SceneManager/ValleyIV/PowerPlateau3Top.png"

--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -428,7 +428,7 @@
             100,
             100,
             1080,
-            520
+            420
         ],
         "template": [
             "SceneManager/MapWuling/JingyuValley4Top.png",
@@ -1204,7 +1204,7 @@
             100,
             100,
             1080,
-            520
+            420
         ],
         "template": [
             "SceneManager/MapWuling/MarkerStone4Top.png",
@@ -1242,7 +1242,7 @@
                     100,
                     100,
                     1080,
-                    520
+                    420
                 ],
                 "template": [
                     "SceneManager/MapWuling/MarkerStoneCoreTop.png"


### PR DESCRIPTION
close #3069
close #3055

## Summary by Sourcery

修复场景传送配置，使特定区域内的传送会跳转到正确的地区信息。

错误修复：
- 更正 Valley IV 区域的场景传送目标。
- 更正 Wuling 区域的场景传送目标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix scene teleport configuration so teleportation in specific areas routes to the correct region information.

Bug Fixes:
- Correct scene teleport targets for the Valley IV area.
- Correct scene teleport targets for the Wuling area.

</details>