### PR TITLE
fix(选剑演武): 尝试修复编队界面点击失效

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
@@ -12,17 +12,41 @@
         "action": "Click",
         "post_wait_freezes": 100,
         "next": [
-            "TrialOfSwordmancyChooseTeam"
+            "TrialOfSwordmancyPrepareTeam"
         ]
     },
-    "TrialOfSwordmancyChooseTeam": {
+    "TrialOfSwordmancyPrepareTeam": {
+        // 同 ProtocolSpaceEnterSpacePrepareSuccess
+        "desc": "准备编队界面",
+        "recognition": "TemplateMatch",
+        "roi": [
+            0,
+            0,
+            100,
+            100
+        ],
+        "template": "ProtocolSpace/TeamChooseIcon.png",
+        "pre_wait_freezes": {
+            "time": 200,
+            "target": [
+                0,
+                0,
+                100,
+                200
+            ]
+        },
+        "next": [
+            "TrialOfSwordmancyConfirmTeam"
+        ]
+    },
+    "TrialOfSwordmancyConfirmTeam": {
         "desc": "开始战斗前确认编队", // TODO: 编队切换
         "recognition": "And",
         "all_of": [
             "YellowConfirmButtonType2"
         ],
+        "pre_wait_freezes": 400,
         "action": "Click",
-        "post_wait_freezes": 100,
         "next": [
             "[JumpBack]SceneWaitLoadingExit",
             "TrialOfSwordmancyEnterTrial"


### PR DESCRIPTION
fix #3606

## Summary by Sourcery

Bug Fixes:
- 调整 TrialOfSwordmancy 战斗配置，以修复在编队界面上点击无响应的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust the TrialOfSwordmancy fight configuration to fix unresponsive click handling on the formation screen.

</details>