### PR TITLE
fix: 偶现进入珍贵物品栏失败

### DIFF
--- a/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
@@ -5,7 +5,7 @@
         "post_delay": 0,
         "next": [
             "AutoUseSpMedicationInStashValuablesTab",
-            "[JumpBack]SceneStashValuablesTab"
+            "[JumpBack]SceneEnterMenuValuablesValuableTab"
         ],
         "focus": {
             "Node.Action.Starting": "即将进入珍贵物品标签页"

--- a/assets/resource/pipeline/BatchUseDetector/main.json
+++ b/assets/resource/pipeline/BatchUseDetector/main.json
@@ -5,7 +5,7 @@
         "post_delay": 0,
         "next": [
             "BatchUseDetectorInStashValuablesTab",
-            "[JumpBack]SceneStashValuablesTab"
+            "[JumpBack]SceneEnterMenuValuablesValuableTab"
         ],
         "focus": {
             "Node.Action.Starting": "主任务启动"

--- a/assets/resource/pipeline/Interface/InScene/ValuablesTab.json
+++ b/assets/resource/pipeline/Interface/InScene/ValuablesTab.json
@@ -10,8 +10,7 @@
                     23,
                     23
                 ],
-                "template": "SceneManager/ValuablesTabChoosed.png",
-                "threshold": 0.6
+                "template": "SceneManager/ValuablesTabChoosed.png"
             }
         },
         "focus": {

--- a/assets/resource/pipeline/Interface/SceneMenu.json
+++ b/assets/resource/pipeline/Interface/SceneMenu.json
@@ -51,13 +51,12 @@
             "[JumpBack]SceneAnyEnterWorld"
         ]
     },
-    "SceneStashValuablesTab": {
+    "SceneEnterMenuValuablesValuableTab": {
         "desc": "从任意界面进入贵重品库的珍贵物品页",
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "_SceneStashValuablesTabIn",
-            "_SceneStashValuablesTabSwitch",
+            "__ScenePrivateMenuValuablesEnterValuableTab",
             "[JumpBack]SceneEnterMenuValuables"
         ]
     },

--- a/assets/resource/pipeline/PullCountCalculator.json
+++ b/assets/resource/pipeline/PullCountCalculator.json
@@ -63,7 +63,7 @@
         "desc": "进入贵重品库珍贵物品页，界面跳转交由 SceneManager Pipeline 处理",
         "next": [
             "PullCountCalculatorInStashValuablesTab",
-            "[JumpBack]SceneStashValuablesTab"
+            "[JumpBack]SceneEnterMenuValuablesValuableTab"
         ],
         "focus": {
             "Node.Action.Starting": "即将进入贵重品库珍贵物品页"

--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -776,17 +776,7 @@
         "pre_delay": 0,
         "post_delay": 0
     },
-    "_SceneStashValuablesTabIn": {
-        "recognition": {
-            "type": "And",
-            "param": {
-                "all_of": [
-                    "InStashValuablesTab"
-                ]
-            }
-        }
-    },
-    "_SceneStashValuablesTabSwitch": {
+    "__ScenePrivateMenuValuablesEnterValuableTab": {
         "desc": "切换到珍贵物品标签页",
         "recognition": {
             "type": "TemplateMatch",
@@ -797,20 +787,36 @@
                     23,
                     23
                 ],
-                "template": "SceneManager/ValuablesTabNotChoose.png",
-                "threshold": 0.6
+                "template": "SceneManager/ValuablesTabNotChoose.png"
             }
         },
         "action": {
             "type": "Click"
         },
-        "post_wait_freezes": 100,
         "next": [
-            "_SceneStashValuablesTabIn"
-        ],
-        "focus": {
-            "Node.Action.Starting": "切换到珍贵物品页界面"
-        }
+            "__ScenePrivateAnyEnterValuableTabSuccess"
+        ]
+    },
+    "__ScenePrivateAnyEnterValuableTabSuccess": {
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "InStashValuablesTab"
+                ]
+            }
+        },
+        "pre_wait_freezes": {
+            "target": [
+                0,
+                -200,
+                200,
+                200
+            ],
+            "time": 100
+        },
+        "pre_delay": 0,
+        "post_delay": 0
     },
     "__ScenePrivateWorldEnterMenuOperationalManual": {
         "desc": "从大世界进入行动手册菜单",


### PR DESCRIPTION
#3278

## Summary by Sourcery

Bug Fixes:
- 通过更新相关场景和界面流水线的 JSON 配置，修复了间歇性无法进入贵重物品标签页的问题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix intermittent failure to enter the valuables tab by updating related scene and interface pipeline JSON configurations

</details>