### PR TITLE
fix(MapNavigator): 恢复长距离自动冲刺

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -46,6 +46,8 @@ constexpr int32_t kActionJumpSettleMs = 500;
 constexpr int32_t kActionInteractAttempts = 5;
 constexpr int32_t kActionInteractHoldMs = 100;
 constexpr int32_t kAutoSprintCooldownMs = 1500;
+// Braking buffer (world units) ahead of a strict-arrival waypoint: sprint stays allowed until within
+// arrival_distance + this margin, leaving room to brake and land precisely.
 constexpr double kStrictArrivalSprintBrakeDistance = 6.0;
 constexpr int32_t kWalkResetReleaseMs = 120;
 constexpr double kSamePointActionChainDistance = 0.2;

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -46,6 +46,7 @@ constexpr int32_t kActionJumpSettleMs = 500;
 constexpr int32_t kActionInteractAttempts = 5;
 constexpr int32_t kActionInteractHoldMs = 100;
 constexpr int32_t kAutoSprintCooldownMs = 1500;
+constexpr double kStrictArrivalSprintBrakeDistance = 6.0;
 constexpr int32_t kWalkResetReleaseMs = 120;
 constexpr double kSamePointActionChainDistance = 0.2;
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -842,9 +842,15 @@ bool NavigationStateMachine::TickNavigate()
 
     const bool turn_calm = !steering.issued || std::abs(steering.yaw_delta_deg) < 30.0;
     const bool target_requires_strict_arrival = waypoint.RequiresStrictArrival();
+    const double sprint_remaining =
+        nav_run_result.has_corridor_heading && std::isfinite(nav_run_result.remaining_to_anchor)
+            ? nav_run_result.remaining_to_anchor
+            : route.along_track_remaining;
+    const bool has_strict_arrival_braking_room = !target_requires_strict_arrival
+        || route.waypoint_distance > arrival_distance + kStrictArrivalSprintBrakeDistance;
     const bool allow_sprint =
         turn_calm && motion_controller_->SupportsSprint() && startup_grace_elapsed && param_.sprint_threshold > 0.0
-        && !target_requires_strict_arrival && route.along_track_remaining > param_.sprint_threshold
+        && has_strict_arrival_braking_room && sprint_remaining > param_.sprint_threshold
         && (runtime_state_.flow.last_auto_sprint_time.time_since_epoch().count() == 0
             || std::chrono::duration_cast<std::chrono::milliseconds>(now - runtime_state_.flow.last_auto_sprint_time).count()
                    >= kAutoSprintCooldownMs);

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -846,6 +846,8 @@ bool NavigationStateMachine::TickNavigate()
         nav_run_result.has_corridor_heading && std::isfinite(nav_run_result.remaining_to_anchor)
             ? nav_run_result.remaining_to_anchor
             : route.along_track_remaining;
+    // Strict-arrival goals no longer block sprint outright; allow it until a braking buffer before the
+    // waypoint so long straight runs into a strict goal still sprint, then brake in time to land.
     const bool has_strict_arrival_braking_room = !target_requires_strict_arrival
         || route.waypoint_distance > arrival_distance + kStrictArrivalSprintBrakeDistance;
     const bool allow_sprint =


### PR DESCRIPTION
## Summary by Sourcery

调整导航状态机中的自动冲刺条件，在仍然允许在安全情况下进行长距离冲刺的同时，尊重严格到达（strict-arrival）制动距离。

Bug Fixes:
- 通过基于到锚点的剩余距离或路线距离来决定冲刺资格，恢复沿导航走廊的自动长距离冲刺，同时为严格到达航路点保留足够的停车距离。

Enhancements:
- 引入一个可配置的严格到达冲刺制动距离常量，用于在接近严格到达航路点时限制自动冲刺。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust auto-sprint conditions in the navigation state machine to respect strict-arrival braking distance while still allowing long-distance sprinting when safe.

Bug Fixes:
- Restore automatic long-distance sprinting along navigation corridors by basing sprint eligibility on remaining distance to anchor or route distance, while preserving stopping room for strict-arrival waypoints.

Enhancements:
- Introduce a configurable strict-arrival sprint braking distance constant used to gate auto-sprint near strict-arrival waypoints.

</details>