### PR TITLE
fix: 主进程退出后agent残留

### DIFF
--- a/agent/cpp-algo/source/Common/ParentProcessWatcher.cpp
+++ b/agent/cpp-algo/source/Common/ParentProcessWatcher.cpp
@@ -1,0 +1,126 @@
+#include "ParentProcessWatcher.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <thread>
+
+#include <MaaUtils/Logger.h>
+
+#ifdef _WIN32
+
+#include <MaaUtils/SafeWindows.hpp>
+
+#include <tlhelp32.h>
+
+#else
+
+#include <cerrno>
+#include <csignal>
+#include <unistd.h>
+
+#endif
+
+namespace common
+{
+
+namespace
+{
+
+constexpr auto kPollInterval = std::chrono::seconds(1);
+
+#ifdef _WIN32
+
+// 通过 ToolHelp 快照在 PID 表中找父 PID。
+// 不依赖 ntdll 私有 API（NtQueryInformationProcess），跨 Windows 版本更稳。
+DWORD QueryParentProcessId(DWORD pid)
+{
+    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (snapshot == INVALID_HANDLE_VALUE) {
+        return 0;
+    }
+
+    DWORD parent_pid = 0;
+    PROCESSENTRY32W entry {};
+    entry.dwSize = sizeof(entry);
+
+    if (Process32FirstW(snapshot, &entry)) {
+        do {
+            if (entry.th32ProcessID == pid) {
+                parent_pid = entry.th32ParentProcessID;
+                break;
+            }
+        } while (Process32NextW(snapshot, &entry));
+    }
+
+    CloseHandle(snapshot);
+    return parent_pid;
+}
+
+void RunWatcherLoop(HANDLE parent_handle, DWORD parent_pid)
+{
+    // 启动时一次性 OpenProcess(SYNCHRONIZE)，循环里只用 WaitForSingleObject(0) 探活，
+    // 避免每秒重新查 PID 时遇到 PID 复用导致误判。
+    while (true) {
+        DWORD wait_result = WaitForSingleObject(parent_handle, 0);
+        if (wait_result == WAIT_OBJECT_0) {
+            LogWarn << "Parent process exited; shutting down cpp-algo." << VAR(parent_pid);
+            CloseHandle(parent_handle);
+            std::exit(0);
+        }
+        if (wait_result == WAIT_FAILED) {
+            LogWarn << "WaitForSingleObject failed on parent handle." << VAR(parent_pid)
+                    << VAR(GetLastError());
+        }
+        std::this_thread::sleep_for(kPollInterval);
+    }
+}
+
+#else
+
+void RunWatcherLoop(pid_t parent_pid)
+{
+    while (true) {
+        if (kill(parent_pid, 0) != 0 && errno == ESRCH) {
+            LogWarn << "Parent process exited; shutting down cpp-algo." << VAR(parent_pid);
+            std::exit(0);
+        }
+        std::this_thread::sleep_for(kPollInterval);
+    }
+}
+
+#endif
+
+} // namespace
+
+void StartParentProcessWatcher()
+{
+#ifdef _WIN32
+    DWORD self_pid = GetCurrentProcessId();
+    DWORD parent_pid = QueryParentProcessId(self_pid);
+    if (parent_pid == 0) {
+        LogWarn << "Failed to query parent pid; parent watcher disabled." << VAR(self_pid);
+        return;
+    }
+
+    HANDLE parent_handle = OpenProcess(SYNCHRONIZE, FALSE, parent_pid);
+    if (parent_handle == nullptr) {
+        LogWarn << "Failed to open parent process; parent watcher disabled." << VAR(parent_pid)
+                << VAR(GetLastError());
+        return;
+    }
+
+    LogInfo << "Parent process watcher started." << VAR(parent_pid);
+    std::thread(RunWatcherLoop, parent_handle, parent_pid).detach();
+#else
+    pid_t parent_pid = getppid();
+    if (parent_pid <= 1) {
+        LogWarn << "Invalid parent pid; parent watcher disabled." << VAR(parent_pid);
+        return;
+    }
+
+    LogInfo << "Parent process watcher started." << VAR(parent_pid);
+    std::thread(RunWatcherLoop, parent_pid).detach();
+#endif
+}
+
+} // namespace common

