### PR TITLE
fix(自动使用理智药剂):修复因排序问题，红色理智药在右边时将绿色理智药作为识别结果的bug

### DIFF
--- a/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
@@ -98,7 +98,7 @@
                 "template": "Valuables/EmergencySpBoosterExpireSoon.png",
                 "green_mask": true,
                 "threshold": 0.84,
-                "order_by": "Vertical"
+                "order_by": "Score"
             }
         }
     },


### PR DESCRIPTION
修改方法：
红理智药识别按分数排序，避免出现在右边导致识别绿色日期的理智药的bug

## Summary by Sourcery

Bug Fixes:
- 修正红色理智药水的检测顺序，以避免在红色药水出现在右侧时误将标有绿色日期的药水识别为红色药水。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct red sanity potion detection order so it no longer misidentifies the green-dated potion when the red potion appears on the right.

</details>