### PR TITLE
feat: 选剑演武 增加刷 25 点

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -1037,5 +1037,6 @@
     "option.TrialOfSwordmancyMode.label": "Task Mode",
     "option.TrialOfSwordmancyMode.description": "Daily Trial of Swordmancy: Auto draw cards and battle\nFarm Coating: Start from the nameplate drawing screen in Free Calculation mode",
     "option.TrialOfSwordmancyMode.cases.Daily.label": "Daily Trial of Swordmancy",
-    "option.TrialOfSwordmancyMode.cases.Coating.label": "Farm Coating"
+    "option.TrialOfSwordmancyMode.cases.Coating.label": "Farm Coating",
+    "option.TrialOfSwordmancyMode.cases.Farm25.label": "Farm 25 Points"
 }

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -1035,7 +1035,7 @@
     "task.TrialOfSwordmancy.label": "🗡️Trial of Swordmancy",
     "task.TrialOfSwordmancy.description": "Automatically complete Daily Trial of Swordmancy / Farm Coating",
     "option.TrialOfSwordmancyMode.label": "Task Mode",
-    "option.TrialOfSwordmancyMode.description": "Daily Trial of Swordmancy: Auto draw cards and battle\nFarm Coating: Start from the nameplate drawing screen in Free Calculation mode",
+    "option.TrialOfSwordmancyMode.description": "Daily Trial of Swordmancy: Auto draw cards and battle\nFarm Coating: Start from the nameplate drawing screen in Free Calculation mode\nFarm 25 Points: Same as Farm Coating — start from the nameplate drawing screen in Free Calculation mode",
     "option.TrialOfSwordmancyMode.cases.Daily.label": "Daily Trial of Swordmancy",
     "option.TrialOfSwordmancyMode.cases.Coating.label": "Farm Coating",
     "option.TrialOfSwordmancyMode.cases.Farm25.label": "Farm 25 Points"

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -1037,5 +1037,6 @@
     "option.TrialOfSwordmancyMode.label": "タスクモード",
     "option.TrialOfSwordmancyMode.description": "デイリー剣術演武：自動でカードを引いて戦闘\nコーティング周回：自由演算モード中、銘牌ガチャ画面からタスクを開始してください",
     "option.TrialOfSwordmancyMode.cases.Daily.label": "デイリー剣術演武",
-    "option.TrialOfSwordmancyMode.cases.Coating.label": "コーティング周回"
+    "option.TrialOfSwordmancyMode.cases.Coating.label": "コーティング周回",
+    "option.TrialOfSwordmancyMode.cases.Farm25.label": "25点周回"
 }

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -1035,7 +1035,7 @@
     "task.TrialOfSwordmancy.label": "🗡️剣術演武",
     "task.TrialOfSwordmancy.description": "デイリー剣術演武 / コーティング周回を自動完了",
     "option.TrialOfSwordmancyMode.label": "タスクモード",
-    "option.TrialOfSwordmancyMode.description": "デイリー剣術演武：自動でカードを引いて戦闘\nコーティング周回：自由演算モード中、銘牌ガチャ画面からタスクを開始してください",
+    "option.TrialOfSwordmancyMode.description": "デイリー剣術演武：自動でカードを引いて戦闘\nコーティング周回：自由演算モード中、銘牌ガチャ画面からタスクを開始してください\n25点周回：コーティング周回と同様、自由演算モード中、銘牌ガチャ画面からタスクを開始してください",
     "option.TrialOfSwordmancyMode.cases.Daily.label": "デイリー剣術演武",
     "option.TrialOfSwordmancyMode.cases.Coating.label": "コーティング周回",
     "option.TrialOfSwordmancyMode.cases.Farm25.label": "25点周回"

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -1037,5 +1037,6 @@
     "option.TrialOfSwordmancyMode.label": "작업 모드",
     "option.TrialOfSwordmancyMode.description": "일일 검술 연무: 자동 카드 뽑기 및 전투\n코팅 파밍: 자유 연산 모드에서 명함 뽑기 화면으로 시작하세요",
     "option.TrialOfSwordmancyMode.cases.Daily.label": "일일 검술 연무",
