### PR TITLE
fix(MapNavigator): 允许避障恢复重复跳跃

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -75,6 +75,10 @@ constexpr double kWaypointArrivalSlack = 0.5;
 constexpr int32_t kObstacleRecoveryMinTriggerMs = 3500;
 constexpr int32_t kDynamicRecoveryRetryIntervalMs = kObstacleRecoveryMinTriggerMs;
 constexpr int32_t kDynamicRecoveryTotalTimeoutMs = 30000;
+// Jump is the primary obstacle response; only after this many jumps fail to break free does
+// recovery fall back to a navmesh detour. Keeps the agent hopping low blockers before it
+// abandons the precise route.
+constexpr int32_t kRecoveryJumpAttemptsBeforeDetour = 2;
 constexpr double kDynamicRecoveryResetDistance = 2.0;
 constexpr double kCloseGoalDetourSuppressSlack = 6.0;
 

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -75,7 +75,6 @@ constexpr double kWaypointArrivalSlack = 0.5;
 constexpr int32_t kObstacleRecoveryMinTriggerMs = 3500;
 constexpr int32_t kDynamicRecoveryRetryIntervalMs = kObstacleRecoveryMinTriggerMs;
 constexpr int32_t kDynamicRecoveryTotalTimeoutMs = 30000;
-constexpr int32_t kDynamicRecoveryMaxAttemptsPerAnchor = 3;
 constexpr double kDynamicRecoveryResetDistance = 2.0;
 constexpr double kCloseGoalDetourSuppressSlack = 6.0;
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -77,7 +77,8 @@ struct DynamicRecoveryState
     std::chrono::steady_clock::time_point started_at {};
     std::chrono::steady_clock::time_point last_replan_at {};
     size_t anchor_index = std::numeric_limits<size_t>::max();
-    int attempt_count = 0;
+    int jump_attempt_count = 0;
+    int detour_attempt_count = 0;
     bool active = false;
 
     void Reset()
@@ -86,7 +87,8 @@ struct DynamicRecoveryState
         started_at = {};
         last_replan_at = {};
         anchor_index = std::numeric_limits<size_t>::max();
-        attempt_count = 0;
+        jump_attempt_count = 0;
+        detour_attempt_count = 0;
         active = false;
     }
 };

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -735,25 +735,18 @@ bool NavigationStateMachine::TickNavigate()
                                             && std::chrono::duration_cast<std::chrono::milliseconds>(now - recovery.last_replan_at).count()
                                                    < kDynamicRecoveryRetryIntervalMs;
             if (!retry_cooling_down) {
-                if (recovery.attempt_count >= kDynamicRecoveryMaxAttemptsPerAnchor) {
-                    return FailNavigation(
-                        "dynamic_recovery_exhausted",
-                        "Dynamic recovery attempts were exhausted and navigation was terminated.",
-                        route.progress_distance,
-                        NaviMath::NormalizeAngle(route.route_heading - current_heading),
-                        stalled_ms);
-                }
-
                 recovery.last_replan_at = now;
+                ++recovery.jump_attempt_count;
                 const NaviPosition jump_start = *position_;
-                LogInfo << "Dynamic recovery jump pulse issued." << VAR(recovery.attempt_count + 1);
+                LogInfo << "Dynamic recovery jump pulse issued." << VAR(recovery.jump_attempt_count)
+                        << VAR(recovery.detour_attempt_count);
                 motion_controller_->SetAction(LocalDriverAction::JumpForward, true);
                 utils::SleepFor(kActionJumpSettleMs);
                 motion_controller_->SetForwardState(false);
                 if (!CaptureCurrentPosition(false) || position_provider_->LastCaptureWasHeld()
                     || position_provider_->LastCaptureWasBlackScreen() || !position_->valid) {
                     LogWarn << "Dynamic recovery waiting for post-jump local tracking fix." << VAR(stalled_ms)
-                            << VAR(recovery.attempt_count);
+                            << VAR(recovery.jump_attempt_count);
                     utils::SleepFor(kTargetTickMs);
                     return true;
                 }
@@ -790,9 +783,10 @@ bool NavigationStateMachine::TickNavigate()
                     recovery.started_at = now;
                     recovery.anchor_index = post_jump_anchor->first;
                     recovery.last_replan_at = now;
+                    recovery.jump_attempt_count = 1;
                 }
 
