### PR TITLE
fix:修复赠送干员礼物多次选中同一干员

### DIFF
--- a/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
@@ -615,15 +615,7 @@
             }
         },
         "action": {
-            "type": "Click",
-            "param": {
-                "target_offset": [
-                    -30,
-                    50,
-                    0,
-                    0
-                ]
-            }
+            "type": "Click"
         },
         "next": [
             "GiftOperatorCheckSelected1"
@@ -643,15 +635,7 @@
             }
         },
         "action": {
-            "type": "Click",
-            "param": {
-                "target_offset": [
-                    -30,
-                    50,
-                    0,
-                    0
-                ]
-            }
+            "type": "Click"
         },
         "next": [
             "GiftOperatorCheckSelected2"
@@ -671,15 +655,7 @@
             }
         },
         "action": {
-            "type": "Click",
-            "param": {
-                "target_offset": [
-                    -30,
-                    50,
-                    0,
-                    0
-                ]
-            }
+            "type": "Click"
         },
         "next": [
             "GiftOperatorCheckSelected3"

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
@@ -504,26 +504,6 @@
             }
         }
     },
-    "GiftOperatorTrustValue": {
-        "desc": "干员信赖度数值",
-        "recognition": {
-            "type": "OCR",
-            "param": {
-                "roi": "GiftOperatorTrustIcon",
-                "roi_offset": [
-                    14,
-                    1,
-                    19,
-                    -2
-                ],
-                "expected": [
-                    "^((?!200).)*$"
-                ],
-                "only_rec": true,
-                "order_by": "Vertical"
-            }
-        }
-    },
     "GiftOperatorNotSelect": {
         "desc": "干员未被选择",
         "recognition": {
@@ -531,7 +511,7 @@
             "param": {
                 "roi": "GiftOperatorTrustIcon",
                 "roi_offset": [
-                    42,
+                    40,
                     -85,
                     5,
                     5
@@ -562,7 +542,27 @@
                     ]
                 ],
                 "connected": true,
-                "count": 100,
+                "count": 150,
+                "order_by": "Vertical"
+            }
+        }
+    },
+    "GiftOperatorTrustValue": {
+        "desc": "干员信赖度数值",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": "GiftOperatorNotSelect",
+                "roi_offset": [
+                    -25,
+                    87,
+                    7,
+                    -8
+                ],
+                "expected": [
+                    "^((?!200).)*$"
+                ],
+                "only_rec": true,
                 "order_by": "Vertical"
             }
         }
@@ -608,8 +608,8 @@
             "param": {
                 "all_of": [
                     "GiftOperatorTrustIcon",
-                    "GiftOperatorTrustValue",
-                    "GiftOperatorNotSelect"
+                    "GiftOperatorNotSelect",
+                    "GiftOperatorTrustValue"
                 ],
                 "box_index": 2
             }
@@ -636,8 +636,8 @@
             "param": {
                 "all_of": [
                     "GiftOperatorTrustIcon",
-                    "GiftOperatorTrustValue",
-                    "GiftOperatorNotSelect"
+                    "GiftOperatorNotSelect",
+                    "GiftOperatorTrustValue"
                 ],
                 "box_index": 2
             }
@@ -664,8 +664,8 @@
             "param": {
                 "all_of": [
                     "GiftOperatorTrustIcon",
-                    "GiftOperatorTrustValue",
-                    "GiftOperatorNotSelect"
+                    "GiftOperatorNotSelect",
+                    "GiftOperatorTrustValue"
                 ],
                 "box_index": 2
             }

--- a/assets/resource_adb/pipeline/GiftOperator/GiftOperatorContact.json
+++ b/assets/resource_adb/pipeline/GiftOperator/GiftOperatorContact.json
@@ -39,10 +39,22 @@
         "recognition": {
             "param": {
                 "roi_offset": [
-                    42,
-                    -104,
-                    -24,
-                    0
+                    49,
+                    -106,
+                    6,
+                    5
+                ]
+            }
+        }
+    },
+    "GiftOperatorTrustValue": {
+        "recognition": {
+            "param": {
+                "roi_offset": [
+                    -32,
+                    106,
+                    12,
+                    -6
                 ]
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 防止在赠送流程中，在一次赠送操作里多次选择同一名运营人员。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent gifting flow from allowing the same operator to be selected multiple times in a single gift operation.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 防止在赠送流程中，在一次赠送操作里多次选择同一名运营人员。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent gifting flow from allowing the same operator to be selected multiple times in a single gift operation.

</details>

</details>