### PR TITLE
feat: 添加藏剑谷淤积点

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -9,6 +9,7 @@
     "global.region.TestArea": "Test Area",
     "global.region.QingboStockade": "Qingbo Stockade",
     "global.region.MarkerStone": "Marker Stone",
+    "global.region.SwordVaultDale": "Sword Vault Dale",
     "item.XiraniteGourd": "Xiranite Gourd",
     "item.XiraniteJadeGourd": "Xiranite Jade Gourd",
     "task.DeliveryJobs.AcceptJobOnly": "Accept-jobs-only mode is enabled. The subsequent transfer flow has been stopped. Please complete the delivery and run the task again.",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -9,6 +9,7 @@
     "global.region.TestArea": "実験区域",
     "global.region.QingboStockade": "清波寨",
     "global.region.MarkerStone": "首墩",
+    "global.region.SwordVaultDale": "蔵剣谷",
     "item.XiraniteGourd": "息壌ひょうたん",
     "item.XiraniteJadeGourd": "息壌玉ひょうたん",
     "task.DeliveryJobs.AcceptJobOnly": "依頼受注のみモードが有効です。以降の転送フローを停止しました。配達を完了してから、もう一度タスクを実行してください。",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -9,6 +9,7 @@
     "global.region.TestArea": "실험 구역",
     "global.region.QingboStockade": "청파채",
     "global.region.MarkerStone": "마커 스톤",
+    "global.region.SwordVaultDale": "검고리 골짜기",
     "item.XiraniteGourd": "식양 호리병",
     "item.XiraniteJadeGourd": "식양 옥 호리병",
     "task.DeliveryJobs.AcceptJobOnly": "임무 수락 전용 모드가 활성화되었습니다. 이후 전달 절차를 중지합니다. 배송을 완료한 뒤 작업을 다시 실행해 주세요.",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -9,6 +9,7 @@
     "global.region.TestArea": "试验园区",
     "global.region.QingboStockade": "清波寨",
     "global.region.MarkerStone": "首墩",
+    "global.region.SwordVaultDale": "藏剑谷",
     "item.XiraniteGourd": "息壤葫芦",
     "item.XiraniteJadeGourd": "息壤玉葫芦",
     "task.DeliveryJobs.AcceptJobOnly": "已开启仅接取任务模式，停止后续转交流程，请完成送货后再次运行任务",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -9,6 +9,7 @@
     "global.region.TestArea": "實驗園區",
     "global.region.QingboStockade": "清波寨",
     "global.region.MarkerStone": "首墩",
+    "global.region.SwordVaultDale": "藏劍谷",
     "item.XiraniteGourd": "息壤葫蘆",
     "item.XiraniteJadeGourd": "息壤玉葫蘆",
     "task.DeliveryJobs.AcceptJobOnly": "已開啟僅接取任務模式，停止後續轉交流程，請完成送貨後再次執行任務",

--- a/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
+++ b/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
@@ -65,6 +65,7 @@
             "WLWulingCityLocationAssertion",
             "WLQingboStockadeLocationAssertion",
             "WLMarkerStoneLocationAssertion",
+            "WLSwordVaultDaleLocationAssertion",
             // 如果上述所有地区都没有命中，则无事发生
             "AutoEssenceLocationSetupFailed"
         ],
@@ -92,6 +93,7 @@
             "WLWulingCityLocationAssertion",
             "WLQingboStockadeLocationAssertion",
             "WLMarkerStoneLocationAssertion",
+            "WLSwordVaultDaleLocationAssertion",
             // 如果上述所有地区都没有命中，则自动导航到指定的某个淤积点
             "AutoEssenceSpecifiedLocation"
         ],

--- a/assets/resource/pipeline/AutoEssence/RegionNodes/WLSwordVaultDale.json
+++ b/assets/resource/pipeline/AutoEssence/RegionNodes/WLSwordVaultDale.json
@@ -1,0 +1,189 @@
+{
+    "WLSwordVaultDaleMoveToTriggerPointAuto": {
+        "anchor": {
+            "AutoEssenceMoveToTriggerPoint": "WLSwordVaultDaleMoveToTriggerPoint",
+            "AutoEssenceWalkAround": "WLSwordVaultDaleWalkAround1"
+        },
+        "next": [
+            "[JumpBack]WLSwordVaultDaleMaybeTeleport",
+            "WLSwordVaultDaleMoveToTriggerPoint"
+        ]
+    },
+    "WLSwordVaultDaleLocationAssertion": {
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "MapTrackerAssertLocation",
+                "custom_recognition_param": {
+                    "expected": [
+                        {
+                            // 淤积点附近
+                            "map_name": "map02_lv006",
+                            "target": [
+                                386.7,
+                                294.8,
+                                21.4,
+                                20.7
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "anchor": {
+            "AutoEssenceMoveToTriggerPoint": "WLSwordVaultDaleMoveToTriggerPoint",
+            "AutoEssenceWalkAround": "WLSwordVaultDaleWalkAround1"
+        },
+        "focus": {
+            "Node.Action.Starting": "📍附近的能量淤积点：\n<p style=\"text-align: center\"><strong>藏剑谷</strong></p>"
+        }
+    },
+    "WLSwordVaultDaleMaybeTeleport": {
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "MapTrackerAssertLocation",
+                "custom_recognition_param": {
+                    "expected": [
+                        {
+                            // 距离淤积点最近的锚点附近
+                            "map_name": "map02_lv006",
+                            "target": [
+                                352.0,
+                                290.4,
+                                12.0,
+                                12.6
+                            ]
+                        },
+                        {
+                            // 淤积点附近
+                            "map_name": "map02_lv006",
+                            "target": [
+                                386.7,
+                                294.8,
+                                21.4,
+                                20.7
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "inverse": true,
+        "next": [
+            "SceneEnterWorldWulingSwordVaultDale3"
+        ],
+        "focus": {
+            "Node.Action.Starting": "✈️准备传送到最近锚点"
+        }
+    },
+    "WLSwordVaultDaleMoveToTriggerPoint": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv006",
+                    "path": [
+                        [
+                            357.4,
+                            291.4
+                        ],
+                        [
+                            366.3,
+                            297.7
+                        ],
+                        [
+                            398.7,
+                            306.5
+                        ]
+                    ],
+                    "path_trim": true
+                }
+            }
+        },
+        "next": [
+            "WLSwordVaultDaleMoveToTriggerPointExact"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在前往激发点附近"
+        }
+    },
+    "WLSwordVaultDaleMoveToTriggerPointExact": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv006",
+                    "path": [
+                        [
+                            398.7,
+                            306.5
+                        ]
+                    ]
+                }
+            }
+        },
+        "next": [
+            "AutoEssenceAtTriggerState"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在前往激发点"
+        }
+    },
+    "WLSwordVaultDaleWalkAround1": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv006",
+                    "path": [
+                        [
+                            400.7,
+                            304.5
+                        ]
+                    ],
+                    "rotation_lower_threshold": 12.0,
+                    "rotation_upper_threshold": 120.0,
+                    "sprint_threshold": 6.0
+                }
+            }
+        },
+        "next": [
+            "AutoEssenceCheckOngoing",
+            "WLSwordVaultDaleWalkAround2"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在散步中"
+        }
+    },
+    "WLSwordVaultDaleWalkAround2": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv006",
+                    "path": [
+                        [
+                            399.2,
+                            307.8
+                        ]
+                    ],
+                    "rotation_lower_threshold": 12.0,
+                    "rotation_upper_threshold": 120.0,
+                    "sprint_threshold": 6.0
+                }
+            }
+        },
+        "next": [
+            "AutoEssenceCheckOngoing",
+            "WLSwordVaultDaleWalkAround1"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在散步中"
+        }
+    }
+}

