### PR TITLE
fix: 最后一个协议空间偶现无法进入

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/OperationalManual.json
+++ b/assets/resource/pipeline/ProtocolSpace/OperationalManual.json
@@ -83,7 +83,16 @@
             950,
             280
         ],
-        "end_hold": 200
+        "end_hold": 200,
+        "post_wait_freezes": {
+            "target": [
+                825,
+                210,
+                280,
+                350
+            ],
+            "time": 200
+        }
     },
     "ProtocolSpaceOperationalManualScrollEnd": {
         "desc": "右侧滚动模拟空间列表找到最后一个item图标，表示到末尾了",


### PR DESCRIPTION
close #3493

## Summary by Sourcery

Bug Fixes:
- 通过调整 OperationalManual 协议配置，解决间歇性无法进入最终协议空间的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve intermittent failure to enter the final protocol space by adjusting the OperationalManual protocol configuration.

</details>