### PR TITLE
refactor(AutoEssence): 使用AutoAltClick重构所有Alt点击节点

### DIFF
--- a/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
+++ b/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
@@ -28,8 +28,8 @@
             "SceneAnyEnterWorld"
         ]
     },
-    "AutoEssenceTryRechallengeFromBattleResult": {
-        "desc": "再来一次",
+    "__AutoEssenceRecoEssenceTrigger": {
+        "desc": "寻找激发的大世界按钮（仅识别）",
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -42,6 +42,17 @@
                 "template": "AutoEssence/EssenceTrigger.png",
                 "green_mask": true,
                 "order_by": "Score"
+            }
+        }
+    },
+    "AutoEssenceTryRechallengeFromBattleResult": {
+        "desc": "再来一次",
+        "recognition": {
+            "type": "Or",
+            "param": {
+                "any_of": [
+                    "__AutoEssenceRecoEssenceTrigger"
+                ]
             }
         },
         "pre_wait_freezes": 600,
@@ -115,17 +126,11 @@
     "AutoEssenceClickTriggerButton": {
         "desc": "正式识别并点击激发的大世界按钮（Alt 点击）",
         "recognition": {
-            "type": "TemplateMatch",
+            "type": "Or",
             "param": {
-                "roi": [
-                    800,
-                    450,
-                    100,
-                    180
-                ],
-                "template": "AutoEssence/EssenceTrigger.png",
-                "green_mask": true,
-                "order_by": "Score"
+                "any_of": [
+                    "__AutoEssenceRecoEssenceTrigger"
+                ]
             }
         },
         "action": {
@@ -275,8 +280,8 @@
             "Node.Action.Starting": "👷无视风险，继续刷取"
         }
     },
-    "AutoEssenceChallengeEnter": {
-        "desc": "识别是否成功进入挑战",
+    "__AutoEssenceRecoEssenceOngoing": {
+        "desc": "寻找挑战进行中的状态（仅识别）",
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -288,6 +293,17 @@
                 ],
                 "template": "AutoEssence/EssenceOngoing.png",
                 "green_mask": true
+            }
+        }
+    },
+    "AutoEssenceChallengeEnter": {
+        "desc": "识别是否成功进入挑战",
+        "recognition": {
+            "type": "Or",
+            "param": {
+                "any_of": [
+                    "__AutoEssenceRecoEssenceOngoing"
+                ]
             }
         },
         "next": [
@@ -322,16 +338,11 @@
     "AutoEssenceCheckOngoing": {
         "desc": "检查挑战是否仍在进行中",
         "recognition": {
-            "type": "TemplateMatch",
+            "type": "Or",
             "param": {
-                "roi": [
-                    0,
-                    40,
-                    260,
-                    330
-                ],
-                "template": "AutoEssence/EssenceOngoing.png",
-                "green_mask": true
+                "any_of": [
+                    "__AutoEssenceRecoEssenceOngoing"
+                ]
             }
         },
         "inverse": true,
@@ -389,8 +400,8 @@
             "AutoEssenceClickObtainButton"
         ]
     },
-    "AutoEssenceClickObtainButton": {
-        "desc": "正式识别并点击领取奖励的大世界按钮（Alt 点击）",
+    "__AutoEssenceRecoEssenceObtain": {
+        "desc": "寻找领取奖励的状态（仅识别）",
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -404,6 +415,17 @@
                 "green_mask": true,
                 "threshold": 0.45,
                 "order_by": "Score"
+            }
+        }
+    },
+    "AutoEssenceClickObtainButton": {
+        "desc": "正式识别并点击领取奖励的大世界按钮（Alt 点击）",
+        "recognition": {
+            "type": "Or",
+            "param": {
+                "any_of": [
+                    "__AutoEssenceRecoEssenceObtain"
+                ]
             }
         },
         "action": {
@@ -444,18 +466,11 @@
     "AutoEssenceClickDiscardButton": {
         "desc": "正式识别并点击放弃奖励的大世界按钮（Alt 点击）",
         "recognition": {
-            "type": "TemplateMatch",
+            "type": "Or",
             "param": {
-                "roi": [
-                    780,
-                    340,
-                    170,
-                    310
-                ],
-                "template": "AutoEssence/EssenceObtain.png",
-                "green_mask": true,
-                "threshold": 0.45,
-                "order_by": "Score"
+                "any_of": [
+                    "__AutoEssenceRecoEssenceObtain"
+                ]
             }
         },
         "action": {

--- a/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
+++ b/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
@@ -47,7 +47,7 @@
         "pre_wait_freezes": 600,
         "pre_delay": 300,
         "next": [
-            "AutoEssenceClickTriggerButtonPre"
+            "AutoEssenceClickTriggerButton"
         ],
         "focus": {
             "Node.Action.Starting": "⚡激发界面开始挑战"
@@ -112,37 +112,8 @@
             "Node.Action.Starting": "😎滴！MapTracker智能导航已就绪"
         }
     },
-    "__AutoEssenceAltKeyUp": {
-        "desc": "释放键盘 Alt 键（通过覆写 AutoEssenceAfterAltKeyUp 锚点即可设置该节点执行完毕后的下一个节点）",
-        "action": {
-            "type": "KeyUp",
-            "param": {
-                "key": 18
-            }
-        },
-        "next": [
-            "AutoEssenceMistakeFactoryDevice",
-            "[Anchor]AutoEssenceAfterAltKeyUp"
-        ]
-    },
-    "AutoEssenceClickTriggerButtonPre": {
-        "desc": "准备点击激发的大世界按钮，先按下 Alt 键",
-        "action": {
-            "type": "KeyDown",
-            "param": {
-                "key": 18
-            }
-        },
-        "timeout": 1000,
-        "next": [
-            "AutoEssenceClickTriggerButton"
-        ],
-        "on_error": [
-            "AutoEssenceClickTriggerButtonFailedPre"
-        ]
-    },
     "AutoEssenceClickTriggerButton": {
-        "desc": "正式识别并点击激发的大世界按钮",
+        "desc": "正式识别并点击激发的大世界按钮（Alt 点击）",
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -158,33 +129,28 @@
             }
         },
         "action": {
-            "type": "Click"
+            "type": "Custom",
+            "param": {
+                "custom_action": "AutoAltClickAction"
+            }
         },
-        "anchor": {
-            "AutoEssenceAfterAltKeyUp": "AutoEssenceReadyToStart"
-        },
+        "timeout": 2000,
         "next": [
-            "__AutoEssenceAltKeyUp"
+            "AutoEssenceMistakeFactoryDevice",
+            "AutoEssenceReadyToStart"
+        ],
+        "on_error": [
+            "AutoEssenceClickTriggerButtonFailed"
         ],
         "focus": {
             "Node.Action.Starting": "👆点击激发按钮"
         }
     },
-    "AutoEssenceClickTriggerButtonFailedPre": {
-        "desc": "未能识别到激发的大世界按钮，先释放 Alt 键",
-        "action": {
-            "type": "KeyUp",
-            "param": {
-                "key": 18
-            }
-        },
-        "next": [
-            "AutoEssenceClickTriggerButtonFailed"
-        ]
-    },
     "AutoEssenceClickTriggerButtonFailed": {
-        "desc": "未能识别到激发的大世界按钮、且释放了 Alt 键之后的守卫节点",
+        "desc": "未能识别到激发的大世界按钮的守卫节点",
         "max_hit": 8,
+        "pre_delay": 0,
+        "post_delay": 0,
         "next": [
             "[Anchor]AutoEssenceMoveToTriggerPoint"
         ]
@@ -416,23 +382,15 @@
         }
     },
     "AutoEssenceClickObtainButtonPre": {
-        "desc": "准备识别并点击领取奖励（或放弃奖励）的大世界按钮，先按下 Alt 键",
-        "action": {
-            "type": "KeyDown",
-            "param": {
-                "key": 18
-            }
-        },
-        "timeout": 1000,
+        "desc": "领取奖励的路由守卫节点（覆写其 next 为 AutoEssenceClickDiscardButton 即可实现不领取奖励）",
+        "pre_delay": 0,
+        "post_delay": 0,
         "next": [
-            "AutoEssenceClickObtainButton" // 覆写为 AutoEssenceClickDiscardButton 即可实现不领取奖励
-        ],
-        "on_error": [
-            "AutoEssenceClickObtainButtonFailedPre"
+            "AutoEssenceClickObtainButton"
         ]
     },
     "AutoEssenceClickObtainButton": {
-        "desc": "正式识别并点击领取奖励的大世界按钮",
+        "desc": "正式识别并点击领取奖励的大世界按钮（Alt 点击）",
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -449,50 +407,42 @@
             }
         },
         "action": {
-            "type": "Click",
+            "type": "Custom",
             "param": {
-                "target_offset": [
-                    -10,
-                    15,
-                    -10,
-                    -60
-                ]
+                "custom_action": "AutoAltClickAction",
+                "custom_action_param": {
+                    "target_offset": [
+                        -10,
+                        15,
+                        -10,
+                        -60
+                    ]
+                }
             }
         },
