### PR TITLE
perf(MapNavigator): 优化 navmesh 规划响应速度

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -71,8 +71,9 @@ bool StartsWith(std::string_view text, std::string_view prefix)
 
 bool IsBaseNavZoneName(std::string_view zone_id)
 {
-    return std::any_of(kBaseNavZoneAliases.begin(), kBaseNavZoneAliases.end(),
-                       [zone_id](const BaseNavZoneAlias& alias) { return alias.zone_id == zone_id; });
+    return std::any_of(kBaseNavZoneAliases.begin(), kBaseNavZoneAliases.end(), [zone_id](const BaseNavZoneAlias& alias) {
+        return alias.zone_id == zone_id;
+    });
 }
 
 std::string InferBaseNavZone(const std::string& locator_zone, const std::string& map_name)
@@ -82,8 +83,9 @@ std::string InferBaseNavZone(const std::string& locator_zone, const std::string&
         return source;
     }
     for (const BaseNavZoneAlias& alias : kBaseNavZoneAliases) {
-        if (std::any_of(alias.prefixes.begin(), alias.prefixes.end(),
-                        [&source](std::string_view prefix) { return StartsWith(source, prefix); })) {
+        if (std::any_of(alias.prefixes.begin(), alias.prefixes.end(), [&source](std::string_view prefix) {
+                return StartsWith(source, prefix);
+            })) {
             return std::string(alias.zone_id);
         }
     }
@@ -125,7 +127,7 @@ std::filesystem::path ResolveNavmeshFile(const std::string& configured_path)
         return configured;
     }
 