-                ++recovery.attempt_count;
+                ++recovery.detour_attempt_count;
                 if (TryApplyDynamicOverlayToAnchor(
                         "recovery_navmesh_detour",
                         post_jump_anchor->first,
@@ -803,16 +797,9 @@ bool NavigationStateMachine::TickNavigate()
                     return true;
                 }
 
-                LogWarn << "Dynamic recovery detour attempt failed." << VAR(recovery.attempt_count) << VAR(post_jump_anchor->first)
-                        << VAR(route.progress_distance) << VAR(stalled_ms);
-                if (recovery.attempt_count >= kDynamicRecoveryMaxAttemptsPerAnchor) {
-                    return FailNavigation(
-                        "dynamic_recovery_exhausted",
-                        "Dynamic recovery attempts were exhausted and navigation was terminated.",
-                        route.progress_distance,
-                        NaviMath::NormalizeAngle(route.route_heading - current_heading),
-                        stalled_ms);
-                }
+                LogWarn << "Dynamic recovery detour attempt failed." << VAR(recovery.detour_attempt_count)
+                        << VAR(recovery.jump_attempt_count) << VAR(post_jump_anchor->first) << VAR(route.progress_distance)
+                        << VAR(stalled_ms);
                 utils::SleepFor(kTargetTickMs);
                 return true;
             }

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -704,11 +704,13 @@ bool NavigationStateMachine::TickNavigate()
         }
     }
 
+    // Near a strict-arrival goal only the *detour* is unsafe (it routes away from the exact point);
+    // a jump is still a safe nudge, so recovery is allowed to enter here and the suppression is
+    // applied to the detour step alone, below.
     const bool near_strict_goal = waypoint.RequiresStrictArrival()
         && route.waypoint_distance <= arrival_distance + kCloseGoalDetourSuppressSlack;
     const bool should_try_recovery = session_->phase() == NaviPhase::Navigate && stalled_ms >= kObstacleRecoveryMinTriggerMs
-                                     && (route.progress_distance > kNoProgressMinDistance || waypoint.RequiresStrictArrival())
-                                     && !near_strict_goal;
+                                     && (route.progress_distance > kNoProgressMinDistance || waypoint.RequiresStrictArrival());
     if (should_try_recovery) {
         const std::optional<DynamicAnchor> anchor = ResolveCurrentAnchor(session_, *position_);
         if (anchor) {
@@ -786,20 +788,29 @@ bool NavigationStateMachine::TickNavigate()
                     recovery.jump_attempt_count = 1;
                 }
 
-                ++recovery.detour_attempt_count;
-                if (TryApplyDynamicOverlayToAnchor(
-                        "recovery_navmesh_detour",
-                        post_jump_anchor->first,
-                        post_jump_anchor->second,
-                        true,
-                        route.route_heading)) {
-                    SelectPhaseForCurrentWaypoint("recovery_navmesh_detour");
-                    return true;
-                }
+                // The jump pulse above runs every recovery tick — so even once we are detouring, a
+                // fresh stall keeps trying to hop free first ("jump during detour"). The detour is the
+                // fallback: it only kicks in after the jump has failed kRecoveryJumpAttemptsBeforeDetour
+                // times for this anchor, and is suppressed next to a strict goal where it would route
+                // away from the exact point (there we keep jumping instead).
+                const bool detour_allowed =
+                    !near_strict_goal && recovery.jump_attempt_count >= kRecoveryJumpAttemptsBeforeDetour;
+                if (detour_allowed) {
+                    ++recovery.detour_attempt_count;
+                    if (TryApplyDynamicOverlayToAnchor(
+                            "recovery_navmesh_detour",
+                            post_jump_anchor->first,
+                            post_jump_anchor->second,
+                            true,
+                            route.route_heading)) {
+                        SelectPhaseForCurrentWaypoint("recovery_navmesh_detour");
+                        return true;
+                    }
 
-                LogWarn << "Dynamic recovery detour attempt failed." << VAR(recovery.detour_attempt_count)
-                        << VAR(recovery.jump_attempt_count) << VAR(post_jump_anchor->first) << VAR(route.progress_distance)
-                        << VAR(stalled_ms);
+                    LogWarn << "Dynamic recovery detour attempt failed." << VAR(recovery.detour_attempt_count)
+                            << VAR(recovery.jump_attempt_count) << VAR(post_jump_anchor->first)
+                            << VAR(route.progress_distance) << VAR(stalled_ms);
+                }
                 utils::SleepFor(kTargetTickMs);
                 return true;
             }


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

针对严格到达（strict-arrival）目标附近的动态障碍恢复逻辑进行调整，在优先重复跳跃尝试的同时，延后并限制绕行（detour）的使用。

Bug 修复：
- 允许在严格到达目标附近继续执行动态恢复跳跃，而不是像之前那样与绕行一起被抑制。

增强功能：
- 在动态恢复中将跳跃尝试和绕行尝试分开计数，以支持差异化的行为和日志记录。
- 将导航网格（navmesh）绕行的激活建立在最小失败跳跃次数的前提上，并在非常接近严格到达目标时抑制绕行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust dynamic obstacle recovery near strict-arrival goals to prioritize repeated jump attempts while deferring and limiting detour usage.

Bug Fixes:
- Allow dynamic recovery jumps to continue near strict-arrival goals instead of being suppressed along with detours.

Enhancements:
- Separate accounting of jump and detour attempts in dynamic recovery to enable differentiated behavior and logging.
- Gate navmesh detour activation on a minimum number of failed jump attempts and suppress detours when very close to strict-arrival goals.

</details>