### PR TITLE
fix: 部分设备反复在esc菜单跳转

### DIFF
--- a/assets/resource/pipeline/Interface/Scene.json
+++ b/assets/resource/pipeline/Interface/Scene.json
@@ -7,6 +7,7 @@
         "rate_limit": 0,
         "next": [
             "__ScenePrivateCloseADBExit",
+            "__ScenePrivateMenuListLoadingEnterWorld",
             "__ScenePrivateMenuListEnterWorld",
             "__ScenePrivateAnyEnterWorldSuccess",
             "[JumpBack]__ScenePrivateLogin",

--- a/assets/resource/pipeline/SceneManager/SceneCommon.json
+++ b/assets/resource/pipeline/SceneManager/SceneCommon.json
@@ -11,7 +11,7 @@
                 "key": 27 // ESC
             }
         },
-        "post_delay": 600
+        "post_delay": 1000
     },
     "__ScenePrivateLoggedOutConfirm": {
         "desc": "确认自动登出弹窗",

--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -1,4 +1,24 @@
 {
+    "__ScenePrivateMenuListLoadingEnterWorld": {
+        "desc": "从菜单总列表退出到大世界，部分电脑从菜单列表回到大世界会卡很久，菜单列表是从上往下渐显加载，因此抓一下右上方先出现的特征",
+        "recognition": "OCR",
+        "roi": [
+            830,
+            0,
+            180,
+            50
+        ],
+        "expected": [
+            "BREAKING",
+            "NEWS"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateMenuListEnterWorld"
+        ]
+    },
     "__ScenePrivateMenuListEnterWorld": {
         "desc": "从菜单总列表退出到大世界，避免电脑比较卡反复在菜单总列表和大世界之间切换",
         "recognition": "And",


### PR DESCRIPTION
#3734
close #3750

## Summary by Sourcery

Bug Fixes:
- 解决由于错误的场景/菜单配置，导致某些设备反复返回到 ESC 菜单的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve an issue where some devices repeatedly navigated back to the ESC menu due to incorrect scene/menu configuration.

</details>