### PR TITLE
feat: 增加选剑自动战斗前传送一下回血

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -1068,5 +1068,6 @@
     "option.TrialOfSwordmancyOverflow.cases.None.label": "No overflow",
     "option.TrialOfSwordmancyOverflow.cases.Once.label": "Accept 1 overflow",
     "option.TrialOfSwordmancyOverflow.cases.Twice.label": "Accept 1-2 overflows",
-    "option.TrialOfSwordmancyAutoFight.label": "Enable auto-battle"
+    "option.TrialOfSwordmancyAutoFight.label": "Enable auto-battle",
+    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "Teleport to heal before each battle"
 }

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -1068,5 +1068,6 @@
     "option.TrialOfSwordmancyOverflow.cases.None.label": "オーバーフローしない",
     "option.TrialOfSwordmancyOverflow.cases.Once.label": "1回オーバーフローを許可",
     "option.TrialOfSwordmancyOverflow.cases.Twice.label": "1-2回オーバーフローを許可",
-    "option.TrialOfSwordmancyAutoFight.label": "自動戦闘を有効化"
+    "option.TrialOfSwordmancyAutoFight.label": "自動戦闘を有効化",
+    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "各戦闘前にテレポートしてHP回復"
 }

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -1068,5 +1068,6 @@
     "option.TrialOfSwordmancyOverflow.cases.None.label": "오버플로우 안 함",
     "option.TrialOfSwordmancyOverflow.cases.Once.label": "1회 오버플로우 허용",
     "option.TrialOfSwordmancyOverflow.cases.Twice.label": "1-2회 오버플로우 허용",
-    "option.TrialOfSwordmancyAutoFight.label": "자동 전투 활성화"
+    "option.TrialOfSwordmancyAutoFight.label": "자동 전투 활성화",
+    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "전투 전마다 순간이동해 체력 회복"
 }

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -1068,5 +1068,6 @@
     "option.TrialOfSwordmancyOverflow.cases.None.label": "不接受溢出",
     "option.TrialOfSwordmancyOverflow.cases.Once.label": "接受1次溢出",
     "option.TrialOfSwordmancyOverflow.cases.Twice.label": "接受1/2次溢出",
-    "option.TrialOfSwordmancyAutoFight.label": "启用自动战斗"
+    "option.TrialOfSwordmancyAutoFight.label": "启用自动战斗",
+    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "每次战斗前传送回复血量"
 }

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -1068,5 +1068,6 @@
     "option.TrialOfSwordmancyOverflow.cases.None.label": "不接受溢出",
     "option.TrialOfSwordmancyOverflow.cases.Once.label": "接受1次溢出",
     "option.TrialOfSwordmancyOverflow.cases.Twice.label": "接受1/2次溢出",
-    "option.TrialOfSwordmancyAutoFight.label": "啟用自動戰鬥"
+    "option.TrialOfSwordmancyAutoFight.label": "啟用自動戰鬥",
+    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "每次戰鬥前傳送回復血量"
 }

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -9,42 +9,6 @@
             "[JumpBack]TrialOfSwordmancyGotoTrialArenaStart"
         ]
     },
-    "TrialOfSwordmancyDailyAutoFightResetState": {
-        "desc": "自动作战模式下，一次性重置到选剑演武入口",
-        "enabled": false,
-        "max_hit": 1,
-        "recognition": "DirectHit",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "TrialOfSwordmancyGotoTrialArenaStart"
-            ]
-        },
-        "post_delay": 0,
-        "next": [
-            "TrialOfSwordmancyDailyMain"
-        ]
-    },
-    "TrialOfSwordmancyDailyAutoFightRearmResetState": {
-        "desc": "自动作战模式下，为下一轮重新启用入口重置",
-        "enabled": false,
-        "recognition": "DirectHit",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "ClearHitCount",
-        "custom_action_param": {
-            "nodes": [
-                "TrialOfSwordmancyDailyAutoFightResetState",
-                "TrialOfSwordmancyGotoTrialArenaCpp"
-            ]
-        },
-        "post_delay": 0,
-        "next": [
-            "TrialOfSwordmancyMain"
-        ]
-    },
     "TrialOfSwordmancyDailyCheckRewardMode": {
         "desc": "检查是否处于奖励演算模式",
         "recognition": "And",

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -9,6 +9,42 @@
             "[JumpBack]TrialOfSwordmancyGotoTrialArenaStart"
         ]
     },
