### PR TITLE
fix: 升级干员点击失败

### DIFF
--- a/assets/resource/pipeline/LevelUpOperator.json
+++ b/assets/resource/pipeline/LevelUpOperator.json
@@ -68,6 +68,7 @@
                 ]
             }
         },
+        "pre_wait_freezes": 100,
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
@@ -95,6 +96,7 @@
         "action": {
             "type": "Click"
         },
+        "post_wait_freezes": 100,
         "post_delay": 0,
         "next": [
             "LevelUpOperatorInitialSelectOperatorPosition"
@@ -137,17 +139,7 @@
             }
         },
         "pre_delay": 0,
-        "action": {
-            "type": "Click",
-            "param": {
-                "target": [
-                    56,
-                    106,
-                    32,
-                    32
-                ]
-            }
-        },
+        "action": "Click",
         "post_wait_freezes": 100,
         "post_delay": 0,
         "rate_limit": 0,
@@ -180,10 +172,10 @@
             "type": "Click",
             "param": {
                 "target": [
-                    528,
-                    92,
-                    178,
-                    182
+                    -100,
+                    100,
+                    30,
+                    30
                 ]
             }
         },
@@ -220,18 +212,18 @@
                 ]
             }
         },
+        "pre_wait_freezes": {
+            "time": 200,
+            "target": [
+                0,
+                0,
+                200,
+                100
+            ]
+        },
         "pre_delay": 0,
         "action": {
             "type": "DoNothing"
-        },
-        "post_wait_freezes": {
-            "time": 100,
-            "target": [
-                1046,
-                221,
-                177,
-                44
-            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -310,11 +302,12 @@
             "param": {
                 "roi": [
                     1000,
-                    240,
+                    210,
                     88,
-                    30
+                    60
                 ],
                 "expected": [
+                    "LEVEL",
                     "等级",
                     "等級",
                     "(?i)Level",
@@ -324,17 +317,7 @@
             }
         },
         "pre_delay": 0,
-        "action": {
-            "type": "Click",
-            "param": {
-                "target": [
-                    1025,
-                    225,
-                    70,
-                    32
-                ]
-            }
-        },
+        "action": "Click",
         "post_delay": 0,
         "next": [
             "LevelUpOperatorLevelUpButton",
@@ -476,6 +459,7 @@
                 ]
             }
         },
+        "post_wait_freezes": 100,
         "next": [
             "LevelUpOperatorClearSwipeRightHitCount"
         ]
@@ -511,6 +495,7 @@
                 "green_mask": true
             }
         },
+        "pre_wait_freezes": 100,
         "action": "Click",
         "post_delay": 0,
         "next": [

--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -229,7 +229,7 @@
             }
         },
         "pre_wait_freezes": {
-            "time": 100,
+            "time": 200,
             "target": [
                 0,
                 0,


### PR DESCRIPTION
close #2994

## 由 Sourcery 提供的摘要

调整干员升级和主菜单场景的流水线，以解决点击升级干员时产生的错误。

错误修复：
- 通过更新 `LevelUpOperator` 流水线配置，修复干员升级点击操作。
- 更正 `SceneMenu` 场景流水线配置，确保干员升级交互能够稳定触发。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust operator level-up and main menu scene pipelines to resolve failures when clicking to upgrade an operator.

Bug Fixes:
- Fix operator level-up click actions by updating the LevelUpOperator pipeline configuration.
- Correct SceneMenu scene pipeline configuration to ensure operator upgrade interactions trigger reliably.

</details>