-    for (const char* relative_path : { kDefaultCompressedNavmeshRelativePath, kDefaultNavmeshRelativePath }) {
+    for (const char* relative_path : { kDefaultNavmeshRelativePath, kDefaultCompressedNavmeshRelativePath }) {
         if (auto found = FindExistingFromParents(relative_path); found.has_value()) {
             return *found;
         }
@@ -133,20 +135,20 @@ std::filesystem::path ResolveNavmeshFile(const std::string& configured_path)
     return std::filesystem::path(kDefaultNavmeshRelativePath);
 }
 
-std::shared_ptr<CachedNavmesh> LoadCachedNavmesh(const std::filesystem::path& navmesh_path)
+std::shared_ptr<CachedNavmesh> LoadCachedNavmesh(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
 {
     static std::unordered_map<std::string, std::shared_ptr<CachedNavmesh>> cache;
     static std::mutex cache_mutex;
 
-    const std::string cache_key = std::filesystem::absolute(navmesh_path).lexically_normal().string();
+    const std::string cache_key = std::filesystem::absolute(navmesh_path).lexically_normal().string() + "#" + navmesh_zone;
     const std::lock_guard lock(cache_mutex);
     if (auto iter = cache.find(cache_key); iter != cache.end()) {
         return iter->second;
     }
 
-    const auto load_result = navmesh::LoadBaseNavPack(navmesh_path);
+    const auto load_result = navmesh::LoadBaseNavPack(navmesh_path, navmesh_zone);
     if (!load_result.ok()) {
-        LogError << "Failed to load navmesh .nav file." << VAR(navmesh_path) << VAR(load_result.message);
+        LogError << "Failed to load navmesh .nav file." << VAR(navmesh_path) << VAR(navmesh_zone) << VAR(load_result.message);
         return nullptr;
     }
     auto loaded = std::make_shared<CachedNavmesh>(std::move(*load_result.pack));
@@ -286,14 +288,14 @@ bool ExpandNavmeshWaypoints(const NaviParam& param, const NaviPosition& initial_
         return true;
     }
 
-    const std::filesystem::path navmesh_path = ResolveNavmeshFile(param.navmesh_file);
-    const auto navmesh = LoadCachedNavmesh(navmesh_path);
-    if (!navmesh) {
+    auto state = MakeExpansionState(param, initial_pos);
+    if (!state) {
         return false;
     }
 
-    auto state = MakeExpansionState(param, initial_pos);
-    if (!state) {
+    const std::filesystem::path navmesh_path = ResolveNavmeshFile(param.navmesh_file);
+    const auto navmesh = LoadCachedNavmesh(navmesh_path, state->navmesh_zone);
+    if (!navmesh) {
         return false;
     }
 

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
@@ -80,6 +80,8 @@ const char* ToString(BaseNavLoadStatus status)
         return "duplicate_zone";
     case BaseNavLoadStatus::HashMismatch:
         return "hash_mismatch";
+    case BaseNavLoadStatus::ZoneNotFound:
+        return "zone_not_found";
     }
     return "unknown";
 }

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.h
@@ -21,6 +21,7 @@ enum class BaseNavLoadStatus
     InvalidSize,
     DuplicateZone,
     HashMismatch,
+    ZoneNotFound,
 };
 
 struct BaseNavZone

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -6,7 +6,6 @@
 #include <limits>
 #include <queue>
 #include <tuple>
-#include <unordered_set>
 #include <utility>
 
 #include "BaseNavGeometry.h"
@@ -19,7 +18,6 @@ namespace navmesh
 namespace
 {
 
-constexpr double kIndexBinSize = 96.0;
 constexpr double kBridgeFixedCost = 12.0;
 constexpr double kBridgeGapCostFactor = 3.0;
 constexpr double kBridgeHeightCostFactor = 40.0;
@@ -38,19 +36,9 @@ struct QueueNode
 BaseNavPlanner::BaseNavPlanner(const BaseNavPack& pack)
     : pack_(pack)
     , triangle_zones_(pack.triangles().size(), 0)
-    , adjacency_(pack.triangles().size())
-    , triangle_bounds_(pack.triangles().size())
-    , triangle_heights_(pack.triangles().size(), 0.0)
+    , adjacency_offsets_(pack.triangles().size() + 1, 0)
 {
     buildIndex();
-}
-
-size_t BaseNavPlanner::BinKeyHash::operator()(const BinKey& key) const
-{
-    uint64_t value = static_cast<uint64_t>(key.zone_id);
-    value = value * 1'099'511'628'211ULL ^ static_cast<uint32_t>(key.x);
-    value = value * 1'099'511'628'211ULL ^ static_cast<uint32_t>(key.y);
-    return static_cast<size_t>(value);
 }
 
 void BaseNavPlanner::buildIndex()
@@ -61,33 +49,19 @@ void BaseNavPlanner::buildIndex()
             triangle_zones_[index] = zone.zone_id;
         }
     }
+    // BNAV stores links sorted by source, so the CSR adjacency can be built in one pass.
+    adjacency_links_.reserve(pack_.links().size());
+    size_t next_source = 0;
     for (const BaseNavLink& link : pack_.links()) {
-        if (link.source < adjacency_.size() && link.target < adjacency_.size()) {
-            adjacency_[link.source].push_back(link.target);
+        if (link.source < triangle_zones_.size() && link.target < triangle_zones_.size()) {
+            while (next_source <= link.source) {
+                adjacency_offsets_[next_source++] = static_cast<uint32_t>(adjacency_links_.size());
+            }
+            adjacency_links_.push_back(link.target);
         }
     }
-
-    for (uint32_t triangle_index = 0; triangle_index < pack_.triangles().size(); ++triangle_index) {
-        triangle_heights_[triangle_index] = triangleAverageHeight(triangle_index);
-        const uint16_t zone_id = triangle_zones_[triangle_index];
-        if (zone_id == 0) {
-            continue;
-        }
-        const auto points = trianglePoints(triangle_index);
-        const double left = std::min({ points[0].x, points[1].x, points[2].x });
-        const double right = std::max({ points[0].x, points[1].x, points[2].x });
-        const double top = std::min({ points[0].y, points[1].y, points[2].y });
-        const double bottom = std::max({ points[0].y, points[1].y, points[2].y });
-        triangle_bounds_[triangle_index] = { left, top, right, bottom };
-        const int32_t left_bin = static_cast<int32_t>(std::floor(left / kIndexBinSize));
-        const int32_t right_bin = static_cast<int32_t>(std::floor(right / kIndexBinSize));
-        const int32_t top_bin = static_cast<int32_t>(std::floor(top / kIndexBinSize));
-        const int32_t bottom_bin = static_cast<int32_t>(std::floor(bottom / kIndexBinSize));
-        for (int32_t bin_x = left_bin; bin_x <= right_bin; ++bin_x) {
-            for (int32_t bin_y = top_bin; bin_y <= bottom_bin; ++bin_y) {
-                bins_[BinKey { .zone_id = zone_id, .x = bin_x, .y = bin_y }].push_back(triangle_index);
-            }
-        }
+    while (next_source < adjacency_offsets_.size()) {
+        adjacency_offsets_[next_source++] = static_cast<uint32_t>(adjacency_links_.size());
     }
 }
 
@@ -147,7 +121,8 @@ BaseNavRouteResult BaseNavPlanner::findPath(const BaseNavRouteRequest& request) 
             return result;
         }
         closed[current] = 1;
-        for (uint32_t next : adjacency_[current]) {
+        for (uint32_t adjacency_index = adjacency_offsets_[current]; adjacency_index < adjacency_offsets_[current + 1]; ++adjacency_index) {
+            const uint32_t next = adjacency_links_[adjacency_index];
             if (next >= triangles.size() || triangle_zones_[next] != zone->zone_id) {
                 continue;
             }
@@ -171,13 +146,32 @@ BaseNavRouteResult BaseNavPlanner::findPath(const BaseNavRouteRequest& request) 
 
 std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const WorldPoint& point, double radius) const
 {
-    const auto candidates = candidateTriangles(zone_id, point, radius);
+    const BaseNavZone* zone = pack_.findZone(zone_id);
+    if (zone == nullptr) {
+        return std::nullopt;
+    }
+
     std::optional<BaseNavSnapResult> best;
-    for (uint32_t triangle_index : candidates) {
+    const uint32_t zone_end = zone->first_triangle + zone->triangle_count;
+    for (uint32_t triangle_index = zone->first_triangle; triangle_index < zone_end && triangle_index < pack_.triangles().size();
+         ++triangle_index) {
+        if (triangle_zones_[triangle_index] != zone_id) {
+            continue;
+        }
         const auto points = trianglePoints(triangle_index);
+        const double left = std::min({ points[0].x, points[1].x, points[2].x });
+        const double right = std::max({ points[0].x, points[1].x, points[2].x });
+        const double top = std::min({ points[0].y, points[1].y, points[2].y });
+        const double bottom = std::max({ points[0].y, points[1].y, points[2].y });
+        if (point.x < left - radius || point.x > right + radius || point.y < top - radius || point.y > bottom + radius) {
+            continue;
+        }
+        if (detail::PointInTriangle(point, points)) {
+            return BaseNavSnapResult { .triangle = triangle_index, .point = point, .distance = 0.0 };
+        }
         const WorldPoint snapped = detail::ClosestPointOnTriangle(point, points);
         const double distance = detail::Distance(snapped, point);
-        if (distance > radius && !detail::PointInTriangle(point, points)) {
+        if (distance > radius) {
             continue;
         }
         if (!best || distance < best->distance) {
@@ -185,42 +179,6 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
         }
     }
     return best;
-}
-
-std::vector<uint32_t> BaseNavPlanner::candidateTriangles(uint16_t zone_id, const WorldPoint& point, double radius) const
-{
-    const BaseNavZone* zone = pack_.findZone(zone_id);
-    if (zone == nullptr) {
-        return {};
-    }
-    std::vector<uint32_t> result;
-    std::unordered_set<uint32_t> seen;
-    const int32_t left_bin = static_cast<int32_t>(std::floor((point.x - radius) / kIndexBinSize));
-    const int32_t right_bin = static_cast<int32_t>(std::floor((point.x + radius) / kIndexBinSize));
-    const int32_t top_bin = static_cast<int32_t>(std::floor((point.y - radius) / kIndexBinSize));
-    const int32_t bottom_bin = static_cast<int32_t>(std::floor((point.y + radius) / kIndexBinSize));
-    for (int32_t bin_x = left_bin; bin_x <= right_bin; ++bin_x) {
-        for (int32_t bin_y = top_bin; bin_y <= bottom_bin; ++bin_y) {
-            const auto iter = bins_.find(BinKey { .zone_id = zone_id, .x = bin_x, .y = bin_y });
-            if (iter == bins_.end()) {
-                continue;
-            }
-            for (uint32_t triangle_index : iter->second) {
-                if (!seen.insert(triangle_index).second) {
-                    continue;
-                }
-                const auto& bounds = triangle_bounds_[triangle_index];
-                if (bounds[0] - radius <= point.x && point.x <= bounds[2] + radius && bounds[1] - radius <= point.y
-                    && point.y <= bounds[3] + radius) {
-                    result.push_back(triangle_index);
-                }
-            }
-        }
-    }
-    if (result.empty() && radius < kIndexBinSize) {
-        return candidateTriangles(zone_id, point, kIndexBinSize);
-    }
-    return result;
 }
 
 std::array<WorldPoint, 3> BaseNavPlanner::trianglePoints(uint32_t triangle_index) const
@@ -330,7 +288,7 @@ double BaseNavPlanner::transitionCost(uint32_t lhs, uint32_t rhs) const
         return detail::Distance(lhs_center, *midpoint) + detail::Distance(*midpoint, rhs_center);
     }
     const auto bridge_points = closestEdgeBridgePoints(lhs, rhs);
-    const double height_delta = std::abs(triangle_heights_[lhs] - triangle_heights_[rhs]);
+    const double height_delta = std::abs(triangleAverageHeight(lhs) - triangleAverageHeight(rhs));
     if (height_delta > kBridgeMaxHeightDelta) {
         return std::numeric_limits<double>::infinity();
     }

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -37,8 +37,10 @@ BaseNavPlanner::BaseNavPlanner(const BaseNavPack& pack)
     : pack_(pack)
     , triangle_zones_(pack.triangles().size(), 0)
     , adjacency_offsets_(pack.triangles().size() + 1, 0)
+    , triangle_heights_(pack.triangles().size(), 0.0)
 {
     buildIndex();
+    computeTriangleHeights();
 }
 
 void BaseNavPlanner::buildIndex()
@@ -49,29 +51,42 @@ void BaseNavPlanner::buildIndex()
             triangle_zones_[index] = zone.zone_id;
         }
     }
-    // BNAV stores links sorted by source, so the CSR adjacency can be built in one pass.
-    adjacency_links_.reserve(pack_.links().size());
-    size_t next_source = 0;
+    size_t valid_link_count = 0;
     for (const BaseNavLink& link : pack_.links()) {
         if (link.source < triangle_zones_.size() && link.target < triangle_zones_.size()) {
-            while (next_source <= link.source) {
-                adjacency_offsets_[next_source++] = static_cast<uint32_t>(adjacency_links_.size());
-            }
-            adjacency_links_.push_back(link.target);
+            ++adjacency_offsets_[link.source + 1];
+            ++valid_link_count;
         }
     }
-    while (next_source < adjacency_offsets_.size()) {
-        adjacency_offsets_[next_source++] = static_cast<uint32_t>(adjacency_links_.size());
+    for (size_t index = 1; index < adjacency_offsets_.size(); ++index) {
+        adjacency_offsets_[index] += adjacency_offsets_[index - 1];
+    }
+
+    adjacency_links_.resize(valid_link_count);
+    std::vector<uint32_t> next_offsets = adjacency_offsets_;
+    for (const BaseNavLink& link : pack_.links()) {
+        if (link.source < triangle_zones_.size() && link.target < triangle_zones_.size()) {
+            adjacency_links_[next_offsets[link.source]++] = link.target;
+        }
+    }
+}
+
+void BaseNavPlanner::computeTriangleHeights()
+{
+    const auto& triangles = pack_.triangles();
+    const auto& vertices = pack_.vertices();
+    for (size_t index = 0; index < triangles.size(); ++index) {
+        const auto& triangle = triangles[index];
+        triangle_heights_[index] =
+            (static_cast<double>(vertices[triangle.vertices[0]].height) + static_cast<double>(vertices[triangle.vertices[1]].height)
+             + static_cast<double>(vertices[triangle.vertices[2]].height))
+            / 3.0;
     }
 }
 
 double BaseNavPlanner::triangleAverageHeight(uint32_t triangle_index) const
 {
-    const auto& triangle = pack_.triangles()[triangle_index];
-    const auto& vertices = pack_.vertices();
-    return (static_cast<double>(vertices[triangle.vertices[0]].height) + static_cast<double>(vertices[triangle.vertices[1]].height)
-            + static_cast<double>(vertices[triangle.vertices[2]].height))
-           / 3.0;
+    return triangle_heights_[triangle_index];
 }
 
 BaseNavRouteResult BaseNavPlanner::findPath(const BaseNavRouteRequest& request) const

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "BaseNavPack.h"
@@ -59,29 +58,12 @@ public:
     std::optional<BaseNavSnapResult> snap(uint16_t zone_id, const WorldPoint& point, double radius) const;
 
 private:
-    struct BinKey
-    {
-        uint16_t zone_id = 0;
-        int32_t x = 0;
-        int32_t y = 0;
-
-        bool operator==(const BinKey& rhs) const { return zone_id == rhs.zone_id && x == rhs.x && y == rhs.y; }
-    };
-
-    struct BinKeyHash
-    {
-        size_t operator()(const BinKey& key) const;
-    };
-
     const BaseNavPack& pack_;
     std::vector<uint16_t> triangle_zones_;
-    std::vector<std::vector<uint32_t>> adjacency_;
-    std::vector<std::array<double, 4>> triangle_bounds_;
-    std::vector<double> triangle_heights_;
-    std::unordered_map<BinKey, std::vector<uint32_t>, BinKeyHash> bins_;
+    std::vector<uint32_t> adjacency_offsets_;
+    std::vector<uint32_t> adjacency_links_;
 
     void buildIndex();
-    std::vector<uint32_t> candidateTriangles(uint16_t zone_id, const WorldPoint& point, double radius) const;
     double triangleAverageHeight(uint32_t triangle_index) const;
     std::array<WorldPoint, 3> trianglePoints(uint32_t triangle_index) const;
     std::optional<std::array<WorldPoint, 2>> sharedEdgePortal(uint32_t lhs, uint32_t rhs) const;

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -62,8 +62,10 @@ private:
     std::vector<uint16_t> triangle_zones_;
     std::vector<uint32_t> adjacency_offsets_;
     std::vector<uint32_t> adjacency_links_;
+    std::vector<double> triangle_heights_;
 
     void buildIndex();
+    void computeTriangleHeights();
     double triangleAverageHeight(uint32_t triangle_index) const;
     std::array<WorldPoint, 3> trianglePoints(uint32_t triangle_index) const;
     std::optional<std::array<WorldPoint, 2>> sharedEdgePortal(uint32_t lhs, uint32_t rhs) const;

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -1,10 +1,14 @@
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -26,7 +30,7 @@ constexpr size_t kVertexSize = 12;
 constexpr size_t kTriangleSize = 36;
 constexpr size_t kLinkSize = 8;
 constexpr uint16_t kBaseNavVersion = 2;
-constexpr size_t kGzipReadChunkSize = 1 << 20;
+constexpr size_t kGzipReadChunkSize = 4 << 20;
 constexpr uint64_t kFnvOffset = 14'695'981'039'346'656'037ULL;
 constexpr uint64_t kFnvPrime = 1'099'511'628'211ULL;
 
@@ -49,6 +53,12 @@ uint32_t ReadU32(const uint8_t*& cursor)
                            | (static_cast<uint32_t>(cursor[2]) << 16) | (static_cast<uint32_t>(cursor[3]) << 24);
     cursor += 4;
     return value;
+}
+
+uint32_t PeekU32(const uint8_t* bytes)
+{
+    return static_cast<uint32_t>(bytes[0]) | (static_cast<uint32_t>(bytes[1]) << 8) | (static_cast<uint32_t>(bytes[2]) << 16)
+           | (static_cast<uint32_t>(bytes[3]) << 24);
 }
 
 uint64_t ReadU64(const uint8_t*& cursor)
