### PR TITLE
feat: AutoAltClick添加target_offset参数

### DIFF
--- a/agent/go-service/common/autoalt/click.go
+++ b/agent/go-service/common/autoalt/click.go
@@ -1,0 +1,50 @@
+package autoalt
+
+import (
+	"encoding/json"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+type autoAltClickParam struct {
+	// TargetOffset is an optional [dx, dy, dw, dh] offset applied to the
+	// recognition box before clicking, matching the semantics of the
+	// built-in Click action's target_offset.
+	TargetOffset []int `json:"target_offset,omitempty"`
+}
+
+type AutoAltClickAction struct{}
+
+// Compile-time interface check
+var _ maa.CustomActionRunner = &AutoAltClickAction{}
+
+func (a *AutoAltClickAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	box := arg.Box
+	// custom_action_param is optional; only parse it when present.
+	if param := arg.CustomActionParam; param != "" {
+		var p autoAltClickParam
+		if err := json.Unmarshal([]byte(param), &p); err != nil {
+			log.Warn().
+				Err(err).
+				Str("component", "AutoAltClickAction").
+				Str("custom_action_param", param).
+				Msg("failed to parse custom action param, clicking the box without offset")
+		} else if len(p.TargetOffset) == 4 {
+			box = maa.Rect{
+				box[0] + p.TargetOffset[0],
+				box[1] + p.TargetOffset[1],
+				box[2] + p.TargetOffset[2],
+				box[3] + p.TargetOffset[3],
+			}
+		}
+	}
+
+	ctx.RunAction("__AutoAltClickAltKeyDownAction",
+		maa.Rect{0, 0, 0, 0}, "", nil)
+	ctx.RunAction("__AutoAltClickMouseClickAction",
+		box, "", nil)
+	ctx.RunAction("__AutoAltClickAltKeyUpAction",
+		maa.Rect{0, 0, 0, 0}, "", nil)
+	return true
+}

--- a/agent/go-service/common/autoalt/long_press.go
+++ b/agent/go-service/common/autoalt/long_press.go
@@ -1,4 +1,4 @@
-package autoaltclick
+package autoalt
 
 import (
 	"encoding/json"
@@ -11,23 +11,9 @@ type autoAltLongPressParam struct {
 	Duration int64 `json:"duration"`
 }
 
-type AutoAltClickAction struct{}
-
-// Compile-time interface check
-var _ maa.CustomActionRunner = &AutoAltClickAction{}
-
-func (a *AutoAltClickAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
-	ctx.RunAction("__AutoAltClickAltKeyDownAction",
-		maa.Rect{0, 0, 0, 0}, "", nil)
-	ctx.RunAction("__AutoAltClickMouseClickAction",
-		arg.Box, "", nil)
-	ctx.RunAction("__AutoAltClickAltKeyUpAction",
-		maa.Rect{0, 0, 0, 0}, "", nil)
-	return true
-}
-
 type AutoAltLongPressAction struct{}
 
+// Compile-time interface check
 var _ maa.CustomActionRunner = &AutoAltLongPressAction{}
 
 func (a *AutoAltLongPressAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {

--- a/agent/go-service/common/autoalt/register.go
+++ b/agent/go-service/common/autoalt/register.go
@@ -1,4 +1,4 @@
-package autoaltclick
+package autoalt
 
 import maa "github.com/MaaXYZ/maa-framework-go/v4"
 

--- a/agent/go-service/register.go
+++ b/agent/go-service/register.go
@@ -12,7 +12,7 @@ import (
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/blueprintimport"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/captureuid"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/attachregex"
-	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/autoaltclick"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/autoalt"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/charactercontroller"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/clearhitcount"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/expressionrecognition"
@@ -56,7 +56,7 @@ func registerAll() {
 	pipelineoverride.Register()
 	expressionrecognition.Register()
 	attachregex.Register()
-	autoaltclick.Register()
+	autoalt.Register()
 	charactercontroller.Register()
 	falseaction.Register()
 	schedule.Register()

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -110,13 +110,16 @@ Action 节点用于执行自定义动作。常见写法如下：
 
 ### AutoAltClickAction
 
-`AutoAltClickAction` 实现位于 `agent/go-service/common/autoaltclick`，用于在指定位置执行 Alt + 点击操作。先按下 Alt 键，再点击目标位置，最后松开 Alt 键。
+`AutoAltClickAction` 实现位于 `agent/go-service/common/autoalt`，用于在指定位置执行 Alt + 点击操作。先按下 Alt 键，再点击目标位置，最后松开 Alt 键。
 
-- 参数：无。目标位置由 Pipeline 节点的 `box` 决定。
+- 参数：
+    - `target_offset?: [int, int, int, int]`：可选。形如 `[dx, dy, dw, dh]`，叠加到 `box` 后再取中心点击，语义与内置 `Click` 动作的 `target_offset` 一致；省略时直接点击 `box` 中心。
+
+默认目标位置由 Pipeline 节点的 `box` 决定。
 
 ### AutoAltLongPressAction
 
-`AutoAltLongPressAction` 实现位于 `agent/go-service/common/autoaltclick`，用于在指定位置执行 Alt + 长按操作。
+`AutoAltLongPressAction` 实现位于 `agent/go-service/common/autoalt`，用于在指定位置执行 Alt + 长按操作。
 
 - 参数：
     - `duration: int`：长按持续时间（毫秒），必填。


### PR DESCRIPTION
## 概要

此 PR 为 AutoAltClick 添加了 target_offset 参数（可选参数，不影响原接口使用），后续会用在 AutoEssence 任务的重构中。

此外拆分了 autoalt 中的两个 CustomAction 到不同的文件。

## Summary by Sourcery

为 AutoAlt 点击动作添加可配置的目标偏移支持，并将 AutoAlt 自定义动作移动到共享包中。

新功能：
- 允许 `AutoAltClickAction` 接受可选的 `target_offset` 参数，用于相对于流水线框（pipeline box）调整点击位置。

增强内容：
- 将 `AutoAltClickAction` 和 `AutoAltLongPressAction` 的实现移动到公共的 `autoalt` 包中，并相应更新注册方式。

文档：
- 更新自定义动作开发者文档，以说明新的 `target_offset` 参数，以及 AutoAlt 动作所在的新 `autoalt` 包位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable target offset support to AutoAlt click actions and relocate AutoAlt custom actions into a shared package.

New Features:
- Allow AutoAltClickAction to accept an optional target_offset parameter to adjust the click position relative to the pipeline box.

Enhancements:
- Move AutoAltClickAction and AutoAltLongPressAction implementations into a common autoalt package and update registration accordingly.

Documentation:
- Update custom action developer documentation to describe the new target_offset parameter and the new autoalt package location for AutoAlt actions.

</details>