### PR TITLE
chore: 修改后台控制器不可用说明

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -33,6 +33,19 @@
             "permission_required": true
         },
         {
+            "name": "Win32-Window-Background",
+            "label": "$controller.Win32-Window-Background.label",
+            "type": "Win32",
+            "win32": {
+                "class_regex": "UnityWndClass",
+                "window_regex": "Endfield",
+                "screencap": "PrintWindow",
+                "mouse": "SendMessageWithWindowPos",
+                "keyboard": "PostMessage"
+            },
+            "permission_required": true
+        },
+        {
             "name": "ADB",
             "label": "$controller.ADB.label",
             "description": "$controller.ADB.description",

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -35,6 +35,7 @@
         {
             "name": "Win32-Window-Background",
             "label": "$controller.Win32-Window-Background.label",
+            "description": "$controller.Win32-Window-Background.description",
             "type": "Win32",
             "win32": {
                 "class_regex": "UnityWndClass",

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -708,6 +708,7 @@
     "resource.CN.label": "General Resources (currently best supported in Simplified Chinese)",
     "controller.Win32-Front.label": "PC-Foreground",
     "controller.Win32-Front.description": "Best stability. Requires the game window to remain in the foreground and unobstructed; will fully grab the mouse.",
+    "controller.Win32-Window-Background.label": "PC-Background (Deprecated - incompatible with new version)",
     "controller.ADB.label": "Android",
     "controller.ADB.description": "Supports Android emulators and physical Android devices.",
     "controller.Wlroots.label": "Linux-Wlroots",

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -709,6 +709,7 @@
     "controller.Win32-Front.label": "PC-Foreground",
     "controller.Win32-Front.description": "Best stability. Requires the game window to remain in the foreground and unobstructed; will fully grab the mouse.",
     "controller.Win32-Window-Background.label": "PC-Background (Deprecated - incompatible with new version)",
+    "controller.Win32-Window-Background.description": "Due to game updates, it can no longer be adapted. The background controller has been deprecated and will be removed in a future version.",
     "controller.ADB.label": "Android",
     "controller.ADB.description": "Supports Android emulators and physical Android devices.",
     "controller.Wlroots.label": "Linux-Wlroots",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -708,6 +708,7 @@
     "resource.CN.label": "共通リソース（現在は簡体字中国語のみサポートが良好）",
     "controller.Win32-Front.label": "PC-前面",
     "controller.Win32-Front.description": "安定性が最も高い。ゲームウィンドウを最前面に表示し、遮られないようにする必要があります。マウスを完全に占有します。",
+    "controller.Win32-Window-Background.label": "PC-バックグラウンド（非推奨 - 新バージョンに対応不可）",
     "controller.ADB.label": "Android",
     "controller.ADB.description": "Androidエミュレーターおよび実機Androidデバイスに対応しています。",
     "controller.Wlroots.label": "Linux-Wlroots",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -709,6 +709,7 @@
     "controller.Win32-Front.label": "PC-前面",
     "controller.Win32-Front.description": "安定性が最も高い。ゲームウィンドウを最前面に表示し、遮られないようにする必要があります。マウスを完全に占有します。",
     "controller.Win32-Window-Background.label": "PC-バックグラウンド（非推奨 - 新バージョンに対応不可）",
+    "controller.Win32-Window-Background.description": "ゲームの更新により適応を継続できなくなりました。バックグラウンドコントローラーは非推奨となり、今後のバージョンで削除される予定です。",
     "controller.ADB.label": "Android",
     "controller.ADB.description": "Androidエミュレーターおよび実機Androidデバイスに対応しています。",
     "controller.Wlroots.label": "Linux-Wlroots",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -709,6 +709,7 @@
     "controller.Win32-Front.label": "PC-포그라운드",
     "controller.Win32-Front.description": "안정성이 가장 뛰어납니다. 게임 창이 항상 최앞단에 있고 가려지지 않아야 하며, 마우스를 완전히 점유합니다.",
     "controller.Win32-Window-Background.label": "PC-백그라운드 (사용 중단 - 새 버전 호환 불가)",
+    "controller.Win32-Window-Background.description": "게임 업데이트로 인해 더 이상 호환할 수 없습니다. 백그라운드 컨트롤러는 사용 중단되었으며 향후 버전에서 제거될 예정입니다.",
     "controller.ADB.label": "Android",
     "controller.ADB.description": "안드로이드 에뮬레이터 및 실물 안드로이드 기기를 지원합니다.",
     "controller.Wlroots.label": "Linux-Wlroots",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -708,6 +708,7 @@
     "resource.CN.label": "공통 리소스 (현재 간체 중국어만 잘 지원됨)",
     "controller.Win32-Front.label": "PC-포그라운드",
     "controller.Win32-Front.description": "안정성이 가장 뛰어납니다. 게임 창이 항상 최앞단에 있고 가려지지 않아야 하며, 마우스를 완전히 점유합니다.",
+    "controller.Win32-Window-Background.label": "PC-백그라운드 (사용 중단 - 새 버전 호환 불가)",
     "controller.ADB.label": "Android",
     "controller.ADB.description": "안드로이드 에뮬레이터 및 실물 안드로이드 기기를 지원합니다.",
     "controller.Wlroots.label": "Linux-Wlroots",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -709,6 +709,7 @@
     "controller.Win32-Front.label": "电脑端-前台",
     "controller.Win32-Front.description": "稳定性最好，需要游戏窗口保持在最前且不被遮挡，会完全抢占鼠标",
     "controller.Win32-Window-Background.label": "电脑端-后台弃用(无法适配新版本)",
+    "controller.Win32-Window-Background.description": "因游戏更新导致无法继续适配，后台控制器已弃用，并将在后续版本中移除。",
     "controller.ADB.label": "安卓端",
     "controller.ADB.description": "支持安卓模拟器和实体安卓设备",
     "controller.Wlroots.label": "Linux端-Wlroots",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -708,6 +708,7 @@
     "resource.CN.label": "通用资源（目前仅简中支持较好）",
     "controller.Win32-Front.label": "电脑端-前台",
     "controller.Win32-Front.description": "稳定性最好，需要游戏窗口保持在最前且不被遮挡，会完全抢占鼠标",
+    "controller.Win32-Window-Background.label": "电脑端-后台弃用(无法适配新版本)",
     "controller.ADB.label": "安卓端",
     "controller.ADB.description": "支持安卓模拟器和实体安卓设备",
     "controller.Wlroots.label": "Linux端-Wlroots",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -515,6 +515,7 @@
     "controller.Win32-Front.label": "電腦端-前台",
     "controller.Win32-Front.description": "穩定性最好，需要遊戲視窗保持在最前且不被遮擋，會完全搶占滑鼠",
     "controller.Win32-Window-Background.label": "電腦端-後台棄用(無法適配新版本)",
+    "controller.Win32-Window-Background.description": "因遊戲更新導致無法繼續適配，後台控制器已棄用，並將在後續版本中移除。",
     "controller.ADB.label": "安卓端",
     "controller.ADB.description": "支援安卓模擬器及實體安卓裝置",
     "controller.Wlroots.label": "Linux端-Wlroots",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -514,6 +514,7 @@
     "resource.CN.label": "通用資源（目前僅簡中支援較好）",
     "controller.Win32-Front.label": "電腦端-前台",
     "controller.Win32-Front.description": "穩定性最好，需要遊戲視窗保持在最前且不被遮擋，會完全搶占滑鼠",
+    "controller.Win32-Window-Background.label": "電腦端-後台棄用(無法適配新版本)",
     "controller.ADB.label": "安卓端",
     "controller.ADB.description": "支援安卓模擬器及實體安卓裝置",
     "controller.Wlroots.label": "Linux端-Wlroots",

--- a/assets/tasks/AutoStockStaple.json
+++ b/assets/tasks/AutoStockStaple.json
@@ -5,6 +5,11 @@
             "label": "$task.AutoStockStaple.label",
             "entry": "AutoStockStapleSchedule",
             "description": "$task.AutoStockStaple.description",
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "regional_development"
             ],

--- a/assets/tasks/AutoUseSpMedication.json
+++ b/assets/tasks/AutoUseSpMedication.json
@@ -5,6 +5,11 @@
             "entry": "AutoUseSpMedicationEntry",
             "label": "$task.AutoUseSpMedication.label",
             "name": "AutoUseSpMedication",
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "valuables_vault"
             ],

--- a/assets/tasks/BakerEntry.json
+++ b/assets/tasks/BakerEntry.json
@@ -5,7 +5,14 @@
             "label": "$task.BakerEntry.label",
             "entry": "BakerEntry",
             "description": "$task.BakerEntry.description",
-            "group": ["other_menu"]
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
+            "group": [
+                "other_menu"
+            ]
         }
     ],
     "option": {}

