### PR TITLE
fix(MapLocator): 断言定位前重置 Locator 跟踪状态

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
@@ -412,6 +412,13 @@ MaaBool MAA_CALL MapLocateAssertLocationRun(
         return MAA_FALSE;
     }
 
+    auto locator = getOrInitLocator();
+    if (!locator) {
+        LogError << "MapLocateAssertLocation: Locator init failed";
+        return MAA_FALSE;
+    }
+    locator->resetTrackingState();
+
     const LocateOptions options = BuildAssertLocateOptions(param);
     LocateResult result;
     constexpr auto cold_start_retry_delay = std::chrono::milliseconds(300);


### PR DESCRIPTION
MapLocateAssertLocation 在执行断言定位前未重置 Locator 的跟踪状态， 可能复用上一次导航遗留的跟踪上下文导致定位判断异常。改为在校验参数后
显式获取（或初始化）Locator 并调用 resetTrackingState()，确保每次断言
定位都从干净状态开始。

## Summary by Sourcery

错误修复：
- 在 `MapLocateAssertLocationRun` 开始时重置 Locator 跟踪状态，以避免复用先前导航遗留的过期跟踪上下文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Reset the Locator tracking state at the start of MapLocateAssertLocationRun to avoid reusing stale tracking context from previous navigations.

</details>