### PR TITLE
chore: 更改欢迎消息(公告)为 api 的链接

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -5,7 +5,7 @@
     "version": "v0.1.0",
     "contact": "$contact.file",
     "license": "locales/LICENSE_SHORT.md",
-    "welcome": "README.md",
+    "welcome": "https://end.maafw.com/Announcement.md",
     "icon": "locales/MaaEnd-Tiny.png",
     "github": "https://github.com/MaaEnd/MaaEnd",
     "mirrorchyan_rid": "MaaEnd",

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -5,7 +5,7 @@
     "version": "v0.1.0",
     "contact": "$contact.file",
     "license": "locales/LICENSE_SHORT.md",
-    "welcome": "https://end.maafw.com/Announcement.md",
+    "welcome": "https://end.maafw.com/anno.md",
     "icon": "locales/MaaEnd-Tiny.png",
     "github": "https://github.com/MaaEnd/MaaEnd",
     "mirrorchyan_rid": "MaaEnd",


### PR DESCRIPTION
可以在 api 仓库修改给用户的公告
目前没有填对应内容,大家看看 https://github.com/MaaEnd/MaaEndAPI/blob/main/API/anno.md 要写什么
目前的显示效果:
<img width="1944" height="1104" alt="6e496ee599d8892469f99729ac0b48a6" src="https://github.com/user-attachments/assets/4efdb0c3-e737-478e-b4a6-2099b325c321" />

## Summary by Sourcery

增强：
- 通过更新接口配置，使客户端公告入口与集中化的 MaaEndAPI 公告端点保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Align the client announcement entry with the centralized MaaEndAPI announcement endpoint by updating the interface configuration.

</details>

## Summary by Sourcery

增强功能：
- 通过接口配置，将应用内公告/欢迎消息路由到由 MaaEndAPI 仓库管理的内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Route the in-app announcement/welcome message to content managed in the MaaEndAPI repository via the interface configuration.

</details>