### PR TITLE
revert: revert #3708 中对文档段落的异常合并

### DIFF
--- a/docs/en_us/developers/README.md
+++ b/docs/en_us/developers/README.md
@@ -30,7 +30,8 @@ It is recommended to read in the following order:
 7.  When using a specific advanced component → Check the corresponding document under `components/`
 8.  When maintaining a specific task → Check the corresponding document under `tasks/`
 
-> [!WARNING] > **Before submitting any code, you must read the [Coding Standards](./coding-standards.md) first.**
+> [!WARNING]
+> **Before submitting any code, you must read the [Coding Standards](./coding-standards.md) first.**
 > Non-compliant PRs will be rejected immediately.
 
 ## Documentation Index

--- a/docs/en_us/developers/super-basic-introduction.md
+++ b/docs/en_us/developers/super-basic-introduction.md
@@ -609,7 +609,8 @@ After finishing this introduction, continue in order:
 | 3     | [tools-and-debug.md](./tools-and-debug.md)   | Debugging tools, Maa Pipeline Support usage                           |
 | 4     | [coding-standards.md](./coding-standards.md) | Coding conventions — must-read before submitting                      |
 
-> [!NOTE] > **External resources**
+> [!NOTE]
+> **External resources**
 >
 > These links point to separate projects or third-party services outside of MaaEnd, provided for reference.
 
@@ -631,7 +632,8 @@ When you hit something you don't understand, don't panic and don't rush to ask a
 
 ---
 
-> [!NOTE] > **Final Words**
+> [!NOTE]
+> **Final Words**
 >
 > You don't need to learn everything from start to finish before you begin. The best way to learn:
 >

--- a/docs/en_us/developers/tasks/auto-stockstaple-maintain.md
+++ b/docs/en_us/developers/tasks/auto-stockstaple-maintain.md
@@ -143,7 +143,8 @@ Therefore, the `And` conditions for `AutoStockBuyItemValleyIVTask` are:
 
 When all three hit simultaneously, click the item card (`target_offset: [-50, 95, 0, 0]`), `next` enters `AutoStockStapleQuantityControl`.
 
-> [!IMPORTANT] > `AutoStockBuyItemValleyIVTask` only means "a candidate item was recognized and purchase determination entered", **it does not equal** a completed purchase. Whether an order is actually placed depends on whether the quantity control branch reaches `AutoStockStapleQuantityControlConfirmBuy`.
+> [!IMPORTANT]
+> `AutoStockBuyItemValleyIVTask` only means "a candidate item was recognized and purchase determination entered", **it does not equal** a completed purchase. Whether an order is actually placed depends on whether the quantity control branch reaches `AutoStockStapleQuantityControlConfirmBuy`.
 
 ### 5. Sold Out and Swipe
 

--- a/docs/zh_cn/developers/README.md
+++ b/docs/zh_cn/developers/README.md
@@ -30,7 +30,8 @@ flowchart TD
 7. 用到某个高级组件时 → 查 `components/` 下的对应文档
 8. 维护某个具体任务时 → 查 `tasks/` 下的对应文档
 
-> [!WARNING] > **提交任何代码前，必须先通读 [编码规范](./coding-standards.md)。**
+> [!WARNING]
+> **提交任何代码前，必须先通读 [编码规范](./coding-standards.md)。**
 > 不合规范的 PR 会被直接打回。
 
 ## 文档索引

--- a/docs/zh_cn/developers/components/better-sliding.md
+++ b/docs/zh_cn/developers/components/better-sliding.md
@@ -58,7 +58,8 @@
 | `TargetReverse`           | `bool`          | 否   | 为 `true` 时从范围远端计算目标：Value 模式为 `maxQuantity - Target`；Percentage 模式为 `round(maxQuantity * (100 - Target) / 100)`，钳制到 `[1, maxQuantity]`。默认 `false`。 |
 | `FinishAfterPreciseClick` | `bool`          | 否   | 为 `true` 时精确点击后直接返回成功，不再进入数量校验与微调流程。默认 `false`。                                                                                                |
 
-> [!note] > `TargetType` 与 `TargetReverse` 的组合计算逻辑：
+> [!note]
+> `TargetType` 与 `TargetReverse` 的组合计算逻辑：
 >
 > | TargetType     | TargetReverse | 有效目标                                                               |
 > | -------------- | ------------- | ---------------------------------------------------------------------- |

--- a/docs/zh_cn/developers/components/capture-uid.md
+++ b/docs/zh_cn/developers/components/capture-uid.md
@@ -64,7 +64,8 @@
 | `allow_unknown`          | `bool` | `true`  | OCR 失败时返回 `"unknown"` 而非报错。为 `false` 时 OCR 失败将导致动作失败。              |
 | `clear_cache`            | `bool` | `false` | 清空 UID 缓存并立即返回，不执行截屏 OCR。                                                |
 
-> [!note] > `clear_cache` 为 `true` 时，其余参数均不生效——动作仅清空缓存后直接返回成功。
+> [!note]
+> `clear_cache` 为 `true` 时，其余参数均不生效——动作仅清空缓存后直接返回成功。
 
 ## 在 Go 代码中直接调用
 

--- a/docs/zh_cn/developers/super-basic-introduction.md
+++ b/docs/zh_cn/developers/super-basic-introduction.md
@@ -609,7 +609,8 @@ Push（上传）
 | 3    | [tools-and-debug.md](./tools-and-debug.md)   | 调试工具、Maa Pipeline Support 用法        |
 | 4    | [coding-standards.md](./coding-standards.md) | 编码规范，提交前必读                       |
 
-> [!NOTE] > **外部资源**
+> [!NOTE]
+> **外部资源**
 
 > 以下链接指向 MaaEnd 以外的独立项目或第三方服务，供拓展参考。
 
@@ -631,7 +632,8 @@ Push（上传）
 
 ---
 
-> [!NOTE] > **最后几句**
+> [!NOTE]
+> **最后几句**
 >
 > 你不需要从头学到尾才开始动手。最好的学习方式：
 >


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 修复开发者指南中 NOTE/WARNING/IMPORTANT 提示块的格式，使标题在英文和中文文档中都能正确渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix formatting of NOTE/WARNING/IMPORTANT admonition blocks in developer guides so titles render correctly in both English and Chinese docs.

</details>