--- a/assets/tasks/Crafting.json
+++ b/assets/tasks/Crafting.json
@@ -5,6 +5,11 @@
             "label": "$task.Crafting.label",
             "entry": "CraftingStart",
             "description": "$task.Crafting.description",
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "backpack"
             ]

--- a/assets/tasks/CreditShopping.json
+++ b/assets/tasks/CreditShopping.json
@@ -15,6 +15,11 @@
                 "CreditShoppingForce",
                 "CreditShoppingKeepShelfRecord"
             ],
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "other_menu"
             ]

--- a/assets/tasks/DailyRewards.json
+++ b/assets/tasks/DailyRewards.json
@@ -12,6 +12,11 @@
                 "DailyEventRewards",
                 "DailyProtocolPassRewards"
             ],
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "other_menu"
             ]

--- a/assets/tasks/DeliveryJobs.json
+++ b/assets/tasks/DeliveryJobs.json
@@ -12,6 +12,11 @@
                 "DeliveryJobsAcceptJobOnly",
                 "DeliveryJobsPackCargoOnly"
             ],
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "regional_development"
             ]

--- a/assets/tasks/DijiangRewards.json
+++ b/assets/tasks/DijiangRewards.json
@@ -11,6 +11,11 @@
                 "ClueSetting",
                 "SelectToGrow"
             ],
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "dijiang_ship"
             ]

