### PR TITLE
feat(MapNavigator): 优先信任 RUN 点而不是使用 NavMesh 重新规划

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
@@ -272,7 +272,6 @@ double CorridorCoincidence(
     if (corridor.points.size() < 2 || authored.size() < 2) {
         return 1.0;
     }
-    const double safe_step = std::max(step, 0.1);
     size_t total = 0;
     size_t coincident = 0;
     const auto tally = [&](const navmesh::WorldPoint& p) {
@@ -281,26 +280,18 @@ double CorridorCoincidence(
             ++coincident;
         }
     };
-    tally(corridor.points.front());
-    for (size_t i = 0; i + 1 < corridor.points.size(); ++i) {
-        const navmesh::WorldPoint& a = corridor.points[i];
-        const navmesh::WorldPoint& b = corridor.points[i + 1];
-        const double seg = std::hypot(b.x - a.x, b.y - a.y);
-        const int steps = static_cast<int>(std::ceil(seg / safe_step));
-        for (int k = 1; k <= steps; ++k) {
-            const double t = static_cast<double>(k) / static_cast<double>(steps);
-            tally({ .x = a.x + (b.x - a.x) * t, .y = a.y + (b.y - a.y) * t });
-        }
-    }
+    ForEachResampledPoint(corridor.points, step, tally);
     return total == 0 ? 1.0 : static_cast<double>(coincident) / static_cast<double>(total);
 }
 
