### PR TITLE
fix:偶发培养仓关闭按钮点击失败

### DIFF
--- a/assets/resource/pipeline/Common/Button/CloseRewardsButton.json
+++ b/assets/resource/pipeline/Common/Button/CloseRewardsButton.json
@@ -19,9 +19,6 @@
             "timeout": 1000
         },
         "pre_delay": 0,
-        "action": {
-            "type": "Click"
-        },
         "post_wait_freezes": {
             "time": 80,
             "target": [

--- a/assets/resource/pipeline/DijiangRewards/GrowthChamber.json
+++ b/assets/resource/pipeline/DijiangRewards/GrowthChamber.json
@@ -116,7 +116,15 @@
         },
         "pre_delay": 0,
         "action": {
-            "type": "Click"
+            "type": "Click",
+            "param": {
+                "target_offset": [
+                    9,
+                    9,
+                    -17,
+                    -15
+                ]
+            }
         },
         "post_delay": 0,
         "rate_limit": 0,


### PR DESCRIPTION
fix #3142
添加了target_offset
移除了识别按钮中的action

## Summary by Sourcery

通过调整 Growth Chamber 的配置，修复在点击其关闭按钮时偶发的失败问题。

Bug Fixes:
- 通过更新按钮配置，解决在点击 Growth Chamber 奖励关闭按钮时偶发点击失败的问题。

Enhancements:
- 调整 Growth Chamber 和关闭奖励按钮的配置，改为使用目标偏移量（target offset），而不再依赖按钮内部动作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix intermittent failure when clicking the Growth Chamber close button by adjusting its configuration.

Bug Fixes:
- Resolve intermittent click failures on the Growth Chamber rewards close button by updating its button configuration.

Enhancements:
- Adjust Growth Chamber and close-rewards button configuration to use target offset instead of relying on in-button actions.

</details>