### PR TITLE
fix(MapNavigator): 增强 NAVMESH 端点规划鲁棒性

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -406,18 +406,6 @@ bool AppendNavmeshWaypoint(
     const navmesh::BaseNavRouteRequest request = BuildRouteRequest(param, state, waypoint);
     const auto route_result = navmesh.planner.findPath(request);
     if (!route_result.ok()) {
-        const double direct_distance = std::hypot(waypoint.x - state.route_start.x, waypoint.y - state.route_start.y);
-        const double fallback_distance = kBootstrapOwnershipMaxDistance + param.navmesh_snap_radius;
-        if (direct_distance <= fallback_distance) {
-            out_path.emplace_back(waypoint.x, waypoint.y, ActionType::RUN);
-            out_path.back().strict_arrival = true;
-            out_path.back().zone_id = state.current_zone;
-            state.route_start = { .x = waypoint.x, .y = waypoint.y };
-            LogWarn << "NAVMESH waypoint fallback to strict RUN." << VAR(state.navmesh_zone) << VAR(state.current_zone)
-                    << VAR(waypoint.x) << VAR(waypoint.y) << VAR(navmesh::ToString(route_result.status)) << VAR(direct_distance)
-                    << VAR(fallback_distance);
-            return true;
-        }
         LogError << "Failed to plan NAVMESH waypoint." << VAR(state.navmesh_zone) << VAR(state.current_zone) << VAR(waypoint.x)
                  << VAR(waypoint.y) << VAR(navmesh::ToString(route_result.status));
         return false;

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -406,6 +406,18 @@ bool AppendNavmeshWaypoint(
     const navmesh::BaseNavRouteRequest request = BuildRouteRequest(param, state, waypoint);
     const auto route_result = navmesh.planner.findPath(request);
     if (!route_result.ok()) {
+        const double direct_distance = std::hypot(waypoint.x - state.route_start.x, waypoint.y - state.route_start.y);
+        const double fallback_distance = kBootstrapOwnershipMaxDistance + param.navmesh_snap_radius;
+        if (direct_distance <= fallback_distance) {
+            out_path.emplace_back(waypoint.x, waypoint.y, ActionType::RUN);
+            out_path.back().strict_arrival = true;
+            out_path.back().zone_id = state.current_zone;
+            state.route_start = { .x = waypoint.x, .y = waypoint.y };
+            LogWarn << "NAVMESH waypoint fallback to strict RUN." << VAR(state.navmesh_zone) << VAR(state.current_zone)
+                    << VAR(waypoint.x) << VAR(waypoint.y) << VAR(navmesh::ToString(route_result.status)) << VAR(direct_distance)
+                    << VAR(fallback_distance);
+            return true;
+        }
         LogError << "Failed to plan NAVMESH waypoint." << VAR(state.navmesh_zone) << VAR(state.current_zone) << VAR(waypoint.x)
                  << VAR(waypoint.y) << VAR(navmesh::ToString(route_result.status));
         return false;

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -438,7 +438,10 @@ BaseNavRouteResult BaseNavPlanner::findPath(const BaseNavRouteRequest& request) 
     if (request.blocked_triangles.empty() && segmentHeightWalkable(zone->zone_id, start->point, goal->point)) {
         BaseNavRouteResult result;
         result.status = BaseNavRouteStatus::Success;
-        result.triangles = { start->triangle, goal->triangle };
+        result.triangles.push_back(start->triangle);
+        if (goal->triangle != start->triangle) {
+            result.triangles.push_back(goal->triangle);
+        }
         result.path.zone_id = zone->zone_id;
         result.path.zone_name = zone->name;
         result.path.points = { start->point, goal->point };

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -428,6 +428,24 @@ BaseNavRouteResult BaseNavPlanner::findPath(const BaseNavRouteRequest& request) 
         }
     }
 
+    // A* over the triangle adjacency graph reports Unreachable on fragmented / overlapping meshes where
+    // the goal sits in a tiny disconnected component, or just past a height step the bridge-cost cutoff
+    // (kBridgeMaxHeightDelta) rejects — even when the goal is a short, flat walk away. Both endpoints have
+    // already snapped onto the mesh here, so when the straight segment between them stays on walkable mesh
+    // with continuous ground height it is a sound proof the goal is reachable; accept it as a direct path.
+    // Skipped when triangles are blocked (an obstacle-detour query), where a straight shortcut would walk
+    // back through the very obstacle the detour is trying to bypass.
+    if (request.blocked_triangles.empty() && segmentHeightWalkable(zone->zone_id, start->point, goal->point)) {
+        BaseNavRouteResult result;
+        result.status = BaseNavRouteStatus::Success;
+        result.triangles = { start->triangle, goal->triangle };
+        result.path.zone_id = zone->zone_id;
+        result.path.zone_name = zone->name;
+        result.path.points = { start->point, goal->point };
+        result.cost = detail::Distance(start->point, goal->point);
+        return result;
+    }
+
     BaseNavRouteResult result;
     result.status = BaseNavRouteStatus::Unreachable;
     return result;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过在可行走网格上存在连续地面高度且没有被阻挡三角形的情况下，接受直接终点线段，来防止出现错误的“路径不可达”结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent spurious Unreachable path results by accepting a direct endpoint segment when it lies on walkable mesh with continuous ground height and no blocked triangles.

</details>