### PR TITLE
fix: 抢委托 all_of index 错误

### DIFF
--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobs.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobs.json
@@ -250,7 +250,7 @@
                 ]
             }
         ],
-        "box_index": 4,
+        "box_index": 3,
         "action": "Click",
         "post_wait_freezes": {
             "time": 2000,


### PR DESCRIPTION
fix #3451

## Summary by Sourcery

Bug Fixes:
- 修复了抢委托的 `SeizeDeliveryJobs.json` 流水线资源中配置错误的 `all_of` 索引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix misconfigured all_of index in the SeizeDeliveryJobs.json pipeline resource for抢委托.

</details>