### PR TITLE
perf(map): 降低MapTrackerMove光标重置频率

### DIFF
--- a/agent/go-service/maptracker/default/infer.go
+++ b/agent/go-service/maptracker/default/infer.go
@@ -94,7 +94,7 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 		return nil, false
 	}
 
-	rotStep := max(2, min(8, int(math.Round(8-param.Precision*6))))
+	rotStep := max(2, min(6, int(math.Round(6-param.Precision*4))))
 
 	// Initialize map resources
 	internal.Resource.InitRawMaps(ctx)

--- a/agent/go-service/maptracker/default/move.go
+++ b/agent/go-service/maptracker/default/move.go
@@ -146,6 +146,8 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 
 	log.Info().Str("map", param.MapName).Int("targetsCount", len(param.Path)).Msg("Starting navigation to targets")
 
+	// Start of all targets, reset cursor and initial movement state
+	ca.ResetCursor(control.CursorResetActive)
 	if !param.NoEnsureInitialMovementState {
 		// Reset player movement state
 		ca.AggressivelyResetPlayerMovement()
@@ -242,7 +244,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					log.Debug().Float64("nextDeltaRot", float64(nextDeltaRot)).Msg("Finishing target, foreseeing rotation adjustment for next target")
 					augNextDeltaRot := float64(nextDeltaRot) * 0.618
 					ca.RotateCamera(int(augNextDeltaRot*rotationSpeed), 0)
-					ca.AggressivelyResetCamera()
+					ca.ResetCursor(control.CursorResetLazy)
 				} else if !param.NoEnsureFinalOrientation && i == len(param.Path)-1 && len(param.Path) >= 2 {
 					// Ensure camera orientation when reached the final target
 					finalTarget := param.Path[len(param.Path)-1]
@@ -251,7 +253,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					orientDeltaRot := calcDeltaRotation(rot, orientTargetRot)
 					log.Debug().Float64("orientDeltaRot", float64(orientDeltaRot)).Msg("Finishing target, ensuring final camera orientation")
 					ca.RotateCamera(int(float64(orientDeltaRot)*rotationSpeed), 0)
-					ca.AggressivelyResetCamera()
+					ca.ResetCursor(control.CursorResetLazy)
 				}
 			}
 
@@ -380,7 +382,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 						startTime:       time.Now(),
 						expectedElapsed: ca.GetPlayerMovement().EtaOfRotation(math.Abs(finalDeltaRot)),
 					}
-					ca.AggressivelyResetCamera()
+					ca.ResetCursor(control.CursorResetLazy)
 				}
 			}
 		}
@@ -500,6 +502,8 @@ func (a *MapTrackerMove) parseParam(paramStr string) (*MapTrackerMoveParam, erro
 }
 
 func doPlayerStop(ca control.ControlAdaptor) {
+	// Actively reset cursor to prevent other tasks' potential issue
+	ca.ResetCursor(control.CursorResetActive)
 	// Softly stop movement first
 	ca.SetPlayerMovement(control.MovementStop, control.PolicyLazy)
 	// Then reset player to running state to ensure consistent movement state for next navigation

--- a/agent/go-service/maptracker/default/zipline.go
+++ b/agent/go-service/maptracker/default/zipline.go
@@ -106,6 +106,7 @@ func (a *MapTrackerZipline) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool
 		return false
 	}
 	similarity := minicv.ImageSimilarity(before, after, [2]int{50, 50})
+	ca.ResetCursor(control.CursorResetActive)
 	if similarity > MINIMAP_SIMILARITY_THRESHOLD {
 		log.Warn().Float64("similarity", similarity).Msg("Zipline fast travel did not start")
 		maafocus.Print(ctx, "未检测到移动")
@@ -205,7 +206,6 @@ func (a *MapTrackerZipline) rotateTowardTarget(ctx *maa.Context, ctrl *maa.Contr
 			return true
 		}
 		ca.RotateCamera(int(float64(deltaRot)*ROTATION_DEFAULT_SPEED), 0)
-		ca.ResetCamera()
 		time.Sleep(rotationInterval)
 	}
 	return false

