### PR TITLE
fix: 售卖弹性物资文案错误

### DIFF
--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -420,7 +420,7 @@
         "rate_limit": 0
     },
     "AutoSellFriendsPricesExpectedBuy": {
-        "desc": "当前价格符合预期，在当前好友飞船上，可以直接购买",
+        "desc": "当前价格符合预期，在当前好友飞船上，可以直接售卖",
         "recognition": "Custom",
         "custom_recognition": "ExpressionRecognition",
         "custom_recognition_param": {
@@ -433,7 +433,7 @@
             "AutoSellFriendsPricesExpectedBuyBackToSellGoods"
         ],
         "focus": {
-            "Node.Recognition.Succeeded": "当前拜访好友是最高价，可以购买"
+            "Node.Recognition.Succeeded": "当前拜访好友是最高价，可以售卖"
         }
     },
     "AutoSellFriendsPricesExpectedBuyBackToSellGoods": {


### PR DESCRIPTION
close #3843

## 由 Sourcery 提供的摘要

错误修复：
- 修正 AutoSell ItemTask 资源配置中出售弹性材料时显示的文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the displayed text for selling elastic materials in the AutoSell ItemTask resource configuration.

</details>