### PR TITLE
refactor: 避免传送寻路失败后死循环

### DIFF
--- a/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute1.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute1.json
@@ -13,9 +13,15 @@
     },
     "AutoCollectCommonRoute1": {
         "desc": "10个映火荞花",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldValleyIVTheHub1"
+            ]
+        },
         "next": [
-            "AutoCollectCommonRoute1AssertLocation1",
-            "[JumpBack]SceneEnterWorldValleyIVTheHub1"
+            "AutoCollectCommonRoute1AssertLocation1"
         ]
     },
     "AutoCollectCommonRoute1End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute2.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute2.json
@@ -13,9 +13,15 @@
     },
     "AutoCollectCommonRoute2": {
         "desc": "8个黯银柑实",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldValleyIVTheHub1"
+            ]
+        },
         "next": [
-            "AutoCollectCommonRoute2AssertLocation1",
-            "[JumpBack]SceneEnterWorldValleyIVTheHub1"
+            "AutoCollectCommonRoute2AssertLocation1"
         ]
     },
     "AutoCollectCommonRoute2End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute3.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute3.json
@@ -12,9 +12,15 @@
         }
     },
     "AutoCollectCommonRoute3": {
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingMarkerStone4"
+            ]
+        },
         "next": [
-            "AutoCollectCommonRoute3AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingMarkerStone4"
+            "AutoCollectCommonRoute3AssertLocation1"
         ]
     },
     "AutoCollectCommonRoute3End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute4.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute4.json
@@ -12,9 +12,15 @@
         }
     },
     "AutoCollectCommonRoute4": {
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley6"
+            ]
+        },
         "next": [
-            "AutoCollectCommonRoute4AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley6"
+            "AutoCollectCommonRoute4AssertLocation1"
         ]
     },
     "AutoCollectCommonRoute4End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute5.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute5.json
@@ -12,9 +12,15 @@
         }
     },
     "AutoCollectCommonRoute5": {
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingMarkerStone1"
+            ]
+        },
         "next": [
-            "AutoCollectCommonRoute5AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingMarkerStone1"
+            "AutoCollectCommonRoute5AssertLocation1"
         ]
     },
     "AutoCollectCommonRoute5End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute6.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute6.json
@@ -12,9 +12,15 @@
         }
     },
     "AutoCollectCommonRoute6": {
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingMarkerStone3"
+            ]
+        },
         "next": [
-            "AutoCollectCommonRoute6AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingMarkerStone3"
+            "AutoCollectCommonRoute6AssertLocation1"
         ]
     },
     "AutoCollectCommonRoute6End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute7.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute7.json
@@ -12,9 +12,15 @@
         }
     },
     "AutoCollectCommonRoute7": {
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingMarkerStone1"
+            ]
+        },
         "next": [
-            "AutoCollectCommonRoute7AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingMarkerStone1"
+            "AutoCollectCommonRoute7AssertLocation1"
         ]
     },
     "AutoCollectCommonRoute7End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute8.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectCommonRoute8.json
