### PR TITLE
fix:添加最大拖动次数,防止仓库已满的情况下仍然拖动物品

### DIFF
--- a/assets/resource/pipeline/StashBackpack.json
+++ b/assets/resource/pipeline/StashBackpack.json
@@ -96,12 +96,33 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "StashBackpackUsableItemsStoreFull",
             "[JumpBack]StashBackpackUsableItemsLimitedDrag",
             "EmptyNode"
         ]
     },
+    "StashBackpackUsableItemsStoreFull": {
+        "desc": "仓库已满",
+        "recognition": "OCR",
+        "roi": [
+            319,
+            0,
+            601,
+            122
+        ],
+        "expected": [
+            "目标空间已满，部分物品未能完全移动",
+            "目標空間已滿，部分物品未能完全移動",
+            "(?i)Target\\s*space\\s*is\\s*full\\. Not every item could be moved\\.",
+            "空きがないため、一部のアイテムは移動できません"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
     "StashBackpackUsableItemsLimitedDrag": {
         "desc": "拖动物品到仓库",
+        "max_hit": 5, //防止重复拖动物品导致卡住
         "recognition": "And",
         "all_of": [
             {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过设置最大拖拽次数，在仓库或背包已满时阻止物品被重复拖拽。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent dragging items repeatedly when the stash or backpack is already full by enforcing a maximum drag count.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 通过设置最大拖拽次数，在仓库或背包已满时阻止物品被重复拖拽。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent dragging items repeatedly when the stash or backpack is already full by enforcing a maximum drag count.

</details>

</details>