--- a/agent/go-service/pkg/control/adaptor.go
+++ b/agent/go-service/pkg/control/adaptor.go
@@ -58,13 +58,10 @@ type ControlAdaptor interface {
 	// This will not change the player movement state.
 	PlayerJump()
 
-	// ResetCamera eliminates the side effect of camera rotation solidly.
-	// Different implementations may have different ways to achieve this.
-	ResetCamera()
-
-	// AggressivelyResetCamera eliminates the side effect of camera rotation.
-	// Different implementations may have different ways to achieve this.
-	AggressivelyResetCamera()
+	// ResetCursor eliminates the side effect of camera rotation.
+	// The policy controls the activeness of this action, see [CursorResetPolicy] for details.
+	// Implementations without cursor drift may treat this as a no-op.
+	ResetCursor(policy CursorResetPolicy)
 
 	// AggressivelyResetPlayerMovement provides an aggressive way to reset player movement for initialization purpose.
 	// Different implementations may have different ways to achieve this.
@@ -150,4 +147,16 @@ const (
 	// PolicyActive performs extra key actions to actively ensure the new movement state is achieved,
 	// which may cause more latency but also more robustness.
 	PolicyActive PlayerMovementPolicy = 2
+)
+
+/* ******** Cursor Reset Policy Enumeration ******** */
+
+type CursorResetPolicy int
+
+const (
+	// CursorResetLazy resets the cursor only when it nears a screen edge
+	// or the reset interval has elapsed, avoiding unnecessary reset actions.
+	CursorResetLazy CursorResetPolicy = 0
+	// CursorResetActive always resets the cursor immediately.
+	CursorResetActive CursorResetPolicy = 1
 )

--- a/agent/go-service/pkg/control/adaptor_adb.go
+++ b/agent/go-service/pkg/control/adaptor_adb.go
@@ -188,5 +188,5 @@ const (
 	cameraContact                 = 1
 	sprintButtonContact           = 2
 	jumpButtonContact             = 3
-	defaultTouchActionDelayMillis = 50
+	defaultTouchActionDelayMillis = 60
 )

--- a/agent/go-service/pkg/control/adaptor_adb.go
+++ b/agent/go-service/pkg/control/adaptor_adb.go
@@ -162,12 +162,8 @@ func (aca *ADBControlAdaptor) PlayerJump() {
 	aca.TouchClick(jumpButtonContact, JUMP_BUTTON_X, JUMP_BUTTON_Y, defaultTouchActionDelayMillis*4, 0)
 }
 
-func (aca *ADBControlAdaptor) ResetCamera() {
-	// ADB has no need to reset camera
-}
-
-func (aca *ADBControlAdaptor) AggressivelyResetCamera() {
-	// ADB has no need to reset camera aggressively
+func (aca *ADBControlAdaptor) ResetCursor(_ CursorResetPolicy) {
+	// ADB has no need to reset cursor
 }
 
 func (aca *ADBControlAdaptor) AggressivelyResetPlayerMovement() {

--- a/agent/go-service/pkg/control/adaptor_desktop.go
+++ b/agent/go-service/pkg/control/adaptor_desktop.go
@@ -27,6 +27,13 @@ type desktopControlAdaptor struct {
 	keys             desktopKeyBindings
 	pm               PlayerMovement
 	lastMotionIsWalk bool
+
+	// cursorDX, cursorDY track the cursor offset from the screen center accumulated
+	// by camera rotations since the last reset.
+	cursorDX int
+	cursorDY int
+	// lastResetTime records when the camera was last reset, used by the lazy policy.
+	lastResetTime time.Time
 }
 
 func newDesktopControlAdaptor(ctx *maa.Context, ctrl *maa.Controller, w, h int, keys desktopKeyBindings) *desktopControlAdaptor {
@@ -93,7 +100,10 @@ func (dca *desktopControlAdaptor) KeyType(keyCode int, delayMillis int) {
 
 func (dca *desktopControlAdaptor) RotateCamera(dx, dy int) {
 	cx, cy := dca.w/2, dca.h/2
-	dca.SwipeHover(0, cx, cy, dx, dy, defaultDesktopKeyActionDelayMillis*3, defaultDesktopKeyActionDelayMillis)
+	fromX, fromY := cx+dca.cursorDX, cy+dca.cursorDY
+	dca.SwipeHover(0, fromX, fromY, dx, dy, defaultDesktopKeyActionDelayMillis*3, defaultDesktopKeyActionDelayMillis)
+	dca.cursorDX += dx
+	dca.cursorDY += dy
 }
 
 func (dca *desktopControlAdaptor) GetPlayerMovement() PlayerMovement {
@@ -159,22 +169,35 @@ func (dca *desktopControlAdaptor) PlayerJump() {
 	dca.KeyType(dca.keys.Space, defaultDesktopKeyActionDelayMillis*4)
 }
 
-func (dca *desktopControlAdaptor) ResetCamera() {
-	// Policy: use ALT key to release mouse cursor and reset its position using a move, then release ALT key
-	cx, cy := dca.w/2, dca.h/2
-	stepDelayMillis := defaultDesktopKeyActionDelayMillis / 3
-	dca.KeyDown(dca.keys.Alt, stepDelayMillis)
-	dca.TouchMove(0, cx, cy, stepDelayMillis)
-	dca.KeyUp(dca.keys.Alt, stepDelayMillis)
-}
-
-func (dca *desktopControlAdaptor) AggressivelyResetCamera() {
+func (dca *desktopControlAdaptor) ResetCursor(policy CursorResetPolicy) {
+	if !dca.shouldResetCursor(policy) {
+		return
+	}
 	// Policy: use ALT key to release mouse cursor and reset its position using a click, then release ALT key
 	cx, cy := dca.w/2, dca.h/2
 	stepDelayMillis := defaultDesktopKeyActionDelayMillis / 3
 	dca.KeyDown(dca.keys.Alt, stepDelayMillis)
 	dca.TouchClick(0, cx, cy, stepDelayMillis, 0)
 	dca.KeyUp(dca.keys.Alt, stepDelayMillis)
+	dca.cursorDX, dca.cursorDY = 0, 0
+	dca.lastResetTime = time.Now()
+}
+
+// shouldResetCursor reports whether the cursor should be reset under the given policy.
+func (dca *desktopControlAdaptor) shouldResetCursor(policy CursorResetPolicy) bool {
+	abs := func(v int) int {
+		if v < 0 {
+			return -v
+		}
+		return v
+	}
+	if policy >= CursorResetActive {
+		return true
+	}
+	if abs(dca.cursorDX) > dca.w/4 || abs(dca.cursorDY) > dca.h/4 {
+		return true
+	}
+	return time.Since(dca.lastResetTime) > cursorResetMaxInterval
 }
 
 func (dca *desktopControlAdaptor) AggressivelyResetPlayerMovement() {
@@ -188,6 +211,9 @@ func (dca *desktopControlAdaptor) AggressivelyResetPlayerMovement() {
 }
 
 const defaultDesktopKeyActionDelayMillis = 25
+
+// cursorResetMaxInterval is the maximum time a lazy cursor reset may be deferred.
+const cursorResetMaxInterval = 2 * time.Second
 
 // defaultDesktopKeyBindings returns the default key bindings for desktop controllers.
 // Values follow Win32 Virtual-Key conventions.

--- a/agent/go-service/pkg/control/adaptor_desktop.go
+++ b/agent/go-service/pkg/control/adaptor_desktop.go
@@ -210,7 +210,7 @@ func (dca *desktopControlAdaptor) AggressivelyResetPlayerMovement() {
 	dca.lastMotionIsWalk = false
 }
 
-const defaultDesktopKeyActionDelayMillis = 25
+const defaultDesktopKeyActionDelayMillis = 30
 
 // cursorResetMaxInterval is the maximum time a lazy cursor reset may be deferred.
 const cursorResetMaxInterval = 2 * time.Second

--- a/agent/go-service/pkg/control/adaptor_desktop.go
+++ b/agent/go-service/pkg/control/adaptor_desktop.go
@@ -218,25 +218,15 @@ const cursorResetMaxInterval = 2 * time.Second
 // defaultDesktopKeyBindings returns the default key bindings for desktop controllers.
 // Values follow Win32 Virtual-Key conventions.
 func defaultDesktopKeyBindings() desktopKeyBindings {
-	const (
-		vkW     = 0x57
-		vkA     = 0x41
-		vkS     = 0x53
-		vkD     = 0x44
-		vkShift = 0x10
-		vkCtrl  = 0x11
-		vkAlt   = 0x12
-		vkSpace = 0x20
-	)
 	return desktopKeyBindings{
-		W:     vkW,
-		A:     vkA,
-		S:     vkS,
-		D:     vkD,
-		Shift: vkShift,
-		Ctrl:  vkCtrl,
-		Alt:   vkAlt,
-		Space: vkSpace,
+		W:     0x57,
+		A:     0x41,
+		S:     0x53,
+		D:     0x44,
+		Shift: 0x10,
+		Ctrl:  0x11,
+		Alt:   0x12,
+		Space: 0x20,
 	}
 }
 

--- a/agent/go-service/pkg/control/adaptor_wlroots.go
+++ b/agent/go-service/pkg/control/adaptor_wlroots.go
@@ -41,6 +41,6 @@ func (wca *wlrootsControlAdaptor) RotateCamera(dx, dy int) {
 	wca.SwipeHover(0, 0, 0, dx, dy, defaultDesktopKeyActionDelayMillis*3, defaultDesktopKeyActionDelayMillis)
 }
 
-func (wca *wlrootsControlAdaptor) AggressivelyResetCamera() {
+func (wca *wlrootsControlAdaptor) ResetCursor(_ CursorResetPolicy) {
 	// wlroots uses relative mouse move for camera rotation, no cursor reset needed.
 }


### PR DESCRIPTION
## 概要

此 PR 通过缓存光标状态，降低了光标重置的频率。此外更新了部分 control 常量。

## Summary by Sourcery

引入光标感知的相机控制以及可配置的光标重置策略，以在地图跟踪和导航过程中减少不必要的光标重置。

新功能：
- 添加光标偏移跟踪和基于时间的策略，用于在相机旋转后决定何时重置光标。
- 在控制适配器接口上暴露一个 `CursorResetPolicy`，并将其集成到地图导航和滑索（zipline）流程中，以控制重置操作的激进程度。

增强项：
- 调整默认按键和触控动作延迟，并简化桌面端按键绑定常量，以实现更一致的控制行为。
- 调优地图跟踪推理中的旋转步长计算，以减小旋转增量并提升精度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce cursor-aware camera control and configurable cursor reset policies to reduce unnecessary cursor resets during map tracking and navigation.

New Features:
- Add cursor offset tracking and time-based policies for when to reset the cursor after camera rotations.
- Expose a CursorResetPolicy on the control adaptor interface and integrate it into map navigation and zipline flows to control reset aggressiveness.

Enhancements:
- Adjust default key and touch action delays and simplify desktop key binding constants for more consistent control behavior.
- Tune rotation step calculation in map tracking inference to reduce rotation increments and improve precision.

</details>