### PR TITLE
fix: 调整礼物选择和联系文字的颜色阈值

### DIFF
--- a/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
@@ -237,9 +237,9 @@
             "param": {
                 "roi": "GiftOperatorCheckSelectedLabelColor",
                 "lower": [
-                    50,
-                    50,
-                    50
+                    40,
+                    40,
+                    40
                 ],
                 "upper": [
                     55,

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
@@ -225,9 +225,9 @@
             "param": {
                 "roi": "GiftOperatorGiftSelectedLabelColor",
                 "lower": [
-                    72,
-                    72,
-                    66
+                    60,
+                    60,
+                    60
                 ],
                 "upper": [
                     114,


### PR DESCRIPTION
## Summary by Sourcery

调整 GiftOperator UI JSON 资源中礼物选择和联系人相关文本的颜色阈值配置。

增强内容：
- 微调 GiftOperatorGiftFlow 中礼物选择界面的颜色阈值设置。
- 更新 GiftOperatorContact 中联系人相关文本的颜色阈值设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust color threshold configurations for gift selection and contact-related texts in GiftOperator UI JSON resources.

Enhancements:
- Tune color threshold settings for the gift selection interface in GiftOperatorGiftFlow.
- Update color threshold settings for contact-related text in GiftOperatorContact.

</details>

增强内容：
- 在 `GiftOperatorGiftFlow` 中微调礼物选择界面的颜色阈值设置。
- 在 `GiftOperatorContact` 中更新与联系人相关文本的颜色阈值设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整 GiftOperator UI JSON 资源中礼物选择和联系人相关文本的颜色阈值配置。

增强内容：
- 微调 GiftOperatorGiftFlow 中礼物选择界面的颜色阈值设置。
- 更新 GiftOperatorContact 中联系人相关文本的颜色阈值设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust color threshold configurations for gift selection and contact-related texts in GiftOperator UI JSON resources.

Enhancements:
- Tune color threshold settings for the gift selection interface in GiftOperatorGiftFlow.
- Update color threshold settings for contact-related text in GiftOperatorContact.

</details>

</details>