### PR TITLE
feat: minicv添加多命中模板匹配和色值掩膜模板匹配

### DIFF
--- a/agent/go-service/pkg/minicv/image_utils.go
+++ b/agent/go-service/pkg/minicv/image_utils.go
@@ -1,4 +1,3 @@
-// Copyright (c) 2026 Harry Huang
 package minicv
 
 import (

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"image"
 	_ "image/png"
-	"math"
 	"os"
 	"runtime"
 	"sync"
-	"unsafe"
 )
 
 // Template represents a preloaded template image along with its integral array and statistics for matching.
@@ -133,101 +131,6 @@ func subpixelOffset(neg, pos float64) float64 {
 
 	offset := (wp2 - wn2) / sum
 	return min(1.0, max(-1.0, offset))
-}
-
-func dotRGBA3(imgPix, tplPix *uint8, pixels int) uint64 {
-	if pixels <= 0 {
-		return 0
-	}
-	return dotRGBA3Impl(unsafe.Pointer(imgPix), unsafe.Pointer(tplPix), pixels)
-}
-
-// ComputeNCC computes the normalized cross-correlation between a rectangle region in the haystack image
-// and a template image, using precomputed integral array for efficiency
-func ComputeNCC(img *image.RGBA, imgIntArr IntegralArray, tpl *image.RGBA, tplStats StatsResult, ox, oy int) float64 {
-	iw, ih := img.Rect.Dx(), img.Rect.Dy()
-	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
-	if ox < 0 || oy < 0 || ox+tw > iw || oy+th > ih {
-		return 0.0
-	}
-
-	ipx, is := img.Pix, img.Stride
-	tpx, ts := tpl.Pix, tpl.Stride
-
-	var dot uint64
-	iOff := oy*is + ox*4
-	tOff := 0
-	for range th {
-		dot += dotRGBA3(&ipx[iOff], &tpx[tOff], tw)
-		iOff += is
-		tOff += ts
-	}
-
-	count := float64(tw * th * 3)
-	imgStats := imgIntArr.GetAreaStats(ox, oy, tw, th)
-	stdProd := imgStats.Std * tplStats.Std
-	if stdProd < 1e-12 {
-		return 0.0
-	}
-	return (float64(dot) - count*imgStats.Mean*tplStats.Mean) / stdProd
-}
-
-// ComputeNCCInCircle computes masked normalized cross-correlation at the given top-left corner using circle spans.
-// See [ComputeNCC] for the unmasked version.
-func ComputeNCCInCircle(
-	img *image.RGBA,
-	imgIntArr IntegralArray,
-	tpl *image.RGBA,
-	tplCircleStats StatsResult,
-	spans []circleSpan,
-	pixelCount int,
-	ox, oy int,
-) float64 {
-	if pixelCount <= 0 || tplCircleStats.Std < 1e-12 {
-		return 0.0
-	}
-
-	iw, ih := img.Rect.Dx(), img.Rect.Dy()
-	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
-	if ox < 0 || oy < 0 || ox+tw > iw || oy+th > ih {
-		return 0.0
-	}
-
-	ipx, is := img.Pix, img.Stride
-	tpx, ts := tpl.Pix, tpl.Stride
-
-	var dot uint64
-	var sumI float64
-	var sumI2 float64
-
-	for _, sp := range spans {
-		ty := sp.Y
-		x0 := sp.X0
-		x1 := sp.X1
-		width := x1 - x0 + 1
-
-		rowSum, rowSumSq := imgIntArr.GetRowRangeIntegral(oy+ty, ox+x0, width)
-		sumI += rowSum
-		sumI2 += rowSumSq
-
-		iOff := (oy+ty)*is + (ox+x0)*4
-		tOff := ty*ts + x0*4
-		dot += dotRGBA3(&ipx[iOff], &tpx[tOff], width)
-	}
-
-	count := float64(pixelCount * 3)
-	imgMean := sumI / count
-	imgVar := sumI2 - count*imgMean*imgMean
-	if imgVar < 1e-12 {
-		return 0.0
-	}
-	imgStd := math.Sqrt(imgVar)
-	stdProd := imgStd * tplCircleStats.Std
-	if stdProd < 1e-12 {
-		return 0.0
-	}
-
-	return (float64(dot) - count*imgMean*tplCircleStats.Mean) / stdProd
 }
 
 // MatchTemplate performs template matching on the whole image,
@@ -588,4 +491,107 @@ func MatchTemplateAnyScale(
 	}
 
 	return bestX, bestY, bestScore, bestScale
+}
+
+// MatchTemplateHit represents a template match result.
+type MatchTemplateHit struct {
+	X   float64
+	Y   float64
+	Val float64
+}
+
+// MatchTemplateMultiHit returns repeated template matches from a precomputed NCC matrix.
+func MatchTemplateMultiHit(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplStats StatsResult,
+	threshold float64,
+	maxHits int,
+) []MatchTemplateHit {
+	matrix := ComputeNCCMatrix(img, imgIntArr, tpl, tplStats)
+	if len(matrix) == 0 {
+		return nil
+	}
+	return collectMultiHitFromNCCMatrix(matrix, tpl.Rect.Dx(), tpl.Rect.Dy(), threshold, maxHits)
+}
+
+// MatchTemplateMultiHitWithMask returns repeated template matches while ignoring template pixels of the mask color.
+func MatchTemplateMultiHitWithMask(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplStats StatsResult,
+	maskColorRGB888 int32,
+	threshold float64,
+	maxHits int,
+) []MatchTemplateHit {
+	matrix := ComputeNCCMatrixWithMask(img, imgIntArr, tpl, tplStats, maskColorRGB888)
+	if len(matrix) == 0 {
+		return nil
+	}
+	return collectMultiHitFromNCCMatrix(matrix, tpl.Rect.Dx(), tpl.Rect.Dy(), threshold, maxHits)
+}
+
+func collectMultiHitFromNCCMatrix(matrix [][]float64, tplW, tplH int, threshold float64, maxHits int) []MatchTemplateHit {
+	if maxHits <= 0 {
+		return nil
+	}
+
+	hits := make([]MatchTemplateHit, 0, maxHits)
+	for len(hits) < maxHits {
+		fx, fy, fm := findBestNCCInMatrix(matrix)
+		if fm < threshold {
+			break
+		}
+
+		x, y := subpixelNCCInMatrix(matrix, fx, fy, fm)
+		hits = append(hits, MatchTemplateHit{X: x, Y: y, Val: fm})
+		suppressNCCMatrix(matrix, fx, fy, tplW, tplH)
+	}
+	return hits
+}
+
+func findBestNCCInMatrix(matrix [][]float64) (x, y int, val float64) {
+	bestX, bestY, bestVal := 0, 0, -1.0
+	for y, row := range matrix {
+		for x, v := range row {
+			if v > bestVal {
+				bestX, bestY, bestVal = x, y, v
+			}
+		}
+	}
+	return bestX, bestY, bestVal
+}
+
+func subpixelNCCInMatrix(matrix [][]float64, x, y int, val float64) (float64, float64) {
+	leftNCC, rightNCC := val, val
+	upNCC, downNCC := val, val
+	if x > 0 {
+		leftNCC = matrix[y][x-1]
+	}
+	if x+1 < len(matrix[y]) {
+		rightNCC = matrix[y][x+1]
+	}
+	if y > 0 {
+		upNCC = matrix[y-1][x]
+	}
+	if y+1 < len(matrix) {
+		downNCC = matrix[y+1][x]
+	}
+	return float64(x) + subpixelOffset(leftNCC, rightNCC), float64(y) + subpixelOffset(upNCC, downNCC)
+}
+
+func suppressNCCMatrix(matrix [][]float64, x, y, w, h int) {
+	if len(matrix) == 0 {
+		return
+	}
+
+	y1 := min(len(matrix), y+h)
+	for row := max(0, y); row < y1; row++ {
+		x1 := min(len(matrix[row]), x+w)
+		for col := max(0, x); col < x1; col++ {
+			matrix[row][col] = 0
+		}
+	}
 }

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -164,39 +164,6 @@ func MatchTemplateWithMask(
 	return MatchTemplateInAreaWithMask(img, imgIntArr, tpl, tplStats, maskColorRGB888, [4]int{0, 0, iw, ih})
 }
 
