### PR TITLE
fix: 修复万能传送因新地图加入导致的偏移

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -245,10 +245,10 @@
         "desc": "在武陵总览界面，进入武陵-景玉谷地图",
         "action": "Click",
         "target": [
-            480,
-            450,
-            125,
-            80
+            416,
+            369,
+            99,
+            72
         ],
         "next": [
             "__ScenePrivateMapAnyEnterMapWulingJingyuValleySuccess"
@@ -258,9 +258,9 @@
         "desc": "在武陵总览界面，进入武陵-武陵城地图",
         "action": "Click",
         "target": [
-            510,
+            470,
             140,
-            130,
+            100,
             80
         ],
         "next": [
@@ -271,10 +271,10 @@
         "desc": "在武陵总览界面，进入武陵-清波寨地图",
         "action": "Click",
         "target": [
-            770,
-            360,
-            115,
-            55
+            663,
+            293,
+            96,
+            94
         ],
         "next": [
             "__ScenePrivateMapAnyEnterMapWulingQingboStockadeSuccess"
@@ -284,10 +284,10 @@
         "desc": "在武陵总览界面，进入武陵-首墩地图",
         "action": "Click",
         "target": [
-            312,
-            393,
-            75,
-            57
+            277,
+            290,
+            69,
+            89
         ],
         "next": [
             "__ScenePrivateMapAnyEnterMapWulingMarkerStoneSuccess"
@@ -297,10 +297,10 @@
         "desc": "在武陵总览界面，进入武陵-试验园区地图",
         "action": "Click",
         "target": [
-            755,
-            174,
-            99,
-            86
+            699,
+            133,
+            84,
+            71
         ],
         "next": [
             "__ScenePrivateMapAnyEnterMapWulingTestAreaSuccess"


### PR DESCRIPTION
在武陵地图总览页面，因为新地图加入，导致原有地图选择区域中心点向右下偏移；我调整了点击选区以适应新地图加入
close #3419
close #3417

## Summary by Sourcery

错误修复：
- 修复由于新增地图导致五菱地图总览中点击区域对齐不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect click region alignment on the Wuling map overview caused by the addition of a new map.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 修复由于新增地图导致五菱地图总览中点击区域对齐不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect click region alignment on the Wuling map overview caused by the addition of a new map.

</details>

</details>