### PR TITLE
fix: 售卖产品库存为0失败

### DIFF
--- a/agent/go-service/bettersliding/handlers.go
+++ b/agent/go-service/bettersliding/handlers.go
@@ -216,7 +216,7 @@ func (a *BetterSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa.Cu
 
 	a.exceeded = false
 	if a.ExceedingOverrideEnable != "" {
-		if upperOverflow || lowerOverflow {
+		if upperOverflow || lowerOverflow || a.maxQuantity == 0 {
 			a.exceeded = true
 			if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingDone, buttonTarget{}, 0, a.GreenMask); err != nil {
 				logEvent := a.logger.Error().
@@ -233,12 +233,16 @@ func (a *BetterSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa.Cu
 				return false
 			}
 
-			a.logger.Warn().
+			logEvent := a.logger.Warn().
 				Int("original_target", a.OriginalTarget).
 				Int("resolved_target", a.Target).
 				Int("max_quantity", a.maxQuantity).
-				Str("override_node", a.ExceedingOverrideEnable).
-				Msg("target out of range: exceeding override scheduled, branching to done")
+				Str("override_node", a.ExceedingOverrideEnable)
+			if a.maxQuantity == 0 {
+				logEvent.Msg("max quantity is zero, skipping via exceeding override")
+			} else {
+				logEvent.Msg("target out of range: exceeding override scheduled, branching to done")
+			}
 			return true
 		}
 
@@ -664,6 +668,9 @@ func (a *BetterSlidingAction) resetState() {
 }
 
 func resolveMaxQuantityNext(maxQuantity int, target int) (string, error) {
+	if maxQuantity == target {
+		return nodeBetterSlidingDone, nil
+	}
 	if maxQuantity < target {
 		return "", fmt.Errorf("max quantity %d lower than target %d", maxQuantity, target)
 	}


### PR DESCRIPTION
close #3108

## 由 Sourcery 提供的概要

在更好的滑动数量解析中处理边界情况，以避免在可用数量为零或恰好等于目标值时发生失败。

Bug 修复：
- 将最大数量为零视为触发覆盖流程的“超出”条件，而不是在销售无库存产品时导致失败。
- 当最大数量等于目标值时，允许最大数量解析成功，而不是将其视为错误。

改进：
- 改进与超出覆盖相关的警告日志，以区分“零数量跳过”和“目标超出范围”这两种情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle edge cases in better sliding quantity resolution to avoid failures when available quantity is zero or exactly equals the target.

Bug Fixes:
- Treat zero max quantity as an exceeding condition that triggers the override flow instead of causing a failure when selling products with no stock.
- Allow the max quantity resolution to succeed when the max quantity equals the target instead of treating it as an error.

Enhancements:
- Improve warning logs around exceeding overrides to distinguish between zero-quantity skips and general out-of-range targets.

</details>