-    "option.TrialOfSwordmancyMode.cases.Coating.label": "코팅 파밍"
+    "option.TrialOfSwordmancyMode.cases.Coating.label": "코팅 파밍",
+    "option.TrialOfSwordmancyMode.cases.Farm25.label": "25점 파밍"
 }

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -1035,7 +1035,7 @@
     "task.TrialOfSwordmancy.label": "🗡️검술 연무",
     "task.TrialOfSwordmancy.description": "일일 검술 연무 / 코팅 파밍 자동 완료",
     "option.TrialOfSwordmancyMode.label": "작업 모드",
-    "option.TrialOfSwordmancyMode.description": "일일 검술 연무: 자동 카드 뽑기 및 전투\n코팅 파밍: 자유 연산 모드에서 명함 뽑기 화면으로 시작하세요",
+    "option.TrialOfSwordmancyMode.description": "일일 검술 연무: 자동 카드 뽑기 및 전투\n코팅 파밍: 자유 연산 모드에서 명함 뽑기 화면으로 시작하세요\n25점 파밍: 코팅 파밍과 동일, 자유 연산 모드에서 명함 뽑기 화면으로 시작하세요",
     "option.TrialOfSwordmancyMode.cases.Daily.label": "일일 검술 연무",
     "option.TrialOfSwordmancyMode.cases.Coating.label": "코팅 파밍",
     "option.TrialOfSwordmancyMode.cases.Farm25.label": "25점 파밍"

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -1035,7 +1035,7 @@
     "task.TrialOfSwordmancy.label": "🗡️选剑演武",
     "task.TrialOfSwordmancy.description": "自动完成每日选剑演武 / 刷刻章镀层",
     "option.TrialOfSwordmancyMode.label": "任务模式",
-    "option.TrialOfSwordmancyMode.description": "每日选剑演武：自动抽牌并自动作战\n刷镀层：请在处于自由演算模式下，于抽取铭牌界面开始任务",
+    "option.TrialOfSwordmancyMode.description": "每日选剑演武：自动抽牌并自动作战\n刷镀层：请在处于自由演算模式下，于抽取铭牌界面开始任务\n刷25点：同刷镀层，请在处于自由演算模式下，于抽取铭牌界面开始任务",
     "option.TrialOfSwordmancyMode.cases.Daily.label": "每日选剑演武",
     "option.TrialOfSwordmancyMode.cases.Coating.label": "刷镀层",
     "option.TrialOfSwordmancyMode.cases.Farm25.label": "刷25点"

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -1037,5 +1037,6 @@
     "option.TrialOfSwordmancyMode.label": "任务模式",
     "option.TrialOfSwordmancyMode.description": "每日选剑演武：自动抽牌并自动作战\n刷镀层：请在处于自由演算模式下，于抽取铭牌界面开始任务",
     "option.TrialOfSwordmancyMode.cases.Daily.label": "每日选剑演武",
-    "option.TrialOfSwordmancyMode.cases.Coating.label": "刷镀层"
+    "option.TrialOfSwordmancyMode.cases.Coating.label": "刷镀层",
+    "option.TrialOfSwordmancyMode.cases.Farm25.label": "刷25点"
 }

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -1035,7 +1035,7 @@
     "task.TrialOfSwordmancy.label": "🗡️選劍演武",
     "task.TrialOfSwordmancy.description": "自動完成每日選劍演武 / 刷刻章鍍層",
     "option.TrialOfSwordmancyMode.label": "任務模式",
