### PR TITLE
fix: 仓储节点三级页面无法跳出

### DIFF
--- a/assets/resource/pipeline/Interface/InScene/Region.json
+++ b/assets/resource/pipeline/Interface/InScene/Region.json
@@ -331,34 +331,36 @@
     },
     "InRegionalDevelopmentView2": {
         "desc": "在地区建设二级界面",
-        "recognition": "OCR",
-        "roi": [
-            0,
-            0,
-            400,
-            70
-        ],
-        "expected": [
-            "据点",
-            "據點",
-            "(?i)Outpost",
-            "拠点",
-            "物资调度",
-            "物資調度",
-            "(?i)Stock\\s*Redistribution",
-            "商品取引",
-            "仓储节点",
-            "倉儲節點",
-            "(?i)Depot\\s*Node",
-            "保管ボックス",
-            "环境监测",
-            "環境監測",
-            "(?i)Environment\\s*Monitoring",
-            "環境観測",
-            "거점",
-            "물자 관리",
-            "저장고 노드",
-            "환경 관측"
+        "recognition": "Or",
+        "any_of": [
+            {
+                "recognition": "OCR",
+                "roi": [
+                    0,
+                    0,
+                    400,
+                    70
+                ],
+                "expected": [
+                    "据点",
+                    "據點",
+                    "(?i)Outpost",
+                    "拠点",
+                    "物资调度",
+                    "物資調度",
+                    "(?i)Stock\\s*Redistribution",
+                    "商品取引",
+                    "环境监测",
+                    "環境監測",
+                    "(?i)Environment\\s*Monitoring",
+                    "環境観測",
+                    "거점",
+                    "물자 관리",
+                    "저장고 노드",
+                    "환경 관측"
+                ]
+            },
+            "CheckLocalDepotNodeText"
         ]
     },
     "InWorld": {


### PR DESCRIPTION
close #3051

## Summary by Sourcery

调整三层页面中仓库节点导航的场景内区域配置，以确保退出行为正常运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust in-scene region configuration for warehouse node navigation on the third-level page to allow proper exit behavior.

</details>