### PR TITLE
fix(MapNavigator): A*过于保守 卡死判定失效

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navigation_session.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_session.cpp
@@ -232,6 +232,7 @@ void NavigationSession::AdvanceToNextWaypoint(const char* reason)
     RequireCurrentWaypoint(reason);
     ++current_node_idx_;
     ResetProgress();
+    ResetHardProgress();
 }
 
 void NavigationSession::AdvanceToNextWaypoint(ActionType expected_action, const char* reason)
@@ -248,6 +249,7 @@ void NavigationSession::SkipPastWaypoint(size_t waypoint_idx, const char* reason
     assert(waypoint_idx >= current_node_idx_ && "SkipPastWaypoint cannot move backward.");
     current_node_idx_ = waypoint_idx + 1;
     ResetProgress();
+    ResetHardProgress();
 }
 
 void NavigationSession::ResetProgress()
@@ -288,6 +290,39 @@ double NavigationSession::best_distance_to_target() const
     return best_distance_to_target_;
 }
 
+void NavigationSession::ObserveHardProgress(size_t waypoint_idx, double actual_distance, const std::chrono::steady_clock::time_point& now)
+{
+    const double progress_epsilon = std::max(kNoProgressDistanceEpsilon, kMeasurementDefaultPositionQuantum);
+    if (!hard_progress_initialized_ || hard_progress_waypoint_idx_ != waypoint_idx) {
+        hard_progress_waypoint_idx_ = waypoint_idx;
+        hard_best_distance_ = actual_distance;
+        hard_last_progress_time_ = now;
+        hard_progress_initialized_ = true;
+        return;
+    }
+
+    if (actual_distance < hard_best_distance_ - progress_epsilon) {
+        hard_best_distance_ = actual_distance;
+        hard_last_progress_time_ = now;
+    }
+}
+
+int64_t NavigationSession::HardStalledMs(const std::chrono::steady_clock::time_point& now) const
+{
+    if (!hard_progress_initialized_ || hard_last_progress_time_.time_since_epoch().count() == 0) {
+        return 0;
+    }
+    return std::chrono::duration_cast<std::chrono::milliseconds>(now - hard_last_progress_time_).count();
+}
+
+void NavigationSession::ResetHardProgress()
+{
+    hard_progress_waypoint_idx_ = std::numeric_limits<size_t>::max();
+    hard_best_distance_ = std::numeric_limits<double>::max();
+    hard_last_progress_time_ = {};
+    hard_progress_initialized_ = false;
+}
+
 void NavigationSession::ApplyDynamicOverlay(std::vector<Waypoint> generated_prefix, size_t continue_index, const NaviPosition& pos)
 {
     assert(continue_index <= original_path_.size() && "Dynamic overlay continue index is out of range.");
@@ -300,6 +335,7 @@ void NavigationSession::ApplyDynamicOverlay(std::vector<Waypoint> generated_pref
     current_node_idx_ = 0;
     current_zone_id_ = pos.zone_id;
     ResetProgress();
+    ResetHardProgress();
     LogInfo << "Dynamic route overlay applied." << VAR(generated_count) << VAR(continue_index) << VAR(current_path_.size())
             << VAR(pos.x) << VAR(pos.y) << VAR(pos.zone_id);
 }

--- a/agent/cpp-algo/source/MapNavigator/navigation_session.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_session.h
@@ -57,6 +57,14 @@ struct NavigationSession
     int64_t StalledMs(const std::chrono::steady_clock::time_point& now) const;
     double best_distance_to_target() const;
 
+    // Hard no-progress watchdog. Mirrors ObserveProgress/StalledMs but is *only* cleared by a genuine route
+    // change (waypoint advance / skip / dynamic overlay) — never by ResetProgress. Dynamic-recovery escapes
+    // call ResetProgress on every small jump, so the ordinary stall clock can be reset indefinitely while the
+    // agent thrashes in place; this clock survives those resets and lets the recovery timeout actually fire.
+    void ObserveHardProgress(size_t waypoint_idx, double actual_distance, const std::chrono::steady_clock::time_point& now);
+    int64_t HardStalledMs(const std::chrono::steady_clock::time_point& now) const;
+    void ResetHardProgress();
+
     void ApplyDynamicOverlay(std::vector<Waypoint> generated_prefix, size_t continue_index, const NaviPosition& pos);
 
     NaviPhase phase() const;
@@ -79,6 +87,11 @@ private:
     double best_distance_to_target_ = std::numeric_limits<double>::max();
     std::chrono::steady_clock::time_point last_progress_time_ {};
     bool progress_initialized_ = false;
+
+    size_t hard_progress_waypoint_idx_ = std::numeric_limits<size_t>::max();
+    double hard_best_distance_ = std::numeric_limits<double>::max();
+    std::chrono::steady_clock::time_point hard_last_progress_time_ {};
+    bool hard_progress_initialized_ = false;
 
     void RequireCurrentWaypoint(const char* reason) const;
     void RequireWaypointIndex(size_t index, const char* reason) const;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -666,6 +666,9 @@ bool NavigationStateMachine::TickNavigate()
                                               ? nav_run_result.remaining_to_anchor
                                               : route.progress_distance;
         session_->ObserveProgress(session_->current_node_idx(), effective_progress, now);
+        // Feed the same signal to the hard watchdog, which recovery escapes can never reset (they only clear
+        // the ordinary ObserveProgress clock). This is what lets the recovery timeout below actually fire.
+        session_->ObserveHardProgress(session_->current_node_idx(), effective_progress, now);
     }
     // An OffCorridor replan rebuilds a genuinely different (usually longer) corridor, so reset the stall
     // counter to not penalize the new route. A ProgressRegression replan, by contrast, fires *because* the
