### PR TITLE
fix(AccountSwitch): 账号切换成功后清空CaptureUid缓存

### DIFF
--- a/agent/go-service/captureuid/action.go
+++ b/agent/go-service/captureuid/action.go
@@ -11,6 +11,7 @@ type captureUidParam struct {
 	UseCache            *bool `json:"use_cache,omitempty"`
 	StayOnCurrentScreen *bool `json:"stay_on_current_screen,omitempty"`
 	AllowUnknown        *bool `json:"allow_unknown,omitempty"`
+	ClearCache_         *bool `json:"clear_cache,omitempty"`
 }
 
 type CaptureUidAction struct{}
@@ -32,6 +33,7 @@ func (a *CaptureUidAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 	useCache := true
 	stayOnCurrentScreen := true
 	allowUnknown := true
+	clearCache := false
 
 	if arg != nil && arg.CustomActionParam != "" {
 		var params captureUidParam
@@ -49,6 +51,14 @@ func (a *CaptureUidAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 		if params.AllowUnknown != nil {
 			allowUnknown = *params.AllowUnknown
 		}
+		if params.ClearCache_ != nil {
+			clearCache = *params.ClearCache_
+		}
+	}
+
+	if clearCache {
+		ClearCache()
+		return true
 	}
 
 	uid, err := Capture(ctx, ctrl, useCache, stayOnCurrentScreen, allowUnknown)

--- a/agent/go-service/captureuid/action.go
+++ b/agent/go-service/captureuid/action.go
@@ -11,7 +11,7 @@ type captureUidParam struct {
 	UseCache            *bool `json:"use_cache,omitempty"`
 	StayOnCurrentScreen *bool `json:"stay_on_current_screen,omitempty"`
 	AllowUnknown        *bool `json:"allow_unknown,omitempty"`
-	ClearCache_         *bool `json:"clear_cache,omitempty"`
+	ClearCache          *bool `json:"clear_cache,omitempty"`
 }
 
 type CaptureUidAction struct{}
@@ -51,8 +51,8 @@ func (a *CaptureUidAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 		if params.AllowUnknown != nil {
 			allowUnknown = *params.AllowUnknown
 		}
-		if params.ClearCache_ != nil {
-			clearCache = *params.ClearCache_
+		if params.ClearCache != nil {
+			clearCache = *params.ClearCache
 		}
 	}
 

--- a/agent/go-service/captureuid/capture.go
+++ b/agent/go-service/captureuid/capture.go
@@ -83,6 +83,14 @@ func Capture(ctx *maa.Context, ctrl *maa.Controller, useCache, stayOnCurrentScre
 	return uid, nil
 }
 
+// ClearCache clears the cached UID (thread-safe).
+func ClearCache() {
+	capturedUidMu.Lock()
+	capturedUid = ""
+	capturedUidMu.Unlock()
+	log.Info().Str("component", component).Msg("uid cache cleared")
+}
+
 // GetCachedUID returns the most recently captured UID (thread-safe).
 func GetCachedUID() string {
 	capturedUidMu.Lock()

--- a/assets/resource/pipeline/AccountSwitch.json
+++ b/assets/resource/pipeline/AccountSwitch.json
@@ -296,6 +296,18 @@
             38,
             245,
             255
+        ],
+        "next": [
+            "__AccountSwitchClearUidCache"
         ]
+    },
+    "__AccountSwitchClearUidCache": {
+        "desc": "清空UID缓存",
+        "recognition": "DirectHit",
+        "action": "Custom",
+        "custom_action": "CaptureUid",
+        "custom_action_param": {
+            "clear_cache": true
+        }
     }
 }


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

为捕获服务添加显式清除缓存 UID 的支持，并将其接入账号切换流程。

新功能：
- 在 `CaptureUid` 动作中引入 `clear_cache` 参数，用于触发缓存失效。

增强改进：
- 添加线程安全的 `ClearCache` 助手，用于重置已捕获的 UID，并记录清除缓存事件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for explicitly clearing the cached UID in the capture service and wire it into the account switch flow.

New Features:
- Introduce a clear_cache parameter to the CaptureUid action to trigger cache invalidation.

Enhancements:
- Add a thread-safe ClearCache helper that resets the captured UID and logs the cache clear event.

</details>