### PR TITLE
feat: 万能传送加新地图传送点

### DIFF
--- a/assets/resource/pipeline/Interface/InScene/Region.json
+++ b/assets/resource/pipeline/Interface/InScene/Region.json
@@ -134,6 +134,27 @@
             }
         ]
     },
+    "InMapWulingSwordVaultDale": {
+        "desc": "在武陵-藏剑谷地图界面",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny",
+            {
+                "recognition": "OCR",
+                "roi": [
+                    0,
+                    0,
+                    250,
+                    60
+                ],
+                "expected": [
+                    "藏剑谷",
+                    "Sword Vault Dale",
+                    "藏劍谷"
+                ]
+            }
+        ]
+    },
     "InMapDijiang": {
         "desc": "在帝江号地图界面",
         "recognition": "And",

--- a/assets/resource/pipeline/Interface/SceneWuling.json
+++ b/assets/resource/pipeline/Interface/SceneWuling.json
@@ -44,6 +44,15 @@
             "[JumpBack]SceneEnterMapAny"
         ]
     },
+    "SceneEnterMapWulingSwordVaultDale": {
+        "desc": "从任意界面进入武陵-藏剑谷地图界面",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingSwordVaultDale",
+            "[JumpBack]SceneEnterMapAny"
+        ]
+    },
     "SceneEnterWorldWulingJingyuValley0": {
         "desc": "从任意界面进入-景玉谷-生态实验站",
         "pre_delay": 0,
@@ -454,6 +463,30 @@
         "next": [
             "__ScenePrivateMapWulingTestAreaEnterWorldAnchorWithPick",
             "[JumpBack]SceneEnterMapWulingTestArea"
+        ]
+    },
+    "SceneEnterWorldWulingSwordVaultDale1": {
+        "desc": "从任意界面进入武陵-藏剑谷-东谷遗迹大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingSwordVaultDaleEnterWorldWulingSwordVaultDale1"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingSwordVaultDaleEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingSwordVaultDale"
+        ]
+    },
+    "SceneEnterWorldWulingSwordVaultDale2": {
+        "desc": "从任意界面进入武陵-藏剑谷-悬谷台大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingSwordVaultDaleEnterWorldWulingSwordVaultDale2"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingSwordVaultDaleEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingSwordVaultDale"
         ]
     }
 }

--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -1157,6 +1157,60 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
+    "__ScenePrivateMapWulingSwordVaultDaleEnterWorldWulingSwordVaultDale1": {
+        "desc": "在地图界面找锚点 (藏剑谷-东谷遗迹)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingSwordVaultDale"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv006",
+            "target": [
+                578.5,
+                383.2
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingSwordVaultDaleEnterWorldWulingSwordVaultDale2": {
+        "desc": "在地图界面找锚点 (藏剑谷-悬谷台)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingSwordVaultDale"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv006",
+            "target": [
+                601.6,
+                479.3
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
     "__ScenePrivateMapUnknownEnterWorldWulingMarkerStone4Try1": {
         "desc": "在地图界面找锚点 (首墩-栖云窟)",
         "recognition": "TemplateMatch",

--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -351,7 +351,7 @@
         ]
     },
     "__ScenePrivateMapOverviewWulingEnterMapWulingSwordVaultDale": {
-        "desc": "在武陵总览界面，进入武陵-试验园区地图",
+        "desc": "在武陵总览界面，进入武陵-藏剑谷地图",
         "action": "Click",
         "target": [
             825,

--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -59,6 +59,18 @@
             "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
         ]
     },
+    "__ScenePrivateMapAnyEnterMapWulingSwordVaultDale": {
+        "desc": "在任意地图界面，进入武陵-藏剑谷地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny"
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingSwordVaultDaleSuccess",
+            "__ScenePrivateMapOverviewEnterMapWulingSwordVaultDale",
+            "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
+        ]
+    },
     "__ScenePrivateMapAnyEnterMapWulingJingyuValleySuccess": {
         "desc": "在地图界面，成功进入武陵-景玉谷地图",
         "recognition": "And",
@@ -100,6 +112,15 @@
         "recognition": "And",
         "all_of": [
             "InMapWulingTestArea"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0
+    },
+    "__ScenePrivateMapAnyEnterMapWulingSwordVaultDaleSuccess": {
+        "desc": "在地图界面，成功进入武陵-藏剑谷地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingSwordVaultDale"
         ],
         "pre_delay": 0,
         "post_delay": 0
@@ -241,6 +262,29 @@
             "__ScenePrivateMapOverviewWulingEnterMapWulingTestArea"
         ]
     },
