### PR TITLE
feat(MapNavigator): NavMesh 细分 tier 层

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/MapNavigator.cpp
+++ b/agent/cpp-algo/source/MapNavigator/MapNavigator.cpp
@@ -43,6 +43,11 @@ MaaBool MAA_CALL MapNavigateActionRun(
         return kMaaTrue;
     }
 
+    // Native entry plans on the navmesh base mesh, so normalize live fixes onto the navmesh base-pixel
+    // frame using the navmesh's own baked tier affine. The Compatible entry leaves this off (its frame
+    // is the MapTracker base-px), keeping that path byte-identical.
+    param.normalize_position_via_navmesh = true;
+
     NaviController controller(context);
     return controller.Navigate(param) ? kMaaTrue : kMaaFalse;
 }

--- a/agent/cpp-algo/source/MapNavigator/navi_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navi_controller.cpp
@@ -28,6 +28,9 @@ bool NaviController::Navigate(const NaviParam& param)
     ActionWrapper action_wrapper(ctx_);
     PositionProvider position_provider(action_wrapper.GetCtrl(), maplocator::getOrInitLocator());
     position_provider.ResetTracking();
+    if (param.normalize_position_via_navmesh) {
+        position_provider.SetPositionNormalizer([&param](NaviPosition& pos) { NormalizeLivePositionToBase(param, pos); });
+    }
     const char* controller_type = action_wrapper.controller_type();
     const bool uses_touch_backend = action_wrapper.uses_touch_backend();
     LogInfo << "MapNavigator controller initialized." << VAR(controller_type) << VAR(uses_touch_backend);

--- a/agent/cpp-algo/source/MapNavigator/navi_controller.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_controller.h
@@ -21,6 +21,10 @@ struct NaviParam
     int64_t arrival_timeout = 60000;
     double sprint_threshold = 16.0;
     bool enable_local_driver = true;
