### PR TITLE
feat(MapNavigator): 异步检测 COLLECT

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
@@ -96,25 +96,6 @@ fs::path getExeDir()
     return get_exe_dir();
 }
 
-class ScopedImageBuffer
-{
-public:
-    ScopedImageBuffer()
-        : buffer_(MaaImageBufferCreate())
-    {
-    }
-
-    ~ScopedImageBuffer() { MaaImageBufferDestroy(buffer_); }
-
-    ScopedImageBuffer(const ScopedImageBuffer&) = delete;
-    ScopedImageBuffer& operator=(const ScopedImageBuffer&) = delete;
-
-    MaaImageBuffer* Get() const { return buffer_; }
-
-private:
-    MaaImageBuffer* buffer_;
-};
-
 template <typename T>
 T ParseCustomRecognitionParam(const char* custom_recognition_param)
 {

--- a/agent/cpp-algo/source/MapNavigator/MapNavigatorCompatible.cpp
+++ b/agent/cpp-algo/source/MapNavigator/MapNavigatorCompatible.cpp
@@ -21,6 +21,7 @@
 #include <MaaUtils/NoWarningCV.hpp>
 
 #include "../MapLocator/MapLocateAction.h"
+#include "../utils.h"
 #include "action_wrapper.h"
 #include "navi_controller.h"
 #include "navi_math.h"
@@ -218,54 +219,6 @@ std::optional<MapNavigatorCompatibleLocateDetail> try_parse_locate_detail(const 
     }
     return detail;
 }
-
-class ScopedImageBuffer
-{
-public:
-    ScopedImageBuffer()
-        : buffer_(MaaImageBufferCreate())
-    {
-    }
-
-    ~ScopedImageBuffer()
-    {
-        if (buffer_ != nullptr) {
-            MaaImageBufferDestroy(buffer_);
-        }
-    }
-
-    ScopedImageBuffer(const ScopedImageBuffer&) = delete;
-    ScopedImageBuffer& operator=(const ScopedImageBuffer&) = delete;
-
-    MaaImageBuffer* Get() const { return buffer_; }
-
-private:
-    MaaImageBuffer* buffer_ = nullptr;
-};
-
-class ScopedStringBuffer
-{
-public:
-    ScopedStringBuffer()
-        : buffer_(MaaStringBufferCreate())
-    {
-    }
-
-    ~ScopedStringBuffer()
-    {
-        if (buffer_ != nullptr) {
-            MaaStringBufferDestroy(buffer_);
-        }
-    }
-
-    ScopedStringBuffer(const ScopedStringBuffer&) = delete;
-    ScopedStringBuffer& operator=(const ScopedStringBuffer&) = delete;
-
-    MaaStringBuffer* Get() const { return buffer_; }
-
-private:
-    MaaStringBuffer* buffer_ = nullptr;
-};
 
 struct MapTrackerImageCacheEntry
 {

--- a/agent/cpp-algo/source/MapNavigator/action_executor.cpp
+++ b/agent/cpp-algo/source/MapNavigator/action_executor.cpp
@@ -80,7 +80,7 @@ ActionExecutionResult ActionExecutor::Execute(ActionType action)
         break;
 
     case ActionType::COLLECT:
-        LogWarn << "COLLECT action dispatched to ActionExecutor unexpectedly.";
+        LogInfo << "Action: COLLECT waypoint passed (pass-through; collection is detection-driven while walking).";
         break;
 
     case ActionType::DIG:

--- a/agent/cpp-algo/source/MapNavigator/collectible_scanner.cpp
+++ b/agent/cpp-algo/source/MapNavigator/collectible_scanner.cpp
@@ -1,0 +1,184 @@
+#include "collectible_scanner.h"
+
+#include <cmath>
+#include <utility>
+
+#include <opencv2/imgproc.hpp>
+
+#include <MaaUtils/Logger.h>
+
+#include "navi_config.h"
+
+namespace mapnavigator
+{
+
+namespace
+{
+
+// Scale the base-resolution collect ROI (1280x720, from the pipeline) to the real frame size, clamped.
+cv::Rect ScaledRoi(const cv::Size& frame_size, const cv::Rect& base_roi)
+{
+    const double sx = static_cast<double>(frame_size.width) / static_cast<double>(kCollectRoiBaseWidth);
+    const double sy = static_cast<double>(frame_size.height) / static_cast<double>(kCollectRoiBaseHeight);
+    const cv::Rect roi(
+        static_cast<int>(std::lround(base_roi.x * sx)),
+        static_cast<int>(std::lround(base_roi.y * sy)),
+        static_cast<int>(std::lround(base_roi.width * sx)),
+        static_cast<int>(std::lround(base_roi.height * sy)));
+    return roi & cv::Rect(0, 0, frame_size.width, frame_size.height);
+}
+
+// Collapse a BGRA/BGR/gray ROI to one channel, shared by both detectors. Lives here (not utils.h) so this
+// framework-free worker TU doesn't pull in the framework headers utils.h includes.
+cv::Mat ToGray(const cv::Mat& roi)
+{
+    cv::Mat gray;
+    switch (roi.channels()) {
+    case 4:
+        cv::cvtColor(roi, gray, cv::COLOR_BGRA2GRAY);
+        break;
+    case 3:
+        cv::cvtColor(roi, gray, cv::COLOR_BGR2GRAY);
+        break;
+    default:
+        gray = roi;
+        break;
+    }
+    return gray;
+}
+
+// Fallback detector: threshold bright pixels, close horizontally so a word's glyphs merge into one blob, then
+// look for a connected component shaped like a short, wide, sparse text run. Input is already grayscale.
+bool HasLabelLikeText(const cv::Mat& gray)
+{
+    if (gray.empty()) {
+        return false;
+    }
+
+    cv::Mat bright;
+    cv::threshold(gray, bright, kCollectLabelBrightThreshold, 255, cv::THRESH_BINARY);
+
+    cv::Mat joined;
+    const cv::Mat kernel = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(kCollectLabelMorphWidth, 1));
+    cv::morphologyEx(bright, joined, cv::MORPH_CLOSE, kernel);
+
+    cv::Mat labels;
+    cv::Mat stats;
+    cv::Mat centroids;
+    const int n = cv::connectedComponentsWithStats(joined, labels, stats, centroids, 8, CV_32S);
+
+    int best_w = 0;
+    for (int i = 1; i < n; ++i) {  // 0 is the background component
+        const int w = stats.at<int>(i, cv::CC_STAT_WIDTH);
+        const int h = stats.at<int>(i, cv::CC_STAT_HEIGHT);
+        const int area = stats.at<int>(i, cv::CC_STAT_AREA);
+        if (h < kCollectLabelMinHeight || h > kCollectLabelMaxHeight) {
+            continue;  // too thin to be a glyph row, or too tall to be one
+        }
+        const double fill = static_cast<double>(area) / (static_cast<double>(w) * static_cast<double>(h));
+        if (fill > kCollectLabelMaxFill) {
+            continue;  // a near-solid block is a panel/icon, not sparse text
+        }
+        if (w > best_w) {
+            best_w = w;
+        }
+    }
+
+    if (best_w > 0) {
+        LogDebug << "CollectibleScanner candidate." << VAR(best_w);
+    }
+    return best_w >= kCollectLabelMinWidth;
+}
+
+// Primary detector: template-match the interact icon (white ⟳). Template and ROI share base scale, so it
+// matches at native size (no rescale); a ⟳ is far harder for terrain to fake than a bright blob. Already gray.
+bool MatchesIcon(const cv::Mat& gray, const cv::Mat& templ)
+{
+    if (gray.empty() || templ.empty() || gray.rows < templ.rows || gray.cols < templ.cols) {
+        return false;
+    }
+
+    cv::Mat result;
+    cv::matchTemplate(gray, templ, result, cv::TM_CCOEFF_NORMED);
+    double max_val = 0.0;
+    cv::minMaxLoc(result, nullptr, &max_val, nullptr, nullptr);
+    if (max_val >= 0.5) {  // log near matches to calibrate the threshold without flooding
+        LogDebug << "CollectibleScanner icon match." << VAR(max_val);
+    }
+    return max_val >= kCollectIconMatchThreshold;
+}
+
+} // namespace
+
+CollectibleScanner::CollectibleScanner(const cv::Rect& base_roi, const cv::Mat& icon_template)
+    : base_roi_(base_roi)
+    , icon_template_(icon_template)
+{
+    worker_ = std::thread(&CollectibleScanner::WorkerLoop, this);
+}
+
+CollectibleScanner::~CollectibleScanner()
+{
+    stop_.store(true);
+    cv_.notify_all();
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+}
+
+void CollectibleScanner::SubmitFrame(const cv::Mat& frame)
+{
+    if (frame.empty()) {
+        return;
+    }
+    const cv::Rect roi = ScaledRoi(frame.size(), base_roi_);
+    if (roi.width <= 0 || roi.height <= 0) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        frame(roi).copyTo(pending_roi_);  // deep copy: the controller reuses the frame buffer after we return
+        has_pending_ = true;
+    }
+    cv_.notify_one();
+}
+
+bool CollectibleScanner::ConsumeDetection()
+{
+    return detected_.exchange(false);
+}
+
+void CollectibleScanner::WorkerLoop()
+{
+    for (;;) {
+        cv::Mat roi;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait(lock, [this] { return has_pending_ || stop_.load(); });
+            if (stop_.load()) {
+                return;
+            }
+            roi = std::move(pending_roi_);
+            has_pending_ = false;
+        }
+
+        // Normalize the crop back to the authored ROI size so detection runs in one fixed pixel space.
+        // INTER_AREA for the downscale.
+        cv::Mat normalized;
+        if (roi.size() == base_roi_.size()) {
+            normalized = roi;
+        }
+        else {
+            cv::resize(roi, normalized, base_roi_.size(), 0, 0, cv::INTER_AREA);
+        }
+
+        const cv::Mat gray = ToGray(normalized);
+        const bool hit = icon_template_.empty() ? HasLabelLikeText(gray) : MatchesIcon(gray, icon_template_);
+        if (hit) {
+            detected_.store(true);
+        }
+    }
+}
+
+} // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/collectible_scanner.h
+++ b/agent/cpp-algo/source/MapNavigator/collectible_scanner.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include <opencv2/core.hpp>
+
+namespace mapnavigator
+{
+
+// Off-thread collectible pre-filter. The single nav thread can't run a nested framework recognition mid-tick
+// (it wedges the next controller IPC), so detection runs on a worker that touches ONLY OpenCV; the nav loop
+// does the authoritative stop + collect RunTask once a label is flagged. Primary detector is template-matching
+// the interact ICON (white ⟳ glyph); the bright-text-blob heuristic is the fallback when the icon can't load.
+class CollectibleScanner
+{
+public:
+    // base_roi: scan region in the pipeline's authored base resolution (not live-frame). Frames are cropped to
+    // the rescaled region and normalized back to base_roi's size, so detection runs in one resolution-
+    // independent pixel space. icon_template: grayscale, base scale; empty -> fall back to the heuristic.
+    CollectibleScanner(const cv::Rect& base_roi, const cv::Mat& icon_template);
+    ~CollectibleScanner();
+
+    CollectibleScanner(const CollectibleScanner&) = delete;
+    CollectibleScanner& operator=(const CollectibleScanner&) = delete;
+
+    // Capture-chokepoint side (nav thread). Hands the collect ROI to the worker without blocking; a frame
+    // arriving while the worker is busy overwrites the pending one (latest-wins).
+    void SubmitFrame(const cv::Mat& frame);
+
+    // Nav-loop side. Returns true once per detection (consume-on-read latch), so one flagged label = one
+    // collect attempt; the latch holds across the collect cooldown so a detection isn't lost.
+    bool ConsumeDetection();
+
+private:
+    void WorkerLoop();
+
+    cv::Rect base_roi_;
+    cv::Mat icon_template_;  // grayscale; empty → fall back to the bright-text-blob heuristic
+    std::thread worker_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    cv::Mat pending_roi_;
+    bool has_pending_ = false;
+    std::atomic<bool> stop_ { false };
+    std::atomic<bool> detected_ { false };
+};
+
+} // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/motion_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/motion_controller.cpp
@@ -125,8 +125,21 @@ bool MotionController::SupportsSprint() const
     return action_wrapper_ != nullptr && action_wrapper_->SupportsSprint();
 }
 