@@ -13,9 +13,15 @@
     },
     "AutoCollectCommonRoute8": {
         "desc": "8个金石稻",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingTestArea1"
+            ]
+        },
         "next": [
-            "AutoCollectCommonRoute8AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingTestArea1"
+            "AutoCollectCommonRoute8AssertLocation1"
         ]
     },
     "AutoCollectCommonRoute8End": {

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute1.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute1.json
@@ -1,9 +1,15 @@
 {
     "AutoCollectRoute1Start": {
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity5"
+            ]
+        },
         "next": [
-            "AutoCollectRoute1AssertLocation",
-            "[JumpBack]SceneEnterWorldWulingWulingCity5"
+            "AutoCollectRoute1AssertLocation"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute1.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute10.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute10.json
@@ -2,9 +2,15 @@
     "AutoCollectRoute10Start": {
         "desc": "共两个重红柱状菌采集点",
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley1"
+            ]
+        },
         "next": [
-            "AutoCollectRoute10AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley1"
+            "AutoCollectRoute10AssertLocation1"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute10.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute11.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute11.json
@@ -2,9 +2,15 @@
     "AutoCollectRoute11Start": {
         "desc": "重黯石",
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingJingyuValley4"
+            ]
+        },
         "next": [
-            "AutoCollectRoute11AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingJingyuValley4"
+            "AutoCollectRoute11AssertLocation1"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute11.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute12.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute12.json
@@ -2,9 +2,15 @@
     "AutoCollectRoute12Start": {
         "desc": "中红柱状菌",
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingMarkerStone3"
+            ]
+        },
         "next": [
-            "AutoCollectRoute12AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingMarkerStone3"
+            "AutoCollectRoute12AssertLocation1"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute12.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute13.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute13.json
@@ -2,9 +2,15 @@
     "AutoCollectRoute13Start": {
         "desc": "中黯石",
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldValleyIVOriginLodespring3"
+            ]
+        },
         "next": [
-            "AutoCollectRoute13AssertLocation1",
-            "[JumpBack]SceneEnterWorldValleyIVOriginLodespring3"
+            "AutoCollectRoute13AssertLocation1"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute13.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute14.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute14.json
@@ -2,9 +2,15 @@
     "AutoCollectRoute14Start": {
         "desc": "晶化多齿叶",
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldValleyIVTheHub1"
+            ]
+        },
         "next": [
-            "AutoCollectRoute14AssertLocation1",
-            "[JumpBack]SceneEnterWorldValleyIVTheHub1"
+            "AutoCollectRoute14AssertLocation1"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute14.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute2.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute2.json
@@ -1,9 +1,15 @@
 {
     "AutoCollectRoute2Start": {
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity2"
+            ]
+        },
         "next": [
-            "AutoCollectRoute2AssertLocation",
-            "[JumpBack]SceneEnterWorldWulingWulingCity2"
+            "AutoCollectRoute2AssertLocation"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute2.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute3.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute3.json
@@ -1,9 +1,15 @@
 {
     "AutoCollectRoute3Start": {
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity7"
+            ]
+        },
         "next": [
-            "AutoCollectRoute3AssertLocation",
-            "[JumpBack]SceneEnterWorldWulingWulingCity7"
+            "AutoCollectRoute3AssertLocation"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute3.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute4.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute4.json
@@ -1,9 +1,15 @@
 {
     "AutoCollectRoute4Start": {
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldValleyIVPowerPlateau3"
+            ]
+        },
         "next": [
-            "AutoCollectRoute4AssertLocation",
-            "[JumpBack]SceneEnterWorldValleyIVPowerPlateau3"
+            "AutoCollectRoute4AssertLocation"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute4.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute5.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute5.json
@@ -1,9 +1,15 @@
 {
     "AutoCollectRoute5Start": {
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldValleyIVTheHub2"
+            ]
+        },
         "next": [
-            "AutoCollectRoute5AssertLocation",
-            "[JumpBack]SceneEnterWorldValleyIVTheHub2"
+            "AutoCollectRoute5AssertLocation"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute5.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute6.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute6.json
@@ -1,9 +1,15 @@
 {
     "AutoCollectRoute6Start": {
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldValleyIVTheHub2"
+            ]
+        },
         "next": [
-            "AutoCollectRoute6AssertLocation",
-            "[JumpBack]SceneEnterWorldValleyIVTheHub2"
+            "AutoCollectRoute6AssertLocation"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute6.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute7.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute7.json
@@ -2,9 +2,15 @@
     "AutoCollectRoute7Start": {
         "desc": "本路线包含两个收集点，血菌和武陵石",
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity1"
+            ]
+        },
         "next": [
-            "AutoCollectRoute7AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingWulingCity1"
+            "AutoCollectRoute7AssertLocation1"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute7.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute8.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute8.json
@@ -1,9 +1,15 @@
 {
     "AutoCollectRoute8Start": {
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity7"
+            ]
+        },
         "next": [
-            "AutoCollectRoute8AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingWulingCity7"
+            "AutoCollectRoute8AssertLocation1"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute8.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute9.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute9.json
@@ -2,9 +2,15 @@
     "AutoCollectRoute9Start": {
         "desc": "燎石",
         "enabled": false,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingWulingCity7"
+            ]
+        },
         "next": [
-            "AutoCollectRoute9AssertLocation1",
-            "[JumpBack]SceneEnterWorldWulingWulingCity7"
+            "AutoCollectRoute9AssertLocation1"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "$option.AutoCollectRoute9.label"

--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute999.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute999.json
@@ -1,8 +1,14 @@
 {
     "AutoCollectRoute999Start": {
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldValleyIVPowerPlateau1"
+            ]
+        },
         "next": [
-            "AutoCollectRoute999AssertLocation",
-            "[JumpBack]SceneEnterWorldValleyIVPowerPlateau1"
+            "AutoCollectRoute999AssertLocation"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "开始路线999"

--- a/assets/resource/pipeline/Interface/Example/Scene.json
+++ b/assets/resource/pipeline/Interface/Example/Scene.json
@@ -21,23 +21,16 @@
     "SceneExampleTeleportTask": {
         "desc": "传送接口使用示例",
         "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldValleyIVOriginiumSciencePark0"
+            ]
+        },
         "post_delay": 0,
         "next": [
-            "SceneExampleTeleportTaskInMap",
-            "[JumpBack]SceneEnterMapAny"
-        ]
-    },
-    "SceneExampleTeleportTaskInMap": {
-        "desc": "判断进入地图菜单，开始传送",
-        "recognition": "And",
-        "all_of": [
-            "InMapAny"
-        ],
-        "pre_delay": 0,
-        "post_delay": 0,
-        "next": [
-            "SceneExampleTeleportTaskInContinue",
-            "[JumpBack]SceneEnterWorldValleyIVOriginiumSciencePark0"
+            "SceneExampleTeleportTaskInContinue"
         ]
     },
     "SceneExampleTeleportTaskInContinue": {

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyNav.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyNav.json
@@ -1,9 +1,15 @@
 {
     "TrialOfSwordmancyGotoTrialArenaStart": {
         "desc": "前往演武入口（子任务入口）",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterWorldWulingSwordVaultDale2"
+            ]
+        },
         "next": [
-            "TrialOfSwordmancyInSwordVaultDale",
-            "[JumpBack]SceneEnterWorldWulingSwordVaultDale2"
+            "TrialOfSwordmancyInSwordVaultDale"
         ]
     },
     "TrialOfSwordmancyGotoTrialArenaExit": {


### PR DESCRIPTION
改完以后，万能传送、寻路两个模块分开调用，避免反复传送
1、万能传送失败后，会在SubTask内部任务失败，最终任务失败
2、寻路失败后，直接任务失败

## Summary by Sourcery

Bug Fixes:
- 通过在传送或寻路失败时使每次失败都中止相应任务，防止在自动收集流程中出现潜在的无限循环。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent potential infinite loops in auto-collect flows when teleport or pathfinding fails by making each failure abort the corresponding task.

</details>