### PR TITLE
feat:全屏时先尝试切换到窗口化再进行检测

### DIFF
--- a/agent/go-service/taskersink/aspectratio/altenter_windows.go
+++ b/agent/go-service/taskersink/aspectratio/altenter_windows.go
@@ -1,0 +1,152 @@
+//go:build windows
+
+package aspectratio
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/control"
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	win32WmSysKeyDown = 0x0104
+	win32WmSysKeyUp   = 0x0105
+
+	win32WmSysKeyAltEnterDown = 0x20000000
+	win32WmSysKeyAltEnterUp   = 0xE0000001
+
+	win32VkReturn = 0x0D
+
+	win32DPIAwarenessContextPerMonitorAwareV2 = ^uintptr(3)
+)
+
+var (
+	win32User32                       = windows.NewLazySystemDLL("user32.dll")
+	win32ProcIsWindow                 = win32User32.NewProc("IsWindow")
+	win32ProcPostMessageW             = win32User32.NewProc("PostMessageW")
+	win32ProcGetClientRect            = win32User32.NewProc("GetClientRect")
+	win32ProcSetThreadDpiAwarenessCtx = win32User32.NewProc("SetThreadDpiAwarenessContext")
+)
+
+type win32ControllerInfo struct {
+	Type string `json:"type"`
+	HWnd uint64 `json:"hwnd"`
+}
+
+type win32Rect struct {
+	Left   int32
+	Top    int32
+	Right  int32
+	Bottom int32
+}
+
+func init() {
+	sendAltEnterWindowsImpl = sendAltEnterWin32
+}
+
+func sendAltEnterWin32(controller *maa.Controller) (resolutionReader, error) {
+	hwnd, err := controllerHwndWin32(controller)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureAltEnterWin32APIs(); err != nil {
+		return nil, err
+	}
+	if ret, _, _ := win32ProcIsWindow.Call(hwnd); ret == 0 {
+		return nil, fmt.Errorf("invalid HWND: %d", hwnd)
+	}
+	if ret, _, e := win32ProcPostMessageW.Call(hwnd, win32WmSysKeyDown, win32VkReturn, win32WmSysKeyAltEnterDown); ret == 0 {
+		return nil, fmt.Errorf("PostMessage SYSKEYDOWN failed: %w", e)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if ret, _, e := win32ProcPostMessageW.Call(hwnd, win32WmSysKeyUp, win32VkReturn, win32WmSysKeyAltEnterUp); ret == 0 {
+		return nil, fmt.Errorf("PostMessage SYSKEYUP failed: %w", e)
+	}
+
+	log.Debug().Uint64("hwnd", uint64(hwnd)).Msg("Alt+Enter key sequence completed")
+	return func() (int32, int32, error) {
+		return getClientResolutionWin32(hwnd)
+	}, nil
+}
+
+func ensureAltEnterWin32APIs() error {
+	for _, p := range []*windows.LazyProc{
+		win32ProcIsWindow,
+		win32ProcPostMessageW,
+		win32ProcGetClientRect,
+	} {
+		if err := p.Find(); err != nil {
+			return fmt.Errorf("user32 API unavailable: %w", err)
+		}
+	}
+	return nil
+}
+
+func getClientResolutionWin32(hwnd uintptr) (int32, int32, error) {
+	if err := ensureAltEnterWin32APIs(); err != nil {
+		return 0, 0, err
+	}
+	if ret, _, _ := win32ProcIsWindow.Call(hwnd); ret == 0 {
+		return 0, 0, fmt.Errorf("invalid HWND: %d", hwnd)
+	}
+
+	restoreDPIContext := setDPIAwareWin32()
+	defer restoreDPIContext()
+
+	var rect win32Rect
+	if ret, _, _ := win32ProcGetClientRect.Call(hwnd, uintptr(unsafe.Pointer(&rect))); ret == 0 {
+		return 0, 0, fmt.Errorf("GetClientRect failed for HWND: %d", hwnd)
+	}
+
+	width := rect.Right - rect.Left
+	height := rect.Bottom - rect.Top
+	if width <= 0 || height <= 0 {
+		return 0, 0, fmt.Errorf("invalid client rect for HWND %d: %dx%d", hwnd, width, height)
+	}
+	return width, height, nil
+}
+
+func setDPIAwareWin32() func() {
+	if err := win32ProcSetThreadDpiAwarenessCtx.Find(); err != nil {
+		return func() {}
+	}
+	oldCtx, _, _ := win32ProcSetThreadDpiAwarenessCtx.Call(win32DPIAwarenessContextPerMonitorAwareV2)
+	return func() {
+		if oldCtx != 0 {
+			win32ProcSetThreadDpiAwarenessCtx.Call(oldCtx)
+		}
+	}
+}
+
+func controllerHwndWin32(controller *maa.Controller) (uintptr, error) {
+	if controller == nil {
+		return 0, fmt.Errorf("nil controller")
+	}
+
+	infoStr, err := controller.GetInfo()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get controller info: %w", err)
+	}
+	if strings.TrimSpace(infoStr) == "" {
+		return 0, fmt.Errorf("empty controller info")
+	}
+
+	var info win32ControllerInfo
+	if err := json.Unmarshal([]byte(infoStr), &info); err != nil {
+		return 0, fmt.Errorf("failed to parse controller info: %w", err)
+	}
+	if info.Type != "" && !strings.EqualFold(info.Type, control.CONTROL_TYPE_WIN32) {
+		return 0, fmt.Errorf("controller type is %q, not win32", info.Type)
+	}
+	if info.HWnd == 0 {
+		return 0, fmt.Errorf("controller info has no hwnd")
+	}
+	return uintptr(info.HWnd), nil
+}