+void MotionController::SetSprintSuppressed(bool suppressed)
+{
+    if (suppressed && !sprint_suppressed_ && sprint_active_ && is_moving_forward_ && action_wrapper_ != nullptr) {
+        action_wrapper_->ResetForwardWalkSync(kSprintCancelReleaseMs);
+        sprint_active_ = false;
+        LogInfo << "Sprint cancelled near collect point (dropped to walking speed).";
+    }
+    sprint_suppressed_ = suppressed;
+}
+
 bool MotionController::TriggerSprint()
 {
+    if (sprint_suppressed_) {
+        return false;
+    }
     if (!SupportsSprint()) {
         return false;
     }

--- a/agent/cpp-algo/source/MapNavigator/motion_controller.h
+++ b/agent/cpp-algo/source/MapNavigator/motion_controller.h
@@ -20,6 +20,7 @@ public:
     TurnCommandResult ApplySteering(double yaw_delta_deg);
     bool TriggerSprint();
     bool SupportsSprint() const;
+    void SetSprintSuppressed(bool suppressed);
     void SetAction(LocalDriverAction action, bool force);
 
     bool IsMoving() const;
@@ -44,6 +45,7 @@ private:
     bool is_moving_ = false;
     bool is_moving_forward_ = false;
     bool sprint_active_ = false;
+    bool sprint_suppressed_ = false;
 };
 
 } // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -137,6 +137,25 @@ constexpr const char* kDefaultCollectEntry = "AutoCollectClickStart";
 constexpr const char* kCollectPipelineOverride = R"({"AutoCollectClickEnd":{"next":[]}})";
 constexpr int32_t kCollectPostSleepMs = 80;
 
