### PR TITLE
fix: 武陵城储备站传送点偶现点击偏移

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -872,8 +872,8 @@
         "custom_action_param": {
             "map_name": "map02_lv002",
             "target": [
-                694,
-                916
+                695.9,
+                917.5
             ],
             "on_find": "Click"
         },


### PR DESCRIPTION
close #3532

## Summary by Sourcery

Bug Fixes:
- 修复在与五菱城预留站传送点交互时，偶发出现点击偏移的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix intermittent click offset when interacting with the Wuling City reserve station teleport point.

</details>