### PR TITLE
feat(tools): 优化MapTracker路径编辑工具的导出体验

### DIFF
--- a/tools/map_tracker/_internal/core_utils.py
+++ b/tools/map_tracker/_internal/core_utils.py
@@ -501,7 +501,14 @@ class ViewportManager:
         self._vx = real_x - view_w / 2.0
         self._vy = real_y - view_h / 2.0
 
-    def fit_to(self, real_points: list[Point], padding: float = 0.3) -> None:
+    def fit_to(
+        self,
+        real_points: list[Point],
+        *,
+        padding: float,
+        min_zoom: float,
+        max_zoom: float,
+    ) -> None:
         if not real_points:
             return
         min_x = min(p[0] for p in real_points)
@@ -515,7 +522,7 @@ class ViewportManager:
         fit_w = max(1.0, self._vw * (1.0 - 2.0 * padding))
         fit_h = max(1.0, self._vh * (1.0 - 2.0 * padding))
         target_zoom = min(fit_w / span_x, fit_h / span_y)
-        self.zoom = target_zoom
+        self.zoom = max(min_zoom, min(max_zoom, target_zoom))
 
         view_w = self._vw / self._zoom
         view_h = self._vh / self._zoom

--- a/tools/map_tracker/_internal/core_utils.py
+++ b/tools/map_tracker/_internal/core_utils.py
@@ -505,9 +505,9 @@ class ViewportManager:
         self,
         real_points: list[Point],
         *,
-        padding: float,
-        min_zoom: float,
-        max_zoom: float,
+        padding: float = 0.0,
+        min_zoom: float | None = None,
+        max_zoom: float | None = None,
     ) -> None:
         if not real_points:
             return
@@ -521,7 +521,10 @@ class ViewportManager:
         padding = max(0.0, min(0.49, padding))
         fit_w = max(1.0, self._vw * (1.0 - 2.0 * padding))
         fit_h = max(1.0, self._vh * (1.0 - 2.0 * padding))
+
         target_zoom = min(fit_w / span_x, fit_h / span_y)
+        min_zoom = self._min_zoom if min_zoom is None else max(self._min_zoom, min_zoom)
+        max_zoom = self._max_zoom if max_zoom is None else min(self._max_zoom, max_zoom)
         self.zoom = max(min_zoom, min(max_zoom, target_zoom))
 
         view_w = self._vw / self._zoom

--- a/tools/map_tracker/_internal/gui_pages.py
+++ b/tools/map_tracker/_internal/gui_pages.py
@@ -3,7 +3,14 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from .core_utils import Drawer, MapImageLayer, MapName, ViewportManager, cv2
+from .core_utils import (
+    Drawer,
+    MapImageLayer,
+    MapName,
+    ViewportManager,
+    clipboard_copy_text,
+    cv2,
+)
 from .gui_widgets import Button, DropdownSelectWidget, ScrollableListWidget, WidgetGroup
 from .sprite_utils import get_sprite_image
 
@@ -587,6 +594,200 @@ class MapImageSelectStep(StepPage):
         if self._on_select is None:
             raise NotImplementedError()
         self._on_select(map_name)