-// The authored line from the current waypoint up to and including the anchor. Fewer than 2 points when
-// the span can't be assembled (caller then keeps the navmesh corridor).
+// The authored line from the current waypoint up to and including the anchor. Returns empty unless the
+// anchor is actually reached (a control node or path end first truncates the span), so the caller falls
+// back to the navmesh corridor instead of trusting a line that stops short of the anchor.
 std::vector<navmesh::WorldPoint> BuildAuthoredSpanPolyline(const NavigationSession& session, size_t anchor_index)
 {
     const std::vector<Waypoint>& waypoints = session.current_path();
     std::vector<navmesh::WorldPoint> poly;
+    bool reached_anchor = false;
     for (size_t index = session.current_node_idx(); index < waypoints.size(); ++index) {
         const Waypoint& waypoint = waypoints[index];
         if (!waypoint.HasPosition()) {
@@ -309,8 +300,12 @@ std::vector<navmesh::WorldPoint> BuildAuthoredSpanPolyline(const NavigationSessi
         poly.push_back({ .x = waypoint.x, .y = waypoint.y });
         const std::optional<size_t> canonical = session.CanonicalIndexAtCurrentPath(index);
         if (canonical && *canonical == anchor_index) {
+            reached_anchor = true;
             break;
         }
+    }
+    if (!reached_anchor) {
+        return {};
     }
     return poly;
 }
@@ -346,7 +341,7 @@ bool NavRunController::buildPlan(
     };
 
     // The literal-vs-navmesh choice is per anchor span: decide once, reuse across soft replans.
-    // invalidate() (anchor/zone change) resets plan_ and forces a fresh decision.
+    // invalidate() (anchor/zone change, or recovery's nav_run_dirty) resets plan_ for a fresh decision.
     const bool same_span = plan_.valid && plan_.anchor_index == anchor_index;
     std::vector<navmesh::WorldPoint> authored = BuildAuthoredSpanPolyline(session, anchor_index);
     const bool authored_usable = authored.size() >= 2;

--- a/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
@@ -240,6 +240,81 @@ int64_t ElapsedMs(std::chrono::steady_clock::time_point from, std::chrono::stead
     return std::chrono::duration_cast<std::chrono::milliseconds>(to - from).count();
 }
 
+double PointToSegmentDistance(const navmesh::WorldPoint& p, const navmesh::WorldPoint& a, const navmesh::WorldPoint& b)
+{
+    const double dx = b.x - a.x;
+    const double dy = b.y - a.y;
+    const double len_sq = dx * dx + dy * dy;
+    if (len_sq <= std::numeric_limits<double>::epsilon()) {
+        return std::hypot(p.x - a.x, p.y - a.y);
+    }
+    const double t = std::clamp(((p.x - a.x) * dx + (p.y - a.y) * dy) / len_sq, 0.0, 1.0);
+    return std::hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy));
+}
+
+double PointToPolylineDistance(const navmesh::WorldPoint& p, const std::vector<navmesh::WorldPoint>& poly)
+{
+    double best = std::numeric_limits<double>::infinity();
+    for (size_t i = 0; i + 1 < poly.size(); ++i) {
+        best = std::min(best, PointToSegmentDistance(p, poly[i], poly[i + 1]));
+    }
+    return best;
+}
+
+// Fraction of the corridor (resampled every ~`step` world units) within `eps` of the authored line:
+// ~1.0 when it tracks the line, ~0 when it detours (route3 ~0.05). 1.0 on degenerate input.
+double CorridorCoincidence(
+    const navmesh::WorldPath& corridor,
+    const std::vector<navmesh::WorldPoint>& authored,
+    double eps,
+    double step)
+{
+    if (corridor.points.size() < 2 || authored.size() < 2) {
+        return 1.0;
+    }
+    const double safe_step = std::max(step, 0.1);
+    size_t total = 0;
+    size_t coincident = 0;
+    const auto tally = [&](const navmesh::WorldPoint& p) {
+        ++total;
+        if (PointToPolylineDistance(p, authored) <= eps) {
+            ++coincident;
+        }
+    };
+    tally(corridor.points.front());
+    for (size_t i = 0; i + 1 < corridor.points.size(); ++i) {
+        const navmesh::WorldPoint& a = corridor.points[i];
+        const navmesh::WorldPoint& b = corridor.points[i + 1];
+        const double seg = std::hypot(b.x - a.x, b.y - a.y);
+        const int steps = static_cast<int>(std::ceil(seg / safe_step));
+        for (int k = 1; k <= steps; ++k) {
+            const double t = static_cast<double>(k) / static_cast<double>(steps);
+            tally({ .x = a.x + (b.x - a.x) * t, .y = a.y + (b.y - a.y) * t });
+        }
+    }
+    return total == 0 ? 1.0 : static_cast<double>(coincident) / static_cast<double>(total);
+}
+
+// The authored line from the current waypoint up to and including the anchor. Fewer than 2 points when
+// the span can't be assembled (caller then keeps the navmesh corridor).
+std::vector<navmesh::WorldPoint> BuildAuthoredSpanPolyline(const NavigationSession& session, size_t anchor_index)
+{
+    const std::vector<Waypoint>& waypoints = session.current_path();
+    std::vector<navmesh::WorldPoint> poly;
+    for (size_t index = session.current_node_idx(); index < waypoints.size(); ++index) {
+        const Waypoint& waypoint = waypoints[index];
+        if (!waypoint.HasPosition()) {
+            break;
+        }
+        poly.push_back({ .x = waypoint.x, .y = waypoint.y });
+        const std::optional<size_t> canonical = session.CanonicalIndexAtCurrentPath(index);
+        if (canonical && *canonical == anchor_index) {
+            break;
+        }
+    }
+    return poly;
+}
+
 } // namespace
 
 void NavRunController::invalidate()
