### PR TITLE
fix: 消除adb的分辨率提示的歧义

### DIFF
--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -149,7 +149,7 @@
     "tasker.aspect_ratio_warning.controller_label": "Current controller:",
     "tasker.aspect_ratio_warning.current_resolution": "Current resolution:",
     "tasker.aspect_ratio_warning.requirement_label": "Required:",
-    "tasker.aspect_ratio_warning.requirement_exact": "Exact %dx%d",
+    "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 aspect ratio and at least 1280x720; for example 3840x2160, 2560x1440, 1920x1080, 1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "Windowed mode; fullscreen requires a physical 16:9 monitor, which your current display does not meet.",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -149,7 +149,7 @@
     "tasker.aspect_ratio_warning.controller_label": "Current controller:",
     "tasker.aspect_ratio_warning.current_resolution": "Current resolution:",
     "tasker.aspect_ratio_warning.requirement_label": "Required:",
-    "tasker.aspect_ratio_warning.requirement_exact": "Exact %dx%d; other 16:9 resolutions such as 1920x1080 are not accepted",
+    "tasker.aspect_ratio_warning.requirement_exact": "Exact %dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 aspect ratio and at least 1280x720; for example 3840x2160, 2560x1440, 1920x1080, 1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "Windowed mode; fullscreen requires a physical 16:9 monitor, which your current display does not meet.",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -149,7 +149,7 @@
     "tasker.aspect_ratio_warning.controller_label": "現在のコントローラー：",
     "tasker.aspect_ratio_warning.current_resolution": "現在の解像度：",
     "tasker.aspect_ratio_warning.requirement_label": "必要条件：",
-    "tasker.aspect_ratio_warning.requirement_exact": "正確に %dx%d",
+    "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比率かつ 1280x720 以上。例: 3840x2160、2560x1440、1920x1080、1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "ウィンドウモード；全画面モードでは物理的に 16:9 のディスプレイが必要ですが、現在のディスプレイは条件を満たしません。",
     "maptracker.emergency_stop.title": "🚨 緊急停止",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -149,7 +149,7 @@
     "tasker.aspect_ratio_warning.controller_label": "現在のコントローラー：",
     "tasker.aspect_ratio_warning.current_resolution": "現在の解像度：",
     "tasker.aspect_ratio_warning.requirement_label": "必要条件：",
-    "tasker.aspect_ratio_warning.requirement_exact": "正確に %dx%d。1920x1080 など他の 16:9 解像度でも通りません",
+    "tasker.aspect_ratio_warning.requirement_exact": "正確に %dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比率かつ 1280x720 以上。例: 3840x2160、2560x1440、1920x1080、1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "ウィンドウモード；全画面モードでは物理的に 16:9 のディスプレイが必要ですが、現在のディスプレイは条件を満たしません。",
     "maptracker.emergency_stop.title": "🚨 緊急停止",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -149,7 +149,7 @@
     "tasker.aspect_ratio_warning.controller_label": "현재 컨트롤러:",
     "tasker.aspect_ratio_warning.current_resolution": "현재 해상도:",
     "tasker.aspect_ratio_warning.requirement_label": "요구 사항:",
-    "tasker.aspect_ratio_warning.requirement_exact": "정확히 %dx%d여야 하며",
+    "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 비율이고 최소 1280x720 이상이어야 합니다; 예: 3840x2160, 2560x1440, 1920x1080, 1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "창 모드; 전체 화면 모드는 물리적으로 16:9 해상도 모니터가 필요하며 현재 디스플레이는 조건에 맞지 않습니다.",
     "maptracker.emergency_stop.title": "🚨 긴급 정지",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -149,7 +149,7 @@
     "tasker.aspect_ratio_warning.controller_label": "현재 컨트롤러:",
     "tasker.aspect_ratio_warning.current_resolution": "현재 해상도:",
     "tasker.aspect_ratio_warning.requirement_label": "요구 사항:",
-    "tasker.aspect_ratio_warning.requirement_exact": "정확히 %dx%d여야 하며, 1920x1080 같은 다른 16:9 해상도도 허용되지 않습니다",
+    "tasker.aspect_ratio_warning.requirement_exact": "정확히 %dx%d여야 하며",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 비율이고 최소 1280x720 이상이어야 합니다; 예: 3840x2160, 2560x1440, 1920x1080, 1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "창 모드; 전체 화면 모드는 물리적으로 16:9 해상도 모니터가 필요하며 현재 디스플레이는 조건에 맞지 않습니다.",
     "maptracker.emergency_stop.title": "🚨 긴급 정지",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -149,7 +149,7 @@
     "tasker.aspect_ratio_warning.controller_label": "当前控制器：",
     "tasker.aspect_ratio_warning.current_resolution": "当前分辨率：",
     "tasker.aspect_ratio_warning.requirement_label": "目标要求：",
-    "tasker.aspect_ratio_warning.requirement_exact": "精确 %dx%d",
+    "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例且不低于 1280x720；例如 3840x2160、2560x1440、1920x1080、1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "窗口模式；全屏模式需使用物理分辨率16:9的显示器，当前显示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -149,7 +149,7 @@
     "tasker.aspect_ratio_warning.controller_label": "当前控制器：",
     "tasker.aspect_ratio_warning.current_resolution": "当前分辨率：",
     "tasker.aspect_ratio_warning.requirement_label": "目标要求：",
-    "tasker.aspect_ratio_warning.requirement_exact": "精确 %dx%d；1920x1080 等 16:9 分辨率也不通过",
+    "tasker.aspect_ratio_warning.requirement_exact": "精确 %dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例且不低于 1280x720；例如 3840x2160、2560x1440、1920x1080、1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "窗口模式；全屏模式需使用物理分辨率16:9的显示器，当前显示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -149,7 +149,7 @@
     "tasker.aspect_ratio_warning.controller_label": "目前控制器：",
     "tasker.aspect_ratio_warning.current_resolution": "目前解析度：",
     "tasker.aspect_ratio_warning.requirement_label": "目標要求：",
-    "tasker.aspect_ratio_warning.requirement_exact": "精確 %dx%d；1920x1080 等其他 16:9 解析度也不通過",
+    "tasker.aspect_ratio_warning.requirement_exact": "精確 %dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例且不低於 1280x720；例如 3840x2160、2560x1440、1920x1080、1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "視窗模式；全螢幕模式需使用物理解析度 16:9 的顯示器，目前顯示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -149,7 +149,7 @@
     "tasker.aspect_ratio_warning.controller_label": "目前控制器：",
     "tasker.aspect_ratio_warning.current_resolution": "目前解析度：",
     "tasker.aspect_ratio_warning.requirement_label": "目標要求：",
-    "tasker.aspect_ratio_warning.requirement_exact": "精確 %dx%d",
+    "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例且不低於 1280x720；例如 3840x2160、2560x1440、1920x1080、1280x720",
     "tasker.aspect_ratio_warning.full_screen_illegal": "視窗模式；全螢幕模式需使用物理解析度 16:9 的顯示器，目前顯示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",


### PR DESCRIPTION
原来那个太容易让人误会了。

## Summary by Sourcery

错误修复：
- 调整所有语言中的 ADB 分辨率相关本地化字符串，去除具有误导性的措辞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust ADB resolution-related localized strings in all languages to remove misleading wording.

</details>