### PR TITLE
feat(map): 变更部分高级参数

### DIFF
--- a/agent/go-service/maptracker/compatible/assert_compatible.go
+++ b/agent/go-service/maptracker/compatible/assert_compatible.go
@@ -89,6 +89,5 @@ func (r *MapTrackerAssertLocationCompatible) convertParam(param *mapLocateAssert
 			},
 		},
 		Threshold: param.LocThreshold,
-		FastMode:  true,
 	}, nil
 }

--- a/agent/go-service/maptracker/compatible/assert_compatible_test.go
+++ b/agent/go-service/maptracker/compatible/assert_compatible_test.go
@@ -76,9 +76,6 @@ func TestMapTrackerAssertLocationCompatibleConvertsRegionalSamples(t *testing.T)
 					t.Fatalf("target[%d] got %.3f, want %.3f", i, condition.Target[i], expect)
 				}
 			}
-			if !converted.FastMode {
-				t.Fatal("expected fast_mode")
-			}
 		})
 	}
 }

--- a/agent/go-service/maptracker/default/assert_location.go
+++ b/agent/go-service/maptracker/default/assert_location.go
@@ -4,8 +4,6 @@ package maptrackerdefault
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
@@ -27,8 +25,6 @@ type MapTrackerAssertLocationParam struct {
 	Precision float64 `json:"precision,omitempty"`
 	// Threshold controls the minimum confidence required to consider the inference successful.
 	Threshold float64 `json:"threshold,omitempty"`
-	// Whether to enable fast mode for matching.
-	FastMode bool `json:"fast_mode,omitempty"`
 }
 
 var _ maa.CustomRecognitionRunner = &MapTrackerAssertLocation{}
@@ -42,28 +38,9 @@ func (r *MapTrackerAssertLocation) Run(ctx *maa.Context, arg *maa.CustomRecognit
 		return nil, false
 	}
 
-	mapNameRegex := ".*"
-	if param.FastMode {
-		// Build map_name_regex based on expected conditions to focus the search
-		mapNamesMap := make(map[string]struct{})
-		var mapNames []string
-		for _, condition := range param.Expected {
-			if _, exists := mapNamesMap[condition.MapName]; !exists {
-				mapNamesMap[condition.MapName] = struct{}{}
-				mapNames = append(mapNames, regexp.QuoteMeta(condition.MapName))
-			}
-		}
-		if len(mapNames) == 0 {
-			log.Error().Msg("Failed to extract map names from expected conditions")
-			return nil, false
-		}
-
-		mapNameRegex = "^(" + strings.Join(mapNames, "|") + ")$"
-	}
-
 	// Prepare and run MapTrackerInfer
 	inferConfig := map[string]any{
-		"map_name_regex": mapNameRegex,
+		"map_name_regex": ".*",
 		"precision":      param.Precision,
 		"threshold":      param.Threshold,
 	}

--- a/agent/go-service/maptracker/default/infer.go
+++ b/agent/go-service/maptracker/default/infer.go
@@ -40,12 +40,20 @@ type MapTrackerInferParam struct {
 	Precision float64 `json:"precision,omitempty"`
 	// Threshold controls the minimum confidence required to consider the inference successful.
 	Threshold float64 `json:"threshold,omitempty"`
+	// AllowedModes controls which location inference modes are allowed.
+	AllowedModes int `json:"allowed_modes,omitempty"`
 }
+
+const (
+	INFER_MODE_FULL_SEARCH = 1
+	INFER_MODE_FAST_SEARCH = 2
+)
 
 var mapTrackerInferDefaultParam = MapTrackerInferParam{
 	MapNameRegex: "^map\\d+_lv\\d+$",
 	Precision:    0.5,
 	Threshold:    0.4,
+	AllowedModes: INFER_MODE_FULL_SEARCH | INFER_MODE_FAST_SEARCH,
 }
 
 // MapTrackerInfer is the custom recognition component for map tracking
@@ -147,6 +155,12 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 			if globalInferState.IsImmediateTrackLoss() {
 				// It's an immediate track loss, start a new pending
 				globalInferState.SetPending(*loc)
+
+				if param.AllowedModes&INFER_MODE_FAST_SEARCH == 0 {
+					// If fast search is not allowed, directly take this hit as final to avoid long wait for next hit
+					// Otherwise, don't set finalLoc here to wait for next fast search
+					finalLoc = loc
+				}
 			} else {
 				// It's a stale track loss, directly replace convinced with this new hit
 				globalInferState.SetConvinced(*loc)
@@ -232,6 +246,12 @@ func (r *MapTrackerInfer) parseParam(paramStr string) (*MapTrackerInferParam, er
 			} else if param.Threshold < 0.0 || param.Threshold > 1.0 {
 				return nil, fmt.Errorf("invalid threshold value: %f", param.Threshold)
 			}
+
+			if param.AllowedModes == 0 {
+				param.AllowedModes = mapTrackerInferDefaultParam.AllowedModes
+			} else if param.AllowedModes&INFER_MODE_FULL_SEARCH == 0 {
+				return nil, fmt.Errorf("allowed_modes must include INFER_MODE_FULL_SEARCH")
+			}
 		} else {
 			return nil, fmt.Errorf("failed to unmarshal parameters: %w", err)
 		}
