### PR TITLE
fix: 开荒辅助自动剧情无法退出

### DIFF
--- a/assets/resource/pipeline/RealTimeTask/AutoSkip.json
+++ b/assets/resource/pipeline/RealTimeTask/AutoSkip.json
@@ -91,8 +91,7 @@
                     90
                 ],
                 "template": "RealTimeTask/AutoSkipA.png",
-                "threshold": 0.7,
-                "inverse": true
+                "threshold": 0.7
             },
             {
                 "recognition": "TemplateMatch",
@@ -103,10 +102,10 @@
                     90
                 ],
                 "template": "RealTimeTask/AutoSkipEsc.png",
-                "threshold": 0.7,
-                "inverse": true
+                "threshold": 0.7
             }
         ],
+        "inverse": true,
         "pre_delay": 0,
         "post_delay": 0,
         "focus": {


### PR DESCRIPTION
close #3266

## Summary by Sourcery

Bug Fixes:
- 通过更新 AutoSkip 管线设置，修复在使用早期游戏辅助功能时无法退出自动剧情模式的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve inability to exit auto-story mode when using the early-game assistance feature by updating AutoSkip pipeline settings.

</details>