@@ -74,6 +84,29 @@ float ReadF32(const uint8_t*& cursor)
     return value;
 }
 
+BaseNavTriangle ReadTriangleRecord(const uint8_t*& cursor)
+{
+    BaseNavTriangle triangle;
+    for (uint32_t& value : triangle.vertices) {
+        value = ReadU32(cursor);
+    }
+    for (int32_t& value : triangle.neighbors) {
+        value = ReadI32(cursor);
+    }
+    triangle.component_id = ReadU32(cursor);
+    triangle.center_u = ReadF32(cursor);
+    triangle.center_v = ReadF32(cursor);
+    return triangle;
+}
+
+BaseNavLink ReadLinkRecord(const uint8_t*& cursor)
+{
+    BaseNavLink link;
+    link.source = ReadU32(cursor);
+    link.target = ReadU32(cursor);
+    return link;
+}
+
 uint64_t Fnv64Update(uint64_t hash, const uint8_t* bytes, size_t size)
 {
     for (size_t index = 0; index < size; ++index) {
@@ -96,9 +129,43 @@ BaseNavLoadResult Fail(BaseNavLoadStatus status, std::string message)
     return result;
 }
 
+size_t LowerBoundLinkSource(const uint8_t* link_bytes, uint32_t link_count, uint32_t source)
+{
+    size_t left = 0;
+    size_t right = link_count;
+    while (left < right) {
+        const size_t middle = left + (right - left) / 2;
+        const uint32_t middle_source = PeekU32(link_bytes + middle * kLinkSize);
+        if (middle_source < source) {
+            left = middle + 1;
+        }
+        else {
+            right = middle;
+        }
+    }
+    return left;
+}
+
 bool HasGzipSuffix(const std::filesystem::path& path)
 {
     return path.extension() == ".gz";
+}
+
+std::optional<size_t> ReadGzipUncompressedSize(const std::filesystem::path& path)
+{
+    std::ifstream input(path, std::ios::binary | std::ios::ate);
+    if (!input) {
+        return std::nullopt;
+    }
+    if (input.tellg() < static_cast<std::streampos>(4)) {
+        return std::nullopt;
+    }
+    input.seekg(-4, std::ios::end);
+    std::array<uint8_t, 4> size_bytes {};
+    if (!ReadExact(input, size_bytes.data(), size_bytes.size())) {
+        return std::nullopt;
+    }
+    return static_cast<size_t>(PeekU32(size_bytes.data()));
 }
 
 BaseNavLoadResult ReadGzipFile(const std::filesystem::path& path, std::vector<uint8_t>* output)
@@ -110,6 +177,10 @@ BaseNavLoadResult ReadGzipFile(const std::filesystem::path& path, std::vector<ui
 #endif
     if (file == nullptr) {
         return Fail(BaseNavLoadStatus::FileOpenFailed, "failed to open gzip nav file");
+    }
+    gzbuffer(file, static_cast<unsigned int>(kGzipReadChunkSize));
+    if (const auto uncompressed_size = ReadGzipUncompressedSize(path); uncompressed_size && *uncompressed_size > 0) {
+        output->reserve(*uncompressed_size);
     }
 
     std::vector<uint8_t> buffer(kGzipReadChunkSize);
@@ -158,7 +229,7 @@ BaseNavLoadResult ReadNavFileBytes(const std::filesystem::path& path, std::vecto
 
 }
 
-BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path)
+BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string_view zone_name)
 {
     std::vector<uint8_t> file_bytes;
     const BaseNavLoadResult read_result = ReadNavFileBytes(path, &file_bytes);
@@ -212,15 +283,6 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path)
     const uint8_t* triangle_bytes = file_bytes.data() + triangle_offset;
     const uint8_t* link_bytes = file_bytes.data() + link_offset;
 
