### PR TITLE
fix: align README and CI workflow versions

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -132,7 +132,7 @@ jobs:
           path: artifacts
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,10 +17,10 @@ jobs:
           show-progress: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"

--- a/.github/workflows/i18n-sync.yml
+++ b/.github/workflows/i18n-sync.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           submodules: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Use Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'pnpm'

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,14 @@
 <!-- markdownlint-disable MD033 MD041 -->
 <p align="center">
-  <img alt="LOGO" src="https://maaend.com/MaaEnd-Tiny-512.png" width="256" height="256" />
+  <img alt="Don't discuss MAA on Skland" src="https://end.maafw.com/NoSkland-Tiny.webp" width="280" />
+</p>
+
+<p align="center"><strong>Don't discuss MAA on Skland!</strong></p>
+
+---
+
+<p align="center">
+  <img alt="LOGO" src="https://end.maafw.com/MaaEnd-Tiny-512.png" width="256" height="256" />
 </p>
 
 <div align="center">
@@ -81,7 +89,7 @@ With your support, MaaEnd continues to grow and improve. ❤️
 
 Come hang out and chat with everyone:
 
-- 💬 **User QQ Group**: [1097256935](https://qm.qq.com/q/2AK5MoVfOQ)  
+- 💬 **User QQ Group**: [1103911816](https://qm.qq.com/q/YLkMv83h0Q)  
   For usage questions, feature requests, and casual chatting.
 - 👨‍💻 **Developer QQ Group**: [1072587329](https://qm.qq.com/q/EyirQpBiW4)  
   Dedicated to development discussion. (For general usage questions, please go to the user group above.)


### PR DESCRIPTION
## Changes

- Sync user QQ group in English README to match Chinese README (1103911816)
- Unify logo URL across READMEs to `end.maafw.com`
- Add Skland warning banner to English README
- Bump `pnpm/action-setup`, `actions/setup-node`, `actions/setup-python` to v6 in CI workflows

## Details

### README Inconsistencies

The Chinese and English READMEs had different user QQ group numbers and logo URLs. This PR synchronizes them:

- User QQ Group: 1103911816 (was 1097256935 in English)
- Logo URL: `https://end.maafw.com/MaaEnd-Tiny-512.png` (was `https://maaend.com/MaaEnd-Tiny-512.png` in English)
- Added the "Don't discuss MAA on Skland" warning banner to the English README

### CI Workflow Version Alignment

Several GitHub Actions were using outdated versions:

- `pnpm/action-setup`: v4 → v6
- `actions/setup-node`: v4 → v6
- `actions/setup-python`: v5 → v6

This ensures consistency across all workflow files and uses the latest stable versions.

## 由 Sourcery 提供的总结

在整个项目中统一文档内容和 CI 工作流中使用的 Action 版本。

构建（Build）：
- 在格式化和测试工作流中将 `pnpm/action-setup` 升级到 v6，将 `actions/setup-node` 升级到 v6。
- 在文档和 i18n 同步工作流中将 `actions/setup-python` 升级到 v6。

文档（Documentation）：
- 更新英文版 README 的 logo URL 和用户 QQ 群信息，使其与中文版 README 保持一致，并添加 Skland 警告横幅。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align documentation content and CI workflow action versions across the project.

Build:
- Bump pnpm/action-setup to v6 and actions/setup-node to v6 in formatting and test workflows.
- Upgrade actions/setup-python to v6 in documentation and i18n sync workflows.

Documentation:
- Update the English README logo URL and user QQ group to match the Chinese README and add a Skland warning banner.

</details>