### PR TITLE
fix(AutoEcoFarm): 盲走前尝试节点改用 MapTrackerMove 普通导航

### DIFF
--- a/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitValleyIV.json
+++ b/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitValleyIV.json
@@ -483,20 +483,14 @@
         "desc": "[ValleyIV版]尝试直接走出基地",
         "recognition": "DirectHit",
         "action": "Custom",
-        "custom_action": "MapNavigateAction",
+        "custom_action": "MapTrackerMove",
         "custom_action_param": {
+            "map_name": "map01_lv005",
             "path": [
-                {
-                    "action": "ZONE",
-                    "zone_id": "ValleyIV_Base"
-                },
-                {
-                    "action": "NAVMESH",
-                    "target": [
-                        0,
-                        0
-                    ]
-                }
+                [
+                    0,
+                    0
+                ]
             ]
         }
     }

--- a/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitWulin.json
+++ b/assets/resource/pipeline/AutoEcoFarm/RegionNodes/AutoEcoFarmInitWulin.json
@@ -387,20 +387,14 @@
         "desc": "[Wulin版]尝试直接走出基地",
         "recognition": "DirectHit",
         "action": "Custom",
-        "custom_action": "MapNavigateAction",
+        "custom_action": "MapTrackerMove",
         "custom_action_param": {
+            "map_name": "map02_lv002",
             "path": [
-                {
-                    "action": "ZONE",
-                    "zone_id": "Wuling_Base"
-                },
-                {
-                    "action": "NAVMESH",
-                    "target": [
-                        673,
-                        230
-                    ]
-                }
+                [
+                    673,
+                    230
+                ]
             ]
         }
     }


### PR DESCRIPTION
因为需要朝固定方向移动，不需要navmash，这样反而会乱走导致方向不对

## Summary by Sourcery

错误修复：
- 通过在 ValleyIV 和 Wulin 区域的节点配置中，将基于 navmesh 的导航替换为 `MapTrackerMove`，纠正 AutoEcoFarm 在盲走前的移动方向。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct AutoEcoFarm pre-blind-walk movement direction by replacing navmesh-based navigation with MapTrackerMove in ValleyIV and Wulin region node configs.

</details>