-// MatchCircleTemplate matches a circular region inside the template on the whole image.
-// Returns (x, y, val) of the best match, where (x, y) is the top-left corner with subpixel accuracy.
-func MatchCircleTemplate(
-	img *image.RGBA,
-	imgIntArr IntegralArray,
-	tpl *image.RGBA,
-	tplCircleStats StatsResult,
-	tplCirclePolar Circle,
-) (x, y, val float64) {
-	if img == nil || tpl == nil {
-		return 0, 0, 0
-	}
-	iw, ih := img.Rect.Dx(), img.Rect.Dy()
-	return MatchCircleTemplateInArea(img, imgIntArr, tpl, tplCircleStats, tplCirclePolar, [4]int{0, 0, iw, ih})
-}
-
-// MatchCircleTemplateWithMask matches a circular region inside the template while ignoring template pixels of the mask color.
-// Returns (x, y, val) of the best match, where (x, y) is the top-left corner with subpixel accuracy.
-func MatchCircleTemplateWithMask(
-	img *image.RGBA,
-	imgIntArr IntegralArray,
-	tpl *image.RGBA,
-	tplCircleStats StatsResult,
-	tplCirclePolar Circle,
-	maskColorRGB888 int32,
-) (x, y, val float64) {
-	if img == nil || tpl == nil {
-		return 0, 0, 0
-	}
-	iw, ih := img.Rect.Dx(), img.Rect.Dy()
-	return MatchCircleTemplateInAreaWithMask(img, imgIntArr, tpl, tplCircleStats, tplCirclePolar, maskColorRGB888, [4]int{0, 0, iw, ih})
-}
-
 // MatchTemplateInArea performs template matching such that the center of the template
 // remains within the specified area's rectangle (x, y, w, h).
 // Returns (x, y, val) of the best match, where (x, y) is the top-left corner with subpixel accuracy.
@@ -382,29 +349,9 @@ func MatchTemplateInAreaWithMask(
 	return subX, subY, fm
 }
 
