### PR TITLE
fix: 售卖弹性物资当前好友判断错误

### DIFF
--- a/assets/resource/pipeline/AutoSell/Recognition.json
+++ b/assets/resource/pipeline/AutoSell/Recognition.json
@@ -191,8 +191,7 @@
                 "template": [
                     "AutoSell/SellTicketFriendValleyIV.png",
                     "AutoSell/SellTicketFriendWuling.png"
-                ],
-                "threshold": 0.9
+                ]
             },
             {
                 "recognition": "OCR",


### PR DESCRIPTION
close #3528

## Summary by Sourcery

Bug Fixes:
- 修正 AutoSell 弹性物品配置中与好友相关的识别逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct friend-related recognition logic in the AutoSell elastic items configuration.

</details>