### PR TITLE
fix: 修复售卖弹性物资好友界面动画识别

### DIFF
--- a/agent/go-service/autosell/autosell.go
+++ b/agent/go-service/autosell/autosell.go
@@ -173,6 +173,10 @@ func (a *AutoSellItemExecuteItemTaskAction) Run(ctx *maa.Context, arg *maa.Custo
 			hasError = true
 			break
 		}
+		if !detail.Status.Success() {
+			hasError = true
+			break
+		}
 	}
 	if hasError {
 		return false

--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -346,6 +346,7 @@
                 "threshold": 0.9
             }
         ],
+        "box_index": 1,
         "pre_wait_freezes": 100,
         "pre_delay": 0,
         "post_delay": 0,


### PR DESCRIPTION
close #3115

## Summary by Sourcery

Bug Fixes:
- 在自动出售处理过程中，当明细状态不是成功时，将该条目执行标记为失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Mark item execution as failed when the detail status is not successful during auto-sell processing.

</details>