### PR TITLE
fix: 非 ADB 控制器要求最低分辨率

### DIFF
--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -162,32 +162,43 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		return
 	}
 
+	aspectRatioOK := isAspectRatio16x9(int(width), int(height))
+	minResolutionOK := isAtLeastTargetResolution(int(width), int(height))
+
 	log.Debug().
 		Uint64("task_id", detail.TaskID).
 		Str("entry", detail.Entry).
 		Str("controller_name", pienv.ControllerName()).
 		Str("controller_type", controlType).
-		Str("requirement", "aspect_ratio").
-		Str("mode", "aspect_ratio_only").
+		Str("requirement", "aspect_ratio_min_resolution").
+		Str("mode", "aspect_ratio_min_resolution").
 		Int32("width", width).
 		Int32("height", height).
+		Int("target_width", targetWidth).
+		Int("target_height", targetHeight).
+		Bool("aspect_ratio_ok", aspectRatioOK).
+		Bool("min_resolution_ok", minResolutionOK).
 		Float64("target_ratio", targetRatio).
-		Msg("Using aspect ratio check for non-ADB controller")
+		Msg("Using aspect ratio and minimum resolution check for non-ADB controller")
 
-	if !isAspectRatio16x9(int(width), int(height)) {
+	if !aspectRatioOK || !minResolutionOK {
 		actualRatio := calculateAspectRatio(int(width), int(height))
 		log.Error().
 			Uint64("task_id", detail.TaskID).
 			Str("entry", detail.Entry).
 			Str("controller_name", pienv.ControllerName()).
 			Str("controller_type", controlType).
-			Str("requirement", "aspect_ratio").
+			Str("requirement", "aspect_ratio_min_resolution").
 			Bool("stop_task", true).
 			Int32("width", width).
 			Int32("height", height).
+			Int("target_width", targetWidth).
+			Int("target_height", targetHeight).
+			Bool("aspect_ratio_ok", aspectRatioOK).
+			Bool("min_resolution_ok", minResolutionOK).
 			Float64("actual_ratio", actualRatio).
 			Float64("target_ratio", targetRatio).
-			Str("mode", "aspect_ratio_only").
+			Str("mode", "aspect_ratio_min_resolution").
 			Msg("resolution check failed")
 		fullScreen, _ := gamesetting.GetVideoFullScreen()
 		if fullScreen == 1 {
@@ -203,10 +214,14 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		Str("entry", detail.Entry).
 		Str("controller_name", pienv.ControllerName()).
 		Str("controller_type", controlType).
-		Str("requirement", "aspect_ratio").
+		Str("requirement", "aspect_ratio_min_resolution").
 		Int32("width", width).
 		Int32("height", height).
-		Str("mode", "aspect_ratio_only").
+		Int("target_width", targetWidth).
+		Int("target_height", targetHeight).
+		Bool("aspect_ratio_ok", aspectRatioOK).
+		Bool("min_resolution_ok", minResolutionOK).
+		Str("mode", "aspect_ratio_min_resolution").
 		Msg("resolution check passed")
 }
 
@@ -243,6 +258,19 @@ func isAspectRatio16x9(width, height int) bool {
 
 	// Check if ratio is within tolerance of 16:9
 	return math.Abs(ratio-targetRatio) <= targetRatio*tolerance
+}
+
+func isAtLeastTargetResolution(width, height int) bool {
+	if width <= 0 || height <= 0 {
+		return false
+	}
+
+	longSide := max(width, height)
+	shortSide := min(width, height)
+	targetLongSide := max(targetWidth, targetHeight)
+	targetShortSide := min(targetWidth, targetHeight)
+
+	return longSide >= targetLongSide && shortSide >= targetShortSide
 }
 
 // calculateAspectRatio calculates the aspect ratio, always returning the larger/smaller ratio

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -150,7 +150,7 @@
     "tasker.aspect_ratio_warning.current_resolution": "Current resolution:",
     "tasker.aspect_ratio_warning.requirement_label": "Required:",
     "tasker.aspect_ratio_warning.requirement_exact": "Exact %dx%d; other 16:9 resolutions such as 1920x1080 are not accepted",
-    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 aspect ratio; for example 3840x2160, 2560x1440, 1920x1080, 1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 aspect ratio and at least 1280x720; for example 3840x2160, 2560x1440, 1920x1080, 1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "Windowed mode; fullscreen requires a physical 16:9 monitor, which your current display does not meet.",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",
     "maptracker.emergency_stop.desc": "Navigation aborted.",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -150,7 +150,7 @@
     "tasker.aspect_ratio_warning.current_resolution": "現在の解像度：",
     "tasker.aspect_ratio_warning.requirement_label": "必要条件：",
     "tasker.aspect_ratio_warning.requirement_exact": "正確に %dx%d。1920x1080 など他の 16:9 解像度でも通りません",
-    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比率。例: 3840x2160、2560x1440、1920x1080、1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比率かつ 1280x720 以上。例: 3840x2160、2560x1440、1920x1080、1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "ウィンドウモード；全画面モードでは物理的に 16:9 のディスプレイが必要ですが、現在のディスプレイは条件を満たしません。",
     "maptracker.emergency_stop.title": "🚨 緊急停止",
     "maptracker.emergency_stop.desc": "ナビゲーションを中止しました。",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -150,7 +150,7 @@
     "tasker.aspect_ratio_warning.current_resolution": "현재 해상도:",
     "tasker.aspect_ratio_warning.requirement_label": "요구 사항:",
     "tasker.aspect_ratio_warning.requirement_exact": "정확히 %dx%d여야 하며, 1920x1080 같은 다른 16:9 해상도도 허용되지 않습니다",
-    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 비율; 예: 3840x2160, 2560x1440, 1920x1080, 1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 비율이고 최소 1280x720 이상이어야 합니다; 예: 3840x2160, 2560x1440, 1920x1080, 1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "창 모드; 전체 화면 모드는 물리적으로 16:9 해상도 모니터가 필요하며 현재 디스플레이는 조건에 맞지 않습니다.",
     "maptracker.emergency_stop.title": "🚨 긴급 정지",
     "maptracker.emergency_stop.desc": "길찾기가 중단되었습니다.",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -150,7 +150,7 @@
     "tasker.aspect_ratio_warning.current_resolution": "当前分辨率：",
     "tasker.aspect_ratio_warning.requirement_label": "目标要求：",
     "tasker.aspect_ratio_warning.requirement_exact": "精确 %dx%d；1920x1080 等 16:9 分辨率也不通过",
-    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例；例如 3840x2160、2560x1440、1920x1080、1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例且不低于 1280x720；例如 3840x2160、2560x1440、1920x1080、1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "窗口模式；全屏模式需使用物理分辨率16:9的显示器，当前显示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",
     "maptracker.emergency_stop.desc": "寻路已中止。",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -150,7 +150,7 @@
     "tasker.aspect_ratio_warning.current_resolution": "目前解析度：",
     "tasker.aspect_ratio_warning.requirement_label": "目標要求：",
     "tasker.aspect_ratio_warning.requirement_exact": "精確 %dx%d；1920x1080 等其他 16:9 解析度也不通過",
-    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例；例如 3840x2160、2560x1440、1920x1080、1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例且不低於 1280x720；例如 3840x2160、2560x1440、1920x1080、1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "視窗模式；全螢幕模式需使用物理解析度 16:9 的顯示器，目前顯示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",
     "maptracker.emergency_stop.desc": "尋路已中止。",


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

对非 ADB 控制器同时强制执行纵横比和最小分辨率检查，并更新相关日志和本地化条目。

Bug 修复：
- 防止在显示器满足纵横比要求但低于支持的最小分辨率时，非 ADB 控制器仍然通过校验。

功能增强：
- 添加一个可复用的辅助工具，用于验证当前分辨率是否达到或超过目标分辨率，并在日志中输出关于纵横比和分辨率检查的详细标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce both aspect ratio and minimum resolution checks for non-ADB controllers and update related logging and localization entries.

Bug Fixes:
- Prevent non-ADB controllers from passing validation when the display meets aspect ratio requirements but is below the minimum supported resolution.

Enhancements:
- Add a reusable helper to verify that the current resolution meets or exceeds the target resolution and expose detailed flags in logs for aspect ratio and resolution checks.

</details>