+    "__ScenePrivateMapOverviewEnterMapWulingSwordVaultDale": {
+        "desc": "在地图总览界面，进入武陵-藏剑谷地图",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    -450,
+                    -150,
+                    350,
+                    150
+                ],
+                "template": [
+                    "SceneManager/MapOverviewWulingChoose.png",
+                    "SceneManager/MapOverviewWulingNotChoose.png"
+                ],
+                "threshold": 0.9
+            }
+        },
+        "next": [
+            "[JumpBack]__ScenePrivateMapOverviewSwitchMapOverviewWuling",
+            "__ScenePrivateMapOverviewWulingEnterMapWulingSwordVaultDale"
+        ]
+    },
     "__ScenePrivateMapOverviewWulingEnterMapWulingJingyuValley": {
         "desc": "在武陵总览界面，进入武陵-景玉谷地图",
         "action": "Click",
@@ -304,6 +348,19 @@
         ],
         "next": [
             "__ScenePrivateMapAnyEnterMapWulingTestAreaSuccess"
+        ]
+    },
+    "__ScenePrivateMapOverviewWulingEnterMapWulingSwordVaultDale": {
+        "desc": "在武陵总览界面，进入武陵-试验园区地图",
+        "action": "Click",
+        "target": [
+            825,
+            537,
+            88,
+            78
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingSwordVaultDaleSuccess"
         ]
     },
     "__ScenePrivateMapWulingJingyuValleyEnterWorldAnchor": {
@@ -447,6 +504,20 @@
         "recognition": "And",
         "all_of": [
             "InMapWulingTestArea"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapTeleportSuccess",
+            "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
+        ]
+    },
+    "__ScenePrivateMapWulingSwordVaultDaleEnterWorldAnchorWithPick": {
+        "desc": "在武陵-藏剑谷地图界面，进入[锚点]大世界",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingSwordVaultDale"
         ],
         "pre_delay": 0,
         "post_delay": 0,


### PR DESCRIPTION
新增
藏剑谷-东谷遗迹
"SceneEnterWorldWulingSwordVaultDale1"
藏剑谷-悬谷台
"SceneEnterWorldWulingSwordVaultDale2"

## Summary by Sourcery

添加新的武陵子区域传送目的地，并更新相关场景配置。

新功能：
- 在武陵剑阁子区域中新增两个传送目的地，用于场景内传送。

增强：
- 扩展武陵场景和传送配置，以支持新的武陵剑阁位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new Wuling sub-region teleport destinations and update related scene configuration.

New Features:
- Introduce two new teleport destinations within the Wuling Sword Vault sub-regions for in-scene teleportation.

Enhancements:
- Extend Wuling scene and teleport configuration to support the new Wuling Sword Vault locations.

</details>

新功能：
- 在场景内区域及场景配置中，新增两个五菱剑阁子区域的传送目的地。
- 扩展五菱场景传送配置，以支持新的五菱剑阁位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加新的武陵子区域传送目的地，并更新相关场景配置。

新功能：
- 在武陵剑阁子区域中新增两个传送目的地，用于场景内传送。

增强：
- 扩展武陵场景和传送配置，以支持新的武陵剑阁位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new Wuling sub-region teleport destinations and update related scene configuration.

New Features:
- Introduce two new teleport destinations within the Wuling Sword Vault sub-regions for in-scene teleportation.

Enhancements:
- Extend Wuling scene and teleport configuration to support the new Wuling Sword Vault locations.

</details>

</details>