### PR TITLE
fix(ProdManual): 新增点击领取后的延迟，避免动画未加载完就识别

### DIFF
--- a/assets/resource/pipeline/ProdManual.json
+++ b/assets/resource/pipeline/ProdManual.json
@@ -146,6 +146,7 @@
                 ]
             }
         },
+        "pre_wait_freezes": 400,
         "action": {
             "type": "Click",
             "param": {}
@@ -557,7 +558,8 @@
             "type": "Click",
             "param": {}
         },
-        "next": [
+         "post_wait_freezes": 400,
+        "next": [   
             "ProdManualConfirmReward"
         ],
         "focus": {

--- a/assets/resource/pipeline/ProdManual.json
+++ b/assets/resource/pipeline/ProdManual.json
@@ -558,7 +558,7 @@
             "type": "Click",
             "param": {}
         },
-         "post_wait_freezes": 400,
+        "post_wait_freezes": 400,
         "next": [   
             "ProdManualConfirmReward"
         ],

--- a/assets/resource/pipeline/ProdManual.json
+++ b/assets/resource/pipeline/ProdManual.json
@@ -146,7 +146,6 @@
                 ]
             }
         },
-        "pre_wait_freezes": 400,
         "action": {
             "type": "Click",
             "param": {}
@@ -182,6 +181,7 @@
                 ]
             }
         }
+            "post_wait_freezes": 400,
     },
     "ProdManualOpenInBackpack": {
         "recognition": {

--- a/assets/resource/pipeline/ProdManual.json
+++ b/assets/resource/pipeline/ProdManual.json
@@ -180,8 +180,8 @@
                     -28
                 ]
             }
-        }
-            "post_wait_freezes": 400,
+        },
+            "post_wait_freezes": 400
     },
     "ProdManualOpenInBackpack": {
         "recognition": {

--- a/assets/resource/pipeline/ProdManual.json
+++ b/assets/resource/pipeline/ProdManual.json
@@ -128,6 +128,7 @@
             "type": "Click",
             "param": {}
         },
+        "post_wait_freezes": 400,
         "next": [
             "ProdManualNext",
             "ProdManualConfirmUpdate",
@@ -180,8 +181,7 @@
                     -28
                 ]
             }
-        },
-            "post_wait_freezes": 400
+        }
     },
     "ProdManualOpenInBackpack": {
         "recognition": {


### PR DESCRIPTION
fix #2327
 新增两处延迟
 1.点击领取后的post_wait_freezes
 2.ProdManualConfirmReward后的post_wait_freezes
 产物升级页可能在单个领取中接续一般奖励领取后出现，所以也加一个延迟

## Summary by Sourcery

在 ProdManual 流水线中添加计时延迟，以确保在奖励识别和商品升级处理之前，动画能够完整播放完毕。

Bug 修复：
- 在点击领取奖励后延迟处理，避免在动画结束前就识别奖励。
- 在商品升级页面引入预延迟，包括在其跟随正常奖励领取之后的情况，以防止过早识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add timing delays to the ProdManual pipeline to ensure animations complete before reward recognition and product upgrade handling.

Bug Fixes:
- Delay processing after clicking reward claim to avoid recognizing rewards before animations finish.
- Introduce a pre-delay on the product upgrade page, including when it follows a normal reward claim, to prevent premature recognition.

</details>

## Summary by Sourcery

在 ProdManual 流程中添加计时延迟，确保在动画完成后才进行奖励识别和产品升级处理。

Bug 修复：
- 在 ProdManual 流程中点击领取奖励后增加处理延迟，避免在领取动画完成前就识别奖励。
- 在产品升级页面（包括在正常领取奖励之后进入该页面的情况）添加确认后的延迟，以防止过早进行识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add timing delays to the ProdManual pipeline to ensure reward recognition and product upgrade handling occur only after animations complete.

Bug Fixes:
- Delay processing after clicking reward claim in the ProdManual flow to avoid recognizing rewards before the completion of claim animations.
- Introduce a post-confirmation delay on the product upgrade page, including when it follows a normal reward claim, to prevent premature recognition.

</details>