### PR TITLE
fix(AutoEcoFarm):修复地图上找农田标记时的逻辑错误

### DIFF
--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
@@ -354,7 +354,7 @@
             "time": 200
         },
         "next": [
-            "[JumpBack]_AutoEcoFarmIsMrarking",
+            "_AutoEcoFarmIsMrarking",
             "[JumpBack]_AutoEcoFarmMutiSelection",
             "_AutoEcoFarmAlreadySetTarget",
             "_AutoEcoFarmSetTarget",
@@ -414,7 +414,7 @@
             }
         },
         "next": [
-            "_AutoEcoFarmJumpBack"
+            "_AutoEcoFarmFindFarmlandCustom"
         ]
     },
     "_AutoEcoFarmAlreadySetTarget": {

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmFindFarmland.json
@@ -358,7 +358,7 @@
             "[JumpBack]_AutoEcoFarmMutiSelection",
             "_AutoEcoFarmAlreadySetTarget",
             "_AutoEcoFarmSetTarget",
-            "[JumpBack]_AutoEcoFarmFarmlandStillVisibleRetry",
+            "_AutoEcoFarmFarmlandStillVisibleRetry",
             "[JumpBack]_AutoEcoFarmMoveMouse",
             //识别不到农田的话不结束脚本，而是只结束该子任务，因为农田可能就在边上
             "SceneAnyEnterWorld"
@@ -383,7 +383,7 @@
             }
         },
         "next": [
-            "_AutoEcoFarmJumpBack"
+            "_AutoEcoFarmFindFarmlandCustom"
         ]
     },
     "_AutoEcoFarmIsMrarking": {


### PR DESCRIPTION
将AutoEcoFarmFindFarmlandCustom的next里面的2个节点取消JumpBack，而是直接连接回该节点，不然不会再次识别

## Summary by Sourcery

Bug Fixes:
- 修正农田搜索节点连接，使基于地图的农田标记可以被重复识别，而不是在第一次识别后就失效。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct farmland search node connections so the map-based farmland marker can be recognized repeatedly instead of failing after the first pass.

</details>