### PR TITLE
fix(SellProduct): 临时排除活动物品以避免生成到可售卖列表

### DIFF
--- a/assets/tasks/SellProduct.json
+++ b/assets/tasks/SellProduct.json
@@ -3981,28 +3981,6 @@
                     }
                 },
                 {
-                    "name": "息壤玉葫芦",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem1": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤玉葫芦",
-                                    "息壤玉葫蘆",
-                                    "息壌玉ひょうたん",
-                                    "Xiranite Jade Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductSkyKingFlatsSellAttempt1SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteJadeGourd"
-                },
-                {
                     "name": "中容武陵电池",
                     "pipeline_override": {
                         "SellProductSkyKingFlatsSelectItem1": {
@@ -4045,28 +4023,6 @@
                         }
                     },
                     "label": "$item.HetonitePart"
-                },
-                {
-                    "name": "息壤葫芦",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem1": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤葫芦",
-                                    "息壤葫蘆",
-                                    "息壌ひょうたん",
-                                    "Xiranite Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductSkyKingFlatsSellAttempt1SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteGourd"
                 },
                 {
                     "name": "低容武陵电池",
@@ -4221,28 +4177,6 @@
                     }
                 },
                 {
-                    "name": "息壤玉葫芦",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem2": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤玉葫芦",
-                                    "息壤玉葫蘆",
-                                    "息壌玉ひょうたん",
-                                    "Xiranite Jade Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductSkyKingFlatsSellAttempt2SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteJadeGourd"
-                },
-                {
                     "name": "中容武陵电池",
                     "pipeline_override": {
                         "SellProductSkyKingFlatsSelectItem2": {
@@ -4285,28 +4219,6 @@
                         }
                     },
                     "label": "$item.HetonitePart"
-                },
-                {
-                    "name": "息壤葫芦",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem2": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤葫芦",
-                                    "息壤葫蘆",
-                                    "息壌ひょうたん",
-                                    "Xiranite Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductSkyKingFlatsSellAttempt2SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteGourd"
                 },
                 {
                     "name": "低容武陵电池",
@@ -4461,28 +4373,6 @@
                     }
                 },
                 {
-                    "name": "息壤玉葫芦",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem3": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤玉葫芦",
-                                    "息壤玉葫蘆",
-                                    "息壌玉ひょうたん",
-                                    "Xiranite Jade Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductSkyKingFlatsSellAttempt3SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteJadeGourd"
-                },
-                {
                     "name": "中容武陵电池",
                     "pipeline_override": {
                         "SellProductSkyKingFlatsSelectItem3": {
@@ -4525,28 +4415,6 @@
                         }
                     },
                     "label": "$item.HetonitePart"
-                },
-                {
-                    "name": "息壤葫芦",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem3": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤葫芦",
-                                    "息壤葫蘆",
-                                    "息壌ひょうたん",
-                                    "Xiranite Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductSkyKingFlatsSellAttempt3SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteGourd"
                 },
                 {
                     "name": "低容武陵电池",
@@ -4701,28 +4569,6 @@
                     }
                 },
                 {
-                    "name": "息壤玉葫芦",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem4": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤玉葫芦",
-                                    "息壤玉葫蘆",
-                                    "息壌玉ひょうたん",
-                                    "Xiranite Jade Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductSkyKingFlatsSellAttempt4SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteJadeGourd"
-                },
-                {
                     "name": "中容武陵电池",
                     "pipeline_override": {
                         "SellProductSkyKingFlatsSelectItem4": {
@@ -4765,28 +4611,6 @@
                         }
                     },
                     "label": "$item.HetonitePart"
-                },
-                {
-                    "name": "息壤葫芦",
-                    "pipeline_override": {
-                        "SellProductSkyKingFlatsSelectItem4": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤葫芦",
-                                    "息壤葫蘆",
-                                    "息壌ひょうたん",
-                                    "Xiranite Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductSkyKingFlatsSellAttempt4SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteGourd"
                 },
                 {
                     "name": "低容武陵电池",
@@ -5247,28 +5071,6 @@
                     }
                 },
                 {
-                    "name": "息壤玉葫芦",
-                    "pipeline_override": {
-                        "SellProductCardiacRemediationStationSelectItem1": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤玉葫芦",
-                                    "息壤玉葫蘆",
-                                    "息壌玉ひょうたん",
-                                    "Xiranite Jade Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductCardiacRemediationStationSellAttempt1SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteJadeGourd"
-                },
-                {
                     "name": "中容武陵电池",
                     "pipeline_override": {
                         "SellProductCardiacRemediationStationSelectItem1": {
@@ -5311,28 +5113,6 @@
                         }
                     },
                     "label": "$item.HetonitePart"
-                },
-                {
-                    "name": "息壤葫芦",
-                    "pipeline_override": {
-                        "SellProductCardiacRemediationStationSelectItem1": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤葫芦",
-                                    "息壤葫蘆",
-                                    "息壌ひょうたん",
-                                    "Xiranite Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductCardiacRemediationStationSellAttempt1SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteGourd"
                 },
                 {
                     "name": "低容武陵电池",
@@ -5465,28 +5245,6 @@
                     }
                 },
                 {
-                    "name": "息壤玉葫芦",
-                    "pipeline_override": {
-                        "SellProductCardiacRemediationStationSelectItem2": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤玉葫芦",
-                                    "息壤玉葫蘆",
-                                    "息壌玉ひょうたん",
-                                    "Xiranite Jade Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductCardiacRemediationStationSellAttempt2SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteJadeGourd"
-                },
-                {
                     "name": "中容武陵电池",
                     "pipeline_override": {
                         "SellProductCardiacRemediationStationSelectItem2": {
@@ -5529,28 +5287,6 @@
                         }
                     },
                     "label": "$item.HetonitePart"
-                },
-                {
-                    "name": "息壤葫芦",
-                    "pipeline_override": {
-                        "SellProductCardiacRemediationStationSelectItem2": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤葫芦",
-                                    "息壤葫蘆",
-                                    "息壌ひょうたん",
-                                    "Xiranite Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductCardiacRemediationStationSellAttempt2SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteGourd"
                 },
                 {
                     "name": "低容武陵电池",
@@ -5683,28 +5419,6 @@
                     }
                 },
                 {
-                    "name": "息壤玉葫芦",
-                    "pipeline_override": {
-                        "SellProductCardiacRemediationStationSelectItem3": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤玉葫芦",
-                                    "息壤玉葫蘆",
-                                    "息壌玉ひょうたん",
-                                    "Xiranite Jade Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductCardiacRemediationStationSellAttempt3SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteJadeGourd"
-                },
-                {
                     "name": "中容武陵电池",
                     "pipeline_override": {
                         "SellProductCardiacRemediationStationSelectItem3": {
@@ -5747,28 +5461,6 @@
                         }
                     },
                     "label": "$item.HetonitePart"
-                },
-                {
-                    "name": "息壤葫芦",
-                    "pipeline_override": {
-                        "SellProductCardiacRemediationStationSelectItem3": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤葫芦",
-                                    "息壤葫蘆",
-                                    "息壌ひょうたん",
-                                    "Xiranite Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductCardiacRemediationStationSellAttempt3SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteGourd"
                 },
                 {
                     "name": "低容武陵电池",
@@ -5901,28 +5593,6 @@
                     }
                 },
                 {
-                    "name": "息壤玉葫芦",
-                    "pipeline_override": {
-                        "SellProductCardiacRemediationStationSelectItem4": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤玉葫芦",
-                                    "息壤玉葫蘆",
-                                    "息壌玉ひょうたん",
-                                    "Xiranite Jade Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductCardiacRemediationStationSellAttempt4SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteJadeGourd"
-                },
-                {
                     "name": "中容武陵电池",
                     "pipeline_override": {
                         "SellProductCardiacRemediationStationSelectItem4": {
@@ -5965,28 +5635,6 @@
                         }
                     },
                     "label": "$item.HetonitePart"
-                },
-                {
-                    "name": "息壤葫芦",
-                    "pipeline_override": {
-                        "SellProductCardiacRemediationStationSelectItem4": {
-                            "enabled": true,
-                            "custom_recognition_param": {
-                                "candidates": [
-                                    "息壤葫芦",
-                                    "息壤葫蘆",
-                                    "息壌ひょうたん",
-                                    "Xiranite Gourd"
-                                ]
-                            }
-                        },
-                        "SellProductCardiacRemediationStationSellAttempt4SetMissHandler": {
-                            "anchor": {
-                                "SellProductPriorityGoodMissHandler": "SellProductPriorityGoodMissWarning"
-                            }
-                        }
-                    },
-                    "label": "$item.XiraniteGourd"
                 },
                 {
                     "name": "低容武陵电池",

--- a/tools/pipeline-generate/SellProduct/data.mjs
+++ b/tools/pipeline-generate/SellProduct/data.mjs
@@ -54,6 +54,13 @@ function buildItemLocaleKeyByCNName() {
 // 用于反查物品的 i18n key，进而生成 `$item.xxx` 形式的可翻译 label。
 const ITEM_LOCALE_KEY_BY_CN_NAME = buildItemLocaleKeyByCNName();
 
+// TODO(SellProduct): 活动结束后，临时排除以下活动物品，避免继续生成到可售卖列表。
+// 当 settlement_trade.json 数据更新并确认活动物品已移除后，删除该常量与下方过滤判断。
+const TEMP_EXCLUDED_ITEM_CN_NAMES = new Set([
+    "息壤玉葫芦",
+    "息壤葫芦",
+]);
+
 // 单次遍历 settlements，同时构建：
 //   - ITEMS：物品字典（key → {name, label, candidates}）。candidates 是 CN/TC/JP/EN 候选名，
 //     由 Go 侧 SellProductNormalizedItemMatch 做抗噪声匹配（不含 `^...$` 锚定符）。
@@ -70,6 +77,9 @@ for (const [
     const stats = new Map();
     for (const level of Object.values(settlement.byProsperityLevel)) {
         for (const item of level.tradeItems) {
+            if (TEMP_EXCLUDED_ITEM_CN_NAMES.has(item.name.CN)) {
+                continue;
+            }
             let key = ITEM_KEY_BY_ID.get(item.itemId);
             if (!key) {
                 const localeKey = ITEM_LOCALE_KEY_BY_CN_NAME.get(item.name.CN);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 在结算处理过程中过滤指定的事件条目，使其不再被生成到可售产品列表中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Filter out designated event items during settlement processing so they are no longer generated into the sellable product list.

</details>