-    uint64_t hash = kFnvOffset;
-    hash = Fnv64Update(hash, zone_table, static_cast<size_t>(zone_table_size));
-    hash = Fnv64Update(hash, vertex_bytes, static_cast<size_t>(vertex_size));
-    hash = Fnv64Update(hash, triangle_bytes, static_cast<size_t>(triangle_size));
-    hash = Fnv64Update(hash, link_bytes, static_cast<size_t>(link_size));
-    if (hash != build_hash) {
-        return Fail(BaseNavLoadStatus::HashMismatch, "nav build hash mismatch");
-    }
-
     std::vector<BaseNavZone> zones;
     zones.reserve(zone_count);
     std::set<uint16_t> zone_ids;
@@ -251,49 +313,105 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path)
         }
         zones.push_back(std::move(zone));
     }
+    std::optional<BaseNavZone> selected_zone;
+    for (const BaseNavZone& zone : zones) {
+        if (static_cast<uint64_t>(zone.first_triangle) + zone.triangle_count > triangle_count) {
+            return Fail(BaseNavLoadStatus::InvalidSize, "zone triangle range is outside triangle table");
+        }
+        if (!zone_name.empty() && zone.name == zone_name) {
+            selected_zone = zone;
+        }
+    }
+    if (!zone_name.empty() && !selected_zone) {
+        return Fail(BaseNavLoadStatus::ZoneNotFound, "nav zone not found");
+    }
+    // Zone-scoped gzip loads rely on the gzip stream CRC and skip the full-package FNV scan.
+    const bool should_verify_hash = zone_name.empty() || !HasGzipSuffix(path);
+    if (should_verify_hash) {
+        uint64_t hash = kFnvOffset;
+        hash = Fnv64Update(hash, zone_table, static_cast<size_t>(zone_table_size));
+        hash = Fnv64Update(hash, vertex_bytes, static_cast<size_t>(vertex_size));
+        hash = Fnv64Update(hash, triangle_bytes, static_cast<size_t>(triangle_size));
+        hash = Fnv64Update(hash, link_bytes, static_cast<size_t>(link_size));
+        if (hash != build_hash) {
+            return Fail(BaseNavLoadStatus::HashMismatch, "nav build hash mismatch");
+        }
+    }
 
