### PR TITLE
ci: 添加自动创建 release 分支与 cherry-pick release 分支提交并提 pr 的工作流

### DIFF
--- a/.github/workflows/cherry-pick-to-v2.yml
+++ b/.github/workflows/cherry-pick-to-v2.yml
@@ -99,10 +99,10 @@ jobs:
           echo "Cherry-picking commit: $MERGE_SHA (parents: $PARENT_COUNT)"
 
           if [ "$PARENT_COUNT" -le 1 ]; then
-            git cherry-pick "$MERGE_SHA"
+            git cherry-pick -x "$MERGE_SHA"
           else
-            echo "Merge commit detected, using -m 1"
-            git cherry-pick -m 1 "$MERGE_SHA"
+            echo "Merge commit detected, using -m 1 -x"
+            git cherry-pick -m 1 -x "$MERGE_SHA"
           fi
 
           # 追加 [skip changelog]，避免反向移植 commit 出现在后续版本的 changelog 中。

--- a/.github/workflows/cherry-pick-to-v2.yml
+++ b/.github/workflows/cherry-pick-to-v2.yml
@@ -1,0 +1,150 @@
+name: cherry-pick-to-v2
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cherry-pick:
+    if: |
+      github.repository_owner == 'MaaEnd' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.base.ref, 'release/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract PR metadata
+        id: pr
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          MERGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          RELEASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          FIX_BRANCH="fix/pr-${PR_NUMBER}"
+
+          echo "pr_number=${PR_NUMBER}" | tee -a "$GITHUB_OUTPUT"
+          echo "merge_sha=${MERGE_SHA}" | tee -a "$GITHUB_OUTPUT"
+          echo "release_branch=${RELEASE_BRANCH}" | tee -a "$GITHUB_OUTPUT"
+          echo "fix_branch=${FIX_BRANCH}" | tee -a "$GITHUB_OUTPUT"
+
+          # PR_TITLE 通过 env 传递避免 shell 注入；多行安全写入 GITHUB_OUTPUT
+          {
+            echo "pr_title<<PRTITLE_EOF"
+            echo "$PR_TITLE"
+            echo "PRTITLE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Processing PR #${PR_NUMBER}: '${PR_TITLE}'"
+          echo "  Merged into: ${RELEASE_BRANCH}"
+          echo "  Merge commit: ${MERGE_SHA}"
+
+      # 分支存在检查放在 checkout 之前，避免全量 clone 后发现分支已存在
+      - name: Check if fix branch already exists
+        id: precheck
+        env:
+          FIX_BRANCH: ${{ steps.pr.outputs.fix_branch }}
+        run: |
+          set -euo pipefail
+
+          if git ls-remote --heads "https://github.com/${{ github.repository }}" "$FIX_BRANCH" | grep -q .; then
+            echo "Fix branch $FIX_BRANCH already exists on remote. Skipping cherry-pick."
+            echo "exists=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        if: steps.precheck.outputs.exists != 'true'
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.MAAEND_BOT_TOKEN }}
+          ref: v2
+          # cherry-pick 需要访问 release 分支上的 commit，必须全量 clone
+          fetch-depth: 0
+
+      - name: Cherry-pick merge commit and push fix branch
+        if: steps.precheck.outputs.exists != 'true'
+        id: cherry
+        env:
+          FIX_BRANCH: ${{ steps.pr.outputs.fix_branch }}
+          MERGE_SHA: ${{ steps.pr.outputs.merge_sha }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$FIX_BRANCH"
+
+          # 用 git cat-file 检测是否为 merge commit（有多个 parent），
+          # 比依赖 git 英文错误消息更可靠
+          PARENT_COUNT=$(git cat-file -p "$MERGE_SHA" | grep -c '^parent ' || true)
+
+          echo "Cherry-picking commit: $MERGE_SHA (parents: $PARENT_COUNT)"
+
+          if [ "$PARENT_COUNT" -le 1 ]; then
+            git cherry-pick "$MERGE_SHA"
+          else
+            echo "Merge commit detected, using -m 1"
+            git cherry-pick -m 1 "$MERGE_SHA"
+          fi
+
+          # 追加 [skip changelog] 避免重复出现在 changelog 中
+          git log -1 --format=%B > /tmp/commit_msg.txt
+          echo "" >> /tmp/commit_msg.txt
+          echo "[skip changelog]" >> /tmp/commit_msg.txt
+          git commit --amend -F /tmp/commit_msg.txt
+
+          git push origin "$FIX_BRANCH"
+
+      - name: Create pull request to v2
+        if: steps.precheck.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.MAAEND_BOT_TOKEN }}
+          FIX_BRANCH: ${{ steps.pr.outputs.fix_branch }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_TITLE: ${{ steps.pr.outputs.pr_title }}
+          RELEASE_BRANCH: ${{ steps.pr.outputs.release_branch }}
+        run: |
+          set -euo pipefail
+
+          EXISTING_PR="$(gh pr list --base v2 --head "$FIX_BRANCH" --state open --json number --jq '.[0].number // empty')"
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR already exists: #${EXISTING_PR}. No new PR created."
+            exit 0
+          fi
+
+          # 用 python 做模板替换，避免 sed 注入（| & 等特殊字符）
+          PR_BODY="$(python3 -c "
+          import os
+          body = '''## Summary
+          - This PR automatically cherry-picks the fix merged into a release branch (\`__RELEASE_BRANCH__\`) back to the main development branch (\`v2\`).
+          - Original PR: #__PR_NUMBER__
+          - Original title: __PR_TITLE__
+
+          ## Why
+          The fix was first applied to a release branch. This PR ensures the same fix is also available in the main development branch (v2).
+
+          ## Auto-generated
+          This PR was created automatically by the \`cherry-pick-to-v2\` workflow.
+          [skip changelog]
+          '''
+          body = body.replace('__RELEASE_BRANCH__', os.environ['RELEASE_BRANCH'])
+          body = body.replace('__PR_NUMBER__',     os.environ['PR_NUMBER'])
+          body = body.replace('__PR_TITLE__',      os.environ['PR_TITLE'])
+          print(body)
+          ")"
+
+          gh pr create \
+            --base v2 \
+            --head "$FIX_BRANCH" \
+            --title "fix: cherry-pick #${PR_NUMBER} from ${RELEASE_BRANCH} to v2" \
+            --body "$PR_BODY"

--- a/.github/workflows/cherry-pick-to-v2.yml
+++ b/.github/workflows/cherry-pick-to-v2.yml
@@ -96,10 +96,13 @@ jobs:
             git cherry-pick -m 1 "$MERGE_SHA"
           fi
 
-          # 追加 [skip changelog] 避免重复出现在 changelog 中
+          # 追加 [skip changelog]，避免反向移植 commit 出现在后续版本的 changelog 中。
+          # 原始 fix 已在对应正式版的 changelog 体现，后续 RC/beta 不应再计入。
           git log -1 --format=%B > /tmp/commit_msg.txt
-          echo "" >> /tmp/commit_msg.txt
-          echo "[skip changelog]" >> /tmp/commit_msg.txt
+          if ! grep -qF '[skip changelog]' /tmp/commit_msg.txt; then
+            echo "" >> /tmp/commit_msg.txt
+            echo "[skip changelog]" >> /tmp/commit_msg.txt
+          fi
           git commit --amend -F /tmp/commit_msg.txt
 
           git push origin "$FIX_BRANCH"

--- a/.github/workflows/cherry-pick-to-v2.yml
+++ b/.github/workflows/cherry-pick-to-v2.yml
@@ -1,3 +1,12 @@
+# 修复 PR 自动反向移植到 v2
+#
+# 当针对 release/v* 分支的 PR 被合并时：
+#   → cherry-pick 该合并提交到基于 v2 的 fix/pr-<N> 分支
+#   → 自动创建从 fix/pr-<N> 到 v2 的 PR
+#
+# cherry-pick 的 commit 会自动追加 [skip changelog]，
+# 防止反向移植的修复在后续版本的 changelog 中重复出现。
+
 name: cherry-pick-to-v2
 
 on:

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,3 +1,13 @@
+# 发布分支自动管理
+#
+# RC 版本（vX.Y.Z-rc.N）作为预发布被发布时：
+#   → 从该 RC tag 创建 release/vX.Y 分支
+#
+# 正式版 .0（vX.Y.0）作为正式发布被发布时：
+#   → 删除所有旧的 release/v* 分支（保留当前分支和仍有 open PR 的分支）
+#
+# Hotfix（vX.Y.Z, Z>0）发布时不会触发任何操作。
+
 name: create-release-branch
 
 on:

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -133,10 +133,15 @@ jobs:
             fi
 
             # 检查是否存在打开的 PR 以此分支为 base
-            OPEN_PR="$(gh pr list --base "$branch" --state open --json number --jq '.[0].number // empty' || true)"
-            if [ -n "$OPEN_PR" ]; then
-              echo "  Keeping $branch (open PR #${OPEN_PR} targets it)"
-              SKIPPED_PR=$((SKIPPED_PR + 1))
+            # 用 if 捕获 gh 退出码，失败时跳过（宁可保留分支也不盲目删除）
+            if OPEN_PR="$(gh pr list --base "$branch" --state open --json number --jq '.[0].number // empty' 2>/dev/null)"; then
+              if [ -n "$OPEN_PR" ]; then
+                echo "  Keeping $branch (open PR #${OPEN_PR} targets it)"
+                SKIPPED_PR=$((SKIPPED_PR + 1))
+                continue
+              fi
+            else
+              echo "  Skipping $branch (gh pr list failed — cannot verify open PRs)"
               continue
             fi
 

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,0 +1,156 @@
+name: create-release-branch
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  # ── RC 发布：创建 release/vX.Y 分支 ─────────────────────────────
+  create-branch:
+    if: |
+      github.repository_owner == 'MaaEnd' &&
+      github.event.release.prerelease == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate RC tag and extract base version
+        id: version
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+
+          # 只处理 RC 标签（vX.Y.Z-rc.N），跳过 beta/alpha 等其他预发布
+          if [[ ! "$TAG" =~ ^v([0-9]+\.[0-9]+)\.[0-9]+-rc\.[0-9]+$ ]]; then
+            echo "Tag '$TAG' does not match RC pattern (required: vX.Y.Z-rc.N). Skipping."
+            exit 0
+          fi
+
+          # 提取中版本号：vX.Y.Z-rc.N → vX.Y，分支名 release/vX.Y
+          BASE_VERSION="${BASH_REMATCH[1]}"
+          BRANCH_NAME="release/${BASE_VERSION}"
+
+          echo "tag=${TAG}" | tee -a "$GITHUB_OUTPUT"
+          echo "branch_name=${BRANCH_NAME}" | tee -a "$GITHUB_OUTPUT"
+          echo "proceed=true" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Checkout repository at RC tag
+        if: steps.version.outputs.proceed == 'true'
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.MAAEND_BOT_TOKEN }}
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Create release branch
+        if: steps.version.outputs.proceed == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.version.outputs.branch_name }}
+          TAG_NAME: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # 检查分支是否已存在
+          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q .; then
+            echo "Branch $BRANCH_NAME already exists. Skipping."
+            exit 0
+          fi
+
+          # 当前处于 detached HEAD（RC tag），用 HEAD 创建分支
+          # 避免 shallow clone 下 tag ref 不可用的问题
+          git checkout -b "$BRANCH_NAME" HEAD
+          git push origin "$BRANCH_NAME"
+
+          echo "Created and pushed branch: $BRANCH_NAME (from tag: $TAG_NAME)"
+
+      - name: Log summary
+        if: steps.version.outputs.proceed == 'true'
+        run: |
+          echo "::notice::Release branch '${{ steps.version.outputs.branch_name }}' created from tag '${{ steps.version.outputs.tag }}'"
+
+  # ── Stable .0 发布：清理旧 release 分支 ────────────────────────
+  cleanup-branches:
+    if: |
+      github.repository_owner == 'MaaEnd' &&
+      github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate stable .0 tag
+        id: version
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+
+          # 只处理 .0 结尾的正式版（vX.Y.0），跳过 hotfix（vX.Y.Z, Z>0）
+          if [[ ! "$TAG" =~ ^v([0-9]+\.[0-9]+)\.0$ ]]; then
+            echo "Tag '$TAG' is not a .0 stable release. Skipping cleanup."
+            exit 0
+          fi
+
+          # 提取中版本号：vX.Y.0 → vX.Y，分支名 release/vX.Y
+          CURRENT_BRANCH="release/${BASH_REMATCH[1]}"
+
+          echo "tag=${TAG}" | tee -a "$GITHUB_OUTPUT"
+          echo "current_branch=${CURRENT_BRANCH}" | tee -a "$GITHUB_OUTPUT"
+          echo "proceed=true" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        if: steps.version.outputs.proceed == 'true'
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.MAAEND_BOT_TOKEN }}
+          # 仅需获取凭证用于 git push --delete 等远程操作
+
+      - name: Clean up old release branches
+        if: steps.version.outputs.proceed == 'true'
+        env:
+          CURRENT_BRANCH: ${{ steps.version.outputs.current_branch }}
+          GH_TOKEN: ${{ secrets.MAAEND_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # 仅静默 git ls-remote 自身错误，awk/sed 错误正常传播
+          OLD_BRANCHES=$(git ls-remote --heads origin 'release/v*' 2>/dev/null | awk '{print $2}' | sed 's|refs/heads/||')
+
+          if [ -z "$OLD_BRANCHES" ]; then
+            echo "No old release/v* branches found."
+            exit 0
+          fi
+
+          echo "Current release branch: $CURRENT_BRANCH"
+          echo "Existing release branches:"
+          echo "$OLD_BRANCHES"
+
+          DELETED=0
+          SKIPPED_PR=0
+          for branch in $OLD_BRANCHES; do
+            if [ "$branch" = "$CURRENT_BRANCH" ]; then
+              echo "  Keeping $branch (current)"
+              continue
+            fi
+
+            # 检查是否存在打开的 PR 以此分支为 base
+            OPEN_PR="$(gh pr list --base "$branch" --state open --json number --jq '.[0].number // empty' || true)"
+            if [ -n "$OPEN_PR" ]; then
+              echo "  Keeping $branch (open PR #${OPEN_PR} targets it)"
+              SKIPPED_PR=$((SKIPPED_PR + 1))
+              continue
+            fi
+
+            echo "  Deleting $branch..."
+            git push origin --delete "$branch" 2>/dev/null && DELETED=$((DELETED + 1)) \
+              || echo "    (skipped: no longer exists or no permission)"
+          done
+
+          echo "Deleted $DELETED old release branch(es)."
+          if [ "$SKIPPED_PR" -gt 0 ]; then
+            echo "Skipped $SKIPPED_PR branch(es) with open PRs."
+          fi
+
+      - name: Log summary
+        if: steps.version.outputs.proceed == 'true'
+        run: |
+          echo "::notice::Old release branches cleaned up (current: ${{ steps.version.outputs.current_branch }})"

--- a/docs/zh_cn/developers/README.md
+++ b/docs/zh_cn/developers/README.md
@@ -52,6 +52,7 @@ flowchart TD
 | [工具与调试](./tools-and-debug.md)                            | 开发工具清单、常用调试入口、交流群信息       |
 | [节点测试](./node-testing.md)                                 | 如何编写和运行节点测试，验证识别是否稳定命中 |
 | [Pipeline 协议](https://maafw.com/docs/3.1-PipelineProtocol/) | MaaFramework 官方 Pipeline 协议全文          |
+| [发版流程](./release-process.md)                               | 发版周期、分支模型、PR 往哪提、自动化说明    |
 
 ### Tier 3 — 规范与约束
 
@@ -116,6 +117,7 @@ flowchart TD
 | 改 Pipeline 节点         | [components-guide.md](./components-guide.md) → [common-buttons.md](./common-buttons.md) / [in-scene.md](./in-scene.md) / [scene-manager.md](./scene-manager.md) |
 | 写或调 Go Service        | [components-guide.md](./components-guide.md) → [custom.md](./custom.md)                                                                                         |
 | 查阅编码规范             | [coding-standards.md](./coding-standards.md)                                                                                                                    |
+| 发版 / 提 PR 该往哪分支   | [release-process.md](./release-process.md)                                                                                                                       |
 
 ## 交流
 

--- a/docs/zh_cn/developers/getting-started.md
+++ b/docs/zh_cn/developers/getting-started.md
@@ -376,7 +376,9 @@ Pipeline 跑通后，补齐配套：
 git push origin feat/auto-sell-items
 ```
 
-在 GitHub 把 Draft PR 改为 **Ready for Review**，等待 maintainer review。
+在 GitHub 把 Draft PR 改为 **Ready for Review**，Base 分支选择 `v2`，等待 maintainer review。
+
+> 如果你修的 Bug 在最新正式版（Stable）里也存在，需要往 `release/vX.Y` 分支提，详见[发版流程](./release-process.md)。
 
 恭喜您完成了第一个任务！
 

--- a/docs/zh_cn/developers/release-process.md
+++ b/docs/zh_cn/developers/release-process.md
@@ -1,0 +1,91 @@
+# 发版流程
+
+本文档说明 MaaEnd 的发布分支模型、PR 目标分支选择，以及维护者的发版操作流程。
+
+---
+
+## 普通开发者
+
+以下内容所有贡献者都需要了解。主要是 **PR 往哪个分支提**。
+
+### 分支模型
+
+| 分支           | 用途                               | 允许合入的类型                                           |
+| -------------- | ---------------------------------- | -------------------------------------------------------- |
+| `v2`           | 主开发分支                         | `feat` `refactor` `perf` `fix` `docs` `chore` … 所有类型 |
+| `release/vX.Y` | 当前发布分支（如 `release/v2.16`） | **仅 `fix`**                                             |
+
+> 日常开发（新功能、重构、修 Bug）默认往 `v2` 分支提。`release/vX.Y` 只在特定场景下使用。
+
+### 我该往哪个分支提 PR？
+
+``` text
+你的改动是什么？
+  ├─ 新功能 / 重构 / 日常修复  → 往 v2 分支提
+  └─ 修复影响正式版（Stable）的 Bug   → 往 release/vX.Y 分支提
+```
+
+**简单判断：这个 Bug 在最新正式版里也存在吗？**
+
+- 不存在（只出现在公测版）→ `v2`
+- 存在 → `release/vX.Y`
+
+> 如果往 `release/vX.Y` 分支提了 fix PR，合入后 CI 会**自动**把修复 cherry-pick 回 `v2` 并发起 PR，**不需要你提两个 PR**。
+
+### 分支命名
+
+- 功能分支：`feat/简短描述`（如 `feat/auto-sell-items`）
+- 修复分支：`fix/简短描述`
+
+---
+
+## 维护者
+
+以下内容仅供维护者（有发版权限的人）参考。
+
+### 发版周期
+
+``` text
+每天       Beta（vX.Y.Z-beta.N）→ 基于 v2（周四不发 Beta，发 RC）
+    周四   RC（vX.Y.Z-rc.N）→ 基于 v2
+           ├─ CI 自动创建 release/vX.Y 分支
+           └─ 此后 release 分支只接受 fix PR
+    周五   Stable（vX.Y.0）→ 基于 release/vX.Y
+           ├─ CI 自动清理旧 release/v* 分支
+           └─ 可按需发 Hotfix（vX.Y.1, vX.Y.2 …）
+```
+
+### 发版操作
+
+1. **Beta / RC**：在 `v2` 上打 tag（如 `v2.17.0-beta.1`、`v2.17.0-rc.1`），推送即可触发 CI 构建和发布
+2. **Stable**：在 `release/vX.Y` 分支上打 tag（如 `v2.17.0`），推送后触发正式版构建和发布
+3. **Hotfix**：修复合入 `release/vX.Y` 后，在 release 分支上打新 tag（如 `v2.17.1`）
+
+### 自动化
+
+| 触发事件                 | 自动行为                                      | 工作流                      |
+| ------------------------ | --------------------------------------------- | --------------------------- |
+| RC 版本发布              | 创建 `release/vX.Y` 分支                      | `create-release-branch.yml` |
+| Stable `.0` 发布         | 删除旧 `release/v*` 分支（保留有 open PR 的） | `create-release-branch.yml` |
+| Fix PR 合入 release 分支 | Cherry-pick 到 `fix/pr-N` 并向 `v2` 发起 PR   | `cherry-pick-to-v2.yml`     |
+
+### Hotfix 流程
+
+1. 基于 `release/vX.Y` 创建 fix 分支，提交修复
+2. 提 PR 到 `release/vX.Y`，合入
+3. CI 自动 cherry-pick 到 `v2`，在 v2 上出现一条 `fix: cherry-pick #N from release/vX.Y to v2` 的 PR——**直接合入即可**
+4. 在 release 分支上打新 tag（如 `v2.16.1`）触发发版
+
+### Cherry-pick PR 有冲突怎么办
+
+手动解决冲突，向 `fix/pr-N` 分支推送修复，然后合入。
+
+### 旧 release 分支何时删除
+
+新 Stable `.0` 发布时自动删除。删除前会检查是否有未合入的 open PR，有则跳过（但应尽快处理掉）。
+
+### 注意事项
+
+- Stable `.0` 的 tag **必须在 release 分支上打**，否则 changelog 不会包含 hotfix 修复
+- Hotfix tag（`vX.Y.Z`，Z>0）不会触发清理，release 分支继续存活
+- 自动 cherry-pick 的 commit 带有 `[skip changelog]`，不会在后续版本的 changelog 中重复出现


### PR DESCRIPTION
用法是修复就往 release 分支提 pr 就行，发版就往 release 分支打 tag

## Summary by Sourcery

添加 GitHub Actions 工作流，用于管理发布分支，并自动将发布分支中的修复 cherry-pick 回 v2 开发分支。

CI：
- 新增工作流，用于从 RC 标签创建 `release/vX.Y` 分支，并在稳定版 .0 发布后清理失效的发布分支。
- 新增工作流：在 PR 合并到 `release/v*` 分支时，将该合并提交 cherry-pick 到 `v2`，并自动创建后续跟进 PR。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add GitHub Actions workflows to manage release branches and automate cherry-picking fixes from release branches back into the v2 development branch.

CI:
- Introduce workflow to create release/vX.Y branches from RC tags and clean up obsolete release branches after stable .0 releases.
- Add workflow that, on merge of a PR into a release/v* branch, cherry-picks the merge commit onto v2 and opens an auto-generated follow-up PR.

</details>

## Summary by Sourcery

为发布分支的自动化管理，以及从发布分支回传修复到 v2 开发分支，引入自动化流程。

CI：
- 新增工作流：从 RC 标签创建 `release/vX.Y` 分支，并在稳定版 `.0` 发布后清理过时的发布分支。
- 新增工作流：在 PR 合并到 `release/v*` 分支时，将该合并提交 cherry-pick 到 `v2` 分支，并自动创建后续跟进 PR。

文档：
- 记录发布流程，包括分支模型、PR 目标分支规则和维护者的发布步骤，并从开发者指南中添加链接指向该文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce automated management of release branches and backporting of fixes from release branches to the v2 development branch.

CI:
- Add workflow to create release/vX.Y branches from RC tags and clean up obsolete release branches after stable .0 releases.
- Add workflow that, on merge of a PR into a release/v* branch, cherry-picks the merge commit onto v2 and opens an auto-generated follow-up PR.

Documentation:
- Document the release process, including branch model, PR target branch rules, and maintainer release procedures, and link it from the developer guides.

</details>