--- a/agent/cpp-algo/source/Common/ParentProcessWatcher.h
+++ b/agent/cpp-algo/source/Common/ParentProcessWatcher.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace common
+{
+
+// 启动父进程存活监视器。
+//
+// 进程启动时记录父进程 PID 并打开句柄（Windows）/ 保留 PID（POSIX），
+// 之后在后台分离线程里每秒检查一次：
+//   - 父进程仍在  → 继续监视。
+//   - 父进程已退出 → 立即 std::exit(0) 结束当前 cpp-algo 进程，
+//                    避免 MXU / MFAA 等宿主崩溃后 cpp-algo 残留为孤儿。
+//
+// 仅应在 main() 启动阶段调用一次。线程为 detach 设计，进程退出时随之结束。
+void StartParentProcessWatcher();
+
+} // namespace common

--- a/agent/cpp-algo/source/main.cpp
+++ b/agent/cpp-algo/source/main.cpp
@@ -3,6 +3,7 @@
 #include <MaaAgentServer/MaaAgentServerAPI.h>
 #include <MaaToolkit/MaaToolkitAPI.h>
 
+#include "Common/ParentProcessWatcher.h"
 #include "MapLocator/MapLocateAction.h"
 #include "MapNavigator/MapNavigator.h"
 #include "MapNavigator/MapNavigatorCompatible.h"
@@ -24,6 +25,9 @@ int main(int argc, char** argv)
         std::cerr << "socket_id is provided by AgentIdentifier." << std::endl;
         return -1;
     }
+
+    // 父进程一旦退出立刻结束自己，避免 MXU/MFAA 崩溃后 cpp-algo 残留。
+    common::StartParentProcessWatcher();
 
     Test();
 