+constexpr const char* kCollectPrewarmOverride =
+    R"({"AutoCollectClick":{"action":{"type":"DoNothing"},"next":[]},"AutoCollectClickEnd":{"next":[]}})";
+constexpr const char* kCollectRoiNode = "AutoCollectClick";
+constexpr int32_t kCollectRoiBaseWidth = 1280;
+constexpr int32_t kCollectRoiBaseHeight = 720;
+
+constexpr const char* kCollectIconRelativePath = "resource/image/RealTimeTask/AutoPick.png";
+constexpr double kCollectIconMatchThreshold = 0.75;
+constexpr int32_t kCollectLabelBrightThreshold = 210;  // 0-255 luma; near-white glyphs survive, grass (~200) drops
+constexpr int32_t kCollectLabelMorphWidth = 8;         // horizontal close width that merges glyphs into a word
+constexpr int32_t kCollectLabelMinWidth = 24;          // ~2-char CJK name floor (the 5-char label measured 78px)
+constexpr int32_t kCollectLabelMinHeight = 7;          // reject thin specks (label glyph row ~14px)
+constexpr int32_t kCollectLabelMaxHeight = 26;         // reject tall non-text structures
+constexpr double kCollectLabelMaxFill = 0.80;          // text is sparse (label fill ~0.4-0.66); solid blob = panel/icon
+constexpr int32_t kCollectScanIntervalMs = 1500;
+constexpr double kCollectRetryMinMoveWu = 2.5;
+constexpr double kCollectSprintSuppressBandWu = 8.0;
+constexpr int32_t kSprintCancelReleaseMs = 60;
+
 constexpr const char* kDefaultDigEntry = "AutoCollectDigStart";
 constexpr const char* kDigPipelineOverride = R"({"AutoCollectDigEnd":{"next":[]}})";
 constexpr int32_t kDigPostSleepMs = 80;

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -94,6 +94,13 @@ constexpr double kCloseGoalDetourSuppressSlack = 6.0;
 constexpr int32_t kLocalizationLossUnstickIntervalMs = kObstacleRecoveryMinTriggerMs;
 constexpr int32_t kLocalizationLossTimeoutMs = kDynamicRecoveryTotalTimeoutMs;
 
+// Off-route wedge watchdog. Corridor progress (what the stall clocks see) keeps advancing while the authored
+// cursor is pinned far off-route, so a bad latch wanders with zero route progress until the action hard-fails.
+// Runs only while off-corridor with no straight-line gain: replan first, then fail-fast so the pipeline retries.
+constexpr int32_t kOffRouteWedgeReplanMs = 6000;
+constexpr int32_t kOffRouteWedgeReplanCooldownMs = 4000;
+constexpr int32_t kOffRouteWedgeFailMs = 12000;
+
 // --- NavRunController (RUN corridor follower) ---
 constexpr double kNavRunLookaheadLowSpeedM = 2.5;
 constexpr double kNavRunLookaheadWalkM = 4.0;

--- a/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
@@ -20,11 +20,12 @@ namespace mapnavigator
 // HEADING  - 无坐标朝向节点，执行时只调整镜头到指定角度，再按下W继续前进
 // NAVMESH  - 语义寻路节点，读取 .nav 并从当前定位位置自动规划到 target
 // ZONE     - 无坐标区域声明节点，要求后续定位稳定落在指定 zone 后再继续
-// COLLECT  - 精确抵达后停车，同步触发 AutoCollectClickStart pipeline 子任务
-//            （OCR + AutoAltClickAction），不退出 NaviController，避免每次采集
-//            都重建定位/重新 Bootstrap/吃掉起步宽限
-// DIG      - 同 COLLECT，但触发的是 AutoCollectDigStart pipeline 子任务
-//            （无条件 Click target=true 两次），用于挖掘点
+// COLLECT  - 仅作为"开启采集扫描"的路径点：经过时按普通路点直接推进，不再到点停车。
+//            采集完全由行进中的异步图标检测驱动——检测到采集物才立即停车并触发
+//            AutoCollectClickStart 子任务（OCR + AutoAltClickAction），没有采集物时不空停。
+//            （检测命中后有位移防卡死门限，避免被一直匹配到的非采集物困住）
+// DIG      - 触发 AutoCollectDigStart pipeline 子任务（无条件 Click target=true 两次），用于挖掘点。
+//            与 COLLECT 不同，DIG 仍是精确抵达后停车触发（挖掘是定点动作，非行进检测）
 #define NAVI_ACTION_TYPES(X) \
     X(RUN)                   \
     X(SPRINT)                \
@@ -81,7 +82,7 @@ struct Waypoint
         }
         return strict_arrival || action == ActionType::SPRINT || action == ActionType::JUMP || action == ActionType::INTERACT
                || action == ActionType::FIGHT || action == ActionType::TRANSFER || action == ActionType::PORTAL
-               || action == ActionType::NAVMESH || action == ActionType::COLLECT || action == ActionType::DIG;
+               || action == ActionType::NAVMESH || action == ActionType::DIG;
     }
 
     bool HasPosition() const { return has_position; }

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -122,6 +122,25 @@ struct SteeringRateState
     }
 };
 
+// Off-route wedge watchdog clock. Fed straight-line distance to the current waypoint and only run while the agent
+// is off the route corridor, so it grows only during a genuine no-progress wedge that the corridor-fed stall
+// clocks miss. Drives a replan, then a fail-fast.
+struct OffRouteWedgeState
+{
+    std::chrono::steady_clock::time_point since {};
+    std::chrono::steady_clock::time_point last_replan_at {};
+    double best_distance = std::numeric_limits<double>::max();
+    bool active = false;
+
+    void Reset()
+    {
+        since = {};
+        last_replan_at = {};
+        best_distance = std::numeric_limits<double>::max();
+        active = false;
+    }
+};
+
 struct NavigationRuntimeState
 {
     RouteTrackerState route;
@@ -130,6 +149,7 @@ struct NavigationRuntimeState
     DynamicRecoveryState recovery;
     LocalizationLossState localization_loss;
     SteeringRateState steering_rate;
+    OffRouteWedgeState offroute;
     bool dynamic_replan_requested = false;
     bool nav_run_dirty = true;
 
@@ -138,6 +158,7 @@ struct NavigationRuntimeState
         route.ResetTracking();
         recovery.Reset();
         steering_rate.Reset();
+        offroute.Reset();
         dynamic_replan_requested = false;
         nav_run_dirty = true;
     }
@@ -149,6 +170,7 @@ struct NavigationRuntimeState
         recovery.Reset();
         localization_loss.Reset();
         steering_rate.Reset();
+        offroute.Reset();
         dynamic_replan_requested = false;
         nav_run_dirty = true;
         flow.navigate_started_at = now;
@@ -159,6 +181,7 @@ struct NavigationRuntimeState
     {
         route.ResetTracking();
         recovery.Reset();
+        offroute.Reset();
         dynamic_replan_requested = false;
         nav_run_dirty = true;
         flow.last_auto_sprint_time = {};

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -53,10 +53,10 @@ bool ReadRoiArray(const json::value& holder, cv::Rect* out)
             return false;
         }
     }
-    out->x = arr.at(0).as_integer();
-    out->y = arr.at(1).as_integer();
-    out->width = arr.at(2).as_integer();
-    out->height = arr.at(3).as_integer();
+    out->x = static_cast<int>(std::lround(arr.at(0).as_double()));
+    out->y = static_cast<int>(std::lround(arr.at(1).as_double()));
+    out->width = static_cast<int>(std::lround(arr.at(2).as_double()));
+    out->height = static_cast<int>(std::lround(arr.at(3).as_double()));
     return out->width > 0 && out->height > 0;
 }
 
