### PR TITLE
ci: 更新Actions版本消除 Node.js 20警告

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -107,7 +107,7 @@ jobs:
           fi
 
       - name: Upload docs sync artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: docs-sync-artifacts
           path: artifacts/
@@ -126,7 +126,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download docs sync artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: docs-sync-artifacts
           path: artifacts

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -48,7 +48,7 @@ jobs:
       repo_sha: ${{ steps.snapshot.outputs.repo_sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.MAAEND_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.repository.default_branch }}
@@ -107,7 +107,7 @@ jobs:
           fi
 
       - name: Upload docs sync artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: docs-sync-artifacts
           path: artifacts/
@@ -119,14 +119,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.MAAEND_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           ref: ${{ needs.prepare.outputs.repo_sha }}
           fetch-depth: 0
 
       - name: Download docs sync artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: docs-sync-artifacts
           path: artifacts

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.MAAEND_BOT_TOKEN }}
           show-progress: false
@@ -26,7 +26,7 @@ jobs:
           cache: "pnpm"
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "stable"
           cache-dependency-path: agent/go-service/go.sum

--- a/.github/workflows/i18n-sync.yml
+++ b/.github/workflows/i18n-sync.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.MAAEND_BOT_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -27,7 +27,7 @@ jobs:
   meta:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - id: set_tag
