### PR TITLE
fix(MapNavigator): 修复 NavMesh 数据包未按预期加载

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
@@ -91,21 +91,9 @@ struct MapLocateAssertLocationOutput
 
 fs::path getExeDir()
 {
-#ifdef _WIN32
-    const auto process_path = MAA_NS::get_process_path(GetCurrentProcessId());
-#else
-    const auto process_path = MAA_NS::get_process_path(::getpid());
-#endif
-    if (process_path && !process_path->empty()) {
-        return process_path->parent_path();
-    }
-
-    std::error_code ec;
-    const fs::path cwd = fs::current_path(ec);
-    if (!ec && !cwd.empty()) {
-        return cwd;
-    }
-    return {};
+    // Shared single-source resolution (see source/utils.h). Kept as a thin alias so MapLocator and
+    // MapNavigator anchor resources identically.
+    return get_exe_dir();
 }
 
 class ScopedImageBuffer

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -351,9 +351,28 @@ bool NavigationStateMachine::Run()
 bool NavigationStateMachine::Bootstrap()
 {
     runtime_state_.BeginNavigation(std::chrono::steady_clock::now());
+
+    if (session_->HasSatisfiedFinalSuccess(*position_, "bootstrap_already_at_final_goal")) {
+        return true;
+    }
+
     const std::optional<DynamicAnchor> anchor = ResolveBootstrapAnchor(param_, session_, *position_);
     if (anchor && TryApplyDynamicOverlayToAnchor("bootstrap_navmesh_overlay", anchor->first, anchor->second, false)) {
         SelectPhaseForCurrentWaypoint("bootstrap_navmesh_overlay");
+        return true;
+    }
+
+    const std::optional<BootstrapContinueCandidate> continue_candidate =
+        ResolveBootstrapContinueCandidate(session_->original_path(), *position_);
+    if (continue_candidate && continue_candidate->continue_index > 0
+        && continue_candidate->continue_index < session_->original_path().size()) {
+        session_->ApplyDynamicOverlay({}, continue_candidate->continue_index, *position_);
+        runtime_state_.route.Reset();
+        runtime_state_.nav_run_dirty = true;
+        LogInfo << "Bootstrap serial route continue after navmesh overlay unavailable."
+                << VAR(continue_candidate->continue_index) << VAR(continue_candidate->route_distance) << VAR(position_->x)
+                << VAR(position_->y) << VAR(position_->zone_id);
+        SelectPhaseForCurrentWaypoint("bootstrap_serial_continue");
         return true;
     }
 

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -22,6 +22,7 @@
 #include <MaaUtils/Logger.h>
 
 #include "../Navmesh/BaseNavReader.h"
+#include "../utils.h"
 #include "navi_config.h"
 #include "navi_controller.h"
 #include "navi_math.h"
@@ -135,23 +136,39 @@ std::optional<std::filesystem::path> FindExistingFromParents(const std::filesyst
 
 std::filesystem::path ResolveNavmeshFile(const std::string& configured_path)
 {
+    std::error_code ec;
+    const std::filesystem::path exe_dir = get_exe_dir();
+    const std::filesystem::path navmesh_dir = exe_dir / ".." / "resource" / "model" / "map" / "navmesh";
+
     if (!configured_path.empty()) {
         const std::filesystem::path configured(configured_path);
         if (configured.is_absolute()) {
             return configured;
         }
+        const std::filesystem::path anchored = exe_dir / ".." / configured;
+        if (std::filesystem::exists(anchored, ec) && !ec) {
+            return anchored;
+        }
         if (auto found = FindExistingFromParents(configured); found.has_value()) {
             return *found;
         }
-        return configured;
+        return anchored;
     }
 
-    for (const char* relative_path : { kDefaultNavmeshRelativePath, kDefaultCompressedNavmeshRelativePath }) {
+    for (const char* file_name : { "base.nav.gz", "base.nav" }) {
+        const std::filesystem::path candidate = navmesh_dir / file_name;
+        if (std::filesystem::exists(candidate, ec) && !ec) {
+            return candidate;
+        }
+    }
+
+    for (const char* relative_path : { kDefaultCompressedNavmeshRelativePath, kDefaultNavmeshRelativePath }) {
         if (auto found = FindExistingFromParents(relative_path); found.has_value()) {
             return *found;
         }
     }
-    return std::filesystem::path(kDefaultNavmeshRelativePath);
+
+    return navmesh_dir / "base.nav.gz";
 }
 
 std::string BuildNavmeshCacheKey(const std::filesystem::path& navmesh_path, const std::string& navmesh_zone)
@@ -163,7 +180,7 @@ std::shared_ptr<CachedNavmesh> LoadNavmeshPack(const std::filesystem::path& navm
 {
     const auto load_result = navmesh::LoadBaseNavPack(navmesh_path, navmesh_zone);
     if (!load_result.ok()) {
-        LogError << "Failed to load navmesh .nav file." << VAR(navmesh_path) << VAR(navmesh_zone) << VAR(load_result.message);
+        LogError << "Failed to load navmesh pack." << VAR(navmesh_path) << VAR(navmesh_zone) << VAR(load_result.message);
         return nullptr;
     }
     return std::make_shared<CachedNavmesh>(std::move(*load_result.pack));
@@ -446,6 +463,11 @@ navmesh::WorldPoint OffsetPoint(const NaviPosition& position, double heading, do
 }
 
 } // namespace
+
+std::filesystem::path ResolveNavmeshFilePath(const std::string& configured_path)
+{
+    return ResolveNavmeshFile(configured_path);
+}
 
 std::string InitialExpectedZone(const NaviParam& param)
 {

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -145,6 +145,10 @@ std::filesystem::path ResolveNavmeshFile(const std::string& configured_path)
         if (configured.is_absolute()) {
             return configured;
         }
+        // A relative override resolves exe-anchored first (production layout), then falls back to the
+        // CWD-walk for dev. If it exists nowhere, we intentionally return the exe-anchored path rather
+        // than the bare relative one so a not-found diagnostic names the deployed location instead of a
+        // CWD-relative path that only resolves in dev.
         const std::filesystem::path anchored = exe_dir / ".." / configured;
         if (std::filesystem::exists(anchored, ec) && !ec) {
             return anchored;

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <vector>
@@ -13,6 +14,7 @@ namespace mapnavigator
 
 struct NaviParam;
 
+std::filesystem::path ResolveNavmeshFilePath(const std::string& configured_path = {});
 std::string InitialExpectedZone(const NaviParam& param);
 void PreloadNavmeshWaypoints(const NaviParam& param);
 bool ExpandNavmeshWaypoints(const NaviParam& param, const NaviPosition& initial_pos, std::vector<Waypoint>& out_path);

--- a/agent/cpp-algo/source/utils.h
+++ b/agent/cpp-algo/source/utils.h
@@ -1,11 +1,42 @@
 #pragma once
 
+#include <filesystem>
+#include <system_error>
+
 #include <MaaFramework/MaaAPI.h>
 #include <MaaUtils/NoWarningCV.hpp>
+#include <MaaUtils/Platform.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 inline cv::Mat to_mat(const MaaImageBuffer* buffer)
 {
     return cv::Mat(MaaImageBufferHeight(buffer), MaaImageBufferWidth(buffer), MaaImageBufferType(buffer), MaaImageBufferGetRawData(buffer));
+}
+
+// Directory containing the running executable. Resolve bundled resources against this rather than
+// the process current-working-directory: the CWD differs between dev and production, but resources
+// always ship at a fixed location relative to the binary. This is the single anchor used by every
+// resource lookup (MapLocator models, navmesh pack, ...).
+inline std::filesystem::path get_exe_dir()
+{
+#ifdef _WIN32
+    const auto process_path = MAA_NS::get_process_path(GetCurrentProcessId());
+#else
+    const auto process_path = MAA_NS::get_process_path(::getpid());
+#endif
+    if (process_path && !process_path->empty()) {
+        return process_path->parent_path();
+    }
+
+    std::error_code ec;
+    const std::filesystem::path cwd = std::filesystem::current_path(ec);
+    if (!ec && !cwd.empty()) {
+        return cwd;
+    }
+    return {};
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
- close #3442

## Summary by Sourcery

统一可执行文件目录解析方式，并改进导航网格（navmesh）资源加载和导航引导（bootstrap）行为。

New Features:
- 提供共享的可执行文件目录辅助工具，用于在 `MapLocator` 和 `MapNavigator` 中统一锚定资源路径。
- 新增公开 API，可从可选的配置值解析导航网格文件路径。

Bug Fixes:
- 确保在未提供显式路径或配置为相对路径时，导航网格包会相对于可执行文件的资源目录进行解析。
- 当从父路径查找失败时，回退到打包在导航网格目录中的合理默认导航网格文件。
- 改进引导行为：当已经处于最终目标位置时跳过导航；当导航网格覆盖不可用时，继续沿用现有路线。

Enhancements:
- 更新日志，使其更准确地描述导航网格包加载失败的原因。
- 重构 `MapLocator` 以复用共享的可执行文件目录辅助工具，从而使两个组件以相同方式锚定资源路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify executable-directory resolution and improve navmesh resource loading and navigation bootstrap behavior.

New Features:
- Provide a shared executable-directory helper for consistent resource path anchoring across MapLocator and MapNavigator.
- Add a public API to resolve the navmesh file path from an optional configured value.

Bug Fixes:
- Ensure navmesh packs are resolved relative to the executable’s resource directory when no explicit path is provided or when a relative path is configured.
- Fallback to a sensible default navmesh file within the bundled navmesh directory when lookup from parent paths fails.
- Improve bootstrap behavior by skipping navigation when already at the final goal and by continuing an existing route if navmesh overlays are unavailable.

Enhancements:
- Update logging to more accurately describe navmesh pack load failures.
- Refactor MapLocator to reuse the shared executable-directory helper so both components anchor resources identically.

</details>