### PR TITLE
fix: 修复软骨饼干配置名错误

### DIFF
--- a/assets/resource/pipeline/AutoStockStaple/General/QuantityControl.json
+++ b/assets/resource/pipeline/AutoStockStaple/General/QuantityControl.json
@@ -712,7 +712,7 @@
                     "patch": {
                         "AutoStockInStapleItemName": {
                             "attach": {
-                                "cartilage_cookie": false
+                                "cartilage_tack": false
                             }
                         }
                     }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修正 AutoStockStaple 一般数量控制 JSON 中命名错误的配置项，使商品的基础自动补货数量能够被正确应用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the misnamed configuration entry in the AutoStockStaple general quantity control JSON so the item’s base auto restock quantity is applied properly.

</details>
- 修正某个物品的自动备货基础数量控制设置中配置名称错误的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 修正 AutoStockStaple 一般数量控制 JSON 中命名错误的配置项，使商品的基础自动补货数量能够被正确应用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the misnamed configuration entry in the AutoStockStaple general quantity control JSON so the item’s base auto restock quantity is applied properly.

</details>

</details>