@@ -251,12 +326,39 @@ void NavRunController::invalidate()
 
 bool NavRunController::buildPlan(
     const NaviParam& param,
+    const NavigationSession& session,
     const NaviPosition& position,
     size_t anchor_index,
     const Waypoint& anchor,
     NavRunReplanReason reason,
     std::chrono::steady_clock::time_point now)
 {
+    const auto commit = [&](navmesh::WorldPath path, bool literal) {
+        plan_.valid = true;
+        plan_.zone_id = position.zone_id;
+        plan_.anchor_index = anchor_index;
+        plan_.anchor_pos = { .x = anchor.x, .y = anchor.y };
+        plan_.literal = literal;
+        plan_.path = std::move(path);
+        plan_.corridor_arc_prefix = BuildCorridorArcPrefix(plan_.path);
+        plan_.cursor = 0;
+        plan_.planned_at = now;
+    };
+
+    // The literal-vs-navmesh choice is per anchor span: decide once, reuse across soft replans.
+    // invalidate() (anchor/zone change) resets plan_ and forces a fresh decision.
+    const bool same_span = plan_.valid && plan_.anchor_index == anchor_index;
+    std::vector<navmesh::WorldPoint> authored = BuildAuthoredSpanPolyline(session, anchor_index);
+    const bool authored_usable = authored.size() >= 2;
+
+    // Already literal this span: rebuild from the advanced waypoint, skip the A* (it would detour again).
+    if (same_span && plan_.literal && authored_usable) {
+        navmesh::WorldPath literal_path;
+        literal_path.points = std::move(authored);
+        commit(std::move(literal_path), true);
+        return true;
+    }
+
     const navmesh::WorldPoint start { .x = position.x, .y = position.y };
     const navmesh::WorldPoint goal { .x = anchor.x, .y = anchor.y };
     auto route = PlanNavmeshRoute(param, position.zone_id, start, goal);
@@ -266,14 +368,35 @@ bool NavRunController::buildPlan(
         return false;
     }
 
-    plan_.valid = true;
-    plan_.zone_id = position.zone_id;
-    plan_.anchor_index = anchor_index;
-    plan_.anchor_pos = { .x = anchor.x, .y = anchor.y };
-    plan_.path = std::move(route->path);
-    plan_.corridor_arc_prefix = BuildCorridorArcPrefix(plan_.path);
-    plan_.cursor = 0;
-    plan_.planned_at = now;
+    bool literal = same_span && plan_.literal;
+    if (!same_span && authored_usable) {
+        // Fresh span: go literal iff the corridor barely coincides (detoured) AND the line really crosses
+        // water. off_mesh is sampled only after the cheap coincidence gate passes; -1 = not evaluated.
+        const double coincidence =
+            CorridorCoincidence(route->path, authored, kCorridorLiteralFidelityEpsilonM, kCorridorLiteralSampleStepM);
+        double off_mesh = -1.0;
+        if (coincidence < kCorridorLiteralMinCoincidence) {
+            off_mesh = NavmeshOffMeshFraction(param, position.zone_id, authored, kCorridorLiteralSampleStepM);
+            literal = off_mesh > kCorridorLiteralMinOffMeshFraction;
+        }
+        // Log both outcomes so the decision is diagnosable on-device (route3: coincidence ~0.05,
+        // off_mesh ~0.63, authored.size 21).
+        LogDebug << "NavRunController corridor-source decision." << VAR(anchor_index) << VAR(literal)
+                 << VAR(coincidence) << VAR(off_mesh) << VAR(route->path.points.size()) << VAR(authored.size());
+        if (literal) {
+            LogInfo << "NavRunController trusting authored RUN line (corridor detours off-mesh)."
+                    << VAR(anchor_index) << VAR(coincidence) << VAR(off_mesh) << VAR(authored.size());
+        }
+    }
+
+    if (literal && authored_usable) {
+        navmesh::WorldPath literal_path;
+        literal_path.points = std::move(authored);
+        commit(std::move(literal_path), true);
+    }
+    else {
+        commit(std::move(route->path), false);
+    }
     return true;
 }
 
