### PR TITLE
Revert "fix: 切账号增加一个有限重试。 (#3170)"

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -949,7 +949,7 @@
     "task.ResourceRecycleStation.focus.LimitReached": "Rare resource limit reached, scrolling",
     "task.ResourceRecycleStation.focus.Found": "Resource recycle station found",
     "task.ResourceRecycleStation.focus.Empty": "No collectible resources in this region",
-    "task.AccountSwitch.label": "🔁 Auto Account Switch",
+    "task.AccountSwitch.label": "Auto Account Switch",
     "task.AccountSwitch.description": "Automatically log out and switch to an account by matching the last 4 digits",
     "option.AccountSwitchLastFourDigits.label": "Target account last 4 digits",
     "option.AccountSwitchLastFourDigits.LastFourDigits.label": "Enter last 4 digits"

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -949,7 +949,7 @@
     "task.ResourceRecycleStation.focus.LimitReached": "希少資源が上限に達しました、スクロール中",
     "task.ResourceRecycleStation.focus.Found": "資源回収ステーションを発見",
     "task.ResourceRecycleStation.focus.Empty": "この地域に収集可能な資源はありません",
-    "task.AccountSwitch.label": "🔁 自動アカウント切替",
+    "task.AccountSwitch.label": "自動アカウント切替",
     "task.AccountSwitch.description": "現在のアカウントからログアウトし、指定した下4桁のアカウントに切り替えます",
     "option.AccountSwitchLastFourDigits.label": "対象アカウント下4桁",
     "option.AccountSwitchLastFourDigits.LastFourDigits.label": "下4桁を入力"

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -949,7 +949,7 @@
     "task.ResourceRecycleStation.focus.LimitReached": "희귀 자원 한도 도달, 스크롤 중",
     "task.ResourceRecycleStation.focus.Found": "자원 재활용 스테이션 발견",
     "task.ResourceRecycleStation.focus.Empty": "이 지역에 수집 가능한 자원이 없습니다",
-    "task.AccountSwitch.label": "🔁 자동 계정 전환",
+    "task.AccountSwitch.label": "자동 계정 전환",
     "task.AccountSwitch.description": "현재 계정에서 로그아웃하고 지정한 마지막 4자리 계정으로 전환합니다",
     "option.AccountSwitchLastFourDigits.label": "대상 계정 마지막 4자리",
     "option.AccountSwitchLastFourDigits.LastFourDigits.label": "마지막 4자리 입력"

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -949,7 +949,7 @@
     "task.ResourceRecycleStation.focus.LimitReached": "稀有资源已达上限，滑动查看",
     "task.ResourceRecycleStation.focus.Found": "发现资源回收站",
     "task.ResourceRecycleStation.focus.Empty": "该地区暂无可收取资源",
-    "task.AccountSwitch.label": "🔁 自动切换账号",
+    "task.AccountSwitch.label": "自动切换账号",
     "task.AccountSwitch.description": "自动登出当前账号并切换到指定账号的后四位",
     "option.AccountSwitchLastFourDigits.label": "目标账号后四位",
     "option.AccountSwitchLastFourDigits.LastFourDigits.label": "输入账号后四位"

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -949,7 +949,7 @@
     "task.ResourceRecycleStation.focus.LimitReached": "稀有資源已達上限，滑動查看",
     "task.ResourceRecycleStation.focus.Found": "發現資源回收站",
     "task.ResourceRecycleStation.focus.Empty": "該地區暫無可收取資源",
-    "task.AccountSwitch.label": "🔁 自動切換帳號",
+    "task.AccountSwitch.label": "自動切換帳號",
     "task.AccountSwitch.description": "自動登出當前帳號並切換到指定帳號的後四位",
     "option.AccountSwitchLastFourDigits.label": "目標帳號後四位",
     "option.AccountSwitchLastFourDigits.LastFourDigits.label": "輸入帳號後四位"

--- a/assets/resource/pipeline/AccountSwitch.json
+++ b/assets/resource/pipeline/AccountSwitch.json
@@ -130,7 +130,6 @@
         ]
     },
     "__AccountSwitchClickDropdown": {
-        "max_hit": 3,
         "desc": "点击账号下拉按钮",
         "recognition": {
             "type": "TemplateMatch",
@@ -154,8 +153,7 @@
         },
         "post_wait_freezes": 500,
         "next": [
-            "__AccountSwitchOCRSelectAccount",
-            "__AccountSwitchClickDropdown"
+            "__AccountSwitchOCRSelectAccount"
         ]
     },
     "__AccountSwitchOCRSelectAccount": {


### PR DESCRIPTION
This reverts commit 8c28715afc14b043a89ade0b53bfcebe2d8690e3.

## Summary by Sourcery

增强：
- 通过移除最近添加的有限重试逻辑及其相关资源，恢复此前的账户切换行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Restore previous account switching behavior by removing the recently added limited retry logic and its associated resources.

</details>