+    // When set, live fixes are projected onto the navmesh base-pixel frame via the navmesh's own baked
+    // tier affine (see NormalizeLivePositionToBase). Native MapNavigator turns this on; the Compatible
+    // entry leaves it off so its MapTracker-base-px frame is preserved byte-for-byte.
+    bool normalize_position_via_navmesh = false;
 };
 
 class NaviController

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -366,6 +366,8 @@ void UpdateStateFromRegularWaypoint(const Waypoint& waypoint, NavmeshExpansionSt
 
 navmesh::BaseNavRouteRequest BuildRouteRequest(
     const NaviParam& param,
+    const navmesh::BaseNavPack& pack,
+    const std::string& locator_zone,
     const std::string& navmesh_zone,
     const navmesh::WorldPoint& start,
     const navmesh::WorldPoint& goal,
@@ -378,12 +380,18 @@ navmesh::BaseNavRouteRequest BuildRouteRequest(
     request.snap_radius = param.navmesh_snap_radius;
     request.max_cost = param.navmesh_max_cost;
     request.blocked_triangles = blocked_triangles;
+    // The locator zone is the tier the agent is on; feed its baked dominant-floor height so snap resolves
+    // onto the right floor of the multi-floor base. A geometry / base / unknown locator yields the sentinel
+    // -> floor-blind, byte-identical to the pre-floor behavior. Mirrors the python tool's floor_y_for(tier).
+    request.floor_y = pack.floorYForZoneName(locator_zone);
     return request;
 }
 
-navmesh::BaseNavRouteRequest BuildRouteRequest(const NaviParam& param, const NavmeshExpansionState& state, const Waypoint& waypoint)
+navmesh::BaseNavRouteRequest BuildRouteRequest(
+    const NaviParam& param, const navmesh::BaseNavPack& pack, const NavmeshExpansionState& state, const Waypoint& waypoint)
 {
-    return BuildRouteRequest(param, state.navmesh_zone, state.route_start, { .x = waypoint.x, .y = waypoint.y });
+    return BuildRouteRequest(
+        param, pack, state.current_zone, state.navmesh_zone, state.route_start, { .x = waypoint.x, .y = waypoint.y });
 }
 
 void LogGeneratedNavmeshPath(
@@ -433,7 +441,7 @@ bool AppendBlindTargetFallback(
             .x = target.x + (start.x - target.x) * t,
             .y = target.y + (start.y - target.y) * t,
         };
-        navmesh::BaseNavRouteRequest request = BuildRouteRequest(param, state.navmesh_zone, start, probe);
+        navmesh::BaseNavRouteRequest request = BuildRouteRequest(param, navmesh.pack, state.current_zone, state.navmesh_zone, start, probe);
         request.snap_radius = snap_radius;
         const auto route = navmesh.planner.findPath(request);
         if (!route.ok() || route.path.points.empty()) {
@@ -477,7 +485,7 @@ bool AppendNavmeshWaypoint(
     NavmeshExpansionState& state,
     std::vector<Waypoint>& out_path)
 {
-    const navmesh::BaseNavRouteRequest request = BuildRouteRequest(param, state, waypoint);
+    const navmesh::BaseNavRouteRequest request = BuildRouteRequest(param, navmesh.pack, state, waypoint);
     const auto route_result = navmesh.planner.findPath(request);
     if (!route_result.ok()) {
         LogWarn << "NAVMESH waypoint not directly reachable; attempting blind-target fallback." << VAR(state.navmesh_zone)
@@ -551,6 +559,31 @@ navmesh::WorldPoint OffsetPoint(const NaviPosition& position, double heading, do
 std::filesystem::path ResolveNavmeshFilePath(const std::string& configured_path)
 {
     return ResolveNavmeshFile(configured_path);
+}
+
+void NormalizeLivePositionToBase(const NaviParam& param, NaviPosition& pos)
+{
+    if (pos.zone_id.empty()) {
+        return;
+    }
+    const std::string navmesh_zone = InferBaseNavZone(pos.zone_id, param.map_name);
+    if (navmesh_zone.empty()) {
+        return;
+    }
+    const std::filesystem::path navmesh_path = ResolveNavmeshFile(param.navmesh_file);
+    const auto navmesh = LoadCachedNavmesh(navmesh_path, navmesh_zone);
+    if (!navmesh) {
+        return;
+    }
+    const auto projection = navmesh->pack.projectToBase(pos.zone_id, pos.x, pos.y);
+    if (projection && projection->was_tier) {
+        // Tier-template-pixel fix -> navmesh base-pixel via the navmesh's OWN baked affine. zone_id is
+        // kept as the locator naming: zone validation matches against it and InferBaseNavZone already maps
+        // it to the parent geometry zone for routing. Geometry / base-matched / unknown zones never reach
+        // this branch (they project to identity), so this is zero-regression by construction.
+        pos.x = projection->x;
+        pos.y = projection->y;
+    }
 }
 
 std::string InitialExpectedZone(const NaviParam& param)
@@ -629,7 +662,7 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(
         return std::nullopt;
     }
 
-    const auto request = BuildRouteRequest(param, navmesh_zone, start, goal, blocked_triangles);
+    const auto request = BuildRouteRequest(param, navmesh->pack, locator_zone, navmesh_zone, start, goal, blocked_triangles);
     const auto route_result = navmesh->planner.findPath(request);
     if (!route_result.ok()) {
         if (blocked_triangles.empty()) {

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -16,6 +16,11 @@ struct NaviParam;
 
 std::filesystem::path ResolveNavmeshFilePath(const std::string& configured_path = {});
 std::string InitialExpectedZone(const NaviParam& param);
+// Maps a live locator fix onto the navmesh base-pixel frame using the navmesh's OWN baked tier affine
+// (the same is_tier / base = s*tier + t the python tool uses), in place. A geometry / base-matched /
+// unknown zone projects to identity, so this is a no-op there — only a tier-template-pixel fix is
+// rewritten. Never consults the external MapTracker transforms.
+void NormalizeLivePositionToBase(const NaviParam& param, NaviPosition& pos);
 void PreloadNavmeshWaypoints(const NaviParam& param);
 bool ExpandNavmeshWaypoints(const NaviParam& param, const NaviPosition& initial_pos, std::vector<Waypoint>& out_path);
 std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(

--- a/agent/cpp-algo/source/MapNavigator/position_provider.cpp
+++ b/agent/cpp-algo/source/MapNavigator/position_provider.cpp
@@ -113,7 +113,19 @@ bool PositionProvider::Capture(NaviPosition* out_pos, bool force_global_search, 
     out_pos->timestamp = capture_started_at;
     last_capture_was_held_ = locate_result.position->isHeld;
     held_fix_streak_ = last_capture_was_held_ ? (held_fix_streak_ + 1) : 0;
+
+    // Single chokepoint: every capture path (semantic nodes, the state machine, WaitForFix) funnels
+    // through here, and out_pos is always repopulated from the fresh locate result above before this
+    // runs, so the normalizer is applied exactly once per fix — double-transform is impossible.
+    if (position_normalizer_) {
+        position_normalizer_(*out_pos);
+    }
     return true;
+}
+
+void PositionProvider::SetPositionNormalizer(std::function<void(NaviPosition&)> normalizer)
+{
+    position_normalizer_ = std::move(normalizer);
 }
 
 bool PositionProvider::WaitForFix(

--- a/agent/cpp-algo/source/MapNavigator/position_provider.h
+++ b/agent/cpp-algo/source/MapNavigator/position_provider.h
@@ -29,9 +29,15 @@ public:
     bool LastCaptureWasBlackScreen() const;
     int HeldFixStreak() const;
 
+    // Optional post-locate hook: maps every successful fix onto a common coordinate frame at the single
+    // capture chokepoint (so every consumer — WaitForFix, the state machine, semantic nodes — sees the
+    // same frame). Defaults to absent, i.e. the raw locator output is passed through unchanged.
+    void SetPositionNormalizer(std::function<void(NaviPosition&)> normalizer);
+
 private:
     MaaController* controller_;
     std::shared_ptr<maplocator::MapLocator> locator_;
+    std::function<void(NaviPosition&)> position_normalizer_;
     bool uses_adb_minimap_roi_ = false;
     bool last_capture_was_held_ = false;
     bool last_capture_was_black_screen_ = false;

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <optional>
 #include <utility>
 
 #include "BaseNavPack.h"
@@ -57,6 +58,39 @@ const BaseNavZone* BaseNavPack::findZoneByName(const std::string& name) const
 {
     const auto iter = std::find_if(zones_.begin(), zones_.end(), [&name](const BaseNavZone& zone) { return zone.name == name; });
     return iter == zones_.end() ? nullptr : &*iter;
+}
+
+std::optional<BaseNavBaseProjection> BaseNavPack::projectToBase(const std::string& zone_name, double x, double y) const
+{
+    const BaseNavZone* zone = findZoneByName(zone_name);
+    if (zone == nullptr) {
+        return std::nullopt;
+    }
+    if (!IsTierZone(*zone)) {
+        // Geometry zone: python's geometry_zone_id() returns self and applies no affine.
+        return BaseNavBaseProjection { zone, x, y, false };
+    }
+    const BaseNavZone* parent = findZone(static_cast<uint16_t>(zone->component_count));
+    if (parent == nullptr) {
+        return std::nullopt;
+    }
+    // base = s * tier + t, with transform = {sx, tx, sy, ty} — byte-identical to basenav_preview.py.
+    const std::array<float, 4>& t = zone->transform;
+    return BaseNavBaseProjection {
+        parent,
+        static_cast<double>(t[0]) * x + static_cast<double>(t[1]),
+        static_cast<double>(t[2]) * y + static_cast<double>(t[3]),
+        true,
+    };
+}
+
+float BaseNavPack::floorYForZoneName(const std::string& zone_name) const
+{
+    const BaseNavZone* zone = findZoneByName(zone_name);
+    if (zone == nullptr || zone->floor_y <= kBaseNavFloorYValidMin) {
+        return kBaseNavFloorYNone;
+    }
+    return zone->floor_y;
 }
 
 const char* ToString(BaseNavLoadStatus status)

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.h
@@ -24,6 +24,19 @@ enum class BaseNavLoadStatus
     ZoneNotFound,
 };
 
+// Sentinel for BaseNavZone::floor_y: the zone has no baked dominant-floor height (the
+// "…_Base" overview tiers, geometry zones, and any v2 pack which predates the field). The
+// floor-aware snap treats anything <= kBaseNavFloorYValidMin as "no floor" and falls back to
+// the floor-blind path. Mirrors basenav_preview.py (FLOOR_Y_NONE / FLOOR_Y_VALID_MIN).
+inline constexpr float kBaseNavFloorYNone = -1.0e30F;
+inline constexpr float kBaseNavFloorYValidMin = -1.0e29F;
+
+// Half-width (in pixels == world Y == mesh height) of the band around a zone's baked floor_y that
+// the floor-aware snap PREFERS. A surface within the band always outranks an off-band one; the band
+// is a preference, never a hard gate (the nearest surface is still returned if nothing is in-band).
+// Mirrors basenav_preview.py (FLOOR_BAND).
+inline constexpr float kBaseNavFloorBand = 12.0F;
+
 struct BaseNavZone
 {
     uint16_t zone_id = 0;
@@ -35,6 +48,31 @@ struct BaseNavZone
     float width = 0.0F;
     float height = 0.0F;
     std::array<float, 4> transform { 1.0F, 0.0F, 1.0F, 0.0F };
+    // v3: dominant walkable-floor height (== world Y) the tier depicts; snap prefers triangles
+    // within kBaseNavFloorBand of it so a multi-floor base resolves onto the right floor.
+    float floor_y = kBaseNavFloorYNone;
+};
+
+// Bit0 of BaseNavZone::flags marks a "tier" zone: a 0-triangle zone that carries only the
+// tier-template-pixel -> base-pixel affine onto its parent geometry zone (parent zone_id in
+// component_count, affine in transform = {sx, tx, sy, ty}). Mirrors tools/MapNavigator
+// basenav_preview.py (TIER_FLAG = 0x0001).
+inline constexpr uint16_t kBaseNavTierFlag = 0x0001U;
+
+inline bool IsTierZone(const BaseNavZone& zone)
+{
+    return (zone.flags & kBaseNavTierFlag) != 0U;
+}
+
+// Result of mapping a (zone_name, x, y) query onto the base-pixel frame via the navmesh's own
+// baked affine. For a non-tier (geometry) zone the projection is the identity; for an unknown
+// zone projectToBase returns std::nullopt (callers treat that as identity / no-op).
+struct BaseNavBaseProjection
+{
+    const BaseNavZone* geometry_zone = nullptr;
+    double x = 0.0;
+    double y = 0.0;
+    bool was_tier = false;
 };
 
 struct BaseNavVertex
@@ -84,6 +122,16 @@ public:
     const std::vector<BaseNavLink>& links() const;
     const BaseNavZone* findZone(uint16_t zone_id) const;
     const BaseNavZone* findZoneByName(const std::string& name) const;
+
+    // Maps (zone_name, x, y) onto the base-pixel frame using the navmesh's OWN baked tier affine,
+    // mirroring the python tool (is_tier -> geometry_zone_id + base = s*tier + t). A geometry zone
+    // projects to identity; an unknown zone returns std::nullopt. Never consults any external table.
+    std::optional<BaseNavBaseProjection> projectToBase(const std::string& zone_name, double x, double y) const;
+
+    // Baked dominant-floor height of the named zone (a tier carries the floor it depicts; geometry / base /
+    // unknown zones return kBaseNavFloorYNone -> floor-blind). The route planner feeds this into snap so a
+    // multi-floor base resolves onto the right floor. Mirrors basenav_preview.py BaseNavField.floor_y_for.
+    float floorYForZoneName(const std::string& zone_name) const;
 
 private:
     friend BaseNavPack detail::MakeBaseNavPack(

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -368,13 +368,40 @@ BaseNavRouteResult BaseNavPlanner::findPath(const BaseNavRouteRequest& request) 
         return result;
     }
 
-    const auto start = snap(zone->zone_id, request.start, request.snap_radius);
+    // A tier zone carries no triangles — it is just the affine onto its parent geometry zone. Mirror the
+    // python tool (is_tier -> geometry_zone_id + base = s*tier + t): map the query points through the
+    // tier's OWN baked affine and route on the parent's triangles. Current callers pass the already-inferred
+    // geometry zone, so this branch is inert for them; it is the planner's self-sufficient fallback so a tier
+    // zone_id never has to be resolved through the external MapTracker transforms.
+    WorldPoint start_point = request.start;
+    WorldPoint goal_point = request.goal;
+    // Resolve the floor to snap onto. The request's floor_y (set by runtime callers from the locator/tier
+    // zone) takes precedence; otherwise fall back to the queried zone's own baked floor, captured BEFORE any
+    // tier->parent reassignment so the planner's self-sufficient tier-zone branch stays floor-aware. A
+    // geometry query with no request floor yields the sentinel -> legacy floor-blind snap, byte-for-byte.
+    const float floor_y = request.floor_y > kBaseNavFloorYValidMin ? request.floor_y : zone->floor_y;
+    if (IsTierZone(*zone)) {
+        const BaseNavZone* parent = pack_.findZone(static_cast<uint16_t>(zone->component_count));
+        if (parent == nullptr) {
+            BaseNavRouteResult result;
+            result.status = BaseNavRouteStatus::ZoneNotFound;
+            return result;
+        }
+        const std::array<float, 4>& t = zone->transform;
+        start_point = { static_cast<double>(t[0]) * start_point.x + static_cast<double>(t[1]),
+                        static_cast<double>(t[2]) * start_point.y + static_cast<double>(t[3]) };
+        goal_point = { static_cast<double>(t[0]) * goal_point.x + static_cast<double>(t[1]),
+                       static_cast<double>(t[2]) * goal_point.y + static_cast<double>(t[3]) };
+        zone = parent;
+    }
+
+    const auto start = snap(zone->zone_id, start_point, request.snap_radius, floor_y);
     if (!start) {
         BaseNavRouteResult result;
         result.status = BaseNavRouteStatus::StartNotWalkable;
         return result;
     }
-    const auto goal = snap(zone->zone_id, request.goal, request.snap_radius);
+    const auto goal = snap(zone->zone_id, goal_point, request.snap_radius, floor_y);
     if (!goal) {
         BaseNavRouteResult result;
         result.status = BaseNavRouteStatus::GoalNotWalkable;
@@ -464,7 +491,7 @@ BaseNavRouteResult BaseNavPlanner::findPath(const BaseNavRouteRequest& request) 
     return result;
 }
 
-std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const WorldPoint& point, double radius) const
+std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const WorldPoint& point, double radius, float floor_y) const
 {
     const BaseNavZone* zone = pack_.findZone(zone_id);
     if (zone == nullptr) {
@@ -477,6 +504,47 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
     if (candidates.empty() && query_radius < kIndexBinSize) {
         // 半径不足一格时邻域可能为空,放宽到整格再取候选(命中仍受 radius 距离剔除约束)。
         candidates = candidateTriangles(zone_id, point, kIndexBinSize);
+    }
+
+    if (floor_y > kBaseNavFloorYValidMin) {
+        // Floor-aware path: a click in a multi-floor base projects onto several STACKED triangles
+        // (other floors / walls overlap this (u,v)). Rank so an in-band surface (|height-floor_y| <=
+        // kBaseNavFloorBand) always beats an off-band one, then by snap distance, then by height
+        // proximity to floor_y. The band is a PREFERENCE — if nothing lands in-band we still return the
+        // nearest surface (never nullopt), so floor_y only re-ranks onto the right floor, never gates it
+        // out. Mirrors basenav_preview.py BaseNavField.snap (floor-aware branch). The zone + bbox culls
+        // match the legacy path below so the effective candidate set equals the python tool's.
+        std::optional<std::tuple<int, double, double>> best_key;
+        std::optional<BaseNavSnapResult> best_floor;
+        for (const uint32_t triangle_index : candidates) {
+            if (triangle_zones_[triangle_index] != zone_id) {
+                continue;
+            }
+            const auto points = trianglePoints(triangle_index);
+            const double left = std::min({ points[0].x, points[1].x, points[2].x });
+            const double right = std::max({ points[0].x, points[1].x, points[2].x });
+            const double top = std::min({ points[0].y, points[1].y, points[2].y });
+            const double bottom = std::max({ points[0].y, points[1].y, points[2].y });
+            if (point.x < left - radius || point.x > right + radius || point.y < top - radius || point.y > bottom + radius) {
+                continue;
+            }
+            WorldPoint snapped = point;
+            double distance = 0.0;
+            if (!detail::PointInTriangle(point, points)) {
+                snapped = detail::ClosestPointOnTriangle(point, points);
+                distance = detail::Distance(snapped, point);
+                if (distance > radius) {
+                    continue;
+                }
+            }
+            const double delta = std::abs(triangle_heights_[triangle_index] - static_cast<double>(floor_y));
+            const std::tuple<int, double, double> key { delta <= static_cast<double>(kBaseNavFloorBand) ? 0 : 1, distance, delta };
+            if (!best_key || key < *best_key) {
+                best_key = key;
+                best_floor = BaseNavSnapResult { .triangle = triangle_index, .point = snapped, .distance = distance };
+            }
+        }
+        return best_floor;
     }
 
     std::optional<BaseNavSnapResult> best;

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -30,6 +30,9 @@ struct BaseNavRouteRequest
     double snap_radius = 5.0;
     double max_cost = 0.0;
     std::vector<uint32_t> blocked_triangles;
+    // Dominant-floor height of the floor being navigated (from the locator/tier zone). Lets snap resolve
+    // onto the right floor of a multi-floor base. kBaseNavFloorYNone (default) keeps the floor-blind path.
+    float floor_y = kBaseNavFloorYNone;
 };
 
 enum class BaseNavRouteStatus
@@ -57,7 +60,12 @@ public:
     explicit BaseNavPlanner(const BaseNavPack& pack);
 
     BaseNavRouteResult findPath(const BaseNavRouteRequest& request) const;
-    std::optional<BaseNavSnapResult> snap(uint16_t zone_id, const WorldPoint& point, double radius) const;
+    // `floor_y` re-ranks the snap onto the correct floor of a multi-floor base: surfaces within
+    // kBaseNavFloorBand of it are preferred, off-band ones are a graceful fallback (never gated to
+    // nullopt). kBaseNavFloorYNone (the default) keeps the legacy floor-blind behavior byte-for-byte.
+    // Mirrors basenav_preview.py BaseNavField.snap.
+    std::optional<BaseNavSnapResult> snap(
+        uint16_t zone_id, const WorldPoint& point, double radius, float floor_y = kBaseNavFloorYNone) const;
 
     // Navmesh raycast: true when the straight segment a->b stays on walkable mesh within `zone_id`.
     // Fails closed on any ambiguity.

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -29,7 +29,7 @@ constexpr size_t kZonePrefixSize = 44;
 constexpr size_t kVertexSize = 12;
 constexpr size_t kTriangleSize = 36;
 constexpr size_t kLinkSize = 8;
-constexpr uint16_t kBaseNavVersion = 2;
+constexpr uint16_t kBaseNavRevision = 3;
 constexpr size_t kGzipReadChunkSize = 4 << 20;
 constexpr uint64_t kFnvOffset = 14'695'981'039'346'656'037ULL;
 constexpr uint64_t kFnvPrime = 1'099'511'628'211ULL;
@@ -248,9 +248,10 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     const uint8_t* header_cursor = file_bytes.data() + 4;
     const uint16_t version = ReadU16(header_cursor);
     (void)ReadU16(header_cursor); // flags
-    if (version != kBaseNavVersion) {
+    if (version == 0 || version > kBaseNavRevision) {
         return Fail(BaseNavLoadStatus::UnsupportedVersion, "unsupported nav version");
     }
+    const size_t zone_prefix_size = kZonePrefixSize + (version >= kBaseNavRevision ? 4 : 0);
     const uint32_t zone_count = ReadU32(header_cursor);
     const uint32_t vertex_count = ReadU32(header_cursor);
     const uint32_t triangle_count = ReadU32(header_cursor);
@@ -288,7 +289,7 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     std::set<uint16_t> zone_ids;
     const uint8_t* zone_cursor = zone_table;
     for (uint32_t index = 0; index < zone_count; ++index) {
-        if (static_cast<size_t>(zone_end - zone_cursor) < kZonePrefixSize) {
+        if (static_cast<size_t>(zone_end - zone_cursor) < zone_prefix_size) {
             return Fail(BaseNavLoadStatus::InvalidSize, "zone table is truncated");
         }
         BaseNavZone zone;
@@ -302,6 +303,11 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
         zone.height = ReadF32(zone_cursor);
         for (float& value : zone.transform) {
             value = ReadF32(zone_cursor);
+        }
+        if (version >= kBaseNavRevision) {
+            // current revision carries one extra per-zone value here; earlier packs leave it
+            // at its sentinel.
+            zone.floor_y = ReadF32(zone_cursor);
         }
         if (static_cast<size_t>(zone_end - zone_cursor) < name_size) {
             return Fail(BaseNavLoadStatus::InvalidSize, "zone name is truncated");
@@ -391,7 +397,23 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
         }
         selected_zone->first_triangle = 0;
         selected_zone->triangle_count = static_cast<uint32_t>(triangles.size());
-        zones = { *selected_zone };
+        // Keep the selected geometry zone PLUS its tier children (zones whose component_count points
+        // back at it). Tier zones are 0-triangle affine metadata, so retaining them never touches the
+        // sliced geometry / snap graph / golden-hash parity (this in-memory vector is not serialized) —
+        // it just lets a zone-scoped pack still resolve a tier zone_id to base via its OWN baked affine,
+        // mirroring the python loader which holds every zone.
+        std::vector<BaseNavZone> scoped_zones;
+        scoped_zones.reserve(zones.size());
+        scoped_zones.push_back(*selected_zone);
+        for (const BaseNavZone& candidate : zones) {
+            if (IsTierZone(candidate) && candidate.component_count == selected_zone->zone_id) {
+                BaseNavZone tier = candidate;
+                tier.first_triangle = 0;
+                tier.triangle_count = 0;
+                scoped_zones.push_back(std::move(tier));
+            }
+        }
+        zones = std::move(scoped_zones);
     }
 
     std::vector<BaseNavLink> links;

--- a/tools/MapNavigator/app_tk.py
+++ b/tools/MapNavigator/app_tk.py
@@ -376,7 +376,7 @@ class RouteEditorApp:
             anchor="w",
         )
         self.astar_path_label.pack(side=tk.LEFT, padx=(0, 8))
-        tk.Label(astar_row, text="底图:", font=("Microsoft YaHei", 9)).pack(side=tk.LEFT, padx=(0, 4))
+        tk.Label(astar_row, text="zone:", font=("Microsoft YaHei", 9)).pack(side=tk.LEFT, padx=(0, 4))
         self.astar_display_zone_combo = ttk.Combobox(
             astar_row,
             values=self.astar_display_zone_ids,
@@ -386,8 +386,8 @@ class RouteEditorApp:
         )
         self.astar_display_zone_combo.pack(side=tk.LEFT, padx=(0, 8))
         self.astar_display_zone_combo.bind("<<ComboboxSelected>>", lambda _event: self._on_astar_display_zone_changed())
-        tk.Label(astar_row, text="zone:", font=("Microsoft YaHei", 9)).pack(side=tk.LEFT, padx=(0, 4))
-        self.astar_zone_combo = ttk.Combobox(astar_row, width=8, textvariable=self.astar_zone_var, state="disabled")
+        tk.Label(astar_row, text="tier:", font=("Microsoft YaHei", 9)).pack(side=tk.LEFT, padx=(0, 4))
+        self.astar_zone_combo = ttk.Combobox(astar_row, width=20, textvariable=self.astar_zone_var, state="disabled")
         self.astar_zone_combo.pack(side=tk.LEFT, padx=(0, 8))
         self.astar_zone_combo.bind("<<ComboboxSelected>>", lambda _event: self._on_astar_zone_changed())
         self.btn_clear_astar = tk.Button(astar_row, text="清除预览", command=self.clear_astar_preview, width=10)
@@ -505,9 +505,14 @@ class RouteEditorApp:
             return
 
         if self.astar_mode_var.get():
+            # Copied coords are navmesh waypoints, always in base-px. The route is already
+            # base-px; the start/goal fallback is in the display frame, so map tier-px back.
             points = self.astar_route.points if self.astar_route is not None else []
             if not points:
                 points = [point for point in (self.astar_start, self.astar_goal) if point is not None]
+                tier_id = self._active_display_tier_id()
+                if tier_id is not None:
+                    points = [self.astar_field.tier_to_base(tier_id, point[0], point[1]) for point in points]
             if not points:
                 self._set_status("当前没有可复制的 A* 预览点。", "#f59e0b")
                 return
@@ -829,7 +834,7 @@ class RouteEditorApp:
             self._sync_assert_controls()
             if not normalize_zone_id(self.astar_display_zone_var.get()):
                 self.astar_display_zone_var.set(self._default_astar_display_zone())
-            self._select_astar_zone_for_display()
+            self._refresh_astar_zone_choices()
             self._set_status("A* 模式：左键点起点，再点终点生成预览路线。", "#3b82f6")
         else:
             self._set_status("返回路径编辑模式。", "#10b981")
@@ -844,7 +849,7 @@ class RouteEditorApp:
         if not zone_id:
             return
         self.astar_display_zone_var.set(zone_id)
-        self._select_astar_zone_for_display()
+        self._refresh_astar_zone_choices()
         self._reset_astar_view_state()
         self._refresh_zone_label()
         self.fit_view()
@@ -939,8 +944,6 @@ class RouteEditorApp:
 
     def _on_basenav_core_loaded(self, field, input_file) -> None:
         self.astar_field = field
-        zone_ids = [field.zone_label(zone_id) for zone_id in field.zone_ids()]
-        self.astar_zone_combo["values"] = zone_ids
         self.astar_basenav_path_var.set(input_file.name)
         self.astar_mode_var.set(True)
         self.astar_display_zone_ids = list(BASE_NAV_DISPLAY_ZONE_IDS)
@@ -950,9 +953,8 @@ class RouteEditorApp:
             or self.astar_display_zone_var.get() not in self.astar_display_zone_ids
         ):
             self.astar_display_zone_var.set(self._default_astar_display_zone())
-        if zone_ids:
-            self.astar_zone_var.set(zone_ids[0])
-        self._select_astar_zone_for_display()
+        # 右侧 zone 下拉只列出当前底图(base)自己的 tier,不跨 base 混用。
+        self._refresh_astar_zone_choices()
         self._sync_astar_controls()
         self.clear_astar_preview(redraw=False)
         self.btn_load_basenav.config(state=tk.NORMAL)
@@ -1006,14 +1008,29 @@ class RouteEditorApp:
         if self.astar_field is None or self.astar_start is None or self.astar_goal is None:
             return
         try:
-            zone_id = self._astar_zone_id()
+            zone_id = self._astar_routing_zone_id()
+            # Clicks land in the display frame; when a real tier底图 is shown that frame is
+            # tier-px, but the mesh (snap/A*) lives in base-px on the parent zone. Map the
+            # endpoints tier_px -> base_px so routing is correct; route points come back in
+            # base-px and are re-expressed for drawing via _route_display_points().
+            tier_id = self._active_display_tier_id()
+            start = self.astar_start
+            goal = self.astar_goal
+            if tier_id is not None:
+                start = self.astar_field.tier_to_base(tier_id, start[0], start[1])
+                goal = self.astar_field.tier_to_base(tier_id, goal[0], goal[1])
+            # The selected tier's baked dominant-floor height scopes snap to the right floor
+            # (the parent base mesh stacks every floor at each (u,v)). None for base/overview
+            # selections, which keeps the floor-blind legacy routing untouched.
+            floor_y = self.astar_field.floor_y_for(self._astar_zone_id())
             self.astar_route = find_preview_route(
                 self.astar_field,
                 zone_id,
                 self._display_zone_id(),
-                self.astar_start,
-                self.astar_goal,
+                start,
+                goal,
                 ASTAR_PREVIEW_SNAP_RADIUS,
+                floor_y,
             )
         except Exception as exc:
             self.astar_route = None
@@ -1027,22 +1044,78 @@ class RouteEditorApp:
     def _astar_zone_id(self) -> int:
         return int(self.astar_zone_var.get().split(":", maxsplit=1)[0])
 
-    def _select_astar_zone_for_display(self) -> None:
+    def _astar_routing_zone_id(self) -> int:
+        # tier zones have no triangles; route/snap against the parent geometry zone.
+        zone_id = self._astar_zone_id()
+        if self.astar_field is not None:
+            return self.astar_field.geometry_zone_id(zone_id)
+        return zone_id
+
+    def _active_display_tier_id(self) -> int | None:
+        # zone_id of the tier whose OWN template should back the canvas (tier-px world
+        # frame), or None for the plain base view. The identity "…_Base" tier resolves to
+        # the base image and maps tier_px==base_px, so it is treated as base (None) — only
+        # a real, translated tier swaps the底图 to its template.
+        if not self.astar_mode_var.get() or self.astar_field is None:
+            return None
+        try:
+            zone_id = self._astar_zone_id()
+        except (ValueError, AttributeError):
+            return None
+        if not self.astar_field.is_tier(zone_id):
+            return None
+        zone = self.astar_field.zone_by_id.get(zone_id)
+        if zone is None:
+            return None
+        sx, tx, sy, ty = zone.transform
+        if tx == 0.0 and ty == 0.0 and sx == 1.0 and sy == 1.0:
+            return None
+        return zone_id
+
+    def _render_background_zone(self) -> str:
+        # Zone-id string handed to the renderer for the底图: a real tier shows its OWN
+        # template; otherwise the selected base composite. world == that image's pixels.
+        tier_id = self._active_display_tier_id()
+        if tier_id is not None:
+            zone = self.astar_field.zone_by_id.get(tier_id)
+            if zone is not None and zone.name:
+                return zone.name
+        return self._display_zone_id()
+
+    def _route_display_points(self) -> list[tuple[float, float]]:
+        # A* route points in the CURRENT display frame: tier-px when a real tier is shown
+        # (the route is planned in base-px on the parent mesh), else base-px unchanged.
+        if self.astar_route is None or not self.astar_route.points:
+            return []
+        tier_id = self._active_display_tier_id()
+        if tier_id is None:
+            return list(self.astar_route.points)
+        return [self.astar_field.base_to_tier(tier_id, point[0], point[1]) for point in self.astar_route.points]
+
+    def _refresh_astar_zone_choices(self) -> None:
+        # Repopulate the right-hand zone dropdown with ONLY the selected底图(base)'s
+        # tiers. Keep the current selection if it still belongs; else default to the
+        # first entry (the identity "…_Base" = whole base view).
         if self.astar_field is None:
             return
-        zone_label = self.astar_field.suggested_zone_label(self._display_zone_id())
-        if zone_label:
-            self.astar_zone_var.set(zone_label)
+        choices = self.astar_field.zone_choices_for_base(self._display_zone_id())
+        self.astar_zone_combo["values"] = choices
+        if choices and self.astar_zone_var.get() not in choices:
+            self.astar_zone_var.set(choices[0])
 
     def _select_astar_display_for_zone(self) -> None:
+        # A selected tier's parent (component_count) decides the底图; in practice the
+        # dropdown only offers the current base's tiers so this just keeps them in sync.
         if self.astar_field is None:
             return
-        zone_label = self.astar_zone_var.get()
-        if ":" not in zone_label:
+        try:
+            base_id = self.astar_field.geometry_zone_id(self._astar_zone_id())
+        except (ValueError, AttributeError):
             return
-        zone_name = normalize_zone_id(zone_label.split(":", maxsplit=1)[1])
-        if zone_name in self.astar_display_zone_ids:
-            self.astar_display_zone_var.set(zone_name)
+        base = self.astar_field.zone_by_id.get(base_id)
+        if base is not None and base.name in self.astar_display_zone_ids and self.astar_display_zone_var.get() != base.name:
+            self.astar_display_zone_var.set(base.name)
+            self._refresh_astar_zone_choices()
 
     def _on_assert_zone_changed(self) -> None:
         zone_id = normalize_zone_id(self.assert_zone_var.get())
@@ -1266,7 +1339,7 @@ class RouteEditorApp:
         self.schedule_redraw(fast=False, margin_fraction=self.PAN_MARGIN_FRACTION)
 
     def fit_view(self) -> None:
-        zone_id = self._display_zone_id()
+        zone_id = self._render_background_zone()
         points = [] if self.assert_mode_var.get() or self.astar_mode_var.get() else self.zone_state.current_points(self.points)
 
         box_min_x, box_max_x, box_min_y, box_max_y = 0, 100, 0, 100
@@ -1275,13 +1348,14 @@ class RouteEditorApp:
             box_max_x, box_max_y = map_image.size
 
         assert_target = self._current_assert_target()
+        route_points = self._route_display_points()
         if self.assert_mode_var.get() and assert_target is not None:
             target_x, target_y, target_w, target_h = assert_target
             box_min_x, box_max_x = target_x, target_x + target_w
             box_min_y, box_max_y = target_y, target_y + target_h
-        elif self.astar_mode_var.get() and self.astar_route is not None and self.astar_route.points:
-            xs = [point[0] for point in self.astar_route.points]
-            ys = [point[1] for point in self.astar_route.points]
+        elif self.astar_mode_var.get() and route_points:
+            xs = [point[0] for point in route_points]
+            ys = [point[1] for point in route_points]
             box_min_x, box_max_x = min(xs), max(xs)
             box_min_y, box_max_y = min(ys), max(ys)
         elif self.astar_mode_var.get() and self.astar_field is not None and self.astar_zone_var.get() and map_image is None:
@@ -1319,8 +1393,8 @@ class RouteEditorApp:
 
     def _do_redraw(self, fast: bool, margin_fraction: float = 0.0) -> None:
         self._redraw_pending = False
-        zone_id = self._display_zone_id()
-        if zone_id != self.renderer.last_params[0]:
+        render_zone = self._render_background_zone()
+        if render_zone != self.renderer.last_params[0]:
             self.renderer.reset_view()
         if self.assert_mode_var.get() or self.astar_mode_var.get():
             self.zone_point_global_indices = []
@@ -1329,7 +1403,7 @@ class RouteEditorApp:
             self.zone_point_global_indices = self.zone_state.point_indices(self.points)
             points = [self.points[index] for index in self.zone_point_global_indices]
 
-        self.renderer.request_render(zone_id, fast=fast, margin_fraction=margin_fraction)
+        self.renderer.request_render(render_zone, fast=fast, margin_fraction=margin_fraction)
         self._render_path(points)
         self._render_nodes(points)
         self._render_assert_rect()
@@ -1432,7 +1506,7 @@ class RouteEditorApp:
 
         preview_points = []
         if self.astar_route is not None:
-            preview_points = self.astar_route.points
+            preview_points = self._route_display_points()
         elif self.astar_start is not None:
             preview_points = [self.astar_start]
 
@@ -1762,7 +1836,7 @@ class RouteEditorApp:
         except ValueError:
             index = 0
         self.astar_display_zone_var.set(self.astar_display_zone_ids[(index + delta) % len(self.astar_display_zone_ids)])
-        self._select_astar_zone_for_display()
+        self._refresh_astar_zone_choices()
         self._reset_astar_view_state()
         self._refresh_zone_label()
         self.fit_view()
@@ -2341,6 +2415,11 @@ class RouteEditorApp:
         if target is None:
             messagebox.showwarning("复制失败", "请先在 A* 模式点击目标点")
             return
+
+        # NAVMESH targets are base-px; convert from the display frame when a tier底图 is shown.
+        tier_id = self._active_display_tier_id()
+        if tier_id is not None:
+            target = self.astar_field.tier_to_base(tier_id, target[0], target[1])
 
         payload = {
             "action": "NAVMESH",

--- a/tools/MapNavigator/basenav_preview.py
+++ b/tools/MapNavigator/basenav_preview.py
@@ -13,9 +13,19 @@ import numpy as np
 
 
 MAGIC = b"BNAV"
-VERSION = 2
+VERSION = 3  # v3 appends a per-zone float `floor_y` to each zone record; v2 had none
+VERSION_MIN = 2  # oldest on-disk version still accepted; v2 zone records lack floor_y -> FLOOR_Y_NONE
 FNV_OFFSET = 14695981039346656037
 FNV_PRIME = 1099511628211
+# Sentinel floor height for tier zones whose dominant walkable floor is unknown (the two
+# "…_Base" overview tiers, and any geometry zone). Anything below FLOOR_Y_VALID_MIN means
+# "no floor", so the floor-aware snap/route/overlay degrade to the legacy floor-blind path.
+FLOOR_Y_NONE = -1.0e30
+FLOOR_Y_VALID_MIN = -1.0e29
+# Height half-band (px == world-Y units) around a tier's baked floor_y. snap/route/overlay
+# PREFER triangles within floor_y±FLOOR_BAND; off-band surfaces are a graceful fallback,
+# never a hard gate — so floor_y only re-ranks, never fails snap to None / a route to empty.
+FLOOR_BAND = 12.0
 BRIDGE_FIXED_COST = 12.0
 BRIDGE_GAP_COST_FACTOR = 3.0
 BRIDGE_HEIGHT_COST_FACTOR = 40.0
@@ -44,8 +54,13 @@ SEGMENT_PARALLEL_EPSILON = 1e-12
 # 的 snap 退化成线性扫描;取 8px 让每个 bin 仅含数十个三角形,snap 提前命中。
 INDEX_BIN_SIZE = 16.0
 
+# BaseNavZone.flags bit0: zone is a tier overlay (zero triangles; its mesh lives in
+# the parent geometry zone addressed by component_count; transform = tier_px→base_px).
+TIER_FLAG = 0x0001
+
 HEADER_STRUCT = struct.Struct("<4sHHIIIIQQQQQ")
-ZONE_STRUCT = struct.Struct("<HHIIIIff4f")
+ZONE_STRUCT = struct.Struct("<HHIIIIff4ff")  # v3: ...transform(4f) + floor_y(f)
+ZONE_STRUCT_V2 = struct.Struct("<HHIIIIff4f")  # v2: legacy zone record without floor_y
 VERTEX_STRUCT = struct.Struct("<fff")
 TRIANGLE_STRUCT = struct.Struct("<IIIiiiIff")
 LINK_STRUCT = struct.Struct("<II")
@@ -81,6 +96,7 @@ class _BaseNavZone:
     height: float
     transform: tuple[float, float, float, float]
     flags: int = 0
+    floor_y: float = FLOOR_Y_NONE
 
 
 @dataclass(frozen=True, slots=True)
@@ -140,9 +156,10 @@ def find_preview_route(
     start: tuple[float, float],
     goal: tuple[float, float],
     snap_radius: float,
+    floor_y: float | None = None,
 ) -> PreviewRoute:
     del display_zone_id
-    route = field.find_route(zone_id, start, goal, snap_radius)
+    route = field.find_route(zone_id, start, goal, snap_radius, floor_y)
     return PreviewRoute(points=route.points, world_points=route.points, cells=[], segment_breaks=route.segment_breaks)
 
 
@@ -258,6 +275,70 @@ class BaseNavField:
     def zone_ids(self) -> list[int]:
         return [zone.zone_id for zone in self.zones]
 
+    def is_tier(self, zone_id: int) -> bool:
+        zone = self.zone_by_id.get(zone_id)
+        return bool(zone is not None and zone.flags & TIER_FLAG)
+
+    def floor_y_for(self, zone_id: int) -> float | None:
+        # The zone's baked dominant-floor height, or None when unset (the "…_Base" overview
+        # tiers and geometry zones). Callers pass this into snap/find_route to scope routing
+        # to the floor the selected tier depicts; None keeps the floor-blind legacy path.
+        zone = self.zone_by_id.get(zone_id)
+        if zone is None or zone.floor_y <= FLOOR_Y_VALID_MIN:
+            return None
+        return zone.floor_y
+
+    def geometry_zone_id(self, zone_id: int) -> int:
+        # tier zones carry zero triangles (their mesh lives in the parent geometry
+        # zone, addressed via component_count). Snap / A* / walkable-preview must run
+        # against that parent; clicks are already in the parent's (base) pixel system.
+        zone = self.zone_by_id.get(zone_id)
+        if zone is not None and zone.flags & TIER_FLAG:
+            return zone.component_count
+        return zone_id
+
+    def tier_to_base(self, zone_id: int, x: float, y: float) -> tuple[float, float]:
+        # tier_px -> base_px via the baked affine (base = s*tier + t). Identity for
+        # non-tier / unknown zones so callers can pass any zone_id unconditionally.
+        zone = self.zone_by_id.get(zone_id)
+        if zone is None or not (zone.flags & TIER_FLAG):
+            return x, y
+        sx, tx, sy, ty = zone.transform
+        return sx * x + tx, sy * y + ty
+
+    def base_to_tier(self, zone_id: int, x: float, y: float) -> tuple[float, float]:
+        # base_px -> tier_px via the inverse affine (tier = (base - t) / s). Identity
+        # for non-tier / unknown / degenerate zones.
+        zone = self.zone_by_id.get(zone_id)
+        if zone is None or not (zone.flags & TIER_FLAG):
+            return x, y
+        sx, tx, sy, ty = zone.transform
+        if sx == 0.0 or sy == 0.0:
+            return x, y
+        return (x - tx) / sx, (y - ty) / sy
+
+    def tier_zone_ids_for(self, parent_zone_id: int) -> list[int]:
+        # Tiers whose parent geometry zone == parent_zone_id, identity ("…_Base")
+        # first so the dropdown defaults to the whole-base view.
+        tiers = [
+            zone for zone in self.zones
+            if zone.flags & TIER_FLAG and zone.component_count == parent_zone_id
+        ]
+        tiers.sort(key=lambda z: (z.transform[1] != 0.0 or z.transform[3] != 0.0, z.name))
+        return [zone.zone_id for zone in tiers]
+
+    def zone_choices_for_base(self, base_name: str) -> list[str]:
+        # Right-hand "zone" dropdown content for the selected base底图: ONLY this
+        # base's tiers (no cross-base mixing). Bases without tiers fall back to the
+        # base itself so the dropdown is never empty and routing still works.
+        base = self.zone_by_name.get(base_name)
+        if base is None:
+            return []
+        tier_ids = self.tier_zone_ids_for(base.zone_id)
+        if tier_ids:
+            return [self.zone_label(zone_id) for zone_id in tier_ids]
+        return [self.zone_label(base.zone_id)]
+
     def zone_label(self, zone_id: int) -> str:
         zone = self.zone_by_id.get(zone_id)
         return f"{zone.zone_id}:{zone.name}" if zone is not None else str(zone_id)
@@ -301,27 +382,72 @@ class BaseNavField:
         zone = self.zone_by_id.get(zone_id)
         if zone is None or zone.width <= 0 or zone.height <= 0:
             return None
-        _scale = 0.5
-        _w = math.ceil(zone.width * _scale)
-        _h = math.ceil(zone.height * _scale)
-        image = Image.new("RGBA", (_w, _h), (0, 0, 0, 0))
-        draw = ImageDraw.Draw(image)
-        start = zone.first_triangle
-        end = start + zone.triangle_count
-        total = end - start
-        _step = max(1, total // 50) if total > 100 else 1
-        for _idx, triangle_index in enumerate(range(start, end)):
-            tv = self.triangles[triangle_index].vertices
-            pts = [
-                (self.vertices[tv[0]].u * _scale, self.vertices[tv[0]].v * _scale),
-                (self.vertices[tv[1]].u * _scale, self.vertices[tv[1]].v * _scale),
-                (self.vertices[tv[2]].u * _scale, self.vertices[tv[2]].v * _scale),
-            ]
-            draw.polygon(pts, fill=(255, 0, 0, 46))
-            if total > 100 and _idx % _step == 0:
-                _report_progress(progress_callback, _idx / total)
-        image = image.resize((math.ceil(zone.width), math.ceil(zone.height)), Image.Resampling.NEAREST)
+        if zone.flags & TIER_FLAG:
+            image = self._tier_overlay_image(zone, Image, ImageDraw)
+        else:
+            _scale = 0.5
+            _w = math.ceil(zone.width * _scale)
+            _h = math.ceil(zone.height * _scale)
+            image = Image.new("RGBA", (_w, _h), (0, 0, 0, 0))
+            draw = ImageDraw.Draw(image)
+            start = zone.first_triangle
+            end = start + zone.triangle_count
+            total = end - start
+            _step = max(1, total // 50) if total > 100 else 1
+            for _idx, triangle_index in enumerate(range(start, end)):
+                tv = self.triangles[triangle_index].vertices
+                pts = [
+                    (self.vertices[tv[0]].u * _scale, self.vertices[tv[0]].v * _scale),
+                    (self.vertices[tv[1]].u * _scale, self.vertices[tv[1]].v * _scale),
+                    (self.vertices[tv[2]].u * _scale, self.vertices[tv[2]].v * _scale),
+                ]
+                draw.polygon(pts, fill=(255, 0, 0, 46))
+                if total > 100 and _idx % _step == 0:
+                    _report_progress(progress_callback, _idx / total)
+            image = image.resize((math.ceil(zone.width), math.ceil(zone.height)), Image.Resampling.NEAREST)
         self.overlay_cache[zone_id] = image
+        return image
+
+    def _tier_overlay_image(self, zone, Image, ImageDraw):
+        # A tier has no triangles of its own; its mesh lives in the PARENT geometry zone
+        # (base pixels). Render the walkable surface onto the tier's OWN template canvas
+        # (tier pixels, sized to this tier zone), mapping each parent triangle inside the
+        # tier footprint base_px -> tier_px via the inverse affine (tier = (base - t)/s).
+        # So a selected tier shows its real template底图 with the可行走面 aligned on top —
+        # the visual oracle for the baked affine — instead of boxing a region in the base.
+        parent = self.zone_by_id.get(zone.component_count)
+        if parent is None or parent.width <= 0 or parent.height <= 0:
+            return None
+        sx, tx, sy, ty = zone.transform
+        if sx == 0.0 or sy == 0.0:
+            return None
+        # footprint in base_px (this tier's extent) — cheap cull of parent triangles
+        fxs = (tx, sx * zone.width + tx)
+        fys = (ty, sy * zone.height + ty)
+        fx0, fx1 = min(fxs), max(fxs)
+        fy0, fy1 = min(fys), max(fys)
+        # Only paint THIS tier's floor. The parent base zone stacks every floor's mesh at
+        # each (u,v); without the band filter the overlay shows other floors / walls bleeding
+        # through the tier底图. Keep triangles within floor_y±FLOOR_BAND (height == world Y),
+        # so the可行走面 rendering matches the floor the tier actually depicts. floor_y unset
+        # (the "…_Base" overview tiers) falls back to painting all triangles, as before.
+        floor_y = zone.floor_y
+        has_floor = floor_y > FLOOR_Y_VALID_MIN
+        image = Image.new("RGBA", (math.ceil(zone.width), math.ceil(zone.height)), (0, 0, 0, 0))
+        draw = ImageDraw.Draw(image)
+        start = parent.first_triangle
+        end = start + parent.triangle_count
+        for triangle_index in range(start, end):
+            cx, cy = self.triangles[triangle_index].center
+            if cx < fx0 or cx > fx1 or cy < fy0 or cy > fy1:
+                continue
+            if has_floor and abs(self.triangle_height[triangle_index] - floor_y) > FLOOR_BAND:
+                continue
+            points = [
+                ((self.vertices[index].u - tx) / sx, (self.vertices[index].v - ty) / sy)
+                for index in self.triangles[triangle_index].vertices
+            ]
+            draw.polygon(points, fill=(255, 0, 0, 46))
         return image
 
     def walkable_dots_image(
@@ -369,11 +495,16 @@ class BaseNavField:
         start: tuple[float, float],
         goal: tuple[float, float],
         snap_radius: float,
+        floor_y: float | None = None,
     ) -> _BaseNavRoute:
-        start_snap = self.snap(zone_id, start, snap_radius)
+        # floor_y (the active tier's baked dominant-floor height) only steers the endpoint
+        # snap onto the correct floor; once both ends land on that floor's A* component the
+        # corridor stays on it (coplanar-stitch links don't cross heights). A* itself is left
+        # unfiltered so a legitimate on-floor ramp is never gated out — never fail closed.
+        start_snap = self.snap(zone_id, start, snap_radius, floor_y)
         if start_snap is None:
             raise ValueError("起点附近没有可走三角面")
-        goal_snap = self.snap(zone_id, goal, snap_radius)
+        goal_snap = self.snap(zone_id, goal, snap_radius, floor_y)
         if goal_snap is None:
             raise ValueError("终点附近没有可走三角面")
 
@@ -403,7 +534,13 @@ class BaseNavField:
         points, segment_breaks = self._triangle_path_points(triangle_path, start_snap.point, goal_snap.point)
         return _BaseNavRoute(points=points, triangles=triangle_path, cost=cost, segment_breaks=segment_breaks)
 
-    def snap(self, zone_id: int, point: tuple[float, float], radius: float) -> _SnapResult | None:
+    def snap(
+        self,
+        zone_id: int,
+        point: tuple[float, float],
+        radius: float,
+        floor_y: float | None = None,
+    ) -> _SnapResult | None:
         zone = self.zone_by_id.get(zone_id)
         if zone is None or zone.triangle_count <= 0:
             return None
@@ -411,20 +548,47 @@ class BaseNavField:
         candidates = self._candidate_triangles(zone_id, point, query_radius)
         if not candidates and query_radius < self.bin_size:
             candidates = self._candidate_triangles(zone_id, point, self.bin_size)
-        best: _SnapResult | None = None
+        if floor_y is None or floor_y <= FLOOR_Y_VALID_MIN:
+            # Legacy floor-blind path — byte-identical to the pre-floor behavior so a base
+            # view / unbaked zone keeps the 9 golden-hash routing parity exactly.
+            best: _SnapResult | None = None
+            for triangle_index in candidates:
+                triangle_vertices = self._triangle_points(triangle_index)
+                if _point_in_triangle(point, *triangle_vertices):
+                    # 命中即最优(距离 0),提前返回;与 C++ BaseNavPlanner::snap 行为一致,
+                    # 避免在细碎三角形堆叠的 bin 中线性扫遍上万个候选。
+                    return _SnapResult(triangle=triangle_index, point=point, distance=0.0)
+                snapped = _closest_point_on_triangle(point, triangle_vertices)
+                distance = math.hypot(snapped[0] - point[0], snapped[1] - point[1])
+                if distance > query_radius:
+                    continue
+                if best is None or distance < best.distance:
+                    best = _SnapResult(triangle=triangle_index, point=snapped, distance=distance)
+            return best
+        # Floor-aware path: a click in a multi-floor base projects onto several STACKED
+        # triangles (other floors / walls overlap this (u,v)). Rank so an in-band surface
+        # (|height-floor_y| <= FLOOR_BAND) always beats an off-band one, then by snap
+        # distance, then by height proximity to floor_y. The band is a PREFERENCE — if
+        # nothing lands in-band we still return the nearest surface (never None), so
+        # floor_y only re-ranks the snap target onto the correct floor, never gates it out.
+        best_key: tuple[int, float, float] | None = None
+        best_floor: _SnapResult | None = None
         for triangle_index in candidates:
             triangle_vertices = self._triangle_points(triangle_index)
             if _point_in_triangle(point, *triangle_vertices):
-                # 命中即最优(距离 0),提前返回;与 C++ BaseNavPlanner::snap 行为一致,
-                # 避免在细碎三角形堆叠的 bin 中线性扫遍上万个候选。
-                return _SnapResult(triangle=triangle_index, point=point, distance=0.0)
-            snapped = _closest_point_on_triangle(point, triangle_vertices)
-            distance = math.hypot(snapped[0] - point[0], snapped[1] - point[1])
-            if distance > query_radius:
-                continue
-            if best is None or distance < best.distance:
-                best = _SnapResult(triangle=triangle_index, point=snapped, distance=distance)
-        return best
+                snapped = point
+                distance = 0.0
+            else:
+                snapped = _closest_point_on_triangle(point, triangle_vertices)
+                distance = math.hypot(snapped[0] - point[0], snapped[1] - point[1])
+                if distance > query_radius:
+                    continue
+            delta = abs(self.triangle_height[triangle_index] - floor_y)
+            key = (0 if delta <= FLOOR_BAND else 1, distance, delta)
+            if best_key is None or key < best_key:
+                best_key = key
+                best_floor = _SnapResult(triangle=triangle_index, point=snapped, distance=distance)
+        return best_floor
 
     def is_segment_walkable(self, zone_id: int, a: tuple[float, float], b: tuple[float, float]) -> bool:
         # Navmesh raycast: True when the straight segment a->b stays on walkable mesh within zone_id.
@@ -1005,7 +1169,7 @@ def _read_basenav(
     version = header_values[1]
     if magic != MAGIC:
         raise ValueError("invalid BaseNav magic")
-    if version != VERSION:
+    if not (VERSION_MIN <= version <= VERSION):
         raise ValueError("unsupported BaseNav version")
 
     zone_count = int(header_values[3])
@@ -1039,9 +1203,10 @@ def _read_basenav(
     # 区表含变长名字,数量很小,保留 Python 解析。
     zones = []
     cursor = zone_table_offset
+    zone_struct = ZONE_STRUCT if version >= 3 else ZONE_STRUCT_V2
     for _index in range(zone_count):
-        values = ZONE_STRUCT.unpack_from(data, offset=cursor)
-        cursor += ZONE_STRUCT.size
+        values = zone_struct.unpack_from(data, offset=cursor)
+        cursor += zone_struct.size
         name_size = int(values[2])
         name = data[cursor:cursor + name_size].tobytes().decode("utf-8")
         cursor += name_size
@@ -1056,6 +1221,7 @@ def _read_basenav(
                 width=float(values[6]),
                 height=float(values[7]),
                 transform=(float(values[8]), float(values[9]), float(values[10]), float(values[11])),
+                floor_y=float(values[12]) if version >= 3 else FLOOR_Y_NONE,
             )
         )
     if cursor != vertex_offset:


### PR DESCRIPTION
## Summary by Sourcery

引入分层感知的导航网格（navmesh）路径规划与可视化能力，并在各类工具与原生规划器中加入按区域划分的楼层高度元数据。

新功能：
- 在导航网格包中为每个区域添加主导楼层元数据和层级标记（tier flags），以支持多楼层基地和层级叠加显示。
- 在 Python 工具和 C++ 规划器中启用基于层级的映射投影，使层级模板像素与基地像素之间能够进行转换。
- 暴露楼层感知的吸附与路径规划功能，在存在楼层数据时优先选择靠近选定楼层的三角形，同时在缺失楼层数据时保留原有行为。
- 使用导航网格烘焙的变换，将实时定位器位置归一化到导航网格的基地像素坐标系中，并通过一个新的导航参数进行控制。

增强改进：
- 更新 MapNavigator UI，以区分基础区域（base zones）与层级（tiers），并仅在隶属于选定基础区域的层级内进行路径规划。
- 使用映射到层级空间中的父几何网格渲染层级覆盖（tier overlays），从而使模板与可行走表面在视觉上对齐。
- 扩展 BaseNav 加载器以同时接受旧版 v2 和新版 v3 包格式，并在处理旧数据时保持黄金哈希（golden-hash）一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce tier-aware navmesh routing and visualization with per-zone floor height metadata across tools and native planner.

New Features:
- Add per-zone dominant-floor metadata and tier flags to navmesh packs to support multi-floor bases and tier overlays.
- Enable tier-based projection between tier template pixels and base pixels for both Python tools and C++ planner.
- Expose floor-aware snapping and routing that prefer triangles near the selected floor while preserving legacy behavior when floor data is absent.
- Normalize live locator positions onto the navmesh base-pixel frame using the navmesh's baked transforms, controlled by a new navigation parameter.

Enhancements:
- Update MapNavigator UI to distinguish base zones and tiers, and route only within tiers belonging to the selected base.
- Render tier overlays using the parent geometry mesh mapped into tier space, so templates and walkable surfaces align visually.
- Extend BaseNav loaders to accept both legacy v2 and new v3 pack formats while keeping golden-hash parity for legacy data.

</details>