### PR TITLE
fix(SellProduct): 修复未配置售卖后恢复干员报错的问题

### DIFF
--- a/assets/resource/pipeline/SellProduct/Outposts/CardiacRemediationStation.json
+++ b/assets/resource/pipeline/SellProduct/Outposts/CardiacRemediationStation.json
@@ -53,7 +53,7 @@
         "desc": "心脏修缮站设置售卖后恢复干员锚点",
         "pre_delay": 0,
         "anchor": {
-            "SellProductAfterSellOperator": ""
+            "SellProductAfterSellOperator": "SellProductAfterSellOperator"
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/SellProduct/Outposts/InfrastructureOutpost.json
+++ b/assets/resource/pipeline/SellProduct/Outposts/InfrastructureOutpost.json
@@ -53,7 +53,7 @@
         "desc": "基建前站设置售卖后恢复干员锚点",
         "pre_delay": 0,
         "anchor": {
-            "SellProductAfterSellOperator": ""
+            "SellProductAfterSellOperator": "SellProductAfterSellOperator"
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/SellProduct/Outposts/ReconstructionCommand.json
+++ b/assets/resource/pipeline/SellProduct/Outposts/ReconstructionCommand.json
@@ -53,7 +53,7 @@
         "desc": "重建指挥部设置售卖后恢复干员锚点",
         "pre_delay": 0,
         "anchor": {
-            "SellProductAfterSellOperator": ""
+            "SellProductAfterSellOperator": "SellProductAfterSellOperator"
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/SellProduct/Outposts/RefugeeCamp.json
+++ b/assets/resource/pipeline/SellProduct/Outposts/RefugeeCamp.json
@@ -53,7 +53,7 @@
         "desc": "难民暂居处设置售卖后恢复干员锚点",
         "pre_delay": 0,
         "anchor": {
-            "SellProductAfterSellOperator": ""
+            "SellProductAfterSellOperator": "SellProductAfterSellOperator"
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/SellProduct/Outposts/SkyKingFlats.json
+++ b/assets/resource/pipeline/SellProduct/Outposts/SkyKingFlats.json
@@ -53,7 +53,7 @@
         "desc": "天王坪援建点设置售卖后恢复干员锚点",
         "pre_delay": 0,
         "anchor": {
-            "SellProductAfterSellOperator": ""
+            "SellProductAfterSellOperator": "SellProductAfterSellOperator"
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/SellProduct/SellCore.json
+++ b/assets/resource/pipeline/SellProduct/SellCore.json
@@ -432,5 +432,11 @@
         "next": [
             "[Anchor]SellProductAfterSellOperator"
         ]
+    },
+    "SellProductAfterSellOperator": {
+        "desc": "未配置售卖后恢复干员，结束售卖流程",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
     }
 }

--- a/assets/tasks/SellProduct.json
+++ b/assets/tasks/SellProduct.json
@@ -1120,7 +1120,7 @@
                     "pipeline_override": {
                         "SellProductRefugeeCampSetAfterSellOperatorAnchor": {
                             "anchor": {
-                                "SellProductAfterSellOperator": ""
+                                "SellProductAfterSellOperator": "SellProductAfterSellOperator"
                             }
                         }
                     }
@@ -4380,7 +4380,7 @@
                     "pipeline_override": {
                         "SellProductInfrastructureOutpostSetAfterSellOperatorAnchor": {
                             "anchor": {
-                                "SellProductAfterSellOperator": ""
+                                "SellProductAfterSellOperator": "SellProductAfterSellOperator"
                             }
                         }
                     }
@@ -7464,7 +7464,7 @@
                     "pipeline_override": {
                         "SellProductReconstructionCommandSetAfterSellOperatorAnchor": {
                             "anchor": {
-                                "SellProductAfterSellOperator": ""
+                                "SellProductAfterSellOperator": "SellProductAfterSellOperator"
                             }
                         }
                     }
@@ -10488,7 +10488,7 @@
                     "pipeline_override": {
                         "SellProductSkyKingFlatsSetAfterSellOperatorAnchor": {
                             "anchor": {
-                                "SellProductAfterSellOperator": ""
+                                "SellProductAfterSellOperator": "SellProductAfterSellOperator"
                             }
                         }
                     }
@@ -13660,7 +13660,7 @@
                     "pipeline_override": {
                         "SellProductCardiacRemediationStationSetAfterSellOperatorAnchor": {
                             "anchor": {
-                                "SellProductAfterSellOperator": ""
+                                "SellProductAfterSellOperator": "SellProductAfterSellOperator"
                             }
                         }
                     }

--- a/tools/add_node_defaults.py
+++ b/tools/add_node_defaults.py
@@ -8,6 +8,7 @@ from pathlib import Path
 DEFAULT_PATTERNS = [
     "assets/resource/pipeline/Common/*.json",
     "assets/resource/pipeline/EnvironmentMonitoring/Locations.json",
+    "assets/resource/pipeline/SellProduct/SellCore.json",
 ]
 FIELD_NAMES = (
     "rate_limit",

--- a/tools/pipeline-generate/SellProduct/data.mjs
+++ b/tools/pipeline-generate/SellProduct/data.mjs
@@ -339,7 +339,7 @@ function buildRestoreOperatorCases(nodePrefix) {
             pipeline_override: {
                 [`SellProduct${nodePrefix}SetAfterSellOperatorAnchor`]: {
                     anchor: {
-                        SellProductAfterSellOperator: "",
+                        SellProductAfterSellOperator: "SellProductAfterSellOperator",
                     },
                 },
             },

--- a/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
+++ b/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
@@ -52,7 +52,7 @@
     "SellProduct${LocationId}SetAfterSellOperatorAnchor": {
         "desc": "${LocationDesc}设置售卖后恢复干员锚点",
         "anchor": {
-            "SellProductAfterSellOperator": ""
+            "SellProductAfterSellOperator": "SellProductAfterSellOperator"
         },
         "pre_delay": 0,
         "post_delay": 0,


### PR DESCRIPTION
原来 next 里不能仅有空 anchor

## Summary by Sourcery

修复 SellProduct 流水线，以在销售完成后正确处理恢复运营商（restoring operators），并确保默认节点值应用于 SellProduct 核心定义。

Bug Fixes（错误修复）:
- 更正 SellProduct 流水线中的 restoring-operator 锚点配置，避免在未配置售后恢复时出现错误。

Enhancements（功能增强）:
- 将 SellProduct 核心流水线定义纳入默认节点值生成流程，使其能够获得标准默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SellProduct pipelines to correctly handle restoring operators after selling and ensure default node values are applied to SellProduct core definitions.

Bug Fixes:
- Correct restoring-operator anchor configuration in SellProduct pipelines to avoid errors when no post-sale restore is configured.

Enhancements:
- Include SellProduct core pipeline definitions in the default node-value generation so they receive standard defaults.

</details>