### PR TITLE
fix(MapNavigator): NavMesh 可能错误越过临近不可通行区域

### DIFF
--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <numeric>
 #include <queue>
 #include <tuple>
 #include <utility>
@@ -22,6 +23,8 @@ constexpr double kBridgeFixedCost = 12.0;
 constexpr double kBridgeGapCostFactor = 3.0;
 constexpr double kBridgeHeightCostFactor = 40.0;
 constexpr double kBridgeMaxHeightDelta = 3.0;
+constexpr uint32_t kSmallBridgeComponentMaxTriangles = 512;
+constexpr double kSmallBridgeMaxGap = 4.0;
 
 struct QueueNode
 {
@@ -29,6 +32,35 @@ struct QueueNode
     double priority = 0.0;
 
     bool operator<(const QueueNode& rhs) const { return priority > rhs.priority; }
+};
+
+struct DisjointSet
+{
+    std::vector<uint32_t> parent;
+
+    explicit DisjointSet(size_t count)
+        : parent(count, 0)
+    {
+        std::iota(parent.begin(), parent.end(), 0U);
+    }
+
+    uint32_t find(uint32_t value)
+    {
+        while (parent[value] != value) {
+            parent[value] = parent[parent[value]];
+            value = parent[value];
+        }
+        return value;
+    }
+
+    void unite(uint32_t lhs, uint32_t rhs)
+    {
+        const uint32_t lhs_root = find(lhs);
+        const uint32_t rhs_root = find(rhs);
+        if (lhs_root != rhs_root) {
+            parent[rhs_root] = lhs_root;
+        }
+    }
 };
 
 }
@@ -51,9 +83,11 @@ void BaseNavPlanner::buildIndex()
             triangle_zones_[index] = zone.zone_id;
         }
     }
