### PR TITLE
fix(MapNavigator): 定位丢失时增加超时与脱困，避免无限卡死

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -78,6 +78,12 @@ constexpr int32_t kDynamicRecoveryTotalTimeoutMs = 30000;
 constexpr int32_t kDynamicRecoveryMaxAttemptsPerAnchor = 3;
 constexpr double kDynamicRecoveryResetDistance = 2.0;
 constexpr double kCloseGoalDetourSuppressSlack = 6.0;
+// When the locator yields no usable fix for a sustained period (e.g. the agent was shoved across a
+// zone boundary into a sub-zone the active route was not planned in, so every fix fails zone
+// validation), stop holding forward into the obstacle, hop periodically to dislodge, and fail-fast
+// once the loss outlasts the timeout so the pipeline can retry instead of stalling forever.
+constexpr int32_t kLocalizationLossUnstickIntervalMs = kObstacleRecoveryMinTriggerMs;
+constexpr int32_t kLocalizationLossTimeoutMs = kDynamicRecoveryTotalTimeoutMs;
 
 // --- NavRunController (RUN corridor follower) ---
 constexpr double kNavRunLookaheadLowSpeedM = 2.5;

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -91,12 +91,25 @@ struct DynamicRecoveryState
     }
 };
 
+struct LocalizationLossState
+{
+    std::chrono::steady_clock::time_point started_at {};
+    std::chrono::steady_clock::time_point last_unstick_at {};
+
+    void Reset()
+    {
+        started_at = {};
+        last_unstick_at = {};
+    }
+};
+
 struct NavigationRuntimeState
 {
     RouteTrackerState route;
     FlowState flow;
     SemanticState semantic;
     DynamicRecoveryState recovery;
+    LocalizationLossState localization_loss;
     bool dynamic_replan_requested = false;
     bool nav_run_dirty = true;
 
@@ -113,6 +126,7 @@ struct NavigationRuntimeState
         route.Reset();
         semantic.ResetTransient();
         recovery.Reset();
+        localization_loss.Reset();
         dynamic_replan_requested = false;
         nav_run_dirty = true;
         flow.navigate_started_at = now;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -418,6 +418,45 @@ bool NavigationStateMachine::CaptureCurrentPosition(bool force_global_search)
     return position_provider_->Capture(position_, force_global_search, session_->current_zone_id());
 }
 
+// A sustained run of unusable fixes (commonly: the agent was shoved across a zone boundary into a
+// sub-zone the route was not planned in, so every locate fails zone validation) would otherwise hold
+// forward into the obstacle forever — the recovery block and its timeout sit past this point and are
+// never reached. Stop pressing forward, hop periodically to dislodge, and fail-fast on timeout.
+bool NavigationStateMachine::HandleLocalizationLoss()
+{
+    const auto now = std::chrono::steady_clock::now();
+    LocalizationLossState& loss = runtime_state_.localization_loss;
+    if (loss.started_at.time_since_epoch().count() == 0) {
+        loss.started_at = now;
+    }
+    motion_controller_->SetForwardState(false);
+
+    const int64_t loss_elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - loss.started_at).count();
+    if (loss_elapsed_ms >= kLocalizationLossTimeoutMs) {
+        return FailNavigation(
+            "localization_lost_timeout",
+            "Localization lost beyond timeout (likely shoved off-route into another zone); terminating navigation.",
+            0.0,
+            0.0,
+            0);
+    }
+
+    const bool unstick_cooling = loss.last_unstick_at.time_since_epoch().count() > 0
+                                 && std::chrono::duration_cast<std::chrono::milliseconds>(now - loss.last_unstick_at).count()
+                                        < kLocalizationLossUnstickIntervalMs;
+    if (loss_elapsed_ms >= kLocalizationLossUnstickIntervalMs && !unstick_cooling) {
+        loss.last_unstick_at = now;
+        LogInfo << "Localization lost; blind unstick hop issued." << VAR(loss_elapsed_ms);
+        motion_controller_->SetAction(LocalDriverAction::JumpForward, true);
+        utils::SleepFor(kActionJumpSettleMs);
+        motion_controller_->SetForwardState(false);
+        return true;
+    }
+
+    utils::SleepFor(kLocatorRetryIntervalMs);
+    return true;
+}
+
 bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
     const char* reason,
     size_t continue_index,
@@ -522,9 +561,9 @@ bool NavigationStateMachine::TickNavigate()
     }
 
     if (!CaptureCurrentPosition(false)) {
-        utils::SleepFor(kLocatorRetryIntervalMs);
-        return true;
+        return HandleLocalizationLoss();
     }
