### PR TITLE
fix(MapNavigator): 路线规划 snap 吸附小碎片岛导致目标不可达

### DIFF
--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -651,6 +651,15 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
         candidates = candidateTriangles(zone_id, point, kIndexBinSize);
     }
 
+    // A (u,v) can stack a tiny disconnected fragment (baked wall-top / ledge, never the real walkable floor)
+    // right over the dominant surface. Snapping onto it strands the endpoint in a micro-component and A* then
+    // false-reports Unreachable. Demote such a fragment so a non-island candidate always wins — the same
+    // size cutoff the bridge logic treats as a stitchable island. Only re-ranks when both compete; the common
+    // single-surface (u,v) is untouched.
+    const auto is_small_island = [&](uint32_t triangle_index) {
+        return natural_component_sizes_[natural_component_ids_[triangle_index]] <= kSmallBridgeComponentMaxTriangles;
+    };
+
     if (floor_y > kBaseNavFloorYValidMin) {
         // Floor-aware path: a click in a multi-floor base projects onto several STACKED triangles
         // (other floors / walls overlap this (u,v)). Rank so an in-band surface (|height-floor_y| <=
@@ -659,7 +668,7 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
         // nearest surface (never nullopt), so floor_y only re-ranks onto the right floor, never gates it
         // out. Mirrors basenav_preview.py BaseNavField.snap (floor-aware branch). The zone + bbox culls
         // match the legacy path below so the effective candidate set equals the python tool's.
-        std::optional<std::tuple<int, double, double>> best_key;
+        std::optional<std::tuple<int, int, double, double>> best_key;
         std::optional<BaseNavSnapResult> best_floor;
         for (const uint32_t triangle_index : candidates) {
             if (triangle_zones_[triangle_index] != zone_id) {
@@ -683,7 +692,8 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
                 }
             }
             const double delta = std::abs(triangle_heights_[triangle_index] - static_cast<double>(floor_y));
-            const std::tuple<int, double, double> key { delta <= static_cast<double>(kBaseNavFloorBand) ? 0 : 1, distance, delta };
+            const std::tuple<int, int, double, double> key { delta <= static_cast<double>(kBaseNavFloorBand) ? 0 : 1,
+                                                             is_small_island(triangle_index) ? 1 : 0, distance, delta };
             if (!best_key || key < *best_key) {
                 best_key = key;
                 best_floor = BaseNavSnapResult { .triangle = triangle_index, .point = snapped, .distance = distance };
@@ -692,8 +702,11 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
         return best_floor;
     }
 
+    // Floor-blind path: rank by (non-island first, then snap distance, then smallest index). With no island
+    // in play this is exactly the legacy order — containing surfaces (distance 0) win, ties by smallest index —
+    // so the golden-hash parity holds; it only diverges to skip a micro-component when a real surface competes.
+    std::optional<std::tuple<int, double, uint32_t>> best_key;
     std::optional<BaseNavSnapResult> best;
-    uint32_t inside_triangle = kInvalidTriangle; // 取包含该点的最小下标三角形,与原升序扫描的取舍一致
     for (const uint32_t triangle_index : candidates) {
         if (triangle_zones_[triangle_index] != zone_id) {
             continue;
@@ -706,24 +719,20 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
         if (point.x < left - radius || point.x > right + radius || point.y < top - radius || point.y > bottom + radius) {
             continue;
         }
-        if (detail::PointInTriangle(point, points)) {
-            if (triangle_index < inside_triangle) {
-                inside_triangle = triangle_index; // 不提前返回:候选按格序排列,须扫完才能确定最小下标
+        WorldPoint snapped = point;
+        double distance = 0.0;
+        if (!detail::PointInTriangle(point, points)) {
+            snapped = detail::ClosestPointOnTriangle(point, points);
+            distance = detail::Distance(snapped, point);
+            if (distance > radius) {
+                continue;
             }
-            continue;
         }
-        const WorldPoint snapped = detail::ClosestPointOnTriangle(point, points);
-        const double distance = detail::Distance(snapped, point);
-        if (distance > radius) {
-            continue;
-        }
-        // 距离更近则更新;等距时取更小下标,与原升序扫描的取舍一致。
-        if (!best || distance < best->distance || (distance == best->distance && triangle_index < best->triangle)) {
+        const std::tuple<int, double, uint32_t> key { is_small_island(triangle_index) ? 1 : 0, distance, triangle_index };
+        if (!best_key || key < *best_key) {
+            best_key = key;
             best = BaseNavSnapResult { .triangle = triangle_index, .point = snapped, .distance = distance };
         }
-    }
-    if (inside_triangle != kInvalidTriangle) {
-        return BaseNavSnapResult { .triangle = inside_triangle, .point = point, .distance = 0.0 };
     }
     return best;
 }

--- a/tools/MapNavigator/basenav_preview.py
+++ b/tools/MapNavigator/basenav_preview.py
@@ -561,6 +561,11 @@ class BaseNavField:
         points, segment_breaks = self._triangle_path_points(triangle_path, start_snap.point, goal_snap.point)
         return _BaseNavRoute(points=points, triangles=triangle_path, cost=cost, segment_breaks=segment_breaks)
 
+    def _is_small_island(self, triangle_index: int) -> bool:
+        # A micro-component (baked wall-top / ledge, not the real floor) stacked over the dominant
+        # surface; demote it in snap so a real surface always wins. Same cutoff the bridge logic uses.
+        return self.natural_component_size[self.natural_component[triangle_index]] <= SMALL_BRIDGE_COMPONENT_MAX_TRIANGLES
+
     def snap(
         self,
         zone_id: int,
@@ -576,20 +581,25 @@ class BaseNavField:
         if not candidates and query_radius < SNAP_FALLBACK_RADIUS:
             candidates = self._candidate_triangles(zone_id, point, SNAP_FALLBACK_RADIUS)
         if floor_y is None or floor_y <= FLOOR_Y_VALID_MIN:
-            # Legacy floor-blind path — byte-identical to the pre-floor behavior so a base
-            # view / unbaked zone keeps the 9 golden-hash routing parity exactly.
+            # Floor-blind path: rank by (non-island, distance, index). With no island in play this is the
+            # legacy order (containing surfaces win at distance 0, ties by smallest index) so golden-hash
+            # parity holds; it only diverges to skip a micro-component when a real surface competes. Mirrors
+            # C++ BaseNavPlanner::snap.
+            best_rank: tuple[int, float, int] | None = None
             best: _SnapResult | None = None
             for triangle_index in candidates:
                 triangle_vertices = self._triangle_points(triangle_index)
                 if _point_in_triangle(point, *triangle_vertices):
-                    # 命中即最优(距离 0),提前返回;与 C++ BaseNavPlanner::snap 行为一致,
-                    # 避免在细碎三角形堆叠的 bin 中线性扫遍上万个候选。
-                    return _SnapResult(triangle=triangle_index, point=point, distance=0.0)
-                snapped = _closest_point_on_triangle(point, triangle_vertices)
-                distance = math.hypot(snapped[0] - point[0], snapped[1] - point[1])
-                if distance > query_radius:
-                    continue
-                if best is None or distance < best.distance:
+                    snapped = point
+                    distance = 0.0
+                else:
+                    snapped = _closest_point_on_triangle(point, triangle_vertices)
+                    distance = math.hypot(snapped[0] - point[0], snapped[1] - point[1])
+                    if distance > query_radius:
+                        continue
+                rank = (1 if self._is_small_island(triangle_index) else 0, distance, triangle_index)
+                if best_rank is None or rank < best_rank:
+                    best_rank = rank
                     best = _SnapResult(triangle=triangle_index, point=snapped, distance=distance)
             return best
         # Floor-aware path: a click in a multi-floor base projects onto several STACKED
@@ -598,7 +608,7 @@ class BaseNavField:
         # distance, then by height proximity to floor_y. The band is a PREFERENCE — if
         # nothing lands in-band we still return the nearest surface (never None), so
         # floor_y only re-ranks the snap target onto the correct floor, never gates it out.
-        best_key: tuple[int, float, float] | None = None
+        best_key: tuple[int, int, float, float] | None = None
         best_floor: _SnapResult | None = None
         for triangle_index in candidates:
             triangle_vertices = self._triangle_points(triangle_index)
@@ -611,7 +621,7 @@ class BaseNavField:
                 if distance > query_radius:
                     continue
             delta = abs(self.triangle_height[triangle_index] - floor_y)
-            key = (0 if delta <= FLOOR_BAND else 1, distance, delta)
+            key = (0 if delta <= FLOOR_BAND else 1, 1 if self._is_small_island(triangle_index) else 0, distance, delta)
             if best_key is None or key < best_key:
                 best_key = key
                 best_floor = _SnapResult(triangle=triangle_index, point=snapped, distance=distance)


### PR DESCRIPTION
<img width="1710" height="852" alt="navmesh_snap_fix_before_after" src="https://github.com/user-attachments/assets/fbe8ce35-6465-4851-963f-5d03f3254736" />

## Summary by Sourcery

调整导航网格（navmesh）端点吸附逻辑，避免将端点吸附到会导致路径终点不可达的小型、断开的碎片上；同时在不存在此类“孤岛”竞争时，保留原有的旧版行为。

Bug Fixes:
- 防止吸附后的端点落在小型、断开的导航网格碎片上，从而避免路径被困导致错误的“不可达（Unreachable）”结果。

Enhancements:
- 统一 C++ 和 Python 中 MapNavigator 的吸附启发式规则，在楼层感知（floor-aware）和非楼层感知（floor-blind）路径中，都优先考虑非孤岛的导航表面，而不是微小组件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust navmesh snapping to avoid snapping onto tiny disconnected fragments that make route endpoints unreachable, while preserving legacy behavior when no such islands compete.

Bug Fixes:
- Prevent snapped endpoints from landing on small disconnected navmesh fragments that strand routes and cause false Unreachable results.

Enhancements:
- Unify C++ and Python MapNavigator snapping heuristics to rank non-island surfaces ahead of micro-components in both floor-aware and floor-blind paths.

</details>