-    "option.TrialOfSwordmancyMode.description": "每日選劍演武：自動抽牌並自動作戰\n刷鍍層：請在處於自由演算模式下，於抽取銘牌界面開始任務",
+    "option.TrialOfSwordmancyMode.description": "每日選劍演武：自動抽牌並自動作戰\n刷鍍層：請在處於自由演算模式下，於抽取銘牌界面開始任務\n刷25點：同刷鍍層，請在處於自由演算模式下，於抽取銘牌界面開始任務",
     "option.TrialOfSwordmancyMode.cases.Daily.label": "每日選劍演武",
     "option.TrialOfSwordmancyMode.cases.Coating.label": "刷鍍層",
     "option.TrialOfSwordmancyMode.cases.Farm25.label": "刷25點"

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -1037,5 +1037,6 @@
     "option.TrialOfSwordmancyMode.label": "任務模式",
     "option.TrialOfSwordmancyMode.description": "每日選劍演武：自動抽牌並自動作戰\n刷鍍層：請在處於自由演算模式下，於抽取銘牌界面開始任務",
     "option.TrialOfSwordmancyMode.cases.Daily.label": "每日選劍演武",
-    "option.TrialOfSwordmancyMode.cases.Coating.label": "刷鍍層"
+    "option.TrialOfSwordmancyMode.cases.Coating.label": "刷鍍層",
+    "option.TrialOfSwordmancyMode.cases.Farm25.label": "刷25點"
 }

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancy.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancy.json
@@ -5,7 +5,8 @@
         "post_delay": 0,
         "next": [
             "TrialOfSwordmancyDaily",
-            "TrialOfSwordmancyCoating"
+            "TrialOfSwordmancyCoating",
+            "TrialOfSwordmancyFarm25"
         ]
     },
     "TrialOfSwordmancyDaily": {
@@ -21,6 +22,15 @@
     },
     "TrialOfSwordmancyCoating": {
         "desc": "自动刷镀层",
+        "enabled": false,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "TrialOfSwordmancyCoatingMain"
+        ]
+    },
+    "TrialOfSwordmancyFarm25": {
+        "desc": "自动刷25点",
         "enabled": false,
         "pre_delay": 0,
         "post_delay": 0,

--- a/assets/tasks/TrialOfSwordmancy.json
+++ b/assets/tasks/TrialOfSwordmancy.json
@@ -41,6 +41,40 @@
                             "enabled": true
                         }
                     }
+                },
+                {
+                    "name": "Farm25",
+                    "label": "$option.TrialOfSwordmancyMode.cases.Farm25.label",
+                    "pipeline_override": {
+                        "TrialOfSwordmancyFarm25": {
+                            "enabled": true
+                        },
+                        "TrialOfSwordmancyCoatingCheck1": {
+                            "any_of": [
+                                "TrialOfSwordmancyBattlePts5"
+                            ]
+                        },
+                        "TrialOfSwordmancyCoatingCheck2": {
+                            "any_of": [
+                                "TrialOfSwordmancyBattlePts10"
+                            ]
+                        },
+                        "TrialOfSwordmancyCoatingCheck3": {
+                            "any_of": [
+                                "TrialOfSwordmancyBattlePts4"
+                            ]
+                        },
+                        "TrialOfSwordmancyCoatingCheck4": {
+                            "any_of": [
+                                "TrialOfSwordmancyBattlePts9"
+                            ]
+                        },
+                        "TrialOfSwordmancyCoatingCheck5": {
+                            "any_of": [
+                                "TrialOfSwordmancyBattlePts3"
+                            ]
+                        }
+                    }
                 }
             ]
         }


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

为“Trial of Swordmancy（剑术试炼）”模式新增一个 25 分选项，并将其接入任务和流水线配置。

新功能：
- 为 “Trial of Swordmancy（剑术试炼）”活动引入一个 25 分变体。

增强与改进：
- 更新 “Trial of Swordmancy（剑术试炼）”的流水线和任务配置，以支持新的 25 分变体。
- 为新的 “Trial of Swordmancy（剑术试炼）”选项刷新所有受支持语言的界面本地化条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new 25-point option to the Trial of Swordmancy mode and wire it into task and pipeline configuration.

New Features:
- Introduce a 25-point variant for the Trial of Swordmancy activity.

Enhancements:
- Update Trial of Swordmancy pipeline and task configuration to support the new 25-point variant.
- Refresh interface localization entries across all supported languages for the new Trial of Swordmancy option.

</details>