+    runtime_state_.localization_loss.Reset();
 
     const semantic_nodes::Result inline_semantic_result = semantic_nodes::ConsumeInlineSemantics(semantic_ctx);
     if (inline_semantic_result.request_failure) {

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -426,13 +426,13 @@ bool NavigationStateMachine::HandleLocalizationLoss()
 {
     const auto now = std::chrono::steady_clock::now();
     LocalizationLossState& loss = runtime_state_.localization_loss;
-    if (loss.started_at.time_since_epoch().count() == 0) {
+    if (loss.started_at == std::chrono::steady_clock::time_point {}) {
         loss.started_at = now;
     }
     motion_controller_->SetForwardState(false);
 
-    const int64_t loss_elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - loss.started_at).count();
-    if (loss_elapsed_ms >= kLocalizationLossTimeoutMs) {
+    const auto loss_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - loss.started_at);
+    if (loss_elapsed >= std::chrono::milliseconds(kLocalizationLossTimeoutMs)) {
         return FailNavigation(
             "localization_lost_timeout",
             "Localization lost beyond timeout (likely shoved off-route into another zone); terminating navigation.",
@@ -441,12 +441,12 @@ bool NavigationStateMachine::HandleLocalizationLoss()
             0);
     }
 
-    const bool unstick_cooling = loss.last_unstick_at.time_since_epoch().count() > 0
-                                 && std::chrono::duration_cast<std::chrono::milliseconds>(now - loss.last_unstick_at).count()
-                                        < kLocalizationLossUnstickIntervalMs;
-    if (loss_elapsed_ms >= kLocalizationLossUnstickIntervalMs && !unstick_cooling) {
+    const bool unstick_cooling = loss.last_unstick_at != std::chrono::steady_clock::time_point {}
+                                 && std::chrono::duration_cast<std::chrono::milliseconds>(now - loss.last_unstick_at)
+                                        < std::chrono::milliseconds(kLocalizationLossUnstickIntervalMs);
+    if (loss_elapsed >= std::chrono::milliseconds(kLocalizationLossUnstickIntervalMs) && !unstick_cooling) {
         loss.last_unstick_at = now;
-        LogInfo << "Localization lost; blind unstick hop issued." << VAR(loss_elapsed_ms);
+        LogInfo << "Localization lost; blind unstick hop issued." << VAR(loss_elapsed.count());
         motion_controller_->SetAction(LocalDriverAction::JumpForward, true);
         utils::SleepFor(kActionJumpSettleMs);
         motion_controller_->SetForwardState(false);

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -36,6 +36,7 @@ private:
     bool TickNavigate();
     bool TickPhase(NaviPhase phase);
     bool CaptureCurrentPosition(bool force_global_search = false);
+    bool HandleLocalizationLoss();
     bool TryApplyDynamicOverlayToAnchor(
         const char* reason,
         size_t continue_index,


### PR DESCRIPTION
当智能体被推过区域边界进入路线未规划的子区域时，每次 locate 都因 YOLO 区域校验失败返回 YoloFailed， CaptureCurrentPosition 持续失败，TickNavigate 在取位失败分支处反复 SleepFor+return，永远到不了后面的恢复/超时逻辑：前进键保持按下、持续顶着障碍物，无任何避障、无超时，直到被外层流水线超时（约 13 分钟）才失败。

新增 HandleLocalizationLoss：取位持续失败时先松开前进键停止顶撞，达到
kLocalizationLossUnstickIntervalMs 后周期性起跳尝试脱困，超过
kLocalizationLossTimeoutMs 仍无有效定位则 FailNavigation 快速失败，让上层 可以重试。取位成功即清空丢失计时。

## Summary by Sourcery

在导航过程中处理持续的定位丢失问题，防止在位置捕获反复失败时出现无限向前移动的情况。

Bug 修复：
- 当由于区域验证问题导致定位反复失败时，通过引入显式的丢失处理逻辑和基于超时的快速失败机制，阻止智能体在障碍物前无限按住前进键。

增强功能：
- 新增“定位丢失”状态：当位置捕获持续失败时，周期性执行“解困跳跃”（unstick hops），并在超时后终止该状态；一旦定位成功，即重置此状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle sustained localization loss during navigation to prevent infinite forward motion when position captures repeatedly fail.

Bug Fixes:
- Stop the agent from indefinitely pressing forward against obstacles when localization repeatedly fails due to zone validation issues by introducing explicit loss handling and timeout-based fast failure.

Enhancements:
- Add a localization loss state with periodic unstick hops and timeout-based termination when captures keep failing, resetting this state once localization succeeds.

</details>