### PR TITLE
fix: 升级武器多点一次排序导致失败

### DIFF
--- a/assets/resource/pipeline/Weapon.json
+++ b/assets/resource/pipeline/Weapon.json
@@ -345,8 +345,36 @@
         "action": {
             "type": "Click"
         },
-        "post_wait_freezes": {
-            "time": 100,
+        "anchor": {
+            "MouseMoveResetAnchor": "MouseMoveReset"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack][Anchor]MouseMoveResetAnchor",
+            "WeaponUpgradeSwitchAscendingSuccess"
+        ]
+    },
+    "WeaponUpgradeSwitchAscendingSuccess": {
+        "desc": "成功切换到升序",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    16,
+                    561,
+                    375,
+                    133
+                ],
+                "expected": [
+                    "升序",
+                    "(?i)ASC",
+                    "昇順"
+                ]
+            }
+        },
+        "pre_wait_freezes": {
+            "time": 300,
             "target": [
                 0,
                 -300,
@@ -354,7 +382,7 @@
                 300
             ]
         },
-        "post_delay": 0,
-        "rate_limit": 0
+        "pre_delay": 0,
+        "post_delay": 0
     }
 }


### PR DESCRIPTION
#3320

## Summary by Sourcery

错误修复：
- 修复由于武器流水线配置中排序不正确而导致的武器升级失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix weapon upgrade failures caused by incorrect sorting in the weapon pipeline configuration.

</details>