### PR TITLE
ci(build):  构建时优先使用 VS2026，VS2022 作为备选

### DIFF
--- a/agent/cpp-algo/CMakePresets.json
+++ b/agent/cpp-algo/CMakePresets.json
@@ -52,18 +52,6 @@
             }
         },
         {
-            "name": "MSVC 2022",
-            "displayName": "MSVC 2022",
-            "description": "MSVC 2022",
-            "generator": "Visual Studio 17 2022",
-            "binaryDir": "${sourceDir}/build",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            }
-        },
-        {
             "name": "MSVC 2026",
             "displayName": "MSVC 2026",
             "description": "MSVC 2026",
@@ -73,22 +61,6 @@
                 "type": "equals",
                 "lhs": "${hostSystemName}",
                 "rhs": "Windows"
-            }
-        },
-        {
-            "name": "MSVC 2022 ARM",
-            "displayName": "MSVC 2022 ARM",
-            "description": "MSVC 2022 ARM",
-            "generator": "Visual Studio 17 2022",
-            "binaryDir": "${sourceDir}/build",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
-            "architecture": {
-                "strategy": "set",
-                "value": "ARM64"
             }
         },
         {
@@ -134,26 +106,10 @@
             "jobs": 16
         },
         {
-            "name": "MSVC 2022 - RelWithDebInfo",
-            "displayName": "MSVC 2022 RelWithDebInfo",
-            "description": "MSVC 2022 RelWithDebInfo",
-            "configurePreset": "MSVC 2022",
-            "configuration": "RelWithDebInfo",
-            "jobs": 16
-        },
-        {
             "name": "MSVC 2026 - RelWithDebInfo",
             "displayName": "MSVC 2026 RelWithDebInfo",
             "description": "MSVC 2026 RelWithDebInfo",
             "configurePreset": "MSVC 2026",
-            "configuration": "RelWithDebInfo",
-            "jobs": 16
-        },
-        {
-            "name": "MSVC 2022 ARM - RelWithDebInfo",
-            "displayName": "MSVC 2022 ARM RelWithDebInfo",
-            "description": "MSVC 2022 ARM RelWithDebInfo",
-            "configurePreset": "MSVC 2022 ARM",
             "configuration": "RelWithDebInfo",
             "jobs": 16
         },

--- a/agent/cpp-algo/CMakePresets.json
+++ b/agent/cpp-algo/CMakePresets.json
@@ -64,10 +64,38 @@
             }
         },
         {
+            "name": "MSVC 2022",
+            "displayName": "MSVC 2022",
+            "description": "MSVC 2022",
+            "generator": "Visual Studio 17 2022",
+            "binaryDir": "${sourceDir}/build",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
             "name": "MSVC 2026 ARM",
             "displayName": "MSVC 2026 ARM",
             "description": "MSVC 2026 ARM",
             "generator": "Visual Studio 18 2026",
+            "binaryDir": "${sourceDir}/build",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            },
+            "architecture": {
+                "strategy": "set",
+                "value": "ARM64"
+            }
+        },
+        {
+            "name": "MSVC 2022 ARM",
+            "displayName": "MSVC 2022 ARM",
+            "description": "MSVC 2022 ARM",
+            "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/build",
             "condition": {
                 "type": "equals",
@@ -114,10 +142,26 @@
             "jobs": 16
         },
         {
+            "name": "MSVC 2022 - RelWithDebInfo",
+            "displayName": "MSVC 2022 RelWithDebInfo",
+            "description": "MSVC 2022 RelWithDebInfo",
+            "configurePreset": "MSVC 2022",
+            "configuration": "RelWithDebInfo",
+            "jobs": 16
+        },
+        {
             "name": "MSVC 2026 ARM - RelWithDebInfo",
             "displayName": "MSVC 2026 ARM RelWithDebInfo",
             "description": "MSVC 2026 ARM RelWithDebInfo",
             "configurePreset": "MSVC 2026 ARM",
+            "configuration": "RelWithDebInfo",
+            "jobs": 16
+        },
+        {
+            "name": "MSVC 2022 ARM - RelWithDebInfo",
+            "displayName": "MSVC 2022 ARM RelWithDebInfo",
+            "description": "MSVC 2022 ARM RelWithDebInfo",
+            "configurePreset": "MSVC 2022 ARM",
             "configuration": "RelWithDebInfo",
             "jobs": 16
         }

--- a/tools/build_and_install.py
+++ b/tools/build_and_install.py
@@ -394,10 +394,9 @@ def build_cpp_algo(
     configure_preset_candidates: list[str]
     if resolved_os == "win":
         if resolved_arch == "aarch64":
-            configure_preset_candidates = ["MSVC 2022 ARM", "MSVC 2026 ARM"]
+            configure_preset_candidates = ["MSVC 2026 ARM"]
         else:
-            # 兼容仅安装 VS2026 的环境：优先尝试 2022，失败时自动回退 2026
-            configure_preset_candidates = ["MSVC 2022", "MSVC 2026"]
+            configure_preset_candidates = ["MSVC 2026"]
     elif resolved_os == "linux":
         if resolved_arch == "aarch64":
             configure_preset_candidates = ["NinjaMulti Linux arm64"]

--- a/tools/build_and_install.py
+++ b/tools/build_and_install.py
@@ -394,9 +394,9 @@ def build_cpp_algo(
     configure_preset_candidates: list[str]
     if resolved_os == "win":
         if resolved_arch == "aarch64":
-            configure_preset_candidates = ["MSVC 2026 ARM"]
+            configure_preset_candidates = ["MSVC 2026 ARM", "MSVC 2022 ARM"]
         else:
-            configure_preset_candidates = ["MSVC 2026"]
+            configure_preset_candidates = ["MSVC 2026", "MSVC 2022"]
     elif resolved_os == "linux":
         if resolved_arch == "aarch64":
             configure_preset_candidates = ["NinjaMulti Linux arm64"]

--- a/tools/build_and_install.py
+++ b/tools/build_and_install.py
@@ -396,6 +396,7 @@ def build_cpp_algo(
         if resolved_arch == "aarch64":
             configure_preset_candidates = ["MSVC 2026 ARM", "MSVC 2022 ARM"]
         else:
+            # 兼容仅安装 VS2022 的环境：优先尝试 2026，失败时自动回退 2022
             configure_preset_candidates = ["MSVC 2026", "MSVC 2022"]
     elif resolved_os == "linux":
         if resolved_arch == "aarch64":


### PR DESCRIPTION
## Summary by Sourcery

构建：
- 更新 Windows C++ 构建配置，在 x64 和 ARM 目标平台上优先尝试使用 MSVC 2026 预设，其次再使用 MSVC 2022。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update Windows C++ build configuration to try MSVC 2026 presets before MSVC 2022 for both x64 and ARM targets.

</details>
- 更新 Windows C++ 构建配置，仅使用 MSVC 2026 预设，移除对 MSVC 2022 的兼容支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

构建：
- 更新 Windows C++ 构建配置，在 x64 和 ARM 目标平台上优先尝试使用 MSVC 2026 预设，其次再使用 MSVC 2022。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update Windows C++ build configuration to try MSVC 2026 presets before MSVC 2022 for both x64 and ARM targets.

</details>

</details>