### PR TITLE
fix: 修复识别文字颜色过于严苛导致失败

### DIFF
--- a/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
@@ -305,16 +305,15 @@
             "param": {
                 "roi": "GiftOperatorCheckSelectedLabelColor",
                 "lower": [
-                    40,
-                    40,
-                    40
+                    52,
+                    52,
+                    45
                 ],
                 "upper": [
-                    55,
-                    55,
-                    55
+                    80,
+                    78,
+                    52
                 ],
-                "connected": true,
                 "count": 10
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修复由于文本颜色检测条件过于严格而导致的 GiftOperator 联系流程中的失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix failures in the GiftOperator contact flow caused by overly strict text color detection criteria.

</details>
- 修复在 GiftOperator 联系流程中，由于文本颜色识别条件过于严格而导致识别失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 修复由于文本颜色检测条件过于严格而导致的 GiftOperator 联系流程中的失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix failures in the GiftOperator contact flow caused by overly strict text color detection criteria.

</details>

</details>