### PR TITLE
fix(map): 修复MapTrackerBigMapFindImage的副作用问题

### DIFF
--- a/agent/go-service/maptracker/bigmap/find_image.go
+++ b/agent/go-service/maptracker/bigmap/find_image.go
@@ -58,7 +58,8 @@ type mapTrackerBigMapFindImageExpected struct {
 	mode      string
 	boolValue bool
 	count     int
-	rect      [4]float64
+	mapName   string
+	target    [4]float64
 }
 
 func (e *mapTrackerBigMapFindImageExpected) UnmarshalJSON(data []byte) error {
@@ -82,22 +83,32 @@ func (e *mapTrackerBigMapFindImageExpected) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	var rectValue []float64
-	if err := json.Unmarshal(data, &rectValue); err == nil {
-		if len(rectValue) != 4 {
-			return fmt.Errorf("expected rectangle must have 4 numbers [x, y, w, h]")
+	var conditionValue struct {
+		MapName string    `json:"map_name"`
+		Target  []float64 `json:"target"`
+	}
+	if err := json.Unmarshal(data, &conditionValue); err == nil {
+		if conditionValue.MapName == "" {
+			return fmt.Errorf("expected map_name must not be empty")
 		}
-		if rectValue[2] <= 0 || rectValue[3] <= 0 {
-			return fmt.Errorf("expected rectangle width and height must be positive")
+		if len(conditionValue.Target) != 4 {
+			return fmt.Errorf("expected target must have 4 numbers [x, y, w, h]")
 		}
-		*e = mapTrackerBigMapFindImageExpected{mode: findImageExpectedModeRect, rect: [4]float64{rectValue[0], rectValue[1], rectValue[2], rectValue[3]}}
+		if conditionValue.Target[2] <= 0 || conditionValue.Target[3] <= 0 {
+			return fmt.Errorf("expected target width and height must be positive")
+		}
+		*e = mapTrackerBigMapFindImageExpected{
+			mode:    findImageExpectedModeLocation,
+			mapName: conditionValue.MapName,
+			target:  [4]float64{conditionValue.Target[0], conditionValue.Target[1], conditionValue.Target[2], conditionValue.Target[3]},
+		}
 		return nil
 	}
 
-	return fmt.Errorf("expected must be a boolean, non-negative integer, or [x, y, w, h]")
+	return fmt.Errorf("expected must be a boolean, non-negative integer, or {\"map_name\": string, \"target\": [x, y, w, h]}")
 }
 
-func (e mapTrackerBigMapFindImageExpected) isSatisfied(matches []MapTrackerBigMapFindImageMatch) bool {
+func (e mapTrackerBigMapFindImageExpected) isSatisfied(mapName string, matches []MapTrackerBigMapFindImageMatch) bool {
 	switch e.mode {
 	case findImageExpectedModeBool:
 		if e.boolValue {
@@ -106,8 +117,11 @@ func (e mapTrackerBigMapFindImageExpected) isSatisfied(matches []MapTrackerBigMa
 		return len(matches) == 0
 	case findImageExpectedModeCount:
 		return len(matches) == e.count
-	case findImageExpectedModeRect:
-		x, y, w, h := e.rect[0], e.rect[1], e.rect[2], e.rect[3]
+	case findImageExpectedModeLocation:
+		if mapName != e.mapName {
+			return false
+		}
+		x, y, w, h := e.target[0], e.target[1], e.target[2], e.target[3]
 		for _, match := range matches {
 			if match.MapX >= x && match.MapX < x+w && match.MapY >= y && match.MapY < y+h {
 				return true
@@ -118,9 +132,9 @@ func (e mapTrackerBigMapFindImageExpected) isSatisfied(matches []MapTrackerBigMa
 }
 
 const (
-	findImageExpectedModeBool  = "bool"
-	findImageExpectedModeCount = "count"
-	findImageExpectedModeRect  = "rect"
+	findImageExpectedModeBool     = "bool"
+	findImageExpectedModeCount    = "count"
+	findImageExpectedModeLocation = "location"
 )
 
 const (
@@ -244,7 +258,7 @@ func (r *MapTrackerBigMapFindImage) runSingleViewportSearch(
 
 	result := r.matchTemplate(cropped, tpl, param, viewport)
 	saveFindImageDebug(inferRes.MapName, tpl, result)
-	return r.buildResult(arg, param, result, "Big-map FindImage completed")
+	return r.buildResult(arg, param, inferRes.MapName, result, "Big-map FindImage completed")
 }
 
 // runMultiViewportSearch iteratively pans the big map to cover all must-see points,
@@ -345,12 +359,13 @@ func (r *MapTrackerBigMapFindImage) runMultiViewportSearch(
 	}
 
 	saveFindImageDebug(inferRes.MapName, tpl, allMatches)
-	return r.buildResult(arg, param, allMatches, "Big-map multi-viewport FindImage completed")
+	return r.buildResult(arg, param, inferRes.MapName, allMatches, "Big-map multi-viewport FindImage completed")
 }
 
 func (r *MapTrackerBigMapFindImage) buildResult(
 	arg *maa.CustomRecognitionArg,
 	param *MapTrackerBigMapFindImageParam,
+	mapName string,
 	matches []MapTrackerBigMapFindImageMatch,
 	message string,
 ) (*maa.CustomRecognitionResult, bool) {
@@ -370,7 +385,7 @@ func (r *MapTrackerBigMapFindImage) buildResult(
 		return nil, false
 	}
 
-	hit := param.Expected.isSatisfied(matches)
+	hit := param.Expected.isSatisfied(mapName, matches)
 	log.Info().
 		Str("template", param.Template).
 		Int("matches", len(matches)).
@@ -658,7 +673,7 @@ func saveFindImageDebug(mapName string, tpl *minicv.Template, matches []MapTrack
 		return
 	}
 
-	canvas := minicv.ImageConvertRGBA(mapImg)
+	canvas := minicv.ImageCopy(mapImg)
 	tplImg := tpl.Image
 	tplW := tplImg.Rect.Dx()
 	tplH := tplImg.Rect.Dy()

--- a/agent/go-service/maptracker/default/assert_location.go
+++ b/agent/go-service/maptracker/default/assert_location.go
@@ -111,7 +111,7 @@ func (r *MapTrackerAssertLocation) Run(ctx *maa.Context, arg *maa.CustomRecognit
 			x, y, w, h := condition.Target[0], condition.Target[1], condition.Target[2], condition.Target[3]
 			if result.X >= x && result.X < x+w && result.Y >= y && result.Y < y+h {
 				log.Info().
-					Interface("expected", condition).
+					Interface("condition", condition).
 					Msg("Location assertion satisfied")
 
 				return &maa.CustomRecognitionResult{
@@ -122,8 +122,17 @@ func (r *MapTrackerAssertLocation) Run(ctx *maa.Context, arg *maa.CustomRecognit
 		}
 	}
 
-	log.Info().Msg("Location assertion not satisfied, no conditions met")
-	return nil, false
+	log.Info().
+		Str("mapName", result.MapName).
+		Float64("x", result.X).
+		Float64("y", result.Y).
+		Interface("expected", param.Expected).
+		Msg("Location assertion not satisfied, no conditions met")
+
+	return &maa.CustomRecognitionResult{
+		Box:    arg.Roi,
+		Detail: fmt.Sprintf("Expected hit one of%v, but got map_name=%s, x=%.1f, y=%.1f", param.Expected, result.MapName, result.X, result.Y),
+	}, false
 }
 
 func (r *MapTrackerAssertLocation) parseParam(paramStr string) (*MapTrackerAssertLocationParam, error) {

--- a/agent/go-service/maptracker/default/assert_location.go
+++ b/agent/go-service/maptracker/default/assert_location.go
@@ -131,7 +131,7 @@ func (r *MapTrackerAssertLocation) Run(ctx *maa.Context, arg *maa.CustomRecognit
 
 	return &maa.CustomRecognitionResult{
 		Box:    arg.Roi,
-		Detail: fmt.Sprintf("Expected hit one of%v, but got map_name=%s, x=%.1f, y=%.1f", param.Expected, result.MapName, result.X, result.Y),
+		Detail: fmt.Sprintf("Expected hit one of %v, but got map_name=%s, x=%.1f, y=%.1f", param.Expected, result.MapName, result.X, result.Y),
 	}, false
 }
 

--- a/agent/go-service/maptracker/default/goal.go
+++ b/agent/go-service/maptracker/default/goal.go
@@ -4,9 +4,7 @@ package maptrackerdefault
 import (
 	"encoding/json"
 	"fmt"
-	"image"
 	"image/color"
-	"image/draw"
 	"math"
 	"time"
 
@@ -491,8 +489,7 @@ func (a *MapTrackerGoal) saveDebugImage(goalCtx *goalContext, pathIDs []int, pat
 		return
 	}
 
-	canvas := image.NewRGBA(mapRGBA.Bounds())
-	draw.Draw(canvas, canvas.Bounds(), mapRGBA, mapRGBA.Bounds().Min, draw.Src)
+	canvas := minicv.ImageCopy(mapRGBA)
 
 	colorPath := color.RGBA{0x2b, 0x62, 0xc0, 0xff}
 	colorPathZipline := color.RGBA{0xff, 0x8c, 0x00, 0xff}

--- a/agent/go-service/pkg/minicv/image_utils.go
+++ b/agent/go-service/pkg/minicv/image_utils.go
@@ -18,6 +18,17 @@ import (
 	xdraw "golang.org/x/image/draw"
 )
 
+// ImageCopy creates a deep copy of an *image.RGBA.
+func ImageCopy(img *image.RGBA) *image.RGBA {
+	if img == nil {
+		return nil
+	}
+	b := img.Bounds()
+	dst := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+	draw.Draw(dst, dst.Bounds(), img, b.Min, draw.Src)
+	return dst
+}
+
 // ImageCropRect crops a rectangular region from the image and clips it to bounds.
 func ImageCropRect(img *image.RGBA, rect image.Rectangle) *image.RGBA {
 	if img == nil {
@@ -30,6 +41,17 @@ func ImageCropRect(img *image.RGBA, rect image.Rectangle) *image.RGBA {
 	}
 	dst := image.NewRGBA(image.Rect(0, 0, clipped.Dx(), clipped.Dy()))
 	draw.Draw(dst, dst.Bounds(), img, clipped.Min, draw.Src)
+	return dst
+}
+
+// ImageCropSquareByRadius crops a square region from the image centered at (centerX, centerY) with the given radius
+func ImageCropSquareByRadius(img *image.RGBA, centerX, centerY, radius int) *image.RGBA {
+	x1, x2 := max(img.Rect.Min.X, centerX-radius), min(img.Rect.Max.X, centerX+radius+1)
+	y1, y2 := max(img.Rect.Min.Y, centerY-radius), min(img.Rect.Max.Y, centerY+radius+1)
+
+	cropRect := image.Rect(x1, y1, x2, y2)
+	dst := image.NewRGBA(image.Rect(0, 0, cropRect.Dx(), cropRect.Dy()))
+	draw.Draw(dst, dst.Bounds(), img, cropRect.Min, draw.Src)
 	return dst
 }
 
@@ -49,17 +71,6 @@ func ImageToBase64JPEG(img image.Image, quality int) (string, error) {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
-}
-
-// ImageCropSquareByRadius crops a square region from the image centered at (centerX, centerY) with the given radius
-func ImageCropSquareByRadius(img *image.RGBA, centerX, centerY, radius int) *image.RGBA {
-	x1, x2 := max(img.Rect.Min.X, centerX-radius), min(img.Rect.Max.X, centerX+radius+1)
-	y1, y2 := max(img.Rect.Min.Y, centerY-radius), min(img.Rect.Max.Y, centerY+radius+1)
-
-	cropRect := image.Rect(x1, y1, x2, y2)
-	dst := image.NewRGBA(image.Rect(0, 0, cropRect.Dx(), cropRect.Dy()))
-	draw.Draw(dst, dst.Bounds(), img, cropRect.Min, draw.Src)
-	return dst
 }
 
 // ImageRotate rotates an image by the given angle (degrees) around its center

--- a/docs/zh_cn/developers/components/map-tracker.md
+++ b/docs/zh_cn/developers/components/map-tracker.md
@@ -310,11 +310,11 @@
 
 - `template`: 模板图片路径。注意这个路径是相对于 `assets/resource` 目录的，例如 `image/MapTracker/BigMapIcons/Pointer.png`（玩家指针图标）。
 
-- `expected`: 布尔值、非负整数、或者由 4 个实数组成的列表 `[x, y, w, h]`。控制命中识别的条件，具体含义如下：
+- `expected`: 布尔值、非负整数、或者条件对象。控制命中识别的条件，具体含义如下：
     - 如果是布尔值 `true`，则表示找到至少一个匹配结果即可命中识别；
     - 如果是布尔值 `false`，则表示找不到匹配结果才能命中识别；
     - 如果是非负整数 `n`，则表示匹配到恰好 `n` 个结果才能命中识别；
-    - 如果是列表 `[x, y, w, h]`，则表示指定的矩形坐标区域内有至少一个匹配结果才能命中识别。
+    - 如果是对象 `{"map_name": "...", "target": [x, y, w, h]}`，则表示指定的地图的矩形坐标区域内有至少一个匹配结果才能命中识别。
 
 可选参数：
 
@@ -345,12 +345,15 @@
         "custom_recognition": "MapTrackerBigMapFindImage",
         "custom_recognition_param": {
             "template": "image/SeizeDeliveryJobs/BlueTaskLocation.png",
-            "expected": [
-                114,
-                514,
-                19,
-                19
-            ],
+            "expected": {
+                "map_name": "map02_lv005",
+                "target": [
+                    114,
+                    514,
+                    19,
+                    19
+                ]
+            },
             "green_mask": true,
             "zoom_value": 0.25
         },

--- a/tools/schema/components/map_tracker.schema.json
+++ b/tools/schema/components/map_tracker.schema.json
@@ -408,15 +408,27 @@
                 },
                 "expected": {
                     "title": "Expected",
-                    "description": "Recognition hit condition: true for at least one match, false for no matches, integer for exact match count, or [x, y, w, h] for a required map-coordinate rectangle hit.",
+                    "description": "Recognition hit condition: true for at least one match, false for no matches, integer for exact match count, or an object with map_name and target for a required map-coordinate rectangle hit.",
                     "oneOf": [
                         { "type": "boolean" },
                         { "type": "integer", "minimum": 0 },
                         {
-                            "type": "array",
-                            "minItems": 4,
-                            "maxItems": 4,
-                            "items": { "type": "number" }
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [ "map_name", "target" ],
+                            "properties": {
+                                "map_name": {
+                                    "title": "Map Name",
+                                    "description": "Map identifier that the match must land on.",
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "target": {
+                                    "title": "Target",
+                                    "description": "Bounding box [x, y, w, h] defining the required hit region in map pixel coordinates.",
+                                    "$ref": "#/$defs/Rect4D"
+                                }
+                            }
                         }
                     ]
                 },


### PR DESCRIPTION
## 概要

此 PR 修复了 MapTrackerBigMapFindImage 会污染原始图片的问题。此外修改了它的参数格式，详见文档。

## Summary by Sourcery

更新大地图图像查找逻辑，以避免修改源图像，并优化预期匹配配置以包含地图上下文。

新功能：
- 支持通过包含地图名称和目标矩形的对象来指定大地图查找的预期条件，而不是使用原始的矩形列表。

错误修复：
- 防止 `MapTrackerBigMapFindImage` 调试输出通过在原图上绘制导致原始地图图像被修改，改为在复制的图像上绘制。
- 改进 `MapTrackerAssertLocation` 失败时的处理方式，返回更详细的结果并提供更丰富的日志记录，而不只是简单的失败标记。

增强：
- 优化大地图图像查找的预期条件评估逻辑，在验证匹配坐标的同时验证地图名称。
- 新增可复用的 RGBA 图像深拷贝辅助函数，并在绘制调试叠加层时使用，以保护源数据不被修改。
- 调整位置断言中的日志字段，使字段名称更清晰，并在不匹配时包含完整的预期上下文。

文档：
- 为大地图图像查找记录新的基于对象的预期条件格式，并相应更新示例配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update big-map image finding to avoid mutating source images and refine expected match configuration to include map context.

New Features:
- Support specifying expected big-map find conditions via an object containing map name and target rectangle instead of a raw rectangle list.

Bug Fixes:
- Prevent MapTrackerBigMapFindImage debug output from mutating the original map image by drawing on a copied image.
- Improve MapTrackerAssertLocation failure handling by returning a detailed result and richer logging instead of a bare failure.

Enhancements:
- Refine expected-condition evaluation for big-map image search to validate map name along with match coordinates.
- Add a reusable RGBA image deep-copy helper and use it where debug overlays are drawn to preserve source data.
- Adjust logging fields in location assertion to use clearer names and include full expectation context on mismatch.

Documentation:
- Document the new object-based expected condition format for big-map image finding and update the example configuration accordingly.

</details>