### PR TITLE
feat(MapNavigator): 增加意外掉水的脱困恢复

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -96,6 +96,12 @@ constexpr double kCloseGoalDetourSuppressSlack = 6.0;
 constexpr int32_t kLocalizationLossUnstickIntervalMs = kObstacleRecoveryMinTriggerMs;
 constexpr int32_t kLocalizationLossTimeoutMs = kDynamicRecoveryTotalTimeoutMs;
 
+// River-fall recovery (see navigator-river-fall-teleport-gap): black-screen loss = fell in water, teleported to
+// shore facing it. Turn 180° away then pulse inland until clear; hard clock bounds thin-shore re-fall loops.
+constexpr int32_t kRiverFallRecoveryTimeoutMs = kDynamicRecoveryTotalTimeoutMs;     // 30s clean fail-fast
+constexpr double kRiverFallRecoveryClearDistance = kDynamicRecoveryResetDistance;   // walked 2m clear of shore
+constexpr int32_t kRiverFallRecoveryPulseMs = kPostHeadingForwardPulseMs;           // proven heading-commit pulse
+
 // Off-route wedge watchdog. Corridor progress (what the stall clocks see) keeps advancing while the authored
 // cursor is pinned far off-route, so a bad latch wanders with zero route progress until the action hard-fails.
 // Runs only while off-corridor with no straight-line gain: replan first, then fail-fast so the pipeline retries.

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -97,11 +97,30 @@ struct LocalizationLossState
 {
     std::chrono::steady_clock::time_point started_at {};
     std::chrono::steady_clock::time_point last_unstick_at {};
+    bool saw_black_screen = false;
 
     void Reset()
     {
         started_at = {};
         last_unstick_at = {};
+        saw_black_screen = false;
+    }
+};
+
+// River-fall recovery latch: a black-screen loss = fell in water + force-teleport to shore facing the water.
+// Armed on both re-acquire paths, consumed in TickNavigate. See navigator-river-fall-teleport-gap.
+struct RiverFallRecoveryState
+{
+    NaviPosition anchor_pos {};
+    // Post-fall facing (minimap arrow = toward water); recovery turns to water_heading + 180 to face inland.
+    double water_heading = 0.0;
+    bool pending = false;
+
+    void Reset()
+    {
+        anchor_pos = {};
+        water_heading = 0.0;
+        pending = false;
     }
 };
 
@@ -148,6 +167,7 @@ struct NavigationRuntimeState
     SemanticState semantic;
     DynamicRecoveryState recovery;
     LocalizationLossState localization_loss;
+    RiverFallRecoveryState river_fall;
     SteeringRateState steering_rate;
     OffRouteWedgeState offroute;
     bool dynamic_replan_requested = false;
@@ -169,6 +189,7 @@ struct NavigationRuntimeState
         semantic.ResetTransient();
         recovery.Reset();
         localization_loss.Reset();
+        river_fall.Reset();
         steering_rate.Reset();
         offroute.Reset();
         dynamic_replan_requested = false;
@@ -181,6 +202,7 @@ struct NavigationRuntimeState
     {
         route.ResetTracking();
         recovery.Reset();
+        river_fall.Reset();
         offroute.Reset();
         dynamic_replan_requested = false;
         nav_run_dirty = true;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -523,6 +523,11 @@ bool NavigationStateMachine::HandleLocalizationLoss()
     if (loss.started_at == std::chrono::steady_clock::time_point {}) {
         loss.started_at = now;
     }
+    // River-fall discriminator: a black capture during a loss = fell in water (the locator folds it into a
+    // generic TrackingLost). Latch it so the re-acquire below can arm recovery. See navigator-river-fall.
+    if (position_provider_->LastCaptureWasBlackScreen()) {
+        loss.saw_black_screen = true;
+    }
     motion_controller_->SetForwardState(false);
 
     const auto loss_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - loss.started_at);
@@ -550,6 +555,7 @@ bool NavigationStateMachine::HandleLocalizationLoss()
             }
             LogInfo << "Localization recovered via global re-acquire; resuming navigation." << VAR(loss_elapsed.count())
                     << VAR(prior_zone) << VAR(position_->zone_id) << VAR(position_->x) << VAR(position_->y);
+            ArmRiverFallRecoveryIfBlackScreenLoss("global_reacquire");
             loss.Reset();
             runtime_state_.route.ResetTracking();
             runtime_state_.nav_run_dirty = true;
@@ -571,6 +577,23 @@ bool NavigationStateMachine::HandleLocalizationLoss()
     }
 
     utils::SleepFor(kLocatorRetryIntervalMs);
+    return true;
+}
+
+bool NavigationStateMachine::ArmRiverFallRecoveryIfBlackScreenLoss(const char* via)
+{
+    if (!runtime_state_.localization_loss.saw_black_screen) {
+        return false;
+    }
+    runtime_state_.river_fall.pending = true;
+    runtime_state_.river_fall.anchor_pos = *position_;
+    // Post-fall facing points at the water (the infinite-jump invariant); recovery turns to water_heading + 180.
+    runtime_state_.river_fall.water_heading = NaviMath::NormalizeAngle(position_->angle);
+    // River-fall owns the recovery: the pre-fall dynamic-recovery anchor is stale after the teleport, and a live
+    // recovery's escaped-obstacle check (runs before the river-fall block) would otherwise pre-empt the about-face.
+    runtime_state_.recovery.Reset();
+    LogInfo << "River-fall recovery armed (black-screen loss recovered)." << VAR(via) << VAR(position_->x)
+            << VAR(position_->y) << VAR(runtime_state_.river_fall.water_heading);
     return true;
 }
 
