### PR TITLE
fix(MapLocator): 移除不必要的门控

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -172,7 +172,7 @@ private:
         const std::string& targetZoneId,
         const YoloCoarseResult& coarse) const;
     std::optional<MapPosition>
-        tryGlobalSearchWithFallback(const cv::Mat& minimap, const std::string& targetZoneId, const SearchConstraint& constraint);
+        tryGlobalSearchWithFallback(const cv::Mat& minimap, const std::string& targetZoneId, const SearchConstraint& constraint, MapPosition* outBestRaw = nullptr);
     MapPosition stabilizePosition(const MapPosition& raw);
     MapPosition acceptPosition(const MapPosition& raw, TimePoint now);
     void drainBackgroundGlobalSearchTasks();
@@ -945,7 +945,8 @@ SearchConstraint MapLocator::Impl::buildSearchConstraint(
 std::optional<MapPosition> MapLocator::Impl::tryGlobalSearchWithFallback(
     const cv::Mat& minimap,
     const std::string& targetZoneId,
-    const SearchConstraint& constraint)
+    const SearchConstraint& constraint,
+    MapPosition* outBestRaw)
 {
     const bool isPathHeatmapZone = IsPathHeatmapZone(targetZoneId);
     const unsigned hardwareThreads = std::max(1U, std::thread::hardware_concurrency());
@@ -986,6 +987,10 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearchWithFallback(
     auto globalResult = primaryAttempt.result;
     const MapPosition& rawGlobalPrimaryPos = primaryAttempt.rawPos;
 
+    if (outBestRaw) {
+        *outBestRaw = rawGlobalPrimaryPos;
+    }
+
     const bool shouldTryDualMode =
         !globalResult && !isPathHeatmapZone && (constraint.yolo_validated || rawGlobalPrimaryPos.score > 0.1);
     if (!shouldTryDualMode) {
@@ -1007,6 +1012,10 @@ std::optional<MapPosition> MapLocator::Impl::tryGlobalSearchWithFallback(
     auto fallbackResult = fallbackAttempt.result;
     const MapPosition& rawGlobalFallbackPos = fallbackAttempt.rawPos;
     const double dist = std::hypot(rawGlobalPrimaryPos.x - rawGlobalFallbackPos.x, rawGlobalPrimaryPos.y - rawGlobalFallbackPos.y);
+
+    if (outBestRaw && rawGlobalFallbackPos.score > rawGlobalPrimaryPos.score) {
+        *outBestRaw = rawGlobalFallbackPos;
+    }
 
     // 双策略验证：正常图传和梯度图传独立得出的坐标若极度相近，且双方分数都过线，才视为互证。
     if (rawGlobalPrimaryPos.score >= kDualGlobalVerifyMinScore && rawGlobalFallbackPos.score >= kDualGlobalVerifyMinScore
@@ -1113,14 +1122,23 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
     }
 
     int maxAllowedLost = IsPathHeatmapZone(targetZoneId) ? 10 : options.max_lost_frames;
-    auto globalResult = tryGlobalSearchWithFallback(minimap, targetZoneId, constraint);
+    MapPosition bestRawGlobal {};
+    auto globalResult = tryGlobalSearchWithFallback(minimap, targetZoneId, constraint, &bestRawGlobal);
     if (!globalResult) {
-        motionTracker->markLost();
-        if (motionTracker->getLostCount() > maxAllowedLost) {
-            motionTracker->forceLost();
-            stablePosition.reset();
+        if (bestRawGlobal.score > kSeamFallbackMinPeakScore) {
+            bestRawGlobal.isHeld = true;
+            globalResult = bestRawGlobal;
+            LogInfo << "Global gate low-confidence: releasing best raw peak (held) to avoid cold-start deadlock."
+                    << VAR(bestRawGlobal.x) << VAR(bestRawGlobal.y) << VAR(bestRawGlobal.score);
         }
-        return LocateResult { .status = LocateStatus::TrackingLost, .debugMessage = "Global search failed." };
+        else {
+            motionTracker->markLost();
+            if (motionTracker->getLostCount() > maxAllowedLost) {
+                motionTracker->forceLost();
+                stablePosition.reset();
+            }
+            return LocateResult { .status = LocateStatus::TrackingLost, .debugMessage = "Global search failed." };
+        }
     }
 
     const auto lastPosOpt = motionTracker->getLastPos();

--- a/agent/cpp-algo/source/MapLocator/MapTypes.h
+++ b/agent/cpp-algo/source/MapLocator/MapTypes.h
@@ -157,6 +157,7 @@ constexpr double kPositionConsensusRadius = 12.0; // 近点判定半径
 constexpr double kFarJumpRejectDistance = 80.0;   // global 跨帧跳变阈值
 constexpr double kHighConfidenceOverride = 0.85;  // 压倒分：远跳但此分以上直接 reseed
 constexpr const char* kColdStartCollectingMessage = "Cold-start collecting.";
+constexpr double kSeamFallbackMinPeakScore = 0.0;
 
 // tracking 窄带多尺度搜索参数。第一项必须为 0.0（即 baseScale），
 // 循环时 baseScale 先跑，达到 kFastTrackingPassScore 则跳过后续尺度

--- a/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
+++ b/agent/cpp-algo/source/MapLocator/MatchStrategy.cpp
@@ -422,10 +422,7 @@ public:
 
     bool validateGlobalSearch(const MatchResultRaw& fineRes, double& outScore) override
     {
-        bool globalAccept = (fineRes.score >= 0.85) || (fineRes.score >= 0.70 && fineRes.delta >= 0.25 && fineRes.psr >= 2.0)
-                            || (fineRes.score >= 0.42 && fineRes.delta >= 0.04 && fineRes.psr >= 3.8)
-                            || (fineRes.score >= 0.40 && fineRes.delta >= 0.05 && fineRes.psr >= 3.8);
-        if (!globalAccept) {
+        if (fineRes.score < matchCfg.passThreshold) {
             return false;
         }
         outScore = fineRes.score;


### PR DESCRIPTION
- fix #3298
- fix #3302

## Summary by Sourcery

放宽全局地图搜索的限制，并暴露最佳原始全局候选结果，以避免在全局搜索失败时出现冷启动死锁问题。

Bug 修复：
- 当全局搜索失败但仍具有最低可接受得分时，通过回退到最佳原始全局峰值来防止冷启动期间发生死锁。
- 将路径热力图（path heatmap）的全局校验逻辑与可配置的通过阈值对齐，而不是依赖硬编码的分数/PSR/delta 门限。

改进：
- 扩展全局搜索辅助工具，可选地输出最佳原始全局候选结果，以供后续决策逻辑使用。
- 在全局搜索中引入可调节的最小峰值得分常量，用于接缝回退（seam-fallback）行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax global map search gating and expose best raw global candidate to avoid cold-start deadlocks when global search fails.

Bug Fixes:
- Prevent deadlock during cold-start by falling back to the best raw global peak when global search fails but has a minimally acceptable score.
- Align path heatmap global validation with configurable pass thresholds instead of hardcoded score/PSR/delta gating.

Enhancements:
- Extend global search helper to optionally output the best raw global candidate for downstream decision logic.
- Introduce a tunable minimum peak score constant for seam-fallback behavior in global search.

</details>