### PR TITLE
feat: 万能传送新增试验园区点

### DIFF
--- a/assets/resource/pipeline/Interface/InScene/Region.json
+++ b/assets/resource/pipeline/Interface/InScene/Region.json
@@ -113,6 +113,27 @@
             }
         ]
     },
+    "InMapWulingTestArea": {
+        "desc": "在武陵-试验园区地图界面",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny",
+            {
+                "recognition": "OCR",
+                "roi": [
+                    0,
+                    0,
+                    250,
+                    60
+                ],
+                "expected": [
+                    "试验园区",
+                    "Test Area",
+                    "實驗園區"
+                ]
+            }
+        ]
+    },
     "InMapDijiang": {
         "desc": "在帝江号地图界面",
         "recognition": "And",
@@ -245,16 +266,16 @@
         "recognition": "And",
         "all_of": [
             {
-                "recognition": "OCR",
-                "roi": [
-                    420,
-                    -100,
-                    450,
-                    100
-                ],
-                "expected": [
-                    "FIELD",
-                    "ENDFIELD"
+        "recognition": "OCR",
+        "roi": [
+            420,
+            -100,
+            450,
+            100
+        ],
+        "expected": [
+            "FIELD",
+            "ENDFIELD"
                 ]
             },
             {

--- a/assets/resource/pipeline/Interface/InScene/Region.json
+++ b/assets/resource/pipeline/Interface/InScene/Region.json
@@ -266,16 +266,16 @@
         "recognition": "And",
         "all_of": [
             {
-        "recognition": "OCR",
-        "roi": [
-            420,
-            -100,
-            450,
-            100
-        ],
-        "expected": [
-            "FIELD",
-            "ENDFIELD"
+                "recognition": "OCR",
+                "roi": [
+                    420,
+                    -100,
+                    450,
+                    100
+                ],
+                "expected": [
+                    "FIELD",
+                    "ENDFIELD"
                 ]
             },
             {

--- a/assets/resource/pipeline/Interface/SceneWuling.json
+++ b/assets/resource/pipeline/Interface/SceneWuling.json
@@ -35,6 +35,15 @@
             "[JumpBack]SceneEnterMapAny"
         ]
     },
+    "SceneEnterMapWulingTestArea": {
+        "desc": "从任意界面进入武陵-试验园区地图界面",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingTestArea",
+            "[JumpBack]SceneEnterMapAny"
+        ]
+    },
     "SceneEnterWorldWulingJingyuValley0": {
         "desc": "从任意界面进入-景玉谷-生态实验站",
         "pre_delay": 0,
@@ -433,6 +442,18 @@
         "next": [
             "__ScenePrivateMapWulingMarkerStoneEnterWorldAnchor",
             "[JumpBack]SceneEnterMapWulingMarkerStone"
+        ]
+    },
+    "SceneEnterWorldWulingTestArea1": {
+        "desc": "从任意界面进入武陵-试验园区-综合科研区下大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingTestAreaEnterWorldWulingTestArea1"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingTestAreaEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingTestArea"
         ]
     }
 }

--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -1130,6 +1130,33 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
+    "__ScenePrivateMapWulingTestAreaEnterWorldWulingTestArea1": {
+        "desc": "在地图界面找锚点 (试验园区-综合科研区下)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingTestArea"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv005",
+            "target": [
+                336.3,
+                420.1
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
     "__ScenePrivateMapUnknownEnterWorldWulingMarkerStone4Try1": {
         "desc": "在地图界面找锚点 (首墩-栖云窟)",
         "recognition": "TemplateMatch",

--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -47,6 +47,18 @@
             "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
         ]
     },
+    "__ScenePrivateMapAnyEnterMapWulingTestArea": {
+        "desc": "在任意地图界面，进入武陵-试验园区地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny"
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingTestAreaSuccess",
+            "__ScenePrivateMapOverviewEnterMapWulingTestArea",
+            "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
+        ]
+    },
     "__ScenePrivateMapAnyEnterMapWulingJingyuValleySuccess": {
         "desc": "在地图界面，成功进入武陵-景玉谷地图",
         "recognition": "And",
@@ -79,6 +91,15 @@
         "recognition": "And",
         "all_of": [
             "InMapWulingMarkerStone"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0
+    },
+    "__ScenePrivateMapAnyEnterMapWulingTestAreaSuccess": {
+        "desc": "在地图界面，成功进入武陵-试验园区地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingTestArea"
         ],
         "pre_delay": 0,
         "post_delay": 0
@@ -197,6 +218,29 @@
             "__ScenePrivateMapOverviewWulingEnterMapWulingMarkerStone"
         ]
     },
+    "__ScenePrivateMapOverviewEnterMapWulingTestArea": {
+        "desc": "在地图总览界面，进入武陵-试验园区地图",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    -450,
+                    -150,
+                    350,
+                    150
+                ],
+                "template": [
+                    "SceneManager/MapOverviewWulingChoose.png",
+                    "SceneManager/MapOverviewWulingNotChoose.png"
+                ],
+                "threshold": 0.9
+            }
+        },
+        "next": [
+            "[JumpBack]__ScenePrivateMapOverviewSwitchMapOverviewWuling",
+            "__ScenePrivateMapOverviewWulingEnterMapWulingTestArea"
+        ]
+    },
     "__ScenePrivateMapOverviewWulingEnterMapWulingJingyuValley": {
         "desc": "在武陵总览界面，进入武陵-景玉谷地图",
         "action": "Click",
@@ -247,6 +291,19 @@
         ],
         "next": [
             "__ScenePrivateMapAnyEnterMapWulingMarkerStoneSuccess"
+        ]
+    },
+    "__ScenePrivateMapOverviewWulingEnterMapWulingTestArea": {
+        "desc": "在武陵总览界面，进入武陵-试验园区地图",
+        "action": "Click",
+        "target": [
+            755,
+            174,
+            99,
+            86
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingTestAreaSuccess"
         ]
     },
     "__ScenePrivateMapWulingJingyuValleyEnterWorldAnchor": {
@@ -309,6 +366,26 @@
             "[JumpBack][Anchor]__ScenePrivateMapSwipeToStep4Anchor"
         ]
     },