--- a/agent/go-service/taskersink/aspectratio/altenter_windows.go
+++ b/agent/go-service/taskersink/aspectratio/altenter_windows.go
@@ -62,12 +62,12 @@ func sendAltEnterWin32(controller *maa.Controller) (resolutionReader, error) {
 	if ret, _, _ := win32ProcIsWindow.Call(hwnd); ret == 0 {
 		return nil, fmt.Errorf("invalid HWND: %d", hwnd)
 	}
-	if ret, _, e := win32ProcPostMessageW.Call(hwnd, win32WmSysKeyDown, win32VkReturn, win32WmSysKeyAltEnterDown); ret == 0 {
-		return nil, fmt.Errorf("PostMessage SYSKEYDOWN failed: %w", e)
+	if err := postMessageWin32(hwnd, win32WmSysKeyDown, win32VkReturn, win32WmSysKeyAltEnterDown, "SYSKEYDOWN"); err != nil {
+		return nil, err
 	}
 	time.Sleep(50 * time.Millisecond)
-	if ret, _, e := win32ProcPostMessageW.Call(hwnd, win32WmSysKeyUp, win32VkReturn, win32WmSysKeyAltEnterUp); ret == 0 {
-		return nil, fmt.Errorf("PostMessage SYSKEYUP failed: %w", e)
+	if err := postMessageWin32(hwnd, win32WmSysKeyUp, win32VkReturn, win32WmSysKeyAltEnterUp, "SYSKEYUP"); err != nil {
+		return nil, err
 	}
 
 	log.Debug().Uint64("hwnd", uint64(hwnd)).Msg("Alt+Enter key sequence completed")
@@ -85,6 +85,16 @@ func ensureAltEnterWin32APIs() error {
 		if err := p.Find(); err != nil {
 			return fmt.Errorf("user32 API unavailable: %w", err)
 		}
+	}
+	return nil
+}
+
+func postMessageWin32(hwnd, msg, wparam, lparam uintptr, op string) error {
+	if ret, _, err := win32ProcPostMessageW.Call(hwnd, msg, wparam, lparam); ret == 0 {
+		if err != nil && err != windows.ERROR_SUCCESS {
+			return fmt.Errorf("PostMessage %s failed: %w", op, err)
+		}
+		return fmt.Errorf("PostMessage %s failed with ret=0", op)
 	}
 	return nil
 }

--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -22,11 +22,6 @@ const (
 	tolerance    = 0.02
 	targetWidth  = 1280
 	targetHeight = 720
-
-	fullscreenToggleSettleDelay    = 3000 * time.Millisecond
-	fullscreenToggleRecheckTimeout = 8000 * time.Millisecond
-	fullscreenToggleRecheckDelay   = 500 * time.Millisecond
-	altEnterKeyStepDelay           = 80 * time.Millisecond
 )
 
 // AspectRatioChecker checks if the device resolution is 16:9 before task execution
@@ -277,7 +272,7 @@ func trySwitchFullscreenToWindowedAndRecheck(controller *maa.Controller, detail 
 		Uint64("task_id", detail.TaskID).
 		Str("entry", detail.Entry).
 		Msg("Alt+Enter completed, waiting for fullscreen toggle to settle")
-	time.Sleep(fullscreenToggleSettleDelay)
+	time.Sleep(3 * time.Second)
 
 	return recheckResolutionAfterFullscreenToggle(controller, detail, width, height)
 }
@@ -325,7 +320,7 @@ func recheckResolutionAfterFullscreenToggle(controller *maa.Controller, detail m
 		}
 
 		elapsed := time.Since(start)
-		if elapsed >= fullscreenToggleRecheckTimeout {
+		if elapsed >= 8*time.Second {
 			log.Warn().
 				Uint64("task_id", detail.TaskID).
 				Str("entry", detail.Entry).
@@ -337,8 +332,8 @@ func recheckResolutionAfterFullscreenToggle(controller *maa.Controller, detail m
 			return width, height, false
 		}
 
-		sleepDuration := fullscreenToggleRecheckDelay
-		if remaining := fullscreenToggleRecheckTimeout - elapsed; remaining < sleepDuration {
+		sleepDuration := 500 * time.Millisecond
+		if remaining := 8*time.Second - elapsed; remaining < sleepDuration {
 			sleepDuration = remaining
 		}
 		time.Sleep(sleepDuration)
@@ -363,15 +358,15 @@ func sendAltEnterAndWait(controller *maa.Controller) {
 	}()
 
 	controller.PostKeyDown(vkAlt).Wait()
-	time.Sleep(altEnterKeyStepDelay)
+	time.Sleep(80 * time.Millisecond)
 
 	controller.PostKeyDown(vkReturn).Wait()
 	enterReleased = false
-	time.Sleep(altEnterKeyStepDelay)
+	time.Sleep(80 * time.Millisecond)
 
 	controller.PostKeyUp(vkReturn).Wait()
 	enterReleased = true
-	time.Sleep(altEnterKeyStepDelay)
+	time.Sleep(80 * time.Millisecond)
 
 	controller.PostKeyUp(vkAlt).Wait()
 	altReleased = true

--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -22,6 +22,11 @@ const (
 	tolerance    = 0.02
 	targetWidth  = 1280
 	targetHeight = 720
+
+	fullscreenToggleSettleDelay    = 3000 * time.Millisecond
+	fullscreenToggleRecheckTimeout = 8000 * time.Millisecond
+	fullscreenToggleRecheckDelay   = 500 * time.Millisecond
+	altEnterKeyStepDelay           = 80 * time.Millisecond
 )
 
 // AspectRatioChecker checks if the device resolution is 16:9 before task execution
@@ -52,28 +57,8 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		return
 	}
 
-	const maxRetries = 20
-	var width, height int32
-	var err error
-	for i := 0; i < maxRetries; i++ {
-		width, height, err = controller.GetResolution()
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to get resolution")
-			return
-		}
-		if width > 100 && height > 100 {
-			break
-		}
-		log.Debug().
-			Int32("width", width).
-			Int32("height", height).
-			Int("attempt", i+1).
-			Msg("Resolution too small, window may not be ready yet, retrying...")
-		time.Sleep(time.Second)
-		controller.PostScreencap().Wait()
-	}
-
-	if width <= 100 || height <= 100 {
+	width, height, ok := readResolutionWithRetry(controller)
+	if !ok {
 		log.Error().
 			Int32("width", width).
 			Int32("height", height).
@@ -162,8 +147,7 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		return
 	}
 
-	aspectRatioOK := isAspectRatio16x9(int(width), int(height))
-	minResolutionOK := isAtLeastTargetResolution(int(width), int(height))
+	aspectRatioOK, minResolutionOK, resolutionOK := isNonADBResolutionOK(width, height)
 
 	log.Debug().
 		Uint64("task_id", detail.TaskID).
@@ -181,7 +165,14 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		Float64("target_ratio", targetRatio).
 		Msg("Using aspect ratio and minimum resolution check for non-ADB controller")
 
-	if !aspectRatioOK || !minResolutionOK {
+	if !resolutionOK {
+		recheckedWidth, recheckedHeight, recheckedOK := trySwitchFullscreenToWindowedAndRecheck(controller, detail, width, height)
+		if recheckedOK {
+			return
+		}
+		width = recheckedWidth
+		height = recheckedHeight
+		aspectRatioOK, minResolutionOK, _ = isNonADBResolutionOK(width, height)
 		actualRatio := calculateAspectRatio(int(width), int(height))
 		log.Error().
 			Uint64("task_id", detail.TaskID).
@@ -223,6 +214,169 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		Bool("min_resolution_ok", minResolutionOK).
 		Str("mode", "aspect_ratio_min_resolution").
 		Msg("resolution check passed")
+}
+
+func readResolutionWithRetry(controller *maa.Controller) (int32, int32, bool) {
+	const maxRetries = 20
+	var width, height int32
+	for i := 0; i < maxRetries; i++ {
+		var err error
+		width, height, err = controller.GetResolution()
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to get resolution")
+			return width, height, false
+		}
+		if width > 100 && height > 100 {
+			return width, height, true
+		}
+		log.Debug().
+			Int32("width", width).
+			Int32("height", height).
+			Int("attempt", i+1).
+			Msg("Resolution too small, window may not be ready yet, retrying...")
+		time.Sleep(time.Second)
+		controller.PostScreencap().Wait()
+	}
+	return width, height, false
+}
+
+func isNonADBResolutionOK(width, height int32) (bool, bool, bool) {
+	aspectRatioOK := isAspectRatio16x9(int(width), int(height))
+	minResolutionOK := isAtLeastTargetResolution(int(width), int(height))
+	return aspectRatioOK, minResolutionOK, aspectRatioOK && minResolutionOK
+}
+
+func trySwitchFullscreenToWindowedAndRecheck(controller *maa.Controller, detail maa.TaskerTaskDetail, width, height int32) (int32, int32, bool) {
+	fullScreen, err := gamesetting.GetVideoFullScreen()
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Uint64("task_id", detail.TaskID).
+			Str("entry", detail.Entry).
+			Msg("Failed to read fullscreen setting, skip Alt+Enter")
+		return width, height, false
+	}
+	if fullScreen != 1 {
+		log.Debug().
+			Uint64("task_id", detail.TaskID).
+			Str("entry", detail.Entry).
+			Uint32("video_full_screen", fullScreen).
+			Msg("Game is not fullscreen, skip Alt+Enter")
+		return width, height, false
+	}
+
+	log.Info().
+		Uint64("task_id", detail.TaskID).
+		Str("entry", detail.Entry).
+		Int32("width", width).
+		Int32("height", height).
+		Msg("Game is fullscreen with invalid resolution, sending Alt+Enter to switch to windowed mode")
+
+	sendAltEnterAndWait(controller)
+	log.Debug().
+		Uint64("task_id", detail.TaskID).
+		Str("entry", detail.Entry).
+		Msg("Alt+Enter completed, waiting for fullscreen toggle to settle")
+	time.Sleep(fullscreenToggleSettleDelay)
+
+	return recheckResolutionAfterFullscreenToggle(controller, detail, width, height)
+}
+
+func recheckResolutionAfterFullscreenToggle(controller *maa.Controller, detail maa.TaskerTaskDetail, oldWidth, oldHeight int32) (int32, int32, bool) {
+	width := oldWidth
+	height := oldHeight
+	start := time.Now()
+
+	for attempt := 1; ; attempt++ {
+		controller.PostScreencap().Wait()
+
+		recheckedWidth, recheckedHeight, err := controller.GetResolution()
+		if err != nil {
+			log.Warn().
+				Err(err).
+				Uint64("task_id", detail.TaskID).
+				Str("entry", detail.Entry).
+				Int("attempt", attempt).
+				Msg("Failed to get resolution during Alt+Enter recheck")
+		} else {
+			width = recheckedWidth
+			height = recheckedHeight
+			aspectRatioOK, minResolutionOK, resolutionOK := isNonADBResolutionOK(width, height)
+			log.Debug().
+				Uint64("task_id", detail.TaskID).
+				Str("entry", detail.Entry).
+				Int("attempt", attempt).
+				Int32("width", width).
+				Int32("height", height).
+				Bool("aspect_ratio_ok", aspectRatioOK).
+				Bool("min_resolution_ok", minResolutionOK).
+				Msg("Rechecked resolution after Alt+Enter")
+
+			if resolutionOK {
+				log.Info().
+					Uint64("task_id", detail.TaskID).
+					Str("entry", detail.Entry).
+					Int32("width", width).
+					Int32("height", height).
+					Int("attempt", attempt).
+					Msg("Resolution check passed after Alt+Enter, continuing task")
+				return width, height, true
+			}
+		}
+
+		elapsed := time.Since(start)
+		if elapsed >= fullscreenToggleRecheckTimeout {
+			log.Warn().
+				Uint64("task_id", detail.TaskID).
+				Str("entry", detail.Entry).
+				Int32("width", width).
+				Int32("height", height).
+				Int("attempt", attempt).
+				Dur("elapsed", elapsed).
+				Msg("Resolution recheck timed out after Alt+Enter")
+			return width, height, false
+		}
+
+		sleepDuration := fullscreenToggleRecheckDelay
+		if remaining := fullscreenToggleRecheckTimeout - elapsed; remaining < sleepDuration {
+			sleepDuration = remaining
+		}
+		time.Sleep(sleepDuration)
+	}
+}
+
+func sendAltEnterAndWait(controller *maa.Controller) {
+	const (
+		vkAlt    = 0x12
+		vkReturn = 0x0D
+	)
+
+	altReleased := false
+	enterReleased := true
+	defer func() {
+		if !enterReleased {
+			controller.PostKeyUp(vkReturn).Wait()
+		}
+		if !altReleased {
+			controller.PostKeyUp(vkAlt).Wait()
+		}
+	}()
+
+	controller.PostKeyDown(vkAlt).Wait()
+	time.Sleep(altEnterKeyStepDelay)
+
+	controller.PostKeyDown(vkReturn).Wait()
+	enterReleased = false
+	time.Sleep(altEnterKeyStepDelay)
+
+	controller.PostKeyUp(vkReturn).Wait()
+	enterReleased = true
+	time.Sleep(altEnterKeyStepDelay)
+
+	controller.PostKeyUp(vkAlt).Wait()
+	altReleased = true
+
+	log.Debug().Msg("Alt+Enter key sequence completed")
 }
 
 func (c *AspectRatioChecker) stopWithWarning(tasker *maa.Tasker, controllerDisplay string, width, height int, followUpLines ...string) {

--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -3,6 +3,7 @@ package aspectratio
 import (
 	"fmt"
 	"math"
+	"runtime"
 	"strings"
 	"time"
 
@@ -26,6 +27,8 @@ const (
 
 // AspectRatioChecker checks if the device resolution is 16:9 before task execution
 type AspectRatioChecker struct{}
+
+type resolutionReader func() (int32, int32, error)
 
 // OnTaskerTask handles tasker task events
 func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventStatus, detail maa.TaskerTaskDetail) {
@@ -242,6 +245,15 @@ func isNonADBResolutionOK(width, height int32) (bool, bool, bool) {
 }
 
 func trySwitchFullscreenToWindowedAndRecheck(controller *maa.Controller, detail maa.TaskerTaskDetail, width, height int32) (int32, int32, bool) {
+	if runtime.GOOS != "windows" {
+		log.Debug().
+			Uint64("task_id", detail.TaskID).
+			Str("entry", detail.Entry).
+			Str("goos", runtime.GOOS).
+			Msg("Skip Alt+Enter outside Windows")
+		return width, height, false
+	}
+
 	fullScreen, err := gamesetting.GetVideoFullScreen()
 	if err != nil {
 		log.Warn().
@@ -267,111 +279,77 @@ func trySwitchFullscreenToWindowedAndRecheck(controller *maa.Controller, detail 
 		Int32("height", height).
 		Msg("Game is fullscreen with invalid resolution, sending Alt+Enter to switch to windowed mode")
 
-	sendAltEnterAndWait(controller)
+	readResolution, err := sendAltEnterWindows(controller)
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Uint64("task_id", detail.TaskID).
+			Str("entry", detail.Entry).
+			Msg("Failed to send Alt+Enter, skip resolution recheck")
+		return width, height, false
+	}
 	log.Debug().
 		Uint64("task_id", detail.TaskID).
 		Str("entry", detail.Entry).
 		Msg("Alt+Enter completed, waiting for fullscreen toggle to settle")
-	time.Sleep(3 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
-	return recheckResolutionAfterFullscreenToggle(controller, detail, width, height)
+	return recheckResolutionAfterFullscreenToggle(readResolution, detail, width, height)
 }
 
-func recheckResolutionAfterFullscreenToggle(controller *maa.Controller, detail maa.TaskerTaskDetail, oldWidth, oldHeight int32) (int32, int32, bool) {
+func recheckResolutionAfterFullscreenToggle(readResolution resolutionReader, detail maa.TaskerTaskDetail, oldWidth, oldHeight int32) (int32, int32, bool) {
 	width := oldWidth
 	height := oldHeight
-	start := time.Now()
 
-	for attempt := 1; ; attempt++ {
-		controller.PostScreencap().Wait()
-
-		recheckedWidth, recheckedHeight, err := controller.GetResolution()
-		if err != nil {
-			log.Warn().
-				Err(err).
-				Uint64("task_id", detail.TaskID).
-				Str("entry", detail.Entry).
-				Int("attempt", attempt).
-				Msg("Failed to get resolution during Alt+Enter recheck")
-		} else {
-			width = recheckedWidth
-			height = recheckedHeight
-			aspectRatioOK, minResolutionOK, resolutionOK := isNonADBResolutionOK(width, height)
-			log.Debug().
-				Uint64("task_id", detail.TaskID).
-				Str("entry", detail.Entry).
-				Int("attempt", attempt).
-				Int32("width", width).
-				Int32("height", height).
-				Bool("aspect_ratio_ok", aspectRatioOK).
-				Bool("min_resolution_ok", minResolutionOK).
-				Msg("Rechecked resolution after Alt+Enter")
-
-			if resolutionOK {
-				log.Info().
-					Uint64("task_id", detail.TaskID).
-					Str("entry", detail.Entry).
-					Int32("width", width).
-					Int32("height", height).
-					Int("attempt", attempt).
-					Msg("Resolution check passed after Alt+Enter, continuing task")
-				return width, height, true
-			}
-		}
-
-		elapsed := time.Since(start)
-		if elapsed >= 8*time.Second {
-			log.Warn().
-				Uint64("task_id", detail.TaskID).
-				Str("entry", detail.Entry).
-				Int32("width", width).
-				Int32("height", height).
-				Int("attempt", attempt).
-				Dur("elapsed", elapsed).
-				Msg("Resolution recheck timed out after Alt+Enter")
-			return width, height, false
-		}
-
-		sleepDuration := 500 * time.Millisecond
-		if remaining := 8*time.Second - elapsed; remaining < sleepDuration {
-			sleepDuration = remaining
-		}
-		time.Sleep(sleepDuration)
+	if readResolution == nil {
+		log.Warn().
+			Uint64("task_id", detail.TaskID).
+			Str("entry", detail.Entry).
+			Msg("Resolution reader is unavailable during Alt+Enter recheck")
+		return width, height, false
 	}
+
+	recheckedWidth, recheckedHeight, err := readResolution()
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Uint64("task_id", detail.TaskID).
+			Str("entry", detail.Entry).
+			Msg("Failed to get resolution during Alt+Enter recheck")
+		return width, height, false
+	}
+
+	width = recheckedWidth
+	height = recheckedHeight
+	aspectRatioOK, minResolutionOK, resolutionOK := isNonADBResolutionOK(width, height)
+	log.Debug().
+		Uint64("task_id", detail.TaskID).
+		Str("entry", detail.Entry).
+		Int32("width", width).
+		Int32("height", height).
+		Bool("aspect_ratio_ok", aspectRatioOK).
+		Bool("min_resolution_ok", minResolutionOK).
+		Msg("Rechecked resolution after Alt+Enter")
+
+	if resolutionOK {
+		log.Info().
+			Uint64("task_id", detail.TaskID).
+			Str("entry", detail.Entry).
+			Int32("width", width).
+			Int32("height", height).
+			Msg("Resolution check passed after Alt+Enter, continuing task")
+		return width, height, true
+	}
+
+	return width, height, false
 }
 
-func sendAltEnterAndWait(controller *maa.Controller) {
-	const (
-		vkAlt    = 0x12
-		vkReturn = 0x0D
-	)
+func sendAltEnterWindows(controller *maa.Controller) (resolutionReader, error) {
+	return sendAltEnterWindowsImpl(controller)
+}
 
-	altReleased := false
-	enterReleased := true
-	defer func() {
-		if !enterReleased {
-			controller.PostKeyUp(vkReturn).Wait()
-		}
-		if !altReleased {
-			controller.PostKeyUp(vkAlt).Wait()
-		}
-	}()
-
-	controller.PostKeyDown(vkAlt).Wait()
-	time.Sleep(80 * time.Millisecond)
-
-	controller.PostKeyDown(vkReturn).Wait()
-	enterReleased = false
-	time.Sleep(80 * time.Millisecond)
-
-	controller.PostKeyUp(vkReturn).Wait()
-	enterReleased = true
-	time.Sleep(80 * time.Millisecond)
-
-	controller.PostKeyUp(vkAlt).Wait()
-	altReleased = true
-
-	log.Debug().Msg("Alt+Enter key sequence completed")
+var sendAltEnterWindowsImpl = func(*maa.Controller) (resolutionReader, error) {
+	return nil, fmt.Errorf("Alt+Enter is only supported on Windows")
 }
 
 func (c *AspectRatioChecker) stopWithWarning(tasker *maa.Tasker, controllerDisplay string, width, height int, followUpLines ...string) {


### PR DESCRIPTION
测试了以下场景
非16：9全屏到16：9窗口化：成功运行
非16：9全屏到非16：9窗口化：成功拦截
16：9窗口化：成功运行

## Summary by Sourcery

通过在 Windows 上尝试将全屏切换为窗口模式来处理无效的非 ADB 分辨率，然后再执行纵横比检查失败流程。

新功能：
- 添加 Windows 特定的 Alt+Enter 处理逻辑，用于将游戏从全屏切换到窗口模式，并重新评估分辨率和纵横比。

增强项：
- 重构分辨率读取逻辑，将其提取为可重用的辅助函数，并加入重试机制和非 ADB 分辨率校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle invalid non-ADB resolutions by attempting to toggle fullscreen to windowed mode on Windows before failing aspect-ratio checks.

New Features:
- Add Windows-specific Alt+Enter handling to toggle the game from fullscreen to windowed mode and re-evaluate resolution and aspect ratio.

Enhancements:
- Refactor resolution reading logic into reusable helpers with retry and non-ADB resolution validation.

</details>