### PR TITLE
fix: 响应时读取 body 便于排查 artifact 下载 403

### DIFF
--- a/tools/locals/setup_workspace/en_us.json
+++ b/tools/locals/setup_workspace/en_us.json
@@ -91,7 +91,7 @@
     "wrn_ci_artifact_no_binary": "[WRN] cpp-algo binary not found inside CI artifact",
     "wrn_ci_artifact_extract_failed": "[WRN] Failed to extract CI artifact: {error}",
     "wrn_ci_artifact_download_failed": "[WRN] Failed to download CI artifact, falling back to release",
-    "wrn_ci_artifact_unexpected_status": "[WRN] CI artifact API returned unexpected HTTP {status} ({reason}), falling back to release",
+    "wrn_ci_artifact_unexpected_status": "[WRN] CI artifact API returned unexpected HTTP {status} ({reason}): {body}",
     "inf_fallback_to_release": "[INF] Falling back to release download for cpp-algo",
     "description": "MaaEnd build tool: Initialize and install dependencies",
     "arg_update": "Update dependencies if they already exist",

--- a/tools/locals/setup_workspace/zh_cn.json
+++ b/tools/locals/setup_workspace/zh_cn.json
@@ -91,7 +91,7 @@
     "wrn_ci_artifact_no_binary": "[WRN] CI artifact 中未找到 cpp-algo 二进制文件",
     "wrn_ci_artifact_extract_failed": "[WRN] 解压 CI artifact 失败: {error}",
     "wrn_ci_artifact_download_failed": "[WRN] 下载 CI artifact 失败，回退到 Release 下载",
-    "wrn_ci_artifact_unexpected_status": "[WRN] CI artifact API 返回意外的 HTTP {status} ({reason})，回退到 Release 下载",
+    "wrn_ci_artifact_unexpected_status": "[WRN] CI artifact API 返回意外的 HTTP {status} ({reason}): {body}",
     "inf_fallback_to_release": "[INF] 回退到从 Release 下载 cpp-algo",
     "description": "MaaEnd 构建工具：初始化并安装依赖项",
     "arg_update": "当依赖项已存在时，是否进行更新操作",

--- a/tools/setup_workspace.py
+++ b/tools/setup_workspace.py
@@ -1075,10 +1075,12 @@ def install_cpp_algo(
                         if 300 <= api_resp.status < 400:
                             storage_url = api_resp.getheader("Location")
                         else:
+                            body = api_resp.read(512).decode("utf-8", errors="replace")
                             print(Console.warn(
                                 t("wrn_ci_artifact_unexpected_status",
                                   status=api_resp.status,
-                                  reason=api_resp.reason)
+                                  reason=api_resp.reason,
+                                  body=body)
                             ))
                 finally:
                     conn.close()


### PR DESCRIPTION
## Summary by Sourcery

改进在下载 CI 工件时，对于意外 HTTP 响应的诊断能力。

Bug Fixes:
- 当工件下载返回意外的状态码时，记录一小段 HTTP 响应体内容，以便更容易调查诸如 403 之类的错误。

Enhancements:
- 更新本地化消息，使其在工件下载出现意外状态时包含响应体信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve diagnostics for unexpected HTTP responses when downloading CI artifacts.

Bug Fixes:
- Log a snippet of the HTTP response body when artifact download returns an unexpected status code to ease investigation of errors like 403.

Enhancements:
- Update localized messages to include the response body information for unexpected artifact download statuses.

</details>