--- a/assets/resource/pipeline/Interface/SceneWuling.json
+++ b/assets/resource/pipeline/Interface/SceneWuling.json
@@ -488,5 +488,17 @@
             "__ScenePrivateMapWulingSwordVaultDaleEnterWorldAnchorWithPick",
             "[JumpBack]SceneEnterMapWulingSwordVaultDale"
         ]
+    },
+    "SceneEnterWorldWulingSwordVaultDale3": {
+        "desc": "从任意界面进入武陵-藏剑谷-谷底秘库大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingSwordVaultDaleEnterWorldWulingSwordVaultDale3"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingSwordVaultDaleEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingSwordVaultDale"
+        ]
     }
 }

--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -1211,6 +1211,33 @@
             "__ScenePrivateMapTeleportConfirm"
         ]
     },
+    "__ScenePrivateMapWulingSwordVaultDaleEnterWorldWulingSwordVaultDale3": {
+        "desc": "在地图界面找锚点 (藏剑谷-谷底秘库)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingSwordVaultDale"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv006",
+            "target": [
+                356.5,
+                297.2
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
     "__ScenePrivateMapUnknownEnterWorldWulingMarkerStone4Try1": {
         "desc": "在地图界面找锚点 (首墩-栖云窟)",
         "recognition": "TemplateMatch",

--- a/assets/tasks/AutoEssence.json
+++ b/assets/tasks/AutoEssence.json
@@ -107,6 +107,17 @@
                             ]
                         }
                     }
+                },
+                {
+                    "name": "WLSwordVaultDale",
+                    "label": "$global.region.SwordVaultDale",
+                    "pipeline_override": {
+                        "AutoEssenceSpecifiedLocation": {
+                            "next": [
+                                "WLSwordVaultDaleMoveToTriggerPointAuto"
+                            ]
+                        }
+                    }
                 }
             ]
         },


### PR DESCRIPTION
close #3561

添加藏剑谷淤积点相关逻辑

## Summary by Sourcery

添加新的剑冢山谷积累点逻辑，并将其集成到武陵场景和自动基质（auto-essence）管线中。

新特性：
- 引入新的武陵藏剑谷区域节点配置，用于自动基质处理。

增强改进：
- 将新的区域节点接入现有的 `AutoEssence`、`SceneWuling` 和 `SceneTeleportWuling` 管线配置。
- 更新所有受支持语言中的本地化界面字符串，以反映新的积累点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new Sword Vault Dale accumulation point logic and integrate it into the Wuling scene and auto-essence pipelines.

New Features:
- Introduce a new Wuling Sword Vault Dale region node configuration for auto-essence handling.

Enhancements:
- Wire the new region node into existing AutoEssence, SceneWuling, and SceneTeleportWuling pipeline configurations.
- Update localized interface strings across all supported languages to reflect the new accumulation point.

</details>

## Summary by Sourcery

为新的五灵剑藏谷聚积点添加配置和本地化支持，并将其集成进自动精华与场景流水线中。

新特性：
- 为自动精华系统引入新的五灵剑藏谷区域节点配置。

改进与优化：
- 将新的区域节点接入现有的 AutoEssence、SceneWuling 和 SceneTeleportWuling 流水线及任务配置中。
- 更新各受支持语言中的本地化界面文案，以引用新的聚积点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration and localization for a new Wuling Sword Vault Dale accumulation point and integrate it into auto-essence and scene pipelines.

New Features:
- Introduce a new Wuling Sword Vault Dale region node configuration for the auto-essence system.

Enhancements:
- Wire the new region node into existing AutoEssence, SceneWuling, and SceneTeleportWuling pipeline and task configurations.
- Update localized interface strings across supported languages to reference the new accumulation point.

</details>