+    "__ScenePrivateMapWulingTestAreaEnterWorldAnchor": {
+        "desc": "在武陵-试验园区地图界面，进入[锚点]大世界",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingTestArea"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapTeleportSuccess",
+            "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapFilterClear",
+            "[JumpBack]__ScenePrivateMapZoomOut",
+            "[JumpBack][Anchor]__ScenePrivateMapSwipeToStep0Anchor",
+            "[JumpBack][Anchor]__ScenePrivateMapSwipeToStep1Anchor",
+            "[JumpBack][Anchor]__ScenePrivateMapSwipeToStep2Anchor",
+            "[JumpBack][Anchor]__ScenePrivateMapSwipeToStep3Anchor",
+            "[JumpBack][Anchor]__ScenePrivateMapSwipeToStep4Anchor"
+        ]
+    },
     "__ScenePrivateMapWulingJingyuValleyEnterWorldAnchorWithPick": {
         "desc": "在武陵-景玉谷地图界面，进入[锚点]大世界",
         "recognition": "And",
@@ -356,6 +433,20 @@
         "recognition": "And",
         "all_of": [
             "InMapWulingMarkerStone"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapTeleportSuccess",
+            "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
+        ]
+    },
+    "__ScenePrivateMapWulingTestAreaEnterWorldAnchorWithPick": {
+        "desc": "在武陵-试验园区地图界面，进入[锚点]大世界",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingTestArea"
         ],
         "pre_delay": 0,
         "post_delay": 0,


### PR DESCRIPTION
尝试新增万能跳转新区域点

## 由 Sourcery 提供的摘要

在武陵场景中新增通用传送目的地，并更新关联的区域和场景配置。

新功能：
- 为武陵场景中的实验公园区域新增一个通用传送点。

增强项：
- 更新武陵场景和区域配置文件，以注册新的传送目的地。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为武陵场景添加一个新的通用传送目标，并在区域、场景以及传送配置文件中完成注册。

New Features:
- 为武陵场景中的实验园区区域新增一个通用传送点。

Enhancements:
- 更新武陵的区域、场景和场景管理器配置，以包含新的传送目标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new universal teleport destination for the Wuling scene and register it across region, scene, and teleport configuration files.

New Features:
- Introduce a universal teleport point for the experimental park area within the Wuling scene.

Enhancements:
- Update region, scene, and scene manager configuration for Wuling to include the new teleport destination.

</details>

</details>