### PR TITLE
doc: issue模板添加上传失败上传到用户群引导

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,6 +28,7 @@ body:
       description: |
         💡 点击界面上“运行日志”右上角的 🗄️ 导出日志文件。  
         ⚠️ **请将上传导出后的 `MaaEnd-logs-xxx.zip` 文件** ⚠️  
+        ⚠️ **上传失败可上传到任意一个用户群，并在下方提供用户群名称、群文件名称** ⚠️  
         ❌ 不要复制文字发送。  
         ❌ 不要截图日志。
     validations:
@@ -38,7 +39,7 @@ body:
     attributes:
       label: 软件画面截图
       description: |
-        请提供出现问题时完整的 MaaEnd 软件画面截图。
+        请提供出现问题时完整的 MaaEnd 软件画面截图。 
         ❌ 不要留空。
     validations:
       required: true
@@ -48,7 +49,7 @@ body:
     attributes:
       label: 游戏画面截图
       description: |
-        请提供出现问题时的游戏画面截图，以便定位识别或操作相关问题。
+        请提供出现问题时的游戏画面截图，以便定位识别或操作相关问题。 
         ❌ 不要留空。
     validations:
       required: true


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 明确错误报告说明，允许用户通过用户群共享上传失败的日志归档，并强调提供完整的 MaaEnd 和游戏内截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify bug report instructions to allow users to share failed upload log archives via user groups and to emphasize providing full MaaEnd and in-game screenshots.

</details>