### PR TITLE
fix: AutoStockStaple允许更多的滑动次数

### DIFF
--- a/assets/resource/pipeline/AutoStockStaple/ValleyIV.json
+++ b/assets/resource/pipeline/AutoStockStaple/ValleyIV.json
@@ -81,7 +81,7 @@
     },
     "AutoStockSwipeValleyIV": {
         "desc": "向下滑动寻找商品，直到找到商品或到达底部",
-        "max_hit": 20,
+        "max_hit": 25,
         "recognition": {
             "type": "And",
             "param": {

--- a/assets/resource/pipeline/AutoStockStaple/Wuling.json
+++ b/assets/resource/pipeline/AutoStockStaple/Wuling.json
@@ -78,7 +78,7 @@
     },
     "AutoStockSwipeWuling": {
         "desc": "向下滑动寻找商品，直到找到商品或到达底部",
-        "max_hit": 20,
+        "max_hit": 25,
         "recognition": {
             "type": "And",
             "param": {


### PR DESCRIPTION
允许AutoStockStaple Swipe超过20次，因为如果购买的长期物资过少（点名批评那几本情报书）谷地商店滑动20次不足以划到底部以识别`soldout`。
武陵没有复现相关问题，不过保守起见也加了一下

## 由 Sourcery 提供的摘要

错误修复：
- 允许 AutoStockStaple 进行更多次滑动操作，这样即使是在长时间的补货采购过程中，也能检测到已售罄的商品。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 防止在补给清单很长、需要超过 20 次滑动才能到达底部的情况下，AutoStockStaple 未能检测到已售罄物品的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent AutoStockStaple from failing to detect sold-out items when more than 20 swipes are needed to reach the bottom of long supply lists.

</details>

</details>