--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -7,6 +7,7 @@ import (
 	"runtime/debug"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/parentwatch"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/bytedance/sonic"
@@ -60,6 +61,9 @@ func main() {
 	log.Info().
 		Str("version", Version).
 		Msg("MaaEnd Agent Service")
+
+	// 父进程一旦退出立刻结束自己，避免 MXU/MFAA 崩溃后 go-service 残留。
+	parentwatch.Start()
 
 	pienv.Init()
 	i18n.Init()

--- a/agent/go-service/pkg/parentwatch/parentwatch.go
+++ b/agent/go-service/pkg/parentwatch/parentwatch.go
@@ -1,0 +1,90 @@
+// Package parentwatch 在后台监视父进程存活情况：父进程一旦退出立即结束当前进程。
+//
+// 用途：MaaFramework 主进程（cpp-algo / go-service 的父进程）异常退出后，
+// MaaAgentServer 仍会阻塞在 IPC 上不会自动结束，残留为孤儿 agent。
+// 启动 watcher 后会有一个独立 goroutine 每秒检查一次父进程：
+//   - 父进程仍在  → 继续监视。
+//   - 父进程已退出 → 直接 os.Exit(0) 结束当前进程。
+//
+// 平台差异：
+//   - Windows：启动时 OpenProcess(SYNCHRONIZE) 持有句柄，循环里
+//     只用 WaitForSingleObject(0) 探活，规避 PID 复用造成的误判。
+//   - POSIX：syscall.Kill(pid, 0) 探活，ESRCH 视为已退出。
+package parentwatch
+
+import (
+	"os"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// PollInterval 是父进程存活检测的默认轮询间隔。
+const PollInterval = 1 * time.Second
+
+// logComponent 是本包统一的 zerolog `component` 字段值。
+const logComponent = "parent-watcher"
+
+// Start 启动父进程监视器。
+// 进程启动时获取父进程 PID 并打开句柄（Windows）/记录 PID（POSIX），
+// 之后在后台 goroutine 中按 PollInterval 周期性检查。
+// 仅应在程序启动阶段调用一次，goroutine 与进程同生命周期。
+func Start() {
+	parentPID := os.Getppid()
+	if parentPID <= 1 {
+		log.Warn().
+			Str("component", logComponent).
+			Int("parent_pid", parentPID).
+			Msg("invalid parent pid, watcher disabled")
+		return
+	}
+
+	watcher, err := newWatcher(parentPID)
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Str("component", logComponent).
+			Int("parent_pid", parentPID).
+			Msg("failed to initialize parent watcher")
+		return
+	}
+
+	log.Info().
+		Str("component", logComponent).
+		Int("parent_pid", parentPID).
+		Msg("parent process watcher started")
+
+	go runLoop(watcher, parentPID)
+}
+
+func runLoop(w watcher, parentPID int) {
+	defer w.Close()
+
+	ticker := time.NewTicker(PollInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		alive, checkErr := w.IsAlive()
+		if checkErr != nil {
+			log.Warn().
+				Err(checkErr).
+				Str("component", logComponent).
+				Int("parent_pid", parentPID).
+				Msg("parent liveness check failed")
+			continue
+		}
+		if !alive {
+			log.Warn().
+				Str("component", logComponent).
+				Int("parent_pid", parentPID).
+				Msg("parent process has exited; shutting down")
+			os.Exit(0)
+		}
+	}
+}
+
+// watcher 是平台相关的探活句柄抽象。
+type watcher interface {
+	IsAlive() (bool, error)
+	Close()
+}

--- a/agent/go-service/pkg/parentwatch/parentwatch_other.go
+++ b/agent/go-service/pkg/parentwatch/parentwatch_other.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package parentwatch
+
+import (
+	"errors"
+	"syscall"
+)
+
+// posixWatcher 在 POSIX 下基于 kill(pid, 0) 探活：
+// 进程不存在时 errno 返回 ESRCH。注意 PID 复用风险：
+// 若父进程退出后系统把同一个 PID 复用给另一个进程，
+// 探活会误判为存活；但子进程在 reparent 后 getppid() 会变成 1，
+// 启动时的初值已经记录在 pid 字段里，可以保持稳定语义。
+type posixWatcher struct {
+	pid int
+}
+
+func newWatcher(pid int) (watcher, error) {
+	return &posixWatcher{pid: pid}, nil
+}
+
+func (w *posixWatcher) IsAlive() (bool, error) {
+	err := syscall.Kill(w.pid, 0)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.ESRCH) {
+		return false, nil
+	}
+	// EPERM 表示目标进程存在但无权访问，依然视为存活。
+	if errors.Is(err, syscall.EPERM) {
+		return true, nil
+	}
+	return false, err
+}
+
+func (w *posixWatcher) Close() {}

--- a/agent/go-service/pkg/parentwatch/parentwatch_windows.go
+++ b/agent/go-service/pkg/parentwatch/parentwatch_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package parentwatch
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// windowsWatcher 在 Windows 下持有父进程的句柄。
+// 启动时一次性 OpenProcess(SYNCHRONIZE)，循环里用 WaitForSingleObject(0) 探活，
+// 避免每次轮询重新查 PID 时遇到 PID 复用导致误判。
+type windowsWatcher struct {
+	handle windows.Handle
+}
+
+func newWatcher(pid int) (watcher, error) {
+	h, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return nil, fmt.Errorf("OpenProcess(%d): %w", pid, err)
+	}
+	return &windowsWatcher{handle: h}, nil
+}
+
+// IsAlive 通过 WaitForSingleObject(0) 探活：
+// 句柄被信号化（WAIT_OBJECT_0）即表示进程已退出。
+func (w *windowsWatcher) IsAlive() (bool, error) {
+	if w.handle == 0 {
+		return false, fmt.Errorf("parent handle is closed")
+	}
+	event, err := windows.WaitForSingleObject(w.handle, 0)
+	if err != nil {
+		return false, err
+	}
+	if event == uint32(windows.WAIT_OBJECT_0) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (w *windowsWatcher) Close() {
+	if w.handle != 0 {
+		_ = windows.CloseHandle(w.handle)
+		w.handle = 0
+	}
+}


### PR DESCRIPTION
close #2741

## Summary by Sourcery

添加父进程监控机制，以确保 cpp-algo 和 go-service 代理在其宿主进程终止时一并退出，防止孤立的代理进程长期驻留。

Bug 修复：
- 当父进程退出时自动终止 cpp-algo 代理，以避免在宿主崩溃后出现孤立进程。
- 当父进程退出时自动终止 go-service 代理，以避免在宿主崩溃后出现孤立进程。

增强：
- 为 cpp-algo 引入跨平台的父进程监控工具，支持 Windows 和 POSIX 实现。
- 为 go-service 引入跨平台的 parentwatch 包，提供 Windows 和非 Windows 实现，并包含结构化日志和可配置轮询机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add parent-process watcher mechanisms to ensure cpp-algo and go-service agents exit when their hosting process terminates, preventing orphaned agent processes from lingering.

Bug Fixes:
- Terminate cpp-algo agent automatically when its parent process exits to avoid orphaned processes after host crashes.
- Terminate go-service agent automatically when its parent process exits to avoid orphaned processes after host crashes.

Enhancements:
- Introduce cross-platform parent process watcher utility for cpp-algo with Windows and POSIX implementations.
- Introduce cross-platform parentwatch package for go-service with Windows and non-Windows implementations, including structured logging and configurable polling.

</details>