### PR TITLE
fix: 抢委托自动送货须知 enable 写反

### DIFF
--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobs.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobs.json
@@ -10,8 +10,8 @@
         ]
     },
     "SeizeDeliveryJobsGuard": {
-        "desc": "自动送委托的风险知悉拦截节点（此节点默认开启）",
-        "enabled": true,
+        "desc": "自动送委托的风险知悉拦截节点（此节点在 tasks 中跟随全自动送货选项默认开启）",
+        "enabled": false,
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,

--- a/assets/tasks/SeizeDeliveryJobs.json
+++ b/assets/tasks/SeizeDeliveryJobs.json
@@ -226,15 +226,15 @@
             "default_case": "No",
             "cases": [
                 {
-                    "name": "No"
-                },
-                {
-                    "name": "Yes",
+                    "name": "No",
                     "pipeline_override": {
                         "SeizeDeliveryJobsGuard": {
-                            "enabled": false
+                            "enabled": true
                         }
                     }
+                },
+                {
+                    "name": "Yes"
                 }
             ]
         },


### PR DESCRIPTION
fix #3544 

## Summary by Sourcery

Bug Fixes:
- 修复了 SeizeDeliveryJobs 自动发货通知配置中启用设置被反转的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix inverted enable setting for the SeizeDeliveryJobs automatic delivery notice configuration.

</details>