### PR TITLE
fix(AutoEcoFarm):优化工作循环时判定标记的逻辑

### DIFF
--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
@@ -124,10 +124,10 @@
             "[JumpBack]_AutoEcoFarmCloseEquipment",
             //识别肥料界面，有的话关了
             "[JumpBack]_AutoEcoFarmCloseFertilizer",
+            //离开农场则退出工作循环
+            "[Anchor]_AutoEcoFarmLeftFarmAnchor",
             //识别工作按钮并点击
             "_AutoEcoFarmFindMenuIcon",
-            //如果还在农田内则任不会结束
-            "_AutoEcoFarmInAnyFarm",
             //第二次保障，判断标记还在不在
             "_AutoEcoFarmTargetExists",
             //所有条件都不满足的情况下，启动最后一跳，再给一次机会
@@ -200,60 +200,6 @@
         "next": [
             "_AutoEcoFarmJumpBack"
         ]
-    },
-    "_AutoEcoFarmInAnyFarm": {
-        "desc": "确认是否在任意农场内,还在的话继续循环",
-        "enabled": true,
-        "recognition": {
-            "type": "Or",
-            "param": {
-                "any_of": [
-                    "_AutoEcoFarmInValleyIVFarm",
-                    "_AutoEcoFarmInWulinFarm"
-                ]
-            }
-        },
-        "next": [
-            "_AutoEcoFarmJump"
-        ]
-    },
-    "_AutoEcoFarmInValleyIVFarm": {
-        "desc": "确认是否在谷地农场内",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map01_lv005",
-                    "target": [
-                        551,
-                        322,
-                        23,
-                        23
-                    ]
-                }
-            ],
-            "precision": 1
-        }
-    },
-    "_AutoEcoFarmInWulinFarm": {
-        "desc": "确认是否在武陵农场内",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        413,
-                        164,
-                        33,
-                        32
-                    ]
-                }
-            ],
-            "precision": 1
-        }
     },
     "_AutoEcoFarmFindMenuIcon": {
         "desc": "寻找采集、播种、浇水的文字",

--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmMoveAndWork.json
@@ -126,10 +126,10 @@
             "[JumpBack]_AutoEcoFarmCloseFertilizer",
             //识别工作按钮并点击
             "_AutoEcoFarmFindMenuIcon",
+            //如果还在农田内则任不会结束
+            "_AutoEcoFarmInAnyFarm",
             //第二次保障，判断标记还在不在
             "_AutoEcoFarmTargetExists",
-            //第三层保障，如果还在农田内则任不会结束
-            "_AutoEcoFarmInAnyFarm",
             //所有条件都不满足的情况下，启动最后一跳，再给一次机会
             "_AutoEcoFarmLastJump",
             //意外错误的话直接退出任务

--- a/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitValleyIV.json
+++ b/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitValleyIV.json
@@ -21,7 +21,9 @@
             "_AutoEcoFarmGotoEcoFarmCppAnchor": "_AutoEcoFarmGotoEcoFarmCppValleyIV",
             //AutoEcoFarmFindFarmland.json 寻找标记部分
             "_AutoEcoFarmFindEcoFarmAnchor": "_AutoEcoFarmFindEcoFarmValleyIV",
-            "_AutoEcoFarmBlindWalkStartAnchor": "_AutoEcoFarmBlindWalkStartValleyIV"
+            "_AutoEcoFarmBlindWalkStartAnchor": "_AutoEcoFarmBlindWalkStartValleyIV",
+            //AutoEcoFarmMoveAndWork.json 工作循环部分
+            "_AutoEcoFarmLeftFarmAnchor": "_AutoEcoFarmLeftFarmValleyIV"
         },
         "next": [
             "[JumpBack][Anchor]_AutoEcoFarmTeleportToFarmAnchor",
@@ -345,6 +347,31 @@
         },
         "next": [
             //JumpBack
+        ]
+    },
+    //确认是否离开谷地农场，离开则退出工作循环。如需更换目标农场，请修改下方 target 坐标，
+    //将矩形范围扩大至覆盖整块目标农场的地图区域
+    "_AutoEcoFarmLeftFarmValleyIV": {
+        "desc": "确认是否离开谷地农场, 离开则退出工作循环",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map01_lv005",
+                    "target": [
+                        551,
+                        322,
+                        23,
+                        23
+                    ]
+                }
+            ],
+            "precision": 1
+        },
+        "inverse": true,
+        "next": [
+            "_AutoEcoFarmCancelMove"
         ]
     },
     //识别地图上农田标题的节点，改ocr内容和节点名就行

