### PR TITLE
fix(MapNavigator): NAVMESH 目标不可达时盲走补全最后一段

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -419,10 +419,15 @@ bool AppendBlindTargetFallback(
     }
     const double snap_radius = std::max(param.navmesh_snap_radius, kBlindTargetFallbackSnapRadius);
 
+    // A probe at distance `offset` from the target snaps to within snap_radius, so its residual gap is at
+    // least (offset - snap_radius). Past (kBlindTargetMaxExtension + snap_radius) every probe would fail the
+    // gap check below, so cap the scan there instead of calling findPath across the whole (possibly long) span.
+    const double probe_limit = std::min(total, kBlindTargetMaxExtension + snap_radius);
+
     navmesh::BaseNavRouteResult approach;
     bool found = false;
     double blind_gap = 0.0;
-    for (double offset = 0.0; offset <= total + 1e-6; offset += kBlindTargetProbeStep) {
+    for (double offset = 0.0; offset <= probe_limit + 1e-6; offset += kBlindTargetProbeStep) {
         const double t = std::min(offset / total, 1.0);
         const navmesh::WorldPoint probe {
             .x = target.x + (start.x - target.x) * t,
@@ -459,7 +464,7 @@ bool AppendBlindTargetFallback(
         out_path.back().strict_arrival = false;
     }
     state.route_start = target;
-    LogWarn << "NAVMESH blind-target fallback applied." << VAR(state.navmesh_zone) << VAR(state.current_zone)
+    LogInfo << "NAVMESH blind-target fallback applied." << VAR(state.navmesh_zone) << VAR(state.current_zone)
             << VAR(waypoint.x) << VAR(waypoint.y) << VAR(blind_gap) << VAR(approach.path.points.back().x)
             << VAR(approach.path.points.back().y);
     return true;

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -74,6 +74,12 @@ constexpr size_t kDetourBlockedTriangleCount = 4;
 constexpr double kDetourBacktrackPenalty = 8.0;
 constexpr double kDetourSnapPenalty = 3.0;
 
+// Blind-target fallback: navmesh omits water, so a target a human can reach is reported unreachable.
+// Route as close as the mesh allows, then walk the residual gap blind toward the exact target.
+constexpr double kBlindTargetFallbackSnapRadius = 12.0;
+constexpr double kBlindTargetMaxExtension = 30.0;
+constexpr double kBlindTargetProbeStep = 2.0;
+
 bool IsNavmeshWaypoint(const Waypoint& waypoint)
 {
     return waypoint.action == ActionType::NAVMESH && waypoint.HasPosition();
@@ -396,6 +402,69 @@ void LogGeneratedNavmeshPath(
             << VAR(navmesh_segment_breaks) << VAR(navmesh_path_points);
 }
 
+// Probe from the target back toward the agent; the first reachable probe is the closest connected mesh
+// point. Route there, then walk the residual gap to the exact target as a single non-strict (blind) RUN.
+bool AppendBlindTargetFallback(
+    const NaviParam& param,
+    const CachedNavmesh& navmesh,
+    const Waypoint& waypoint,
+    NavmeshExpansionState& state,
+    std::vector<Waypoint>& out_path)
+{
+    const navmesh::WorldPoint target { .x = waypoint.x, .y = waypoint.y };
+    const navmesh::WorldPoint start = state.route_start;
+    const double total = std::hypot(target.x - start.x, target.y - start.y);
+    if (total < 1e-6) {
+        return false;
+    }
+    const double snap_radius = std::max(param.navmesh_snap_radius, kBlindTargetFallbackSnapRadius);
+
+    navmesh::BaseNavRouteResult approach;
+    bool found = false;
+    double blind_gap = 0.0;
+    for (double offset = 0.0; offset <= total + 1e-6; offset += kBlindTargetProbeStep) {
+        const double t = std::min(offset / total, 1.0);
+        const navmesh::WorldPoint probe {
+            .x = target.x + (start.x - target.x) * t,
+            .y = target.y + (start.y - target.y) * t,
+        };
+        navmesh::BaseNavRouteRequest request = BuildRouteRequest(param, state.navmesh_zone, start, probe);
+        request.snap_radius = snap_radius;
+        const auto route = navmesh.planner.findPath(request);
+        if (!route.ok() || route.path.points.empty()) {
+            continue;
+        }
+        const navmesh::WorldPoint reached = route.path.points.back();
+        blind_gap = std::hypot(target.x - reached.x, target.y - reached.y);
+        approach = route;
+        found = true;
+        break;
+    }
+
+    if (!found) {
+        return false;
+    }
+    if (blind_gap > kBlindTargetMaxExtension) {
+        LogWarn << "NAVMESH blind-target fallback rejected: residual gap too large." << VAR(state.navmesh_zone)
+                << VAR(state.current_zone) << VAR(waypoint.x) << VAR(waypoint.y) << VAR(blind_gap)
+                << VAR(kBlindTargetMaxExtension);
+        return false;
+    }
+
+    if (!AppendGeneratedNavmeshWaypoints(approach.path, out_path, true)) {
+        return false;
+    }
+    if (blind_gap > kWaypointArrivalSlack) {
+        out_path.emplace_back(target.x, target.y, ActionType::RUN);
+        out_path.back().strict_arrival = false;
+    }
+    state.route_start = target;
+    LogWarn << "NAVMESH blind-target fallback applied." << VAR(state.navmesh_zone) << VAR(state.current_zone)
+            << VAR(waypoint.x) << VAR(waypoint.y) << VAR(blind_gap) << VAR(approach.path.points.back().x)
+            << VAR(approach.path.points.back().y);
+    return true;
+}
+
 bool AppendNavmeshWaypoint(
     const NaviParam& param,
     const CachedNavmesh& navmesh,
@@ -406,6 +475,12 @@ bool AppendNavmeshWaypoint(
     const navmesh::BaseNavRouteRequest request = BuildRouteRequest(param, state, waypoint);
     const auto route_result = navmesh.planner.findPath(request);
     if (!route_result.ok()) {
+        LogWarn << "NAVMESH waypoint not directly reachable; attempting blind-target fallback." << VAR(state.navmesh_zone)
+                << VAR(state.current_zone) << VAR(waypoint.x) << VAR(waypoint.y)
+                << VAR(navmesh::ToString(route_result.status));
+        if (AppendBlindTargetFallback(param, navmesh, waypoint, state, out_path)) {
+            return true;
+        }
         LogError << "Failed to plan NAVMESH waypoint." << VAR(state.navmesh_zone) << VAR(state.current_zone) << VAR(waypoint.x)
                  << VAR(waypoint.y) << VAR(navmesh::ToString(route_result.status));
         return false;


### PR DESCRIPTION
官方 navmesh 刻意排除水面，导致开发者提供的 target 落在水中时被判定
不可达（snap 到与 agent 跨水断连的网格分量），整条线路被强制跳过。
新增盲走兜底：从 target 朝 agent 回退探测，找到最近的可达网格点后走
navmesh 到该点，再以单段非严格（盲走）RUN 补全到精确 target；残余间距
超过 30u 则拒绝兜底。

## Summary by Sourcery

添加导航网格（navmesh）盲目标回退机制，以便在目标位于导航网格之外但在物理上仍可到达时完成路径规划。

Bug 修复：
- 防止在导航网格由于缺失水面多边形而将最终目标报告为不可到达时，整个路径被完全跳过。

增强功能：
- 引入盲目标探测策略：先规划到最近的可达网格点，然后在限定距离内追加一个非严格的奔跑段。
- 在导航网格为某个路径点规划失败时，为盲目标回退机制的成功应用和被拒绝两种情况都添加日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a navmesh blind-target fallback to allow completing routes when the target lies off the navmesh but is still physically reachable.

Bug Fixes:
- Prevent routes from being entirely skipped when the navmesh reports the final target as unreachable due to missing water polygons.

Enhancements:
- Introduce a blind-target probing strategy that routes to the nearest reachable mesh point then extends with a non-strict run segment within a capped distance.
- Add logging for both successful application and rejection of the blind-target fallback when navmesh planning fails for a waypoint.

</details>