### PR TITLE
docs: 编码规范增加必看两个字

### DIFF
--- a/docs/en_us/developers/README.md
+++ b/docs/en_us/developers/README.md
@@ -53,7 +53,7 @@ It is recommended to read in the following order:
 
 | Document                                  | Description                                                          |
 | ----------------------------------------- | -------------------------------------------------------------------- |
-| [Coding Standards](./coding-standards.md) | Pipeline / Go / Cpp coding rules, pre-commit checks, common pitfalls |
+| [Coding Standards (Must-read)](./coding-standards.md) | Pipeline / Go / Cpp coding rules, pre-commit checks, common pitfalls |
 
 ### Pipeline Basic Components
 

--- a/docs/zh_cn/developers/README.md
+++ b/docs/zh_cn/developers/README.md
@@ -53,7 +53,7 @@ flowchart TD
 
 | 文档                              | 说明                                             |
 | --------------------------------- | ------------------------------------------------ |
-| [编码规范](./coding-standards.md) | Pipeline / Go / Cpp 编码规则、提交前检查、常见坑 |
+| [编码规范(必看)](./coding-standards.md) | Pipeline / Go / Cpp 编码规则、提交前检查、常见坑 |
 
 ### Pipeline 基础组件
 


### PR DESCRIPTION
## Summary by Sourcery

在英文和中文开发者指南中将编码规范文档突出为必读内容。

Documentation:
- 在英文版开发者 README 中强调编码规范页面为必读内容。
- 在中文版开发者 README 中强调编码规范页面为“必看”（must-read）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Highlight coding standards documentation as must-read in both English and Chinese developer guides.

Documentation:
- Emphasize the coding standards page as must-read in the English developers README.
- Emphasize the coding standards page as 必看 (must-read) in the Chinese developers README.

</details>