### PR TITLE
feat(map): 添加MapTracker*Compatible系列节点

### DIFF
--- a/agent/go-service/maptracker/compatible/assert_compatible.go
+++ b/agent/go-service/maptracker/compatible/assert_compatible.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Harry Huang
+package maptrackercompatible
+
+import (
+	"encoding/json"
+	"fmt"
+
+	maptrackerdefault "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/default"
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+var _ maa.CustomRecognitionRunner = &MapTrackerAssertLocationCompatible{}
+
+// MapTrackerAssertLocationCompatible converts MapLocateAssertLocation-style params and runs MapTrackerAssertLocation.
+type MapTrackerAssertLocationCompatible struct{}
+
+type mapLocateAssertCompatibleParam struct {
+	ZoneID            string     `json:"zone_id"`
+	ZoneIDAlt         string     `json:"zoneId"`
+	Zone              string     `json:"zone"`
+	Target            [4]float64 `json:"target"`
+	LocThreshold      float64    `json:"loc_threshold,omitempty"`
+	YoloThreshold     float64    `json:"yolo_threshold,omitempty"`
+	ForceGlobalSearch bool       `json:"force_global_search,omitempty"`
+}
+
+func (r *MapTrackerAssertLocationCompatible) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa.CustomRecognitionResult, bool) {
+	param, err := r.parseParam(arg.CustomRecognitionParam)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to parse parameters for MapTrackerAssertLocationCompatible")
+		return nil, false
+	}
+
+	trackerParam, err := r.convertParam(param)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to convert parameters for MapTrackerAssertLocationCompatible")
+		return nil, false
+	}
+
+	trackerParamText, err := json.Marshal(trackerParam)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to serialize MapTrackerAssertLocationCompatible converted parameters")
+		return nil, false
+	}
+
+	forwardArg := *arg
+	forwardArg.CustomRecognitionName = "MapTrackerAssertLocation"
+	forwardArg.CustomRecognitionParam = string(trackerParamText)
+	return (&maptrackerdefault.MapTrackerAssertLocation{}).Run(ctx, &forwardArg)
+}
+
+func (r *MapTrackerAssertLocationCompatible) parseParam(paramStr string) (*mapLocateAssertCompatibleParam, error) {
+	if paramStr == "" {
+		return nil, fmt.Errorf("custom_recognition_param is required")
+	}
+
+	var param mapLocateAssertCompatibleParam
+	if err := json.Unmarshal([]byte(paramStr), &param); err != nil {
+		return nil, fmt.Errorf("failed to parse parameters: %w", err)
+	}
+	if firstNonEmptyString(param.ZoneID, param.ZoneIDAlt, param.Zone) == "" {
+		return nil, fmt.Errorf("zone_id is required")
+	}
+	if param.Target[2] <= 0 || param.Target[3] <= 0 {
+		return nil, fmt.Errorf("target width and height must be positive")
+	}
+	return &param, nil
+}
+
+func (r *MapTrackerAssertLocationCompatible) convertParam(param *mapLocateAssertCompatibleParam) (*maptrackerdefault.MapTrackerAssertLocationParam, error) {
+	zoneID := firstNonEmptyString(param.ZoneID, param.ZoneIDAlt, param.Zone)
+	converted, err := convertCompatibleRect("", compatibleSourceRect{
+		SourceName: zoneID,
+		X:          param.Target[0],
+		Y:          param.Target[1],
+		W:          param.Target[2],
+		H:          param.Target[3],
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &maptrackerdefault.MapTrackerAssertLocationParam{
+		Expected: []maptrackerdefault.LocationCondition{
+			{
+				MapName: converted.MapName,
+				Target:  converted.Target,
+			},
+		},
+		Threshold: param.LocThreshold,
+		FastMode:  true,
+	}, nil
+}

--- a/agent/go-service/maptracker/compatible/assert_compatible_test.go
+++ b/agent/go-service/maptracker/compatible/assert_compatible_test.go
@@ -3,7 +3,6 @@ package maptrackercompatible
 
 import (
 	"math"
-	"os"
 	"testing"
 )
 
@@ -36,9 +35,7 @@ func TestMapTrackerAssertLocationCompatibleRejectsInvalidParams(t *testing.T) {
 }
 
 func TestMapTrackerAssertLocationCompatibleConvertsRegionalSamples(t *testing.T) {
-	if err := os.Chdir(moveCompatibleTestRepoRoot(t)); err != nil {
-		t.Fatal(err)
-	}
+	chdirCompatibleTestRepoRoot(t)
 
 	tests := []struct {
 		name       string
@@ -75,7 +72,7 @@ func TestMapTrackerAssertLocationCompatibleConvertsRegionalSamples(t *testing.T)
 				t.Fatalf("got map %q, want %q", condition.MapName, tt.expectMap)
 			}
 			for i, expect := range tt.expectRect {
-				if math.Abs(condition.Target[i]-expect) > 1.0 {
+				if math.Abs(condition.Target[i]-expect) > 2.0 {
 					t.Fatalf("target[%d] got %.3f, want %.3f", i, condition.Target[i], expect)
 				}
 			}

--- a/agent/go-service/maptracker/compatible/assert_compatible_test.go
+++ b/agent/go-service/maptracker/compatible/assert_compatible_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Harry Huang
+package maptrackercompatible
+
+import (
+	"math"
+	"os"
+	"testing"
+)
+
+func TestMapTrackerAssertLocationCompatibleRejectsInvalidParams(t *testing.T) {
+	action := &MapTrackerAssertLocationCompatible{}
+	tests := []struct {
+		name  string
+		param mapLocateAssertCompatibleParam
+	}{
+		{
+			name:  "MissingZone",
+			param: mapLocateAssertCompatibleParam{Target: [4]float64{1, 2, 3, 4}},
+		},
+		{
+			name:  "InvalidRect",
+			param: mapLocateAssertCompatibleParam{ZoneID: "Wuling_Base", Target: [4]float64{1, 2, 0, 4}},
+		},
+		{
+			name:  "UnknownZone",
+			param: mapLocateAssertCompatibleParam{ZoneID: "Unknown_Base", Target: [4]float64{1, 2, 3, 4}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := action.convertParam(&tt.param); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestMapTrackerAssertLocationCompatibleConvertsRegionalSamples(t *testing.T) {
+	if err := os.Chdir(moveCompatibleTestRepoRoot(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		param      mapLocateAssertCompatibleParam
+		expectMap  string
+		expectRect [4]float64
+	}{
+		{
+			name:       "Wuling",
+			param:      mapLocateAssertCompatibleParam{ZoneID: "Wuling_Base", Target: [4]float64{942, 723, 2, 1}},
+			expectMap:  "map02_lv002",
+			expectRect: [4]float64{664.200, 734.200, 2.075, 1.038},
+		},
+		{
+			name:       "OMVBase",
+			param:      mapLocateAssertCompatibleParam{ZoneID: "OMVBase01", Target: [4]float64{187, 131, 1, 10}},
+			expectMap:  "base01_lv003",
+			expectRect: [4]float64{190.200, 132.825, 1.038, 10.375},
+		},
+	}
+
+	action := &MapTrackerAssertLocationCompatible{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converted, err := action.convertParam(&tt.param)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(converted.Expected) != 1 {
+				t.Fatalf("got %d conditions, want 1", len(converted.Expected))
+			}
+			condition := converted.Expected[0]
+			if condition.MapName != tt.expectMap {
+				t.Fatalf("got map %q, want %q", condition.MapName, tt.expectMap)
+			}
+			for i, expect := range tt.expectRect {
+				if math.Abs(condition.Target[i]-expect) > 1.0 {
+					t.Fatalf("target[%d] got %.3f, want %.3f", i, condition.Target[i], expect)
+				}
+			}
+			if !converted.FastMode {
+				t.Fatal("expected fast_mode")
+			}
+		})
+	}
+}

--- a/agent/go-service/maptracker/compatible/convert.go
+++ b/agent/go-service/maptracker/compatible/convert.go
@@ -1,0 +1,484 @@
+// Copyright (c) 2026 Harry Huang
+package maptrackercompatible
+
+import (
+	"fmt"
+	"image"
+	_ "image/png"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	maptrackerinternal "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/internal"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/resource"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	mapLocatorImageDir         = "resource/image/MapLocator"
+	compatibleTemplateMinScore = 0.80
+	compatibleTemplateMinScale = 0.90
+	compatibleTemplateMaxScale = 1.12
+	compatibleTransformMargin  = 8.0
+)
+
+type compatibleSourcePoint struct {
+	SourceName string
+	X          float64
+	Y          float64
+}
+
+type compatibleConvertedPath struct {
+	MapName string
+	Path    [][2]float64
+}
+
+type compatibleSourceRect struct {
+	SourceName string
+	X          float64
+	Y          float64
+	W          float64
+	H          float64
+}
+
+type compatibleConvertedRect struct {
+	MapName string
+	Target  [4]float64
+}
+
+type compatibleTrackerPoint struct {
+	MapName string
+	X       float64
+	Y       float64
+}
+
+type compatibleLocatorSource struct {
+	Region       string
+	MapPrefix    string
+	LocatorFile  string
+	CandidateMap string
+	IsBase       bool
+}
+
+type compatibleMatchImage struct {
+	Img      *image.RGBA
+	Integral minicv.IntegralArray
+}
+
+type compatibleTransform struct {
+	SourceName string
+	MapName    string
+	OffsetX    float64
+	OffsetY    float64
+	Scale      float64
+	Score      float64
+	Width      int
+	Height     int
+}
+
+type compatibleCoordinateMapper struct {
+	preferredMapName string
+}
+
+var compatibleTransformCache = struct {
+	sync.RWMutex
+	Transforms map[string]compatibleTransform
+}{Transforms: map[string]compatibleTransform{}}
+
+var compatibleTrackerMapCache = struct {
+	sync.Mutex
+	ByPrefix map[string][]string
+}{ByPrefix: map[string][]string{}}
+
+// compatibleZoneRegexp matches MapLocator tier zone IDs like ValleyIV_L1_114.
+var compatibleZoneRegexp = regexp.MustCompile(`^(ValleyIV|Wuling)_L(\d+)_(\d+)$`)
+
+// compatibleTrackerMapRegexp matches MapTracker map names like map01_lv001 or map01_lv003_tier_123.
+var compatibleTrackerMapRegexp = regexp.MustCompile(`^((?:map0[12])|(?:base01))_lv(\d{3})(?:_tier_(\d+))?$`)
+
+func convertCompatiblePoints(preferredMapName string, points []compatibleSourcePoint) (compatibleConvertedPath, error) {
+	if len(points) == 0 {
+		return compatibleConvertedPath{}, fmt.Errorf("MapTrackerMoveCompatible requires at least one coordinate waypoint")
+	}
+
+	mapper := &compatibleCoordinateMapper{preferredMapName: preferredMapName}
+	path := make([][2]float64, 0, len(points))
+	moveMapName := ""
+	for _, sourcePoint := range points {
+		point, err := mapper.mapPoint(sourcePoint.SourceName, sourcePoint.X, sourcePoint.Y)
+		if err != nil {
+			return compatibleConvertedPath{}, err
+		}
+		rootMapName := compatibleRootMapName(point.MapName)
+		if moveMapName == "" {
+			moveMapName = rootMapName
+		} else if moveMapName != rootMapName {
+			return compatibleConvertedPath{}, fmt.Errorf("MapTrackerMove cannot represent route across multiple levels: %s and %s", moveMapName, rootMapName)
+		}
+		path = append(path, [2]float64{point.X, point.Y})
+	}
+
+	if moveMapName == "" {
+		return compatibleConvertedPath{}, fmt.Errorf("failed to resolve converted map_name")
+	}
+	return compatibleConvertedPath{MapName: moveMapName, Path: path}, nil
+}
+
+func convertCompatibleRect(preferredMapName string, rect compatibleSourceRect) (compatibleConvertedRect, error) {
+	if rect.W <= 0 || rect.H <= 0 {
+		return compatibleConvertedRect{}, fmt.Errorf("target width and height must be positive")
+	}
+
+	mapper := &compatibleCoordinateMapper{preferredMapName: preferredMapName}
+	centerX := rect.X + rect.W/2.0
+	centerY := rect.Y + rect.H/2.0
+	transform, err := mapper.resolveTransform(rect.SourceName, centerX, centerY)
+	if err != nil {
+		return compatibleConvertedRect{}, err
+	}
+
+	left := transform.OffsetX + rect.X*transform.Scale
+	top := transform.OffsetY + rect.Y*transform.Scale
+	right := transform.OffsetX + (rect.X+rect.W)*transform.Scale
+	bottom := transform.OffsetY + (rect.Y+rect.H)*transform.Scale
+	if right < left {
+		left, right = right, left
+	}
+	if bottom < top {
+		top, bottom = bottom, top
+	}
+	return compatibleConvertedRect{
+		MapName: compatibleRootMapName(transform.MapName),
+		Target:  [4]float64{left, top, right - left, bottom - top},
+	}, nil
+}
+
+func (m *compatibleCoordinateMapper) mapPoint(sourceName string, x, y float64) (compatibleTrackerPoint, error) {
+	transform, err := m.resolveTransform(sourceName, x, y)
+	if err != nil {
+		return compatibleTrackerPoint{}, err
+	}
+	return compatibleTrackerPoint{
+		MapName: transform.MapName,
+		X:       transform.OffsetX + x*transform.Scale,
+		Y:       transform.OffsetY + y*transform.Scale,
+	}, nil
+}
+
+func (m *compatibleCoordinateMapper) resolveTransform(sourceName string, x, y float64) (compatibleTransform, error) {
+	// 1. Resolve Navigator zone or Tracker map name to concrete image candidates.
+	source, err := resolveCompatibleSourceMap(sourceName, m.preferredMapName)
+	if err != nil {
+		return compatibleTransform{}, err
+	}
+
+	// 2. Reuse cached transforms before loading any image material.
+	if transform, ok := m.tryKnownTransforms(source, x, y); ok {
+		return transform, nil
+	}
+
+	// 3. Match images once and cache only the lightweight transform.
+	transform, err := matchCompatibleTransform(source, x, y)
+	if err != nil {
+		return compatibleTransform{}, err
+	}
+	storeCompatibleTransform(source.transformKey(transform.MapName), transform)
+	return transform, nil
+}
+
+func (m *compatibleCoordinateMapper) tryKnownTransforms(source compatibleLocatorSource, x, y float64) (compatibleTransform, bool) {
+	compatibleTransformCache.RLock()
+	defer compatibleTransformCache.RUnlock()
+	for _, transform := range compatibleTransformCache.Transforms {
+		if transform.SourceName != source.SourceName() || !source.acceptsCandidate(transform.MapName) {
+			continue
+		}
+		tx := transform.OffsetX + x*transform.Scale
+		ty := transform.OffsetY + y*transform.Scale
+		if tx >= -compatibleTransformMargin && tx < float64(transform.Width)+compatibleTransformMargin &&
+			ty >= -compatibleTransformMargin && ty < float64(transform.Height)+compatibleTransformMargin {
+			return transform, true
+		}
+	}
+	return compatibleTransform{}, false
+}
+
+func storeCompatibleTransform(key string, transform compatibleTransform) {
+	compatibleTransformCache.Lock()
+	compatibleTransformCache.Transforms[key] = transform
+	compatibleTransformCache.Unlock()
+}
+
+func resolveCompatibleSourceMap(sourceName string, preferredMapName string) (compatibleLocatorSource, error) {
+	// 1. Accept Tracker map names directly.
+	if sourceName == "" {
+		return compatibleLocatorSource{}, fmt.Errorf("empty source map name")
+	}
+
+	if info, ok := parseCompatibleTrackerMapName(sourceName); ok {
+		return info, nil
+	}
+	// 2. Resolve special one-file base maps.
+	if sourceName == "OMVBase01" {
+		return compatibleLocatorSource{Region: "OMVBase", MapPrefix: "base01", LocatorFile: "OMVBase01.png", CandidateMap: "base01_lv003", IsBase: true}, nil
+	}
+	// 3. Resolve region Base zones such as ValleyIV_Base.
+	if strings.HasSuffix(sourceName, "_Base") {
+		region := strings.TrimSuffix(sourceName, "_Base")
+		prefix, ok := compatibleRegionMapPrefix(region)
+		if !ok {
+			return compatibleLocatorSource{}, fmt.Errorf("unsupported MapNavigator region: %s", region)
+		}
+		candidate := ""
+		if strings.HasPrefix(preferredMapName, prefix+"_lv") && !strings.Contains(preferredMapName, "_tier_") {
+			candidate = preferredMapName
+		}
+		return compatibleLocatorSource{Region: region, MapPrefix: prefix, LocatorFile: "Base.png", CandidateMap: candidate, IsBase: true}, nil
+	}
+	// 4. Resolve tier zones such as ValleyIV_L1_114.
+	if matches := compatibleZoneRegexp.FindStringSubmatch(sourceName); len(matches) == 4 {
+		region := matches[1]
+		prefix, ok := compatibleRegionMapPrefix(region)
+		if !ok {
+			return compatibleLocatorSource{}, fmt.Errorf("unsupported MapNavigator region: %s", region)
+		}
+		level := matches[2]
+		tier := matches[3]
+		return compatibleLocatorSource{
+			Region:       region,
+			MapPrefix:    prefix,
+			LocatorFile:  fmt.Sprintf("Lv%03sTier%s.png", level, tier),
+			CandidateMap: fmt.Sprintf("%s_lv%03s_tier_%s", prefix, level, tier),
+		}, nil
+	}
+	return compatibleLocatorSource{}, fmt.Errorf("unsupported MapNavigator map name: %s", sourceName)
+}
+
+func parseCompatibleTrackerMapName(mapName string) (compatibleLocatorSource, bool) {
+	matches := compatibleTrackerMapRegexp.FindStringSubmatch(mapName)
+	if len(matches) != 4 {
+		return compatibleLocatorSource{}, false
+	}
+	region, ok := compatibleMapPrefixRegion(matches[1])
+	if !ok {
+		return compatibleLocatorSource{}, false
+	}
+	if matches[3] != "" {
+		return compatibleLocatorSource{
+			Region:       region,
+			MapPrefix:    matches[1],
+			LocatorFile:  fmt.Sprintf("Lv%sTier%s.png", matches[2], matches[3]),
+			CandidateMap: mapName,
+		}, true
+	}
+	return compatibleLocatorSource{
+		Region:       region,
+		MapPrefix:    matches[1],
+		LocatorFile:  "Base.png",
+		CandidateMap: mapName,
+		IsBase:       true,
+	}, true
+}
+
+func matchCompatibleTransform(source compatibleLocatorSource, x, y float64) (compatibleTransform, error) {
+	// 1. Crop a template around the source waypoint from the Locator image.
+	locator, err := loadCompatibleImage(filepath.Join(mapLocatorImageDir, source.Region, source.LocatorFile))
+	if err != nil {
+		return compatibleTransform{}, err
+	}
+
+	// 2. Pick candidate Tracker level/tier images from naming rules.
+	candidates, err := source.candidateMaps()
+	if err != nil {
+		return compatibleTransform{}, err
+	}
+	if len(candidates) == 0 {
+		return compatibleTransform{}, fmt.Errorf("no MapTracker candidates for %s", source.SourceName())
+	}
+
+	// 3. Search scale and offset by template matching.
+	best := compatibleTransform{Score: -1}
+	for _, cropSize := range []int{64, 96, 128} {
+		crop, cropLeft, cropTop, ok := cropCompatibleTemplate(locator.Img, x, y, cropSize)
+		if !ok {
+			continue
+		}
+		cropStats := minicv.GetImageStats(crop)
+		if cropStats.Std < 1e-6 {
+			continue
+		}
+		for _, mapName := range candidates {
+			tracker, err := loadCompatibleImage(filepath.Join(maptrackerinternal.MAP_DIR, mapName+".png"))
+			if err != nil {
+				continue
+			}
+			matchX, matchY, score, scale := minicv.MatchTemplateAnyScale(
+				tracker.Img,
+				tracker.Integral,
+				crop,
+				compatibleTemplateMinScale,
+				compatibleTemplateMaxScale,
+				[]int{4, 4},
+			)
+			if score <= best.Score {
+				continue
+			}
+			best = compatibleTransform{
+				SourceName: source.SourceName(),
+				MapName:    mapName,
+				OffsetX:    matchX - float64(cropLeft)*scale,
+				OffsetY:    matchY - float64(cropTop)*scale,
+				Scale:      scale,
+				Score:      score,
+				Width:      tracker.Img.Bounds().Dx(),
+				Height:     tracker.Img.Bounds().Dy(),
+			}
+		}
+		if best.Score >= 0.90 {
+			break
+		}
+	}
+
+	// 4. Keep only high-confidence transforms.
+	if best.Score < compatibleTemplateMinScore {
+		return compatibleTransform{}, fmt.Errorf("failed to match MapNavigator point to MapTracker map: source=%s x=%.1f y=%.1f score=%.3f", source.SourceName(), x, y, best.Score)
+	}
+	log.Info().
+		Str("source", source.SourceName()).
+		Str("map", best.MapName).
+		Float64("score", best.Score).
+		Float64("scale", best.Scale).
+		Msg("MapTrackerMoveCompatible matched runtime coordinate transform")
+	return best, nil
+}
+
+func cropCompatibleTemplate(img *image.RGBA, x, y float64, size int) (*image.RGBA, int, int, bool) {
+	if img == nil || size <= 0 {
+		return nil, 0, 0, false
+	}
+	cx := int(math.Round(x))
+	cy := int(math.Round(y))
+	rect := image.Rect(cx-size/2, cy-size/2, cx+size/2, cy+size/2).Intersect(img.Bounds())
+	if rect.Dx() < 24 || rect.Dy() < 24 {
+		return nil, 0, 0, false
+	}
+	return minicv.ImageCropRect(img, rect), rect.Min.X, rect.Min.Y, true
+}
+
+func loadCompatibleImage(relativePath string) (*compatibleMatchImage, error) {
+	resolvedPath := resource.FindResource(relativePath)
+	if resolvedPath == "" {
+		return nil, fmt.Errorf("resource not found: %s", relativePath)
+	}
+
+	file, err := os.Open(resolvedPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	img, _, err := image.Decode(file)
+	if err != nil {
+		return nil, err
+	}
+	rgba := minicv.ImageConvertRGBA(img)
+	return &compatibleMatchImage{Img: rgba, Integral: minicv.GetIntegralArray(rgba)}, nil
+}
+
+func (s compatibleLocatorSource) candidateMaps() ([]string, error) {
+	if s.CandidateMap != "" {
+		return []string{s.CandidateMap}, nil
+	}
+	if !s.IsBase {
+		return nil, fmt.Errorf("missing tier candidate map for %s", s.SourceName())
+	}
+	return compatibleTrackerBaseMaps(s.MapPrefix)
+}
+
+func compatibleTrackerBaseMaps(prefix string) ([]string, error) {
+	compatibleTrackerMapCache.Lock()
+	if cached, ok := compatibleTrackerMapCache.ByPrefix[prefix]; ok {
+		compatibleTrackerMapCache.Unlock()
+		return cached, nil
+	}
+	compatibleTrackerMapCache.Unlock()
+
+	mapDir := resource.FindResource(maptrackerinternal.MAP_DIR)
+	if mapDir == "" {
+		return nil, fmt.Errorf("MapTracker map directory not found")
+	}
+	entries, err := os.ReadDir(mapDir)
+	if err != nil {
+		return nil, err
+	}
+
+	maps := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".png") {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".png")
+		if strings.HasPrefix(name, prefix+"_lv") && !strings.Contains(name, "_tier_") {
+			maps = append(maps, name)
+		}
+	}
+	sort.Strings(maps)
+
+	compatibleTrackerMapCache.Lock()
+	compatibleTrackerMapCache.ByPrefix[prefix] = maps
+	compatibleTrackerMapCache.Unlock()
+	return maps, nil
+}
+
+func (s compatibleLocatorSource) SourceName() string {
+	return filepath.ToSlash(filepath.Join(s.Region, s.LocatorFile))
+}
+
+func (s compatibleLocatorSource) transformKey(mapName string) string {
+	return s.SourceName() + "|" + mapName
+}
+
+func (s compatibleLocatorSource) acceptsCandidate(mapName string) bool {
+	if s.CandidateMap != "" {
+		return s.CandidateMap == mapName
+	}
+	return strings.HasPrefix(mapName, s.MapPrefix+"_lv")
+}
+
+func compatibleRegionMapPrefix(region string) (string, bool) {
+	switch region {
+	case "ValleyIV":
+		return "map01", true
+	case "Wuling":
+		return "map02", true
+	case "OMVBase":
+		return "base01", true
+	default:
+		return "", false
+	}
+}
+
+func compatibleMapPrefixRegion(prefix string) (string, bool) {
+	switch prefix {
+	case "map01":
+		return "ValleyIV", true
+	case "map02":
+		return "Wuling", true
+	case "base01":
+		return "OMVBase", true
+	default:
+		return "", false
+	}
+}
+
+func compatibleRootMapName(mapName string) string {
+	if index := strings.Index(mapName, "_tier_"); index >= 0 {
+		return mapName[:index]
+	}
+	return mapName
+}

--- a/agent/go-service/maptracker/compatible/convert.go
+++ b/agent/go-service/maptracker/compatible/convert.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -247,13 +248,16 @@ func resolveCompatibleSourceMap(sourceName string, preferredMapName string) (com
 		if !ok {
 			return compatibleLocatorSource{}, fmt.Errorf("unsupported MapNavigator region: %s", region)
 		}
-		level := matches[2]
+		level, err := strconv.Atoi(matches[2])
+		if err != nil {
+			return compatibleLocatorSource{}, fmt.Errorf("invalid MapNavigator level: %s", matches[2])
+		}
 		tier := matches[3]
 		return compatibleLocatorSource{
 			Region:       region,
 			MapPrefix:    prefix,
-			LocatorFile:  fmt.Sprintf("Lv%03sTier%s.png", level, tier),
-			CandidateMap: fmt.Sprintf("%s_lv%03s_tier_%s", prefix, level, tier),
+			LocatorFile:  fmt.Sprintf("Lv%03dTier%s.png", level, tier),
+			CandidateMap: fmt.Sprintf("%s_lv%03d_tier_%s", prefix, level, tier),
 		}, nil
 	}
 	return compatibleLocatorSource{}, fmt.Errorf("unsupported MapNavigator map name: %s", sourceName)

--- a/agent/go-service/maptracker/compatible/move_compatible.go
+++ b/agent/go-service/maptracker/compatible/move_compatible.go
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 Harry Huang
+package maptrackercompatible
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	maptrackerdefault "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/default"
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+var _ maa.CustomActionRunner = &MapTrackerMoveCompatible{}
+
+// MapTrackerMoveCompatible converts MapNavigateAction-style params and runs MapTrackerMove.
+type MapTrackerMoveCompatible struct{}
+
+type mapNavigateCompatibleParam struct {
+	MapName                      string            `json:"map_name"`
+	Path                         []json.RawMessage `json:"path"`
+	NoPrint                      bool              `json:"no_print,omitempty"`
+	PathTrim                     bool              `json:"path_trim,omitempty"`
+	FineApproach                 string            `json:"fine_approach,omitempty"`
+	NoEnsureInitialMovementState bool              `json:"no_ensure_initial_movement_state,omitempty"`
+	NoEnsureFinalOrientation     bool              `json:"no_ensure_final_orientation,omitempty"`
+	ArrivalThreshold             float64           `json:"arrival_threshold,omitempty"`
+	ArrivalTimeout               int64             `json:"arrival_timeout,omitempty"`
+	RotationLowerThreshold       float64           `json:"rotation_lower_threshold,omitempty"`
+	RotationUpperThreshold       float64           `json:"rotation_upper_threshold,omitempty"`
+	SprintThreshold              float64           `json:"sprint_threshold,omitempty"`
+	StuckThreshold               int64             `json:"stuck_threshold,omitempty"`
+	StuckTimeout                 int64             `json:"stuck_timeout,omitempty"`
+	StuckMitigators              []string          `json:"stuck_mitigators,omitempty"`
+	MapNameMatchRule             string            `json:"map_name_match_rule,omitempty"`
+	X                            *float64          `json:"x"`
+	Y                            *float64          `json:"y"`
+	Action                       any               `json:"action,omitempty"`
+	Actions                      any               `json:"actions,omitempty"`
+	Target                       []float64         `json:"target,omitempty"`
+}
+
+type compatibleWaypoint struct {
+	X                  float64
+	Y                  float64
+	ZoneID             string
+	HasPosition        bool
+	UnsupportedActions []string
+}
+
+type compatibleWaypointObject struct {
+	Action     any       `json:"action"`
+	Actions    any       `json:"actions"`
+	ZoneID     string    `json:"zone_id"`
+	ZoneIDAlt  string    `json:"zoneId"`
+	Zone       string    `json:"zone"`
+	MapName    string    `json:"map_name"`
+	MapNameAlt string    `json:"mapName"`
+	X          *float64  `json:"x"`
+	Y          *float64  `json:"y"`
+	Target     []float64 `json:"target"`
+}
+
+func (a *MapTrackerMoveCompatible) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	// 1. Parse MapNavigateAction-compatible input.
+	param, err := a.parseParam(arg.CustomActionParam)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to parse parameters for MapTrackerMoveCompatible")
+		return false
+	}
+	if len(param.Path) == 0 {
+		return true
+	}
+
+	// 2. Convert locator coordinates into MapTrackerMove parameters.
+	moveParam, err := a.convertParam(param)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to convert parameters for MapTrackerMoveCompatible")
+		return false
+	}
+	if len(moveParam.Path) == 0 {
+		return true
+	}
+
+	// 3. Forward to the real MapTrackerMove runner.
+	moveParamText, err := json.Marshal(moveParam)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to serialize MapTrackerMoveCompatible converted parameters")
+		return false
+	}
+
+	log.Info().
+		Str("map", moveParam.MapName).
+		Int("targetsCount", len(moveParam.Path)).
+		Msg("MapTrackerMoveCompatible converted parameters")
+
+	forwardArg := *arg
+	forwardArg.CustomActionName = "MapTrackerMove"
+	forwardArg.CustomActionParam = string(moveParamText)
+	return (&maptrackerdefault.MapTrackerMove{}).Run(ctx, &forwardArg)
+}
+
+func (a *MapTrackerMoveCompatible) parseParam(paramStr string) (*mapNavigateCompatibleParam, error) {
+	if strings.TrimSpace(paramStr) == "" {
+		return &mapNavigateCompatibleParam{}, nil
+	}
+
+	var param mapNavigateCompatibleParam
+	if err := json.Unmarshal([]byte(paramStr), &param); err != nil {
+		return nil, fmt.Errorf("failed to parse parameters: %w", err)
+	}
+	if len(param.Path) == 0 && (param.X != nil || param.Y != nil || param.Target != nil || param.Action != nil || param.Actions != nil) {
+		raw := json.RawMessage(paramStr)
+		param.Path = []json.RawMessage{raw}
+	}
+	return &param, nil
+}
+
+func (a *MapTrackerMoveCompatible) convertParam(param *mapNavigateCompatibleParam) (*maptrackerdefault.MapTrackerMoveParam, error) {
+	// 1. Parse mixed array/object waypoints into a normalized list.
+	waypoints, err := parseCompatibleWaypoints(param)
+	if err != nil {
+		return nil, err
+	}
+	if len(waypoints) == 0 {
+		return nil, fmt.Errorf("MapTrackerMoveCompatible requires at least one coordinate waypoint")
+	}
+
+	// 2. Extract coordinate points from retained waypoints.
+	points := make([]compatibleSourcePoint, 0, len(waypoints))
+	for _, waypoint := range waypoints {
+		if !waypoint.HasPosition {
+			continue
+		}
+
+		for _, action := range waypoint.UnsupportedActions {
+			log.Warn().Str("action", action).Msg("MapTrackerMoveCompatible ignores unsupported waypoint action")
+		}
+
+		sourceMapName := firstNonEmptyString(waypoint.ZoneID, param.MapName)
+		if sourceMapName == "" {
+			return nil, fmt.Errorf("waypoint is missing map_name or zone_id")
+		}
+		points = append(points, compatibleSourcePoint{SourceName: sourceMapName, X: waypoint.X, Y: waypoint.Y})
+	}
+	if len(points) == 0 {
+		return nil, fmt.Errorf("MapTrackerMoveCompatible requires at least one coordinate waypoint")
+	}
+
+	// 3. Convert source map coordinates into MapTracker coordinates.
+	converted, err := convertCompatiblePoints(param.MapName, points)
+	if err != nil {
+		return nil, err
+	}
+
+	// 4. Preserve the MapTrackerMove options that have compatible semantics.
+	return &maptrackerdefault.MapTrackerMoveParam{
+		MapName:                      converted.MapName,
+		Path:                         converted.Path,
+		NoPrint:                      param.NoPrint,
+		PathTrim:                     param.PathTrim,
+		FineApproach:                 param.FineApproach,
+		NoEnsureInitialMovementState: param.NoEnsureInitialMovementState,
+		NoEnsureFinalOrientation:     param.NoEnsureFinalOrientation,
+		ArrivalThreshold:             param.ArrivalThreshold,
+		ArrivalTimeout:               param.ArrivalTimeout,
+		RotationLowerThreshold:       param.RotationLowerThreshold,
+		RotationUpperThreshold:       param.RotationUpperThreshold,
+		SprintThreshold:              param.SprintThreshold,
+		StuckThreshold:               param.StuckThreshold,
+		StuckTimeout:                 param.StuckTimeout,
+		StuckMitigators:              param.StuckMitigators,
+		MapNameMatchRule:             param.MapNameMatchRule,
+	}, nil
+}
+
+func parseCompatibleWaypoints(param *mapNavigateCompatibleParam) ([]compatibleWaypoint, error) {
+	waypoints := make([]compatibleWaypoint, 0, len(param.Path))
+	zoneContext := param.MapName
+	for index, raw := range param.Path {
+		parsed, ok, err := parseCompatibleWaypoint(raw, zoneContext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse waypoint %d: %w", index, err)
+		}
+		if !ok {
+			continue
+		}
+		if parsed.ZoneID != "" {
+			zoneContext = parsed.ZoneID
+		}
+		waypoints = append(waypoints, parsed)
+	}
+	return waypoints, nil
+}
+
+func parseCompatibleWaypoint(raw json.RawMessage, zoneContext string) (compatibleWaypoint, bool, error) {
+	parseArray := func(items []any) (compatibleWaypoint, bool, error) {
+		if len(items) < 2 {
+			return compatibleWaypoint{}, false, nil
+		}
+		x, xOk := items[0].(float64)
+		y, yOk := items[1].(float64)
+		if !xOk || !yOk {
+			return compatibleWaypoint{}, false, fmt.Errorf("array waypoint requires numeric x and y")
+		}
+
+		waypoint := compatibleWaypoint{X: x, Y: y, ZoneID: zoneContext, HasPosition: true}
+		for _, item := range items[2:] {
+			zone, ok := item.(string)
+			if !ok {
+				continue
+			}
+			if isCompatibleActionToken(zone) {
+				if !isCompatiblePlainRunAction(zone) {
+					waypoint.UnsupportedActions = append(waypoint.UnsupportedActions, strings.ToUpper(zone))
+				}
+				continue
+			}
+			waypoint.ZoneID = zone
+		}
+		return waypoint, true, nil
+	}
+
+	parseObject := func(object compatibleWaypointObject) (compatibleWaypoint, bool, error) {
+		zoneID := firstNonEmptyString(object.ZoneID, object.ZoneIDAlt, object.Zone, object.MapName, object.MapNameAlt, zoneContext)
+		actions := append(compatibleActionList(object.Action), compatibleActionList(object.Actions)...)
+		primaryAction := ""
+		if len(actions) > 0 {
+			primaryAction = actions[0]
+		}
+		if primaryAction == "ZONE" {
+			return compatibleWaypoint{ZoneID: zoneID}, zoneID != "", nil
+		}
+		if primaryAction == "NAVMESH" {
+			log.Warn().Msg("MapTrackerMoveCompatible ignores unsupported NAVMESH waypoint")
+			return compatibleWaypoint{}, false, nil
+		}
+		if primaryAction == "HEADING" {
+			if len(object.Target) != 2 {
+				log.Warn().Msg("MapTrackerMoveCompatible ignores unsupported heading-only waypoint")
+				return compatibleWaypoint{}, false, nil
+			}
+			return compatibleWaypoint{X: object.Target[0], Y: object.Target[1], ZoneID: zoneID, HasPosition: true, UnsupportedActions: []string{"HEADING"}}, true, nil
+		}
+		if object.X != nil && object.Y != nil {
+			return compatibleWaypoint{X: *object.X, Y: *object.Y, ZoneID: zoneID, HasPosition: true, UnsupportedActions: unsupportedCompatibleActions(actions)}, true, nil
+		}
+		return compatibleWaypoint{}, false, nil
+	}
+
+	var items []any
+	if err := json.Unmarshal(raw, &items); err == nil {
+		return parseArray(items)
+	}
+
+	var object compatibleWaypointObject
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return compatibleWaypoint{}, false, err
+	}
+	return parseObject(object)
+}
+
+func unsupportedCompatibleActions(actions []string) []string {
+	result := make([]string, 0, len(actions))
+	for _, action := range actions {
+		if !isCompatiblePlainRunAction(action) {
+			result = append(result, strings.ToUpper(action))
+		}
+	}
+	return result
+}
+
+func compatibleActionList(input any) []string {
+	switch value := input.(type) {
+	case string:
+		return []string{strings.ToUpper(value)}
+	case []any:
+		result := make([]string, 0, len(value))
+		for _, item := range value {
+			if text, ok := item.(string); ok {
+				result = append(result, strings.ToUpper(text))
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func isCompatiblePlainRunAction(text string) bool {
+	return text == "" || strings.EqualFold(text, "RUN")
+}
+
+func isCompatibleActionToken(text string) bool {
+	switch strings.ToUpper(text) {
+	case "RUN", "SPRINT", "JUMP", "FIGHT", "INTERACT", "TRANSFER", "PORTAL", "HEADING", "NAVMESH", "ZONE", "COLLECT", "DIG":
+		return true
+	default:
+		return false
+	}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/agent/go-service/maptracker/compatible/move_compatible_test.go
+++ b/agent/go-service/maptracker/compatible/move_compatible_test.go
@@ -19,6 +19,22 @@ func moveCompatibleTestRepoRoot(t *testing.T) string {
 	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
 }
 
+func chdirCompatibleTestRepoRoot(t *testing.T) {
+	t.Helper()
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(moveCompatibleTestRepoRoot(t)); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCwd); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func mustRawMessages(t *testing.T, values ...any) []json.RawMessage {
 	t.Helper()
 	result := make([]json.RawMessage, 0, len(values))
@@ -32,10 +48,21 @@ func mustRawMessages(t *testing.T, values ...any) []json.RawMessage {
 	return result
 }
 
-func TestMapTrackerMoveCompatibleRejectsEmptyOrUnknownRoutes(t *testing.T) {
-	if err := os.Chdir(moveCompatibleTestRepoRoot(t)); err != nil {
+func TestResolveCompatibleSourceMapPadsTierLevel(t *testing.T) {
+	source, err := resolveCompatibleSourceMap("ValleyIV_L1_114", "")
+	if err != nil {
 		t.Fatal(err)
 	}
+	if source.LocatorFile != "Lv001Tier114.png" {
+		t.Fatalf("got locator file %q", source.LocatorFile)
+	}
+	if source.CandidateMap != "map01_lv001_tier_114" {
+		t.Fatalf("got candidate map %q", source.CandidateMap)
+	}
+}
+
+func TestMapTrackerMoveCompatibleRejectsEmptyOrUnknownRoutes(t *testing.T) {
+	chdirCompatibleTestRepoRoot(t)
 
 	tests := []struct {
 		name  string
@@ -76,9 +103,7 @@ func TestMapTrackerMoveCompatibleRejectsEmptyOrUnknownRoutes(t *testing.T) {
 }
 
 func TestMapTrackerMoveCompatibleConvertsRegionalSamples(t *testing.T) {
-	if err := os.Chdir(moveCompatibleTestRepoRoot(t)); err != nil {
-		t.Fatal(err)
-	}
+	chdirCompatibleTestRepoRoot(t)
 
 	tests := []struct {
 		name    string
@@ -142,7 +167,7 @@ func TestMapTrackerMoveCompatibleConvertsRegionalSamples(t *testing.T) {
 			for i, expect := range tt.expects {
 				got := converted.Path[i]
 				dist := math.Hypot(got[0]-expect[0], got[1]-expect[1])
-				if dist > 1.0 {
+				if dist > 2.0 {
 					t.Fatalf("point %d got [%.3f, %.3f], want [%.3f, %.3f], dist %.3f", i, got[0], got[1], expect[0], expect[1], dist)
 				}
 			}

--- a/agent/go-service/maptracker/compatible/move_compatible_test.go
+++ b/agent/go-service/maptracker/compatible/move_compatible_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Harry Huang
+package maptrackercompatible
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func moveCompatibleTestRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get test file path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func mustRawMessages(t *testing.T, values ...any) []json.RawMessage {
+	t.Helper()
+	result := make([]json.RawMessage, 0, len(values))
+	for _, value := range values {
+		content, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result = append(result, content)
+	}
+	return result
+}
+
+func TestMapTrackerMoveCompatibleRejectsEmptyOrUnknownRoutes(t *testing.T) {
+	if err := os.Chdir(moveCompatibleTestRepoRoot(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		param mapNavigateCompatibleParam
+	}{
+		{
+			name: "NavmeshOnly",
+			param: mapNavigateCompatibleParam{
+				Path: mustRawMessages(t,
+					map[string]any{"action": "ZONE", "zone_id": "Wuling_Base"},
+					map[string]any{"action": "NAVMESH", "target": []any{942.0, 723.0}},
+				),
+			},
+		},
+		{
+			name: "HeadingOnly",
+			param: mapNavigateCompatibleParam{
+				Path: mustRawMessages(t, map[string]any{"action": "HEADING", "angle": 90.0}),
+			},
+		},
+		{
+			name: "UnknownMap",
+			param: mapNavigateCompatibleParam{
+				Path: mustRawMessages(t,
+					map[string]any{"action": "ZONE", "zone_id": "Unknown_Base"},
+					[]any{1.0, 2.0},
+				),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := (&MapTrackerMoveCompatible{}).convertParam(&tt.param); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestMapTrackerMoveCompatibleConvertsRegionalSamples(t *testing.T) {
+	if err := os.Chdir(moveCompatibleTestRepoRoot(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		param   mapNavigateCompatibleParam
+		expects [][2]float64
+	}{
+		{
+			name: "ValleyIV",
+			param: mapNavigateCompatibleParam{
+				Path: mustRawMessages(t,
+					map[string]any{"action": "ZONE", "zone_id": "ValleyIV_Base"},
+					[]any{532.0, 697.0},
+					[]any{574.0, 735.0},
+				),
+			},
+			expects: [][2]float64{
+				{478.960, 267.960},
+				{524.845, 309.475},
+			},
+		},
+		{
+			name: "Wuling",
+			param: mapNavigateCompatibleParam{
+				MapName: "map02_lv002",
+				Path: mustRawMessages(t,
+					map[string]any{"action": "ZONE", "zone_id": "Wuling_Base"},
+					[]any{942.0, 723.0},
+					[]any{944.0, 723.0},
+				),
+			},
+			expects: [][2]float64{
+				{664.200, 734.200},
+				{666.275, 734.200},
+			},
+		},
+		{
+			name: "OMVBase",
+			param: mapNavigateCompatibleParam{
+				Path: mustRawMessages(t,
+					map[string]any{"action": "ZONE", "zone_id": "OMVBase01"},
+					[]any{187.0, 141.0},
+					[]any{187.0, 131.0},
+				),
+			},
+			expects: [][2]float64{
+				{190.200, 143.200},
+				{190.200, 132.825},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converted, err := (&MapTrackerMoveCompatible{}).convertParam(&tt.param)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(converted.Path) != len(tt.expects) {
+				t.Fatalf("got %d points, want %d", len(converted.Path), len(tt.expects))
+			}
+			for i, expect := range tt.expects {
+				got := converted.Path[i]
+				dist := math.Hypot(got[0]-expect[0], got[1]-expect[1])
+				if dist > 1.0 {
+					t.Fatalf("point %d got [%.3f, %.3f], want [%.3f, %.3f], dist %.3f", i, got[0], got[1], expect[0], expect[1], dist)
+				}
+			}
+		})
+	}
+}

--- a/agent/go-service/maptracker/register.go
+++ b/agent/go-service/maptracker/register.go
@@ -3,6 +3,7 @@ package maptracker
 
 import (
 	maptrackerbigmap "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/bigmap"
+	maptrackercompatible "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/compatible"
 	maptrackerdefault "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/default"
 	"github.com/MaaXYZ/maa-framework-go/v4"
 )
@@ -12,6 +13,8 @@ func Register() {
 	maa.AgentServerRegisterCustomRecognition("MapTrackerInfer", &maptrackerdefault.MapTrackerInfer{})
 	maa.AgentServerRegisterCustomRecognition("MapTrackerBigMapInfer", &maptrackerbigmap.MapTrackerBigMapInfer{})
 	maa.AgentServerRegisterCustomRecognition("MapTrackerAssertLocation", &maptrackerdefault.MapTrackerAssertLocation{})
+	maa.AgentServerRegisterCustomRecognition("MapTrackerAssertLocationCompatible", &maptrackercompatible.MapTrackerAssertLocationCompatible{})
 	maa.AgentServerRegisterCustomAction("MapTrackerMove", &maptrackerdefault.MapTrackerMove{})
+	maa.AgentServerRegisterCustomAction("MapTrackerMoveCompatible", &maptrackercompatible.MapTrackerMoveCompatible{})
 	maa.AgentServerRegisterCustomAction("MapTrackerBigMapPick", &maptrackerbigmap.MapTrackerBigMapPick{})
 }

--- a/tools/schema/custom.action.schema.json
+++ b/tools/schema/custom.action.schema.json
@@ -56,6 +56,7 @@
                 "MapNavigateAction",
                 "MapTrackerBigMapPick",
                 "MapTrackerMove",
+                "MapTrackerMoveCompatible",
                 "OCREssenceInventoryNumberAction",
                 "PipelineOverride",
                 "PipelineOverrideAction",

--- a/tools/schema/custom.recognition.schema.json
+++ b/tools/schema/custom.recognition.schema.json
@@ -15,6 +15,7 @@
                 "ImageCheckNotPassedRecognition",
                 "MapLocateAssertLocation",
                 "MapTrackerAssertLocation",
+                "MapTrackerAssertLocationCompatible",
                 "MapTrackerBigMapInfer",
                 "MapTrackerInfer",
                 "PuzzleRecognition",


### PR DESCRIPTION
## 概要

此 PR 添加了 `MapTrackerAssertLocationCompatible` 和 `MapTrackerMoveCompatible` 节点。

使用方式：

```diff
- "custom_recognition": "MapLocateAssertLocation",
+ "custom_recognition": "MapTrackerAssertLocationCompatible",
```

```diff
- "custom_action": "MapNavigateAction",
+ "custom_action": "MapTrackerMoveCompatible",
```

## 关联

Refer #1514
Refer #3125

## Summary by Sourcery

为旧版导航/位置节点添加兼容层，以复用 MapTracker 的内部实现。

新功能：
- 引入 `MapTrackerMoveCompatible` 自定义动作，以使用 `MapNavigateAction` 风格的参数来运行 `MapTrackerMove`。
- 引入 `MapTrackerAssertLocationCompatible` 自定义识别，以使用 `MapLocateAssertLocation` 风格的参数来运行 `MapTrackerAssertLocation`。

增强内容：
- 实现 MapNavigator 分区与 MapTracker 地图之间的坐标和矩形转换，使用基于图像的模板匹配，并对变换结果和基础地图发现进行缓存。

测试：
- 添加单元测试，覆盖参数校验、坐标转换精度，以及针对新兼容 MapTracker 节点的区域示例用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add compatibility layer for legacy navigation/location nodes to reuse MapTracker internals.

New Features:
- Introduce MapTrackerMoveCompatible custom action to run MapTrackerMove using MapNavigateAction-style parameters.
- Introduce MapTrackerAssertLocationCompatible custom recognition to run MapTrackerAssertLocation using MapLocateAssertLocation-style parameters.

Enhancements:
- Implement coordinate and rectangle conversion between MapNavigator zones and MapTracker maps using image-based template matching with caching for transforms and base map discovery.

Tests:
- Add unit tests covering parameter validation, coordinate conversion accuracy, and region-specific samples for the new compatible MapTracker nodes.

</details>