### PR TITLE
fix: 修复移动后等待时间过短,导致干员选择位置变化

### DIFF
--- a/assets/resource/pipeline/GiftOperator/GiftOperatorNavigation.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorNavigation.json
@@ -49,7 +49,8 @@
                     "path": [
                         {
                             "action": "HEADING",
-                            "angle": 270
+                            "angle": 270,
+                            "zone_id": "OMVBase01"
                         }
                     ]
                 }
@@ -97,7 +98,8 @@
                     "path": [
                         {
                             "action": "HEADING",
-                            "angle": 0
+                            "angle": 0,
+                            "zone_id": "OMVBase01"
                         }
                     ]
                 }
@@ -145,7 +147,8 @@
                     "path": [
                         {
                             "action": "HEADING",
-                            "angle": 90
+                            "angle": 90,
+                            "zone_id": "OMVBase01"
                         }
                     ]
                 }
@@ -222,7 +225,8 @@
                             "target": [
                                 183,
                                 174
-                            ]
+                            ],
+                            "zone_id": "OMVBase01"
                         }
                     ]
                 }

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorNavigation.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorNavigation.json
@@ -41,6 +41,7 @@
     "GiftOperatorMoveLocation1": {
         "desc": "转向270度(正西)尝试接触到干员(预设位置1)",
         "max_hit": 1,
+        "post_delay": 1000, //需要等待角色彻底停下
         "action": {
             "type": "Custom",
             "param": {
@@ -60,6 +61,7 @@
     "GiftOperatorMoveLocation1Move": {
         "desc": "移动尝试接触到干员(预设位置1)",
         "max_hit": 1,
+        "post_delay": 1000, //需要等待角色彻底停下
         "action": {
             "type": "Custom",
             "param": {
@@ -90,6 +92,7 @@
     "GiftOperatorMoveLocation2": {
         "desc": "转向0度(正北)尝试接触到干员(预设位置2)",
         "max_hit": 1,
+        "post_delay": 1000, //需要等待角色彻底停下
         "action": {
             "type": "Custom",
             "param": {
@@ -109,6 +112,7 @@
     "GiftOperatorMoveLocation2Move": {
         "desc": "移动尝试接触到干员(预设位置2)",
         "max_hit": 1,
+        "post_delay": 1000, //需要等待角色彻底停下
         "action": {
             "type": "Custom",
             "param": {
@@ -139,6 +143,7 @@
     "GiftOperatorMoveLocation3": {
         "desc": "转向90度(正东)尝试接触到干员(预设位置3)",
         "max_hit": 1,
+        "post_delay": 1000, //需要等待角色彻底停下
         "action": {
             "type": "Custom",
             "param": {
@@ -158,6 +163,7 @@
     "GiftOperatorMoveLocation3Move": {
         "desc": "移动尝试接触到干员(预设位置3)",
         "max_hit": 1,
+        "post_delay": 1000, //需要等待角色彻底停下
         "action": {
             "type": "Custom",
             "param": {
@@ -199,6 +205,10 @@
                             195.4
                         ],
                         [
+                            189.8,
+                            183.2
+                        ],
+                        [
                             186.0,
                             177.3
                         ]
@@ -213,6 +223,7 @@
     },
     "GiftOperatorGoAheadContact": {
         "desc": "继续向前走尝试接触联络台",
+        "post_delay": 1000, //需要等待角色彻底停下
         "max_hit": 6,
         "action": {
             "type": "Custom",


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 增加 GiftOperator 导航管线中移动后的等待时长，以防止出现非预期的操作员位置偏移。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Increase the post-movement wait duration in the GiftOperator navigation pipeline to prevent unintended operator position shifts.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 增加 GiftOperator 导航管线中移动后的等待时长，以防止出现非预期的操作员位置偏移。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Increase the post-movement wait duration in the GiftOperator navigation pipeline to prevent unintended operator position shifts.

</details>

</details>