### PR TITLE
perf: 应急理智加强剂没有时执行任务结果改为成功

### DIFF
--- a/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/AutoUseSpMedication.json
@@ -329,8 +329,6 @@
     "AutoUseSpMedicationUseNoEmergencySanityBooster": {
         "desc": "提示没有应急理智加强剂并结束任务,只有用户选择了使用应急理智加强剂的任意选项才会跳转到这个节点",
         "enabled": true,
-        "action": "Custom",
-        "custom_action": "FalseAction",
         "focus": {
             "Node.Recognition.Succeeded": "没有应急理智加强剂，结束任务"
         }


### PR DESCRIPTION
不然用户会问任务失败了然后提issue

## Summary by Sourcery

Bug Fixes:
- 在 AutoUseSpMedication 流水线中，当未使用应急理智药剂时，确保任务被视为成功而不是失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure tasks are treated as successful rather than failed when no emergency sanity booster is used in the AutoUseSpMedication pipeline.

</details>