@@ -315,7 +335,7 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 	}
 
 	// Try fast search if stable
-	if isStable() {
+	if param.AllowedModes&INFER_MODE_FAST_SEARCH != 0 && isStable() {
 		fastBestVal := -1.0
 		fastBestX, fastBestY := 0.0, 0.0
 		fastBestMapName := ""

--- a/docs/en_us/developers/components/map-tracker(advanced).md
+++ b/docs/en_us/developers/components/map-tracker(advanced).md
@@ -39,6 +39,8 @@ Optional parameters:
 
 - `threshold`: A real number between $(0, 1]$, default `0.4`. Controls the confidence threshold for matching. Matching results below this value will not be recognized.
 
+- `allowed_modes`: Integer, default `3`. Advanced parameter that controls which location inference modes are allowed. The value is a bitwise OR of `INFER_MODE_FULL_SEARCH = 1` and `INFER_MODE_FAST_SEARCH = 2`. This parameter must include `INFER_MODE_FULL_SEARCH`.
+
 ### Recognition: MapTrackerBigMapInfer
 
 🗺️ Infer the coordinates and map zoom of the current view area in the map within the large map interface.

--- a/docs/en_us/developers/components/map-tracker.md
+++ b/docs/en_us/developers/components/map-tracker.md
@@ -179,8 +179,6 @@ Required parameters:
 
 - `threshold`: Same meaning as the `threshold` parameter in the [MapTrackerInfer](./map-tracker%28advanced%29.md#recognition-maptrackerinfer) node.
 
-- `fast_mode`: Boolean value, default `false`. Controls whether to enable fast matching mode to further improve recognition speed. Unless encountering performance bottlenecks, it is not recommended to enable this mode.
-
 </details>
 
 #### Example Usage

--- a/docs/zh_cn/developers/components/map-tracker(advanced).md
+++ b/docs/zh_cn/developers/components/map-tracker(advanced).md
@@ -39,6 +39,8 @@
 
 - `threshold`: 介于 $(0, 1]$ 的实数，默认 `0.4`。控制匹配的置信度阈值。低于此值的匹配结果将不命中识别。
 
+- `allowed_modes`: 整数，默认 `3`。高级参数，控制允许使用的定位推断模式，取值为 `INFER_MODE_FULL_SEARCH = 1` 与 `INFER_MODE_FAST_SEARCH = 2` 的按位或结果。该参数必须包含 `INFER_MODE_FULL_SEARCH`。
+
 ### Recognition: MapTrackerBigMapInfer
 
 🗺️ 在大地图界面中推断当前视野区域在地图中的坐标与地图缩放。

--- a/docs/zh_cn/developers/components/map-tracker.md
+++ b/docs/zh_cn/developers/components/map-tracker.md
@@ -270,8 +270,6 @@
 
 - `threshold`: 含义同 [MapTrackerInfer](./map-tracker%28advanced%29.md#recognition-maptrackerinfer) 节点中的 `threshold` 参数。
 
-- `fast_mode`: 真假值，默认 `false`。控制是否开启快速匹配模式，以额外提升识别速度。除非遇到性能瓶颈，否则不建议开启此模式。
-
 </details>
 
 #### 示例用法

--- a/tools/map_tracker/_internal/location_service.py
+++ b/tools/map_tracker/_internal/location_service.py
@@ -97,7 +97,7 @@ class LocationService:
                 continue
             try:
                 with self._infer_lock:
-                    result = self._maa_interface.do_infer()
+                    result = self._maa_interface.do_infer(precision=0.9)
                 if not self._is_map_match(result["map_name"], self._expected_map_name):
                     raise ValueError(
                         f"Location map mismatch, expected '{self._expected_map_name}', got '{result['map_name']}'"
@@ -140,7 +140,7 @@ class LocationService:
     def infer_once(self, expected_map_name: str) -> MapTrackerInferResult:
         self._ensure_initialized()
         with self._infer_lock:
-            result = self._maa_interface.do_infer()
+            result = self._maa_interface.do_infer(precision=0.9)
         if not self._is_map_match(result["map_name"], expected_map_name):
             raise ValueError(
                 f"Location map mismatch, expected '{expected_map_name}', got '{result['map_name']}'"

--- a/tools/map_tracker/_internal/maa_interface.py
+++ b/tools/map_tracker/_internal/maa_interface.py
@@ -87,7 +87,7 @@ class MaaInterface:
             window = self._find_win32_window()
             self.controller = Win32Controller(
                 window.hwnd,
-                screencap_method=MaaWin32ScreencapMethodEnum.Background,
+                screencap_method=MaaWin32ScreencapMethodEnum.FramePool,
                 mouse_method=MaaWin32InputMethodEnum.Seize,
                 keyboard_method=MaaWin32InputMethodEnum.Seize,
             )
@@ -176,7 +176,9 @@ class MaaInterface:
         except Exception:
             pass
 
-    def do_infer(self) -> MapTrackerInferResult:
+    def do_infer(
+        self, *, precision: float, allowed_modes: int = 3
+    ) -> MapTrackerInferResult:
         if self.controller is None:
             raise MaaRuntimeError("Controller not initialized")
         if self.agent_client is None:
@@ -192,7 +194,8 @@ class MaaInterface:
                         "custom_recognition": "MapTrackerInfer",
                         "custom_recognition_param": {
                             "map_name_regex": ".*",
-                            "precision": 0.8,
+                            "precision": precision,
+                            "allowed_modes": allowed_modes,
                         },
                     },
                 },
@@ -266,14 +269,3 @@ class MaaInterface:
 
         if not task_detail.status.succeeded:
             raise MaaRuntimeError("Goal action failed")
-
-
-# Testing
-if __name__ == "__main__":
-    maa_interface = MaaInterface()
-    try:
-        maa_interface.init_controller()
-        maa_interface.init_agent()
-        maa_interface.do_infer()
-    finally:
-        maa_interface.dispose_agent()

--- a/tools/schema/components/map_tracker.schema.json
+++ b/tools/schema/components/map_tracker.schema.json
@@ -335,12 +335,6 @@
                     "exclusiveMinimum": 0,
                     "maximum": 1,
                     "default": 0.4
-                },
-                "fast_mode": {
-                    "title": "Fast Mode",
-                    "description": "Enable fast matching mode for extra speed. Not recommended unless hitting performance bottleneck.",
-                    "type": "boolean",
-                    "default": false
                 }
             }
         },

--- a/tools/schema/components/map_tracker.schema.json
+++ b/tools/schema/components/map_tracker.schema.json
@@ -364,6 +364,14 @@
                     "exclusiveMinimum": 0,
                     "maximum": 1,
                     "default": 0.4
+                },
+                "allowed_modes": {
+                    "title": "Allowed Modes",
+                    "description": "Bitmask controlling which location inference modes are allowed. 1 = FullSearch, 2 = FastSearch. Default 3 (both).",
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3,
+                    "default": 3
                 }
             }
         },


