### PR TITLE
chore: 拜访好友未选择助力方式时增加提示

### DIFF
--- a/agent/go-service/visitfriends/visitfriends.go
+++ b/agent/go-service/visitfriends/visitfriends.go
@@ -220,7 +220,8 @@ func (a *VisitFriendsMenuScanTargetFriendOpenAction) Run(ctx *maa.Context, arg *
 	params := nodeWithAttach.Attach
 
 	if !params.ControlNexusAssist && !params.MFGCabinAssist && !params.GrowthChamberAssist {
-		log.Error().Str("component", "VisitFriends").Str("step", "open_item").Msg("no assist enabled, skip open item action")
+		log.Warn().Str("component", "VisitFriends").Str("step", "open_item").Msg("no assist enabled, skip open item action")
+		maafocus.Print(ctx, i18n.T("visitfriends.no_assist_enabled"))
 		return false
 	}
 

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -12,6 +12,7 @@
     "visitfriends.can_growth_chamber": "assist Growth Chamber",
     "visitfriends.current_counts": "Assist count: %d, Clue exchange count: %d",
     "visitfriends.check_friend": "Checking friend %s",
+    "visitfriends.no_assist_enabled": "At least one assist method must be selected",
     "autosell.check_item_price_moderate": "Checking price for %s; moderate price volatility",
     "autosell.check_item_price_large": "Checking price for %s; large price volatility",
     "autosell.check_item_price_massive": "Checking price for %s; extreme price volatility",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -12,6 +12,7 @@
     "visitfriends.can_growth_chamber": "成長室を支援",
     "visitfriends.current_counts": "支援回数: %d、手がかり交換回数: %d",
     "visitfriends.check_friend": "フレンドを確認中: %s",
+    "visitfriends.no_assist_enabled": "支援方式を1つ以上選択してください",
     "autosell.check_item_price_moderate": "物資 %s の価格を確認中（価格変動は中程度）",
     "autosell.check_item_price_large": "物資 %s の価格を確認中（価格変動は大きい）",
     "autosell.check_item_price_massive": "物資 %s の価格を確認中（価格変動は極大）",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -12,6 +12,7 @@
     "visitfriends.can_growth_chamber": "성장실 지원",
     "visitfriends.current_counts": "현재 지원 횟수: %d, 단서 교환 횟수: %d",
     "visitfriends.check_friend": "친구 확인 중: %s",
+    "visitfriends.no_assist_enabled": "최소 하나 이상의 지원 방식을 선택해야 합니다",
     "autosell.check_item_price_moderate": "%s 물자 가격 확인 중, 가격 변동 보통",
     "autosell.check_item_price_large": "%s 물자 가격 확인 중, 가격 변동 큼",
     "autosell.check_item_price_massive": "%s 물자 가격 확인 중, 가격 변동 매우 큼",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -12,6 +12,7 @@
     "visitfriends.can_growth_chamber": "助力生长舱",
     "visitfriends.current_counts": "当前助力次数：%d，线索交换次数：%d",
     "visitfriends.check_friend": "检查好友 %s",
+    "visitfriends.no_assist_enabled": "需要至少选择一个助力方式",
     "autosell.check_item_price_moderate": "检查物资 %s 价格，该物资价格变动适中",
     "autosell.check_item_price_large": "检查物资 %s 价格，该物资价格变动较大",
     "autosell.check_item_price_massive": "检查物资 %s 价格，该物资价格变动极大",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -12,6 +12,7 @@
     "visitfriends.can_growth_chamber": "助力生長艙",
     "visitfriends.current_counts": "當前助力次數：%d，線索交換次數：%d",
     "visitfriends.check_friend": "檢查好友 %s",
+    "visitfriends.no_assist_enabled": "需要至少選擇一個助力方式",
     "autosell.check_item_price_moderate": "檢查物資 %s 價格，該物資價格變動適中",
     "autosell.check_item_price_large": "檢查物資 %s 價格，該物資價格變動較大",
     "autosell.check_item_price_massive": "檢查物資 %s 價格，該物資價格變動極大",


### PR DESCRIPTION
## Summary by Sourcery

通过在未启用任何协助选项时发出警告并提供面向用户的提示，改进“拜访好友”功能的协助选项选择流程。

增强内容：
- 在拜访好友期间未选择任何协助选项时，将日志严重级别降级，并更为优雅地跳过打开该物品。
- 当用户在“拜访好友”功能中未启用任何协助选项时，新增一条本地化的面向用户的消息提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the Visit Friends assist selection flow by warning when no assist option is enabled and providing a user-facing prompt.

Enhancements:
- Downgrade the log severity when no assist option is selected during friend visits and skip opening the item more gracefully.
- Add a localized user-facing message shown when the user has not enabled any assist option in the Visit Friends feature.

</details>