### PR TITLE
fix: 首墩地图选择失败

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -1,4 +1,5 @@
 {
+    // https://assets.zmdmap.com/data/entity/1.2.5/maaend_entities.json
     "__ScenePrivateMapUnknownEnterWorldWulingWulingCityCoreTry1": {
         "desc": "在地图界面找锚点 (武陵城核心区)",
         "recognition": "And",
@@ -1033,8 +1034,8 @@
         "custom_action_param": {
             "map_name": "map02_lv004",
             "target": [
-                498.8,
-                203.5
+                498.9,
+                199.9
             ],
             "on_find": "Click"
         },
@@ -1060,8 +1061,8 @@
         "custom_action_param": {
             "map_name": "map02_lv004",
             "target": [
-                418.8,
-                322.3
+                419.0,
+                317.0
             ],
             "on_find": "Click"
         },
@@ -1087,8 +1088,8 @@
         "custom_action_param": {
             "map_name": "map02_lv004",
             "target": [
-                600.1,
-                328.4
+                600.6,
+                328.7
             ],
             "on_find": "Click"
         },
@@ -1114,8 +1115,8 @@
         "custom_action_param": {
             "map_name": "map02_lv004",
             "target": [
-                512.9,
-                673.5
+                512.1,
+                672.8
             ],
             "on_find": "Click"
         },


### PR DESCRIPTION
close #3188

## Summary by Sourcery

错误修复：
- 通过调整传送配置，修复了武陵场景中第一个码头地图选择失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix map selection failure for the first pier in the Wuling scene by adjusting teleport configuration.

</details>