### PR TITLE
fix(TrialOfSwordmancy): 修复点击取消按钮后,点击开始演算过快导致点击失效

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -288,6 +288,7 @@
         ],
         "pre_delay": 0,
         "action": "Click",
+        "post_wait_freezes": 20,
         "post_delay": 0,
         "next": [
             "TrialOfSwordmancyDailyCancelGiveUpSuccess"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复 TrialOfSwordmancy 每日运行配置，以确保在取消后过快开始新的运行时，不再出现点击被忽略的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix TrialOfSwordmancy daily run configuration so that starting a run too quickly after cancelling no longer causes clicks to be ignored.

</details>