### PR TITLE
feat: 自动战斗时显卡资源不足增加提示

### DIFF
--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -87,8 +87,52 @@ func getCharactorLevelShow(ctx *maa.Context, img image.Image) bool {
 	return detail.Hit
 }
 
+// captureDurationTracker 统计截图识别的平均耗时：每 reportWindow 计算一次窗口内平均值并重置，
+// 若平均耗时超过 alertThreshold，则通过 maafocus 提醒用户降低显卡资源占用。
+type captureDurationTracker struct {
+	reportWindow   time.Duration
+	alertThreshold time.Duration
+	total          time.Duration
+	count          int
+	windowStart    time.Time
+}
+
+// record 累计一次耗时，并在窗口结束时返回该窗口的平均耗时（毫秒）；
+// 仅当窗口刚结束时 ok 为 true，否则 ok 为 false。
+func (t *captureDurationTracker) record(d time.Duration) (avgMs int64, ok bool) {
+	now := time.Now()
+	if t.windowStart.IsZero() {
+		t.windowStart = now
+	}
+	t.total += d
+	t.count++
+
+	if now.Sub(t.windowStart) < t.reportWindow {
+		return 0, false
+	}
+
+	avg := t.total / time.Duration(t.count)
+	t.total = 0
+	t.count = 0
+	t.windowStart = now
+	return avg.Milliseconds(), true
+}
+
+var capturePerf = &captureDurationTracker{
+	reportWindow:   5 * time.Second,
+	alertThreshold: 500 * time.Millisecond,
+}
+
 // captureAndUpdateScreenDetail 因 DirectHit 耗时 50ms，在 action 里直接截图并更新屏幕分析状态。
 func captureAndUpdateScreenDetail(ctx *maa.Context) (image.Image, bool) {
+	start := time.Now()
+	defer func() {
+		if avgMs, ok := capturePerf.record(time.Since(start)); ok &&
+			time.Duration(avgMs)*time.Millisecond > capturePerf.alertThreshold {
+			maafocus.Print(ctx, i18n.T("autofight.capture_slow", avgMs))
+		}
+	}()
+
 	ctx.GetTasker().GetController().PostScreencap().Wait()
 	img, err := ctx.GetTasker().GetController().CacheImage()
 	if err != nil {

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -49,6 +49,7 @@
     "autofight.health_dangerous_switch": "Operator #%d health critical, switching to operator #%d",
     "autofight.enemy_accumulating_power": "Enemy is accumulating power",
     "autofight.exit_fight": "Exiting combat",
+    "autofight.capture_slow": "Combat recognition averages %d ms, please try to reduce GPU resource usage",
     "autofight.adjust_view": "Adjusting view",
     "autofight.move_back": "Enemy not found for a while, moving back",
     "autofight.move_forward": "Enemy not found for a while, moving forward",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -49,6 +49,7 @@
     "autofight.health_dangerous_switch": "オペレーター %d 号のHPが危険、%d 号に切り替えます",
     "autofight.enemy_accumulating_power": "敵がチャージ中",
     "autofight.exit_fight": "戦闘シーンを離脱",
+    "autofight.capture_slow": "戦闘認識の平均処理時間が %d ms です。GPU リソースの使用を減らしてください",
     "autofight.adjust_view": "視点を調整",
     "autofight.move_back": "敵が長時間見つからないため、後退します",
     "autofight.move_forward": "敵が長時間見つからないため、前進します",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -49,6 +49,7 @@
     "autofight.health_dangerous_switch": "%d번 오퍼레이터 체력 위험, %d번 오퍼레이터로 전환합니다",
     "autofight.enemy_accumulating_power": "적이 차징 중",
     "autofight.exit_fight": "전투 장면 이탈",
+    "autofight.capture_slow": "전투 인식 평균 소요 시간 %d ms, GPU 리소스 사용을 줄여 주세요",
     "autofight.adjust_view": "시점 조정",
     "autofight.move_back": "적을 오래 찾지 못해 후퇴합니다",
     "autofight.move_forward": "적을 오래 찾지 못해 전진합니다",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -49,6 +49,7 @@
     "autofight.health_dangerous_switch": "当前 %d 号干员血量危险，切换到 %d 号干员",
     "autofight.enemy_accumulating_power": "敌人正在蓄力",
     "autofight.exit_fight": "退出战斗场景",
+    "autofight.capture_slow": "战斗识别平均耗时 %d ms，请尝试减少显卡资源占用",
     "autofight.adjust_view": "调整视角",
     "autofight.move_back": "长时间找不到敌人，后退",
     "autofight.move_forward": "长时间找不到敌人，前进",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -49,6 +49,7 @@
     "autofight.health_dangerous_switch": "當前 %d 號幹員血量危險，切換到 %d 號幹員",
     "autofight.enemy_accumulating_power": "敵人正在蓄力",
     "autofight.exit_fight": "退出戰鬥場景",
+    "autofight.capture_slow": "戰鬥識別平均耗時 %d ms，請嘗試減少顯示卡資源佔用",
     "autofight.adjust_view": "調整視角",
     "autofight.move_back": "長時間找不到敵人，後退",
     "autofight.move_forward": "長時間找不到敵人，前進",


### PR DESCRIPTION
close #3435

## Summary by Sourcery

为自动战斗（autofight）屏幕截取添加性能监控，并在截屏持续缓慢时通知用户，建议减少 GPU 资源占用。

New Features:
- 在滑动时间窗口内跟踪自动战斗屏幕截取的平均耗时，当其超过配置的阈值时触发告警。
- 当屏幕截取性能下降时，通过 maafocus 显示本地化的警告信息，提示可能存在 GPU 资源耗尽的风险。

Chores:
- 为自动战斗截屏缓慢警告在所有受支持的语言中添加新的本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add performance monitoring for autofight screen capture and notify users when capture is consistently slow, suggesting GPU resource reduction.

New Features:
- Track average autofight screen capture duration over a sliding time window and trigger alerts when it exceeds a configured threshold.
- Display a localized warning message via maafocus when screen capture performance degrades, indicating potential GPU resource exhaustion.

Chores:
- Add new localization strings for the autofight slow capture warning across supported languages.

</details>