### PR TITLE
fix(PlayCover): 修复选择 PlayCover 控制器后显示不兼容已适配 ADB 的任务的问题

### DIFF
--- a/assets/tasks/AndroidOpenGame.json
+++ b/assets/tasks/AndroidOpenGame.json
@@ -6,7 +6,8 @@
             "entry": "AndroidOpenGame",
             "description": "$task.AndroidOpenGame.description",
             "controller": [
-                "ADB"
+                "ADB",
+                "PlayCover"
             ],
             "group": ["other_menu"]
         }

--- a/assets/tasks/AutoCollect.json
+++ b/assets/tasks/AutoCollect.json
@@ -7,6 +7,7 @@
             "description": "$task.AutoCollect.description",
             "controller": [
                 "ADB",
+                "PlayCover",
                 "Win32-Front",
                 "Wlroots"
             ],

--- a/assets/tasks/AutoEssence.json
+++ b/assets/tasks/AutoEssence.json
@@ -7,6 +7,7 @@
             "description": "$task.AutoEssence.description",
             "controller": [
                 "ADB",
+                "PlayCover",
                 "Win32-Front",
                 "Wlroots"
             ],

--- a/assets/tasks/AutoStockStaple.json
+++ b/assets/tasks/AutoStockStaple.json
@@ -8,6 +8,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/AutoUseSpMedication.json
+++ b/assets/tasks/AutoUseSpMedication.json
@@ -8,6 +8,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/BakerEntry.json
+++ b/assets/tasks/BakerEntry.json
@@ -8,6 +8,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/Crafting.json
+++ b/assets/tasks/Crafting.json
@@ -8,6 +8,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/CreditShopping.json
+++ b/assets/tasks/CreditShopping.json
@@ -18,6 +18,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/DailyRewards.json
+++ b/assets/tasks/DailyRewards.json
@@ -15,6 +15,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/DeliveryJobs.json
+++ b/assets/tasks/DeliveryJobs.json
@@ -15,6 +15,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/DijiangRewards.json
+++ b/assets/tasks/DijiangRewards.json
@@ -14,6 +14,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/EnvironmentMonitoring.json
+++ b/assets/tasks/EnvironmentMonitoring.json
@@ -8,7 +8,8 @@
             "controller": [
                 "Win32-Front",
                 "Wlroots",
-                "ADB"
+                "ADB",
+                "PlayCover"
             ],
             "group": [
                 "regional_development"

--- a/assets/tasks/GearAssembly.json
+++ b/assets/tasks/GearAssembly.json
@@ -12,6 +12,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/GiftOperator.json
+++ b/assets/tasks/GiftOperator.json
@@ -15,7 +15,8 @@
             "controller": [
                 "Win32-Front",
                 "Wlroots",
-                "ADB"
+                "ADB",
+                "PlayCover"
             ]
         }
     ],

--- a/assets/tasks/PullCountCalculator.json
+++ b/assets/tasks/PullCountCalculator.json
@@ -7,6 +7,7 @@
             "description": "$task.PullCountCalculator.description",
             "controller": [
                 "ADB",
+                "PlayCover",
                 "Win32-Front",
                 "Wlroots"
             ],

--- a/assets/tasks/ReadAllWiki.json
+++ b/assets/tasks/ReadAllWiki.json
@@ -8,6 +8,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/ReceiveProdManual.json
+++ b/assets/tasks/ReceiveProdManual.json
@@ -8,6 +8,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/SellProduct.json
+++ b/assets/tasks/SellProduct.json
@@ -14,6 +14,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/SimpleProductionBatchStart.json
+++ b/assets/tasks/SimpleProductionBatchStart.json
@@ -8,6 +8,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/VisitFriends.json
+++ b/assets/tasks/VisitFriends.json
@@ -12,6 +12,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [

--- a/assets/tasks/Weapon.json
+++ b/assets/tasks/Weapon.json
@@ -8,6 +8,7 @@
             "controller": [
                 "Win32-Front",
                 "ADB",
+                "PlayCover",
                 "Wlroots"
             ],
             "group": [


### PR DESCRIPTION
## 概要
标记适配 ADB 的任务兼容 PlayCover 控制器，修复选择 PlayCover 控制器后，部分已适配 ADB 的任务在 MXU 中显示为不兼容、无法勾选的问题。

## Summary by Sourcery

Bug Fixes:
- 解决一个问题：在使用 PlayCover 控制器时，一些经过 ADB 适配的任务会显示为不兼容，且无法被选中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve an issue where some ADB-adapted tasks were shown as incompatible and could not be selected when using the PlayCover controller.

</details>