### PR TITLE
fix(MapNavigator): 修复工具在启用或关闭 Assert 模式时会重置视图

### DIFF
--- a/tools/MapNavigator/app_tk.py
+++ b/tools/MapNavigator/app_tk.py
@@ -816,7 +816,7 @@ class RouteEditorApp:
             self._set_status("返回路径编辑模式。", "#10b981")
         self._sync_assert_controls()
         self._refresh_zone_label()
-        self.fit_view()
+        self.schedule_redraw(fast=False)
 
     def _sync_astar_controls(self) -> None:
         active = self.astar_mode_var.get()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过改为调度重绘来停止在断言模式变化时触发完整视图适配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop triggering a full view fit when Assert mode changes by scheduling a redraw instead.

</details>