### PR TITLE
ci: 添加地图文件同步工作流到sync-zmdmap

### DIFF
--- a/.github/workflows/sync-zmdmap.yml
+++ b/.github/workflows/sync-zmdmap.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  sync-zmdmap:
+  sync-data:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -50,9 +50,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH_NAME"
           git add assets/data/ZmdMap
-          git commit -m "chore: sync zmdmap data" \
-            -m "This commit was automatically generated." \
-            -m "[skip changelog]"
+          git commit -m "chore: sync zmdmap data" -m "This commit was automatically generated." -m "[skip changelog]"
           git push --force-with-lease origin "HEAD:$BRANCH_NAME"
 
       - name: Create or update PR
@@ -64,28 +62,116 @@ jobs:
           set -euo pipefail
 
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
-
           PR_TITLE="chore: sync zmdmap data"
-
           PR_BODY="## Summary
 
           This PR automatically synchronized data files from zmdmap.
 
           Please review the changes before merging it."
-
           pr_number="$(gh pr list --base "$BASE_BRANCH" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')"
 
           if [ -n "$pr_number" ]; then
             gh pr edit "$pr_number" --title "$PR_TITLE" --body "$PR_BODY"
           else
-            gh pr create \
-              --base "$BASE_BRANCH" \
-              --head "$BRANCH_NAME" \
-              --title "$PR_TITLE" \
-              --body "$PR_BODY"
+            gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" --title "$PR_TITLE" --body "$PR_BODY"
           fi
 
       - name: Show no-op result
         if: steps.changes.outputs.has_changes != 'true'
         run: |
           echo "No changes detected in ZmdMap data."