+    const uint32_t selected_first_triangle = selected_zone ? selected_zone->first_triangle : 0;
+    const uint32_t selected_triangle_count = selected_zone ? selected_zone->triangle_count : triangle_count;
+    const uint32_t selected_triangle_end = selected_first_triangle + selected_triangle_count;
+    const bool zone_scoped = selected_zone.has_value();
+
+    std::vector<BaseNavTriangle> triangles;
+    triangles.reserve(selected_triangle_count);
+    uint32_t first_vertex = zone_scoped ? vertex_count : 0;
+    uint32_t last_vertex = 0;
+    const uint8_t* triangle_cursor = triangle_bytes + static_cast<uint64_t>(selected_first_triangle) * kTriangleSize;
+    for (uint32_t index = 0; index < selected_triangle_count; ++index) {
+        BaseNavTriangle triangle = ReadTriangleRecord(triangle_cursor);
+        for (uint32_t value : triangle.vertices) {
+            if (value >= vertex_count) {
+                return Fail(BaseNavLoadStatus::InvalidSize, "triangle vertex index is outside vertex table");
+            }
+            if (zone_scoped) {
+                first_vertex = std::min(first_vertex, value);
+                last_vertex = std::max(last_vertex, value);
+            }
+        }
+        if (zone_scoped) {
+            for (int32_t& neighbor : triangle.neighbors) {
+                if (neighbor < 0 || static_cast<uint32_t>(neighbor) < selected_first_triangle
+                    || static_cast<uint32_t>(neighbor) >= selected_triangle_end) {
+                    neighbor = -1;
+                    continue;
+                }
+                neighbor -= static_cast<int32_t>(selected_first_triangle);
+            }
+        }
+        triangles.push_back(triangle);
+    }
+
+    const uint32_t selected_vertex_count = zone_scoped ? (triangles.empty() ? 0 : last_vertex - first_vertex + 1) : vertex_count;
     std::vector<BaseNavVertex> vertices;
