### PR TITLE
fix(AutoStockpile): 适配滑条隐藏时状况

### DIFF
--- a/assets/resource/pipeline/AutoStockpile/Purchase.json
+++ b/assets/resource/pipeline/AutoStockpile/Purchase.json
@@ -25,6 +25,7 @@
         "rate_limit": 0,
         "next": [
             "AutoStockpileDevSkipSwipe",
+            "AutoStockpileCheckSliding",
             "AutoStockpileSwipeSpecificQuantity",
             "AutoStockpileSwipeMax"
         ]
@@ -182,8 +183,7 @@
         },
         "pre_delay": 0,
         "action": {
-            "type": "Click",
-            "param": {}
+            "type": "Click"
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -204,8 +204,7 @@
         "pre_wait_freezes": 80,
         "pre_delay": 0,
         "action": {
-            "type": "Click",
-            "param": {}
+            "type": "Click"
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -226,11 +225,45 @@
         "pre_wait_freezes": 80,
         "pre_delay": 0,
         "action": {
-            "type": "Click",
-            "param": {}
+            "type": "Click"
         },
         "post_wait_freezes": 80,
         "post_delay": 0,
         "rate_limit": 0
+    },
+    "AutoStockpileCheckSliding": {
+        "desc": "检查滑条是否存在，当购买数量为1时滑条会隐藏",
+        "recognition": {
+            "type": "ColorMatch",
+            "param": {
+                "roi": [
+                    450,
+                    485,
+                    325,
+                    40
+                ],
+                "lower": [
+                    [
+                        80,
+                        80,
+                        80
+                    ]
+                ],
+                "upper": [
+                    [
+                        100,
+                        100,
+                        100
+                    ]
+                ],
+                "connected": true,
+                "count": 10086
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "AutoStockpileRelayNodeSwipe"
+        ]
     }
 }


### PR DESCRIPTION
- 当最大购买数量为1时，滑条会隐藏

close #3279

## Summary by Sourcery

更新 AutoStockpile 采购流水线配置，以处理当最大可购买数量为 1 时滑块被隐藏的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update AutoStockpile purchase pipeline configuration to handle cases where the slider is hidden when maximum purchase quantity is 1.

</details>