+
+  sync-map:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.MAAEND_BOT_TOKEN }}
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install -r tools/map_tracker/requirements.txt
+
+      - name: Fetch layout data
+        run: |
+          python3 tools/map_tracker/map_fetcher.py json -o .cache/data
+
+      - name: Fetch map images
+        run: |
+          python3 tools/map_tracker/map_fetcher.py image -i .cache/data -o .cache/images
+
+      - name: Generate level maps
+        run: |
+          python3 tools/map_tracker/map_generator.py distinguish_levels -i .cache/images -o .cache/final --layout-dir .cache/data
+
+      - name: Generate tier maps
+        run: |
+          python3 tools/map_tracker/map_generator.py tidy_tiers -i .cache/images -o .cache/final
+
+      - name: Generate bbox data
+        run: |
+          python3 tools/map_tracker/map_generator.py bbox -i .cache/final -o .cache/final
+
+      - name: Copy results to assets
+        run: |
+          cp -f .cache/final/*.png assets/resource/image/MapTracker/map/
+          cp -f .cache/final/*.json assets/data/MapTracker/
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git add -N assets/resource/image/MapTracker/map/ assets/data/MapTracker/
+          if [ -z "$(git status --porcelain assets/resource/image/MapTracker/map/ assets/data/MapTracker/)" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          BRANCH_NAME: "feat/sync-map-image"
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH_NAME"
+          git add assets/resource/image/MapTracker/map/ assets/data/MapTracker/
+          git commit -m "feat(map): sync map image" -m "This commit was automatically generated." -m "[skip changelog]"
+          git push --force-with-lease origin "HEAD:$BRANCH_NAME"
+
+      - name: Create or update PR
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.MAAEND_BOT_TOKEN }}
+          BRANCH_NAME: "feat/sync-map-image"
+        run: |
+          set -euo pipefail
+
+          BASE_BRANCH="${{ github.event.repository.default_branch }}"
+          PR_TITLE="feat(map): sync map image"
+          PR_BODY="## Summary
+
+          This PR automatically synchronized map images and bbox data from zmdmap.
+
+          Please review the changes before merging it."
+          pr_number="$(gh pr list --base "$BASE_BRANCH" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')"
+
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" --title "$PR_TITLE" --body "$PR_BODY"
+          else
+            gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" --title "$PR_TITLE" --body "$PR_BODY"
+          fi
+
+      - name: Show no-op result
+        if: steps.changes.outputs.has_changes != 'true'
+        run: |
+          echo "No changes detected in map images."

--- a/.github/workflows/sync-zmdmap.yml
+++ b/.github/workflows/sync-zmdmap.yml
@@ -30,20 +30,33 @@ jobs:
         run: |
           python3 tools/map_tracker/map_fetcher.py json -o assets/data/ZmdMap
 
+      - name: Get version info
+        id: version
+        run: |
+          readarray -t VER < <(python3 tools/map_tracker/map_fetcher.py version -i assets/data/ZmdMap/version.json)
+          echo "version=${VER[0]}" >> "$GITHUB_OUTPUT"
+          echo "game_version=${VER[1]}" >> "$GITHUB_OUTPUT"
+          echo "res_version=${VER[2]}" >> "$GITHUB_OUTPUT"
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.MAAEND_BOT_TOKEN }}
           add-paths: assets/data/ZmdMap
-          commit-message: "chore: sync zmdmap data"
+          commit-message: "chore: sync zmdmap data ${{ steps.version.outputs.version }}"
           branch: chore/sync-zmdmap-data
-          title: "chore: sync zmdmap data"
+          title: "chore: sync zmdmap data ${{ steps.version.outputs.version }}"
           body: |
             ## Summary
 
             This PR automatically synchronized data files from zmdmap.
 
             Please review the changes before merging it.
+
+            **Version Information:**
+            - Version: ${{ steps.version.outputs.version }}
+            - Game Version: ${{ steps.version.outputs.game_version }}
+            - Resource Version: ${{ steps.version.outputs.res_version }}
 
   sync-map:
     runs-on: ubuntu-latest
@@ -66,6 +79,14 @@ jobs:
       - name: Fetch layout data
         run: |
           python3 tools/map_tracker/map_fetcher.py json -o .cache/data
+
+      - name: Get version info
+        id: version
+        run: |
+          readarray -t VER < <(python3 tools/map_tracker/map_fetcher.py version -i .cache/data/version.json)
+          echo "version=${VER[0]}" >> "$GITHUB_OUTPUT"
+          echo "game_version=${VER[1]}" >> "$GITHUB_OUTPUT"
+          echo "res_version=${VER[2]}" >> "$GITHUB_OUTPUT"
 
       - name: Fetch map images
         run: |
@@ -95,12 +116,17 @@ jobs:
           add-paths: |
             assets/resource/image/MapTracker/map/
             assets/data/MapTracker/
-          commit-message: "feat(map): sync map image"
+          commit-message: "feat(map): sync map image ${{ steps.version.outputs.version }}"
           branch: feat/sync-map-image
-          title: "feat(map): sync map image"
+          title: "feat(map): sync map image ${{ steps.version.outputs.version }}"
           body: |
             ## Summary
 
             This PR automatically synchronized map images and bbox data from zmdmap.
 
             Please review the changes before merging it.
+
+            **Version Information:**
+            - Version: ${{ steps.version.outputs.version }}
+            - Game Version: ${{ steps.version.outputs.game_version }}
+            - Resource Version: ${{ steps.version.outputs.res_version }}

--- a/.github/workflows/sync-zmdmap.yml
+++ b/.github/workflows/sync-zmdmap.yml
@@ -30,56 +30,20 @@ jobs:
         run: |
           python3 tools/map_tracker/map_fetcher.py json -o assets/data/ZmdMap
 
-      - name: Check for changes
-        id: changes
-        run: |
-          if [ -z "$(git status --porcelain assets/data/ZmdMap)" ]; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.MAAEND_BOT_TOKEN }}
+          add-paths: assets/data/ZmdMap
+          commit-message: "chore: sync zmdmap data"
+          branch: chore/sync-zmdmap-data
+          title: "chore: sync zmdmap data"
+          body: |
+            ## Summary
 
-      - name: Commit and push
-        if: steps.changes.outputs.has_changes == 'true'
-        env:
-          BRANCH_NAME: "chore/sync-zmdmap-data"
-        run: |
-          set -euo pipefail
+            This PR automatically synchronized data files from zmdmap.
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$BRANCH_NAME"
-          git add assets/data/ZmdMap
-          git commit -m "chore: sync zmdmap data" -m "This commit was automatically generated." -m "[skip changelog]"
-          git push --force-with-lease origin "HEAD:$BRANCH_NAME"
-
-      - name: Create or update PR
-        if: steps.changes.outputs.has_changes == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.MAAEND_BOT_TOKEN }}
-          BRANCH_NAME: "chore/sync-zmdmap-data"
-        run: |
-          set -euo pipefail
-
-          BASE_BRANCH="${{ github.event.repository.default_branch }}"
-          PR_TITLE="chore: sync zmdmap data"
-          PR_BODY="## Summary
-
-          This PR automatically synchronized data files from zmdmap.
-
-          Please review the changes before merging it."
-          pr_number="$(gh pr list --base "$BASE_BRANCH" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')"
-
-          if [ -n "$pr_number" ]; then
-            gh pr edit "$pr_number" --title "$PR_TITLE" --body "$PR_BODY"
-          else
-            gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" --title "$PR_TITLE" --body "$PR_BODY"
-          fi
-
-      - name: Show no-op result
-        if: steps.changes.outputs.has_changes != 'true'
-        run: |
-          echo "No changes detected in ZmdMap data."
+            Please review the changes before merging it.
 
   sync-map:
     runs-on: ubuntu-latest
@@ -124,54 +88,19 @@ jobs:
           cp -f .cache/final/*.png assets/resource/image/MapTracker/map/
           cp -f .cache/final/*.json assets/data/MapTracker/
 
-      - name: Check for changes
-        id: changes
-        run: |
-          git add -N assets/resource/image/MapTracker/map/ assets/data/MapTracker/
-          if [ -z "$(git status --porcelain assets/resource/image/MapTracker/map/ assets/data/MapTracker/)" ]; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.MAAEND_BOT_TOKEN }}
+          add-paths: |
+            assets/resource/image/MapTracker/map/
+            assets/data/MapTracker/
+          commit-message: "feat(map): sync map image"
+          branch: feat/sync-map-image
+          title: "feat(map): sync map image"
+          body: |
+            ## Summary
 
-      - name: Commit and push
-        if: steps.changes.outputs.has_changes == 'true'
-        env:
-          BRANCH_NAME: "feat/sync-map-image"
-        run: |
-          set -euo pipefail
+            This PR automatically synchronized map images and bbox data from zmdmap.
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$BRANCH_NAME"
-          git add assets/resource/image/MapTracker/map/ assets/data/MapTracker/
-          git commit -m "feat(map): sync map image" -m "This commit was automatically generated." -m "[skip changelog]"
-          git push --force-with-lease origin "HEAD:$BRANCH_NAME"
-
-      - name: Create or update PR
-        if: steps.changes.outputs.has_changes == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.MAAEND_BOT_TOKEN }}
-          BRANCH_NAME: "feat/sync-map-image"
-        run: |
-          set -euo pipefail
-
-          BASE_BRANCH="${{ github.event.repository.default_branch }}"
-          PR_TITLE="feat(map): sync map image"
-          PR_BODY="## Summary
-
-          This PR automatically synchronized map images and bbox data from zmdmap.
-
-          Please review the changes before merging it."
-          pr_number="$(gh pr list --base "$BASE_BRANCH" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')"
-
-          if [ -n "$pr_number" ]; then
-            gh pr edit "$pr_number" --title "$PR_TITLE" --body "$PR_BODY"
-          else
-            gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" --title "$PR_TITLE" --body "$PR_BODY"
-          fi
-
-      - name: Show no-op result
-        if: steps.changes.outputs.has_changes != 'true'
-        run: |
-          echo "No changes detected in map images."
+            Please review the changes before merging it.

--- a/tools/map_tracker/map_fetcher.py
+++ b/tools/map_tracker/map_fetcher.py
@@ -19,7 +19,7 @@ import numpy as np
 from typing import NamedTuple
 
 from _internal.core_utils import _R, _G, _Y, _C, _A, _0, cv2
-from _internal.zmdmap_schemas import RegionLayoutTable, GridTiersTable
+from _internal.zmdmap_schemas import RegionLayoutTable, GridTiersTable, EntitiesTable
 from _internal.http_utils import download_image, download_json
 
 
@@ -134,6 +134,15 @@ def cmd_json(output_dir: str, use_cache: bool = False) -> None:
     if not _download_json_cached(entities_url, entities_dest, use_cache):
         print(f"  {_R}Failed to fetch entities data{_0}")
         raise SystemExit(1)
+
+    entities_table = EntitiesTable.load(entities_dest)
+    total = sum(
+        len(e)
+        for r in entities_table.regions.values()
+        for l in r.levels.values()
+        for e in l.categories.values()
+    )
+    print(f"  {_G}Entities: {_C}{total}{_G} entries across {_C}{len(entities_table.regions)}{_G} regions{_0}")
 
     # Download grid_tiers first to discover region names
     print(f"  Downloading grid_tiers...")
@@ -289,6 +298,33 @@ def cmd_image(
             print(f"  {_G}Downloaded {tier_count} tier image(s){_0}")
 
 
+# ── version subcommand ────────────────────────────────────────────────────────
+
+
+def cmd_version(input_file: str) -> None:
+    """Parse the first version entry from a version JSON file and print version info."""
+    try:
+        with open(input_file, encoding="utf-8") as f:
+            raw = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"  {_R}Failed to read file: {e}{_0}")
+        raise SystemExit(1)
+
+    try:
+        ver_list = raw["data"]["list"]
+        entry = ver_list[0]
+        version = entry["version"]
+        game_version = entry["game_version"]
+        res_version = entry["resource_bundles"][0]["res_version"]
+    except (TypeError, KeyError, IndexError):
+        print(f"  {_R}Not a valid version file{_0}")
+        raise SystemExit(1)
+
+    print(version)
+    print(game_version)
+    print(res_version)
+
+
 # ── main ──────────────────────────────────────────────────────────────────────
 
 
@@ -326,18 +362,25 @@ def main():
         help="Only download region images, skip tier images",
     )
 
+    # version
+    p_ver = sub.add_parser("version", help="Parse version info from a version JSON file")
+    p_ver.add_argument(
+        "-i", "--input-file", required=True, help="Path to version JSON file"
+    )
+
     args = parser.parse_args()
 
-    print(f"{_G}MapFetcher{_0} [{args.command}]")
-
-    if args.command == "json":
-        cmd_json(args.output_dir, args.with_cache)
-    elif args.command == "image":
-        cmd_image(
-            args.input_dir, args.output_dir, args.match, args.with_cache, args.no_tiers
-        )
-
-    print(f"\n{_G}Done.{_0}")
+    if args.command == "version":
+        cmd_version(args.input_file)
+    else:
+        print(f"{_G}MapFetcher{_0} [{args.command}]")
+        if args.command == "json":
+            cmd_json(args.output_dir, args.with_cache)
+        elif args.command == "image":
+            cmd_image(
+                args.input_dir, args.output_dir, args.match, args.with_cache, args.no_tiers
+            )
+        print(f"\n{_G}Done.{_0}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

此 PR 为 sync-zmdmap 添加了自动同步地图文件的工作流，并优化 PR 的自动创建。

目前采用手动触发的方式触发此工作流，后续运行稳定即可实现定时拉取。

## Summary by Sourcery

添加自动化工作流程和配套工具，通过手动触发的 CI 来同步来自 zmdmap 的 ZmdMap 数据和地图追踪器资源。

New Features:
- 引入一个 workflow 任务，用于获取 ZmdMap 的 JSON 数据，并为数据更新创建带版本信息的 pull request。
- 添加一个 workflow 任务，用于生成和同步地图追踪器图片、层级地图以及边界框数据，并通过 pull request 写回到仓库。
- 扩展 `map_fetcher` CLI，新增 `version` 子命令，用于从下载的 JSON 中解析版本元数据并对外暴露，以便自动化使用。

Enhancements:
- 增强 JSON 获取命令，使其在同步运行期间报告聚合实体统计信息，从而提供更好的可见性。

CI:
- 重构现有的 `sync-zmdmap` workflow，使用 `create-pull-request` 来实现自动化的带版本 PR 创建，并将数据同步和地图资源同步的职责拆分到不同的任务中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automated workflows and supporting tooling to sync ZmdMap data and map tracker assets from zmdmap via manual CI triggers.

New Features:
- Introduce a workflow job to fetch ZmdMap JSON data and open versioned pull requests for data updates.
- Add a workflow job to generate and sync map tracker images, tier maps, and bounding box data into the repository via pull requests.
- Extend the map_fetcher CLI with a version subcommand to parse version metadata from downloaded JSON and expose it for automation.

Enhancements:
- Enhance the JSON fetching command to report aggregated entities statistics for better visibility during sync runs.

CI:
- Refactor the existing sync-zmdmap workflow to use create-pull-request for automated, versioned PR creation and split responsibilities between data and map asset syncing jobs.

</details>