### PR TITLE
fix:修复赠送礼物任务选择干员名字任务点击失效

### DIFF
--- a/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
@@ -742,8 +742,10 @@
             "time": 200,
             "timeout": 3000
         },
+        "pre_delay": 0,
         "next": [
-            "GiftOperatorSkipDialog"
+            "GiftOperatorSkipDialog",
+            "GiftOperatorWaitChat" //防止干员突然走过来导致选项位置变化点击丢失
         ]
     }
 }

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
@@ -361,7 +361,8 @@
         "next": [
             "GiftOperatorBranchGift",
             "GiftOperatorBranchReceive",
-            "GiftOperatorBranchMaxAffinity"
+            "GiftOperatorBranchMaxAffinity",
+            "GiftOperatorSkipDialog"
         ]
     }
 }

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
@@ -317,13 +317,13 @@
             "type": "Click"
         },
         "post_wait_freezes": {
-            "time": 500,
-            "timeout": 3000,
+            "time": 1000,
+            "timeout": 2000,
             "target": [
-                992,
-                469,
-                203,
-                102
+                831,
+                403,
+                161,
+                176
             ]
         },
         "next": [


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 恢复在礼品任务流程中“选择运营商名称”步骤的点击处理功能，使任务可以正常完成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore click handling for the 'select operator name' step in the gift task flow so the task can be completed normally.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 恢复在礼品任务流程中“选择运营商名称”步骤的点击处理功能，使任务可以正常完成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore click handling for the 'select operator name' step in the gift task flow so the task can be completed normally.

</details>

</details>