### PR TITLE
refactor(EnvironmentMonitoring): 精简传送后位置检查流程

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AnnularWaterfall.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AnnularWaterfall.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToAnnularWaterfallNotAtStartPos": {
-        "desc": "不在环形瀑布任务开始位置附近，先传送再复核落点",
+        "desc": "不在环形瀑布任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToAnnularWaterfallRecheckStartPos",
-            "GoToAnnularWaterfallReEnterMap"
-        ]
-    },
-    "GoToAnnularWaterfallRecheckStartPos": {
-        "desc": "传送后再次检查是否已在环形瀑布任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv003",
-                    "target": [
-                        496.1,
-                        360.1,
-                        19.3,
-                        14.3
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToAnnularWaterfallMapTrackerMove"
-        ]
-    },
-    "GoToAnnularWaterfallReEnterMap": {
-        "desc": "传送后仍未到达环形瀑布任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingQingboStockade3"
-            ]
-        },
-        "next": [
-            "GoToAnnularWaterfallFinalCheckStartPos"
-        ]
-    },
-    "GoToAnnularWaterfallFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在环形瀑布任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv003",
-                    "target": [
-                        496.1,
-                        360.1,
-                        19.3,
-                        14.3
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToAnnularWaterfallMapTrackerMove"
+            "GoToAnnularWaterfallStartPos"
         ]
     },
     "GoToAnnularWaterfallMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/BambooWaterChimes.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/BambooWaterChimes.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToBambooWaterChimesNotAtStartPos": {
-        "desc": "不在水竹铃任务开始位置附近，先传送再复核落点",
+        "desc": "不在水竹铃任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToBambooWaterChimesRecheckStartPos",
-            "GoToBambooWaterChimesReEnterMap"
-        ]
-    },
-    "GoToBambooWaterChimesRecheckStartPos": {
-        "desc": "传送后再次检查是否已在水竹铃任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv003",
-                    "target": [
-                        300,
-                        460,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToBambooWaterChimesMapTrackerMove"
-        ]
-    },
-    "GoToBambooWaterChimesReEnterMap": {
-        "desc": "传送后仍未到达水竹铃任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingQingboStockade1"
-            ]
-        },
-        "next": [
-            "GoToBambooWaterChimesFinalCheckStartPos"
-        ]
-    },
-    "GoToBambooWaterChimesFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在水竹铃任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv003",
-                    "target": [
-                        300,
-                        460,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToBambooWaterChimesMapTrackerMove"
+            "GoToBambooWaterChimesStartPos"
         ]
     },
     "GoToBambooWaterChimesMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/CloudrestEcoSite.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/CloudrestEcoSite.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToCloudrestEcoSiteNotAtStartPos": {
-        "desc": "不在栖云生态点任务开始位置附近，先传送再复核落点",
+        "desc": "不在栖云生态点任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToCloudrestEcoSiteRecheckStartPos",
-            "GoToCloudrestEcoSiteReEnterMap"
-        ]
-    },
-    "GoToCloudrestEcoSiteRecheckStartPos": {
-        "desc": "传送后再次检查是否已在栖云生态点任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        604.3,
-                        422.8,
-                        42.7,
-                        39.4
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToCloudrestEcoSiteMapTrackerMove"
-        ]
-    },
-    "GoToCloudrestEcoSiteReEnterMap": {
-        "desc": "传送后仍未到达栖云生态点任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingMarkerStoneCore"
-            ]
-        },
-        "next": [
-            "GoToCloudrestEcoSiteFinalCheckStartPos"
-        ]
-    },
-    "GoToCloudrestEcoSiteFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在栖云生态点任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        604.3,
-                        422.8,
-                        42.7,
-                        39.4
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToCloudrestEcoSiteMapTrackerMove"
+            "GoToCloudrestEcoSiteStartPos"
         ]
     },
     "GoToCloudrestEcoSiteMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToFloraObservationPointNotAtStartPos": {
-        "desc": "不在植物观察点任务开始位置附近，先传送再复核落点",
+        "desc": "不在植物观察点任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToFloraObservationPointRecheckStartPos",
-            "GoToFloraObservationPointReEnterMap"
-        ]
-    },
-    "GoToFloraObservationPointRecheckStartPos": {
-        "desc": "传送后再次检查是否已在植物观察点任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        602.8,
-                        325,
-                        9.7,
-                        8.1
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToFloraObservationPointMapTrackerMove"
-        ]
-    },
-    "GoToFloraObservationPointReEnterMap": {
-        "desc": "传送后仍未到达植物观察点任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingMarkerStone3"
-            ]
-        },
-        "next": [
-            "GoToFloraObservationPointFinalCheckStartPos"
-        ]
-    },
-    "GoToFloraObservationPointFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在植物观察点任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        602.8,
-                        325,
-                        9.7,
-                        8.1
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToFloraObservationPointMapTrackerMove"
+            "GoToFloraObservationPointStartPos"
         ]
     },
     "GoToFloraObservationPointMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToHangingVinesNotAtStartPos": {
-        "desc": "不在垂藤任务开始位置附近，先传送再复核落点",
+        "desc": "不在垂藤任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToHangingVinesRecheckStartPos",
-            "GoToHangingVinesReEnterMap"
-        ]
-    },
-    "GoToHangingVinesRecheckStartPos": {
-        "desc": "传送后再次检查是否已在垂藤任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        602.8,
-                        325,
-                        9.7,
-                        8.1
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToHangingVinesMapTrackerMove"
-        ]
-    },
-    "GoToHangingVinesReEnterMap": {
-        "desc": "传送后仍未到达垂藤任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingMarkerStone3"
-            ]
-        },
-        "next": [
-            "GoToHangingVinesFinalCheckStartPos"
-        ]
-    },
-    "GoToHangingVinesFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在垂藤任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        602.8,
-                        325,
-                        9.7,
-                        8.1
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToHangingVinesMapTrackerMove"
+            "GoToHangingVinesStartPos"
         ]
     },
     "GoToHangingVinesMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/MysteriousCryptidGraffiti.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/MysteriousCryptidGraffiti.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToMysteriousCryptidGraffitiNotAtStartPos": {
-        "desc": "不在谜之生物的涂鸦任务开始位置附近，先传送再复核落点",
+        "desc": "不在谜之生物的涂鸦任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToMysteriousCryptidGraffitiRecheckStartPos",
-            "GoToMysteriousCryptidGraffitiReEnterMap"
-        ]
-    },
-    "GoToMysteriousCryptidGraffitiRecheckStartPos": {
-        "desc": "传送后再次检查是否已在谜之生物的涂鸦任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv003",
-                    "target": [
-                        384.5,
-                        542,
-                        28,
-                        28
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToMysteriousCryptidGraffitiMapTrackerMove"
-        ]
-    },
-    "GoToMysteriousCryptidGraffitiReEnterMap": {
-        "desc": "传送后仍未到达谜之生物的涂鸦任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingQingboStockade2"
-            ]
-        },
-        "next": [
-            "GoToMysteriousCryptidGraffitiFinalCheckStartPos"
-        ]
-    },
-    "GoToMysteriousCryptidGraffitiFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在谜之生物的涂鸦任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv003",
-                    "target": [
-                        384.5,
-                        542,
-                        28,
-                        28
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToMysteriousCryptidGraffitiMapTrackerMove"
+            "GoToMysteriousCryptidGraffitiStartPos"
         ]
     },
     "GoToMysteriousCryptidGraffitiMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToPeachTreeAtBabblesSHomeNotAtStartPos": {
-        "desc": "不在念念家的桃树任务开始位置附近，先传送再复核落点",
+        "desc": "不在念念家的桃树任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToPeachTreeAtBabblesSHomeRecheckStartPos",
-            "GoToPeachTreeAtBabblesSHomeReEnterMap"
-        ]
-    },
-    "GoToPeachTreeAtBabblesSHomeRecheckStartPos": {
-        "desc": "传送后再次检查是否已在念念家的桃树任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004_tier_328",
-                    "target": [
-                        514,
-                        666,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToPeachTreeAtBabblesSHomeMapTrackerMove"
-        ]
-    },
-    "GoToPeachTreeAtBabblesSHomeReEnterMap": {
-        "desc": "传送后仍未到达念念家的桃树任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingMarkerStone4"
-            ]
-        },
-        "next": [
-            "GoToPeachTreeAtBabblesSHomeFinalCheckStartPos"
-        ]
-    },
-    "GoToPeachTreeAtBabblesSHomeFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在念念家的桃树任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004_tier_328",
-                    "target": [
-                        514,
-                        666,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToPeachTreeAtBabblesSHomeMapTrackerMove"
+            "GoToPeachTreeAtBabblesSHomeStartPos"
         ]
     },
     "GoToPeachTreeAtBabblesSHomeMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Rainbow.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Rainbow.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToRainbowNotAtStartPos": {
-        "desc": "不在彩虹任务开始位置附近，先传送再复核落点",
+        "desc": "不在彩虹任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToRainbowRecheckStartPos",
-            "GoToRainbowReEnterMap"
-        ]
-    },
-    "GoToRainbowRecheckStartPos": {
-        "desc": "传送后再次检查是否已在彩虹任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004_tier_328",
-                    "target": [
-                        508.2,
-                        663,
-                        18.1,
-                        15.6
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToRainbowMapTrackerMove"
-        ]
-    },
-    "GoToRainbowReEnterMap": {
-        "desc": "传送后仍未到达彩虹任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingMarkerStone4"
-            ]
-        },
-        "next": [
-            "GoToRainbowFinalCheckStartPos"
-        ]
-    },
-    "GoToRainbowFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在彩虹任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004_tier_328",
-                    "target": [
-                        508.2,
-                        663,
-                        18.1,
-                        15.6
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToRainbowMapTrackerMove"
+            "GoToRainbowStartPos"
         ]
     },
     "GoToRainbowMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToSerenityGardenTianshiPillarNotAtStartPos": {
-        "desc": "不在安思园的天师桩任务开始位置附近，先传送再复核落点",
+        "desc": "不在安思园的天师桩任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToSerenityGardenTianshiPillarRecheckStartPos",
-            "GoToSerenityGardenTianshiPillarReEnterMap"
-        ]
-    },
-    "GoToSerenityGardenTianshiPillarRecheckStartPos": {
-        "desc": "传送后再次检查是否已在安思园的天师桩任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        402.4,
-                        313.4,
-                        20.8,
-                        17.4
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToSerenityGardenTianshiPillarMapTrackerMove"
-        ]
-    },
-    "GoToSerenityGardenTianshiPillarReEnterMap": {
-        "desc": "传送后仍未到达安思园的天师桩任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingMarkerStone2"
-            ]
-        },
-        "next": [
-            "GoToSerenityGardenTianshiPillarFinalCheckStartPos"
-        ]
-    },
-    "GoToSerenityGardenTianshiPillarFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在安思园的天师桩任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        402.4,
-                        313.4,
-                        20.8,
-                        17.4
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToSerenityGardenTianshiPillarMapTrackerMove"
+            "GoToSerenityGardenTianshiPillarStartPos"
         ]
     },
     "GoToSerenityGardenTianshiPillarMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/TreeOfTheOldCourtyard.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/TreeOfTheOldCourtyard.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToTreeOfTheOldCourtyardNotAtStartPos": {
-        "desc": "不在旧庭树任务开始位置附近，先传送再复核落点",
+        "desc": "不在旧庭树任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToTreeOfTheOldCourtyardRecheckStartPos",
-            "GoToTreeOfTheOldCourtyardReEnterMap"
-        ]
-    },
-    "GoToTreeOfTheOldCourtyardRecheckStartPos": {
-        "desc": "传送后再次检查是否已在旧庭树任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        491.2,
-                        197.9,
-                        11.7,
-                        10.7
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToTreeOfTheOldCourtyardMapTrackerMove"
-        ]
-    },
-    "GoToTreeOfTheOldCourtyardReEnterMap": {
-        "desc": "传送后仍未到达旧庭树任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingMarkerStone1"
-            ]
-        },
-        "next": [
-            "GoToTreeOfTheOldCourtyardFinalCheckStartPos"
-        ]
-    },
-    "GoToTreeOfTheOldCourtyardFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在旧庭树任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        491.2,
-                        197.9,
-                        11.7,
-                        10.7
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToTreeOfTheOldCourtyardMapTrackerMove"
+            "GoToTreeOfTheOldCourtyardStartPos"
         ]
     },
     "GoToTreeOfTheOldCourtyardMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WaterTemperatureController.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WaterTemperatureController.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToWaterTemperatureControllerNotAtStartPos": {
-        "desc": "不在净水温控装置任务开始位置附近，先传送再复核落点",
+        "desc": "不在净水温控装置任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToWaterTemperatureControllerRecheckStartPos",
-            "GoToWaterTemperatureControllerReEnterMap"
-        ]
-    },
-    "GoToWaterTemperatureControllerRecheckStartPos": {
-        "desc": "传送后再次检查是否已在净水温控装置任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        408.5,
-                        312.7,
-                        16.8,
-                        18.2
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToWaterTemperatureControllerMapTrackerMove"
-        ]
-    },
-    "GoToWaterTemperatureControllerReEnterMap": {
-        "desc": "传送后仍未到达净水温控装置任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingMarkerStone2"
-            ]
-        },
-        "next": [
-            "GoToWaterTemperatureControllerFinalCheckStartPos"
-        ]
-    },
-    "GoToWaterTemperatureControllerFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在净水温控装置任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv004",
-                    "target": [
-                        408.5,
-                        312.7,
-                        16.8,
-                        18.2
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToWaterTemperatureControllerMapTrackerMove"
+            "GoToWaterTemperatureControllerStartPos"
         ]
     },
     "GoToWaterTemperatureControllerMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WitheredBranches.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WitheredBranches.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToWitheredBranchesNotAtStartPos": {
-        "desc": "不在枯枝任务开始位置附近，先传送再复核落点",
+        "desc": "不在枯枝任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToWitheredBranchesRecheckStartPos",
-            "GoToWitheredBranchesReEnterMap"
-        ]
-    },
-    "GoToWitheredBranchesRecheckStartPos": {
-        "desc": "传送后再次检查是否已在枯枝任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv003",
-                    "target": [
-                        496.1,
-                        360.1,
-                        19.3,
-                        14.3
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToWitheredBranchesMapTrackerMove"
-        ]
-    },
-    "GoToWitheredBranchesReEnterMap": {
-        "desc": "传送后仍未到达枯枝任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingQingboStockade3"
-            ]
-        },
-        "next": [
-            "GoToWitheredBranchesFinalCheckStartPos"
-        ]
-    },
-    "GoToWitheredBranchesFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在枯枝任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv003",
-                    "target": [
-                        496.1,
-                        360.1,
-                        19.3,
-                        14.3
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToWitheredBranchesMapTrackerMove"
+            "GoToWitheredBranchesStartPos"
         ]
     },
     "GoToWitheredBranchesMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToAncientTreeNotAtStartPos": {
-        "desc": "不在古树任务开始位置附近，先传送再复核落点",
+        "desc": "不在古树任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToAncientTreeRecheckStartPos",
-            "GoToAncientTreeReEnterMap"
-        ]
-    },
-    "GoToAncientTreeRecheckStartPos": {
-        "desc": "传送后再次检查是否已在古树任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        280,
-                        580,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToAncientTreeMapTrackerMove"
-        ]
-    },
-    "GoToAncientTreeReEnterMap": {
-        "desc": "传送后仍未到达古树任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingJingyuValley7"
-            ]
-        },
-        "next": [
-            "GoToAncientTreeFinalCheckStartPos"
-        ]
-    },
-    "GoToAncientTreeFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在古树任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        280,
-                        580,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToAncientTreeMapTrackerMove"
+            "GoToAncientTreeStartPos"
         ]
     },
     "GoToAncientTreeMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInTheBlightTide.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInTheBlightTide.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToBeaconDamagedInTheBlightTideNotAtStartPos": {
-        "desc": "不在侵蚀潮中损坏的信标任务开始位置附近，先传送再复核落点",
+        "desc": "不在侵蚀潮中损坏的信标任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToBeaconDamagedInTheBlightTideRecheckStartPos",
-            "GoToBeaconDamagedInTheBlightTideReEnterMap"
-        ]
-    },
-    "GoToBeaconDamagedInTheBlightTideRecheckStartPos": {
-        "desc": "传送后再次检查是否已在侵蚀潮中损坏的信标任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        640,
-                        255,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToBeaconDamagedInTheBlightTideMapTrackerMove"
-        ]
-    },
-    "GoToBeaconDamagedInTheBlightTideReEnterMap": {
-        "desc": "传送后仍未到达侵蚀潮中损坏的信标任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingWulingCity0"
-            ]
-        },
-        "next": [
-            "GoToBeaconDamagedInTheBlightTideFinalCheckStartPos"
-        ]
-    },
-    "GoToBeaconDamagedInTheBlightTideFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在侵蚀潮中损坏的信标任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        640,
-                        255,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToBeaconDamagedInTheBlightTideMapTrackerMove"
+            "GoToBeaconDamagedInTheBlightTideStartPos"
         ]
     },
     "GoToBeaconDamagedInTheBlightTideMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToCisternOriginiumSlugsNotAtStartPos": {
-        "desc": "不在蓄水源石虫任务开始位置附近，先传送再复核落点",
+        "desc": "不在蓄水源石虫任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToCisternOriginiumSlugsRecheckStartPos",
-            "GoToCisternOriginiumSlugsReEnterMap"
-        ]
-    },
-    "GoToCisternOriginiumSlugsRecheckStartPos": {
-        "desc": "传送后再次检查是否已在蓄水源石虫任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        280,
-                        580,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToCisternOriginiumSlugsMapTrackerMove"
-        ]
-    },
-    "GoToCisternOriginiumSlugsReEnterMap": {
-        "desc": "传送后仍未到达蓄水源石虫任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingJingyuValley7"
-            ]
-        },
-        "next": [
-            "GoToCisternOriginiumSlugsFinalCheckStartPos"
-        ]
-    },
-    "GoToCisternOriginiumSlugsFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在蓄水源石虫任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        280,
-                        580,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToCisternOriginiumSlugsMapTrackerMove"
+            "GoToCisternOriginiumSlugsStartPos"
         ]
     },
     "GoToCisternOriginiumSlugsMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToCleansingJadeNotAtStartPos": {
-        "desc": "不在漱玉任务开始位置附近，先传送再复核落点",
+        "desc": "不在漱玉任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToCleansingJadeRecheckStartPos",
-            "GoToCleansingJadeReEnterMap"
-        ]
-    },
-    "GoToCleansingJadeRecheckStartPos": {
-        "desc": "传送后再次检查是否已在漱玉任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        255,
-                        395,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToCleansingJadeMapTrackerMove"
-        ]
-    },
-    "GoToCleansingJadeReEnterMap": {
-        "desc": "传送后仍未到达漱玉任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingJingyuValley4"
-            ]
-        },
-        "next": [
-            "GoToCleansingJadeFinalCheckStartPos"
-        ]
-    },
-    "GoToCleansingJadeFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在漱玉任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        255,
-                        395,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToCleansingJadeMapTrackerMove"
+            "GoToCleansingJadeStartPos"
         ]
     },
     "GoToCleansingJadeMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToCollapsedTianshiPillarNotAtStartPos": {
-        "desc": "不在倒塌的天师桩任务开始位置附近，先传送再复核落点",
+        "desc": "不在倒塌的天师桩任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToCollapsedTianshiPillarRecheckStartPos",
-            "GoToCollapsedTianshiPillarReEnterMap"
-        ]
-    },
-    "GoToCollapsedTianshiPillarRecheckStartPos": {
-        "desc": "传送后再次检查是否已在倒塌的天师桩任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        210,
-                        635,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToCollapsedTianshiPillarMapTrackerMove"
-        ]
-    },
-    "GoToCollapsedTianshiPillarReEnterMap": {
-        "desc": "传送后仍未到达倒塌的天师桩任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingJingyuValley8"
-            ]
-        },
-        "next": [
-            "GoToCollapsedTianshiPillarFinalCheckStartPos"
-        ]
-    },
-    "GoToCollapsedTianshiPillarFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在倒塌的天师桩任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        210,
-                        635,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToCollapsedTianshiPillarMapTrackerMove"
+            "GoToCollapsedTianshiPillarStartPos"
         ]
     },
     "GoToCollapsedTianshiPillarMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToEcologyNearTheFieldLogisticsDepotNotAtStartPos": {
-        "desc": "不在储备站周围的生态环境任务开始位置附近，先传送再复核落点",
+        "desc": "不在储备站周围的生态环境任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToEcologyNearTheFieldLogisticsDepotRecheckStartPos",
-            "GoToEcologyNearTheFieldLogisticsDepotReEnterMap"
-        ]
-    },
-    "GoToEcologyNearTheFieldLogisticsDepotRecheckStartPos": {
-        "desc": "传送后再次检查是否已在储备站周围的生态环境任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        689.6,
-                        917.3,
-                        6,
-                        5.5
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove"
-        ]
-    },
-    "GoToEcologyNearTheFieldLogisticsDepotReEnterMap": {
-        "desc": "传送后仍未到达储备站周围的生态环境任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingWulingCity8"
-            ]
-        },
-        "next": [
-            "GoToEcologyNearTheFieldLogisticsDepotFinalCheckStartPos"
-        ]
-    },
-    "GoToEcologyNearTheFieldLogisticsDepotFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在储备站周围的生态环境任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        689.6,
-                        917.3,
-                        6,
-                        5.5
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove"
+            "GoToEcologyNearTheFieldLogisticsDepotStartPos"
         ]
     },
     "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToEternalSunsetNotAtStartPos": {
-        "desc": "不在栖霞驻影任务开始位置附近，先传送再复核落点",
+        "desc": "不在栖霞驻影任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToEternalSunsetRecheckStartPos",
-            "GoToEternalSunsetReEnterMap"
-        ]
-    },
-    "GoToEternalSunsetRecheckStartPos": {
-        "desc": "传送后再次检查是否已在栖霞驻影任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        315,
-                        305,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToEternalSunsetMapTrackerMove"
-        ]
-    },
-    "GoToEternalSunsetReEnterMap": {
-        "desc": "传送后仍未到达栖霞驻影任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingJingyuValley2"
-            ]
-        },
-        "next": [
-            "GoToEternalSunsetFinalCheckStartPos"
-        ]
-    },
-    "GoToEternalSunsetFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在栖霞驻影任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        315,
-                        305,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToEternalSunsetMapTrackerMove"
+            "GoToEternalSunsetStartPos"
         ]
     },
     "GoToEternalSunsetMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToIndoorCropsNotAtStartPos": {
-        "desc": "不在室内作物任务开始位置附近，先传送再复核落点",
+        "desc": "不在室内作物任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToIndoorCropsRecheckStartPos",
-            "GoToIndoorCropsReEnterMap"
-        ]
-    },
-    "GoToIndoorCropsRecheckStartPos": {
-        "desc": "传送后再次检查是否已在室内作物任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        240,
-                        695,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToIndoorCropsMapTrackerMove"
-        ]
-    },
-    "GoToIndoorCropsReEnterMap": {
-        "desc": "传送后仍未到达室内作物任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingWulingCity4"
-            ]
-        },
-        "next": [
-            "GoToIndoorCropsFinalCheckStartPos"
-        ]
-    },
-    "GoToIndoorCropsFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在室内作物任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        240,
-                        695,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToIndoorCropsMapTrackerMove"
+            "GoToIndoorCropsStartPos"
         ]
     },
     "GoToIndoorCropsMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToInflatedAndGlowingBugspittingLankybeastNotAtStartPos": {
-        "desc": "不在肚子鼓气后发光的吐虫长股兽任务开始位置附近，先传送再复核落点",
+        "desc": "不在肚子鼓气后发光的吐虫长股兽任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToInflatedAndGlowingBugspittingLankybeastRecheckStartPos",
-            "GoToInflatedAndGlowingBugspittingLankybeastReEnterMap"
-        ]
-    },
-    "GoToInflatedAndGlowingBugspittingLankybeastRecheckStartPos": {
-        "desc": "传送后再次检查是否已在肚子鼓气后发光的吐虫长股兽任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        416.7,
-                        844.3,
-                        11.4,
-                        10.6
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove"
-        ]
-    },
-    "GoToInflatedAndGlowingBugspittingLankybeastReEnterMap": {
-        "desc": "传送后仍未到达肚子鼓气后发光的吐虫长股兽任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingWulingCity7"
-            ]
-        },
-        "next": [
-            "GoToInflatedAndGlowingBugspittingLankybeastFinalCheckStartPos"
-        ]
-    },
-    "GoToInflatedAndGlowingBugspittingLankybeastFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在肚子鼓气后发光的吐虫长股兽任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        416.7,
-                        844.3,
-                        11.4,
-                        10.6
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove"
+            "GoToInflatedAndGlowingBugspittingLankybeastStartPos"
         ]
     },
     "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToMiniShellbeastNotAtStartPos": {
-        "desc": "不在小壳兽任务开始位置附近，先传送再复核落点",
+        "desc": "不在小壳兽任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToMiniShellbeastRecheckStartPos",
-            "GoToMiniShellbeastReEnterMap"
-        ]
-    },
-    "GoToMiniShellbeastRecheckStartPos": {
-        "desc": "传送后再次检查是否已在小壳兽任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        238.6,
-                        694.1,
-                        15.2,
-                        14.6
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToMiniShellbeastMapTrackerMove"
-        ]
-    },
-    "GoToMiniShellbeastReEnterMap": {
-        "desc": "传送后仍未到达小壳兽任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingWulingCity4"
-            ]
-        },
-        "next": [
-            "GoToMiniShellbeastFinalCheckStartPos"
-        ]
-    },
-    "GoToMiniShellbeastFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在小壳兽任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        238.6,
-                        694.1,
-                        15.2,
-                        14.6
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToMiniShellbeastMapTrackerMove"
+            "GoToMiniShellbeastStartPos"
         ]
     },
     "GoToMiniShellbeastMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToObservantSableChestedFowlbeastNotAtStartPos": {
-        "desc": "不在东张西望的黑腹雉羽兽任务开始位置附近，先传送再复核落点",
+        "desc": "不在东张西望的黑腹雉羽兽任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToObservantSableChestedFowlbeastRecheckStartPos",
-            "GoToObservantSableChestedFowlbeastReEnterMap"
-        ]
-    },
-    "GoToObservantSableChestedFowlbeastRecheckStartPos": {
-        "desc": "传送后再次检查是否已在东张西望的黑腹雉羽兽任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        342.2,
-                        124.2,
-                        4,
-                        4
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToObservantSableChestedFowlbeastMapTrackerMove"
-        ]
-    },
-    "GoToObservantSableChestedFowlbeastReEnterMap": {
-        "desc": "传送后仍未到达东张西望的黑腹雉羽兽任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingJingyuValley0"
-            ]
-        },
-        "next": [
-            "GoToObservantSableChestedFowlbeastFinalCheckStartPos"
-        ]
-    },
-    "GoToObservantSableChestedFowlbeastFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在东张西望的黑腹雉羽兽任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        342.2,
-                        124.2,
-                        4,
-                        4
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToObservantSableChestedFowlbeastMapTrackerMove"
+            "GoToObservantSableChestedFowlbeastStartPos"
         ]
     },
     "GoToObservantSableChestedFowlbeastMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/PierWaterwheel.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/PierWaterwheel.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToPierWaterwheelNotAtStartPos": {
-        "desc": "不在码头水车任务开始位置附近，先传送再复核落点",
+        "desc": "不在码头水车任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToPierWaterwheelRecheckStartPos",
-            "GoToPierWaterwheelReEnterMap"
-        ]
-    },
-    "GoToPierWaterwheelRecheckStartPos": {
-        "desc": "传送后再次检查是否已在码头水车任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        492.5,
-                        178,
-                        13.2,
-                        13
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToPierWaterwheelMapTrackerMove"
-        ]
-    },
-    "GoToPierWaterwheelReEnterMap": {
-        "desc": "传送后仍未到达码头水车任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingJingyuValley1"
-            ]
-        },
-        "next": [
-            "GoToPierWaterwheelFinalCheckStartPos"
-        ]
-    },
-    "GoToPierWaterwheelFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在码头水车任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        492.5,
-                        178,
-                        13.2,
-                        13
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToPierWaterwheelMapTrackerMove"
+            "GoToPierWaterwheelStartPos"
         ]
     },
     "GoToPierWaterwheelMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToRainbowFinNotAtStartPos": {
-        "desc": "不在七彩鳞任务开始位置附近，先传送再复核落点",
+        "desc": "不在七彩鳞任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToRainbowFinRecheckStartPos",
-            "GoToRainbowFinReEnterMap"
-        ]
-    },
-    "GoToRainbowFinRecheckStartPos": {
-        "desc": "传送后再次检查是否已在七彩鳞任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        125,
-                        815,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToRainbowFinMapTrackerMove"
-        ]
-    },
-    "GoToRainbowFinReEnterMap": {
-        "desc": "传送后仍未到达七彩鳞任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingJingyuValley10"
-            ]
-        },
-        "next": [
-            "GoToRainbowFinFinalCheckStartPos"
-        ]
-    },
-    "GoToRainbowFinFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在七彩鳞任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        125,
-                        815,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToRainbowFinMapTrackerMove"
+            "GoToRainbowFinStartPos"
         ]
     },
     "GoToRainbowFinMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToVigorousCisternOriginiumSlugNotAtStartPos": {
-        "desc": "不在充满活力的蓄水源石虫任务开始位置附近，先传送再复核落点",
+        "desc": "不在充满活力的蓄水源石虫任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToVigorousCisternOriginiumSlugRecheckStartPos",
-            "GoToVigorousCisternOriginiumSlugReEnterMap"
-        ]
-    },
-    "GoToVigorousCisternOriginiumSlugRecheckStartPos": {
-        "desc": "传送后再次检查是否已在充满活力的蓄水源石虫任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        210,
-                        635,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToVigorousCisternOriginiumSlugMapTrackerMove"
-        ]
-    },
-    "GoToVigorousCisternOriginiumSlugReEnterMap": {
-        "desc": "传送后仍未到达充满活力的蓄水源石虫任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingJingyuValley8"
-            ]
-        },
-        "next": [
-            "GoToVigorousCisternOriginiumSlugFinalCheckStartPos"
-        ]
-    },
-    "GoToVigorousCisternOriginiumSlugFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在充满活力的蓄水源石虫任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        210,
-                        635,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToVigorousCisternOriginiumSlugMapTrackerMove"
+            "GoToVigorousCisternOriginiumSlugStartPos"
         ]
     },
     "GoToVigorousCisternOriginiumSlugMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/Waterlamp.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/Waterlamp.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToWaterlampNotAtStartPos": {
-        "desc": "不在水灯虫任务开始位置附近，先传送再复核落点",
+        "desc": "不在水灯虫任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToWaterlampRecheckStartPos",
-            "GoToWaterlampReEnterMap"
-        ]
-    },
-    "GoToWaterlampRecheckStartPos": {
-        "desc": "传送后再次检查是否已在水灯虫任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        420.3,
-                        848,
-                        10.3,
-                        8.9
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToWaterlampMapTrackerMove"
-        ]
-    },
-    "GoToWaterlampReEnterMap": {
-        "desc": "传送后仍未到达水灯虫任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingWulingCity7"
-            ]
-        },
-        "next": [
-            "GoToWaterlampFinalCheckStartPos"
-        ]
-    },
-    "GoToWaterlampFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在水灯虫任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        420.3,
-                        848,
-                        10.3,
-                        8.9
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToWaterlampMapTrackerMove"
+            "GoToWaterlampStartPos"
         ]
     },
     "GoToWaterlampMapTrackerMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/XiraniteNexus.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/XiraniteNexus.json
