### PR TITLE
fix(MapNavigator): 修复切换 tier 时不进行重定位

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -435,10 +435,33 @@ bool NavigationStateMachine::HandleLocalizationLoss()
     if (loss_elapsed >= std::chrono::milliseconds(kLocalizationLossTimeoutMs)) {
         return FailNavigation(
             "localization_lost_timeout",
-            "Localization lost beyond timeout (likely shoved off-route into another zone); terminating navigation.",
+            "Localization lost beyond timeout (re-acquire failed; likely shoved off-route into another zone); terminating navigation.",
             0.0,
             0.0,
             0);
+    }
+
+    const bool relocalize_cooling =
+        last_global_relocalize_at_ != std::chrono::steady_clock::time_point {}
+        && std::chrono::duration_cast<std::chrono::milliseconds>(now - last_global_relocalize_at_)
+               < std::chrono::milliseconds(kRelocationRetryIntervalMs);
+    if (!relocalize_cooling) {
+        last_global_relocalize_at_ = now;
+        const std::string prior_zone = session_->current_zone_id();
+        if (position_provider_->Capture(position_, /*force_global_search=*/true, /*expected_zone_id=*/std::string())) {
+            if (!position_->zone_id.empty() && position_->zone_id != prior_zone) {
+                // Pin subsequent tracking ticks to the zone we actually re-acquired in, else the next
+                // CaptureCurrentPosition(false) would re-impose the stale expected_zone and fail again.
+                session_->UpdateCurrentZone(position_->zone_id);
+            }
+            LogInfo << "Localization recovered via global re-acquire; resuming navigation." << VAR(loss_elapsed.count())
+                    << VAR(prior_zone) << VAR(position_->zone_id) << VAR(position_->x) << VAR(position_->y);
+            loss.Reset();
+            runtime_state_.route.ResetTracking();
+            runtime_state_.nav_run_dirty = true;
+            session_->ResetProgress();
+            return true;
+        }
     }
 
     const bool unstick_cooling = loss.last_unstick_at != std::chrono::steady_clock::time_point {}

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <functional>
 
 #include "nav_run_controller.h"
@@ -60,6 +61,7 @@ private:
     MaaContext* maa_context_;
     NavigationRuntimeState runtime_state_ {};
     NavRunController nav_run_controller_ {};
+    std::chrono::steady_clock::time_point last_global_relocalize_at_ {};
 };
 
 } // namespace mapnavigator


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 当机器人可能被推入另一个区域时，在超时之前全局重新获取定位，从而恢复导航。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Recover navigation by globally re-acquiring localization before timing out when the robot may have been shoved into another zone.

</details>