### PR TITLE
fix: 部分寻路开始时禁用冲刺

### DIFF
--- a/assets/resource/pipeline/AutoEssence/RegionNodes/WLMarkerStone.json
+++ b/assets/resource/pipeline/AutoEssence/RegionNodes/WLMarkerStone.json
@@ -110,7 +110,8 @@
                             394.0
                         ]
                     ],
-                    "path_trim": true
+                    "path_trim": true,
+                    "no_ensure_initial_movement_state": true
                 }
             }
         },

--- a/assets/resource/pipeline/AutoSell/Common.json
+++ b/assets/resource/pipeline/AutoSell/Common.json
@@ -29,7 +29,8 @@
                     188.8,
                     134.8
                 ]
-            ]
+            ],
+            "no_ensure_initial_movement_state": true
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -78,126 +79,6 @@
             "AutoSellEnterStockRedistribution"
         ]
     },
-    // "AutoSellShipEnterStockRedistribution": {
-    //     "desc": "从飞船走向弹性需求物资界面",
-    //     "recognition": "TemplateMatch",
-    //     "roi": [
-    //         0,
-    //         0,
-    //         100,
-    //         100
-    //     ],
-    //     "template": "VisitFriends/ShipEscButton.png",
-    //     "threshold": 0.9,
-    //     "pre_wait_freezes": 100,
-    //     "pre_delay": 0,
-    //     "action": "Custom",
-    //     "custom_action": "MapNavigateAction",
-    //     "custom_action_param": {
-    //         "path": [
-    //             {
-    //                 "action": "ZONE",
-    //                 "zone_id": "OMVBase01"
-    //             },
-    //             [
-    //                 192,
-    //                 141
-    //             ],
-    //             [
-    //                 187,
-    //                 141,
-    //                 true
-    //             ]
-    //         ]
-    //     },
-    //     "post_delay": 0,
-    //     "rate_limit": 0,
-    //     "next": [
-    //         "AutoSellShipEnterStockRedistribution2"
-    //     ],
-    //     "focus": {
-    //         "Node.Action.Starting": "正在走向物资调度终端"
-    //     }
-    // },
-    // "AutoSellShipEnterStockRedistribution2": {
-    //     "desc": "cpp寻路转向太慢了，容易走到别的房间回不来，因此写两段能快速转向",
-    //     "recognition": "TemplateMatch",
-    //     "roi": [
-    //         0,
-    //         0,
-    //         100,
-    //         100
-    //     ],
-    //     "template": "VisitFriends/ShipEscButton.png",
-    //     "threshold": 0.9,
-    //     "pre_wait_freezes": 100,
-    //     "pre_delay": 0,
-    //     "action": "Custom",
-    //     "custom_action": "MapNavigateAction",
-    //     "custom_action_param": {
-    //         "path": [
-    //             {
-    //                 "action": "ZONE",
-    //                 "zone_id": "OMVBase01"
-    //             },
-    //             [
-    //                 187,
-    //                 141
-    //             ],
-    //             [
-    //                 187,
-    //                 131,
-    //                 true
-    //             ]
-    //         ]
-    //     },
-    //     "post_delay": 0,
-    //     "rate_limit": 0,
-    //     "next": [
-    //         "AutoSellEnterStockRedistribution"
-    //     ]
-    // },
-    // "AutoSellEnterShipSuccess": {
-    //     "desc": "进入好友船成功的标志，go寻路走向终点不稳定",
-    //     "recognition": "TemplateMatch",
-    //     "roi": [
-    //         0,
-    //         0,
-    //         100,
-    //         100
-    //     ],
-    //     "template": "VisitFriends/ShipEscButton.png",
-    //     "threshold": 0.9,
-    //     "pre_delay": 0,
-    //     "post_delay": 0,
-    //     "pre_wait_freezes": 100,
-    //     "rate_limit": 0,
-    //     "action": "Custom",
-    //     "custom_action": "MapTrackerMove",
-    //     "custom_action_param": {
-    //         "map_name": "base01_lv003",
-    //         "path": [
-    //             [
-    //                 196.9,
-    //                 143.6
-    //             ],
-    //             [
-    //                 190.3,
-    //                 143.6
-    //             ],
-    //             [
-    //                 190.3,
-    //                 139.1
-    //             ]
-    //         ]
-    //     },
-    //     "focus": {
-    //         "Node.Action.Starting": "正在走向物资调度终端"
-    //     },
-    //     "next": [
-    //         "AutoSellEnterStockRedistribution"
-    //     ]
-    // },
     "AutoSellEnterStockRedistribution": {
         "desc": "进入物资调度页面",
         "recognition": "TemplateMatch",


### PR DESCRIPTION
## 概要

此 PR 为售卖弹性物资和首墩淤积点刷取禁用了寻路初始冲刺。

## 关联

Fix #3439 。

## Summary by Sourcery

在特定自动寻路流程开始时禁用初始冲刺。

Bug 修复：
- 防止在为弹性材料销售路线开始寻路时出现非预期的冲刺。
- 防止在为第一个沉积物累积点刷取路线开始寻路时出现非预期的冲刺。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable the initial sprint at the start of specific automated pathfinding routines.

Bug Fixes:
- Prevent unintended sprinting when starting pathfinding for elastic-material selling routes.
- Prevent unintended sprinting when starting pathfinding for the first sediment accumulation point farming routes.

</details>