### PR TITLE
fix: 售卖物资在好友界面失败

### DIFF
--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -342,8 +342,7 @@
                 "template": [
                     "AutoSell/SellTicketFriendValleyIV.png",
                     "AutoSell/SellTicketFriendWuling.png"
-                ],
-                "threshold": 0.9
+                ]
             }
         ],
         "pre_wait_freezes": {


### PR DESCRIPTION
close #3164

## Summary by Sourcery

错误修复：
- 更正物品任务的自动出售配置，使得在好友界面中出售材料功能正常工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct auto-sell configuration for item tasks so selling materials works in the friend interface.

</details>