-// MatchCircleTemplateInArea matches a circular region inside the template in a rectangular search area.
-// tplCirclePolar is the template-space circle and rect is the image-space area (x, y, w, h)
-// where the template center is constrained to remain.
-// Returns (x, y, val) where (x, y) is top-left with subpixel accuracy.
-func MatchCircleTemplateInArea(
-	img *image.RGBA,
-	imgIntArr IntegralArray,
-	tpl *image.RGBA,
-	tplCircleStats StatsResult,
-	tplCirclePolar Circle,
-	rect [4]int,
-) (x, y, val float64) {
-	if img == nil || tpl == nil {
-		return 0, 0, 0
-	}
-	_ = tplCircleStats
-	maskColorRGB888 := int32(0x00FF00)
-	circleTpl := buildCircleMaskTemplate(tpl, tplCirclePolar, maskColorRGB888)
-	circleTplStats := GetImageStats(circleTpl)
-	return MatchTemplateInAreaWithMask(img, imgIntArr, circleTpl, circleTplStats, maskColorRGB888, rect)
-}
-
-func buildCircleMaskTemplate(tpl *image.RGBA, circle Circle, maskColorRGB888 int32) *image.RGBA {
+// BuildCircleMaskTemplate creates a template whose pixels outside the circle are filled with the mask color.
+// This is useful if you want to create a circular template from a rectangular image.
+func BuildCircleMaskTemplate(tpl *image.RGBA, circle Circle, maskColorRGB888 int32) *image.RGBA {
 	w, h := tpl.Rect.Dx(), tpl.Rect.Dy()
 	circleTpl := image.NewRGBA(image.Rect(0, 0, w, h))
 
@@ -433,26 +380,6 @@ func buildCircleMaskTemplate(tpl *image.RGBA, circle Circle, maskColorRGB888 int
 	}
 
 	return circleTpl
-}
-
-// MatchCircleTemplateInAreaWithMask matches a circular region inside the template in a rectangular search area while ignoring template pixels of the mask color.
-// Returns (x, y, val) where (x, y) is top-left with subpixel accuracy.
-func MatchCircleTemplateInAreaWithMask(
-	img *image.RGBA,
-	imgIntArr IntegralArray,
-	tpl *image.RGBA,
-	tplCircleStats StatsResult,
-	tplCirclePolar Circle,
-	maskColorRGB888 int32,
-	rect [4]int,
-) (x, y, val float64) {
-	if img == nil || tpl == nil {
-		return 0, 0, 0
-	}
-	_ = tplCircleStats
-	circleTpl := buildCircleMaskTemplate(tpl, tplCirclePolar, maskColorRGB888)
-	circleTplStats := GetImageStats(circleTpl)
-	return MatchTemplateInAreaWithMask(img, imgIntArr, circleTpl, circleTplStats, maskColorRGB888, rect)
 }
 
 // MatchTemplateAnyScale performs iterative template matching over a scale range.

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -148,6 +148,22 @@ func MatchTemplate(
 	return MatchTemplateInArea(img, imgIntArr, tpl, tplStats, [4]int{0, 0, iw, ih})
 }
 
+// MatchTemplateWithMask performs template matching on the whole image while ignoring template pixels of the mask color.
+// Returns (x, y, val) of the best match, where x and y are subpixel-accurate coordinates.
+func MatchTemplateWithMask(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplStats StatsResult,
+	maskColorRGB888 int32,
+) (x, y, val float64) {
+	if img == nil || tpl == nil {
+		return 0, 0, 0
+	}
+	iw, ih := img.Rect.Dx(), img.Rect.Dy()
+	return MatchTemplateInAreaWithMask(img, imgIntArr, tpl, tplStats, maskColorRGB888, [4]int{0, 0, iw, ih})
+}
+
 // MatchCircleTemplate matches a circular region inside the template on the whole image.
 // Returns (x, y, val) of the best match, where (x, y) is the top-left corner with subpixel accuracy.
 func MatchCircleTemplate(
@@ -162,6 +178,23 @@ func MatchCircleTemplate(
 	}
 	iw, ih := img.Rect.Dx(), img.Rect.Dy()
 	return MatchCircleTemplateInArea(img, imgIntArr, tpl, tplCircleStats, tplCirclePolar, [4]int{0, 0, iw, ih})
+}
+
+// MatchCircleTemplateWithMask matches a circular region inside the template while ignoring template pixels of the mask color.
+// Returns (x, y, val) of the best match, where (x, y) is the top-left corner with subpixel accuracy.
+func MatchCircleTemplateWithMask(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplCircleStats StatsResult,
+	tplCirclePolar Circle,
+	maskColorRGB888 int32,
+) (x, y, val float64) {
+	if img == nil || tpl == nil {
+		return 0, 0, 0
+	}
+	iw, ih := img.Rect.Dx(), img.Rect.Dy()
+	return MatchCircleTemplateInAreaWithMask(img, imgIntArr, tpl, tplCircleStats, tplCirclePolar, maskColorRGB888, [4]int{0, 0, iw, ih})
 }
 
 // MatchTemplateInArea performs template matching such that the center of the template
@@ -250,16 +283,14 @@ func MatchTemplateInArea(
 	return subX, subY, fm
 }
 
-// MatchCircleTemplateInArea matches a circular region inside the template in a rectangular search area.
-// tplCirclePolar is the template-space circle and rect is the image-space area (x, y, w, h)
-// where the template center is constrained to remain.
-// Returns (x, y, val) where (x, y) is top-left with subpixel accuracy.
-func MatchCircleTemplateInArea(
+// MatchTemplateInAreaWithMask performs template matching in a rectangular search area while ignoring template pixels of the mask color.
+// Returns (x, y, val) of the best match, where (x, y) is the top-left corner with subpixel accuracy.
+func MatchTemplateInAreaWithMask(
 	img *image.RGBA,
 	imgIntArr IntegralArray,
 	tpl *image.RGBA,
-	tplCircleStats StatsResult,
-	tplCirclePolar Circle,
+	tplStats StatsResult,
+	maskColorRGB888 int32,
 	rect [4]int,
 ) (x, y, val float64) {
 	if img == nil || tpl == nil {
@@ -272,11 +303,14 @@ func MatchCircleTemplateInArea(
 		return 0, 0, 0
 	}
 
-	spans, pixelCount := buildCircleSpans(tw, th, tplCirclePolar)
+	spans, pixelCount, tplMaskStats := buildMaskSpans(tpl, maskColorRGB888)
 	if pixelCount == 0 {
 		return 0, 0, 0
 	}
-	if tplCircleStats.Std < 1e-12 {
+	if pixelCount == tw*th {
+		tplMaskStats = tplStats
+	}
+	if tplMaskStats.Std < 1e-12 {
 		return 0, 0, 0
 	}
 
@@ -301,7 +335,7 @@ func MatchCircleTemplateInArea(
 		lx, ly, lm := minX, minY, -1.0
 		for y := minY + id*stepLen; y <= maxY; y += numWorkers * stepLen {
 			for x := minX; x <= maxX; x += stepLen {
-				s := ComputeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, x, y)
+				s := ComputeNCCWithMaskSpans(img, imgIntArr, tpl, tplMaskStats, spans, pixelCount, x, y)
 				if s > lm {
 					lm, lx, ly = s, x, y
 				}
@@ -323,7 +357,7 @@ func MatchCircleTemplateInArea(
 	fm, fx, fy := bc.s, bc.x, bc.y
 	for y := max(minY, bc.y-stepLen+1); y <= min(maxY, bc.y+stepLen-1); y++ {
 		for x := max(minX, bc.x-stepLen+1); x <= min(maxX, bc.x+stepLen-1); x++ {
-			s := ComputeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, x, y)
+			s := ComputeNCCWithMaskSpans(img, imgIntArr, tpl, tplMaskStats, spans, pixelCount, x, y)
 			if s > fm {
 				fm, fx, fy = s, x, y
 			}
@@ -334,7 +368,7 @@ func MatchCircleTemplateInArea(
 		if tx < minX || tx > maxX || ty < minY || ty > maxY {
 			return fallback
 		}
-		return ComputeNCCInCircle(img, imgIntArr, tpl, tplCircleStats, spans, pixelCount, tx, ty)
+		return ComputeNCCWithMaskSpans(img, imgIntArr, tpl, tplMaskStats, spans, pixelCount, tx, ty)
 	}
 
 	upNCC := evalOr(fx, fy-1, fm)
@@ -346,6 +380,79 @@ func MatchCircleTemplateInArea(
 	subY := float64(fy) + subpixelOffset(upNCC, downNCC)
 
 	return subX, subY, fm
+}
+
+// MatchCircleTemplateInArea matches a circular region inside the template in a rectangular search area.
+// tplCirclePolar is the template-space circle and rect is the image-space area (x, y, w, h)
+// where the template center is constrained to remain.
+// Returns (x, y, val) where (x, y) is top-left with subpixel accuracy.
+func MatchCircleTemplateInArea(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplCircleStats StatsResult,
+	tplCirclePolar Circle,
+	rect [4]int,
+) (x, y, val float64) {
+	if img == nil || tpl == nil {
+		return 0, 0, 0
+	}
+	_ = tplCircleStats
+	maskColorRGB888 := int32(0x00FF00)
+	circleTpl := buildCircleMaskTemplate(tpl, tplCirclePolar, maskColorRGB888)
+	circleTplStats := GetImageStats(circleTpl)
+	return MatchTemplateInAreaWithMask(img, imgIntArr, circleTpl, circleTplStats, maskColorRGB888, rect)
+}
+
+func buildCircleMaskTemplate(tpl *image.RGBA, circle Circle, maskColorRGB888 int32) *image.RGBA {
+	w, h := tpl.Rect.Dx(), tpl.Rect.Dy()
+	circleTpl := image.NewRGBA(image.Rect(0, 0, w, h))
+
+	maskR := uint8((uint32(maskColorRGB888) >> 16) & 0xFF)
+	maskG := uint8((uint32(maskColorRGB888) >> 8) & 0xFF)
+	maskB := uint8(uint32(maskColorRGB888) & 0xFF)
+	r2 := circle.Radius * circle.Radius
+
+	for y := range h {
+		srcOff := y * tpl.Stride
+		dstOff := y * circleTpl.Stride
+		for x := range w {
+			dx := x - circle.X
+			dy := y - circle.Y
+			if circle.Radius >= 0 && dx*dx+dy*dy <= r2 {
+				copy(circleTpl.Pix[dstOff:dstOff+4], tpl.Pix[srcOff:srcOff+4])
+			} else {
+				circleTpl.Pix[dstOff] = maskR
+				circleTpl.Pix[dstOff+1] = maskG
+				circleTpl.Pix[dstOff+2] = maskB
+				circleTpl.Pix[dstOff+3] = 255
+			}
+			srcOff += 4
+			dstOff += 4
+		}
+	}
+
+	return circleTpl
+}
+
+// MatchCircleTemplateInAreaWithMask matches a circular region inside the template in a rectangular search area while ignoring template pixels of the mask color.
+// Returns (x, y, val) where (x, y) is top-left with subpixel accuracy.
+func MatchCircleTemplateInAreaWithMask(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplCircleStats StatsResult,
+	tplCirclePolar Circle,
+	maskColorRGB888 int32,
+	rect [4]int,
+) (x, y, val float64) {
+	if img == nil || tpl == nil {
+		return 0, 0, 0
+	}
+	_ = tplCircleStats
+	circleTpl := buildCircleMaskTemplate(tpl, tplCirclePolar, maskColorRGB888)
+	circleTplStats := GetImageStats(circleTpl)
+	return MatchTemplateInAreaWithMask(img, imgIntArr, circleTpl, circleTplStats, maskColorRGB888, rect)
 }
 
 // MatchTemplateAnyScale performs iterative template matching over a scale range.

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -500,7 +500,7 @@ type MatchTemplateHit struct {
 	Val float64
 }
 
-// MatchTemplateMultiHit returns repeated template matches from a precomputed NCC matrix.
+// MatchTemplateMultiHit returns repeated template matches by computing an NCC matrix and repeatedly suppressing previous hit regions.
 func MatchTemplateMultiHit(
 	img *image.RGBA,
 	imgIntArr IntegralArray,
@@ -591,7 +591,7 @@ func suppressNCCMatrix(matrix [][]float64, x, y, w, h int) {
 	for row := max(0, y); row < y1; row++ {
 		x1 := min(len(matrix[row]), x+w)
 		for col := max(0, x); col < x1; col++ {
-			matrix[row][col] = 0
+			matrix[row][col] = -1.0
 		}
 	}
 }

--- a/agent/go-service/pkg/minicv/match_template_test.go
+++ b/agent/go-service/pkg/minicv/match_template_test.go
@@ -1,4 +1,3 @@
-// Copyright (c) 2026 Harry Huang
 package minicv
 
 import (

--- a/agent/go-service/pkg/minicv/match_template_test.go
+++ b/agent/go-service/pkg/minicv/match_template_test.go
@@ -141,6 +141,34 @@ func TestMatchTemplate(t *testing.T) {
 	}
 }
 
+func TestMatchTemplateMultiHitWithMask(t *testing.T) {
+	img := generateMatchTestImage(512, 384)
+	decorateTargetArea(img, 81, 68, 64, 48)
+	for row := range 48 {
+		srcOff := (68+row)*img.Stride + 81*4
+		dstOff := (244+row)*img.Stride + 321*4
+		copy(img.Pix[dstOff:dstOff+64*4], img.Pix[srcOff:srcOff+64*4])
+	}
+	imgIntArr := GetIntegralArray(img)
+	tpl := cropAsTemplate(img, 81, 68, 64, 48)
+
+	maskColor := color.RGBA{R: 0, G: 255, B: 0, A: 255}
+	for y := 0; y < tpl.Rect.Dy(); y++ {
+		for x := tpl.Rect.Dx() / 2; x < tpl.Rect.Dx(); x++ {
+			tpl.SetRGBA(x, y, maskColor)
+		}
+	}
+	tplStats := GetImageStats(tpl)
+
+	hits := MatchTemplateMultiHitWithMask(img, imgIntArr, tpl, tplStats, 0x00FF00, 0.9999, 4)
+	if len(hits) != 2 {
+		t.Fatalf("unexpected hit count: got=%d, want=2", len(hits))
+	}
+
+	assertMatchNear(t, hits[0].X, hits[0].Y, 81, 68)
+	assertMatchNear(t, hits[1].X, hits[1].Y, 321, 244)
+}
+
 func TestMatchCircleTemplateNilInputs(t *testing.T) {
 	img := generateMatchTestImage(128, 128)
 	imgIntArr := GetIntegralArray(img)

--- a/agent/go-service/pkg/minicv/match_template_test.go
+++ b/agent/go-service/pkg/minicv/match_template_test.go
@@ -141,6 +141,31 @@ func TestMatchTemplate(t *testing.T) {
 	}
 }
 
+func maskTemplateRightHalf(tpl *image.RGBA) {
+	maskColor := color.RGBA{R: 0, G: 255, B: 0, A: 255}
+	for y := 0; y < tpl.Rect.Dy(); y++ {
+		for x := tpl.Rect.Dx() / 2; x < tpl.Rect.Dx(); x++ {
+			tpl.SetRGBA(x, y, maskColor)
+		}
+	}
+}
+
+func TestMatchTemplateWithMask(t *testing.T) {
+	img := generateMatchTestImage(512, 384)
+	decorateTargetArea(img, 81, 68, 64, 48)
+	imgIntArr := GetIntegralArray(img)
+	tpl := cropAsTemplate(img, 81, 68, 64, 48)
+	maskTemplateRightHalf(tpl)
+	tplStats := GetImageStats(tpl)
+
+	x, y, score := MatchTemplateWithMask(img, imgIntArr, tpl, tplStats, 0x00FF00)
+
+	assertMatchNear(t, x, y, 81, 68)
+	if score < 0.9999 {
+		t.Fatalf("unexpected match score: got=%.6f, want>=0.9999", score)
+	}
+}
+
 func TestMatchTemplateMultiHitWithMask(t *testing.T) {
 	img := generateMatchTestImage(512, 384)
 	decorateTargetArea(img, 81, 68, 64, 48)
@@ -151,13 +176,7 @@ func TestMatchTemplateMultiHitWithMask(t *testing.T) {
 	}
 	imgIntArr := GetIntegralArray(img)
 	tpl := cropAsTemplate(img, 81, 68, 64, 48)
-
-	maskColor := color.RGBA{R: 0, G: 255, B: 0, A: 255}
-	for y := 0; y < tpl.Rect.Dy(); y++ {
-		for x := tpl.Rect.Dx() / 2; x < tpl.Rect.Dx(); x++ {
-			tpl.SetRGBA(x, y, maskColor)
-		}
-	}
+	maskTemplateRightHalf(tpl)
 	tplStats := GetImageStats(tpl)
 
 	hits := MatchTemplateMultiHitWithMask(img, imgIntArr, tpl, tplStats, 0x00FF00, 0.9999, 4)
@@ -246,6 +265,23 @@ func TestMatchCircleTemplate(t *testing.T) {
 	}
 }
 
+func TestMatchCircleTemplateWithMask(t *testing.T) {
+	img := generateMatchTestImage(512, 384)
+	decorateTargetArea(img, 155, 113, 96, 96)
+	imgIntArr := GetIntegralArray(img)
+	tpl := cropAsTemplate(img, 155, 113, 96, 96)
+	maskTemplateRightHalf(tpl)
+	polar := Circle{X: 48, Y: 48, Radius: 32}
+	tplCircleStats := GetImageCircleStats(tpl, polar)
+
+	x, y, score := MatchCircleTemplateWithMask(img, imgIntArr, tpl, tplCircleStats, polar, 0x00FF00)
+
+	assertMatchNear(t, x, y, 155, 113)
+	if score < 0.9999 {
+		t.Fatalf("unexpected circle mask match score: got=%.6f, want>=0.9999", score)
+	}
+}
+
 func BenchmarkMatchTemplate(b *testing.B) {
 	img := generateBenchmarkImage(1280, 720)
 	imgIntArr := GetIntegralArray(img)
@@ -271,6 +307,37 @@ func BenchmarkMatchTemplate(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				_, _, _ = MatchTemplate(img, imgIntArr, tpl, tplStats)
+			}
+		})
+	}
+}
+
+func BenchmarkMatchTemplateWithMask(b *testing.B) {
+	img := generateBenchmarkImage(1280, 720)
+	imgIntArr := GetIntegralArray(img)
+
+	benchmarks := []struct {
+		name string
+		tplW int
+		tplH int
+		tplX int
+		tplY int
+	}{
+		{name: "tpl_32x32", tplW: 32, tplH: 32, tplX: 160, tplY: 120},
+		{name: "tpl_64x64", tplW: 64, tplH: 64, tplX: 480, tplY: 240},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			tpl := cropAsTemplate(img, bm.tplX, bm.tplY, bm.tplW, bm.tplH)
+			maskTemplateRightHalf(tpl)
+			tplStats := GetImageStats(tpl)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, _, _ = MatchTemplateWithMask(img, imgIntArr, tpl, tplStats, 0x00FF00)
 			}
 		})
 	}
@@ -318,6 +385,54 @@ func BenchmarkMatchCircleTemplate(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				_, _, _ = MatchCircleTemplate(img, imgIntArr, tpl, tplCircleStats, polar)
+			}
+		})
+	}
+}
+
+func BenchmarkMatchCircleTemplateWithMask(b *testing.B) {
+	img := generateBenchmarkImage(1280, 720)
+	imgIntArr := GetIntegralArray(img)
+
+	benchmarks := []struct {
+		name        string
+		tplW        int
+		tplH        int
+		tplX        int
+		tplY        int
+		polarRadius int
+	}{
+		{
+			name:        "r23",
+			tplW:        128,
+			tplH:        128,
+			tplX:        420,
+			tplY:        260,
+			polarRadius: 23,
+		},
+		{
+			name:        "r45",
+			tplW:        128,
+			tplH:        128,
+			tplX:        420,
+			tplY:        260,
+			polarRadius: 45,
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			tpl := cropAsTemplate(img, bm.tplX, bm.tplY, bm.tplW, bm.tplH)
+			maskTemplateRightHalf(tpl)
+
+			polar := Circle{X: bm.tplW / 2, Y: bm.tplH / 2, Radius: bm.polarRadius}
+			tplCircleStats := GetImageCircleStats(tpl, polar)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, _, _ = MatchCircleTemplateWithMask(img, imgIntArr, tpl, tplCircleStats, polar, 0x00FF00)
 			}
 		})
 	}

