### PR TITLE
perf(map): 提升MapTrackerBigMapPick稳定性

### DIFF
--- a/agent/go-service/maptracker/bigmap/const.go
+++ b/agent/go-service/maptracker/bigmap/const.go
@@ -16,8 +16,8 @@ const (
 const (
 	PADDING_LR           = 0.192 * WORK_W
 	PADDING_TB           = 0.208 * WORK_H
-	SAMPLE_PADDING_LR    = 0.4 * WORK_W
-	SAMPLE_PADDING_TB    = 0.4 * WORK_H
+	SAMPLE_PADDING_LR    = 0.375 * WORK_W
+	SAMPLE_PADDING_TB    = 0.375 * WORK_H
 	WIRE_MATCH_PRECISION = 0.5
 	GAME_MAP_SCALE_MIN   = 1.0
 	GAME_MAP_SCALE_MAX   = 7.0
@@ -36,4 +36,10 @@ const (
 const (
 	BIG_MAP_PAN_FACTOR_NUMERATOR = 2500.0 // panFactor = this constant / screen diagonal size
 	BIG_MAP_PICK_RETRY           = 10
+)
+
+// Big map delay configuration
+const (
+	INFER_PRE_DELAY_MS = 100
+	PAN_POST_DELAY_MS  = 50
 )

--- a/agent/go-service/maptracker/bigmap/pick.go
+++ b/agent/go-service/maptracker/bigmap/pick.go
@@ -39,7 +39,7 @@ type MapTrackerBigMapPickParam struct {
 	// AutoOpenMapScene controls whether to automatically open the big map scene before picking.
 	AutoOpenMapScene bool `json:"auto_open_map_scene,omitempty"`
 	// ZoomValue is the target zoom slider position.
-	// If omitted, defaults to 0.7. Set to 0 to disable auto zoom. Other values should be in range (0, 1].
+	// If omitted, defaults to 0.725. Set to 0 to disable auto zoom. Other values should be in range (0, 1].
 	ZoomValue *float64 `json:"zoom_value,omitempty"`
 }
 
@@ -51,7 +51,7 @@ const (
 
 var mapTrackerBigMapPickDefaultParam = MapTrackerBigMapPickParam{
 	OnFind:    ON_FIND_CLICK,
-	ZoomValue: func() *float64 { v := 0.7; return &v }(),
+	ZoomValue: func() *float64 { v := 0.725; return &v }(),
 }
 
 var _ maa.CustomActionRunner = &MapTrackerBigMapPick{}

--- a/agent/go-service/maptracker/bigmap/pick.go
+++ b/agent/go-service/maptracker/bigmap/pick.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"regexp"
 	"sync"
+	"time"
 
 	internal "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/internal"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/control"
@@ -110,6 +111,7 @@ func (a *MapTrackerBigMapPick) Run(ctx *maa.Context, arg *maa.CustomActionArg) b
 		}
 
 		// Infer current big-map viewport
+		time.Sleep(INFER_PRE_DELAY_MS * time.Millisecond)
 		inferRes, err := doBigMapInferForMap(ctx, ctrl, param.MapName)
 		if err != nil {
 			log.Error().Err(err).Str("map", param.MapName).Int("attempt", attempt).Msg("Currently not in that map")
@@ -155,9 +157,8 @@ func (a *MapTrackerBigMapPick) Run(ctx *maa.Context, arg *maa.CustomActionArg) b
 			Msg("Big-map target is not in viewport, need to pan")
 
 		segments := rand.Intn(3) + 1
-		if !doDragViewport(ca, &inferRes.ViewPort, deltaInViewX, deltaInViewY, panFactor, segments) {
-			continue
-		}
+		doDragViewport(ca, &inferRes.ViewPort, deltaInViewX, deltaInViewY, panFactor, segments)
+		time.Sleep(PAN_POST_DELAY_MS * time.Millisecond)
 	}
 
 	log.Error().

--- a/docs/zh_cn/developers/components/map-tracker.md
+++ b/docs/zh_cn/developers/components/map-tracker.md
@@ -386,7 +386,7 @@
 
 - `auto_open_map_scene`: 真假值，默认 `false`。是否预先自动打开对应的大地图界面。此功能依赖于 SceneManager 系列节点。未启用此功能的情况下，请确认玩家当前已经处于对应的大地图界面。
 
-- `zoom_value`: 控制在寻找目标点之前的自动缩放调整行为，详情参见 [MapTrackerBigMapZoom](#action-maptrackerbigmapzoom) 节点的 `zoom_value` 参数。
+- `zoom_value`: 控制在寻找目标点之前的自动缩放调整行为，详情参见 [MapTrackerBigMapZoom](#action-maptrackerbigmapzoom) 节点的 `zoom_value` 参数。不填时，默认值为 0.725。
 
 #### 示例用法
 

--- a/tools/schema/components/map_tracker.schema.json
+++ b/tools/schema/components/map_tracker.schema.json
@@ -287,7 +287,7 @@
                     "type": "number",
                     "minimum": 0,
                     "maximum": 1,
-                    "default": 0.7
+                    "default": 0.725
                 }
             }
         },


### PR DESCRIPTION
## 概要

此 PR 为 MapTrackerBigMapPick 节点增加了识别前和拖拽后的延时（分别是 100 和 50 毫秒），并略微扩大了采样区域，以期提升稳定性。

## 关联

Fix #3643

## Summary by Sourcery

通过调整采样区域并在推理前和视口平移后引入短暂延时，提升大地图选取逻辑的稳定性。

Enhancements:
- 调整大地图采样边距，略微缩小采样区域边缘，以实现更稳健的检测效果。
- 在大地图选取流程中新增可配置的推理前延时和视口平移后延时，以稳定视口识别和视口平移行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve stability of the big map picking logic by tuning sampling area and introducing small delays before inference and after viewport panning.

Enhancements:
- Adjust big map sampling padding to slightly reduce the sampling area edges for more robust detection.
- Add configurable pre-inference and post-pan delays to the big map picker flow to stabilize viewport recognition and panning.

</details>