--- a/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitWulin.json
+++ b/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitWulin.json
@@ -21,7 +21,9 @@
             "_AutoEcoFarmGotoEcoFarmCppAnchor": "_AutoEcoFarmGotoEcoFarmCppWulin",
             //AutoEcoFarmFindFarmland.json 寻找标记部分
             "_AutoEcoFarmFindEcoFarmAnchor": "_AutoEcoFarmFindEcoFarmWulin",
-            "_AutoEcoFarmBlindWalkStartAnchor": "_AutoEcoFarmBlindWalkStartWulin"
+            "_AutoEcoFarmBlindWalkStartAnchor": "_AutoEcoFarmBlindWalkStartWulin",
+            //AutoEcoFarmMoveAndWork.json 工作循环部分
+            "_AutoEcoFarmLeftFarmAnchor": "_AutoEcoFarmLeftFarmWulin"
         },
         "next": [
             "[JumpBack][Anchor]_AutoEcoFarmTeleportToFarmAnchor",
@@ -250,6 +252,31 @@
         },
         "next": [
             //JumpBack
+        ]
+    },
+    //确认是否离开武陵农场，离开则退出工作循环。如需更换目标农场，请修改下方 target 坐标，
+    //将矩形范围扩大至覆盖整块目标农场的地图区域
+    "_AutoEcoFarmLeftFarmWulin": {
+        "desc": "确认是否离开武陵农场, 离开则退出工作循环",
+        "recognition": "Custom",
+        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition_param": {
+            "expected": [
+                {
+                    "map_name": "map02_lv002",
+                    "target": [
+                        413,
+                        164,
+                        33,
+                        32
+                    ]
+                }
+            ],
+            "precision": 1
+        },
+        "inverse": true,
+        "next": [
+            "_AutoEcoFarmCancelMove"
         ]
     },
     //识别地图上农田标题的节点，改recognition内容

--- a/assets/tasks/AutoEcoFarm.json
+++ b/assets/tasks/AutoEcoFarm.json
@@ -155,9 +155,6 @@
                             "focus": {
                                 "Node.Action.Starting": "等待60秒，让队友多干点活，不是脚本卡咯，别担心"
                             }
-                        },
-                        "_AutoEcoFarmInAnyFarm": {
-                            "enabled": false
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
将农田位置检测重构为锚点模式，反转退出逻辑
- 新增锚点 `_AutoEcoFarmLeftFarmAnchor`，各地区在 `RegionNodes` 的 init 阶段绑定各自的 `MapTrackerAssertLocation` 节点
- 逻辑从 Or 组合 + "在农场内则继续循环" 反转为 `inverse: true` + "离开农场则退出循环"，避免跳过后续 next 判定
- 调整 `_AutoEcoFarmFindMenuLoop.next` 顺序，离开检测优先于菜单识别
- 清理 `tasks/AutoEcoFarm.json` 中已失效的 `_AutoEcoFarmInAnyFarm` 覆写

## Summary by Sourcery

根据离开农场区域（而不是停留在其中）来优化 AutoEcoFarm 工作循环的退出条件。

Bug Fixes:
- 修正农场循环继续逻辑，使其在玩家离开农场时退出，而不是错误地跳过后续的下一步检查。

Enhancements:
- 为位置检测引入按区域划分的农场锚点节点，并在区域初始化期间绑定它们。
- 在 AutoEcoFarm 的 find-menu 循环中，将农场离开检测的优先级提升到菜单识别之前。
- 从 AutoEcoFarm 任务配置中移除已废弃的 `_AutoEcoFarmInAnyFarm` 重写实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine AutoEcoFarm work loop exit conditions based on leaving farm areas instead of remaining inside them.

Bug Fixes:
- Correct farm loop continuation logic to exit when the player leaves a farm instead of incorrectly skipping subsequent next checks.

Enhancements:
- Introduce region-specific farm anchor nodes for location detection and bind them during region initialization.
- Prioritize farm-leave detection ahead of menu recognition in the AutoEcoFarm find-menu loop.
- Remove obsolete _AutoEcoFarmInAnyFarm overrides from the AutoEcoFarm task configuration.

</details>