### PR TITLE
fix: 售卖弹性物资息壤物品混淆

### DIFF
--- a/agent/go-service/autosell/autosell.go
+++ b/agent/go-service/autosell/autosell.go
@@ -197,7 +197,7 @@ func firstContainedKeyword(s string, subs []string) string {
 
 var (
 	moderatePriceKeywords = []string{"锚点", "悬空", "巫术", "天使", "岳研", "冬虫", "武陵", "武侠"}
-	largePriceKeywords    = []string{"谷地水", "团结", "塞什", "星体", "天师", "息壤", "清波", "飞天"}
+	largePriceKeywords    = []string{"谷地水", "团结", "塞什", "星体", "天师", "息壤净", "息壤色", "清波", "飞天"}
 	massivePriceKeywords  = []string{"源石", "警戒", "硬脑", "边角"}
 )
 


### PR DESCRIPTION
close #3476

## Summary by Sourcery

Bug Fixes:
- 修复大额价格自动出售关键词列表中“息壤”物品分组不正确的问题，以避免不同变体被混在一起。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect grouping of '息壤' items in the large-price autosell keyword list to avoid mixing different variants.

</details>