-        "anchor": {
-            "AutoEssenceAfterAltKeyUp": "AutoEssenceChooseScalingPre"
-        },
+        "timeout": 2000,
         "next": [
-            "__AutoEssenceAltKeyUp"
+            "AutoEssenceMistakeFactoryDevice",
+            "AutoEssenceChooseScalingPre"
+        ],
+        "on_error": [
+            "AutoEssenceClickObtainButtonFailed"
         ],
         "focus": {
             "Node.Action.Starting": "👆点击领取奖励按钮"
         }
     },
-    "AutoEssenceClickObtainButtonFailedPre": {
-        "desc": "未能识别到领取奖励（或放弃奖励）的大世界按钮，先释放 Alt 键",
-        "action": {
-            "type": "KeyUp",
-            "param": {
-                "key": 18
-            }
-        },
-        "next": [
-            "AutoEssenceClickObtainButtonFailed"
-        ],
-        "focus": {
-            "Node.Action.Starting": "❓未能找到领取奖励按钮"
-        }
-    },
     "AutoEssenceClickObtainButtonFailed": {
-        "desc": "未能识别到领取奖励的大世界按钮、且释放了 Alt 键之后的守卫节点",
+        "desc": "未能识别到领取奖励的大世界按钮的守卫节点",
         "max_hit": 8,
+        "pre_delay": 0,
+        "post_delay": 0,
         "next": [
             "[Anchor]AutoEssenceMoveToTriggerPoint"
         ]
     },
     "AutoEssenceClickDiscardButton": {
-        "desc": "正式识别并点击放弃奖励的大世界按钮",
+        "desc": "正式识别并点击放弃奖励的大世界按钮（Alt 点击）",
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -509,21 +459,26 @@
             }
         },
         "action": {
-            "type": "Click",
+            "type": "Custom",
             "param": {
-                "target_offset": [
-                    -10,
-                    60,
-                    -10,
-                    -60
-                ]
+                "custom_action": "AutoAltClickAction",
+                "custom_action_param": {
+                    "target_offset": [
+                        -10,
+                        60,
+                        -10,
+                        -60
+                    ]
+                }
             }
         },