@@ -91,7 +91,7 @@ jobs:
     runs-on: ${{ matrix.os == 'win' && 'windows-latest' || (matrix.os == 'macos' && 'macos-latest' || 'ubuntu-latest') }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -113,7 +113,7 @@ jobs:
           sdk-version: 26100
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "agent/go-service/go.mod"
           cache-dependency-path: |
@@ -122,7 +122,7 @@ jobs:
 
       - name: Cache MaaDeps
         id: cache-maadeps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ./agent/cpp-algo/MaaUtils/MaaDeps
@@ -201,12 +201,12 @@ jobs:
 
           cat install/interface.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: MaaEnd-${{ matrix.os }}-${{ matrix.arch }}-intermediate
           path: install
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: cpp-algo-${{ matrix.os }}-${{ matrix.arch }}
           path: |
@@ -224,7 +224,7 @@ jobs:
 
     steps:
       - name: Download Linux artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: MaaEnd-linux-${{ matrix.arch }}-intermediate
           path: "install"
@@ -249,7 +249,7 @@ jobs:
           cd install
           tar -czvf ../MaaEnd-linux-${{ matrix.arch }}.tar.gz .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: MaaEnd-linux-${{ matrix.arch }}-tarball
           path: "MaaEnd-linux-${{ matrix.arch }}.tar.gz"
@@ -263,10 +263,10 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download macOS artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: MaaEnd-macos-${{ matrix.arch }}-intermediate
           path: "install"
@@ -356,7 +356,7 @@ jobs:
             "MaaEnd.dmg" \
             "$APP_NAME"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: MaaEnd-macos-${{ matrix.arch }}-dmg
           path: "MaaEnd.dmg"
@@ -370,10 +370,10 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download Windows artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: MaaEnd-win-${{ matrix.arch }}-intermediate
           path: "install"
@@ -409,7 +409,7 @@ jobs:
         run: |
           Compress-Archive -Path install/* -DestinationPath MaaEnd-win-${{ matrix.arch }}.zip
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: MaaEnd-win-${{ matrix.arch }}-zip
           path: "MaaEnd-win-${{ matrix.arch }}.zip"
@@ -422,7 +422,7 @@ jobs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -445,17 +445,17 @@ jobs:
     needs: [meta, package_linux_tarball, package_macos_dmg, package_win_zip, changelog]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: MaaEnd-*-zip
           path: artifacts
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: MaaEnd-*-tarball
           path: artifacts
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: MaaEnd-*-dmg
           path: artifacts

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -104,7 +104,8 @@ jobs:
       - name: Install macOS dependencies
         if: matrix.os == 'macos'
         run: |
-          brew install ninja cmake
+          brew list ninja >/dev/null 2>&1 || brew install ninja
+          brew list cmake >/dev/null 2>&1 || brew install cmake
 
       - name: Setup Windows 10 SDK
         if: matrix.os == 'win'
@@ -201,12 +202,12 @@ jobs:
 
           cat install/interface.json
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: MaaEnd-${{ matrix.os }}-${{ matrix.arch }}-intermediate
           path: install
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: cpp-algo-${{ matrix.os }}-${{ matrix.arch }}
           path: |
@@ -224,7 +225,7 @@ jobs:
 
     steps:
       - name: Download Linux artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: MaaEnd-linux-${{ matrix.arch }}-intermediate
           path: "install"
@@ -249,7 +250,7 @@ jobs:
           cd install
           tar -czvf ../MaaEnd-linux-${{ matrix.arch }}.tar.gz .
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: MaaEnd-linux-${{ matrix.arch }}-tarball
           path: "MaaEnd-linux-${{ matrix.arch }}.tar.gz"
@@ -266,7 +267,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download macOS artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: MaaEnd-macos-${{ matrix.arch }}-intermediate
           path: "install"
@@ -356,7 +357,7 @@ jobs:
             "MaaEnd.dmg" \
             "$APP_NAME"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: MaaEnd-macos-${{ matrix.arch }}-dmg
           path: "MaaEnd.dmg"
@@ -373,7 +374,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download Windows artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: MaaEnd-win-${{ matrix.arch }}-intermediate
           path: "install"
@@ -409,7 +410,7 @@ jobs:
         run: |
           Compress-Archive -Path install/* -DestinationPath MaaEnd-win-${{ matrix.arch }}.zip
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: MaaEnd-win-${{ matrix.arch }}-zip
           path: "MaaEnd-win-${{ matrix.arch }}.zip"
@@ -445,17 +446,17 @@ jobs:
     needs: [meta, package_linux_tarball, package_macos_dmg, package_win_zip, changelog]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v7
         with:
           pattern: MaaEnd-*-zip
           path: artifacts
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v7
         with:
           pattern: MaaEnd-*-tarball
           path: artifacts
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v7
         with:
           pattern: MaaEnd-*-dmg
           path: artifacts

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -61,14 +61,14 @@ jobs:
           echo is_prerelease=$is_prerelease | tee -a $GITHUB_OUTPUT
 
       - id: maafw-latest-release
-        uses: pozetroninc/github-action-get-latest-release@master
+        uses: step-security/github-action-get-latest-release@v0.8.2
         with:
           repository: MaaXYZ/MaaFramework
           excludes: "draft"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - id: mxu-latest-release
-        uses: pozetroninc/github-action-get-latest-release@master
+        uses: step-security/github-action-get-latest-release@v0.8.2
         with:
           repository: MistEO/MXU
           excludes: ${{ (steps.set_tag.outputs.is_release == 'true' && steps.set_tag.outputs.is_prerelease == 'false') && 'prerelease, draft' || 'draft' }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Setup Windows 10 SDK
         if: matrix.os == 'win'
-        uses: GuillaumeFalourd/setup-windows10-sdk-action@v2.2
+        uses: GuillaumeFalourd/setup-windows10-sdk-action@v2.5
         with:
           sdk-version: 26100
 

--- a/.github/workflows/sync-qq-groups.yml
+++ b/.github/workflows/sync-qq-groups.yml
@@ -7,7 +7,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.MAAEND_BOT_TOKEN }}
           show-progress: false

--- a/.github/workflows/sync_schema_files.yml
+++ b/.github/workflows/sync_schema_files.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Check Out Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.MAAEND_BOT_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
   maa-tools-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: logs
           path: tests/maatools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: logs
           path: tests/maatools


### PR DESCRIPTION
当前分支 `chore/upgrade-github-actions-node24` 相对 `v2` 的替换清单如下：

## 第三方 Action（消除 Node.js 20 警告）

| 文件 | 位置 | 旧版 | 新版 | 影响 Job |
| --- | --- | --- | --- | --- |
| `install.yml` | `meta` → MaaFramework | `pozetroninc/github-action-get-latest-release@master` | `step-security/github-action-get-latest-release@v0.8.2` | `meta` |
| `install.yml` | `meta` → MXU | `pozetroninc/github-action-get-latest-release@master` | `step-security/github-action-get-latest-release@v0.8.2` | `meta` |
| `install.yml` | Windows SDK 安装 | `GuillaumeFalourd/setup-windows10-sdk-action@v2.2` | `GuillaumeFalourd/setup-windows10-sdk-action@v2.5` | `build_and_install (win, *)` |

## 官方 Action 版本升级

| Action | 旧版 | 新版 | 涉及文件 |
| --- | --- | --- | --- |
| `actions/checkout` | v4 / v5 | **v6** | `install.yml`、`docs-sync.yml`、`format.yml`、`i18n-sync.yml`、`sync-qq-groups.yml`、`sync_schema_files.yml`、`test.yml` |
| `actions/upload-artifact` | v4 | **v6** | `install.yml`、`docs-sync.yml`、`test.yml` |
| `actions/download-artifact` | v4 | **v7** | `install.yml`、`docs-sync.yml` |
| `actions/setup-go` | v5 | **v6** | `install.yml`、`format.yml` |
| `actions/cache` | v4 | **v5** | `install.yml` |

## 其他脚本调整（非 Action 替换）

| 文件 | 改动 |
| --- | --- |
| `install.yml` | macOS 依赖安装改为「已安装则跳过」：`brew list ... \|\| brew install ...` |

## 按 Workflow 汇总

| Workflow | 改动项数 |
| --- | --- |
| `install.yml` | 最多：2 个第三方 action + 全套官方 action 升级 + macOS brew 逻辑 |
| `docs-sync.yml` | checkout、upload-artifact、download-artifact |
| `format.yml` | checkout、setup-go |
| `test.yml` | checkout、upload-artifact |
| `i18n-sync.yml` | checkout |
| `sync-qq-groups.yml` | checkout |
| `sync_schema_files.yml` | checkout |

**未改动的 action**（`install.yml` 等）：`robinraju/release-downloader@v1`、`orhun/git-cliff-action@v4`、`softprops/action-gh-release@v2`、`actions/setup-go` 以外的 pnpm/node 相关步骤等。

## 由 Sourcery 提供的摘要

更新 GitHub Actions 工作流程，使用与 Node.js 20 兼容的较新版 Action，并改进安装流水线中在 macOS 上安装依赖的行为。

Build：
- 在所有工作流程中将 `actions/checkout` 提升到 v6。
- 将使用到的 `actions/upload-artifact` 升级到 v6，`actions/download-artifact` 升级到 v7。
- 在格式化和安装工作流程中将 `actions/setup-go` 更新到 v6。
- 在安装工作流程中将 `actions/cache` 升级到 v5。
- 使用 `step-security/github-action-get-latest-release@v0.8.2` 替换 `pozetroninc/github-action-get-latest-release` 来解析发布元数据。
- 在安装工作流程中将 `GuillaumeFalourd/setup-windows10-sdk-action` 更新到 v2.5。
- 修改安装工作流程中在 macOS 上安装依赖的逻辑，跳过对已存在的 Homebrew 包的重新安装。

CI：
- 刷新所有 CI 工作流程（install、docs-sync、format、test、i18n-sync、sync-qq-groups、sync_schema_files），使其使用更新后的 GitHub Actions 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GitHub Actions workflows to use newer, Node.js 20–compatible action versions and improve macOS dependency installation behavior in the install pipeline.

Build:
- Bump actions/checkout to v6 across all workflows.
- Upgrade actions/upload-artifact to v6 and actions/download-artifact to v7 where used.
- Update actions/setup-go to v6 in formatting and install workflows.
- Upgrade actions/cache to v5 in the install workflow.
- Replace pozetroninc/github-action-get-latest-release with step-security/github-action-get-latest-release@v0.8.2 for release metadata resolution.
- Update GuillaumeFalourd/setup-windows10-sdk-action to v2.5 in the install workflow.
- Change macOS dependency installation in install workflow to skip reinstalling already-present Homebrew packages.

CI:
- Refresh all CI workflows (install, docs-sync, format, test, i18n-sync, sync-qq-groups, sync_schema_files) to use the updated GitHub Actions versions.

</details>