### PR TITLE
fix(选剑演武): 兜底激进模式重新进入演算

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -41,6 +41,10 @@
     "TrialOfSwordmancyAggressiveEntry": {
         "desc": "激进模式入口（3次放弃机会）",
         "max_hit": 3, // 此处意为 3 次免费放弃机会
+        "recognition": "And",
+        "all_of": [
+            "TrialOfSwordmancyInTrialMenu"
+        ],
         "next": [
             "TrialOfSwordmancyAggressiveMainLoop"
         ]
@@ -49,7 +53,7 @@
         "desc": "激进模式抽牌循环",
         "recognition": "And",
         "all_of": [
-            "TrialOfSwordmancyHasResource"
+            "TrialOfSwordmancyInTrialMenu"
         ],
         "next": [
             "TrialOfSwordmancyDailyBattlePtsOverflow",
@@ -152,18 +156,15 @@
     },
     "TrialOfSwordmancyDailyReEnterTrialMenu": {
         "desc": "放弃后重新进入演算",
-        "recognition": "Or",
-        "any_of": ["TrialOfSwordmancyEnterTrialMenu"],
-        "action": {
-            "type": "Custom",
-            "param": {
-                "custom_action": "AutoAltClickAction"
-            }
-        },
-        "post_wait_freezes": 100,
+        "recognition": "And",
+        "all_of": [
+            "InWorld"
+        ],
         "next": [
             "TrialOfSwordmancyAggressiveEntry",
-            "TrialOfSwordmancyConservativeMainLoop"
+            "TrialOfSwordmancyConservativeMainLoop",
+            "[JumpBack]TrialOfSwordmancyEnterTrialMenu",
+            "[JumpBack]TrialOfSwordmancyGotoTrialArenaStart"
         ]
     },
     // 保守模式：免费放弃次数耗尽后，6-10 均接单
@@ -171,7 +172,7 @@
         "desc": "保守模式抽牌循环",
         "recognition": "And",
         "all_of": [
-            "TrialOfSwordmancyHasResource"
+            "TrialOfSwordmancyInTrialMenu"
         ],
         "next": [
             "TrialOfSwordmancyConservativeShouldDrawCard",


### PR DESCRIPTION
fix #3618

## Summary by Sourcery

Bug Fixes:
- 修正《Trial of Swordmancy》每日配置，使激进回退模式在后续的模拟条目中能够正常工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct Trial of Swordmancy daily configuration so aggressive fallback mode works properly on subsequent simulation entries.

</details>