### PR TITLE
fix(map): MapTrackerBigMapPick 鲁棒性优化

### DIFF
--- a/agent/go-service/maptracker/bigmap/pick.go
+++ b/agent/go-service/maptracker/bigmap/pick.go
@@ -248,70 +248,91 @@ func (a *MapTrackerBigMapPick) doAutoZoom(ctx *maa.Context, ctrl *maa.Controller
 		return fmt.Errorf("failed to load zoom-out template: %w", err)
 	}
 
-	ctrl.PostScreencap().Wait()
-	img, err := ctrl.CacheImage()
-	if err != nil {
-		return fmt.Errorf("failed to get cached image for auto zoom: %w", err)
-	}
-	if img == nil {
-		return fmt.Errorf("cached image is nil for auto zoom")
-	}
+	const zoomLevelTarget = 0.7
+	triedAgain := false
+	for {
+		ctrl.PostScreencap().Wait()
+		img, err := ctrl.CacheImage()
+		if err != nil {
+			return fmt.Errorf("failed to get cached image for auto zoom: %w", err)
+		}
+		if img == nil {
+			return fmt.Errorf("cached image is nil for auto zoom")
+		}
 
-	screen := minicv.ImageConvertRGBA(img)
-	searchArea := [4]int{
-		int(math.Round(ZOOM_BUTTON_AREA_X)),
-		int(math.Round(ZOOM_BUTTON_AREA_Y)),
-		int(math.Round(ZOOM_BUTTON_AREA_W)),
-		int(math.Round(ZOOM_BUTTON_AREA_H)),
-	}
-	screenIntegral := minicv.GetIntegralArray(screen)
+		screen := minicv.ImageConvertRGBA(img)
+		searchArea := [4]int{
+			int(math.Round(ZOOM_BUTTON_AREA_X)),
+			int(math.Round(ZOOM_BUTTON_AREA_Y)),
+			int(math.Round(ZOOM_BUTTON_AREA_W)),
+			int(math.Round(ZOOM_BUTTON_AREA_H)),
+		}
+		screenIntegral := minicv.GetIntegralArray(screen)
 
-	zoomOutX, zoomOutY, outVal := minicv.MatchTemplateInArea(
-		screen,
-		screenIntegral,
-		zoomOutTemplate.Image,
-		zoomOutTemplate.Stats,
-		searchArea,
-	)
-	zoomInX, zoomInY, inVal := minicv.MatchTemplateInArea(
-		screen,
-		screenIntegral,
-		zoomInTemplate.Image,
-		zoomInTemplate.Stats,
-		searchArea,
-	)
+		zoomOutX, zoomOutY, outVal := minicv.MatchTemplateInArea(
+			screen,
+			screenIntegral,
+			zoomOutTemplate.Image,
+			zoomOutTemplate.Stats,
+			searchArea,
+		)
+		zoomInX, zoomInY, inVal := minicv.MatchTemplateInArea(
+			screen,
+			screenIntegral,
+			zoomInTemplate.Image,
+			zoomInTemplate.Stats,
+			searchArea,
+		)
 
-	outMatched := outVal >= ZOOM_BUTTON_THRESHOLD
-	inMatched := inVal >= ZOOM_BUTTON_THRESHOLD
+		outMatched := outVal >= ZOOM_BUTTON_THRESHOLD
+		inMatched := inVal >= ZOOM_BUTTON_THRESHOLD
 
-	if outMatched && inMatched {
-		cx := int(math.Round((zoomOutX + zoomInX) / 2.0))
-		cy := int(math.Round(zoomInY + (zoomOutY-zoomInY)*0.7))
-		ca.TouchClick(0, cx, cy, 100, 0)
-		time.Sleep(333 * time.Millisecond) // Wait for UI response
-		log.Info().Float64("outVal", outVal).Float64("inVal", inVal).Msg("Auto zoom adjusted by clicking slider area")
-		return nil
-	}
-	if !outMatched && !inMatched {
-		log.Warn().Float64("outVal", outVal).Float64("inVal", inVal).Msg("No zoom button matched for auto zoom")
-		return nil
-	}
+		if outMatched && inMatched {
+			// Good case: both zoom-out and zoom-in buttons are detected, likely showing the zoom slider,
+			// we can click the slider area to adjust zoom level precisely.
+			cx := int(math.Round((zoomOutX + zoomInX) / 2.0))
+			cy := int(math.Round(zoomInY + (zoomOutY-zoomInY)*zoomLevelTarget))
+			ca.TouchClick(0, cx, cy, 100, 250)
+			time.Sleep(250 * time.Millisecond) // Wait for UI response
 
-	pressZoomButton := func(matchX, matchY float64, tpl *image.RGBA) {
-		cx := int(math.Round(matchX + float64(tpl.Rect.Dx())/2.0))
-		cy := int(math.Round(matchY + float64(tpl.Rect.Dy())/2.0))
-		ca.TouchClick(0, cx, cy, 200, 0)
-		time.Sleep(333 * time.Millisecond) // Wait for UI response
-	}
+			log.Info().Float64("outVal", outVal).Float64("inVal", inVal).Msg("Auto zoom adjusted by clicking slider area")
+			return nil // Finished auto zoom
 
-	if outMatched {
-		pressZoomButton(zoomOutX, zoomOutY, zoomOutTemplate.Image)
-		log.Info().Float64("outVal", outVal).Float64("inVal", inVal).Msg("Auto zoom adjusted by pressing zoom-out button")
-	} else {
-		pressZoomButton(zoomInX, zoomInY, zoomInTemplate.Image)
-		log.Info().Float64("outVal", outVal).Float64("inVal", inVal).Msg("Auto zoom adjusted by pressing zoom-in button")
+		} else if !outMatched && !inMatched {
+			// Worst case: neither zoom-out nor zoom-in button is detected,
+			// just skip auto zoom to avoid wrong operation.
+			log.Warn().Float64("outVal", outVal).Float64("inVal", inVal).Msg("No zoom button matched for auto zoom")
+			return nil // Skipped auto zoom
+
+		} else {
+			// Not good case: only one of the two buttons is detected, due to the current zoom level hit the limit,
+			// we can press the detected button to adjust zoom blindly, then start another round of detection.
+
+			pressZoomButton := func(matchX, matchY float64, tpl *image.RGBA) {
+				cx := int(math.Round(matchX + float64(tpl.Rect.Dx())/2.0))
+				cy := int(math.Round(matchY + float64(tpl.Rect.Dy())/2.0))
+				ca.TouchClick(0, cx, cy, 100, 250)
+				ctrl.PostTouchMove(0, 1, 1, 0).Wait() // Move mouse to the corner to avoid blocking the button
+				time.Sleep(250 * time.Millisecond)    // Wait for UI response
+			}
+
+			if outMatched {
+				pressZoomButton(zoomOutX, zoomOutY, zoomOutTemplate.Image)
+				log.Info().Float64("outVal", outVal).Float64("inVal", inVal).Msg("Auto zoom adjusted by pressing zoom-out button")
+			} else {
+				pressZoomButton(zoomInX, zoomInY, zoomInTemplate.Image)
+				log.Info().Float64("outVal", outVal).Float64("inVal", inVal).Msg("Auto zoom adjusted by pressing zoom-in button")
+			}
+
+			if triedAgain {
+				log.Warn().Float64("outVal", outVal).Float64("inVal", inVal).Msg("Still only one button appeared, giving up auto zoom")
+				return nil // Avoid infinite loop, give up after trying again
+			} else {
+				triedAgain = true
+				continue
+			}
+		}
 	}
-	return nil
 }
 
 func doBigMapInferForMap(ctx *maa.Context, ctrl *maa.Controller, mapName string) (*MapTrackerBigMapInferResult, error) {


### PR DESCRIPTION
## 概要

此 PR 针对 MapTrackerBigMapPick 节点的拖拽地图动作进行了鲁棒性优化。主要是采用了二阶段缩放倍率调整的方案，使得地图的缩放倍率更可控。此外延长了缩放地图后的等待时间，以确保 UI 更新完成。

## 关联

修复两个相关问题。

Fix #3023 
Fix #3057 

## Summary by Sourcery

通过引入两阶段缩放调整机制，并在无法可靠检测缩放控件时提供更安全的回退方案，提升 MapTracker 大地图自动缩放逻辑的鲁棒性。

增强内容：
- 优化自动缩放行为：当检测到两个缩放按钮时，优先使用滑块式缩放调整；当两个按钮都不可见时则跳过缩放。
- 新增重试循环：在只检测到一个缩放按钮时，点击该可见的缩放按钮一次以从缩放上/下限状态中恢复，然后重新检测控件，并加入保护机制以避免无限重试。
- 调整自动缩放过程中的点击时机、等待间隔和指针移动，以减少对缩放控件的 UI 干扰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness of the MapTracker big map auto-zoom logic by introducing a two-phase zoom adjustment with safer fallbacks when zoom controls are not reliably detected.

Enhancements:
- Refine auto-zoom behavior to preferentially use slider-based zoom adjustment when both zoom buttons are detected and to skip zoom when neither button is visible.
- Add a retry loop that presses the single visible zoom button once to recover from zoom-limit states, then re-detects controls with safeguards to avoid infinite retries.
- Tune click timing, waiting intervals, and pointer movement during auto-zoom to reduce UI interference with zoom controls.

</details>