### PR TITLE
fix：在点完排序后将滚动条拉到最上面

### DIFF
--- a/assets/resource/pipeline/GearAssembly/GearAssembly.json
+++ b/assets/resource/pipeline/GearAssembly/GearAssembly.json
@@ -50,7 +50,7 @@
         "rate_limit": 0,
         "next": [
             "[JumpBack]GearAssemblySwitchAscending",
-            "GearAssemblySelectFirstGear"
+            "GearAssemblyScrollToTop"
         ]
     },
     "GearAssemblyNonsetGear": {
@@ -87,6 +87,35 @@
         "rate_limit": 0,
         "next": [
             "[JumpBack]GearAssemblySwitchAscending",
+            "GearAssemblyScrollToTop"
+        ]
+    },
+    "GearAssemblyScrollToTop": {
+        "desc": "滑动到最上面",
+        "action": {
+            "type": "Swipe",
+            "param": {
+                "begin": [
+                    452,
+                    621
+                ],
+                "end": [
+                    452,
+                    50
+                ],
+                "duration": 2000
+            }
+        },
+        "post_wait_freezes": {
+            "target": [
+                31,
+                58,
+                418,
+                584
+            ],
+            "time": 200
+        },
+        "next": [
             "GearAssemblySelectFirstGear"
         ]
     },


### PR DESCRIPTION
yj小巧思，更新后点击排序，不会改变当前选中的装备，导致无法直接看到最低级的装备，需要手动拖一下滚动条才行

## Summary by Sourcery

Bug Fixes:
- 修复装备排序问题：在更改排序顺序后，视图会滚动到顶部，而不是将当前选中项留在可视区域之外。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix gear sorting so that after changing sort order the view scrolls to the top instead of leaving the selection out of view.

</details>