--- a/agent/go-service/pkg/minicv/match_template_test.go
+++ b/agent/go-service/pkg/minicv/match_template_test.go
@@ -53,6 +53,41 @@ func decorateTargetArea(img *image.RGBA, x, y, w, h int) {
 	ImageDrawFilledCircle(img, x+w/3, y+h/3, max(3, min(w, h)/10), color.RGBA{R: 0, G: 220, B: 255, A: 255})
 }
 
+func decorateMaskedTargetArea(img *image.RGBA, x, y, w, h int) {
+	decorateTargetArea(img, x, y, w, h)
+	ImageDrawFilledCircle(img, x+w/3, y+h*3/4, max(3, min(w, h)/12), color.RGBA{R: 255, G: 48, B: 180, A: 255})
+	ImageDrawFilledCircle(img, x+w*3/4, y+h/3, max(3, min(w, h)/12), color.RGBA{R: 48, G: 255, B: 180, A: 255})
+}
+
+func maskTemplateOuterRing(tpl *image.RGBA) {
+	w, h := tpl.Rect.Dx(), tpl.Rect.Dy()
+	maskColor := color.RGBA{R: 0, G: 255, B: 0, A: 255}
+	thickX := max(1, w*15/100)
+	thickY := max(1, h*15/100)
+	diagonalHalfThickness := float64(w+h) * 0.05 / 4.0
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			onOuterRing := x < thickX || x >= w-thickX || y < thickY || y >= h-thickY
+			onDiagonal := distanceToMainDiagonal(x, y, w, h) <= diagonalHalfThickness
+			if onOuterRing || onDiagonal {
+				tpl.SetRGBA(x, y, maskColor)
+			}
+		}
+	}
+}
+
+func distanceToMainDiagonal(x, y, w, h int) float64 {
+	if w <= 1 || h <= 1 {
+		return 0
+	}
+
+	fx := float64(x)
+	fy := float64(y)
+	fw := float64(w - 1)
+	fh := float64(h - 1)
+	return math.Abs(fh*fx-fw*fy) / math.Hypot(fw, fh)
+}
+
 func assertMatchNear(t *testing.T, gotX, gotY float64, wantX, wantY int) {
 	t.Helper()
 	if math.Abs(gotX-float64(wantX)) > 0.1 || math.Abs(gotY-float64(wantY)) > 0.1 {
@@ -141,21 +176,12 @@ func TestMatchTemplate(t *testing.T) {
 	}
 }
 
-func maskTemplateRightHalf(tpl *image.RGBA) {
-	maskColor := color.RGBA{R: 0, G: 255, B: 0, A: 255}
-	for y := 0; y < tpl.Rect.Dy(); y++ {
-		for x := tpl.Rect.Dx() / 2; x < tpl.Rect.Dx(); x++ {
-			tpl.SetRGBA(x, y, maskColor)
-		}
-	}
-}
-
 func TestMatchTemplateWithMask(t *testing.T) {
 	img := generateMatchTestImage(512, 384)
-	decorateTargetArea(img, 81, 68, 64, 48)
+	decorateMaskedTargetArea(img, 81, 68, 64, 48)
 	imgIntArr := GetIntegralArray(img)
 	tpl := cropAsTemplate(img, 81, 68, 64, 48)
-	maskTemplateRightHalf(tpl)
+	maskTemplateOuterRing(tpl)
 	tplStats := GetImageStats(tpl)
 
 	x, y, score := MatchTemplateWithMask(img, imgIntArr, tpl, tplStats, 0x00FF00)
@@ -168,7 +194,7 @@ func TestMatchTemplateWithMask(t *testing.T) {
 
 func TestMatchTemplateMultiHitWithMask(t *testing.T) {
 	img := generateMatchTestImage(512, 384)
-	decorateTargetArea(img, 81, 68, 64, 48)
+	decorateMaskedTargetArea(img, 81, 68, 64, 48)
 	for row := range 48 {
 		srcOff := (68+row)*img.Stride + 81*4
 		dstOff := (244+row)*img.Stride + 321*4
@@ -176,7 +202,7 @@ func TestMatchTemplateMultiHitWithMask(t *testing.T) {
 	}
 	imgIntArr := GetIntegralArray(img)
 	tpl := cropAsTemplate(img, 81, 68, 64, 48)
-	maskTemplateRightHalf(tpl)
+	maskTemplateOuterRing(tpl)
 	tplStats := GetImageStats(tpl)
 
 	hits := MatchTemplateMultiHitWithMask(img, imgIntArr, tpl, tplStats, 0x00FF00, 0.9999, 4)
@@ -188,97 +214,15 @@ func TestMatchTemplateMultiHitWithMask(t *testing.T) {
 	assertMatchNear(t, hits[1].X, hits[1].Y, 321, 244)
 }
 
-func TestMatchCircleTemplateNilInputs(t *testing.T) {
-	img := generateMatchTestImage(128, 128)
-	imgIntArr := GetIntegralArray(img)
-	tpl := cropAsTemplate(img, 16, 16, 48, 48)
-	polar := Circle{X: 24, Y: 24, Radius: 12}
-	tplCircleStats := GetImageCircleStats(tpl, polar)
+func TestBuildCircleMaskTemplate(t *testing.T) {
+	tpl := cropAsTemplate(generateMatchTestImage(64, 64), 8, 8, 32, 32)
+	circleTpl := BuildCircleMaskTemplate(tpl, Circle{X: 16, Y: 16, Radius: 8}, 0x00FF00)
 
-	testCases := []struct {
-		name string
-		run  func() (float64, float64, float64)
-	}{
-		{
-			name: "whole_image_nil_img",
-			run: func() (float64, float64, float64) {
-				return MatchCircleTemplate(nil, imgIntArr, tpl, tplCircleStats, polar)
-			},
-		},
-		{
-			name: "whole_image_nil_tpl",
-			run: func() (float64, float64, float64) {
-				return MatchCircleTemplate(img, imgIntArr, nil, tplCircleStats, polar)
-			},
-		},
-		{
-			name: "in_area_nil_img",
-			run: func() (float64, float64, float64) {
-				return MatchCircleTemplateInArea(nil, imgIntArr, tpl, tplCircleStats, polar, [4]int{0, 0, 128, 128})
-			},
-		},
-		{
-			name: "in_area_nil_tpl",
-			run: func() (float64, float64, float64) {
-				return MatchCircleTemplateInArea(img, imgIntArr, nil, tplCircleStats, polar, [4]int{0, 0, 128, 128})
-			},
-		},
+	if got := circleTpl.RGBAAt(16, 16); got != tpl.RGBAAt(16, 16) {
+		t.Fatalf("unexpected center pixel: got=%v, want=%v", got, tpl.RGBAAt(16, 16))
 	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			x, y, score := tc.run()
-			assertZeroMatch(t, x, y, score)
-		})
-	}
-}
-
-func TestMatchCircleTemplate(t *testing.T) {
-	testCases := []struct {
-		name        string
-		tplX        int
-		tplY        int
-		tplW        int
-		tplH        int
-		polarRadius int
-	}{
-		{name: "center", tplX: 592, tplY: 312, tplW: 96, tplH: 96, polarRadius: 23},
-		{name: "near_edge", tplX: 12, tplY: 18, tplW: 96, tplH: 96, polarRadius: 23},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			img := generateMatchTestImage(1280, 720)
-			decorateTargetArea(img, tc.tplX, tc.tplY, tc.tplW, tc.tplH)
-			imgIntArr := GetIntegralArray(img)
-			tpl := cropAsTemplate(img, tc.tplX, tc.tplY, tc.tplW, tc.tplH)
-			polar := Circle{X: tc.tplW / 2, Y: tc.tplH / 2, Radius: tc.polarRadius}
-			tplCircleStats := GetImageCircleStats(tpl, polar)
-
-			x, y, score := MatchCircleTemplate(img, imgIntArr, tpl, tplCircleStats, polar)
-
-			assertMatchNear(t, x, y, tc.tplX, tc.tplY)
-			if score < 0.9999 {
-				t.Fatalf("unexpected circle match score: got=%.6f, want>=0.9999", score)
-			}
-		})
-	}
-}
-
-func TestMatchCircleTemplateWithMask(t *testing.T) {
-	img := generateMatchTestImage(512, 384)
-	decorateTargetArea(img, 155, 113, 96, 96)
-	imgIntArr := GetIntegralArray(img)
-	tpl := cropAsTemplate(img, 155, 113, 96, 96)
-	maskTemplateRightHalf(tpl)
-	polar := Circle{X: 48, Y: 48, Radius: 32}
-	tplCircleStats := GetImageCircleStats(tpl, polar)
-
-	x, y, score := MatchCircleTemplateWithMask(img, imgIntArr, tpl, tplCircleStats, polar, 0x00FF00)
-
-	assertMatchNear(t, x, y, 155, 113)
-	if score < 0.9999 {
-		t.Fatalf("unexpected circle mask match score: got=%.6f, want>=0.9999", score)
+	if got := circleTpl.RGBAAt(0, 0); got.R != 0 || got.G != 255 || got.B != 0 {
+		t.Fatalf("unexpected masked pixel: got=%v, want RGB=(0,255,0)", got)
 	}
 }
 
@@ -330,7 +274,7 @@ func BenchmarkMatchTemplateWithMask(b *testing.B) {
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			tpl := cropAsTemplate(img, bm.tplX, bm.tplY, bm.tplW, bm.tplH)
-			maskTemplateRightHalf(tpl)
+			maskTemplateOuterRing(tpl)
 			tplStats := GetImageStats(tpl)
 
 			b.ReportAllocs()
@@ -338,101 +282,6 @@ func BenchmarkMatchTemplateWithMask(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				_, _, _ = MatchTemplateWithMask(img, imgIntArr, tpl, tplStats, 0x00FF00)
-			}
-		})
-	}
-}
-
-func BenchmarkMatchCircleTemplate(b *testing.B) {
-	img := generateBenchmarkImage(1280, 720)
-	imgIntArr := GetIntegralArray(img)
-
-	benchmarks := []struct {
-		name        string
-		tplW        int
-		tplH        int
-		tplX        int
-		tplY        int
-		polarRadius int
-	}{
-		{
-			name:        "r23",
-			tplW:        128,
-			tplH:        128,
-			tplX:        420,
-			tplY:        260,
-			polarRadius: 23,
-		},
-		{
-			name:        "r45",
-			tplW:        128,
-			tplH:        128,
-			tplX:        420,
-			tplY:        260,
-			polarRadius: 45,
-		},
-	}
-
-	for _, bm := range benchmarks {
-		b.Run(bm.name, func(b *testing.B) {
-			tpl := cropAsTemplate(img, bm.tplX, bm.tplY, bm.tplW, bm.tplH)
-
-			polar := Circle{X: bm.tplW / 2, Y: bm.tplH / 2, Radius: bm.polarRadius}
-			tplCircleStats := GetImageCircleStats(tpl, polar)
-
-			b.ReportAllocs()
-			b.ResetTimer()
-
-			for i := 0; i < b.N; i++ {
-				_, _, _ = MatchCircleTemplate(img, imgIntArr, tpl, tplCircleStats, polar)
-			}
-		})
-	}
-}
-
-func BenchmarkMatchCircleTemplateWithMask(b *testing.B) {
-	img := generateBenchmarkImage(1280, 720)
-	imgIntArr := GetIntegralArray(img)
-
-	benchmarks := []struct {
-		name        string
-		tplW        int
-		tplH        int
-		tplX        int
-		tplY        int
-		polarRadius int
-	}{
-		{
-			name:        "r23",
-			tplW:        128,
-			tplH:        128,
-			tplX:        420,
-			tplY:        260,
-			polarRadius: 23,
-		},
-		{
-			name:        "r45",
-			tplW:        128,
-			tplH:        128,
-			tplX:        420,
-			tplY:        260,
-			polarRadius: 45,
-		},
-	}
-
-	for _, bm := range benchmarks {
-		b.Run(bm.name, func(b *testing.B) {
-			tpl := cropAsTemplate(img, bm.tplX, bm.tplY, bm.tplW, bm.tplH)
-			maskTemplateRightHalf(tpl)
-
-			polar := Circle{X: bm.tplW / 2, Y: bm.tplH / 2, Radius: bm.polarRadius}
-			tplCircleStats := GetImageCircleStats(tpl, polar)
-
-			b.ReportAllocs()
-			b.ResetTimer()
-
-			for i := 0; i < b.N; i++ {
-				_, _, _ = MatchCircleTemplateWithMask(img, imgIntArr, tpl, tplCircleStats, polar, 0x00FF00)
 			}
 		})
 	}

--- a/agent/go-service/pkg/minicv/ncc_utils.go
+++ b/agent/go-service/pkg/minicv/ncc_utils.go
@@ -43,64 +43,6 @@ func ComputeNCC(img *image.RGBA, imgIntArr IntegralArray, tpl *image.RGBA, tplSt
 	return (float64(dot) - count*imgStats.Mean*tplStats.Mean) / stdProd
 }
 
-// ComputeNCCInCircle computes masked normalized cross-correlation at the given top-left corner using circle spans.
-// See [ComputeNCC] for the unmasked version.
-func ComputeNCCInCircle(
-	img *image.RGBA,
-	imgIntArr IntegralArray,
-	tpl *image.RGBA,
-	tplCircleStats StatsResult,
-	spans []circleSpan,
-	pixelCount int,
-	ox, oy int,
-) float64 {
-	if pixelCount <= 0 || tplCircleStats.Std < 1e-12 {
-		return 0.0
-	}
-
-	iw, ih := img.Rect.Dx(), img.Rect.Dy()
-	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
-	if ox < 0 || oy < 0 || ox+tw > iw || oy+th > ih {
-		return 0.0
-	}
-
-	ipx, is := img.Pix, img.Stride
-	tpx, ts := tpl.Pix, tpl.Stride
-
-	var dot uint64
-	var sumI float64
-	var sumI2 float64
-
-	for _, sp := range spans {
-		ty := sp.Y
-		x0 := sp.X0
-		x1 := sp.X1
-		width := x1 - x0 + 1
-
-		rowSum, rowSumSq := imgIntArr.GetRowRangeIntegral(oy+ty, ox+x0, width)
-		sumI += rowSum
-		sumI2 += rowSumSq
-
-		iOff := (oy+ty)*is + (ox+x0)*4
-		tOff := ty*ts + x0*4
-		dot += dotRGBA3(&ipx[iOff], &tpx[tOff], width)
-	}
-
-	count := float64(pixelCount * 3)
-	imgMean := sumI / count
-	imgVar := sumI2 - count*imgMean*imgMean
-	if imgVar < 1e-12 {
-		return 0.0
-	}
-	imgStd := math.Sqrt(imgVar)
-	stdProd := imgStd * tplCircleStats.Std
-	if stdProd < 1e-12 {
-		return 0.0
-	}
-
-	return (float64(dot) - count*imgMean*tplCircleStats.Mean) / stdProd
-}
-
 type maskSpan struct {
 	Y  int
 	X0 int

--- a/agent/go-service/pkg/minicv/ncc_utils.go
+++ b/agent/go-service/pkg/minicv/ncc_utils.go
@@ -1,0 +1,295 @@
+package minicv
+
+import (
+	"image"
+	"math"
+	"unsafe"
+)
+
+func dotRGBA3(imgPix, tplPix *uint8, pixels int) uint64 {
+	if pixels <= 0 {
+		return 0
+	}
+	return dotRGBA3Impl(unsafe.Pointer(imgPix), unsafe.Pointer(tplPix), pixels)
+}
+
+// ComputeNCC computes the normalized cross-correlation between a rectangle region in the haystack image
+// and a template image, using precomputed integral array for efficiency.
+func ComputeNCC(img *image.RGBA, imgIntArr IntegralArray, tpl *image.RGBA, tplStats StatsResult, ox, oy int) float64 {
+	iw, ih := img.Rect.Dx(), img.Rect.Dy()
+	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
+	if ox < 0 || oy < 0 || ox+tw > iw || oy+th > ih {
+		return 0.0
+	}
+
+	ipx, is := img.Pix, img.Stride
+	tpx, ts := tpl.Pix, tpl.Stride
+
+	var dot uint64
+	iOff := oy*is + ox*4
+	tOff := 0
+	for range th {
+		dot += dotRGBA3(&ipx[iOff], &tpx[tOff], tw)
+		iOff += is
+		tOff += ts
+	}
+
+	count := float64(tw * th * 3)
+	imgStats := imgIntArr.GetAreaStats(ox, oy, tw, th)
+	stdProd := imgStats.Std * tplStats.Std
+	if stdProd < 1e-12 {
+		return 0.0
+	}
+	return (float64(dot) - count*imgStats.Mean*tplStats.Mean) / stdProd
+}
+
+// ComputeNCCInCircle computes masked normalized cross-correlation at the given top-left corner using circle spans.
+// See [ComputeNCC] for the unmasked version.
+func ComputeNCCInCircle(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplCircleStats StatsResult,
+	spans []circleSpan,
+	pixelCount int,
+	ox, oy int,
+) float64 {
+	if pixelCount <= 0 || tplCircleStats.Std < 1e-12 {
+		return 0.0
+	}
+
+	iw, ih := img.Rect.Dx(), img.Rect.Dy()
+	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
+	if ox < 0 || oy < 0 || ox+tw > iw || oy+th > ih {
+		return 0.0
+	}
+
+	ipx, is := img.Pix, img.Stride
+	tpx, ts := tpl.Pix, tpl.Stride
+
+	var dot uint64
+	var sumI float64
+	var sumI2 float64
+
+	for _, sp := range spans {
+		ty := sp.Y
+		x0 := sp.X0
+		x1 := sp.X1
+		width := x1 - x0 + 1
+
+		rowSum, rowSumSq := imgIntArr.GetRowRangeIntegral(oy+ty, ox+x0, width)
+		sumI += rowSum
+		sumI2 += rowSumSq
+
+		iOff := (oy+ty)*is + (ox+x0)*4
+		tOff := ty*ts + x0*4
+		dot += dotRGBA3(&ipx[iOff], &tpx[tOff], width)
+	}
+
+	count := float64(pixelCount * 3)
+	imgMean := sumI / count
+	imgVar := sumI2 - count*imgMean*imgMean
+	if imgVar < 1e-12 {
+		return 0.0
+	}
+	imgStd := math.Sqrt(imgVar)
+	stdProd := imgStd * tplCircleStats.Std
+	if stdProd < 1e-12 {
+		return 0.0
+	}
+
+	return (float64(dot) - count*imgMean*tplCircleStats.Mean) / stdProd
+}
+
+type maskSpan struct {
+	Y  int
+	X0 int
+	X1 int
+}
+
+func templateRGBMaskValue(px []uint8, off int) uint32 {
+	return uint32(px[off])<<16 | uint32(px[off+1])<<8 | uint32(px[off+2])
+}
+
+func buildMaskSpans(tpl *image.RGBA, maskColorRGB888 int32) ([]maskSpan, int, StatsResult) {
+	w, h := tpl.Rect.Dx(), tpl.Rect.Dy()
+	maskRGB := uint32(maskColorRGB888) & 0xFFFFFF
+
+	tplPix, tplStride := tpl.Pix, tpl.Stride
+	spans := make([]maskSpan, 0, h)
+	pixelCount := 0
+	var sum uint64
+	var sumSq uint64
+
+	for y := range h {
+		spanStart := -1
+		off := y * tplStride
+		for x := range w {
+			if templateRGBMaskValue(tplPix, off) == maskRGB {
+				if spanStart >= 0 {
+					spans = append(spans, maskSpan{Y: y, X0: spanStart, X1: x - 1})
+					spanStart = -1
+				}
+				off += 4
+				continue
+			}
+
+			if spanStart < 0 {
+				spanStart = x
+			}
+			r, g, b := uint64(tplPix[off]), uint64(tplPix[off+1]), uint64(tplPix[off+2])
+			sum += r + g + b
+			sumSq += r*r + g*g + b*b
+			pixelCount++
+			off += 4
+		}
+		if spanStart >= 0 {
+			spans = append(spans, maskSpan{Y: y, X0: spanStart, X1: w - 1})
+		}
+	}
+
+	if pixelCount == 0 {
+		return spans, 0, StatsResult{}
+	}
+
+	count := float64(pixelCount * 3)
+	mean := float64(sum) / count
+	variance := float64(sumSq) - count*(mean*mean)
+	if variance < 1e-12 {
+		return spans, pixelCount, StatsResult{Mean: mean, Std: 0}
+	}
+	return spans, pixelCount, StatsResult{Mean: mean, Std: math.Sqrt(variance)}
+}
+
+// ComputeNCCWithMaskSpans computes normalized cross-correlation using template mask spans.
+func ComputeNCCWithMaskSpans(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplMaskStats StatsResult,
+	spans []maskSpan,
+	pixelCount int,
+	ox, oy int,
+) float64 {
+	if pixelCount <= 0 || tplMaskStats.Std < 1e-12 {
+		return 0.0
+	}
+
+	iw, ih := img.Rect.Dx(), img.Rect.Dy()
+	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
+	if ox < 0 || oy < 0 || ox+tw > iw || oy+th > ih {
+		return 0.0
+	}
+
+	imgPix, imgStride := img.Pix, img.Stride
+	tplPix, tplStride := tpl.Pix, tpl.Stride
+
+	var dot uint64
+	var sumI float64
+	var sumI2 float64
+
+	for _, sp := range spans {
+		width := sp.X1 - sp.X0 + 1
+
+		rowSum, rowSumSq := imgIntArr.GetRowRangeIntegral(oy+sp.Y, ox+sp.X0, width)
+		sumI += rowSum
+		sumI2 += rowSumSq
+
+		imgOff := (oy+sp.Y)*imgStride + (ox+sp.X0)*4
+		tplOff := sp.Y*tplStride + sp.X0*4
+		dot += dotRGBA3(&imgPix[imgOff], &tplPix[tplOff], width)
+	}
+
+	count := float64(pixelCount * 3)
+	imgMean := sumI / count
+	imgVar := sumI2 - count*imgMean*imgMean
+	if imgVar < 1e-12 {
+		return 0.0
+	}
+	imgStd := math.Sqrt(imgVar)
+	stdProd := imgStd * tplMaskStats.Std
+	if stdProd < 1e-12 {
+		return 0.0
+	}
+
+	return (float64(dot) - count*imgMean*tplMaskStats.Mean) / stdProd
+}
+
+// ComputeNCCMatrix computes normalized cross-correlation for every valid template top-left position.
+func ComputeNCCMatrix(img *image.RGBA, imgIntArr IntegralArray, tpl *image.RGBA, tplStats StatsResult) [][]float64 {
+	if img == nil || tpl == nil || tplStats.Std < 1e-12 {
+		return nil
+	}
+
+	iw, ih := img.Rect.Dx(), img.Rect.Dy()
+	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
+	mw, mh := iw-tw+1, ih-th+1
+	if tw <= 0 || th <= 0 || mw <= 0 || mh <= 0 {
+		return nil
+	}
+
+	matrix := make([][]float64, mh)
+	for y := range mh {
+		matrix[y] = make([]float64, mw)
+	}
+
+	workerCount := min(8, mh)
+	runMatchWorkers(workerCount, func(id int) {
+		for y := id; y < mh; y += workerCount {
+			row := matrix[y]
+			for x := range mw {
+				row[x] = ComputeNCC(img, imgIntArr, tpl, tplStats, x, y)
+			}
+		}
+	})
+
+	return matrix
+}
+
+// ComputeNCCMatrixWithMask computes normalized cross-correlation for every valid position while ignoring mask-color template pixels.
+func ComputeNCCMatrixWithMask(
+	img *image.RGBA,
+	imgIntArr IntegralArray,
+	tpl *image.RGBA,
+	tplStats StatsResult,
+	maskColorRGB888 int32,
+) [][]float64 {
+	if img == nil || tpl == nil {
+		return nil
+	}
+
+	iw, ih := img.Rect.Dx(), img.Rect.Dy()
+	tw, th := tpl.Rect.Dx(), tpl.Rect.Dy()
+	mw, mh := iw-tw+1, ih-th+1
+	if tw <= 0 || th <= 0 || mw <= 0 || mh <= 0 {
+		return nil
+	}
+
+	spans, pixelCount, tplMaskStats := buildMaskSpans(tpl, maskColorRGB888)
+	if pixelCount == 0 {
+		return nil
+	}
+	if pixelCount == tw*th {
+		tplMaskStats = tplStats
+	}
+	if tplMaskStats.Std < 1e-12 {
+		return nil
+	}
+
+	matrix := make([][]float64, mh)
+	for y := range mh {
+		matrix[y] = make([]float64, mw)
+	}
+
+	workerCount := min(8, mh)
+	runMatchWorkers(workerCount, func(id int) {
+		for y := id; y < mh; y += workerCount {
+			row := matrix[y]
+			for x := range mw {
+				row[x] = ComputeNCCWithMaskSpans(img, imgIntArr, tpl, tplMaskStats, spans, pixelCount, x, y)
+			}
+		}
+	})
+
+	return matrix
+}

--- a/agent/go-service/pkg/minicv/stats_utils.go
+++ b/agent/go-service/pkg/minicv/stats_utils.go
@@ -1,4 +1,3 @@
-// Copyright (c) 2026 Harry Huang
 package minicv
 
 import (

--- a/agent/go-service/pkg/minicv/stats_utils_test.go
+++ b/agent/go-service/pkg/minicv/stats_utils_test.go
@@ -1,4 +1,3 @@
-// Copyright (c) 2026 Harry Huang
 package minicv
 
 import (


### PR DESCRIPTION
## 概要

此 PR 向 minicv 添加了多种**色值掩膜（绿幕）模板匹配**函数。

此 PR 还向 minicv 添加了直接计算 NCC 矩阵的函数，并借此实现了函数 `MatchTemplateMultiHit(WithMask)` 用于**多命中模板匹配**。

上述功能将会用在后续的功能开发中。

此外，考虑到绿幕可以平替原来的圆形模板匹配的功能，现已移除圆形模板匹配的接口。调用方应该迁移到使用 `BuildCircleMaskTemplate` 构建蒙版。

## Summary by Sourcery

添加 NCC 矩阵工具和基于掩码的模板匹配（包括多命中 API），并用通用的基于掩码模板替代原有的仅限圆形的匹配实现。

New Features:
- 引入用于整幅图像和基于掩码模板匹配的 NCC 矩阵计算辅助工具。
- 添加支持通过可配置 RGB 颜色进行掩码的单次命中和多次命中模板匹配函数。
- 提供辅助工具，可从矩形图像构建圆形掩码模板，通过用掩码颜色填充非圆形像素来实现。

Enhancements:
- 将 NCC 和掩码跨度计算抽取到专门的工具中，以便在多个匹配函数间复用，并支持基于矩阵的工作流程。
- 用构建在同一 NCC 基元之上的通用掩码匹配接口，替代仅支持圆形模板匹配的接口。

Tests:
- 为带掩码的单次命中和多次命中模板匹配添加单元测试，包括多目标场景和坐标精度检查。
- 为构建圆形掩码模板添加测试，以验证被掩蔽和未被掩蔽的区域。
- 为带掩码的模板匹配添加基准测试，用于评估不同模板尺寸下的性能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add NCC matrix utilities and mask-based template matching, including multi-hit APIs, while replacing circle-specific matching with generalized mask-based templates.

New Features:
- Introduce NCC matrix computation helpers for full-image and mask-based template matching.
- Add single-hit and multi-hit template matching functions that support masking by a configurable RGB color.
- Provide a helper to build circular mask templates from rectangular images by filling non-circular pixels with a mask color.

Enhancements:
- Factor NCC and mask-span computation into dedicated utilities to be reused across matching functions and to support matrix-based workflows.
- Replace circle-only template matching interfaces with generalized mask-based matching built on the same NCC primitives.

Tests:
- Add unit tests for masked single-hit and multi-hit template matching, including multiple-target scenarios and coordinate accuracy checks.
- Add tests for building circular mask templates to validate masked and unmasked regions.
- Add benchmarks for masked template matching to assess performance for different template sizes.

</details>