### PR TITLE
pref: 修改信用点商店Record为不阻塞

### DIFF
--- a/agent/go-service/creditshopping/action_record.go
+++ b/agent/go-service/creditshopping/action_record.go
@@ -11,7 +11,7 @@ import (
 
 const creditShoppingScanItemActionName = "CreditShoppingScanItemAction"
 
-// RecordShelfSnapshotsAction 信用点商店货架库存快照：
+// RecordShelfSnapshotsAction 信用点商店货架库存快照（best-effort，失败仅记日志，不阻断购物主流程）：
 //  1. 经 captureuid 获取 UID 与 RefreshCost，推断本地游戏日（04:00 切日）与第几次刷新；
 //  2. PC 一屏 7+3；ADB 两屏各一排（首屏 slot 0–5 含折扣，滑动后 slot 6–9 含折扣）；
 //  3. 以 uid + game_date + refresh_index 为键写入 JSON，键冲突则覆盖。
@@ -39,7 +39,7 @@ func (a *RecordShelfSnapshotsAction) Run(ctx *maa.Context, arg *maa.CustomAction
 		first, err := screencap(ctrl)
 		if err != nil {
 			log.Error().Err(err).Str("component", component).Msg("record shelf adb: screencap failed")
-			return false
+			return true
 		}
 		imgForMeta = first
 		slots = scanShelfSlotsADB(ctx, ctrl, first)
@@ -47,7 +47,7 @@ func (a *RecordShelfSnapshotsAction) Run(ctx *maa.Context, arg *maa.CustomAction
 		first, err := screencap(ctrl)
 		if err != nil {
 			log.Error().Err(err).Str("component", component).Msg("record shelf: screencap failed")
-			return false
+			return true
 		}
 		imgForMeta = first
 		slots = ScanShelfSlotsPC(ctx, first)
@@ -56,7 +56,7 @@ func (a *RecordShelfSnapshotsAction) Run(ctx *maa.Context, arg *maa.CustomAction
 	uid, err := captureuid.Capture(ctx, ctrl, true, true, true)
 	if err != nil {
 		log.Error().Err(err).Str("component", component).Msg("record shelf: uid capture failed")
-		return false
+		return true
 	}
 	refreshIndex, refreshCost := resolveRefreshIndex(ctx, imgForMeta)
 	entry := snapshotEntry{
@@ -80,7 +80,7 @@ func (a *RecordShelfSnapshotsAction) Run(ctx *maa.Context, arg *maa.CustomAction
 	n, err := upsertShelfSnapshots(path, []snapshotEntry{entry})
 	if err != nil {
 		log.Error().Err(err).Str("component", component).Str("path", path).Msg("record shelf: write failed")
-		return false
+		return true
 	}
 	logSnapshotSaved(path, n)
 	return true

--- a/agent/go-service/creditshopping/adb_shelf.go
+++ b/agent/go-service/creditshopping/adb_shelf.go
@@ -39,20 +39,21 @@ func swipeShelfForADB(ctx *maa.Context, ctrl *maa.Controller, beginY, endY int) 
 func scanShelfSlotsADB(ctx *maa.Context, ctrl *maa.Controller, first image.Image) []SlotRecord {
 	slotsTop := buildSlotRecords(ctx, first, scanShelfNameHits(ctx, first), slotAssignADBTop)
 
-	// 先小幅上滑采集第二屏，采集结束后再滑回原位，避免后续购买节点仍停留在第二屏。
+	// 先小幅上滑采集第二屏；defer 保证任意返回路径都会滑回第一屏，避免后续购买节点仍停留在第二屏。
 	swiped := swipeShelfForADB(ctx, ctrl, adbShelfSwipeBeginY, adbShelfSwipeEndY)
+	if swiped {
+		defer func() {
+			if !swipeShelfForADB(ctx, ctrl, adbShelfSwipeEndY, adbShelfSwipeBeginY) {
+				log.Warn().Str("component", component).Msg("record shelf adb: failed to swipe back after shelf scan")
+			}
+		}()
+	}
 	second, err := screencap(ctrl)
 	if err != nil {
-		if swiped {
-			swipeShelfForADB(ctx, ctrl, adbShelfSwipeEndY, adbShelfSwipeBeginY)
-		}
 		log.Warn().Err(err).Str("component", component).Int("top_slots", len(slotsTop)).Msg("record shelf adb: second screencap failed, keep first row only")
 		return slotsTop
 	}
 	slotsBottom := buildSlotRecords(ctx, second, scanShelfNameHits(ctx, second), slotAssignADBBottom)
-	if swiped && !swipeShelfForADB(ctx, ctrl, adbShelfSwipeEndY, adbShelfSwipeBeginY) {
-		log.Warn().Str("component", component).Msg("record shelf adb: failed to swipe back after shelf scan")
-	}
 
 	merged := mergeSlotRecordsByPosition(slotsTop, slotsBottom)
 	log.Info().

--- a/assets/resource/pipeline/AutoStockStaple/General/Item.json
+++ b/assets/resource/pipeline/AutoStockStaple/General/Item.json
@@ -78,8 +78,12 @@
             "param": {
                 "roi": "AutoStockInStapleItemNameLabelColor",
                 "method": 6,
-                "lower": [150],
-                "upper": [250],
+                "lower": [
+                    180
+                ],
+                "upper": [
+                    255
+                ],
                 "count": 10
             }
         }

--- a/assets/resource/pipeline/CreditShopping/GoToShop.json
+++ b/assets/resource/pipeline/CreditShopping/GoToShop.json
@@ -22,10 +22,10 @@
         "post_wait_freezes": {
             "time": 100,
             "target": [
-                0,
-                554,
-                301,
-                166
+                412,
+                328,
+                127,
+                140
             ]
         },
         "post_delay": 0,


### PR DESCRIPTION
## 由 Sourcery 总结

使信用商店货架快照记录成为尽力而为的操作，并确保 ADB 货架扫描始终尝试返回到第一页，并在失败时进行日志记录。

错误修复：
- 确保 ADB 货架扫描始终推迟执行一次向前滑动以返回到第一页，并在返回滑动失败时记录日志，而不是在视图停留在第二页时静默失败。

功能增强：
- 将信用商店货架快照记录失败（屏幕截图、UID 捕获、文件写入）视为非阻塞，仅记录错误日志，同时允许主购物流程继续进行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make credit shop shelf snapshot recording best-effort and ensure ADB shelf scanning always attempts to return to the first page with logging on failures.

Bug Fixes:
- Ensure ADB shelf scan always defers a swipe back to the first page and logs when the return swipe fails instead of silently leaving the view on the second page.

Enhancements:
- Treat credit shop shelf snapshot recording failures (screencap, UID capture, file write) as non-blocking by logging errors while allowing the main shopping flow to continue.

</details>

Bug 修复：
- 确保 ADB 货架扫描总是会尝试通过延迟清理操作（deferred cleanup）滑动回到第一页，对失败情况进行日志记录，而不是在视图停留在第二页时静默失败。

增强功能：
- 将信用商店货架快照记录失败（包括截图 screencap、UID 捕获、文件写入）视为非致命错误，通过记录日志进行上报，但不打断主要购物流程。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 总结

使信用商店货架快照记录成为尽力而为的操作，并确保 ADB 货架扫描始终尝试返回到第一页，并在失败时进行日志记录。

错误修复：
- 确保 ADB 货架扫描始终推迟执行一次向前滑动以返回到第一页，并在返回滑动失败时记录日志，而不是在视图停留在第二页时静默失败。

功能增强：
- 将信用商店货架快照记录失败（屏幕截图、UID 捕获、文件写入）视为非阻塞，仅记录错误日志，同时允许主购物流程继续进行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make credit shop shelf snapshot recording best-effort and ensure ADB shelf scanning always attempts to return to the first page with logging on failures.

Bug Fixes:
- Ensure ADB shelf scan always defers a swipe back to the first page and logs when the return swipe fails instead of silently leaving the view on the second page.

Enhancements:
- Treat credit shop shelf snapshot recording failures (screencap, UID capture, file write) as non-blocking by logging errors while allowing the main shopping flow to continue.

</details>

</details>