@@ -762,7 +765,13 @@ bool NavigationStateMachine::TickNavigate()
                 recovery.anchor_index = anchor->first;
             }
 
-            const int64_t recovery_elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - recovery.started_at).count();
+            // Measure the recovery timeout from the session hard-progress clock, not this episode's
+            // recovery.started_at. Every small jump "escape" calls recovery.Reset() + ResetProgress(), which
+            // re-stamps started_at and the ordinary stall clock — so a started_at-based elapsed never grows and
+            // the agent can thrash in place indefinitely (observed: ~6 min, 1094 jumps, 0 timeouts). The hard
+            // clock only advances on genuine net progress toward the waypoint, so a livelock now trips the
+            // emergency stop after kDynamicRecoveryTotalTimeoutMs of real no-progress.
+            const int64_t recovery_elapsed_ms = session_->HardStalledMs(now);
             if (recovery_elapsed_ms > kDynamicRecoveryTotalTimeoutMs) {
                 return FailNavigation(
                     "dynamic_recovery_timeout",

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -292,7 +292,8 @@ std::optional<double> BaseNavPlanner::groundHeightNearIndexed(
     return best;
 }
 
-bool BaseNavPlanner::segmentHeightWalkable(uint16_t zone_id, const WorldPoint& a, const WorldPoint& b) const
+bool BaseNavPlanner::segmentHeightWalkable(
+    uint16_t zone_id, const WorldPoint& a, const WorldPoint& b, const std::vector<uint8_t>* blocked) const
 {
     if (pack_.findZone(zone_id) == nullptr) {
         return false;
@@ -308,12 +309,16 @@ bool BaseNavPlanner::segmentHeightWalkable(uint16_t zone_id, const WorldPoint& a
         const WorldPoint point { .x = a.x + (b.x - a.x) * t, .y = a.y + (b.y - a.y) * t };
         if (previous && cached != kInvalidTriangle) {
             if (detail::PointInTriangle(point, trianglePoints(cached))) {
-                continue; // 命中缓存:高度等于 previous,直接进入下一采样点
+                continue; // 命中缓存:高度等于 previous、三角形未变(已判过阻挡),直接进入下一采样点
             }
         }
         const std::optional<double> height = groundHeightNearIndexed(zone_id, point, previous, cached);
         if (!height) {
             return false; // 采样点离开网格,判定捷径不可走
+        }
+        // 直线踩入被封堵三角形即等于直穿障碍本身,拒绝;反之全程绕开封堵集,方为真实可衔接的可达性证明。
+        if (blocked != nullptr && cached < blocked->size() && (*blocked)[cached] != 0) {
+            return false;
         }
         if (previous && std::abs(*height - *previous) > kBridgeMaxHeightDelta) {
             return false; // 地面高度突跳(踩入墙体或跌落台面),为结构性拐角,捷径不可走
@@ -433,9 +438,14 @@ BaseNavRouteResult BaseNavPlanner::findPath(const BaseNavRouteRequest& request) 
     // (kBridgeMaxHeightDelta) rejects — even when the goal is a short, flat walk away. Both endpoints have
     // already snapped onto the mesh here, so when the straight segment between them stays on walkable mesh
     // with continuous ground height it is a sound proof the goal is reachable; accept it as a direct path.
-    // Skipped when triangles are blocked (an obstacle-detour query), where a straight shortcut would walk
-    // back through the very obstacle the detour is trying to bypass.
-    if (request.blocked_triangles.empty() && segmentHeightWalkable(zone->zone_id, start->point, goal->point)) {
+    // For obstacle-detour queries (blocked triangles set) the same proof holds as long as the straight
+    // segment never steps onto a blocked triangle — passing the blocked mask makes segmentHeightWalkable
+    // reject exactly that case. This is the difference between refusing a truly impassable crossing and
+    // refusing two positions that are plainly connectable around the obstacle: the former still fails (the
+    // straight line walks back through the obstacle and trips the mask, or hits a height step), while the
+    // latter is now accepted instead of being lost to a fragmented-mesh A* false Unreachable.
+    const std::vector<uint8_t>* blocked_mask = request.blocked_triangles.empty() ? nullptr : &blocked;
+    if (segmentHeightWalkable(zone->zone_id, start->point, goal->point, blocked_mask)) {
         BaseNavRouteResult result;
         result.status = BaseNavRouteStatus::Success;
         result.triangles.push_back(start->triangle);

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -99,7 +99,13 @@ private:
     // LOS 拉直的可行性判据,取代抽稀中的 march:沿 a→b 采样,要求每点在网格内、且相邻采样的地面高度
     // 跳变不超过 kBridgeMaxHeightDelta。共面捷径全程平坦判可走(被拉直至中线),绕墙捷径因踩墙跳变判
     // 不可走(直角得以保留)。march 在共面重叠缝处误判不可走、使抽稀拉不直,故改用此高度连续性判据。
-    bool segmentHeightWalkable(uint16_t zone_id, const WorldPoint& a, const WorldPoint& b) const;
+    // blocked 非空(绕障查询)时,直线踩入任一被封堵三角形即判不可走——即直线穿回障碍本身;反之直线
+    // 全程绕开封堵集,才作为两端真实可衔接的可达性证明被接受。
+    bool segmentHeightWalkable(
+        uint16_t zone_id,
+        const WorldPoint& a,
+        const WorldPoint& b,
+        const std::vector<uint8_t>* blocked = nullptr) const;
     std::array<WorldPoint, 3> trianglePoints(uint32_t triangle_index) const;
     std::optional<std::array<WorldPoint, 2>> sharedEdgePortal(uint32_t lhs, uint32_t rhs) const;
     std::optional<WorldPoint> sharedEdgeMidpoint(uint32_t lhs, uint32_t rhs) const;

--- a/tools/MapNavigator/basenav_preview.py
+++ b/tools/MapNavigator/basenav_preview.py
@@ -379,6 +379,26 @@ class BaseNavField:
 
         triangle_path, cost = self._astar(start_snap.triangle, goal_snap.triangle)
         if not triangle_path:
+            # A* 在破碎/重叠网格上会把"目标落在微小不连通分量里"或"恰好隔着一道被 BRIDGE_MAX_HEIGHT_DELTA
+            # 拒绝的高度台阶"误报为不可达 —— 哪怕目标其实只是一小段平地之外。两端都已 snap 到网格上,故当两
+            # 点间的直线全程落在可走网格、地面高度连续时,这就是目标可达的充分证明,按直连路径接受。对齐 C++
+            # BaseNavPlanner::findPath 的直连可达性证明,使预览不再把这些"明明可走"的线路画成不可达。预览只做
+            # 直连查询(无绕障/封堵三角形),故无需 C++ 那个 blocked 掩码分支。
+            if self._segment_height_walkable(zone_id, start_snap.point, goal_snap.point):
+                direct_triangles = [start_snap.triangle]
+                if goal_snap.triangle != start_snap.triangle:
+                    direct_triangles.append(goal_snap.triangle)
+                direct_points = _dedupe_points([start_snap.point, goal_snap.point])
+                direct_cost = math.hypot(
+                    goal_snap.point[0] - start_snap.point[0],
+                    goal_snap.point[1] - start_snap.point[1],
+                )
+                return _BaseNavRoute(
+                    points=direct_points,
+                    triangles=direct_triangles,
+                    cost=direct_cost,
+                    segment_breaks=[],
+                )
             raise ValueError("A* 未找到可达路径")
         points, segment_breaks = self._triangle_path_points(triangle_path, start_snap.point, goal_snap.point)
         return _BaseNavRoute(points=points, triangles=triangle_path, cost=cost, segment_breaks=segment_breaks)


### PR DESCRIPTION
fix #3526

## Summary by Sourcery

收紧 MapNavigator 的进度与路径规划行为，以正确检测严重卡死（hard stalls），并接受绕过破碎导航网格导致的 A* 失败的、合法的直线连接。

Bug 修复：
- 确保动态恢复（dynamic recovery）超时时间是相对于一个“硬”无进展看门狗（hard no-progress watchdog）来衡量的，该看门狗仅在路线发生真实变更时重置，从而防止在没有卡死截止条件时出现无限抖动（thrashing）。
- 当路线前进、跳过路径点（waypoint）、或应用动态叠加层（dynamic overlay）时重置“硬”进度看门狗，以保证卡死检测始终与当前路径保持一致。
- 在障碍绕行查询中，如果直线段穿越被阻挡的导航网格三角面，则将其视为无效，避免走捷径时重新进入原本要绕开的障碍物。
- 当直线段始终位于连续且可行走的网格上时，允许在对齐后的起点和终点之间使用直接直线路径（同时在 C++ 规划器和 Python 预览中启用），以减少在破碎或重叠网格上误判为“不可达”的情况。

增强：
- 在 NavigationSession 中暴露并跟踪一个独立的“硬”进度时钟，并由导航状态机驱动，以支持跨多次恢复过程的稳健卡死监控。
- 扩展 BaseNavPlanner 的线段高度可行走性检查，使其可选地使用被阻挡三角面的掩码，从而在绕行场景中实现更精确的视线（LOS）验证。
- 通过在 A* 失败时添加直线可行走性的回退逻辑，使 Python basenav 预览的可达性逻辑与 C++ 规划器保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten MapNavigator’s progress and pathfinding behavior to correctly detect hard stalls and accept valid straight-line connections that bypass fragmented navmesh A* failures.

Bug Fixes:
- Ensure dynamic recovery timeouts are measured against a hard no-progress watchdog that is only reset on real route changes, preventing indefinite thrashing without a stall cutoff.
- Reset the hard progress watchdog whenever the route advances, skips a waypoint, or applies a dynamic overlay to keep stall detection aligned with the current path.
- Treat straight segments as invalid if they traverse blocked navmesh triangles during obstacle-detour queries, avoiding shortcuts that re-enter the obstacle being bypassed.
- Allow direct straight-line paths between snapped start and goal points when the segment remains on continuous, walkable mesh, both in the C++ planner and Python preview, reducing false unreachable results on fragmented or overlapping meshes.

Enhancements:
- Expose and track a separate hard progress clock in NavigationSession and feed it from the navigation state machine to support robust stall monitoring across recovery episodes.
- Extend the BaseNavPlanner segment-height walkability check to optionally use a blocked-triangle mask, enabling more precise LOS validation for detour scenarios.
- Align the Python basenav preview’s reachability logic with the C++ planner by adding a straight-line walkability fallback when A* fails.

</details>