@@ -104,6 +104,11 @@ bool ParseCollectRoiFromNode(MaaContext* context, const char* node_name, cv::Rec
 
     LogWarn << "Collect ROI: no usable roi array in node data." << VAR(node_name);
     return false;
+}
+
+bool RouteHasCollectWaypoint(const std::vector<Waypoint>& path)
+{
+    return std::any_of(path.begin(), path.end(), [](const Waypoint& wp) { return wp.action == ActionType::COLLECT; });
 }
 
 struct BootstrapWaypointCandidate
@@ -1094,10 +1099,7 @@ void NavigationStateMachine::StartCollectScanner()
         return;
     }
 
-    const std::vector<Waypoint>& path = session_->original_path();
-    const bool has_collect =
-        std::any_of(path.begin(), path.end(), [](const Waypoint& wp) { return wp.action == ActionType::COLLECT; });
-    if (!has_collect) {
+    if (!RouteHasCollectWaypoint(session_->original_path())) {
         return;
     }
 
@@ -1174,10 +1176,7 @@ void NavigationStateMachine::PreWarmCollectOcr()
         return;
     }
 
-    const std::vector<Waypoint>& path = session_->original_path();
-    const bool has_collect =
-        std::any_of(path.begin(), path.end(), [](const Waypoint& wp) { return wp.action == ActionType::COLLECT; });
-    if (!has_collect) {
+    if (!RouteHasCollectWaypoint(session_->original_path())) {
         return;
     }
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -867,6 +867,42 @@ bool NavigationStateMachine::TickNavigate()
         }
     }
 
+    // Off-route wedge watchdog (see kOffRouteWedge* in navi_config.h). Only corridor (non-strict RUN) waypoints,
+    // where on_route is meaningful; the stall clocks above are fed corridor progress and miss a pinned-off-route
+    // cursor. Fed straight-line distance, so the timer only grows while genuinely off-route with no inward gain.
+    if (session_->phase() == NaviPhase::Navigate && waypoint.action == ActionType::RUN && !waypoint.RequiresStrictArrival()
+        && !route.on_route) {
+        OffRouteWedgeState& wedge = runtime_state_.offroute;
+        const double progress_epsilon = std::max(kNoProgressDistanceEpsilon, kMeasurementDefaultPositionQuantum);
+        if (!wedge.active || route.progress_distance + progress_epsilon < wedge.best_distance) {
+            wedge.active = true;
+            wedge.best_distance = route.progress_distance;
+            wedge.since = now;
+        }
+        const int64_t wedge_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - wedge.since).count();
+        if (wedge_ms >= kOffRouteWedgeFailMs) {
+            return FailNavigation(
+                "offroute_wedge_timeout",
+                "Off-route with no route progress past the wedge timeout; terminating so the pipeline can retry.",
+                route.progress_distance,
+                NaviMath::NormalizeAngle(route.route_heading - current_heading),
+                stalled_ms);
+        }
+        const bool replan_cooling = wedge.last_replan_at.time_since_epoch().count() > 0
+                                    && std::chrono::duration_cast<std::chrono::milliseconds>(now - wedge.last_replan_at).count()
+                                           < kOffRouteWedgeReplanCooldownMs;
+        if (wedge_ms >= kOffRouteWedgeReplanMs && !replan_cooling) {
+            wedge.last_replan_at = now;
+            LogWarn << "Off-route wedge detected; replanning from current position." << VAR(wedge_ms)
+                    << VAR(route.waypoint_distance) << VAR(route.cross_track) << VAR(session_->current_node_idx());
+            HandleDynamicReplanRequest("offroute_wedge");
+            return true;
+        }
+    }
+    else {
+        runtime_state_.offroute.Reset();
+    }
+
     // Near a strict-arrival goal only the *detour* is unsafe (it routes away from the exact point);
     // a jump is still a safe nudge, so recovery is allowed to enter here and the suppression is
     // applied to the detour step alone, below.

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -1,16 +1,23 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <filesystem>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
+#include <MaaFramework/MaaAPI.h>
+#include <MaaUtils/ImageIo.h>
 #include <MaaUtils/Logger.h>
+#include <meojson/json.hpp>
 
 #include "action_executor.h"
 #include "action_wrapper.h"
+#include "collectible_scanner.h"
 #include "motion_controller.h"
 #include "navi_config.h"
 #include "navi_math.h"
@@ -21,11 +28,83 @@
 #include "semantic_nodes.h"
 #include "steering_controller.h"
 
+#include "../utils.h"
+
 namespace mapnavigator
 {
 
 namespace
 {
+
+// Pull the collect-label ROI from the pipeline node (single source of truth) rather than hardcoding it:
+// MaaContextGetNodeData returns the node's resolved JSON, so editing AutoCollectClick.json's roi
+// automatically retargets the async scanner. The roi is authored in the 1280x720 base frame.
+bool ReadRoiArray(const json::value& holder, cv::Rect* out)
+{
+    if (!holder.is_array()) {
+        return false;
+    }
+    const auto& arr = holder.as_array();
+    if (arr.size() < 4) {
+        return false;
+    }
+    for (size_t i = 0; i < 4; ++i) {
+        if (!arr.at(i).is_number()) {
+            return false;
+        }
+    }
+    out->x = arr.at(0).as_integer();
+    out->y = arr.at(1).as_integer();
+    out->width = arr.at(2).as_integer();
+    out->height = arr.at(3).as_integer();
+    return out->width > 0 && out->height > 0;
+}
+
+bool ParseCollectRoiFromNode(MaaContext* context, const char* node_name, cv::Rect* out)
+{
+    if (context == nullptr || node_name == nullptr) {
+        return false;
+    }
+
+    ScopedStringBuffer buffer;
+    if (buffer.Get() == nullptr || !MaaContextGetNodeData(context, node_name, buffer.Get())) {
+        LogWarn << "Collect ROI: MaaContextGetNodeData failed." << VAR(node_name);
+        return false;
+    }
+    const char* raw = MaaStringBufferGet(buffer.Get());
+    if (raw == nullptr || raw[0] == '\0') {
+        LogWarn << "Collect ROI: empty node data." << VAR(node_name);
+        return false;
+    }
+
+    const auto parsed = json::parse(raw);
+    if (!parsed || !parsed->is_object()) {
+        LogWarn << "Collect ROI: node JSON is not an object." << VAR(node_name);
+        return false;
+    }
+    const auto& node = parsed->as_object();
+
+    // Canonical shape: { "recognition": { "param": { "roi": [x,y,w,h] } } }. Fall back to flatter shapes in
+    // case the framework serializes the loaded node differently.
+    if (node.contains("recognition") && node.at("recognition").is_object()) {
+        const auto& reco = node.at("recognition").as_object();
+        if (reco.contains("param") && reco.at("param").is_object()) {
+            const auto& param = reco.at("param").as_object();
+            if (param.contains("roi") && ReadRoiArray(param.at("roi"), out)) {
+                return true;
+            }
+        }
+        if (reco.contains("roi") && ReadRoiArray(reco.at("roi"), out)) {
+            return true;
+        }
+    }
+    if (node.contains("roi") && ReadRoiArray(node.at("roi"), out)) {
+        return true;
+    }
+
+    LogWarn << "Collect ROI: no usable roi array in node data." << VAR(node_name);
+    return false;
+}
 
 struct BootstrapWaypointCandidate
 {
@@ -333,8 +412,17 @@ bool NavigationStateMachine::Run()
         return false;
     }
 
+    // Absorb the collect-OCR cold start here, while the avatar is still stopped after Bootstrap and before
+    // the first forward press, so it can never land on a while-walking scan tick and freeze the thread.
+    PreWarmCollectOcr();
+
+    // Spin up the background collectible detector (no-op unless the route has a COLLECT waypoint). It runs
+    // off the nav thread on pure OpenCV; the nav loop only reacts to its flag, never recognizes inline.
+    StartCollectScanner();
+
     while (!should_stop_() && session_->phase() != NaviPhase::Finished && session_->phase() != NaviPhase::Failed) {
         if (!TickPhase(session_->phase())) {
+            StopCollectScanner();
             StopMotion();
             return false;
         }
@@ -344,6 +432,7 @@ bool NavigationStateMachine::Run()
         session_->HasSatisfiedFinalSuccess(*position_, "navigation_complete");
     }
 
+    StopCollectScanner();
     StopMotion();
     return !should_stop_() && session_->success();
 }
@@ -728,6 +817,10 @@ bool NavigationStateMachine::TickNavigate()
     }
 
     const Waypoint waypoint = session_->CurrentWaypoint();