+    "TrialOfSwordmancyDailyAutoFightResetState": {
+        "desc": "自动作战模式下，一次性重置到选剑演武入口",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "TrialOfSwordmancyGotoTrialArenaStart"
+            ]
+        },
+        "post_delay": 0,
+        "next": [
+            "TrialOfSwordmancyDailyMain"
+        ]
+    },
+    "TrialOfSwordmancyDailyAutoFightRearmResetState": {
+        "desc": "自动作战模式下，为下一轮重新启用入口重置",
+        "enabled": false,
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "ClearHitCount",
+        "custom_action_param": {
+            "nodes": [
+                "TrialOfSwordmancyDailyAutoFightResetState",
+                "TrialOfSwordmancyGotoTrialArenaCpp"
+            ]
+        },
+        "post_delay": 0,
+        "next": [
+            "TrialOfSwordmancyMain"
+        ]
+    },
     "TrialOfSwordmancyDailyCheckRewardMode": {
         "desc": "检查是否处于奖励演算模式",
         "recognition": "And",

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
@@ -150,5 +150,41 @@
             "TrialOfSwordmancyDailyAutoFightRearmResetState",
             "TrialOfSwordmancyMain"
         ]
+    },
+    "TrialOfSwordmancyDailyAutoFightResetState": {
+        "desc": "自动作战模式下，一次性重置到选剑演武入口",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "TrialOfSwordmancyGotoTrialArenaStart"
+            ]
+        },
+        "post_delay": 0,
+        "next": [
+            "TrialOfSwordmancyDailyMain"
+        ]
+    },
+    "TrialOfSwordmancyDailyAutoFightRearmResetState": {
+        "desc": "自动作战模式下，为下一轮重新启用入口重置",
+        "enabled": false,
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "ClearHitCount",
+        "custom_action_param": {
+            "nodes": [
+                "TrialOfSwordmancyDailyAutoFightResetState",
+                "TrialOfSwordmancyGotoTrialArenaCpp"
+            ]
+        },
+        "post_delay": 0,
+        "next": [
+            "TrialOfSwordmancyMain"
+        ]
     }
 }

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
@@ -147,6 +147,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
+            "TrialOfSwordmancyDailyAutoFightRearmResetState",
             "TrialOfSwordmancyMain"
         ]
     }

--- a/assets/tasks/TrialOfSwordmancy.json
+++ b/assets/tasks/TrialOfSwordmancy.json
@@ -133,8 +133,38 @@
                 {
                     "name": "Yes",
                     "option": [
-                        "AutoFightSetting"
+                        "AutoFightSetting",
+                        "TrialOfSwordmancyRecoverBeforeBattle"
                     ]
+                }
+            ]
+        },
+        "TrialOfSwordmancyRecoverBeforeBattle": {
+            "type": "switch",
+            "label": "$option.TrialOfSwordmancyRecoverBeforeBattle.label",
+            "default_case": "No",
+            "cases": [
+                {
+                    "name": "No"
+                },
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "TrialOfSwordmancyDailyAutoFightResetState": {
+                            "enabled": true
+                        },
+                        "TrialOfSwordmancyDailyAutoFightRearmResetState": {
+                            "enabled": true
+                        },
+                        "TrialOfSwordmancyDailyMain": {
+                            "next": [
+                                "TrialOfSwordmancyDailyAutoFightResetState",
+                                "TrialOfSwordmancyDailyCheckRewardMode",
+                                "[JumpBack]TrialOfSwordmancyEnterTrialMenu",
+                                "[JumpBack]TrialOfSwordmancyGotoTrialArenaStart"
+                            ]
+                        }
+                    }
                 }
             ]
         }


### PR DESCRIPTION
fix #3810
加了个可选项，传送回个血

## Summary by Sourcery

在 Trial of Swordmancy 自动战斗中新增一个可选的战前“传送并治疗”步骤，并将其接入相关任务和流水线配置中。

New Features:
- 引入一个可配置选项，可在开始 Trial of Swordmancy 自动战斗前先进行传送并恢复生命值。

Bug Fixes:
- 通过允许在战斗前进行可选的传送治疗，解决 Trial of Swordmancy 自动战斗可能在低血量状态下开始的问题。

Enhancements:
- 更新 Trial of Swordmancy 的任务与流水线资源，以支持新的战前传送并治疗流程。

Documentation:
- 为新的 Trial of Swordmancy 战前传送选项在各支持语言中新增或更新本地化界面字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an optional pre-battle teleport-and-heal step to Trial of Swordmancy auto battles and wire it into related task and pipeline configurations.

New Features:
- Introduce a configurable option to teleport and recover health before starting Trial of Swordmancy automatic battles.

Bug Fixes:
- Resolve the issue where Trial of Swordmancy auto battles could start with low health by allowing an optional heal via pre-battle teleport.

Enhancements:
- Update Trial of Swordmancy task and pipeline resources to support the new pre-battle teleport-and-heal flow.

Documentation:
- Add or update localized interface strings for the new Trial of Swordmancy pre-battle teleport option across supported languages.

</details>