@@ -226,7 +226,7 @@
         ]
     },
     "GoToXiraniteNexusNotAtStartPos": {
-        "desc": "不在枢壤仪任务开始位置附近，先传送再复核落点",
+        "desc": "不在枢壤仪任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -235,63 +235,7 @@
             ]
         },
         "next": [
-            "GoToXiraniteNexusRecheckStartPos",
-            "GoToXiraniteNexusReEnterMap"
-        ]
-    },
-    "GoToXiraniteNexusRecheckStartPos": {
-        "desc": "传送后再次检查是否已在枢壤仪任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        240,
-                        695,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToXiraniteNexusMapTrackerMove"
-        ]
-    },
-    "GoToXiraniteNexusReEnterMap": {
-        "desc": "传送后仍未到达枢壤仪任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingWulingCity4"
-            ]
-        },
-        "next": [
-            "GoToXiraniteNexusFinalCheckStartPos"
-        ]
-    },
-    "GoToXiraniteNexusFinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在枢壤仪任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        240,
-                        695,
-                        15,
-                        15
-                    ]
-                }
-            ]
-        },
-        "next": [
-            "GoToXiraniteNexusMapTrackerMove"
+            "GoToXiraniteNexusStartPos"
         ]
     },
     "GoToXiraniteNexusMapTrackerMove": {

--- a/docs/en_us/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/en_us/developers/tasks/environment-monitoring-maintain.md
@@ -70,12 +70,11 @@ The chain inside each observation-point `{Id}Job` (rendered from `template.json`
                       ├─ GoTo{Id}StartPos  (MapTrackerAssertLocation / MapLocateAssertLocation confirms position → MapTrackerMove / MapNavigateAction)
                       └─ GoTo{Id}NotAtStartPos
                            └─ SubTask: ${EnterMap}             (teleport)
-                                ├─ GoTo{Id}RecheckStartPos     (re-check position after teleport)
-                                └─ GoTo{Id}ReEnterMap          (second teleport → FinalCheck)
-                                └─ GoTo{Id}MapTrackerMove
-                                     ├─ anchor: EnvironmentMonitoringBackToTerminal → ${GoToMonitoringTerminal}
-                                     ├─ anchor: EnvironmentMonitoringAdjustCamera   → ${Id}AdjustCamera
-                                     └─ next:   EnvironmentMonitoringTakePhoto
+                                └─ GoTo{Id}StartPos            (check whether the task start position has been reached)
+                                     └─ GoTo{Id}MapTrackerMove
+                                          ├─ anchor: EnvironmentMonitoringBackToTerminal → ${GoToMonitoringTerminal}
+                                          ├─ anchor: EnvironmentMonitoringAdjustCamera   → ${Id}AdjustCamera
+                                          └─ next:   EnvironmentMonitoringTakePhoto
 EnvironmentMonitoringTakePhoto        (enters photo mode → adjusts facing → takes photo)
   └─ [Anchor]EnvironmentMonitoringBackToTerminal
        └─ EnvironmentMonitoringGoTo{Outskirts|MarkerStone}MonitoringTerminal

--- a/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
@@ -70,12 +70,11 @@ EnvironmentMonitoringMain
                       ├─ GoTo{Id}StartPos （MapTrackerAssertLocation / MapLocateAssertLocation 已就位 → MapTrackerMove / MapNavigateAction）
                       └─ GoTo{Id}NotAtStartPos
                            └─ SubTask: ${EnterMap}            （传送）
-                                ├─ GoTo{Id}RecheckStartPos    （传送后复核）
-                                └─ GoTo{Id}ReEnterMap         （二次传送 → FinalCheck）
-                                └─ GoTo{Id}MapTrackerMove
-                                     ├─ anchor: EnvironmentMonitoringBackToTerminal → ${GoToMonitoringTerminal}
-                                     ├─ anchor: EnvironmentMonitoringAdjustCamera   → ${Id}AdjustCamera
-                                     └─ next:   EnvironmentMonitoringTakePhoto
+                                └─ GoTo{Id}StartPos           （检查是否已到任务开始位置附近）
+                                     └─ GoTo{Id}MapTrackerMove
+                                          ├─ anchor: EnvironmentMonitoringBackToTerminal → ${GoToMonitoringTerminal}
+                                          ├─ anchor: EnvironmentMonitoringAdjustCamera   → ${Id}AdjustCamera
+                                          └─ next:   EnvironmentMonitoringTakePhoto
 EnvironmentMonitoringTakePhoto       （进入拍照模式 → 朝向 → 拍照）
   └─ [Anchor]EnvironmentMonitoringBackToTerminal
        └─ EnvironmentMonitoringGoTo{Outskirts|MarkerStone}MonitoringTerminal

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/template.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/template.json
@@ -195,7 +195,7 @@
         ]
     },
     "GoTo${Id}NotAtStartPos": {
-        "desc": "不在${Name}任务开始位置附近，先传送再复核落点",
+        "desc": "不在${Name}任务开始位置附近，先传送再检查落点",
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
@@ -204,39 +204,7 @@
             ]
         },
         "next": [
-            "GoTo${Id}RecheckStartPos",
-            "GoTo${Id}ReEnterMap"
-        ]
-    },
-    "GoTo${Id}RecheckStartPos": {
-        "desc": "传送后再次检查是否已在${Name}任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "${MapAssertRecognition}",
-        "custom_recognition_param": "${MapAssertParam}",
-        "next": [
-            "GoTo${Id}MapTrackerMove"
-        ]
-    },
-    "GoTo${Id}ReEnterMap": {
-        "desc": "传送后仍未到达${Name}任务开始位置附近，重试一次传送",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "${EnterMap}"
-            ]
-        },
-        "next": [
-            "GoTo${Id}FinalCheckStartPos"
-        ]
-    },
-    "GoTo${Id}FinalCheckStartPos": {
-        "desc": "二次传送后再次检查是否已在${Name}任务开始位置附近",
-        "recognition": "Custom",
-        "custom_recognition": "${MapAssertRecognition}",
-        "custom_recognition_param": "${MapAssertParam}",
-        "next": [
-            "GoTo${Id}MapTrackerMove"
+            "GoTo${Id}StartPos"
         ]
     },
     "GoTo${Id}MapTrackerMove": {


### PR DESCRIPTION
## 背景

关联 #1733 和 #1762。#1733 的问题是环境监测在传送后没有确认是否到达任务起点，直接进入寻路，导致从错误位置 MapTrackerMove 并触发急停；#1762 为此加入了传送后位置复核和一次重试。

## 变更说明

- 删除环境监测模板中重复的 Recheck / FinalCheck 节点。
- 传送完成后复用已有 GoTo{Id}StartPos 作为唯一落点检查节点。
- 重新生成环境监测观察点 pipeline，并同步维护文档。

## 为什么要精简

- Recheck / FinalCheck 与已有 GoTo{Id}StartPos 使用同一套位置断言，属于重复维护点。
- 传送失败后的自动重试会掩盖万能跳转本身的问题，使问题不能及时暴露。
- 保留一次明确的位置检查已经可以避免从错误位置继续寻路，同时让流程更简单。

## 验证

- pnpm generate:EnvironmentMonitoring
- pnpm exec prettier --check
- pnpm check