### PR TITLE
fix(选剑演武): 处理首次进行第三抽的弹窗

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -86,6 +86,7 @@
         "action": "Click",
         "post_delay": 800,
         "next": [
+            "[JumpBack]TrialOfSwordmancyConfirmDrawCard",
             "[JumpBack]TrialOfSwordmancyDailyDoubleReward",
             "TrialOfSwordmancyAggressiveMainLoop"
         ]
@@ -207,8 +208,17 @@
         "action": "Click",
         "post_delay": 800,
         "next": [
+            "[JumpBack]TrialOfSwordmancyConfirmDrawCard",
             "TrialOfSwordmancyConservativeMainLoop"
         ]
+    },
+    "TrialOfSwordmancyConfirmDrawCard": {
+        "desc": "首次抽牌到第三抽时，会提醒抽取后无法更改翻倍选项，点击确认",
+        "recognition": "And",
+        "all_of": [
+            "YellowConfirmButtonType1"
+        ],
+        "action": "Click"
     },
     // 双倍奖励处理
     "TrialOfSwordmancyDailyDoubleReward": {

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -218,7 +218,8 @@
         "all_of": [
             "YellowConfirmButtonType1"
         ],
-        "action": "Click"
+        "action": "Click",
+        "post_wait_freezes": 1000
     },
     // 双倍奖励处理
     "TrialOfSwordmancyDailyDoubleReward": {


### PR DESCRIPTION
怎么这里还有确认

related: #3616

## Summary by Sourcery

错误修复：
- 修复了在「Trial of Swordmancy」每日流程中，首次第三次抽卡弹窗的行为问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the behavior of the initial third-draw popup in the Trial of Swordmancy daily flow.

</details>