-        "anchor": {
-            "AutoEssenceAfterAltKeyUp": "AutoEssenceConfirmDiscard"
-        },
+        "timeout": 2000,
         "next": [
-            "__AutoEssenceAltKeyUp"
+            "AutoEssenceMistakeFactoryDevice",
+            "AutoEssenceConfirmDiscard"
+        ],
+        "on_error": [
+            "AutoEssenceClickObtainButtonFailed"
         ],
         "focus": {
             "Node.Action.Starting": "👆点击放弃奖励按钮"
@@ -532,6 +487,8 @@
     "AutoEssenceChooseScalingPre": {
         "desc": "准备选择领取倍数的守卫节点",
         "pre_wait_freezes": 1000,
+        "pre_delay": 0,
+        "post_delay": 0,
         "next": [
             // 考虑到双倍领取的许可券可能不足，不论是单倍还是双倍领取，都需要点击一次单倍领取的选项
             "AutoEssenceChooseScaling1",

--- a/assets/resource_adb/pipeline/AutoEssence/AutoEssence.json
+++ b/assets/resource_adb/pipeline/AutoEssence/AutoEssence.json
@@ -1,34 +1,4 @@
 {
-    "__AutoEssenceAltKeyUp": {
-        "desc": "释放键盘 Alt 键（ADB 无需此操作）",
-        "pre_delay": 0,
-        "action": "DoNothing",
-        "post_delay": 0
-    },
-    "AutoEssenceClickTriggerButtonPre": {
-        "desc": "准备点击激发的大世界按钮，先按下 Alt 键（ADB 无需此操作）",
-        "pre_delay": 0,
-        "action": "DoNothing",
-        "post_delay": 0
-    },
-    "AutoEssenceClickTriggerButtonFailedPre": {
-        "desc": "未能识别到激发的大世界按钮，先释放 Alt 键（ADB 无需此操作）",
-        "pre_delay": 0,
-        "action": "DoNothing",
-        "post_delay": 0
-    },
-    "AutoEssenceClickObtainButtonPre": {
-        "desc": "准备识别并点击领取奖励（或放弃奖励）的大世界按钮，先按下 Alt 键（ADB 无需此操作）",
-        "pre_delay": 0,
-        "action": "DoNothing",
-        "post_delay": 0
-    },
-    "AutoEssenceClickObtainButtonFailedPre": {
-        "desc": "未能识别到领取奖励（或放弃奖励）的大世界按钮，先释放 Alt 键（ADB 无需此操作）",
-        "pre_delay": 0,
-        "action": "DoNothing",
-        "post_delay": 0
-    },
     "AutoEssenceClickTriggerButton": {
         "desc": "正式识别并点击激发的大世界按钮（ADB）",
         "recognition": {
@@ -90,14 +60,17 @@
             }
         },
         "action": {
-            "type": "Click",
+            "type": "Custom",
             "param": {
-                "target_offset": [
-                    -10,
-                    20,
-                    -10,
-                    -75
-                ]
+                "custom_action": "AutoAltClickAction",
+                "custom_action_param": {
+                    "target_offset": [
+                        -10,
+                        20,
+                        -10,
+                        -75
+                    ]
+                }
             }
         }
     }


### PR DESCRIPTION
## 概要

此 PR 将 AutoEssence 任务的所有 Alt 点击节点迁移到 AutoAltClick 系列公共节点。

此外提取了公共识别节点以便维护。

## 关联

受益于前置 PR #3590 。

## Summary by Sourcery

重构 AutoEssence 任务，以对所有 Alt-点击交互使用共享的 AutoAltClick 节点，并提取通用识别节点以便于维护。

Enhancements:
- 将所有 AutoEssence 的 Alt-点击节点迁移到共享的 AutoAltClick 通用节点上。
- 提取并集中管理 AutoEssence 使用的通用识别节点，以提升复用性和可维护性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the AutoEssence task to use shared AutoAltClick nodes for all Alt-click interactions and extract common recognition nodes for easier maintenance.

Enhancements:
- Migrate all AutoEssence Alt-click nodes to shared AutoAltClick common nodes.
- Extract and centralize common recognition nodes used by AutoEssence for improved reuse and maintainability.

</details>