### PR TITLE
refactor: 将计划任务改为自定义识别器

### DIFF
--- a/agent/go-service/common/schedule/recognition.go
+++ b/agent/go-service/common/schedule/recognition.go
@@ -12,11 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type scheduleParam struct {
-	Task string `json:"task"`
-}
-
-// weekdayFlags is read from the pipeline node's attach for the Schedule action node.
+// weekdayFlags is read from the configured pipeline node's attach.
 type weekdayFlags struct {
 	Monday    bool `json:"monday"`
 	Tuesday   bool `json:"tuesday"`
@@ -38,52 +34,42 @@ func gameWeekday(now time.Time) time.Weekday {
 	return t.Weekday()
 }
 
-// ScheduleAction runs the configured entry task only on weekdays where the
-// matching flag is enabled, and emits a localized notice on skipped days.
-type ScheduleAction struct{}
+// ScheduleRecognition reports a hit only on weekdays enabled in attach.
+type ScheduleRecognition struct{}
 
 // Compile-time interface check
-var _ maa.CustomActionRunner = &ScheduleAction{}
+var _ maa.CustomRecognitionRunner = &ScheduleRecognition{}
 
-func (a *ScheduleAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+func (r *ScheduleRecognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa.CustomRecognitionResult, bool) {
 	if ctx == nil {
 		log.Error().
-			Str("component", "ScheduleAction").
+			Str("component", "ScheduleRecognition").
 			Msg("got nil context")
-		return false
+		return nil, false
 	}
 	if arg == nil {
 		log.Error().
-			Str("component", "ScheduleAction").
-			Msg("got nil custom action arg")
-		return false
+			Str("component", "ScheduleRecognition").
+			Msg("got nil custom recognition arg")
+		return nil, false
 	}
 
-	var params scheduleParam
-	if err := json.Unmarshal([]byte(arg.CustomActionParam), &params); err != nil {
+	node := strings.TrimSpace(arg.CurrentTaskName)
+	if node == "" {
 		log.Error().
-			Err(err).
-			Str("component", "ScheduleAction").
-			Str("custom_action_param", arg.CustomActionParam).
-			Msg("failed to parse custom action param")
-		return false
+			Str("component", "ScheduleRecognition").
+			Msg("ScheduleRecognition requires a current task name")
+		return nil, false
 	}
 
-	if params.Task == "" {
-		log.Error().
-			Str("component", "ScheduleAction").
-			Msg("Schedule requires non-empty custom_action_param.task")
-		return false
-	}
-
-	flags, err := loadWeekdayFlagsFromAttach(ctx, arg)
+	flags, err := loadWeekdayFlagsFromNode(ctx, node)
 	if err != nil {
 		log.Error().
 			Err(err).
-			Str("component", "ScheduleAction").
-			Str("node", strings.TrimSpace(arg.CurrentTaskName)).
+			Str("component", "ScheduleRecognition").
+			Str("node", node).
 			Msg("failed to load weekday flags from node attach")
-		return false
+		return nil, false
 	}
 
 	weekday := gameWeekday(time.Now())
@@ -91,36 +77,33 @@ func (a *ScheduleAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 
 	if !isEnabledOn(&flags, weekday) {
 		log.Info().
-			Str("component", "ScheduleAction").
+			Str("component", "ScheduleRecognition").
 			Str("weekday", weekday.String()).
-			Str("task", params.Task).
+			Str("node", node).
 			Msg("today is not in schedule, skip task")
 		maafocus.Print(ctx, i18n.T("schedule.skip_today", weekdayName))
-		return true
+		return nil, false
 	}
 
-	detail, err := ctx.RunTask(params.Task)
-	if err != nil || detail == nil {
-		log.Error().
-			Err(err).
-			Str("component", "ScheduleAction").
-			Str("task", params.Task).
-			Msg("failed to run scheduled task")
-		return false
-	}
+	detailJSON, _ := json.Marshal(map[string]any{
+		"scheduled": true,
+		"weekday":   weekday.String(),
+	})
 
-	if !detail.Status.Success() {
-		return false
-	}
-
-	return true
+	return &maa.CustomRecognitionResult{
+		Box:    arg.Roi,
+		Detail: string(detailJSON),
+	}, true
 }
 
-func loadWeekdayFlagsFromAttach(ctx *maa.Context, arg *maa.CustomActionArg) (weekdayFlags, error) {
-	if ctx == nil || arg == nil {
-		return weekdayFlags{}, fmt.Errorf("context or arg is nil")
+func loadWeekdayFlagsFromNode(ctx *maa.Context, node string) (weekdayFlags, error) {
+	if ctx == nil {
+		return weekdayFlags{}, fmt.Errorf("context is nil")
 	}
-	raw, err := ctx.GetNodeJSON(arg.CurrentTaskName)
+	if node == "" {
+		return weekdayFlags{}, fmt.Errorf("node is empty")
+	}
+	raw, err := ctx.GetNodeJSON(node)
 	if err != nil {
 		return weekdayFlags{}, err
 	}

--- a/agent/go-service/common/schedule/register.go
+++ b/agent/go-service/common/schedule/register.go
@@ -3,5 +3,5 @@ package schedule
 import maa "github.com/MaaXYZ/maa-framework-go/v4"
 
 func Register() {
-	maa.AgentServerRegisterCustomAction("ScheduleAction", &ScheduleAction{})
+	maa.AgentServerRegisterCustomRecognition("ScheduleRecognition", &ScheduleRecognition{})
 }

--- a/assets/resource/pipeline/AutoCollect.json
+++ b/assets/resource/pipeline/AutoCollect.json
@@ -2,12 +2,26 @@
     "AutoCollectSchedule": {
         "desc": "自动采集时间任务",
         "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "ScheduleAction",
-        "custom_action_param": {
-            "task": "AutoCollectStart"
-        },
         "post_delay": 0,
+        "next": [
+            "AutoCollectScheduleEnabled",
+            "AutoCollectEnd"
+        ]
+    },
+    "AutoCollectScheduleEnabled": {
+        "desc": "自动采集时间任务命中",
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "ScheduleRecognition",
+                "custom_recognition_param": {}
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "AutoCollectStart"
+        ],
         "attach": {
             "monday": false,
             "tuesday": false,

--- a/assets/resource/pipeline/AutoStockStaple/Main.json
+++ b/assets/resource/pipeline/AutoStockStaple/Main.json
@@ -2,12 +2,26 @@
     "AutoStockStapleSchedule": {
         "desc": "稳定需求物资执行周期",
         "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "ScheduleAction",
-        "custom_action_param": {
-            "task": "AutoStockStapleMain"
-        },
         "post_delay": 0,
+        "next": [
+            "AutoStockStapleScheduleEnabled",
+            "AutoStockStapleDone"
+        ]
+    },
+    "AutoStockStapleScheduleEnabled": {
+        "desc": "稳定需求物资执行周期命中",
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "ScheduleRecognition",
+                "custom_recognition_param": {}
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "AutoStockStapleMain"
+        ],
         "attach": {
             "monday": false,
             "tuesday": false,

--- a/assets/resource/pipeline/ProtocolSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace.json
@@ -2,12 +2,26 @@
     "ProtocolSpaceSchedule": {
         "desc": "协议空间计划任务",
         "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "ScheduleAction",
-        "custom_action_param": {
-            "task": "ProtocolSpaceEntry"
-        },
         "post_delay": 0,
+        "next": [
+            "ProtocolSpaceScheduleEnabled",
+            "ProtocolSpaceScheduleEnd"
+        ]
+    },
+    "ProtocolSpaceScheduleEnabled": {
+        "desc": "协议空间计划任务命中",
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "ScheduleRecognition",
+                "custom_recognition_param": {}
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "ProtocolSpaceEntry"
+        ],
         "attach": {
             "monday": false,
             "tuesday": false,
@@ -17,6 +31,11 @@
             "saturday": false,
             "sunday": false
         }
+    },
+    "ProtocolSpaceScheduleEnd": {
+        "desc": "协议空间计划任务跳过",
+        "pre_delay": 0,
+        "post_delay": 0
     },
     "ProtocolSpaceEntry": {
         "desc": "协议空间任务入口",

--- a/assets/resource/pipeline/SellProduct.json
+++ b/assets/resource/pipeline/SellProduct.json
@@ -2,12 +2,26 @@
     "SellProductSchedule": {
         "desc": "售卖产品计划任务",
         "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "ScheduleAction",
-        "custom_action_param": {
-            "task": "SellProductMain"
-        },
         "post_delay": 0,
+        "next": [
+            "SellProductScheduleEnabled",
+            "SellProductScheduleEnd"
+        ]
+    },
+    "SellProductScheduleEnabled": {
+        "desc": "售卖产品计划任务命中",
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "ScheduleRecognition",
+                "custom_recognition_param": {}
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "SellProductMain"
+        ],
         "attach": {
             "monday": false,
             "tuesday": false,
@@ -17,6 +31,11 @@
             "saturday": false,
             "sunday": false
         }
+    },
+    "SellProductScheduleEnd": {
+        "desc": "售卖产品计划任务跳过",
+        "pre_delay": 0,
+        "post_delay": 0
     },
     "SellProductMain": {
         "desc": "脚本入口",

--- a/assets/tasks/AutoCollect.json
+++ b/assets/tasks/AutoCollect.json
@@ -38,7 +38,7 @@
                     "name": "AutoCollectScheduleMonday",
                     "label": "$option.TaskScheduleMonday.label",
                     "pipeline_override": {
-                        "AutoCollectSchedule": {
+                        "AutoCollectScheduleEnabled": {
                             "attach": {
                                 "monday": true
                             }
@@ -49,7 +49,7 @@
                     "name": "AutoCollectScheduleTuesday",
                     "label": "$option.TaskScheduleTuesday.label",
                     "pipeline_override": {
-                        "AutoCollectSchedule": {
+                        "AutoCollectScheduleEnabled": {
                             "attach": {
                                 "tuesday": true
                             }
@@ -60,7 +60,7 @@
                     "name": "AutoCollectScheduleWednesday",
                     "label": "$option.TaskScheduleWednesday.label",
                     "pipeline_override": {
-                        "AutoCollectSchedule": {
+                        "AutoCollectScheduleEnabled": {
                             "attach": {
                                 "wednesday": true
                             }
@@ -71,7 +71,7 @@
                     "name": "AutoCollectScheduleThursday",
                     "label": "$option.TaskScheduleThursday.label",
                     "pipeline_override": {
-                        "AutoCollectSchedule": {
+                        "AutoCollectScheduleEnabled": {
                             "attach": {
                                 "thursday": true
                             }
@@ -82,7 +82,7 @@
                     "name": "AutoCollectScheduleFriday",
                     "label": "$option.TaskScheduleFriday.label",
                     "pipeline_override": {
-                        "AutoCollectSchedule": {
+                        "AutoCollectScheduleEnabled": {
                             "attach": {
                                 "friday": true
                             }
@@ -93,7 +93,7 @@
                     "name": "AutoCollectScheduleSaturday",
                     "label": "$option.TaskScheduleSaturday.label",
                     "pipeline_override": {
-                        "AutoCollectSchedule": {
+                        "AutoCollectScheduleEnabled": {
                             "attach": {
                                 "saturday": true
                             }
@@ -104,7 +104,7 @@
                     "name": "AutoCollectScheduleSunday",
                     "label": "$option.TaskScheduleSunday.label",
                     "pipeline_override": {
-                        "AutoCollectSchedule": {
+                        "AutoCollectScheduleEnabled": {
                             "attach": {
                                 "sunday": true
                             }

--- a/assets/tasks/AutoStockStaple.json
+++ b/assets/tasks/AutoStockStaple.json
@@ -33,7 +33,7 @@
                     "name": "AutoStockStapleScheduleMonday",
                     "label": "$option.TaskScheduleMonday.label",
                     "pipeline_override": {
-                        "AutoStockStapleSchedule": {
+                        "AutoStockStapleScheduleEnabled": {
                             "attach": {
                                 "monday": true
                             }
@@ -44,7 +44,7 @@
                     "name": "AutoStockStapleScheduleTuesday",
                     "label": "$option.TaskScheduleTuesday.label",
                     "pipeline_override": {
-                        "AutoStockStapleSchedule": {
+                        "AutoStockStapleScheduleEnabled": {
                             "attach": {
                                 "tuesday": true
                             }
@@ -55,7 +55,7 @@
                     "name": "AutoStockStapleScheduleWednesday",
                     "label": "$option.TaskScheduleWednesday.label",
                     "pipeline_override": {
-                        "AutoStockStapleSchedule": {
+                        "AutoStockStapleScheduleEnabled": {
                             "attach": {
                                 "wednesday": true
                             }
@@ -66,7 +66,7 @@
                     "name": "AutoStockStapleScheduleThursday",
                     "label": "$option.TaskScheduleThursday.label",
                     "pipeline_override": {
-                        "AutoStockStapleSchedule": {
+                        "AutoStockStapleScheduleEnabled": {
                             "attach": {
                                 "thursday": true
                             }
@@ -77,7 +77,7 @@
                     "name": "AutoStockStapleScheduleFriday",
                     "label": "$option.TaskScheduleFriday.label",
                     "pipeline_override": {
-                        "AutoStockStapleSchedule": {
+                        "AutoStockStapleScheduleEnabled": {
                             "attach": {
                                 "friday": true
                             }
@@ -88,7 +88,7 @@
                     "name": "AutoStockStapleScheduleSaturday",
                     "label": "$option.TaskScheduleSaturday.label",
                     "pipeline_override": {
-                        "AutoStockStapleSchedule": {
+                        "AutoStockStapleScheduleEnabled": {
                             "attach": {
                                 "saturday": true
                             }
@@ -99,7 +99,7 @@
                     "name": "AutoStockStapleScheduleSunday",
                     "label": "$option.TaskScheduleSunday.label",
                     "pipeline_override": {
-                        "AutoStockStapleSchedule": {
+                        "AutoStockStapleScheduleEnabled": {
                             "attach": {
                                 "sunday": true
                             }

--- a/assets/tasks/ProtocolSpace.json
+++ b/assets/tasks/ProtocolSpace.json
@@ -42,7 +42,7 @@
                     "name": "ProtocolSpaceScheduleMonday",
                     "label": "$option.TaskScheduleMonday.label",
                     "pipeline_override": {
-                        "ProtocolSpaceSchedule": {
+                        "ProtocolSpaceScheduleEnabled": {
                             "attach": {
                                 "monday": true
                             }
@@ -53,7 +53,7 @@
                     "name": "ProtocolSpaceScheduleTuesday",
                     "label": "$option.TaskScheduleTuesday.label",
                     "pipeline_override": {
-                        "ProtocolSpaceSchedule": {
+                        "ProtocolSpaceScheduleEnabled": {
                             "attach": {
                                 "tuesday": true
                             }
@@ -64,7 +64,7 @@
                     "name": "ProtocolSpaceScheduleWednesday",
                     "label": "$option.TaskScheduleWednesday.label",
                     "pipeline_override": {
-                        "ProtocolSpaceSchedule": {
+                        "ProtocolSpaceScheduleEnabled": {
                             "attach": {
                                 "wednesday": true
                             }
@@ -75,7 +75,7 @@
                     "name": "ProtocolSpaceScheduleThursday",
                     "label": "$option.TaskScheduleThursday.label",
                     "pipeline_override": {
-                        "ProtocolSpaceSchedule": {
+                        "ProtocolSpaceScheduleEnabled": {
                             "attach": {
                                 "thursday": true
                             }
@@ -86,7 +86,7 @@
                     "name": "ProtocolSpaceScheduleFriday",
                     "label": "$option.TaskScheduleFriday.label",
                     "pipeline_override": {
-                        "ProtocolSpaceSchedule": {
+                        "ProtocolSpaceScheduleEnabled": {
                             "attach": {
                                 "friday": true
                             }
@@ -97,7 +97,7 @@
                     "name": "ProtocolSpaceScheduleSaturday",
                     "label": "$option.TaskScheduleSaturday.label",
                     "pipeline_override": {
-                        "ProtocolSpaceSchedule": {
+                        "ProtocolSpaceScheduleEnabled": {
                             "attach": {
                                 "saturday": true
                             }
@@ -108,7 +108,7 @@
                     "name": "ProtocolSpaceScheduleSunday",
                     "label": "$option.TaskScheduleSunday.label",
                     "pipeline_override": {
-                        "ProtocolSpaceSchedule": {
+                        "ProtocolSpaceScheduleEnabled": {
                             "attach": {
                                 "sunday": true
                             }

--- a/assets/tasks/SellProduct.json
+++ b/assets/tasks/SellProduct.json
@@ -34,7 +34,7 @@
                     "name": "SellProductScheduleMonday",
                     "label": "$option.TaskScheduleMonday.label",
                     "pipeline_override": {
-                        "SellProductSchedule": {
+                        "SellProductScheduleEnabled": {
                             "attach": {
                                 "monday": true
                             }
@@ -45,7 +45,7 @@
                     "name": "SellProductScheduleTuesday",
                     "label": "$option.TaskScheduleTuesday.label",
                     "pipeline_override": {
-                        "SellProductSchedule": {
+                        "SellProductScheduleEnabled": {
                             "attach": {
                                 "tuesday": true
                             }
@@ -56,7 +56,7 @@
                     "name": "SellProductScheduleWednesday",
                     "label": "$option.TaskScheduleWednesday.label",
                     "pipeline_override": {
-                        "SellProductSchedule": {
+                        "SellProductScheduleEnabled": {
                             "attach": {
                                 "wednesday": true
                             }
@@ -67,7 +67,7 @@
                     "name": "SellProductScheduleThursday",
                     "label": "$option.TaskScheduleThursday.label",
                     "pipeline_override": {
-                        "SellProductSchedule": {
+                        "SellProductScheduleEnabled": {
                             "attach": {
                                 "thursday": true
                             }
@@ -78,7 +78,7 @@
                     "name": "SellProductScheduleFriday",
                     "label": "$option.TaskScheduleFriday.label",
                     "pipeline_override": {
-                        "SellProductSchedule": {
+                        "SellProductScheduleEnabled": {
                             "attach": {
                                 "friday": true
                             }
@@ -89,7 +89,7 @@
                     "name": "SellProductScheduleSaturday",
                     "label": "$option.TaskScheduleSaturday.label",
                     "pipeline_override": {
-                        "SellProductSchedule": {
+                        "SellProductScheduleEnabled": {
                             "attach": {
                                 "saturday": true
                             }
@@ -100,7 +100,7 @@
                     "name": "SellProductScheduleSunday",
                     "label": "$option.TaskScheduleSunday.label",
                     "pipeline_override": {
-                        "SellProductSchedule": {
+                        "SellProductScheduleEnabled": {
                             "attach": {
                                 "sunday": true
                             }

--- a/docs/en_us/developers/tasks/sell-product-maintain.md
+++ b/docs/en_us/developers/tasks/sell-product-maintain.md
@@ -22,7 +22,7 @@ The core maintenance points for SellProduct are as follows:
 | Win outpost generation config    | `tools/pipeline-generate/SellProduct/pipeline-config.json`        | Output to `assets/resource/pipeline/SellProduct/Outposts/${LocationId}.json`                                              |
 | ADB outpost generation config    | `tools/pipeline-generate/SellProduct/pipeline-adb-config.json`    | Output to `assets/resource_adb/pipeline/SellProduct/Outposts/${LocationId}.json`                                          |
 | Task options generation config   | `tools/pipeline-generate/SellProduct/task-config.json`            | Output to `assets/tasks/SellProduct.json`                                                                                 |
-| Task entry point                 | `assets/resource/pipeline/SellProduct.json`                       | `ScheduleAction`, main loop, region entry; manually maintained                                                            |
+| Task entry point                 | `assets/resource/pipeline/SellProduct.json`                       | `ScheduleRecognition`, main loop, region entry; manually maintained                                                       |
 | Region sell entry point          | `assets/resource/pipeline/SellProduct/Sell.json`                  | `next` list from region to outposts; manually maintained                                                                  |
 | Common sell core                 | `assets/resource/pipeline/SellProduct/SellCore.json`              | Sell loop, handling for out-of-stock/insufficient dispatch coupons/exceeded redemption limits, final transaction process  |
 | Common exchange process          | `assets/resource/pipeline/SellProduct/ChangeGoods.json`           | Enter item selection interface, select priority item or default item                                                      |
@@ -263,7 +263,7 @@ SellProductSchedule
 
 Key points:
 
-- `SellProductSchedule` determines the weekday selected by the user via `ScheduleAction` and actually executes `SellProductMain`.
+- `SellProductScheduleEnabled` determines the weekday selected by the user via `ScheduleRecognition`; when it hits, the Pipeline enters `SellProductMain`.
 - `SellProductLoop` only continues execution in the region construction interface; when not on the target interface, it hands over to `SceneEnterMenuRegionalDevelopment`.
 - `SellProductAuto` automatically selects Valley IV or Wuling based on the current region construction page.
 - `SellProduct{Region}Sell` enters the outpost management page of the corresponding region, then iterates through all outposts in that region via `next`.

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -108,23 +108,6 @@ Action 节点用于执行自定义动作。常见写法如下：
 - 若多个节点需要相同白名单，应在任务配置中分别把同一份 `attach` 写入各自节点。
 - 其他任务也建议优先使用通用名，避免与具体业务耦合。
 
-### ScheduleAction
-
-`ScheduleAction` 实现位于 `agent/go-service/common/schedule`，用于按星期几调度子任务。读取当前节点的 `attach` 中的星期开关，仅在匹配的星期几执行指定子任务。
-
-- 参数：
-    - `task: string`：要执行的子任务名，必填。
-- `attach` 字段（写在当前节点的 `attach` 中，可以在任务配置中合并）：
-    - `monday: bool` — 周一是否执行。
-    - `tuesday: bool` — 周二是否执行。
-    - `wednesday: bool` — 周三是否执行。
-    - `thursday: bool` — 周四是否执行。
-    - `friday: bool` — 周五是否执行。
-    - `saturday: bool` — 周六是否执行。
-    - `sunday: bool` — 周日是否执行。
-
-省略某个工作日标志时，默认视为 `false`（当天不执行）。若当天不在调度范围内，该 Action 会发出一条“今日跳过”的本地化提示并返回成功（不执行子任务）。
-
 ### AutoAltClickAction
 
 `AutoAltClickAction` 实现位于 `agent/go-service/common/autoaltclick`，用于在指定位置执行 Alt + 点击操作。先按下 Alt 键，再点击目标位置，最后松开 Alt 键。
@@ -215,6 +198,22 @@ Recognition 节点用于执行自定义识别。常见写法如下：
 - 对 `And` 节点，`box_index` 指向的本次子识别结果当前需要直接包含可解析的 OCR 数值结果。
 - 该识别器只负责表达式求值，不负责业务语义本身，业务侧应在 Pipeline 中自行组织节点与阈值。
 
+### ScheduleRecognition
+
+`ScheduleRecognition` 实现位于 `agent/go-service/common/schedule`，用于按星期几判断当前任务是否应继续执行。它只返回识别是否命中，不在 Go 中直接运行子任务；后续流程应通过 Pipeline 的 `next` 组织。
+
+- 参数：无。
+- `attach` 字段（写在当前识别节点中，可以在任务配置中合并）：
+    - `monday: bool` — 周一是否执行。
+    - `tuesday: bool` — 周二是否执行。
+    - `wednesday: bool` — 周三是否执行。
+    - `thursday: bool` — 周四是否执行。
+    - `friday: bool` — 周五是否执行。
+    - `saturday: bool` — 周六是否执行。
+    - `sunday: bool` — 周日是否执行。
+
+省略某个工作日标志时，默认视为 `false`（当天不执行）。若当天不在调度范围内，该 Recognition 会发出一条“今日跳过”的本地化提示并返回未命中。
+
 ## 小结
 
 写 Pipeline 时，内置的 `TemplateMatch` / `OCR` / `Click` / `Swipe` 能解决绝大多数需求。遇到它们搞不定的——比如要比较两个 OCR 数值、运行时动态调参数、批量跑子任务——再来查这篇，看有没有现成的 Custom 能用。
@@ -227,7 +226,7 @@ Recognition 节点用于执行自定义识别。常见写法如下：
 | 运行时改节点参数              | `PipelineOverride`            |
 | 把关键词拼成正则写回 OCR 节点 | `AttachToExpectedRegexAction` |
 | 计算 OCR 数值表达式           | `ExpressionRecognition`       |
-| 按星期几调度子任务            | `ScheduleAction`              |
+| 按星期几门控后续节点          | `ScheduleRecognition`         |
 | 在指定位置 Alt + 点击         | `AutoAltClickAction`          |
 | 在指定位置 Alt + 长按         | `AutoAltLongPressAction`      |
 

--- a/docs/zh_cn/developers/tasks/sell-product-maintain.md
+++ b/docs/zh_cn/developers/tasks/sell-product-maintain.md
@@ -22,7 +22,7 @@ SellProduct 的核心维护点如下：
 | Win 据点生成配置   | `tools/pipeline-generate/SellProduct/pipeline-config.json`        | 输出到 `assets/resource/pipeline/SellProduct/Outposts/${LocationId}.json`             |
 | ADB 据点生成配置   | `tools/pipeline-generate/SellProduct/pipeline-adb-config.json`    | 输出到 `assets/resource_adb/pipeline/SellProduct/Outposts/${LocationId}.json`         |
 | 任务选项生成配置   | `tools/pipeline-generate/SellProduct/task-config.json`            | 输出到 `assets/tasks/SellProduct.json`                                                |
-| 任务入口           | `assets/resource/pipeline/SellProduct.json`                       | `ScheduleAction`、主循环、地区入口；手写维护                                          |
+| 任务入口           | `assets/resource/pipeline/SellProduct.json`                       | `ScheduleRecognition`、主循环、地区入口；手写维护                                     |
 | 地区售卖入口       | `assets/resource/pipeline/SellProduct/Sell.json`                  | 地区到据点的 `next` 列表；手写维护                                                    |
 | 通用售卖核心       | `assets/resource/pipeline/SellProduct/SellCore.json`              | 售卖循环、缺货/调度券不足/超出兑换上限处理、最终交易流程                              |
 | 通用换货流程       | `assets/resource/pipeline/SellProduct/ChangeGoods.json`           | 进入选择货品界面、选择优先物品或默认物品                                              |
@@ -263,7 +263,7 @@ SellProductSchedule
 
 关键点：
 
-- `SellProductSchedule` 通过 `ScheduleAction` 判断用户选择的星期，实际执行 `SellProductMain`。
+- `SellProductScheduleEnabled` 通过 `ScheduleRecognition` 判断用户选择的星期，命中后由 Pipeline 进入 `SellProductMain`。
 - `SellProductLoop` 只在地区建设界面继续执行；不在目标界面时交给 `SceneEnterMenuRegionalDevelopment`。
 - `SellProductAuto` 会根据当前地区建设页面自动选择四号谷地或武陵。
 - `SellProduct{Region}Sell` 进入对应地区的据点管理页，然后按 `next` 遍历该地区所有据点。

--- a/tools/schema/custom.action.schema.json
+++ b/tools/schema/custom.action.schema.json
@@ -66,7 +66,6 @@
                 "PuzzleAction",
                 "RealTimeTaskAction",
                 "SceneManagerMenuListClickItemAction",
-                "ScheduleAction",
                 "SubTask",
                 "VisitFriendsExecuteVisitAction",
                 "VisitFriendsMainAction",

--- a/tools/schema/custom.recognition.schema.json
+++ b/tools/schema/custom.recognition.schema.json
@@ -19,6 +19,7 @@
                 "MapTrackerBigMapInfer",
                 "MapTrackerInfer",
                 "PuzzleRecognition",
+                "ScheduleRecognition",
                 "SellProductNormalizedItemMatch",
                 "VisitFriendsMenuScanDetailAssistRecognition",
                 "VisitFriendsMenuScanDetailClueExchangeRecognition",


### PR DESCRIPTION
## 变更内容

- 将计划任务调度从 Custom Action 改为 Custom Recognition
- 通过 ScheduleRecognition 的 hit/miss 决定是否进入后续 Pipeline 节点
- 将星期 attach 配置移动到实际识别节点，并同步任务选项 override
- 更新相关开发文档

## 验证

- go test ./common/schedule
- pnpm check
- pnpm test

## Summary by Sourcery

将基于工作日的调度逻辑，从“运行子任务的自定义 Action”重构为“用于控制下游流水线节点的自定义 Recognition”，并相应更新注册信息、流水线、任务以及文档。

新功能：
- 引入 `ScheduleRecognition` 作为自定义 recognition，用于在节点 attach 时报告当前工作日是否启用，并在 recognition 结果中暴露相关元数据。

增强改进：
- 将工作日 attach 配置从独立的 schedule 节点移动到实际的 recognition 节点中，并调整选项覆盖机制以与新的 gating 模型保持一致。

文档：
- 在开发者指南和任务维护文档中，用 `ScheduleRecognition` 替换 `ScheduleAction` 的相关文档，并对其在流水线中的行为和用法进行说明与澄清。

测试：
- 在基于新 recognition 的实现下，保持现有与调度相关的 Go 测试全部通过。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor weekday-based scheduling from a custom action that runs subtasks into a custom recognition used to gate downstream pipeline nodes, and update registrations, pipelines, tasks, and docs accordingly.

New Features:
- Introduce ScheduleRecognition as a custom recognition that reports whether the current weekday is enabled in node attach and exposes metadata in the recognition result.

Enhancements:
- Move weekday attach configuration from separate schedule nodes into the actual recognition node and adjust option overrides to align with the new gating model.

Documentation:
- Replace ScheduleAction documentation with ScheduleRecognition in developer guides and task maintenance docs, clarifying its behavior and usage in pipelines.

Tests:
- Keep existing schedule-related Go tests passing under the new recognition-based implementation.

</details>