### PR TITLE
fix: 处理选剑演武奖励次数用尽后的确认界面

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
@@ -69,10 +69,10 @@
         "post_wait_freezes": 100,
         "next": [
             "TrialOfSwordmancyInTrialMenu",
-            "TrialOfSwordmancyRewardExhuasted"
+            "TrialOfSwordmancyRewardExhausted"
         ]
     },
-    "TrialOfSwordmancyRewardExhuasted": {
+    "TrialOfSwordmancyRewardExhausted": {
         "desc": "奖励次数用尽，即将进入自由演算模式",
         "recognition": "And",
         "all_of": [

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
@@ -68,7 +68,20 @@
         "action": "Click",
         "post_wait_freezes": 100,
         "next": [
-            "TrialOfSwordmancyInTrialMenu"
+            "TrialOfSwordmancyInTrialMenu",
+            "TrialOfSwordmancyRewardExhuasted"
         ]
+    },
+    "TrialOfSwordmancyRewardExhuasted": {
+        "desc": "奖励次数用尽，即将进入自由演算模式",
+        "recognition": "And",
+        "all_of": [
+            "YellowConfirmButtonType1"
+        ],
+        "action": "Click",
+        "next": [], // 任务结束
+        "focus": {
+            "Node.Action.Succeeded": "今日奖励次数已用尽"
+        }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 调整 TrialOfSwordmancy 战斗配置，以在奖励耗尽时正确处理确认界面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust TrialOfSwordmancy fight configuration to correctly handle the confirmation screen when rewards are exhausted.

</details>