+    if (TryScanApproachCollect(route, waypoint)) {
+        return true;
+    }
+
     const double arrival_distance =
         waypoint.action == ActionType::PORTAL ? std::max(route.arrival_band, kPortalCommitDistance) : route.arrival_band;
     if (route.waypoint_distance <= arrival_distance) {
@@ -925,6 +1018,11 @@ bool NavigationStateMachine::TickNavigate()
              << VAR(heading_error) << VAR(steering.yaw_delta_deg)
              << VAR(issued_delta_deg) << VAR(route.waypoint_distance) << VAR(route.on_route);
 
+    // Collect routes: keep sprint for travel but drop to walking speed once near a COLLECT point (cancels any
+    // active sprint), so the detection-stop can land before we overrun the collectible. No-op off collect
+    // routes. Must run before the sprint gate below so a freshly-entered zone suppresses this tick's sprint.
+    UpdateCollectSprintSuppression();
+
     // Balanced sprint gate: burst only when the agent already points down the corridor (heading aligned)
     // and no sharp turn is imminent within the scan window. No clearance term — it reads near zero on
     // bridges and locked sprint out entirely; alignment + upcoming-turn keep it from charging a corner.
@@ -981,6 +1079,152 @@ void NavigationStateMachine::SelectPhaseForCurrentWaypoint(const char* reason)
 void NavigationStateMachine::StopMotion()
 {
     motion_controller_->SetForwardState(false);
+}
+
+NavigationStateMachine::~NavigationStateMachine()
+{
+    // Backstop: guarantee the PositionProvider's frame observer (it captures `this` and reads
+    // collect_scanner_) is torn down before this object dies, even on an early Run() return path.
+    StopCollectScanner();
+}
+
+void NavigationStateMachine::StartCollectScanner()
+{
+    if (collect_scanner_ != nullptr) {
+        return;
+    }
+
+    const std::vector<Waypoint>& path = session_->original_path();
+    const bool has_collect =
+        std::any_of(path.begin(), path.end(), [](const Waypoint& wp) { return wp.action == ActionType::COLLECT; });
+    if (!has_collect) {
+        return;
+    }
+
+    cv::Rect base_roi;
+    if (!ParseCollectRoiFromNode(maa_context_, kCollectRoiNode, &base_roi)) {
+        LogWarn << "Async collectible scanner not started: could not read collect ROI from pipeline."
+                << VAR(kCollectRoiNode);
+        return;
+    }
+
+    const std::filesystem::path icon_path =
+        std::filesystem::absolute(get_exe_dir() / ".." / kCollectIconRelativePath);
+    const cv::Mat icon_template = MAA_NS::imread(icon_path, cv::IMREAD_GRAYSCALE);
+    if (icon_template.empty()) {
+        LogWarn << "Collect icon template not loaded; falling back to bright-text heuristic."
+                << VAR(MAA_NS::path_to_utf8_string(icon_path));
+    }
+    else {
+        LogInfo << "Collect icon template loaded." << VAR(MAA_NS::path_to_utf8_string(icon_path))
+                << VAR(icon_template.cols) << VAR(icon_template.rows);
+    }
+
+    collect_scanner_ = std::make_unique<CollectibleScanner>(base_roi, icon_template);
+    position_provider_->SetFrameObserver([this](const cv::Mat& frame) {
+        if (collect_scanner_ != nullptr) {
+            collect_scanner_->SubmitFrame(frame);
+        }
+    });
+    LogInfo << "Async collectible scanner started." << VAR(base_roi.x) << VAR(base_roi.y) << VAR(base_roi.width)
+            << VAR(base_roi.height);
+    // NOTE: sprint is NOT suppressed for the whole route — that killed fast travel. Suppression is driven per
+    // tick in TickNavigate (UpdateCollectSprintSuppression), enabled only when the avatar is within
+    // kCollectSprintSuppressBandWu of a COLLECT waypoint, so travel between collect points still sprints.
+}
+
+void NavigationStateMachine::StopCollectScanner()
+{
+    if (position_provider_ != nullptr) {
+        position_provider_->SetFrameObserver(nullptr);
+    }
+    if (motion_controller_ != nullptr) {
+        motion_controller_->SetSprintSuppressed(false);
+    }
+    collect_scanner_.reset();
+}
+
+void NavigationStateMachine::UpdateCollectSprintSuppression()
+{
+    if (collect_scanner_ == nullptr || motion_controller_ == nullptr) {
+        return;  // not a collect route — leave sprint behaviour entirely untouched
+    }
+
+    bool near_collect = false;
+    if (position_ != nullptr && position_->valid && session_ != nullptr) {
+        const double band_sq = kCollectSprintSuppressBandWu * kCollectSprintSuppressBandWu;
+        for (const Waypoint& waypoint : session_->current_path()) {
+            if (waypoint.action != ActionType::COLLECT || !waypoint.HasPosition()) {
+                continue;
+            }
+            const double dx = waypoint.x - position_->x;
+            const double dy = waypoint.y - position_->y;
+            if (dx * dx + dy * dy <= band_sq) {
+                near_collect = true;
+                break;
+            }
+        }
+    }
+    motion_controller_->SetSprintSuppressed(near_collect);
+}
+
+void NavigationStateMachine::PreWarmCollectOcr()
+{
+    if (maa_context_ == nullptr) {
+        return;
+    }
+
+    const std::vector<Waypoint>& path = session_->original_path();
+    const bool has_collect =
+        std::any_of(path.begin(), path.end(), [](const Waypoint& wp) { return wp.action == ActionType::COLLECT; });
+    if (!has_collect) {
+        return;
+    }
+
+    LogInfo << "Pre-warming collect OCR model before navigation (absorbs one-time cold start while stopped).";
+    MaaContextRunTask(maa_context_, kDefaultCollectEntry, kCollectPrewarmOverride);
+}
+
+bool NavigationStateMachine::TryScanApproachCollect(const RouteTrackingState& route, const Waypoint& waypoint)
+{
+    (void)waypoint;
+    if (maa_context_ == nullptr || collect_scanner_ == nullptr || !route.startup_motion_confirmed) {
+        return false;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if (collect_scan_last_at_.time_since_epoch().count() != 0
+        && now - collect_scan_last_at_ < std::chrono::milliseconds(kCollectScanIntervalMs)) {
+        return false;
+    }
+
+    if (!collect_scanner_->ConsumeDetection()) {
+        return false;  // background worker has not flagged a collectible — keep walking, zero cost this tick
+    }
+
+    if (collect_attempt_pos_valid_ && position_ != nullptr && position_->valid) {
+        const bool zone_changed = !collect_attempt_pos_.zone_id.empty() && !position_->zone_id.empty()
+                                  && collect_attempt_pos_.zone_id != position_->zone_id;
+        const double moved = std::hypot(position_->x - collect_attempt_pos_.x, position_->y - collect_attempt_pos_.y);
+        if (!zone_changed && moved < kCollectRetryMinMoveWu) {
+            LogDebug << "Collect detection suppressed (anti-stuck): not past the last attempt yet." << VAR(moved);
+            return false;
+        }
+    }
+
+    collect_scan_last_at_ = now;
+    if (position_ != nullptr && position_->valid) {
+        collect_attempt_pos_ = *position_;
+        collect_attempt_pos_valid_ = true;
+    }
+
+    LogInfo << "Async collectible flagged — stopping for authoritative collect." << VAR(route.waypoint_distance)
+            << VAR(session_->current_node_idx());
+    motion_controller_->SetForwardState(false);
+    utils::SleepFor(kStopWaitMs);
+    MaaContextRunTask(maa_context_, kDefaultCollectEntry, kCollectPipelineOverride);
+    utils::SleepFor(kCollectPostSleepMs);
+    return true;
 }
 
 bool NavigationStateMachine::FailNavigation(

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -2,6 +2,8 @@
 
 #include <chrono>
 #include <functional>
+#include <memory>
+#include <string>
 
 #include "nav_run_controller.h"
 #include "navi_controller.h"
@@ -15,6 +17,8 @@ class IActionExecutor;
 class ActionWrapper;
 class MotionController;
 class PositionProvider;
+class CollectibleScanner;
+struct RouteTrackingState;
 
 class NavigationStateMachine
 {
@@ -31,6 +35,7 @@ public:
         MaaContext* maa_context);
 
     bool Run();
+    ~NavigationStateMachine();
 
 private:
     bool Bootstrap();
@@ -50,6 +55,12 @@ private:
     void StopMotion();
     bool FailNavigation(const char* reason, const char* log_message, double current_distance, double yaw_error, int64_t stalled_ms);
 
+    bool TryScanApproachCollect(const RouteTrackingState& route, const Waypoint& waypoint);
+    void PreWarmCollectOcr();
+    void StartCollectScanner();
+    void StopCollectScanner();
+    void UpdateCollectSprintSuppression();
+
     const NaviParam& param_;
     ActionWrapper* action_wrapper_;
     PositionProvider* position_provider_;
@@ -62,6 +73,12 @@ private:
     NavigationRuntimeState runtime_state_ {};
     NavRunController nav_run_controller_ {};
     std::chrono::steady_clock::time_point last_global_relocalize_at_ {};
+
+    std::unique_ptr<CollectibleScanner> collect_scanner_;
+    std::chrono::steady_clock::time_point collect_scan_last_at_ {};
+    // Anti-stuck: position of the last detection-triggered collect attempt.
+    NaviPosition collect_attempt_pos_ {};
+    bool collect_attempt_pos_valid_ = false;
 };
 
 } // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/position_provider.cpp
+++ b/agent/cpp-algo/source/MapNavigator/position_provider.cpp
@@ -42,25 +42,6 @@ bool IsBlackScreen(const cv::Mat& image)
     return mean_luma[0] <= 12.0 && stddev_luma[0] <= 10.0 && dark_ratio >= 0.98;
 }
 
