### PR TITLE
chore: 将应急理智加强剂任务移至理智消耗分组

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -155,7 +155,6 @@
         "tasks/GearAssembly.json",
         "tasks/Weapon.json",
         "tasks/BatchUseDetector.json",
-        "tasks/AutoUseSpMedication.json",
         "tasks/EssenceFilter.json",
         // group: open_world
         "tasks/ResourceRecycleStation.json",
@@ -164,6 +163,7 @@
         "tasks/PuzzleSolver.json",
         "tasks/ImportBluePrints.json",
         // group: sanity_sink
+        "tasks/AutoUseSpMedication.json",
         "tasks/AutoEssence.json",
         "tasks/ProtocolSpace.json",
         // group: dijiang_ship

--- a/assets/tasks/AutoUseSpMedication.json
+++ b/assets/tasks/AutoUseSpMedication.json
@@ -11,7 +11,7 @@
                 "ADB"
             ],
             "group": [
-                "valuables_vault"
+                "sanity_sink"
             ],
             "option": [
                 "AutoUseSpMedicationExpireWithinDays",


### PR DESCRIPTION
与基质刷取、协议空间归类到同一分组，便于理智相关任务集中管理。

## Summary by Sourcery

杂项：
- 在界面配置中，将紧急理智恢复任务与其他理智消耗任务归类在一起。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Regroup the emergency sanity booster task with other sanity consumption tasks in the interface configuration.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

杂项：
- 在界面配置中，将紧急理智恢复任务与其他理智消耗任务归类在一起。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Regroup the emergency sanity booster task with other sanity consumption tasks in the interface configuration.

</details>

</details>