@@ -336,7 +459,7 @@ NavRunTickResult NavRunController::tick(
     }
 
     if (!plan_.valid) {
-        if (!buildPlan(param, position, anchor_index, anchor, NavRunReplanReason::AnchorChanged, now)) {
+        if (!buildPlan(param, *session, position, anchor_index, anchor, NavRunReplanReason::AnchorChanged, now)) {
             return result;
         }
         last_progress_seen_ = now;
@@ -371,7 +494,7 @@ NavRunTickResult NavRunController::tick(
         if (budget_left && (hard_off || cooldown_ready)) {
             plan_.last_soft_replan_at = now;
             plan_.soft_replan_attempts += 1;
-            if (buildPlan(param, position, anchor_index, anchor, reason, now)) {
+            if (buildPlan(param, *session, position, anchor_index, anchor, reason, now)) {
                 auto reprojected = ProjectOntoCorridor(plan_.path, plan_.cursor, position);
                 if (!reprojected) {
                     invalidate();

--- a/agent/cpp-algo/source/MapNavigator/nav_run_controller.h
+++ b/agent/cpp-algo/source/MapNavigator/nav_run_controller.h
@@ -35,6 +35,9 @@ struct NavRunPlan
     NaviPosition anchor_pos {};
     navmesh::WorldPath path;
     std::vector<double> corridor_arc_prefix;
+    // `path` is the authored RUN line itself (corridor would only detour around water). Decided once
+    // per anchor span, reused across its soft replans, reset when the anchor changes.
+    bool literal = false;
     size_t cursor = 0;
     std::chrono::steady_clock::time_point planned_at {};
     std::chrono::steady_clock::time_point last_soft_replan_at {};
@@ -77,6 +80,7 @@ public:
 private:
     bool buildPlan(
         const NaviParam& param,
+        const NavigationSession& session,
         const NaviPosition& position,
         size_t anchor_index,
         const Waypoint& anchor,

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -108,6 +108,11 @@ constexpr int32_t kNavRunSoftReplanCooldownMs = 1200;
 constexpr int32_t kNavRunSoftReplanMaxPerAnchor = 3;
 constexpr int32_t kNavRunProgressRegressionMs = 800;
 
+constexpr double kCorridorLiteralFidelityEpsilonM = 2.0;     // corridor sample within this of the line "coincides"
+constexpr double kCorridorLiteralMinCoincidence = 0.5;       // coincidence below this => corridor detoured (route3 ~0.05)
+constexpr double kCorridorLiteralMinOffMeshFraction = 0.15;  // span must be this much off-mesh to qualify (route3 ~0.43)
+constexpr double kCorridorLiteralSampleStepM = 1.0;          // resample step (world units)
+
 // --- Zone / Portal / Transfer Constants ---
 constexpr int32_t kZoneConfirmRetryIntervalMs = 120;
 constexpr int32_t kZoneConfirmTimeoutMs = 12000;

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -706,6 +706,59 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(
     return route_result;
 }
 
+double NavmeshOffMeshFraction(
+    const NaviParam& param,
+    const std::string& locator_zone,
+    const std::vector<navmesh::WorldPoint>& polyline,
+    double step)
+{
+    if (polyline.size() < 2) {
+        return 0.0;
+    }
+    const std::string navmesh_zone = InferBaseNavZone(locator_zone, param.map_name);
+    if (navmesh_zone.empty()) {
+        return 0.0;
+    }
+    const std::filesystem::path navmesh_path = ResolveNavmeshFile(param.navmesh_file);
+    const auto navmesh = LoadCachedNavmesh(navmesh_path, navmesh_zone);
+    if (!navmesh) {
+        return 0.0;
+    }
+
+    const double safe_step = std::max(step, 0.1);
+    size_t total = 0;
+    size_t off = 0;
+    // projectToBase maps a tier query onto its geometry zone (identity for a base zone), keeping the
+    // frame aligned with the routed mesh; an unresolvable sample is skipped (treated as on-mesh).
+    const auto sample = [&](const navmesh::WorldPoint& p) {
+        const auto proj = navmesh->pack.projectToBase(navmesh_zone, p.x, p.y);
+        if (!proj || proj->geometry_zone == nullptr) {
+            return;
+        }
+        ++total;
+        if (!navmesh->planner.pointOnMesh(proj->geometry_zone->zone_id, { .x = proj->x, .y = proj->y })) {
+            ++off;
+        }
+    };
+
+    // Sample both endpoints of every segment so a mid-segment water dip between on-mesh vertices counts.
+    sample(polyline.front());
+    for (size_t i = 0; i + 1 < polyline.size(); ++i) {
+        const navmesh::WorldPoint& a = polyline[i];
+        const navmesh::WorldPoint& b = polyline[i + 1];
+        const double seg = std::hypot(b.x - a.x, b.y - a.y);
+        const int steps = static_cast<int>(std::ceil(seg / safe_step));
+        for (int k = 1; k <= steps; ++k) {
+            const double t = static_cast<double>(k) / static_cast<double>(steps);
+            sample({ .x = a.x + (b.x - a.x) * t, .y = a.y + (b.y - a.y) * t });
+        }
+    }
+    if (total == 0) {
+        return 0.0;
+    }
+    return static_cast<double>(off) / static_cast<double>(total);
+}
+
 std::optional<navmesh::BaseNavRouteResult> PlanNavmeshDetourRoute(
     const NaviParam& param,
     const NaviPosition& position,

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -725,7 +725,6 @@ double NavmeshOffMeshFraction(
         return 0.0;
     }
 
-    const double safe_step = std::max(step, 0.1);
     size_t total = 0;
     size_t off = 0;
     // projectToBase maps a tier query onto its geometry zone (identity for a base zone), keeping the
@@ -742,17 +741,7 @@ double NavmeshOffMeshFraction(
     };
 
     // Sample both endpoints of every segment so a mid-segment water dip between on-mesh vertices counts.
-    sample(polyline.front());
-    for (size_t i = 0; i + 1 < polyline.size(); ++i) {
-        const navmesh::WorldPoint& a = polyline[i];
-        const navmesh::WorldPoint& b = polyline[i + 1];
-        const double seg = std::hypot(b.x - a.x, b.y - a.y);
-        const int steps = static_cast<int>(std::ceil(seg / safe_step));
-        for (int k = 1; k <= steps; ++k) {
-            const double t = static_cast<double>(k) / static_cast<double>(steps);
-            sample({ .x = a.x + (b.x - a.x) * t, .y = a.y + (b.y - a.y) * t });
-        }
-    }
+    ForEachResampledPoint(polyline, step, sample);
     if (total == 0) {
         return 0.0;
     }

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -29,6 +29,14 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(
     const navmesh::WorldPoint& start,
     const navmesh::WorldPoint& goal,
     const std::vector<uint32_t>& blocked_triangles = {});
+// Fraction of `polyline` (resampled every ~`step` world units, vertices included) lying OFF the
+// navmesh — the signature of water the game omits. Resolves the zone like PlanNavmeshRoute. Returns
+// 0.0 when the zone can't resolve or the line is empty (fail-safe on-mesh).
+double NavmeshOffMeshFraction(
+    const NaviParam& param,
+    const std::string& locator_zone,
+    const std::vector<navmesh::WorldPoint>& polyline,
+    double step);
 std::optional<navmesh::BaseNavRouteResult> PlanNavmeshDetourRoute(
     const NaviParam& param,
     const NaviPosition& position,

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <optional>
@@ -29,6 +32,29 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(
     const navmesh::WorldPoint& start,
     const navmesh::WorldPoint& goal,
     const std::vector<uint32_t>& blocked_triangles = {});
+// Resample `poly` at ~`step` world units (clamped to >=0.1) and invoke `fn` on the leading vertex and
+// every resampled point. Shared by NavmeshOffMeshFraction and NavRunController's CorridorCoincidence so
+// both sampling passes stay identical. Caller guards poly.size() >= 2 for a meaningful result.
+template <typename Fn>
+void ForEachResampledPoint(const std::vector<navmesh::WorldPoint>& poly, double step, Fn&& fn)
+{
+    if (poly.empty()) {
+        return;
+    }
+    const double safe_step = std::max(step, 0.1);
+    fn(poly.front());
+    for (size_t i = 0; i + 1 < poly.size(); ++i) {
+        const navmesh::WorldPoint& a = poly[i];
+        const navmesh::WorldPoint& b = poly[i + 1];
+        const double seg = std::hypot(b.x - a.x, b.y - a.y);
+        const int steps = static_cast<int>(std::ceil(seg / safe_step));
+        for (int k = 1; k <= steps; ++k) {
+            const double t = static_cast<double>(k) / static_cast<double>(steps);
+            fn(navmesh::WorldPoint { .x = a.x + (b.x - a.x) * t, .y = a.y + (b.y - a.y) * t });
+        }
+    }
+}
+
 // Fraction of `polyline` (resampled every ~`step` world units, vertices included) lying OFF the
 // navmesh — the signature of water the game omits. Resolves the zone like PlanNavmeshRoute. Returns
 // 0.0 when the zone can't resolve or the line is empty (fail-safe on-mesh).


### PR DESCRIPTION
## Summary by Sourcery

当导航网格走廊（navmesh corridor）在明显绕开诸如水面等网格外区域（off-mesh regions）时，优先采用预先编写的 RUN 线路，而在其他情况下则继续使用基于导航网格的路径规划。

New Features:
- 在 `NavRunController` 中添加逻辑，可在每个 anchor-span 的粒度上，在“严格跟随预先编写的 RUN 折线（polyline）”与“使用导航网格规划出的走廊”之间进行选择。
- 引入配置阈值，用于控制在什么情况下一个走廊被视为“绕路（detoured）”，以及在何种情况下预先编写的线路已经“足够处于网格外（off-mesh）”而可以被完全信任并按字面执行。

Enhancements:
- 在同一 anchor span 的软重规划（soft replans）之间缓存并复用“字面线路 vs 导航网格”决策，以避免重复绕路。
- 添加诊断日志，用于暴露走廊来源决策以及相关的度量数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prefer authored RUN lines over navmesh replanning when the navmesh corridor clearly detours around off-mesh regions such as water, while retaining navmesh-based routing otherwise.

New Features:
- Add logic in NavRunController to choose between following the authored RUN polyline literally or using a navmesh-planned corridor on a per-anchor-span basis.
- Introduce configuration thresholds to control when a corridor is considered detoured and when an authored line is sufficiently off-mesh to trust literally.

Enhancements:
- Cache and reuse the literal-vs-navmesh decision across soft replans for the same anchor span to avoid repeated detours.
- Add diagnostic logging to surface corridor source decisions and supporting metrics.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

当导航网格走廊（navmesh corridor）在明显绕开诸如水面等网格外区域（off-mesh regions）时，优先采用预先编写的 RUN 线路，而在其他情况下则继续使用基于导航网格的路径规划。

New Features:
- 在 `NavRunController` 中添加逻辑，可在每个 anchor-span 的粒度上，在“严格跟随预先编写的 RUN 折线（polyline）”与“使用导航网格规划出的走廊”之间进行选择。
- 引入配置阈值，用于控制在什么情况下一个走廊被视为“绕路（detoured）”，以及在何种情况下预先编写的线路已经“足够处于网格外（off-mesh）”而可以被完全信任并按字面执行。

Enhancements:
- 在同一 anchor span 的软重规划（soft replans）之间缓存并复用“字面线路 vs 导航网格”决策，以避免重复绕路。
- 添加诊断日志，用于暴露走廊来源决策以及相关的度量数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prefer authored RUN lines over navmesh replanning when the navmesh corridor clearly detours around off-mesh regions such as water, while retaining navmesh-based routing otherwise.

New Features:
- Add logic in NavRunController to choose between following the authored RUN polyline literally or using a navmesh-planned corridor on a per-anchor-span basis.
- Introduce configuration thresholds to control when a corridor is considered detoured and when an authored line is sufficiently off-mesh to trust literally.

Enhancements:
- Cache and reuse the literal-vs-navmesh decision across soft replans for the same anchor span to avoid repeated detours.
- Add diagnostic logging to surface corridor source decisions and supporting metrics.

</details>

</details>