### PR TITLE
perf(MapNavigator): 预加载 navmesh 数据包

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navi_controller.cpp
@@ -47,6 +47,7 @@ bool NaviController::Navigate(const NaviParam& param)
 
     const size_t target_count = param.path.size();
     LogInfo << "Starting navigation to targets." << VAR(target_count);
+    PreloadNavmeshWaypoints(param);
     LogInfo << "Waiting for first valid GPS signal...";
 
     NaviPosition pos;

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -1,5 +1,9 @@
 #include <algorithm>
 #include <array>
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <exception>
 #include <filesystem>
 #include <future>
 #include <memory>
@@ -7,9 +11,11 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include <MaaUtils/Logger.h>
 
@@ -55,6 +61,8 @@ constexpr std::array<BaseNavZoneAlias, 4> kBaseNavZoneAliases {{
     { "base01", { "base01", "OMVBase" } },
     { "dung01", { "dung01", "Dung" } },
 }};
+
+constexpr size_t kNavmeshLoaderWorkerCount = 1;
 
 bool IsNavmeshWaypoint(const Waypoint& waypoint)
 {
@@ -166,34 +174,143 @@ std::mutex& NavmeshFutureCacheMutex()
     return mutex;
 }
 
-NavmeshFuture GetCachedNavmeshFuture(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
+void RemoveCachedNavmeshFutureByKey(const std::string& cache_key)
 {
-    const std::string cache_key = BuildNavmeshCacheKey(navmesh_path, navmesh_zone);
+    const std::lock_guard lock(NavmeshFutureCacheMutex());
+    NavmeshFutureCache().erase(cache_key);
+}
+
+class NavmeshCacheExceptionGuard
+{
+public:
+    explicit NavmeshCacheExceptionGuard(std::string cache_key)
+        : cache_key_(std::move(cache_key))
+        , uncaught_exceptions_(std::uncaught_exceptions())
+    {
+    }
+
+    ~NavmeshCacheExceptionGuard()
+    {
+        if (active_ && std::uncaught_exceptions() > uncaught_exceptions_) {
+            RemoveCachedNavmeshFutureByKey(cache_key_);
+        }
+    }
+
+    NavmeshCacheExceptionGuard(const NavmeshCacheExceptionGuard&) = delete;
+    NavmeshCacheExceptionGuard& operator=(const NavmeshCacheExceptionGuard&) = delete;
+
+    void Dismiss() { active_ = false; }
+
+private:
+    std::string cache_key_;
+    int uncaught_exceptions_ = 0;
+    bool active_ = true;
+};
+
+class NavmeshLoadExecutor
+{
+public:
+    NavmeshLoadExecutor()
+    {
+        workers_.reserve(kNavmeshLoaderWorkerCount);
+        for (size_t index = 0; index < kNavmeshLoaderWorkerCount; ++index) {
+            workers_.emplace_back([this] { WorkerLoop(); });
+        }
+    }
+
+    ~NavmeshLoadExecutor()
+    {
+        {
+            const std::lock_guard lock(mutex_);
+            stopping_ = true;
+        }
+        cv_.notify_all();
+        for (std::thread& worker : workers_) {
+            if (worker.joinable()) {
+                worker.join();
+            }
+        }
+    }
+
+    NavmeshLoadExecutor(const NavmeshLoadExecutor&) = delete;
+    NavmeshLoadExecutor& operator=(const NavmeshLoadExecutor&) = delete;
+
+    NavmeshFuture Submit(std::filesystem::path navmesh_path, std::string navmesh_zone)
+    {
+        std::packaged_task<std::shared_ptr<CachedNavmesh>()> task(
+            [navmesh_path = std::move(navmesh_path), navmesh_zone = std::move(navmesh_zone)] {
+                return LoadNavmeshPack(navmesh_path, navmesh_zone);
+            });
+        NavmeshFuture future = task.get_future().share();
+        {
+            const std::lock_guard lock(mutex_);
+            tasks_.push_back(std::move(task));
+        }
+        cv_.notify_one();
+        return future;
+    }
+
+private:
+    void WorkerLoop()
+    {
+        while (true) {
+            std::packaged_task<std::shared_ptr<CachedNavmesh>()> task;
+            {
+                std::unique_lock lock(mutex_);
+                cv_.wait(lock, [this] { return stopping_ || !tasks_.empty(); });
+                if (stopping_ && tasks_.empty()) {
+                    return;
+                }
+                task = std::move(tasks_.front());
+                tasks_.pop_front();
+            }
+            task();
+        }
+    }
+
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::deque<std::packaged_task<std::shared_ptr<CachedNavmesh>()>> tasks_;
+    std::vector<std::thread> workers_;
+    bool stopping_ = false;
+};
+
+NavmeshLoadExecutor& GetNavmeshLoadExecutor()
+{
+    static NavmeshLoadExecutor executor;
+    return executor;
+}
+
+NavmeshFuture GetCachedFutureByKey(const std::string& cache_key, const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
+{
     const std::lock_guard lock(NavmeshFutureCacheMutex());
     auto& cache = NavmeshFutureCache();
     if (auto iter = cache.find(cache_key); iter != cache.end()) {
         return iter->second;
     }
 
-    auto future =
-        std::async(std::launch::async, [navmesh_path, navmesh_zone] { return LoadNavmeshPack(navmesh_path, navmesh_zone); }).share();
+    auto future = GetNavmeshLoadExecutor().Submit(navmesh_path, navmesh_zone);
     cache.emplace(cache_key, future);
     return future;
 }
 
-void RemoveCachedNavmeshFuture(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
+NavmeshFuture GetCachedNavmeshFuture(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
 {
     const std::string cache_key = BuildNavmeshCacheKey(navmesh_path, navmesh_zone);
-    const std::lock_guard lock(NavmeshFutureCacheMutex());
-    NavmeshFutureCache().erase(cache_key);
+    return GetCachedFutureByKey(cache_key, navmesh_path, navmesh_zone);
 }
 
 std::shared_ptr<CachedNavmesh> LoadCachedNavmesh(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
 {
-    auto navmesh = GetCachedNavmeshFuture(navmesh_path, navmesh_zone).get();
+    const std::string cache_key = BuildNavmeshCacheKey(navmesh_path, navmesh_zone);
+    NavmeshCacheExceptionGuard exception_guard(cache_key);
+    auto navmesh = GetCachedFutureByKey(cache_key, navmesh_path, navmesh_zone).get();
     if (!navmesh) {
-        RemoveCachedNavmeshFuture(navmesh_path, navmesh_zone);
+        RemoveCachedNavmeshFutureByKey(cache_key);
+        exception_guard.Dismiss();
+        return nullptr;
     }
+    exception_guard.Dismiss();
     return navmesh;
 }
 

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -1,9 +1,11 @@
 #include <algorithm>
 #include <array>
 #include <filesystem>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
@@ -135,25 +137,64 @@ std::filesystem::path ResolveNavmeshFile(const std::string& configured_path)
     return std::filesystem::path(kDefaultNavmeshRelativePath);
 }
 
-std::shared_ptr<CachedNavmesh> LoadCachedNavmesh(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
+std::string BuildNavmeshCacheKey(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
 {
-    static std::unordered_map<std::string, std::shared_ptr<CachedNavmesh>> cache;
-    static std::mutex cache_mutex;
+    return std::filesystem::absolute(navmesh_path).lexically_normal().string() + "#" + navmesh_zone;
+}
 
-    const std::string cache_key = std::filesystem::absolute(navmesh_path).lexically_normal().string() + "#" + navmesh_zone;
-    const std::lock_guard lock(cache_mutex);
-    if (auto iter = cache.find(cache_key); iter != cache.end()) {
-        return iter->second;
-    }
-
+std::shared_ptr<CachedNavmesh> LoadNavmeshPack(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
+{
     const auto load_result = navmesh::LoadBaseNavPack(navmesh_path, navmesh_zone);
     if (!load_result.ok()) {
         LogError << "Failed to load navmesh .nav file." << VAR(navmesh_path) << VAR(navmesh_zone) << VAR(load_result.message);
         return nullptr;
     }
-    auto loaded = std::make_shared<CachedNavmesh>(std::move(*load_result.pack));
-    cache.emplace(cache_key, loaded);
-    return loaded;
+    return std::make_shared<CachedNavmesh>(std::move(*load_result.pack));
+}
+
+using NavmeshFuture = std::shared_future<std::shared_ptr<CachedNavmesh>>;
+
+std::unordered_map<std::string, NavmeshFuture>& NavmeshFutureCache()
+{
+    static std::unordered_map<std::string, NavmeshFuture> cache;
+    return cache;
+}
+
+std::mutex& NavmeshFutureCacheMutex()
+{
+    static std::mutex mutex;
+    return mutex;
+}
+
+NavmeshFuture GetCachedNavmeshFuture(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
+{
+    const std::string cache_key = BuildNavmeshCacheKey(navmesh_path, navmesh_zone);
+    const std::lock_guard lock(NavmeshFutureCacheMutex());
+    auto& cache = NavmeshFutureCache();
+    if (auto iter = cache.find(cache_key); iter != cache.end()) {
+        return iter->second;
+    }
+
+    auto future =
+        std::async(std::launch::async, [navmesh_path, navmesh_zone] { return LoadNavmeshPack(navmesh_path, navmesh_zone); }).share();
+    cache.emplace(cache_key, future);
+    return future;
+}
+
+void RemoveCachedNavmeshFuture(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
+{
+    const std::string cache_key = BuildNavmeshCacheKey(navmesh_path, navmesh_zone);
+    const std::lock_guard lock(NavmeshFutureCacheMutex());
+    NavmeshFutureCache().erase(cache_key);
+}
+
+std::shared_ptr<CachedNavmesh> LoadCachedNavmesh(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
+{
+    auto navmesh = GetCachedNavmeshFuture(navmesh_path, navmesh_zone).get();
+    if (!navmesh) {
+        RemoveCachedNavmeshFuture(navmesh_path, navmesh_zone);
+    }
+    return navmesh;
 }
 
 std::vector<std::vector<double>> PathPointsForLog(const navmesh::WorldPath& path)
@@ -270,6 +311,28 @@ std::optional<NavmeshExpansionState> MakeExpansionState(const NaviParam& param, 
     return state;
 }
 
+std::optional<std::string> InferPreloadNavmeshZone(const NaviParam& param)
+{
+    std::string current_zone = param.map_name;
+    for (const Waypoint& waypoint : param.path) {
+        if (waypoint.IsZoneDeclaration()) {
+            current_zone = waypoint.zone_id;
+            continue;
+        }
+        if (IsNavmeshWaypoint(waypoint)) {
+            std::string navmesh_zone = InferBaseNavZone(current_zone, param.map_name);
+            if (navmesh_zone.empty()) {
+                return std::nullopt;
+            }
+            return navmesh_zone;
+        }
+        if (!waypoint.zone_id.empty()) {
+            current_zone = waypoint.zone_id;
+        }
+    }
+    return std::nullopt;
+}
+
 } // namespace
 
 std::string InitialExpectedZone(const NaviParam& param)
@@ -279,6 +342,17 @@ std::string InitialExpectedZone(const NaviParam& param)
     }
     const std::string expected_zone = param.path.front().zone_id.empty() ? param.map_name : param.path.front().zone_id;
     return IsBaseNavZoneName(expected_zone) ? std::string() : expected_zone;
+}
+
+void PreloadNavmeshWaypoints(const NaviParam& param)
+{
+    const auto navmesh_zone = InferPreloadNavmeshZone(param);
+    if (!navmesh_zone) {
+        return;
+    }
+
+    const std::filesystem::path navmesh_path = ResolveNavmeshFile(param.navmesh_file);
+    (void)GetCachedNavmeshFuture(navmesh_path, *navmesh_zone);
 }
 
 bool ExpandNavmeshWaypoints(const NaviParam& param, const NaviPosition& initial_pos, std::vector<Waypoint>& out_path)

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <stop_token>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -164,9 +163,48 @@ using NavmeshTask = std::packaged_task<std::shared_ptr<CachedNavmesh>()>;
 
 struct NavmeshTaskQueue
 {
+    NavmeshTaskQueue()
+        : worker([this] { Run(); })
+    {
+    }
+
+    ~NavmeshTaskQueue()
+    {
+        {
+            const std::lock_guard lock(mutex);
+            stopping = true;
+        }
+        cv.notify_one();
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+
+    NavmeshTaskQueue(const NavmeshTaskQueue&) = delete;
+    NavmeshTaskQueue& operator=(const NavmeshTaskQueue&) = delete;
+
+    void Run()
+    {
+        while (true) {
+            NavmeshTask task;
+            {
+                std::unique_lock lock(mutex);
+                cv.wait(lock, [this] { return stopping || !tasks.empty(); });
+                if (stopping && tasks.empty()) {
+                    return;
+                }
+                task = std::move(tasks.front());
+                tasks.pop_front();
+            }
+            task();
+        }
+    }
+
     std::mutex mutex;
-    std::condition_variable_any cv;
+    std::condition_variable cv;
     std::deque<NavmeshTask> tasks;
+    std::thread worker;
+    bool stopping = false;
 };
 
 std::unordered_map<std::string, NavmeshFuture>& NavmeshFutureCache()
@@ -220,30 +258,6 @@ NavmeshTaskQueue& GetNavmeshTaskQueue()
     return queue;
 }
 
-void NavmeshLoadWorker(std::stop_token stop_token)
-{
-    auto& queue = GetNavmeshTaskQueue();
-    while (true) {
-        NavmeshTask task;
-        {
-            std::unique_lock lock(queue.mutex);
-            queue.cv.wait(lock, stop_token, [&queue] { return !queue.tasks.empty(); });
-            if (queue.tasks.empty()) {
-                return;
-            }
-            task = std::move(queue.tasks.front());
-            queue.tasks.pop_front();
-        }
-        task();
-    }
-}
-
-void EnsureNavmeshLoadWorker()
-{
-    (void)GetNavmeshTaskQueue();
-    static std::jthread worker(NavmeshLoadWorker);
-}
-
 NavmeshFuture EnqueueNavmeshLoad(std::filesystem::path navmesh_path, std::string navmesh_zone)
 {
     NavmeshTask task([navmesh_path = std::move(navmesh_path), navmesh_zone = std::move(navmesh_zone)] {
@@ -251,7 +265,6 @@ NavmeshFuture EnqueueNavmeshLoad(std::filesystem::path navmesh_path, std::string
     });
     NavmeshFuture future = task.get_future().share();
     auto& queue = GetNavmeshTaskQueue();
-    EnsureNavmeshLoadWorker();
     {
         const std::lock_guard lock(queue.mutex);
         queue.tasks.push_back(std::move(task));

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <stop_token>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -61,8 +62,6 @@ constexpr std::array<BaseNavZoneAlias, 4> kBaseNavZoneAliases {{
     { "base01", { "base01", "OMVBase" } },
     { "dung01", { "dung01", "Dung" } },
 }};
-
-constexpr size_t kNavmeshLoaderWorkerCount = 1;
 
 bool IsNavmeshWaypoint(const Waypoint& waypoint)
 {
@@ -161,6 +160,14 @@ std::shared_ptr<CachedNavmesh> LoadNavmeshPack(const std::filesystem::path& navm
 }
 
 using NavmeshFuture = std::shared_future<std::shared_ptr<CachedNavmesh>>;
+using NavmeshTask = std::packaged_task<std::shared_ptr<CachedNavmesh>()>;
+
+struct NavmeshTaskQueue
+{
+    std::mutex mutex;
+    std::condition_variable_any cv;
+    std::deque<NavmeshTask> tasks;
+};
 
 std::unordered_map<std::string, NavmeshFuture>& NavmeshFutureCache()
 {
@@ -207,78 +214,50 @@ private:
     bool active_ = true;
 };
 
-class NavmeshLoadExecutor
+NavmeshTaskQueue& GetNavmeshTaskQueue()
 {
-public:
-    NavmeshLoadExecutor()
-    {
-        workers_.reserve(kNavmeshLoaderWorkerCount);
-        for (size_t index = 0; index < kNavmeshLoaderWorkerCount; ++index) {
-            workers_.emplace_back([this] { WorkerLoop(); });
-        }
-    }
+    static NavmeshTaskQueue queue;
+    return queue;
+}
 
-    ~NavmeshLoadExecutor()
-    {
-        {
-            const std::lock_guard lock(mutex_);
-            stopping_ = true;
-        }
-        cv_.notify_all();
-        for (std::thread& worker : workers_) {
-            if (worker.joinable()) {
-                worker.join();
-            }
-        }
-    }
-
-    NavmeshLoadExecutor(const NavmeshLoadExecutor&) = delete;
-    NavmeshLoadExecutor& operator=(const NavmeshLoadExecutor&) = delete;
-
-    NavmeshFuture Submit(std::filesystem::path navmesh_path, std::string navmesh_zone)
-    {
-        std::packaged_task<std::shared_ptr<CachedNavmesh>()> task(
-            [navmesh_path = std::move(navmesh_path), navmesh_zone = std::move(navmesh_zone)] {
-                return LoadNavmeshPack(navmesh_path, navmesh_zone);
-            });
-        NavmeshFuture future = task.get_future().share();
-        {
-            const std::lock_guard lock(mutex_);
-            tasks_.push_back(std::move(task));
-        }
-        cv_.notify_one();
-        return future;
-    }
-
-private:
-    void WorkerLoop()
-    {
-        while (true) {
-            std::packaged_task<std::shared_ptr<CachedNavmesh>()> task;
-            {
-                std::unique_lock lock(mutex_);
-                cv_.wait(lock, [this] { return stopping_ || !tasks_.empty(); });
-                if (stopping_ && tasks_.empty()) {
-                    return;
-                }
-                task = std::move(tasks_.front());
-                tasks_.pop_front();
-            }
-            task();
-        }
-    }
-
-    std::mutex mutex_;
-    std::condition_variable cv_;
-    std::deque<std::packaged_task<std::shared_ptr<CachedNavmesh>()>> tasks_;
-    std::vector<std::thread> workers_;
-    bool stopping_ = false;
-};
-
-NavmeshLoadExecutor& GetNavmeshLoadExecutor()
+void NavmeshLoadWorker(std::stop_token stop_token)
 {
-    static NavmeshLoadExecutor executor;
-    return executor;
+    auto& queue = GetNavmeshTaskQueue();
+    while (true) {
+        NavmeshTask task;
+        {
+            std::unique_lock lock(queue.mutex);
+            queue.cv.wait(lock, stop_token, [&queue] { return !queue.tasks.empty(); });
+            if (queue.tasks.empty()) {
+                return;
+            }
+            task = std::move(queue.tasks.front());
+            queue.tasks.pop_front();
+        }
+        task();
+    }
+}
+
+void EnsureNavmeshLoadWorker()
+{
+    (void)GetNavmeshTaskQueue();
+    static std::jthread worker(NavmeshLoadWorker);
+}
+
+NavmeshFuture EnqueueNavmeshLoad(std::filesystem::path navmesh_path, std::string navmesh_zone)
+{
+    NavmeshTask task([navmesh_path = std::move(navmesh_path), navmesh_zone = std::move(navmesh_zone)] {
+        return LoadNavmeshPack(navmesh_path, navmesh_zone);
+    });
+    NavmeshFuture future = task.get_future().share();
+    auto& queue = GetNavmeshTaskQueue();
+    EnsureNavmeshLoadWorker();
+    {
+        const std::lock_guard lock(queue.mutex);
+        queue.tasks.push_back(std::move(task));
+    }
+    queue.cv.notify_one();
+    return future;
 }
 
 NavmeshFuture GetCachedFutureByKey(const std::string& cache_key, const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
@@ -289,7 +268,7 @@ NavmeshFuture GetCachedFutureByKey(const std::string& cache_key, const std::file
         return iter->second;
     }
 
-    auto future = GetNavmeshLoadExecutor().Submit(navmesh_path, navmesh_zone);
+    auto future = EnqueueNavmeshLoad(navmesh_path, navmesh_zone);
     cache.emplace(cache_key, future);
     return future;
 }

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -11,6 +11,7 @@ namespace mapnavigator
 struct NaviParam;
 
 std::string InitialExpectedZone(const NaviParam& param);
+void PreloadNavmeshWaypoints(const NaviParam& param);
 bool ExpandNavmeshWaypoints(const NaviParam& param, const NaviPosition& initial_pos, std::vector<Waypoint>& out_path);
 
 } // namespace mapnavigator


### PR DESCRIPTION
再偷点加载时间

## Summary by Sourcery

在导航开始前异步预加载 navmesh 包，以减少阻塞式路径扩展延迟。

New Features:
- 引入基于 navmesh 文件和区域（zone）作为键的 navmesh 包异步加载与共享缓存机制。
- 在导航开始时，根据推断的 navmesh 区域预加载 navmesh 路径点（waypoints）。

Enhancements:
- 重构 navmesh 缓存以使用 shared future 支持并发访问，并复用进行中的加载操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preload navmesh packs asynchronously before navigation to reduce blocking path expansion latency.

New Features:
- Introduce asynchronous loading and shared caching of navmesh packs keyed by navmesh file and zone.
- Add preloading of navmesh waypoints based on inferred navmesh zone at navigation start.

Enhancements:
- Refactor navmesh caching to use shared futures for concurrent access and to reuse in-flight load operations.

</details>