### PR TITLE
feat:添加试验园区淤积点

### DIFF
--- a/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
+++ b/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
@@ -78,6 +78,7 @@
             "WLQingboStockadeLocationAssertion",
             "WLMarkerStoneLocationAssertion",
             "WLSwordVaultDaleLocationAssertion",
+            "WLTestAreaLocationAssertion",
             // 如果上述所有地区都没有命中，则无事发生
             "AutoEssenceLocationSetupFailed"
         ],
@@ -106,6 +107,7 @@
             "WLQingboStockadeLocationAssertion",
             "WLMarkerStoneLocationAssertion",
             "WLSwordVaultDaleLocationAssertion",
+            "WLTestAreaLocationAssertion",
             // 如果上述所有地区都没有命中，则自动导航到指定的某个淤积点
             "AutoEssenceSpecifiedLocation"
         ],

--- a/assets/resource/pipeline/AutoEssence/RegionNodes/WLTestArea.json
+++ b/assets/resource/pipeline/AutoEssence/RegionNodes/WLTestArea.json
@@ -1,0 +1,294 @@
+{
+    "WLTestAreaMoveToTriggerPointAuto": {
+        "anchor": {
+            "AutoEssenceMoveToTriggerPoint": "WLTestAreaMoveToTriggerPoint1",
+            "AutoEssenceWalkAround": "WLTestAreaWalkAround1"
+        },
+        "next": [
+            "[JumpBack]WLTestAreaMaybeTeleport",
+            "WLTestAreaMoveToTriggerPoint1"
+        ]
+    },
+    "WLTestAreaLocationAssertion": {
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "MapTrackerAssertLocation",
+                "custom_recognition_param": {
+                    "expected": [
+                        {
+                            // 淤积点附近
+                            "map_name": "map02_lv005_tier_321",
+                            "target": [
+                                334.8,
+                                352.3,
+                                8.1,
+                                8.1
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "anchor": {
+            "AutoEssenceMoveToTriggerPoint": "WLTestAreaMoveToTriggerPoint1",
+            "AutoEssenceWalkAround": "WLTestAreaWalkAround1"
+        },
+        "focus": {
+            "Node.Action.Starting": "📍附近的能量淤积点：\n<p style=\"text-align: center\"><strong>试验园区</strong></p>"
+        }
+    },
+    "WLTestAreaMaybeTeleport": {
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "MapTrackerAssertLocation",
+                "custom_recognition_param": {
+                    "expected": [
+                        {
+                            // 距离淤积点最近的锚点附近
+                            "map_name": "map02_lv005",
+                            "target": [
+                                327.4,
+                                408.6,
+                                21.5,
+                                17.5
+                            ]
+                        },
+                        {
+                            // 淤积点附近
+                            "map_name": "map02_lv005",
+                            "target": [
+                                331.6,
+                                350.4,
+                                15.3,
+                                14.8
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "inverse": true,
+        "next": [
+            "SceneEnterWorldWulingTestArea1"
+        ],
+        "focus": {
+            "Node.Action.Starting": "✈️准备传送到最近锚点"
+        }
+    },
+    "WLTestAreaMoveToTriggerPoint1": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv005",
+                    "path": [
+                        [
+                            337.0,
+                            418.4
+                        ],
+                        [
+                            337.2,
+                            399.6
+                        ],
+                        [
+                            333.9,
+                            397.1
+                        ],
+                        [
+                            312.0,
+                            397.4
+                        ],
+                        [
+                            309.1,
+                            395.3
+                        ],
+                        [
+                            308.5,
+                            364.5
+                        ],
+                        [
+                            305.5,
+                            360.7
+                        ],
+                        [
+                            290.6,
+                            360.7
+                        ],
+                        [
+                            290.4,
+                            364.9
+                        ],
+                        [
+                            301.0,
+                            365.0
+                        ]
+                    ],
+                    "path_trim": true
+                }
+            }
+        },
+        "next": [
+            "WLTestAreaMoveToTriggerPoint2"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在前往激发点附近(1/3)"
+        }
+    },
+    "WLTestAreaMoveToTriggerPoint2": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv005_tier_322",
+                    "path": [
+                        [
+                            303.2,
+                            364.8
+                        ],
+                        [
+                            316.9,
+                            364.6
+                        ],
+                        [
+                            319.2,
+                            367.6
+                        ],
+                        [
+                            319.0,
+                            377.5
+                        ],
+                        [
+                            321.7,
+                            379.7
+                        ],
+                        [
+                            337.1,
+                            380.3
+                        ],
+                        [
+                            336.9,
+                            375.9
+                        ]
+                    ],
+                    "path_trim": true
+                }
+            }
+        },
+        "next": [
+            "WLTestAreaMoveToTriggerPoint3"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在前往激发点附近(2/3)"
+        }
+    },
+    "WLTestAreaMoveToTriggerPoint3": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv005_tier_321",
+                    "path": [
+                        [
+                            338.7,
+                            367.6
+                        ],
+                        [
+                            338.7,
+                            359.8
+                        ]
+                    ],
+                    "path_trim": true
+                }
+            }
+        },
+        "next": [
+            "WLTestAreaMoveToTriggerPointExact"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在前往激发点附近(3/3)"
+        }
+    },
+    "WLTestAreaMoveToTriggerPointExact": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv005_tier_321",
+                    "path": [
+                        [
+                            338.4,
+                            358.4
+                        ]
+                    ]
+                }
+            }
+        },
+        "post_delay": 1000, //确保彻底停下,防止停下一瞬间看到了,靠惯性滑过目标点
+        "next": [
+            "AutoEssenceAtTriggerState"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在前往激发点"
+        }
+    },
+    "WLTestAreaWalkAround1": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv005_tier_321",
+                    "path": [
+                        [
+                            338.6,
+                            358.6
+                        ]
+                    ],
+                    "rotation_lower_threshold": 12.0,
+                    "rotation_upper_threshold": 120.0,
+                    "sprint_threshold": 6.0
+                }
+            }
+        },
+        "next": [
+            "AutoEssenceCheckOngoing",
+            "WLTestAreaWalkAround2"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在散步中"
+        }
+    },
+    "WLTestAreaWalkAround2": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv005_tier_321",
+                    "path": [
+                        [
+                            338.2,
+                            358.2
+                        ]
+                    ],
+                    "rotation_lower_threshold": 12.0,
+                    "rotation_upper_threshold": 120.0,
+                    "sprint_threshold": 6.0
+                }
+            }
+        },
+        "next": [
+            "AutoEssenceCheckOngoing",
+            "WLTestAreaWalkAround1"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在散步中"
+        }
+    }
+}