+    buildNaturalComponents();
+
     size_t valid_link_count = 0;
     for (const BaseNavLink& link : pack_.links()) {
-        if (link.source < triangle_zones_.size() && link.target < triangle_zones_.size()) {
+        if (isTraversableLink(link.source, link.target)) {
             ++adjacency_offsets_[link.source + 1];
             ++valid_link_count;
         }
@@ -65,9 +99,41 @@ void BaseNavPlanner::buildIndex()
     adjacency_links_.resize(valid_link_count);
     std::vector<uint32_t> next_offsets = adjacency_offsets_;
     for (const BaseNavLink& link : pack_.links()) {
-        if (link.source < triangle_zones_.size() && link.target < triangle_zones_.size()) {
+        if (isTraversableLink(link.source, link.target)) {
             adjacency_links_[next_offsets[link.source]++] = link.target;
         }
+    }
+}
+
+void BaseNavPlanner::buildNaturalComponents()
+{
+    const auto& triangles = pack_.triangles();
+    DisjointSet components(triangles.size());
+    for (uint32_t triangle_index = 0; triangle_index < triangles.size(); ++triangle_index) {
+        for (int32_t neighbor : triangles[triangle_index].neighbors) {
+            if (neighbor < 0) {
+                continue;
+            }
+            const uint32_t next = static_cast<uint32_t>(neighbor);
+            if (next < triangles.size() && triangle_zones_[next] == triangle_zones_[triangle_index]) {
+                components.unite(triangle_index, next);
+            }
+        }
+    }
+
+    constexpr uint32_t kInvalidComponent = std::numeric_limits<uint32_t>::max();
+    std::vector<uint32_t> root_to_component(triangles.size(), kInvalidComponent);
+    natural_component_ids_.assign(triangles.size(), kInvalidComponent);
+    natural_component_sizes_.clear();
+    for (uint32_t triangle_index = 0; triangle_index < triangles.size(); ++triangle_index) {
+        const uint32_t root = components.find(triangle_index);
+        uint32_t& component_id = root_to_component[root];
+        if (component_id == kInvalidComponent) {
+            component_id = static_cast<uint32_t>(natural_component_sizes_.size());
+            natural_component_sizes_.push_back(0);
+        }
+        natural_component_ids_[triangle_index] = component_id;
+        ++natural_component_sizes_[component_id];
     }
 }
 
@@ -87,6 +153,37 @@ void BaseNavPlanner::computeTriangleHeights()
 double BaseNavPlanner::triangleAverageHeight(uint32_t triangle_index) const
 {
     return triangle_heights_[triangle_index];
+}
+
+bool BaseNavPlanner::isNaturalNeighbor(uint32_t lhs, uint32_t rhs) const
+{
+    for (int32_t neighbor : pack_.triangles()[lhs].neighbors) {
+        if (neighbor >= 0 && static_cast<uint32_t>(neighbor) == rhs) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool BaseNavPlanner::isTraversableLink(uint32_t lhs, uint32_t rhs) const
+{
+    if (lhs >= triangle_zones_.size() || rhs >= triangle_zones_.size() || triangle_zones_[lhs] == 0
+        || triangle_zones_[lhs] != triangle_zones_[rhs]) {
+        return false;
+    }
+    if (isNaturalNeighbor(lhs, rhs)) {
+        return true;
+    }
+
+    const uint32_t lhs_component = natural_component_ids_[lhs];
+    const uint32_t rhs_component = natural_component_ids_[rhs];
+    const uint32_t min_component_size = std::min(natural_component_sizes_[lhs_component], natural_component_sizes_[rhs_component]);
+    if (min_component_size > kSmallBridgeComponentMaxTriangles) {
+        return true;
+    }
+
+    const auto bridge_points = closestEdgeBridgePoints(lhs, rhs);
+    return bridge_points && detail::Distance((*bridge_points)[0], (*bridge_points)[1]) <= kSmallBridgeMaxGap;
 }
 
 BaseNavRouteResult BaseNavPlanner::findPath(const BaseNavRouteRequest& request) const

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -63,10 +63,15 @@ private:
     std::vector<uint32_t> adjacency_offsets_;
     std::vector<uint32_t> adjacency_links_;
     std::vector<double> triangle_heights_;
+    std::vector<uint32_t> natural_component_ids_;
+    std::vector<uint32_t> natural_component_sizes_;
 
     void buildIndex();
+    void buildNaturalComponents();
     void computeTriangleHeights();
     double triangleAverageHeight(uint32_t triangle_index) const;
+    bool isNaturalNeighbor(uint32_t lhs, uint32_t rhs) const;
+    bool isTraversableLink(uint32_t lhs, uint32_t rhs) const;
     std::array<WorldPoint, 3> trianglePoints(uint32_t triangle_index) const;
     std::optional<std::array<WorldPoint, 2>> sharedEdgePortal(uint32_t lhs, uint32_t rhs) const;
     std::optional<WorldPoint> sharedEdgeMidpoint(uint32_t lhs, uint32_t rhs) const;

--- a/tools/MapNavigator/basenav_preview.py
+++ b/tools/MapNavigator/basenav_preview.py
@@ -16,6 +16,8 @@ BRIDGE_FIXED_COST = 12.0
 BRIDGE_GAP_COST_FACTOR = 3.0
 BRIDGE_HEIGHT_COST_FACTOR = 40.0
 BRIDGE_MAX_HEIGHT_DELTA = 3.0
+SMALL_BRIDGE_COMPONENT_MAX_TRIANGLES = 512
+SMALL_BRIDGE_MAX_GAP = 4.0
 ROUTE_MIN_POINT_DISTANCE = 6.0
 ROUTE_SIMPLIFY_EPSILON = 3.0
 ROUTE_MAX_POINT_DISTANCE = 4.0
@@ -107,6 +109,8 @@ class BaseNavField:
         self.triangle_bounds: list[tuple[float, float, float, float]] = []
         self.bins: dict[tuple[int, int, int], list[int]] = {}
         self.adjacency: list[list[int]] = [[] for _triangle in self.triangles]
+        self.natural_component: list[int] = []
+        self.natural_component_size: list[int] = []
         self.triangle_height: list[float] = []
         self.overlay_cache = {}
         self._build_index()
@@ -210,9 +214,6 @@ class BaseNavField:
         zone_ranges = []
         for zone in self.zones:
             zone_ranges.append((zone.first_triangle, zone.first_triangle + zone.triangle_count, zone.zone_id))
-        for source, target in self.links:
-            if 0 <= source < len(self.adjacency) and 0 <= target < len(self.adjacency):
-                self.adjacency[source].append(target)
         range_index = 0
         for triangle_index, _triangle in enumerate(self.triangles):
             while range_index + 1 < len(zone_ranges) and triangle_index >= zone_ranges[range_index][1]:
@@ -234,6 +235,57 @@ class BaseNavField:
                 for bin_y in range(math.floor(top / self.bin_size), math.floor(bottom / self.bin_size) + 1):
                     self.bins.setdefault((zone_id, bin_x, bin_y), []).append(triangle_index)
         self.triangle_height = [self._triangle_average_height(triangle_index) for triangle_index in range(len(self.triangles))]
+        self._build_natural_components()
+        for source, target in self.links:
+            if self._is_traversable_link(source, target):
+                self.adjacency[source].append(target)
+
+    def _build_natural_components(self) -> None:
+        self.natural_component = [-1] * len(self.triangles)
+        self.natural_component_size = []
+        for triangle_index in range(len(self.triangles)):
+            if self.natural_component[triangle_index] >= 0:
+                continue
+            component_id = len(self.natural_component_size)
+            self.natural_component[triangle_index] = component_id
+            stack = [triangle_index]
+            size = 0
+            while stack:
+                current = stack.pop()
+                size += 1
+                for neighbor in self.triangles[current].neighbors:
+                    if (
+                        neighbor < 0
+                        or neighbor >= len(self.triangles)
+                        or self.natural_component[neighbor] >= 0
+                        or self.triangle_zone[neighbor] != self.triangle_zone[current]
+                    ):
+                        continue
+                    self.natural_component[neighbor] = component_id
+                    stack.append(neighbor)
+            self.natural_component_size.append(size)
+
+    def _is_traversable_link(self, source: int, target: int) -> bool:
+        if (
+            source < 0
+            or source >= len(self.triangles)
+            or target < 0
+            or target >= len(self.triangles)
+            or self.triangle_zone[source] == 0
+            or self.triangle_zone[source] != self.triangle_zone[target]
+        ):
+            return False
+        if target in self.triangles[source].neighbors:
+            return True
+
+        source_component = self.natural_component[source]
+        target_component = self.natural_component[target]
+        min_component_size = min(self.natural_component_size[source_component], self.natural_component_size[target_component])
+        if min_component_size > SMALL_BRIDGE_COMPONENT_MAX_TRIANGLES:
+            return True
+
+        bridge_points = self._closest_edge_bridge_points(source, target)
+        return bridge_points is not None and _point_distance(bridge_points[0], bridge_points[1]) <= SMALL_BRIDGE_MAX_GAP
 
     def _triangle_average_height(self, triangle_index: int) -> float:
         triangle = self.triangles[triangle_index]


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

通过引入自然三角形组件和桥接约束，将导航网格（navmesh）链接限制为可行走的连接，防止路径穿越附近的不可行走区域。

Bug 修复：
- 防止寻路链接在无效或不匹配的区域之间连接三角形，以避免导航穿过不可行走的空隙。
- 基于组件大小和允许的最大间隙距离，限制小而分离的三角形组件之间的桥接式连接，从而避免路线贴近障碍物穿行。

增强功能：
- 在导航网格中计算并存储相连的自然三角形组件，用于将连续的可行走区域分类，以进行链接校验。
- 使 Python `MapNavigator` 预览工具中的邻接关系构建和桥接约束与 C++ 导航规划器逻辑保持一致，以实现一致的可视化和调试行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict navmesh links to traversable connections by introducing natural triangle components and bridge constraints to prevent routes from crossing nearby non-walkable areas.

Bug Fixes:
- Prevent pathfinding links from connecting triangles across invalid or mismatched zones that could cause navigation to cross non-traversable gaps.
- Limit bridge-style connections between small, separate triangle components based on component size and maximum allowed gap distance to avoid routing through near obstacles.

Enhancements:
- Compute and store connected natural components of triangles in the navmesh to classify contiguous walkable areas for link validation.
- Align the Python MapNavigator preview tool’s adjacency construction and bridge constraints with the C++ nav planner logic for consistent visualization and debugging.

</details>