+
+
+class ExportStringPage(StepPage):
+    """A reusable wizard page that previews, copies, and prints export strings."""
+
+    MAX_OPTIONS = 3
+
+    def __init__(self, title: str, options: dict[str, str]):
+        if len(options) > self.MAX_OPTIONS:
+            raise ValueError(f"ExportStringPage supports at most {self.MAX_OPTIONS} options")
+        super().__init__(StepData(title))
+        self.options = list(options.items())
+        self._export_group = WidgetGroup((0, 0, self.WINDOW_W, self.WINDOW_H))
+        self.groups.append(self._export_group)
+        self._copy_buttons: list[Button] = []
+        self._print_buttons: list[Button] = []
+        self._status_text = ""
+        self._status_color = 0xFFFFFF
+
+        for label, text in self.options:
+            self._copy_buttons.append(
+                Button(
+                    (-100, -100, -90, -90),
+                    "Copy",
+                    base_color=0x2E6FD1,
+                    on_click=self._make_copy_handler(label, text),
+                    font_scale=0.45,
+                )
+            )
+            self._print_buttons.append(
+                Button(
+                    (-100, -100, -90, -90),
+                    "Print",
+                    base_color=0x3C643C,
+                    on_click=self._make_print_handler(text),
+                    font_scale=0.45,
+                )
+            )
+
+    def _make_copy_handler(self, label: str, text: str) -> Callable[[], None]:
+        def on_copy() -> None:
+            if clipboard_copy_text(text):
+                self._clear_status()
+            else:
+                self._set_status(0xFC4040, f"Failed to copy {label}.")
+            self.render_request()
+
+        return on_copy
+
+    def _make_print_handler(self, text: str) -> Callable[[], None]:
+        def on_print() -> None:
+            print(text)
+            self._clear_status()
+            self.render_request()
+
+        return on_print
+
+    def _set_status(self, color: int, text: str) -> None:
+        self._status_color = color
+        self._status_text = text
+
+    def _clear_status(self) -> None:
+        self._status_text = ""
+
+    def _truncate_line(
+        self,
+        drawer: Drawer,
+        line: str,
+        *,
+        font_scale: float,
+        max_width: int,
+    ) -> str:
+        if drawer.get_text_size(line, font_scale)[0] <= max_width:
+            return line
+
+        suffix = "..."
+        lo = 0
+        hi = len(line)
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            candidate = line[:mid] + suffix
+            if drawer.get_text_size(candidate, font_scale)[0] <= max_width:
+                lo = mid
+            else:
+                hi = mid - 1
+        return line[:lo] + suffix
+
+    def _render_preview(
+        self,
+        drawer: Drawer,
+        text: str,
+        rect: tuple[int, int, int, int],
+    ) -> None:
+        x1, y1, x2, y2 = rect
+        drawer.rect((x1, y1), (x2, y2), color=0x000000, thickness=-1)
+        drawer.rect((x1, y1), (x2, y2), color=0x444455, thickness=1)
+
+        pad = 10
+        font_scale = 0.38
+        line_h = 18
+        max_lines = max(1, (y2 - y1 - pad * 2) // line_h)
+        lines = text.splitlines() or [""]
+        if len(lines) > max_lines:
+            lines = lines[: max_lines - 1] + ["..."]
+
+        max_width = max(1, x2 - x1 - pad * 2)
+        text_y = y1 + pad + 13
+        for line in lines:
+            drawer.text(
+                self._truncate_line(
+                    drawer,
+                    line,
+                    font_scale=font_scale,
+                    max_width=max_width,
+                ),
+                (x1 + pad, text_y),
+                font_scale,
+                color=0xFFFFFF,
+            )
+            text_y += line_h
+
+    def _render_content(self, drawer: Drawer) -> None:
+        self._export_group.set_rect((0, 0, self.WINDOW_W, self.WINDOW_H))
+        self._export_group.clear()
+
+        count = max(1, len(self.options))
+        left = 50
+        right = self.WINDOW_W - 50
+        top = 105
+        option_gap = 20
+        header_h = 32
+        preview_h = self.WINDOW_H - self.FOOTER_H - top - header_h - 45
+        button_w = 70
+        button_gap = 8
+        row_h = 30
+        column_w = (right - left - option_gap * (count - 1)) // count
+
+        for idx, (label, text) in enumerate(self.options):
+            x = left + idx * (column_w + option_gap)
+            y = top
+            label_w = column_w - button_w * 2 - button_gap * 2
+            label_rect = (x, y, x + label_w, y + row_h)
+            copy_rect = (
+                label_rect[2] + button_gap,
+                y,
+                label_rect[2] + button_gap + button_w,
+                y + row_h,
+            )
+            print_rect = (
+                copy_rect[2] + button_gap,
+                y,
+                copy_rect[2] + button_gap + button_w,
+                y + row_h,
+            )
+
+            drawer.rect(
+                (label_rect[0], label_rect[1]),
+                (label_rect[2], label_rect[3]),
+                color=0x132B4F,
+                thickness=-1,
+            )
+            drawer.rect(
+                (label_rect[0], label_rect[1]),
+                (label_rect[2], label_rect[3]),
+                color=0x223044,
+                thickness=1,
+            )
+            drawer.text(
+                self._truncate_line(
+                    drawer,
+                    label,
+                    font_scale=0.42,
+                    max_width=max(1, label_w - 20),
+                ),
+                (label_rect[0] + 10, label_rect[3] - 9),
+                0.42,
+                color=0xFFFFFF,
+            )
+            self._export_group.add_button(self._copy_buttons[idx], copy_rect)
+            self._export_group.add_button(self._print_buttons[idx], print_rect)
+
+            self._render_preview(
+                drawer,
+                text,
+                (x, y + header_h, x + column_w, y + header_h + preview_h),
+            )
+
+        if self._status_text:
+            drawer.text_centered(
+                self._status_text,
+                (self.WINDOW_W // 2, self.WINDOW_H - self.FOOTER_H - 18),
+                0.55,
+                color=self._status_color,
+            )
 
 
 class PageStepper:

--- a/tools/map_tracker/map_tracker_editor.py
+++ b/tools/map_tracker/map_tracker_editor.py
@@ -453,7 +453,7 @@ class PathEditPage(MapViewportPage):
 
     def _fit_view_to_points_or_map(self) -> None:
         if self.points:
-            self.view.fit_to(self.points)
+            self.view.fit_to(self.points, padding=0.3, min_zoom=1.0, max_zoom=5.0)
             return
         img_h, img_w = self.img.shape[:2]
         self.view.fit_to([(0, 0), (img_w, img_h)], padding=0.02)
@@ -572,9 +572,9 @@ class PathEditPage(MapViewportPage):
         if d_mid_next < (k - 1) + 1e-6:
             return True
         d_prev_mid = math.hypot(prev_mid_dx, prev_mid_dy)
-        sin_delta_theta = abs(
-            prev_mid_dx * mid_next_dy - prev_mid_dy * mid_next_dx
-        ) / (d_prev_mid * d_mid_next + 1e-6)
+        sin_delta_theta = abs(prev_mid_dx * mid_next_dy - prev_mid_dy * mid_next_dx) / (
+            d_prev_mid * d_mid_next + 1e-6
+        )
         # y = arcsin(k / (x + 1)) -> sin(y) = k / (x + 1) -> sin(y) * (x + 1) = k
         return sin_delta_theta * (d_mid_next + 1) < k
 
@@ -1112,7 +1112,9 @@ class AreaEditPage(MapViewportPage):
     def _fit_view_to_target_or_map(self) -> None:
         if self.target is not None:
             x, y, w, h = self.target
-            self.view.fit_to([(x, y), (x + w, y + h)], padding=0.2)
+            self.view.fit_to(
+                [(x, y), (x + w, y + h)], padding=0.2, min_zoom=1.0, max_zoom=5.0
+            )
             return
         img_h, img_w = self.img.shape[:2]
         self.view.fit_to([(0, 0), (img_w, img_h)], padding=0.02)

--- a/tools/map_tracker/map_tracker_editor.py
+++ b/tools/map_tracker/map_tracker_editor.py
@@ -19,7 +19,6 @@ from typing import NamedTuple
 from _internal.core_utils import (
     _G,
     _Y,
-    _C,
     _0,
     Color,
     Drawer,
@@ -35,6 +34,7 @@ from _internal.gui_pages import (
     StepPage,
     PageStepper,
     MapImageSelectStep,
+    ExportStringPage,
 )
 from _internal.gui_widgets import (
     Button,
@@ -226,8 +226,9 @@ class PathEditPage(MapViewportPage):
         )
         self._finish_button = Button(
             (-100, -100, -90, -90),
-            "Finish",
+            "[E] Export",
             base_color=0x3C643C,
+            hotkey=(ord("e"), ord("E")),
             on_click=self._on_click_finish,
             font_scale=0.45,
         )
@@ -750,7 +751,6 @@ class PathEditPage(MapViewportPage):
         btn_w = sw - pad * 2
         btn_x0 = pad
         has_pipeline = self.pipeline_context is not None
-        dirty = self.is_dirty
 
         record_y0 = cy
         record_y1 = cy + btn_h
@@ -795,15 +795,15 @@ class PathEditPage(MapViewportPage):
             save_y1 = cy + btn_h
             save_rect = (btn_x0, save_y0, btn_x0 + btn_w, save_y1)
             self._save_button.text = "[S] Save"
-            self._save_button.base_color = 0x64C800 if dirty else 0x3C643C
-            self._save_button.text_color = 0xFFFFFF if dirty else 0x648264
+            self._save_button.base_color = 0x3C643C
+            self._save_button.text_color = 0xFFFFFF if self.is_dirty else 0x648264
             self._sidebar_group.add_button(self._save_button, save_rect)
             cy = save_y1 + 8
 
         finish_y0 = cy
         finish_y1 = cy + btn_h
         finish_rect = (btn_x0, finish_y0, btn_x0 + btn_w, finish_y1)
-        self._finish_button.text = "Finish"
+        self._finish_button.text = "[E] Export"
         self._finish_button.base_color = 0x4C4C64 if has_pipeline else 0x3C643C
         self._finish_button.text_color = 0xFFFFFF
         self._sidebar_group.add_button(self._finish_button, finish_rect)
@@ -1073,8 +1073,9 @@ class AreaEditPage(MapViewportPage):
         )
         self._finish_button = Button(
             (-100, -100, -90, -90),
-            "Finish",
+            "[E] Export",
             base_color=0x3C643C,
+            hotkey=(ord("e"), ord("E")),
             on_click=self._on_click_finish,
             font_scale=0.45,
         )
@@ -1199,7 +1200,7 @@ class AreaEditPage(MapViewportPage):
         has_pipeline = self.pipeline_context is not None
         if has_pipeline:
             save_rect = (btn_x0, cy, btn_x0 + btn_w, cy + btn_h)
-            self._save_button.base_color = 0x64C800 if self.is_dirty else 0x3C643C
+            self._save_button.base_color = 0x3C643C
             self._save_button.text_color = 0xFFFFFF if self.is_dirty else 0x648264
             self._sidebar_group.add_button(self._save_button, save_rect)
             cy += btn_h + 8
@@ -1623,177 +1624,90 @@ class EditorAdapterStep(BasePage):
         return self.editor.consume_key(key)
 
 
-class ExportStep(StepPage):
+class ExportStep(ExportStringPage):
     def __init__(
         self, points, import_context, map_name, *, node_type: str = NODE_TYPE_MOVE
     ):
-        super().__init__(StepData("Export / Save Result"))
         self.points = points
         self.import_context = import_context
         self.map_name = map_name
         self.node_type = node_type
+        super().__init__("Export Result", self._build_export_options())
 
-        self.options = [
-            {
-                "label": (
-                    "Just Save to File (Replace path)"
-                    if node_type == NODE_TYPE_MOVE
-                    else "Just Save to File (Replace target)"
-                ),
-                "data": "S",
-                "disabled": import_context is None,
-            },
-            {"label": "Print Context Dict", "data": "D"},
-            {"label": "Print Node JSON", "data": "J"},
-            {
-                "label": (
-                    "Print Point List"
-                    if node_type == NODE_TYPE_MOVE
-                    else "Print Target Rect"
-                ),
-                "data": "L",
-            },
-        ]
-        self.list_widget = ScrollableListWidget(45)
-        self.list_widget.set_items(self.options)
-        self.saved_text = ""
+    def _build_map_stem(self) -> str:
+        raw_map_name = (
+            self.import_context.get("original_map_name", self.map_name)
+            if self.import_context
+            else self.map_name
+        )
+        return os.path.splitext(os.path.basename(raw_map_name))[0]
 
-    def _render_content(self, drawer):
-        self.list_widget.render(drawer, (100, 150, self.WINDOW_W - 100, 350))
-        if self.saved_text:
-            drawer.text_centered(
-                self.saved_text, (self.WINDOW_W // 2, 450), 0.8, color=0x50DC50
-            )
-
-    def _handle_content_mouse(self, event, x, y, flags, param):
-        if self.list_widget.consume_mouse(event, x, y, flags):
-            if self.list_widget.submitted_idx >= 0:
-                self._submit(
-                    self.list_widget.items[self.list_widget.submitted_idx]["data"]
-                )
-            else:
-                self.stepper.request_render()
-            return
-
-    def _handle_content_key(self, key):
-        if self.list_widget.consume_key(key):
-            if self.list_widget.submitted_idx >= 0:
-                self._submit(
-                    self.list_widget.items[self.list_widget.submitted_idx]["data"]
-                )
-            else:
-                self.stepper.request_render()
-            return
-
-    def _submit(self, mode):
-        if mode == "S":
-            handler = self.import_context["handler"]
-            node_name = self.import_context["node_name"]
-            if self.node_type == NODE_TYPE_ASSERT_LOCATION:
-                raw_map_name = self.import_context.get(
-                    "original_map_name", self.map_name
-                )
-                map_name_stem = os.path.splitext(os.path.basename(raw_map_name))[0]
-                ok = handler.replace_assert_location(
-                    node_name, map_name_stem, self.points
-                )
-            else:
-                ok = handler.replace_path(node_name, self.points)
-            if ok:
-                self.saved_text = f"Successfully updated node '{node_name}'!"
-                print(f"\n{_G}Successfully updated node {_0}'{node_name}'")
-            else:
-                self.saved_text = "Failed to update node!"
-            self.stepper.request_render()
-
-        elif mode == "J":
-            raw_map_name = (
-                self.import_context.get("original_map_name", self.map_name)
-                if self.import_context
-                else self.map_name
-            )
-            map_stem = os.path.splitext(os.path.basename(raw_map_name))[0]
-            if self.node_type == NODE_TYPE_ASSERT_LOCATION:
-                param_data = {
-                    "expected": [
-                        {
-                            "map_name": map_stem,
-                            "target": [round(float(v), 1) for v in self.points],
-                        }
-                    ]
-                }
-                node_data = {
-                    "recognition": "Custom",
-                    "custom_recognition": NODE_TYPE_ASSERT_LOCATION,
-                    "custom_recognition_param": param_data,
-                    "action": "DoNothing",
-                }
-            else:
-                param_data = {
-                    "map_name": map_stem,
-                    "path": [[round(p[0], 1), round(p[1], 1)] for p in self.points],
-                }
-                is_new = (
-                    self.import_context.get("is_new_structure", False)
-                    if self.import_context
-                    else False
-                )
-                if is_new:
-                    node_data = {
-                        "action": {
-                            "custom_action": NODE_TYPE_MOVE,
-                            "custom_action_param": param_data,
-                        }
+    def _build_param_data(self) -> dict:
+        map_stem = self._build_map_stem()
+        if self.node_type == NODE_TYPE_ASSERT_LOCATION:
+            return {
+                "expected": [
+                    {
+                        "map_name": map_stem,
+                        "target": [round(float(v), 1) for v in self.points],
                     }
-                else:
-                    node_data = {
-                        "action": "Custom",
-                        "custom_action": NODE_TYPE_MOVE,
-                        "custom_action_param": param_data,
-                    }
-            print(f"\n{_C}--- JSON Snippet ---{_0}\n")
-            print(json.dumps({"NodeName": node_data}, indent=4, ensure_ascii=False))
-            self.saved_text = "JSON output printed to terminal!"
-            self.stepper.request_render()
+                ]
+            }
+        return {
+            "map_name": map_stem,
+            "path": [[round(p[0], 1), round(p[1], 1)] for p in self.points],
+        }
 
-        elif mode == "D":
-            raw_map_name = (
-                self.import_context.get("original_map_name", self.map_name)
-                if self.import_context
-                else self.map_name
-            )
-            map_stem = os.path.splitext(os.path.basename(raw_map_name))[0]
-            if self.node_type == NODE_TYPE_ASSERT_LOCATION:
-                param_data = {
-                    "expected": [
-                        {
-                            "map_name": map_stem,
-                            "target": [round(float(v), 1) for v in self.points],
-                        }
-                    ]
-                }
-            else:
-                param_data = {
-                    "map_name": map_stem,
-                    "path": [[round(p[0], 1), round(p[1], 1)] for p in self.points],
-                }
-            print(f"\n{_C}--- Parameters Dict ---{_0}\n")
-            print(json.dumps(param_data, indent=4, ensure_ascii=False))
-            self.saved_text = "Dict output printed to terminal!"
-            self.stepper.request_render()
+    def _build_node_data(self) -> dict:
+        param_data = self._build_param_data()
+        if self.node_type == NODE_TYPE_ASSERT_LOCATION:
+            return {
+                "recognition": "Custom",
+                "custom_recognition": NODE_TYPE_ASSERT_LOCATION,
+                "custom_recognition_param": param_data,
+                "action": "DoNothing",
+            }
 
-        elif mode == "L":
-            if self.node_type == NODE_TYPE_ASSERT_LOCATION:
-                target_rect = [round(float(v), 1) for v in self.points]
-                print(f"\n{_C}--- Target Rect ---{_0}\n")
-                print(target_rect)
-                self.saved_text = "Target rect printed to terminal!"
-            else:
-                point_list = [[round(p[0], 1), round(p[1], 1)] for p in self.points]
-                print(f"\n{_C}--- Point List ---{_0}\n")
-                print(point_list)
-                self.saved_text = "Point list printed to terminal!"
-            self.stepper.request_render()
+        is_new = (
+            self.import_context.get("is_new_structure", False)
+            if self.import_context
+            else False
+        )
+        if is_new:
+            return {
+                "action": {
+                    "custom_action": NODE_TYPE_MOVE,
+                    "custom_action_param": param_data,
+                }
+            }
+        return {
+            "action": "Custom",
+            "custom_action": NODE_TYPE_MOVE,
+            "custom_action_param": param_data,
+        }
+
+    def _build_list_text(self) -> str:
+        if self.node_type == NODE_TYPE_ASSERT_LOCATION:
+            target_rect = [round(float(v), 1) for v in self.points]
+            return json.dumps(target_rect, ensure_ascii=False)
+        point_list = [[round(p[0], 1), round(p[1], 1)] for p in self.points]
+        return json.dumps(point_list, ensure_ascii=False)
+
+    def _build_export_options(self) -> dict[str, str]:
+        list_label = (
+            "Point List Export"
+            if self.node_type == NODE_TYPE_MOVE
+            else "Target Rect Export"
+        )
+        return {
+            "JSON Dict Export": json.dumps(
+                self._build_param_data(), indent=4, ensure_ascii=False
+            ),
+            "Node JSON Export": json.dumps(
+                {"NodeName": self._build_node_data()}, indent=4, ensure_ascii=False
+            ),
+            list_label: self._build_list_text(),
+        }
 
 
 class RegionEditorAdapterStep(BasePage):


### PR DESCRIPTION
## 概要

此 PR 对 MapTracker 路径编辑工具的导出体验进行了优化。此外优化了初始缩放参数。

## Summary by Sourcery

改进 MapTracker 路径编辑器的导出用户体验，并调整默认视图适配行为。

新功能：
- 添加 `ExportStringPage`，用于预览、复制和打印多种导出字符串变体。
- 通过新的导出页面，从路径编辑器中提供 JSON 字典、节点 JSON，以及点/目标列表的导出功能。

增强优化：
- 将 Finish 操作重命名为更明确的「[E] Export」按钮，并绑定导出快捷键以便更快速地访问。
- 优化初始视图与目标视图的适配行为，使用受限缩放级别以获得更一致的地图缩放效果。
- 简化并集中构建用于导出的地图路径和 assert-location 节点数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the MapTracker path editor’s export UX and adjust default view fitting behavior.

New Features:
- Add an ExportStringPage for previewing, copying, and printing multiple export string variants.
- Expose JSON dict, node JSON, and point/target list exports from the path editor through the new export page.

Enhancements:
- Rename the Finish action to an explicit "[E] Export" button and bind an export hotkey for quicker access.
- Refine initial and target view fitting to use bounded zoom levels for more consistent map scaling.
- Simplify and centralize export data construction for map path and assert-location nodes.

</details>