### PR TITLE
fix(PlayCover): PlayCover控制器改用触摸退出

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -60,7 +60,11 @@
             "type": "PlayCover",
             "playcover": {
                 "uuid": "maa.playcover"
-            }
+            },
+            "attach_resource_path": [
+                "./resource_adb",
+                "./resource_playcover"
+            ]
         },
         {
             "name": "Wlroots",

--- a/assets/resource_playcover/pipeline/SceneManager/SceneCommon.json
+++ b/assets/resource_playcover/pipeline/SceneManager/SceneCommon.json
@@ -1,0 +1,28 @@
+{
+    // PlayCover 控制器没有任何按键能力（ClickKey / KeyDown / KeyUp / InputText 均被
+    // libMaaPlayCoverControlUnit 拒绝，日志为 "not supported on PlayCover"），
+    // 因此 resource_adb 把 ESC 重映射成 BACK 按键（key=4）在 PlayCover 上同样无法执行。
+    //
+    // 这里用「三种标准返回键」的纯触摸点击来替代 ESC：识别到其中之一即点击，
+    // 所有界面都至少包含其一。
+    //   - CloseButtonType1：右上角两种 X（普通面板 X + 圆形菜单 X，已聚合 5 种变体），优先
+    //   - ProtosyncMenuButton：大世界右上角「手表」（协议同步器），大世界叠加态下的兜底返回入口
+    // 仅复用上述节点的识别框；它们各自的 action / next（含 Alt+点击链）不会被执行。
+    "__ScenePrivateAnyExit": {
+        "desc": "PlayCover 触摸版退出场景：识别右上角 X 或大世界手表并点击（无 ESC 按键可用）",
+        "recognition": {
+            "type": "Or",
+            "param": {
+                "any_of": [
+                    "CloseButtonType1",
+                    "ProtosyncMenuButton"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "action": {
+            "type": "Click"
+        },
+        "post_delay": 600
+    }
+}


### PR DESCRIPTION
## 概要

  修复 PlayCover 控制器下退出节点依赖 `ClickKey(ESC)` 导致任务失败的问题。
  改为识别并点击可触发返回的游戏内按键

## 相关 Issue

   #3204
   #2576
   #2712

## Summary by Sourcery

更新 PlayCover 控制器的退出行为，将原先依赖 ESC 键的退出方式改为使用触控交互，以提高任务的稳定性与可靠性。

Bug 修复：
- 修复此前依赖按下 ESC 键退出而导致失败的 PlayCover 控制器流程。

增强/改进：
- 调整界面和场景管理配置，以支持在 PlayCover 环境中通过触控方式退出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update PlayCover controller exit behavior to use touch interaction instead of ESC key to improve task reliability.

Bug Fixes:
- Fix PlayCover controller flows that previously failed because they depended on ESC key presses to exit.

Enhancements:
- Adjust interface and scene management configuration to support touch-based exit in PlayCover environments.

</details>