### PR TITLE
fix: 无法从选剑界面退出

### DIFF
--- a/assets/resource/pipeline/Interface/Scene.json
+++ b/assets/resource/pipeline/Interface/Scene.json
@@ -9,6 +9,7 @@
             "__ScenePrivateCloseADBExit",
             "__ScenePrivateMenuListLoadingEnterWorld",
             "__ScenePrivateMenuListEnterWorld",
+            "__ScenePrivateTrialOfSwordmancyEnterWorld",
             "__ScenePrivateAnyEnterWorldSuccess",
             "[JumpBack]__ScenePrivateLogin",
             "[JumpBack]__ScenePrivateNoticeRewardsUpgrade",

--- a/assets/resource/pipeline/SceneManager/SceneCommon.json
+++ b/assets/resource/pipeline/SceneManager/SceneCommon.json
@@ -4,6 +4,7 @@
     },
     "__ScenePrivateAnyExit": {
         "desc": "退出当前场景，返回上一个场景",
+        "max_hit": 100,
         "pre_delay": 0,
         "action": {
             "type": "ClickKey",

--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -39,6 +39,44 @@
             "__ScenePrivateAnyEnterWorldSuccess"
         ]
     },
+    "__ScenePrivateTrialOfSwordmancyEnterWorld": {
+        "desc": "从选剑演武界面退出到大世界",
+        "recognition": "And",
+        "all_of": [
+            {
+                "recognition": "OCR",
+                "roi": [
+                    0,
+                    0,
+                    200,
+                    60
+                ],
+                "expected": [
+                    "选剑演武"
+                ]
+            },
+            "CloseButtonType1"
+        ],
+        "box_index": 1,
+        "pre_wait_freezes": 100,
+        "action": "Click",
+        "next": [
+            "__ScenePrivateTrialOfSwordmancyEnterWorldConfirm",
+            "__ScenePrivateAnyEnterWorldSuccess"
+        ]
+    },
+    "__ScenePrivateTrialOfSwordmancyEnterWorldConfirm": {
+        "desc": "从选剑演武界面退出到大世界的确认界面",
+        "recognition": "And",
+        "all_of": [
+            "YellowConfirmButtonType1"
+        ],
+        "pre_wait_freezes": 100,
+        "action": "Click",
+        "next": [
+            "__ScenePrivateAnyEnterWorldSuccess"
+        ]
+    },
     "__ScenePrivateWorldEnterMenuList": {
         "desc": "从大世界进入菜单总列表",
         "recognition": {


### PR DESCRIPTION
close #3826

## Summary by Sourcery

错误修复：
- 通过修正相关场景管理配置，修复了无法退出剑选择界面的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix inability to exit the sword selection screen by correcting related scene management configuration.

</details>