### PR TITLE
fix(ProtocolSpace): 修复在选择"危境预演"时仍然显示"选择协议空间等级"选项

### DIFF
--- a/assets/tasks/ProtocolSpace.json
+++ b/assets/tasks/ProtocolSpace.json
@@ -12,8 +12,7 @@
                 "ProtocolSpaceSuccessAction",
                 "ProtocolSpaceSuccessCount",
                 "ProtocolSpaceFailedCount",
-                "ProtocolSpaceTab",
-                "ProtocolSpaceLevel"
+                "ProtocolSpaceTab"
             ],
             "controller": [
                 "Win32-Front",
@@ -425,7 +424,8 @@
                         }
                     },
                     "option": [
-                        "OperatorProgression"
+                        "OperatorProgression",
+                        "ProtocolSpaceLevel"
                     ]
                 },
                 {
@@ -450,7 +450,8 @@
                         }
                     },
                     "option": [
-                        "WeaponProgression"
+                        "WeaponProgression",
+                        "ProtocolSpaceLevel"
                     ]
                 },
                 {


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 确保在 ProtocolSpace 中选择“危境预演”选项时，不再显示“选择协议空间等级”的选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure that selecting the "危境预演" option in ProtocolSpace no longer shows the "选择协议空间等级" choice.

</details>