### PR DESCRIPTION
## 概要

此 PR 移除了 MapTrackerAssertLocation 的 fast_mode 参数，因为从未被使用；向 MapTrackerInfer 添加了 allowed_modes 参数。

此外变更了工具脚本中的某些参数使用。

## 由 Sourcery 提供的摘要

更新地图追踪器位置推断选项和工具，移除未使用的 fast 模式，并引入可配置的允许模式。

新功能：
- 为 `MapTrackerInfer` 添加 `allowed_modes` 参数，用于控制可以使用哪些位置推断模式。

增强改进：
- 从 `MapTrackerAssertLocation` 中移除未使用的 `fast_mode` 选项，并简化其地图名称匹配行为。
- 调整 `MapTrackerInfer` 行为，使快速搜索仅在明确允许时才使用，并在配置 `allowed_modes` 时强制始终启用全面搜索。
- 更新 Python 地图追踪器工具，将 `precision` 和 `allowed_modes` 传入 `MapTrackerInfer`，并默认使用 `FramePool` 屏幕捕捉方法。

文档：
- 在英文和中文的高级地图追踪器文档中记录 `MapTrackerInfer` 的新参数 `allowed_modes`，并从断言相关文档中移除对 `fast_mode` 的引用。

测试：
- 移除与已废弃的 `fast_mode` 参数相关的兼容性测试期望。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update map tracker location inference options and tooling to remove unused fast mode and introduce configurable allowed modes.

New Features:
- Add an allowed_modes parameter to MapTrackerInfer to control which location inference modes can be used.

Enhancements:
- Remove the unused fast_mode option from MapTrackerAssertLocation and simplify its map name matching behavior.
- Adjust MapTrackerInfer behavior so fast search is only used when explicitly allowed, and enforce that full search is always enabled when configuring allowed_modes.
- Update the Python map tracker tooling to pass precision and allowed_modes into MapTrackerInfer and to use the FramePool screen capture method by default.

Documentation:
- Document the new allowed_modes parameter for MapTrackerInfer in both English and Chinese advanced map tracker documentation and remove references to fast_mode from assertion docs.

Tests:
- Remove compatibility test expectations related to the deprecated fast_mode parameter.

</details>