-class ScopedImageBuffer
-{
-public:
-    ScopedImageBuffer()
-        : buffer_(MaaImageBufferCreate())
-    {
-    }
-
-    ~ScopedImageBuffer() { MaaImageBufferDestroy(buffer_); }
-
-    ScopedImageBuffer(const ScopedImageBuffer&) = delete;
-    ScopedImageBuffer& operator=(const ScopedImageBuffer&) = delete;
-
-    MaaImageBuffer* Get() const { return buffer_; }
-
-private:
-    MaaImageBuffer* buffer_;
-};
-
 } // namespace
 
 PositionProvider::PositionProvider(MaaController* controller, std::shared_ptr<maplocator::MapLocator> locator)
@@ -68,6 +49,11 @@ PositionProvider::PositionProvider(MaaController* controller, std::shared_ptr<ma
     , locator_(std::move(locator))
     , uses_adb_minimap_roi_(IsAdbLikeControllerType(DetectControllerType(controller_)))
 {
+}
+
+void PositionProvider::SetFrameObserver(std::function<void(const cv::Mat&)> observer)
+{
+    frame_observer_ = std::move(observer);
 }
 
 bool PositionProvider::Capture(NaviPosition* out_pos, bool force_global_search, const std::string& expected_zone_id)
@@ -89,6 +75,9 @@ bool PositionProvider::Capture(NaviPosition* out_pos, bool force_global_search, 
 
     cv::Mat image = to_mat(buffer.Get());
     last_capture_was_black_screen_ = IsBlackScreen(image);
+    if (frame_observer_) {
+        frame_observer_(image);
+    }
     cv::Mat minimap;
     if (!maplocator::TryExtractMinimap(image, uses_adb_minimap_roi_, &minimap)) {
         return false;

--- a/agent/cpp-algo/source/MapNavigator/position_provider.h
+++ b/agent/cpp-algo/source/MapNavigator/position_provider.h
@@ -34,10 +34,17 @@ public:
     // same frame). Defaults to absent, i.e. the raw locator output is passed through unchanged.
     void SetPositionNormalizer(std::function<void(NaviPosition&)> normalizer);
 
+    // Optional per-frame observer: invoked with the full captured BGR/BGRA frame at the single capture
+    // chokepoint, BEFORE minimap extraction or locate, so it fires on every frame even when localization
+    // fails. Used to feed the async collectible scanner without a second screencap. The callback runs on
+    // the nav thread and must be cheap (it just copies a ROI out to a worker).
+    void SetFrameObserver(std::function<void(const cv::Mat&)> observer);
+
 private:
     MaaController* controller_;
     std::shared_ptr<maplocator::MapLocator> locator_;
     std::function<void(NaviPosition&)> position_normalizer_;
+    std::function<void(const cv::Mat&)> frame_observer_;
     bool uses_adb_minimap_roi_ = false;
     bool last_capture_was_held_ = false;
     bool last_capture_was_black_screen_ = false;

--- a/agent/cpp-algo/source/MapNavigator/semantic_nodes.cpp
+++ b/agent/cpp-algo/source/MapNavigator/semantic_nodes.cpp
@@ -461,39 +461,32 @@ Result HandleArrivalSemantic(const Context& ctx, const Waypoint& waypoint, doubl
         return result;
     }
 
-    if (waypoint.action == ActionType::COLLECT || waypoint.action == ActionType::DIG) {
-        const bool is_dig = waypoint.action == ActionType::DIG;
-        const char* tag = is_dig ? "DIG" : "COLLECT";
-        const char* entry = is_dig ? kDefaultDigEntry : kDefaultCollectEntry;
-        const char* override_json = is_dig ? kDigPipelineOverride : kCollectPipelineOverride;
-        const int32_t post_sleep_ms = is_dig ? kDigPostSleepMs : kCollectPostSleepMs;
-        const char* completed_reason = is_dig ? "dig_completed" : "collect_completed";
-
+    if (waypoint.action == ActionType::DIG) {
         StopMotionAndCommitment(ctx);
 
         if (ctx.maa_context == nullptr) {
-            LogError << "Action: " << tag << " triggered but maa_context is null." << VAR(actual_distance);
+            LogError << "Action: DIG triggered but maa_context is null." << VAR(actual_distance);
             result.request_failure = true;
-            result.failure_reason = is_dig ? "dig_context_missing" : "collect_context_missing";
-            result.failure_log_message = "MaaContext is null when dispatching collect/dig subtask.";
+            result.failure_reason = "dig_context_missing";
+            result.failure_log_message = "MaaContext is null when dispatching dig subtask.";
             return result;
         }
 
-        LogInfo << "Action: " << tag << " triggered, dispatching subtask." << VAR(entry) << VAR(actual_distance);
-        const MaaTaskId sub_id = MaaContextRunTask(ctx.maa_context, entry, override_json);
+        LogInfo << "Action: DIG triggered, dispatching subtask." << VAR(kDefaultDigEntry) << VAR(actual_distance);
+        const MaaTaskId sub_id = MaaContextRunTask(ctx.maa_context, kDefaultDigEntry, kDigPipelineOverride);
         if (sub_id == MaaInvalidId) {
-            LogError << "Action: " << tag << " subtask failed to dispatch." << VAR(entry) << VAR(actual_distance);
+            LogError << "Action: DIG subtask failed to dispatch." << VAR(kDefaultDigEntry) << VAR(actual_distance);
             result.request_failure = true;
-            result.failure_reason = is_dig ? "dig_dispatch_failed" : "collect_dispatch_failed";
-            result.failure_log_message = "MaaContextRunTask returned MaaInvalidId for collect/dig subtask.";
+            result.failure_reason = "dig_dispatch_failed";
+            result.failure_log_message = "MaaContextRunTask returned MaaInvalidId for dig subtask.";
             return result;
         }
 
-        LogInfo << "Action: " << tag << " subtask returned." << VAR(sub_id);
-        utils::SleepFor(post_sleep_ms);
+        LogInfo << "Action: DIG subtask returned." << VAR(sub_id);
+        utils::SleepFor(kDigPostSleepMs);
 
-        ctx.session->NoteCanonicalFinalGoalConsumed(arrived_absolute_node_idx, *ctx.position, completed_reason);
-        ctx.session->AdvanceToNextWaypoint(waypoint.action, completed_reason);
+        ctx.session->NoteCanonicalFinalGoalConsumed(arrived_absolute_node_idx, *ctx.position, "dig_completed");
+        ctx.session->AdvanceToNextWaypoint(waypoint.action, "dig_completed");
         ctx.runtime_state->OnWaypointAdvance();
         ctx.runtime_state->route.Reset();
 
@@ -501,7 +494,7 @@ Result HandleArrivalSemantic(const Context& ctx, const Waypoint& waypoint, doubl
             ctx.session->NoteRouteTailConsumed(*ctx.position, "route_tail_consumed");
         }
         else {
-            SelectPhaseForCurrentWaypoint(ctx, completed_reason);
+            SelectPhaseForCurrentWaypoint(ctx, "dig_completed");
         }
 
         result.consumed = true;

--- a/agent/cpp-algo/source/utils.h
+++ b/agent/cpp-algo/source/utils.h
@@ -16,6 +16,57 @@ inline cv::Mat to_mat(const MaaImageBuffer* buffer)
     return cv::Mat(MaaImageBufferHeight(buffer), MaaImageBufferWidth(buffer), MaaImageBufferType(buffer), MaaImageBufferGetRawData(buffer));
 }
 
+// RAII owners for the C-API Maa*Buffer handles. The framework hands these out via *Create and requires a
+// matching *Destroy; these wrap that lifetime so callers never leak on an early return. Shared here because
+// every screencap/recognition caller needs the exact same boilerplate (previously copy-pasted into ~5 TUs).
+class ScopedImageBuffer
+{
+public:
+    ScopedImageBuffer()
+        : buffer_(MaaImageBufferCreate())
+    {
+    }
+
+    ~ScopedImageBuffer()
+    {
+        if (buffer_ != nullptr) {
+            MaaImageBufferDestroy(buffer_);
+        }
+    }
+
+    ScopedImageBuffer(const ScopedImageBuffer&) = delete;
+    ScopedImageBuffer& operator=(const ScopedImageBuffer&) = delete;
+
+    MaaImageBuffer* Get() const { return buffer_; }
+
+private:
+    MaaImageBuffer* buffer_ = nullptr;
+};
+
+class ScopedStringBuffer
+{
+public:
+    ScopedStringBuffer()
+        : buffer_(MaaStringBufferCreate())
+    {
+    }
+
+    ~ScopedStringBuffer()
+    {
+        if (buffer_ != nullptr) {
+            MaaStringBufferDestroy(buffer_);
+        }
+    }
+
+    ScopedStringBuffer(const ScopedStringBuffer&) = delete;
+    ScopedStringBuffer& operator=(const ScopedStringBuffer&) = delete;
+
+    MaaStringBuffer* Get() const { return buffer_; }
+
+private:
+    MaaStringBuffer* buffer_ = nullptr;
+};
+
 // Directory containing the running executable. Resolve bundled resources against this rather than
 // the process current-working-directory: the CWD differs between dev and production, but resources
 // always ship at a fixed location relative to the binary. This is the single anchor used by every


### PR DESCRIPTION
## Summary by Sourcery

在导航过程中引入异步的可收集物检测，将 `COLLECT` 航点从阻塞式停靠解耦出来，同时增强对偏离路线楔形状态的鲁棒性，并改进缓冲区和 ROI（感兴趣区域）的处理。

New Features:
- 添加后台 `CollectibleScanner`，从统一抓取的帧中读取图像，并通过图标模板匹配或文本启发式规则标记可收集物，而不会阻塞导航主循环。
- 允许 `PositionProvider` 暴露逐帧观察者钩子，使辅助工作线程可以从单一抓拍瓶颈处消费完整帧图像。
- 在移动前预热收集用的 OCR 流水线，并在行走过程中检测到可收集物时异步触发收集任务。

Enhancements:
- 将 `COLLECT` 航点从“需要到达并阻塞”的停靠点改为非阻塞的扫描标记，仅在穿过航点期间检测到目标时才触发收集。
- 在 `COLLECT` 航点附近引入冲刺抑制，使智能体在接近潜在可收集物时自动减速为步行，而不影响长距离移动时的高速行进。
- 从 Maa 流水线节点的 JSON 中动态加载收集 ROI，并从打包的资源中加载收集图标模板，以实现可配置的检测行为。
- 优化 `DIG` 的处理逻辑，使其保持为精确的“停下并执行”的到达航点，并提供更清晰的日志与失败原因，同时将 `COLLECT` 从严格到达类航点中移除。
- 添加偏离路线楔形状态的看门狗，当智能体在通道之外长时间停留且没有直线前进时，触发重新规划并最终快速失败。

Documentation:
- 更新导航领域注释，将 `COLLECT` 描述为非阻塞、由检测驱动的航点，并明确 `DIG` 为阻塞式、精确停下并执行的动作。

Chores:
- 将 `ScopedImageBuffer` 和 `ScopedStringBuffer` 的 RAII 帮助类集中放入 `utils.h`，并在导航和地图定位组件中复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce asynchronous collectible detection during navigation, decoupling COLLECT waypoints from blocking stops while adding robustness against off-route wedges and improving buffer and ROI handling.

New Features:
- Add a background CollectibleScanner that consumes captured frames and flags collectibles via icon template matching or text heuristics without blocking the navigation loop.
- Allow PositionProvider to expose a per-frame observer hook so auxiliary workers can consume full-frame images from the single capture chokepoint.
- Pre-warm the collect OCR pipeline before movement and trigger collect tasks asynchronously when collectibles are detected while walking.

Enhancements:
- Change COLLECT waypoints from blocking arrival points to non-blocking scan markers, with collection only triggered on positive detection during traversal.
- Introduce sprint suppression near COLLECT waypoints so the agent slows to walking speed when close to potential collectibles without affecting long-range travel speed.
- Load collect ROI dynamically from Maa pipeline node JSON and load collect icon templates from bundled resources for configurable detection behaviour.
- Refine DIG handling to remain a precise stop-and-execute waypoint with clearer logging and failure reasons, and remove COLLECT from strict-arrival waypoint classification.
- Add an off-route wedge watchdog that triggers replanning and eventual fast failure when the agent remains off-corridor without straight-line progress.

Documentation:
- Update navigation domain comments to describe COLLECT as a non-blocking, detection-driven waypoint and clarify DIG as a blocking, precise stop-and-execute action.

Chores:
- Centralize ScopedImageBuffer and ScopedStringBuffer RAII helpers in utils.h and reuse them across navigation and map locator components.

</details>

新功能：
- 添加后台 `CollectibleScanner`，消费捕获的帧，通过图标模板匹配或亮色文本启发式来检测可收集物，并以异步方式向导航循环发送信号。
- 允许导航在移动前预热 collect OCR 流水线，并在异步检测到可收集物时停下并调用收集任务，而不阻塞正常 tick。
- 在 `PositionProvider` 上暴露逐帧观察者钩子（per-frame observer hook），从单一的图像捕获瓶颈为可收集物扫描器等辅助视觉工作线程提供数据。

增强：
- 将 COLLECT 航点从“阻塞式到达点”改为“启用扫描的标记点”，只有在行进过程中实际检测到可收集物时才触发收集。
- 在 COLLECT 点附近抑制冲刺（sprint），让角色在潜在可收集物附近适当减速，而不影响整体行程速度。
- 从 Maa 流水线节点 JSON 中动态读取 collect ROI，而不是硬编码坐标，并从资源路径加载 collect 图标模板，以实现更可配置的检测。
- 优化 DIG 处理语义，保持其作为与 COLLECT 区分明确的精确“停下并执行”航点，并提供更清晰的日志与失败原因。
- 将 `ScopedImageBuffer` 和 `ScopedStringBuffer` RAII 帮助类集中放入 `utils.h`，并在导航和地图定位组件中复用。

文档：
- 更新导航域的注释，将新的 COLLECT 语义记录为“非阻塞、基于检测驱动的航点”，并明确说明 DIG 的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导航过程中引入异步的可收集物检测，将 `COLLECT` 航点从阻塞式停靠解耦出来，同时增强对偏离路线楔形状态的鲁棒性，并改进缓冲区和 ROI（感兴趣区域）的处理。

New Features:
- 添加后台 `CollectibleScanner`，从统一抓取的帧中读取图像，并通过图标模板匹配或文本启发式规则标记可收集物，而不会阻塞导航主循环。
- 允许 `PositionProvider` 暴露逐帧观察者钩子，使辅助工作线程可以从单一抓拍瓶颈处消费完整帧图像。
- 在移动前预热收集用的 OCR 流水线，并在行走过程中检测到可收集物时异步触发收集任务。

Enhancements:
- 将 `COLLECT` 航点从“需要到达并阻塞”的停靠点改为非阻塞的扫描标记，仅在穿过航点期间检测到目标时才触发收集。
- 在 `COLLECT` 航点附近引入冲刺抑制，使智能体在接近潜在可收集物时自动减速为步行，而不影响长距离移动时的高速行进。
- 从 Maa 流水线节点的 JSON 中动态加载收集 ROI，并从打包的资源中加载收集图标模板，以实现可配置的检测行为。
- 优化 `DIG` 的处理逻辑，使其保持为精确的“停下并执行”的到达航点，并提供更清晰的日志与失败原因，同时将 `COLLECT` 从严格到达类航点中移除。
- 添加偏离路线楔形状态的看门狗，当智能体在通道之外长时间停留且没有直线前进时，触发重新规划并最终快速失败。

Documentation:
- 更新导航领域注释，将 `COLLECT` 描述为非阻塞、由检测驱动的航点，并明确 `DIG` 为阻塞式、精确停下并执行的动作。

Chores:
- 将 `ScopedImageBuffer` 和 `ScopedStringBuffer` 的 RAII 帮助类集中放入 `utils.h`，并在导航和地图定位组件中复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce asynchronous collectible detection during navigation, decoupling COLLECT waypoints from blocking stops while adding robustness against off-route wedges and improving buffer and ROI handling.

New Features:
- Add a background CollectibleScanner that consumes captured frames and flags collectibles via icon template matching or text heuristics without blocking the navigation loop.
- Allow PositionProvider to expose a per-frame observer hook so auxiliary workers can consume full-frame images from the single capture chokepoint.
- Pre-warm the collect OCR pipeline before movement and trigger collect tasks asynchronously when collectibles are detected while walking.

Enhancements:
- Change COLLECT waypoints from blocking arrival points to non-blocking scan markers, with collection only triggered on positive detection during traversal.
- Introduce sprint suppression near COLLECT waypoints so the agent slows to walking speed when close to potential collectibles without affecting long-range travel speed.
- Load collect ROI dynamically from Maa pipeline node JSON and load collect icon templates from bundled resources for configurable detection behaviour.
- Refine DIG handling to remain a precise stop-and-execute waypoint with clearer logging and failure reasons, and remove COLLECT from strict-arrival waypoint classification.
- Add an off-route wedge watchdog that triggers replanning and eventual fast failure when the agent remains off-corridor without straight-line progress.

Documentation:
- Update navigation domain comments to describe COLLECT as a non-blocking, detection-driven waypoint and clarify DIG as a blocking, precise stop-and-execute action.

Chores:
- Centralize ScopedImageBuffer and ScopedStringBuffer RAII helpers in utils.h and reuse them across navigation and map locator components.

</details>

</details>