@@ -680,7 +703,23 @@ bool NavigationStateMachine::TickNavigate()
     if (!CaptureCurrentPosition(false)) {
         return HandleLocalizationLoss();
     }
-    runtime_state_.localization_loss.Reset();
+    {
+        LocalizationLossState& loss = runtime_state_.localization_loss;
+        if (loss.started_at != std::chrono::steady_clock::time_point {}) {
+            const auto loss_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                     std::chrono::steady_clock::now() - loss.started_at)
+                                     .count();
+            const bool armed = ArmRiverFallRecoveryIfBlackScreenLoss("normal_reacquire");
+            LogInfo << "Localization recovered via normal tracking." << VAR(loss_ms) << VAR(loss.saw_black_screen)
+                    << VAR(armed) << VAR(position_->x) << VAR(position_->y);
+            loss.Reset();
+            if (armed) {
+                return true;
+            }
+        } else {
+            loss.Reset();
+        }
+    }
 
     const semantic_nodes::Result inline_semantic_result = semantic_nodes::ConsumeInlineSemantics(semantic_ctx);
     if (inline_semantic_result.request_failure) {
@@ -865,6 +904,44 @@ bool NavigationStateMachine::TickNavigate()
             SelectPhaseForCurrentWaypoint("waypoint_action_completed");
             return true;
         }
+    }
+
+    if (runtime_state_.river_fall.pending) {
+        RiverFallRecoveryState& rf = runtime_state_.river_fall;
+        if (session_->HardStalledMs(now) > kRiverFallRecoveryTimeoutMs) {
+            return FailNavigation(
+                "river_fall_recovery_timeout",
+                "River-fall recovery made no net progress past the timeout; terminating navigation.",
+                route.progress_distance,
+                NaviMath::NormalizeAngle(route.route_heading - current_heading),
+                stalled_ms);
+        }
+        const double rf_displacement = std::hypot(position_->x - rf.anchor_pos.x, position_->y - rf.anchor_pos.y);
+        const double rf_target_heading = NaviMath::NormalizeAngle(rf.water_heading + 180.0);
+        const double rf_heading_error = NaviMath::NormalizeAngle(rf_target_heading - current_heading);
+        if (rf_displacement >= kRiverFallRecoveryClearDistance) {
+            rf.Reset();
+            runtime_state_.recovery.Reset();
+            runtime_state_.route.ResetTracking();
+            runtime_state_.dynamic_replan_requested = false;
+            runtime_state_.nav_run_dirty = true;
+            session_->ResetProgress();
+            LogInfo << "River-fall recovery cleared; resuming navigation." << VAR(rf_displacement) << VAR(rf_heading_error);
+            SelectPhaseForCurrentWaypoint("river_fall_recovered");
+            return true;
+        }
+        motion_controller_->SetForwardState(false);
+        utils::SleepFor(kStopWaitMs);
+        int turn_units = static_cast<int>(std::lround(rf_heading_error * action_wrapper_->DefaultTurnUnitsPerDegree()));
+        if (turn_units == 0) {
+            turn_units = rf_heading_error > 0.0 ? 1 : -1;
+        }
+        action_wrapper_->SendViewDeltaSync(turn_units, 0);
+        action_wrapper_->PulseForwardSync(kRiverFallRecoveryPulseMs);
+        motion_controller_->SetForwardState(false);
+        LogInfo << "River-fall recovery turn+pulse." << VAR(rf_heading_error) << VAR(turn_units) << VAR(rf_displacement)
+                << VAR(position_->x) << VAR(position_->y);
+        return true;
     }
 
     // Off-route wedge watchdog (see kOffRouteWedge* in navi_config.h). Only corridor (non-strict RUN) waypoints,

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -43,6 +43,7 @@ private:
     bool TickPhase(NaviPhase phase);
     bool CaptureCurrentPosition(bool force_global_search = false);
     bool HandleLocalizationLoss();
+    bool ArmRiverFallRecoveryIfBlackScreenLoss(const char* via);
     bool TryApplyDynamicOverlayToAnchor(
         const char* reason,
         size_t continue_index,


### PR DESCRIPTION
## Summary by Sourcery

添加由黑屏定位丢失触发的“river-fall”恢复流程，并将其集成到导航中。

New Features:
- 将黑屏定位丢失检测为 river-fall 事件，并启动专用的恢复序列。
- 引入 river-fall 恢复状态机，使其先背离水面转向，然后向前脉冲前进，直到安全到达内陆或超时。

Enhancements:
- 扩展定位丢失处理逻辑，用于跟踪黑屏出现情况并记录恢复详情。
- 增强导航运行时状态和配置，加入 river-fall 恢复参数及其生命周期管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a river-fall recovery flow triggered by black-screen localization losses and integrate it into navigation.

New Features:
- Detect black-screen localization losses as river-fall events and arm a dedicated recovery sequence.
- Introduce a river-fall recovery state machine that turns away from the water and pulses forward until safely inland or a timeout.

Enhancements:
- Extend localization loss handling to track black-screen occurrences and log recovery details.
- Augment navigation runtime state and configuration with river-fall recovery parameters and lifecycle management.

</details>