--- a/assets/tasks/AutoEssence.json
+++ b/assets/tasks/AutoEssence.json
@@ -118,6 +118,17 @@
                             ]
                         }
                     }
+                },
+                {
+                    "name": "WLTestArea",
+                    "label": "$global.region.TestArea",
+                    "pipeline_override": {
+                        "AutoEssenceSpecifiedLocation": {
+                            "next": [
+                                "WLTestAreaMoveToTriggerPointAuto"
+                            ]
+                        }
+                    }
                 }
             ]
         },


### PR DESCRIPTION
添加了试验园区淤积点

p.s. 先弄一个能跑通的 
本来想用测试区那个传送点 
但是不知道为什么我这边一直识别不上去

## Summary by Sourcery

将新的 AutoEssence 区域节点（用于实验公园沉积点）集成到现有的流水线和任务配置中。

新功能：
- 为 WLTestArea AutoEssence 区域节点添加配置，以表示实验公园沉积点。
- 将新的 WLTestArea 区域节点接入通用的 AutoEssence 流水线和任务定义，以便在自动化流程中使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a new AutoEssence region node for the experimental park sediment point into the existing pipeline and task configuration.

New Features:
- Add configuration for the WLTestArea AutoEssence region node representing the experimental park sediment point.
- Wire the new WLTestArea region node into the common AutoEssence pipeline and task definitions so it can be used in automation flows.

</details>