### PR TITLE
rft(选剑演武): 给 #3597 提的 pr

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyNav.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyNav.json
@@ -48,10 +48,27 @@
                 "custom_action": "AutoAltClickAction"
             }
         },
-        "post_wait_freezes": 100,
         "next": [
-            // 空节点，触发 JumpBack
+            "TrialOfSwordmancyEnterTrialMenuSuccess"
         ]
+    },
+    "TrialOfSwordmancyEnterTrialMenuSuccess": {
+        "desc": "成功进入演算菜单",
+        "recognition": "Or",
+        "any_of": [
+            "TrialOfSwordmancyDrawCard",
+            "TrialOfSwordmancyCantDrawCard"
+        ],
+        "pre_wait_freezes": {
+            "time": 100,
+            "target": [
+                // 等待抽牌按钮的骰子转动完毕
+                1081,
+                510,
+                68,
+                60
+            ]
+        }
     },
     "TrialOfSwordmancyInSwordVaultDale": {
         "desc": "确认在藏剑谷内",


### PR DESCRIPTION
原来还能给pr提pr

抽牌按钮模板的骰子在载入界面时有旋转动画，需要加个节点等待动画结束

## Summary by Sourcery

调整 TrialOfSwordmancy 的 UI 资源，以正确处理抽牌按钮骰子动画的生命周期。

Bug 修复：
- 通过在 TrialOfSwordmancy 流水线配置中添加专用的等待节点，确保抽牌按钮的骰子动画在交互前完成。

增强：
- 优化 TrialOfSwordmancy 的通用与导航流水线 JSON 资源，以实现更清晰的动画流程控制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust TrialOfSwordmancy UI resources to properly handle the draw-card button dice animation lifecycle.

Bug Fixes:
- Ensure the draw-card button’s dice animation finishes before interaction by adding a dedicated wait node in the TrialOfSwordmancy pipeline configuration.

Enhancements:
- Refine TrialOfSwordmancy common and navigation pipeline JSON resources for clearer animation flow control.

</details>