### PR TITLE
fix: 售卖物资好友列表点击失效

### DIFF
--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -346,8 +346,15 @@
                 "threshold": 0.9
             }
         ],
-        "box_index": 1,
-        "pre_wait_freezes": 100,
+        "pre_wait_freezes": {
+            "target": [
+                460,
+                260,
+                610,
+                310
+            ],
+            "time": 100
+        },
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,


### PR DESCRIPTION
close #3115

## Summary by Sourcery

Bug Fixes:
- 修复 AutoSell 物品任务，使在好友列表中点击条目时能够正确触发出售操作，而不再没有响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the AutoSell item task so that clicking entries in the friend list correctly triggers the sell action instead of being unresponsive.

</details>