### PR TITLE
fix(MapLocator): 修复移除 tryLegacyCoarseSearch 时没删干净留下的💩

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -1,10 +1,12 @@
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <exception>
 #include <filesystem>
 #include <format>
 #include <future>
 #include <mutex>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -34,6 +36,16 @@ std::string TrimLeadingZeros(std::string value)
 {
     value.erase(0, std::min(value.find_first_not_of('0'), value.size() - 1));
     return value;
+}
+
+bool IsSupportedMapImage(const fs::path& path)
+{
+    static constexpr std::array<std::string_view, 5> kMapImageExtensions {
+        ".png", ".jpg", ".jpeg", ".webp", ".bmp"
+    };
+    std::string ext = path.extension().string();
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    return std::ranges::any_of(kMapImageExtensions, [&ext](std::string_view candidate) { return candidate == ext; });
 }
 
 bool MatchesExpectedZoneSelector(const std::string& expected_zone_selector, const YoloCoarseResult& coarse)
@@ -259,7 +271,9 @@ void MapLocator::Impl::loadAvailableZones(const std::string& root)
 
         cv::Mat img = MAA_NS::imread(entryPath, cv::IMREAD_UNCHANGED);
         if (img.empty()) {
-            LogError << "Failed to load map: " << MAA_NS::path_to_utf8_string(entryPath);
+            if (IsSupportedMapImage(entryPath)) {
+                LogError << "Failed to load map: " << MAA_NS::path_to_utf8_string(entryPath);
+            }
             continue;
         }
         if (img.channels() == 3) {

--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -730,6 +730,11 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearch(
         return std::nullopt;
     }
 
+    if (!constraint.yolo_validated) {
+        LogInfo << "Global Search Aborted: no validated YOLO constraint." << VAR(targetZoneId);
+        return std::nullopt;
+    }
+
     const cv::Mat& bigMap = zones.at(targetZoneId);
     const cv::Rect mapBounds(0, 0, bigMap.cols, bigMap.rows);
     if (constraint.mode == GlobalSearchMode::RoiFine) {
@@ -741,12 +746,7 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearch(
         return tryConstrainedFineSearch({ tmplFeat, strategy, bigMap, constrainedRect, targetZoneId, outRawPos });
     }
 
-    if (constraint.mode == GlobalSearchMode::FullMapFine) {
-        return tryConstrainedFineSearch({ tmplFeat, strategy, bigMap, mapBounds, targetZoneId, outRawPos });
-    }
-
-    LogInfo << "Global Search Aborted: no validated YOLO constraint." << VAR(targetZoneId);
-    return std::nullopt;
+    return tryConstrainedFineSearch({ tmplFeat, strategy, bigMap, mapBounds, targetZoneId, outRawPos });
 }
 
 YoloCoarseResult MapLocator::Impl::predictCoarse(const cv::Mat& minimap) const
@@ -891,7 +891,8 @@ SearchConstraint MapLocator::Impl::buildSearchConstraint(
 
     const bool isPathHeatmapZone = IsPathHeatmapZone(targetZoneId);
     if (isPathHeatmapZone) {
-        LogInfo << "YOLO validated path-heatmap zone; keeping legacy coarse heatmap search." << VAR(expectedZoneSelector)
+        constraint.mode = GlobalSearchMode::FullMapFine;
+        LogInfo << "YOLO validated path-heatmap zone; using full-map direct fine search." << VAR(expectedZoneSelector)
                 << VAR(coarse.raw_class) << VAR(targetZoneId);
         return constraint;
     }
@@ -934,7 +935,7 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearchWithFallback(
 {
     const bool isPathHeatmapZone = IsPathHeatmapZone(targetZoneId);
     const unsigned hardwareThreads = std::max(1U, std::thread::hardware_concurrency());
-    const bool canSpeculateDualMode = !isPathHeatmapZone && constraint.mode != GlobalSearchMode::LegacyCoarse && hardwareThreads >= 8;
+    const bool canSpeculateDualMode = !isPathHeatmapZone && constraint.yolo_validated && hardwareThreads >= 8;
 
     auto runSearch = [this, &constraint, &targetZoneId](const cv::Mat& searchMinimap, MatchMode mode) -> GlobalSearchAttempt {
         GlobalSearchAttempt attempt;
@@ -972,7 +973,7 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearchWithFallback(
     const MapPosition& rawGlobalPrimaryPos = primaryAttempt.rawPos;
 
     const bool shouldTryDualMode =
-        !globalResult && !isPathHeatmapZone && (constraint.mode != GlobalSearchMode::LegacyCoarse || rawGlobalPrimaryPos.score > 0.1);
+        !globalResult && !isPathHeatmapZone && (constraint.yolo_validated || rawGlobalPrimaryPos.score > 0.1);
     if (!shouldTryDualMode) {
         if (fallbackTask.valid()) {
             // Keep the future alive so its destructor cannot block the successful path.

--- a/agent/cpp-algo/source/MapLocator/MapTypes.h
+++ b/agent/cpp-algo/source/MapLocator/MapTypes.h
@@ -65,14 +65,13 @@ struct LocateResult
 
 enum class GlobalSearchMode
 {
-    LegacyCoarse,
     FullMapFine,
     RoiFine,
 };
 
 struct SearchConstraint
 {
-    GlobalSearchMode mode = GlobalSearchMode::LegacyCoarse;
+    GlobalSearchMode mode = GlobalSearchMode::FullMapFine;
     bool yolo_validated = false;
     cv::Rect roi {};
 };
@@ -206,7 +205,6 @@ struct TrackingConfig
 struct MatchConfig
 {
     int blurSize = 7;
-    double coarseScale = 0.5;
     int fineSearchRadius = 40;   // 精搜半径(px)
     double passThreshold = 0.55; // 全局搜索及格线, 容忍UI遮挡+光影
     double yoloConfThreshold = 0.60;


### PR DESCRIPTION
- fix #3269
- fix #3258
- fix #3251

## Summary by Sourcery

收紧全局搜索行为，使其依赖经过验证的 YOLO 约束，并移除遗留的粗粒度搜索模式路径。

Bug Fixes（错误修复）:
- 防止在没有经过验证的 YOLO 约束时运行全局搜索，以避免产生无效或噪声匹配结果。
- 调整双模式推测逻辑，仅在 YOLO 已通过验证或初始结果足够强时才启用。

Enhancements（增强 / 改进）:
- 简化全局搜索模式，移除遗留的粗粒度模式，默认使用全图精细搜索。
- 更新路径热力图（path-heatmap）处理逻辑，直接使用全图精细搜索，而不是遗留的粗粒度热力图搜索。
- 从匹配配置中清理过时的粗尺度（coarse-scale）相关配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten global search behavior to rely on validated YOLO constraints and remove legacy coarse search mode paths.

Bug Fixes:
- Prevent global search from running without a validated YOLO constraint, avoiding invalid or noisy matches.
- Adjust dual-mode speculation logic to only engage when YOLO is validated or the initial result is strong enough.

Enhancements:
- Simplify global search modes by removing the legacy coarse mode and defaulting to full-map fine search.
- Update path-heatmap handling to use full-map fine search directly instead of legacy coarse heatmap search.
- Clean up obsolete coarse-scale configuration from match settings.

</details>