### PR TITLE
feat: 新增PostStop自定义动作，用于在Pipeline中主动停止任务链

### DIFF
--- a/agent/go-service/common/poststop/action.go
+++ b/agent/go-service/common/poststop/action.go
@@ -1,0 +1,14 @@
+package poststop
+
+import (
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+)
+
+type PostStop struct{}
+
+var _ maa.CustomActionRunner = &PostStop{}
+
+func (a *PostStop) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	ctx.GetTasker().PostStop()
+	return true
+}

--- a/agent/go-service/common/poststop/register.go
+++ b/agent/go-service/common/poststop/register.go
@@ -1,0 +1,7 @@
+package poststop
+
+import maa "github.com/MaaXYZ/maa-framework-go/v4"
+
+func Register() {
+	maa.AgentServerRegisterCustomAction("PostStop", &PostStop{})
+}

--- a/agent/go-service/register.go
+++ b/agent/go-service/register.go
@@ -18,6 +18,7 @@ import (
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/expressionrecognition"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/falseaction"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/pipelineoverride"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/poststop"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/schedule"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/subtask"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/creditshopping"
@@ -59,6 +60,7 @@ func registerAll() {
 	autoalt.Register()
 	charactercontroller.Register()
 	falseaction.Register()
+	poststop.Register()
 	schedule.Register()
 
 	// Business Custom

--- a/docs/en_us/developers/custom.md
+++ b/docs/en_us/developers/custom.md
@@ -68,6 +68,12 @@ Example file: [`ClearHitCount.json`](../../../assets/resource/pipeline/Interface
 
 Example file: [`PipelineOverride.json`](../../../assets/resource/pipeline/Interface/Example/PipelineOverride.json)
 
+### PostStop
+
+`PostStop` is implemented in `agent/go-service/common/poststop`. It calls `Tasker.PostStop()` to asynchronously stop the current task. Use it when a certain condition in the pipeline warrants terminating the entire task proactively.
+
+- Parameters: none.
+
 ### AttachToExpectedRegexAction
 
 `AttachToExpectedRegexAction` is implemented in `agent/go-service/common/attachregex`. It generically reads keywords from the target node's own `attach`, then writes the merged whitelist regex back into that target OCR node's `expected`.
@@ -193,6 +199,7 @@ When writing Pipeline, the built-in `TemplateMatch` / `OCR` / `Click` / `Swipe` 
 | ------------------------------------------------------------------- | ----------------------------- |
 | Run a sequence of subtasks                                          | `SubTask`                     |
 | Clear a node's hit count                                            | `ClearHitCount`               |
+| Proactively stop the current task                                   | `PostStop`                    |
 | Change node parameters at runtime                                   | `PipelineOverride`            |
 | Build a regex whitelist from keywords and write it into an OCR node | `AttachToExpectedRegexAction` |
 | Evaluate OCR numeric expressions                                    | `ExpressionRecognition`       |

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -108,6 +108,12 @@ Action 节点用于执行自定义动作。常见写法如下：
 - 若多个节点需要相同白名单，应在任务配置中分别把同一份 `attach` 写入各自节点。
 - 其他任务也建议优先使用通用名，避免与具体业务耦合。
 
+### PostStop
+
+`PostStop` 实现位于 `agent/go-service/common/poststop`，调用 `Tasker.PostStop()` 异步停止当前任务。适合在 Pipeline 中某个条件满足后主动终止整个任务的场景。
+
+- 参数：无。
+
 ### AutoAltClickAction
 
 `AutoAltClickAction` 实现位于 `agent/go-service/common/autoalt`，用于在指定位置执行 Alt + 点击操作。先按下 Alt 键，再点击目标位置，最后松开 Alt 键。
@@ -226,6 +232,7 @@ Recognition 节点用于执行自定义识别。常见写法如下：
 | 按顺序跑一组子任务            | `SubTask`                     |
 | 清零某节点的命中计数          | `ClearHitCount`               |
 | 强制让 Action 失败            | `FalseAction`                 |
+| 主动停止当前任务              | `PostStop`                    |
 | 运行时改节点参数              | `PipelineOverride`            |
 | 把关键词拼成正则写回 OCR 节点 | `AttachToExpectedRegexAction` |
 | 计算 OCR 数值表达式           | `ExpressionRecognition`       |

--- a/tools/schema/custom.action.schema.json
+++ b/tools/schema/custom.action.schema.json
@@ -64,6 +64,7 @@
                 "OCREssenceInventoryNumberAction",
                 "PipelineOverride",
                 "PipelineOverrideAction",
+                "PostStop",
                 "PullCountCalculatorAction",
                 "PuzzleAction",
                 "SeizeDeliveryJobsDepartureAction",


### PR DESCRIPTION
## Summary by Sourcery

添加一个新的 PostStop 自定义动作，使流水线可以主动停止当前任务，并在英文和中文的开发者指南中记录其用法。

新特性：
- 引入 PostStop 自定义动作，通过 `Tasker.PostStop` 异步停止当前任务，并将其注册到 agent 服务器。

文档：
- 在英文和中文的自定义动作开发者指南中记录 PostStop 自定义动作及其用途。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new PostStop custom action that allows pipelines to proactively stop the current task and document its usage in both English and Chinese developer guides.

New Features:
- Introduce a PostStop custom action that asynchronously stops the current task via Tasker.PostStop and register it with the agent server.

Documentation:
- Document the PostStop custom action and its purpose in the English and Chinese custom action developer guides.

</details>