-    vertices.reserve(vertex_count);
-    const uint8_t* vertex_cursor = vertex_bytes;
-    for (uint32_t index = 0; index < vertex_count; ++index) {
+    vertices.reserve(selected_vertex_count);
+    const uint8_t* vertex_cursor = vertex_bytes + static_cast<uint64_t>(first_vertex) * kVertexSize;
+    for (uint32_t index = 0; index < selected_vertex_count; ++index) {
         BaseNavVertex vertex;
         vertex.u = ReadF32(vertex_cursor);
         vertex.v = ReadF32(vertex_cursor);
         vertex.height = ReadF32(vertex_cursor);
         vertices.push_back(vertex);
     }
-
-    std::vector<BaseNavTriangle> triangles;
-    triangles.reserve(triangle_count);
-    const uint8_t* triangle_cursor = triangle_bytes;
-    for (uint32_t index = 0; index < triangle_count; ++index) {
-        BaseNavTriangle triangle;
-        for (uint32_t& value : triangle.vertices) {
-            value = ReadU32(triangle_cursor);
-            if (value >= vertex_count) {
-                return Fail(BaseNavLoadStatus::InvalidSize, "triangle vertex index is outside vertex table");
+    if (zone_scoped) {
+        for (BaseNavTriangle& triangle : triangles) {
+            for (uint32_t& vertex_index : triangle.vertices) {
+                vertex_index -= first_vertex;
             }
         }
-        for (int32_t& value : triangle.neighbors) {
-            value = ReadI32(triangle_cursor);
-        }
-        triangle.component_id = ReadU32(triangle_cursor);
-        triangle.center_u = ReadF32(triangle_cursor);
-        triangle.center_v = ReadF32(triangle_cursor);
-        triangles.push_back(triangle);
+        selected_zone->first_triangle = 0;
+        selected_zone->triangle_count = static_cast<uint32_t>(triangles.size());
+        zones = { *selected_zone };
     }
 
     std::vector<BaseNavLink> links;
-    links.reserve(link_count);
-    const uint8_t* link_cursor = link_bytes;
-    for (uint32_t index = 0; index < link_count; ++index) {
-        BaseNavLink link;
-        link.source = ReadU32(link_cursor);
-        link.target = ReadU32(link_cursor);
+    const size_t first_link = zone_scoped ? LowerBoundLinkSource(link_bytes, link_count, selected_first_triangle) : 0;
+    const size_t last_link = zone_scoped ? LowerBoundLinkSource(link_bytes, link_count, selected_triangle_end) : link_count;
+    links.reserve(last_link - first_link);
+    const uint8_t* link_cursor = link_bytes + first_link * kLinkSize;
+    for (size_t index = first_link; index < last_link; ++index) {
+        BaseNavLink link = ReadLinkRecord(link_cursor);
         if (link.source >= triangle_count || link.target >= triangle_count) {
-            LogWarn << "Skipping invalid BaseNav link." << VAR(index) << VAR(link.source) << VAR(link.target)
-                    << VAR(triangle_count);
+            LogWarn << "Skipping invalid BaseNav link." << VAR(index) << VAR(link.source) << VAR(link.target) << VAR(triangle_count);
             continue;
+        }
+        if (zone_scoped) {
+            if (link.source < selected_first_triangle || link.source >= selected_triangle_end || link.target < selected_first_triangle
+                || link.target >= selected_triangle_end) {
+                continue;
+            }
+            link.source -= selected_first_triangle;
+            link.target -= selected_first_triangle;
         }
         links.push_back(link);
     }

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <string_view>
 
 #include "BaseNavPack.h"
 #include "BaseNavPlanner.h"
@@ -8,6 +9,6 @@
 namespace navmesh
 {
 
-BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path);
+BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string_view zone_name = {});
 
 }


### PR DESCRIPTION
## 由 Sourcery 提供的总结

通过支持按区域（zone）加载导航网格（navmesh），并简化内存中的路径规划结构，以实现更快速、更有针对性的查询，从而优化导航网格规划。

新功能：
- 允许按特定区域名称加载 `BaseNavPack`，支持仅加载该区域相关的顶点、三角形和链接子集。
- 引入按区域划分的导航网格缓存，以文件路径和区域标识符为键进行缓存管理。

增强项：
- 增大 gzip 读取缓冲区大小，并根据未压缩大小预先保留输出缓冲区，以加快导航网格文件的加载速度。
- 对基于 gzip 的按区域加载跳过整包 FNV 哈希校验，同时保留对整包加载和非 gzip 文件的完整性检查。
- 在 `BaseNavPlanner` 中用 CSR 风格的表示替换邻接表，以提升遍历性能。
- 简化吸附（snap）查询：通过在区域范围内扫描三角形并结合包围盒裁剪，而不是使用空间分桶索引。
- 在解析导航网格路径时优先选择未压缩的导航网格文件而非压缩文件。
- 当请求的导航区域在导航网格包中不存在时，增加明确的错误报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize navmesh planning by supporting zone-scoped navmesh loading and simplifying in-memory pathfinding structures for faster, more targeted queries.

New Features:
- Allow loading a BaseNavPack scoped to a specific zone name, including subsetted vertices, triangles, and links.
- Introduce per-zone navmesh caching keyed by file path and zone identifier.

Enhancements:
- Increase gzip read buffer size and pre-reserve output using the uncompressed size to speed up navmesh file loading.
- Skip full-package FNV hash verification for gzip-based zone-scoped loads while retaining integrity checks for full loads and non-gzip files.
- Replace adjacency lists with a CSR-style representation in BaseNavPlanner to improve traversal performance.
- Simplify snap queries by scanning triangles within the zone range with bounding-box pruning instead of using a spatial bin index.
- Prefer uncompressed navmesh files over compressed ones when resolving navmesh paths.
- Add explicit error reporting when a requested nav zone is not found in the navmesh pack.

</details>