### PR TITLE
fix: 偶现售卖弹性物资卖不干净

### DIFF
--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -471,15 +471,15 @@
         "pre_delay": 0,
         "action": "Click",
         "target_offset": [
-            -75,
+            -70,
             5,
-            -5,
+            -10,
             -10
         ],
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutoSellFriendsPricesExpectedBuyClick"
+            // "AutoSellFriendsPricesExpectedBuyClick"
         ]
     },
     "AutoSellFriendsPricesExpectedBuyClick": {

--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -479,7 +479,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            // "AutoSellFriendsPricesExpectedBuyClick"
+            "AutoSellFriendsPricesExpectedBuyClick"
         ]
     },
     "AutoSellFriendsPricesExpectedBuyClick": {


### PR DESCRIPTION
close #3283

## Summary by Sourcery

Bug Fixes:
- 修复了一个间歇性问题，即自动出售任务未能完全卖出某些弹性物品。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix intermittent issue where certain elastic items were not fully sold by the auto-sell task.

</details>