### PR TITLE
fix: 选剑自动战斗设置位置

### DIFF
--- a/assets/tasks/TrialOfSwordmancy.json
+++ b/assets/tasks/TrialOfSwordmancy.json
@@ -131,7 +131,10 @@
                     }
                 },
                 {
-                    "name": "Yes"
+                    "name": "Yes",
+                    "option": [
+                        "AutoFightSetting"
+                    ]
                 }
             ]
         }

--- a/assets/tasks/TrialOfSwordmancy.json
+++ b/assets/tasks/TrialOfSwordmancy.json
@@ -35,10 +35,7 @@
                         "TrialOfSwordmancyDaily": {
                             "enabled": true
                         }
-                    },
-                    "option": [
-                        "AutoFightSetting"
-                    ]
+                    }
                 },
                 {
                     "name": "Coating",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- 优化 TrialOfSwordmancy 任务的 JSON，以纠正在选择武器时自动战斗位置设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refine TrialOfSwordmancy task JSON to correct auto battle position settings during sword selection.

</details>