--- a/assets/tasks/GearAssembly.json
+++ b/assets/tasks/GearAssembly.json
@@ -9,6 +9,11 @@
                 "GearAssemblyType",
                 "GearAssemblySortOrder"
             ],
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "valuables_vault"
             ]

--- a/assets/tasks/ReadAllWiki.json
+++ b/assets/tasks/ReadAllWiki.json
@@ -5,7 +5,14 @@
             "label": "$task.ReadAllWiki.label",
             "entry": "WikiReadAll",
             "description": "$task.ReadAllWiki.description",
-            "group": ["other_menu"]
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
+            "group": [
+                "other_menu"
+            ]
         }
     ],
     "option": {}

--- a/assets/tasks/ReceiveProdManual.json
+++ b/assets/tasks/ReceiveProdManual.json
@@ -5,7 +5,14 @@
             "label": "$task.ReceiveProdManual.label",
             "entry": "ProdManualStart",
             "description": "$task.ReceiveProdManual.description",
-            "group": ["backpack"]
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
+            "group": [
+                "backpack"
+            ]
         }
     ],
     "option": {}

--- a/assets/tasks/SellProduct.json
+++ b/assets/tasks/SellProduct.json
@@ -11,6 +11,11 @@
                 "ValleyIVSell",
                 "WulingSell"
             ],
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "regional_development"
             ]

--- a/assets/tasks/SimpleProductionBatchStart.json
+++ b/assets/tasks/SimpleProductionBatchStart.json
@@ -5,7 +5,14 @@
             "label": "$task.SimpleProductionBatch.label",
             "entry": "SimpleProductionBatchStart",
             "description": "$task.SimpleProductionBatch.description",
-            "group": ["backpack"]
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
+            "group": [
+                "backpack"
+            ]
         }
     ],
     "option": {}

--- a/assets/tasks/VisitFriends.json
+++ b/assets/tasks/VisitFriends.json
@@ -9,6 +9,11 @@
                 "VisitFriendsRemark",
                 "ProductionAssistControl"
             ],
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "dijiang_ship"
             ]

--- a/assets/tasks/Weapon.json
+++ b/assets/tasks/Weapon.json
@@ -5,6 +5,11 @@
             "label": "$task.WeaponUpgrade.label",
             "entry": "WeaponUpgradeStart",
             "description": "$task.WeaponUpgrade.description",
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "Wlroots"
+            ],
             "group": [
                 "valuables_vault"
             ]


### PR DESCRIPTION
## Summary by Sourcery

更新接口配置和任务元数据，以优化与“后端控制器不可用”及相关自动化任务有关的描述。

增强内容：
- 更新所有受支持语言中的界面本地化字符串，以更清晰地说明后端控制器不可用的相关信息。
- 调整多种自动化功能（例如：补货、制作、奖励和购物）的任务定义，使其与更新后的后端控制器可用性行为保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update interface configuration and task metadata to refine descriptions related to unavailable backend controllers and associated automated tasks.

Enhancements:
- Refresh interface locale strings across all supported languages to clarify messaging about backend controller unavailability.
- Adjust task definitions for various automated features (e.g., stocking, crafting, rewards, and shopping) to align with updated backend controller availability behavior.

</details>