### PR TITLE
perf: 任务周期判断从0点改为4点

### DIFF
--- a/agent/go-service/common/schedule/action.go
+++ b/agent/go-service/common/schedule/action.go
@@ -27,6 +27,17 @@ type weekdayFlags struct {
 	Sunday    bool `json:"sunday"`
 }
 
+const gameDayBoundaryHour = 4
+
+// gameWeekday returns the weekday by game-day rules: each day starts at 04:00 local time.
+func gameWeekday(now time.Time) time.Weekday {
+	t := now.Local()
+	if t.Hour() < gameDayBoundaryHour {
+		t = t.AddDate(0, 0, -1)
+	}
+	return t.Weekday()
+}
+
 // ScheduleAction runs the configured entry task only on weekdays where the
 // matching flag is enabled, and emits a localized notice on skipped days.
 type ScheduleAction struct{}
@@ -75,7 +86,7 @@ func (a *ScheduleAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		return false
 	}
 
-	weekday := time.Now().Weekday()
+	weekday := gameWeekday(time.Now())
 	weekdayName := i18n.T(weekdayKey(weekday))
 
 	if !isEnabledOn(&flags, weekday) {

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -162,7 +162,7 @@
     "maptracker.navigation_moving.target": "Target: ",
     "maptracker.navigation_finished.complete": "Navigation complete",
     "maptracker.navigation_finished.current": "Current: ",
-    "schedule.skip_today": "Today is %s, skipping the task per execution cycle",
+    "schedule.skip_today": "Current game time is %s, skipping the task per execution schedule",
     "schedule.weekday_monday": "Monday",
     "schedule.weekday_tuesday": "Tuesday",
     "schedule.weekday_wednesday": "Wednesday",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -162,7 +162,7 @@
     "maptracker.navigation_moving.target": "目標：",
     "maptracker.navigation_finished.complete": "ナビゲーション完了",
     "maptracker.navigation_finished.current": "現在：",
-    "schedule.skip_today": "今日は%s、実行周期に従いタスクをスキップします",
+    "schedule.skip_today": "現在のゲーム時間は%s、実行周期に従いタスクをスキップします",
     "schedule.weekday_monday": "月曜日",
     "schedule.weekday_tuesday": "火曜日",
     "schedule.weekday_wednesday": "水曜日",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -162,7 +162,7 @@
     "maptracker.navigation_moving.target": "목표:",
     "maptracker.navigation_finished.complete": "내비게이션 완료",
     "maptracker.navigation_finished.current": "현재:",
-    "schedule.skip_today": "오늘은 %s, 실행 주기에 따라 작업을 건너뜁니다",
+    "schedule.skip_today": "현재 게임 시간은 %s, 실행 주기에 따라 작업을 건너뜁니다",
     "schedule.weekday_monday": "월요일",
     "schedule.weekday_tuesday": "화요일",
     "schedule.weekday_wednesday": "수요일",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -162,7 +162,7 @@
     "maptracker.navigation_moving.target": "目标：",
     "maptracker.navigation_finished.complete": "导航完成",
     "maptracker.navigation_finished.current": "当前：",
-    "schedule.skip_today": "今天是%s，根据执行周期跳过任务",
+    "schedule.skip_today": "现在游戏时间是%s，根据执行周期跳过任务",
     "schedule.weekday_monday": "周一",
     "schedule.weekday_tuesday": "周二",
     "schedule.weekday_wednesday": "周三",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -162,7 +162,7 @@
     "maptracker.navigation_moving.target": "目標：",
     "maptracker.navigation_finished.complete": "導航完成",
     "maptracker.navigation_finished.current": "當前：",
-    "schedule.skip_today": "今天是%s，根據執行週期跳過任務",
+    "schedule.skip_today": "現在遊戲時間是%s，根據執行週期跳過任務",
     "schedule.weekday_monday": "週一",
     "schedule.weekday_tuesday": "週二",
     "schedule.weekday_wednesday": "週三",

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -279,7 +279,7 @@
     "task.GearAssembly.description": "Automatically craft a gear of the specified level",
     "task.ProtocolSpace.label": "⚔️Protocol Space",
     "task.ProtocolSpace.description": "Automatically consume sanity to farm the highest-level Protocol Space rewards until sanity is fully consumed.",
-    "option.TaskSchedule.label": "Execution cycle",
+    "option.TaskSchedule.label": "Execution cycle (game time)",
     "option.TaskScheduleMonday.label": "Monday",
     "option.TaskScheduleTuesday.label": "Tuesday",
     "option.TaskScheduleWednesday.label": "Wednesday",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -594,7 +594,7 @@
     "task.ProtocolSpace.description": "理智を消費してプロトコル空間の最高レベルの報酬を自動で周回し、理智を使い切るまで継続します。",
     "task.WebEvent202605.label": "🎁共賀記念Webイベント自動化",
     "task.WebEvent202605.description": "2026年5月の共賀記念Webイベントを自動でプレイし、ギフトブロックを自動で積み上げます。\n**注意：イベント画面を開いてから開始してください！**",
-    "option.TaskSchedule.label": "実行周期",
+    "option.TaskSchedule.label": "実行周期(ゲーム時間)",
     "option.TaskScheduleMonday.label": "月曜に実行",
     "option.TaskScheduleTuesday.label": "火曜に実行",
     "option.TaskScheduleWednesday.label": "水曜に実行",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -613,7 +613,7 @@
     "task.ProtocolSpace.description": "이성을 소모하여 최고 등급 프로토콜 공간 보상을 자동으로 획득하며, 이성이 모두 소모될 때까지 계속합니다.",
     "task.WebEvent202605.label": "🎁공동 축하 웹 이벤트 자동화",
     "task.WebEvent202605.description": "2026년 5월 공동 축하 웹 이벤트를 자동으로 플레이하고, 선물 블록을 자동으로 쌓습니다.\n**주의: 이벤트 화면을 연 뒤 작업을 시작하세요!**",
-    "option.TaskSchedule.label": "실행 주기",
+    "option.TaskSchedule.label": "실행 주기(게임 시간)",
     "option.TaskScheduleMonday.label": "월요일에 실행",
     "option.TaskScheduleTuesday.label": "화요일에 실행",
     "option.TaskScheduleWednesday.label": "수요일에 실행",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -615,7 +615,7 @@
     "task.GearAssembly.description": "自动制造指定等级的装备",
     "task.ProtocolSpace.label": "⚔️协议空间",
     "task.ProtocolSpace.description": "自动消耗理智刷取最高等级协议空间奖励，直到理智消耗完毕",
-    "option.TaskSchedule.label": "执行周期",
+    "option.TaskSchedule.label": "执行周期(游戏时间)",
     "option.TaskScheduleMonday.label": "周一",
     "option.TaskScheduleTuesday.label": "周二",
     "option.TaskScheduleWednesday.label": "周三",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -664,7 +664,7 @@
     "option.LevelUpOperatorMaxLevelThreshold.inputs.MaxLevelThreshold.label": "最大等級限制",
     "task.ProtocolSpace.label": "⚔️協議空間",
     "task.ProtocolSpace.description": "自動消耗理智刷取最高等級協議空間獎勵，直到理智消耗完畢",
-    "option.TaskSchedule.label": "執行週期",
+    "option.TaskSchedule.label": "執行週期(遊戲時間)",
     "option.TaskScheduleMonday.label": "週一",
     "option.TaskScheduleTuesday.label": "週二",
     "option.TaskScheduleWednesday.label": "週三",


### PR DESCRIPTION
## Summary by Sourcery

调整基于星期的调度逻辑，将比赛日的起始时间从本地时间的午夜改为 04:00，这样在午夜到 04:00 之间的任务将归入前一天。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust weekday-based scheduling to treat the game day as starting at 04:00 local time instead of midnight, so tasks between midnight and 04:00 are attributed to the previous day.

</details>