### PR TITLE
feat(EnvironmentMonitoring): 使用on_finsh及MapTrackerToward实现MapTracker转向行为

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AnnularWaterfall.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AnnularWaterfall.json
@@ -268,15 +268,6 @@
             "EnvironmentMonitoringAdjustCamera": "AnnularWaterfallAdjustCamera"
         },
         "next": [
-            "AnnularWaterfallAdjustHeading"
-        ]
-    },
-    "AnnularWaterfallAdjustHeading": {
-        "desc": "环形瀑布任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/BambooWaterChimes.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/BambooWaterChimes.json
@@ -268,15 +268,6 @@
             "EnvironmentMonitoringAdjustCamera": "BambooWaterChimesAdjustCamera"
         },
         "next": [
-            "BambooWaterChimesAdjustHeading"
-        ]
-    },
-    "BambooWaterChimesAdjustHeading": {
-        "desc": "水竹铃任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/CloudrestEcoSite.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/CloudrestEcoSite.json
@@ -364,15 +364,6 @@
             "EnvironmentMonitoringAdjustCamera": "CloudrestEcoSiteAdjustCamera"
         },
         "next": [
-            "CloudrestEcoSiteAdjustHeading"
-        ]
-    },
-    "CloudrestEcoSiteAdjustHeading": {
-        "desc": "栖云生态点任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
@@ -259,15 +259,6 @@
             "EnvironmentMonitoringAdjustCamera": "FloraObservationPointAdjustCamera"
         },
         "next": [
-            "FloraObservationPointAdjustHeading"
-        ]
-    },
-    "FloraObservationPointAdjustHeading": {
-        "desc": "植物观察点任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
@@ -247,31 +247,19 @@
             "target": [
                 579.2,
                 253.7
-            ]
+            ],
+            "on_finish": {
+                "action": "Custom",
+                "custom_action": "MapTrackerToward",
+                "custom_action_param": {
+                    "angle": 90
+                }
+            }
         },
         "anchor": {
             "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "HangingVinesAdjustCamera"
         },
-        "next": [
-            "HangingVinesAdjustHeading"
-        ]
-    },
-    "HangingVinesAdjustHeading": {
-        "desc": "垂藤任务中调整角色朝向",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "MapNavigateAction",
-        "custom_action_param": {
-            "path": [
-                {
-                    "action": "HEADING",
-                    "angle": 90
-                }
-            ]
-        },
-        "post_delay": 0,
-        "rate_limit": 0,
         "next": [
             "EnvironmentMonitoringTakePhoto"
         ]

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/MysteriousCryptidGraffiti.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/MysteriousCryptidGraffiti.json
@@ -316,15 +316,6 @@
             "EnvironmentMonitoringAdjustCamera": "MysteriousCryptidGraffitiAdjustCamera"
         },
         "next": [
-            "MysteriousCryptidGraffitiAdjustHeading"
-        ]
-    },
-    "MysteriousCryptidGraffitiAdjustHeading": {
-        "desc": "谜之生物的涂鸦任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -253,31 +253,19 @@
                     524.7,
                     665.8
                 ]
-            ]
+            ],
+            "on_finish": {
+                "action": "Custom",
+                "custom_action": "MapTrackerToward",
+                "custom_action_param": {
+                    "angle": 90
+                }
+            }
         },
         "anchor": {
             "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "PeachTreeAtBabblesSHomeAdjustCamera"
         },
-        "next": [
-            "PeachTreeAtBabblesSHomeAdjustHeading"
-        ]
-    },
-    "PeachTreeAtBabblesSHomeAdjustHeading": {
-        "desc": "念念家的桃树任务中调整角色朝向",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "MapNavigateAction",
-        "custom_action_param": {
-            "path": [
-                {
-                    "action": "HEADING",
-                    "angle": 90
-                }
-            ]
-        },
-        "post_delay": 0,
-        "rate_limit": 0,
         "next": [
             "EnvironmentMonitoringTakePhoto"
         ]

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Rainbow.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Rainbow.json
@@ -289,31 +289,19 @@
                     477.1,
                     603.3
                 ]
-            ]
+            ],
+            "on_finish": {
+                "action": "Custom",
+                "custom_action": "MapTrackerToward",
+                "custom_action_param": {
+                    "angle": 260
+                }
+            }
         },
         "anchor": {
             "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "RainbowAdjustCamera"
         },
-        "next": [
-            "RainbowAdjustHeading"
-        ]
-    },
-    "RainbowAdjustHeading": {
-        "desc": "彩虹任务中调整角色朝向",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "MapNavigateAction",
-        "custom_action_param": {
-            "path": [
-                {
-                    "action": "HEADING",
-                    "angle": 260
-                }
-            ]
-        },
-        "post_delay": 0,
-        "rate_limit": 0,
         "next": [
             "EnvironmentMonitoringTakePhoto"
         ]

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
@@ -285,15 +285,6 @@
             "EnvironmentMonitoringAdjustCamera": "SerenityGardenTianshiPillarAdjustCamera"
         },
         "next": [
-            "SerenityGardenTianshiPillarAdjustHeading"
-        ]
-    },
-    "SerenityGardenTianshiPillarAdjustHeading": {
-        "desc": "安思园的天师桩任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/TreeOfTheOldCourtyard.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/TreeOfTheOldCourtyard.json
@@ -259,15 +259,6 @@
             "EnvironmentMonitoringAdjustCamera": "TreeOfTheOldCourtyardAdjustCamera"
         },
         "next": [
-            "TreeOfTheOldCourtyardAdjustHeading"
-        ]
-    },
-    "TreeOfTheOldCourtyardAdjustHeading": {
-        "desc": "旧庭树任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WaterTemperatureController.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WaterTemperatureController.json
@@ -309,15 +309,6 @@
             "EnvironmentMonitoringAdjustCamera": "WaterTemperatureControllerAdjustCamera"
         },
         "next": [
-            "WaterTemperatureControllerAdjustHeading"
-        ]
-    },
-    "WaterTemperatureControllerAdjustHeading": {
-        "desc": "净水温控装置任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WitheredBranches.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WitheredBranches.json
@@ -260,15 +260,6 @@
             "EnvironmentMonitoringAdjustCamera": "WitheredBranchesAdjustCamera"
         },
         "next": [
-            "WitheredBranchesAdjustHeading"
-        ]
-    },
-    "WitheredBranchesAdjustHeading": {
-        "desc": "枯枝任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
@@ -258,15 +258,6 @@
             "EnvironmentMonitoringAdjustCamera": "AncientTreeAdjustCamera"
         },
         "next": [
-            "AncientTreeAdjustHeading"
-        ]
-    },
-    "AncientTreeAdjustHeading": {
-        "desc": "古树任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInTheBlightTide.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInTheBlightTide.json
@@ -296,15 +296,6 @@
             "EnvironmentMonitoringAdjustCamera": "BeaconDamagedInTheBlightTideAdjustCamera"
         },
         "next": [
-            "BeaconDamagedInTheBlightTideAdjustHeading"
-        ]
-    },
-    "BeaconDamagedInTheBlightTideAdjustHeading": {
-        "desc": "侵蚀潮中损坏的信标任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
@@ -258,15 +258,6 @@
             "EnvironmentMonitoringAdjustCamera": "CisternOriginiumSlugsAdjustCamera"
         },
         "next": [
-            "CisternOriginiumSlugsAdjustHeading"
-        ]
-    },
-    "CisternOriginiumSlugsAdjustHeading": {
-        "desc": "蓄水源石虫任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
@@ -256,15 +256,6 @@
             "EnvironmentMonitoringAdjustCamera": "CleansingJadeAdjustCamera"
         },
         "next": [
-            "CleansingJadeAdjustHeading"
-        ]
-    },
-    "CleansingJadeAdjustHeading": {
-        "desc": "漱玉任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
@@ -261,31 +261,19 @@
                     180,
                     618
                 ]
-            ]
+            ],
+            "on_finish": {
+                "action": "Custom",
+                "custom_action": "MapTrackerToward",
+                "custom_action_param": {
+                    "angle": 300
+                }
+            }
         },
         "anchor": {
             "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "CollapsedTianshiPillarAdjustCamera"
         },
-        "next": [
-            "CollapsedTianshiPillarAdjustHeading"
-        ]
-    },
-    "CollapsedTianshiPillarAdjustHeading": {
-        "desc": "倒塌的天师桩任务中调整角色朝向",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "MapNavigateAction",
-        "custom_action_param": {
-            "path": [
-                {
-                    "action": "HEADING",
-                    "angle": 300
-                }
-            ]
-        },
-        "post_delay": 0,
-        "rate_limit": 0,
         "next": [
             "EnvironmentMonitoringTakePhoto"
         ]

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
@@ -247,31 +247,19 @@
             "target": [
                 618.8,
                 901.6
-            ]
+            ],
+            "on_finish": {
+                "action": "Custom",
+                "custom_action": "MapTrackerToward",
+                "custom_action_param": {
+                    "angle": 270
+                }
+            }
         },
         "anchor": {
             "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",
             "EnvironmentMonitoringAdjustCamera": "EcologyNearTheFieldLogisticsDepotAdjustCamera"
         },
-        "next": [
-            "EcologyNearTheFieldLogisticsDepotAdjustHeading"
-        ]
-    },
-    "EcologyNearTheFieldLogisticsDepotAdjustHeading": {
-        "desc": "储备站周围的生态环境任务中调整角色朝向",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "MapNavigateAction",
-        "custom_action_param": {
-            "path": [
-                {
-                    "action": "HEADING",
-                    "angle": 270
-                }
-            ]
-        },
-        "post_delay": 0,
-        "rate_limit": 0,
         "next": [
             "EnvironmentMonitoringTakePhoto"
         ]

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -260,15 +260,6 @@
             "EnvironmentMonitoringAdjustCamera": "EternalSunsetAdjustCamera"
         },
         "next": [
-            "EternalSunsetAdjustHeading"
-        ]
-    },
-    "EternalSunsetAdjustHeading": {
-        "desc": "栖霞驻影任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
@@ -258,15 +258,6 @@
             "EnvironmentMonitoringAdjustCamera": "IndoorCropsAdjustCamera"
         },
         "next": [
-            "IndoorCropsAdjustHeading"
-        ]
-    },
-    "IndoorCropsAdjustHeading": {
-        "desc": "室内作物任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
@@ -260,15 +260,6 @@
             "EnvironmentMonitoringAdjustCamera": "InflatedAndGlowingBugspittingLankybeastAdjustCamera"
         },
         "next": [
-            "InflatedAndGlowingBugspittingLankybeastAdjustHeading"
-        ]
-    },
-    "InflatedAndGlowingBugspittingLankybeastAdjustHeading": {
-        "desc": "肚子鼓气后发光的吐虫长股兽任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
@@ -264,15 +264,6 @@
             "EnvironmentMonitoringAdjustCamera": "MiniShellbeastAdjustCamera"
         },
         "next": [
-            "MiniShellbeastAdjustHeading"
-        ]
-    },
-    "MiniShellbeastAdjustHeading": {
-        "desc": "小壳兽任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
@@ -260,15 +260,6 @@
             "EnvironmentMonitoringAdjustCamera": "ObservantSableChestedFowlbeastAdjustCamera"
         },
         "next": [
-            "ObservantSableChestedFowlbeastAdjustHeading"
-        ]
-    },
-    "ObservantSableChestedFowlbeastAdjustHeading": {
-        "desc": "东张西望的黑腹雉羽兽任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/PierWaterwheel.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/PierWaterwheel.json
@@ -260,15 +260,6 @@
             "EnvironmentMonitoringAdjustCamera": "PierWaterwheelAdjustCamera"
         },
         "next": [
-            "PierWaterwheelAdjustHeading"
-        ]
-    },
-    "PierWaterwheelAdjustHeading": {
-        "desc": "码头水车任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
@@ -284,15 +284,6 @@
             "EnvironmentMonitoringAdjustCamera": "RainbowFinAdjustCamera"
         },
         "next": [
-            "RainbowFinAdjustHeading"
-        ]
-    },
-    "RainbowFinAdjustHeading": {
-        "desc": "七彩鳞任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
@@ -169,7 +169,9 @@
             "InVigorousCisternOriginiumSlugMission"
         ],
         "action": "Click",
-        "next": ["GoToVigorousCisternOriginiumSlug"]
+        "next": [
+            "GoToVigorousCisternOriginiumSlug"
+        ]
     },
     "AlreadyTrackedVigorousCisternOriginiumSlug": {
         "desc": "充满活力的蓄水源石虫任务已经在追踪中",
@@ -178,7 +180,9 @@
             "AlreadyTrackedMissionButton",
             "InVigorousCisternOriginiumSlugMission"
         ],
-        "next": ["GoToVigorousCisternOriginiumSlug"]
+        "next": [
+            "GoToVigorousCisternOriginiumSlug"
+        ]
     },
     "VigorousCisternOriginiumSlugNotAdapted": {
         "desc": "充满活力的蓄水源石虫任务尚未适配，仅接取并追踪",
@@ -236,11 +240,17 @@
         "custom_action": "MapNavigateAction",
         "custom_action_param": {
             "path": [
-                {"action": "NAVMESH", "target": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
                         691.16,
                         1578.78
-                    ]},
-                {"action": "HEADING", "angle": 100}
+                    ]
+                },
+                {
+                    "action": "HEADING",
+                    "angle": 100
+                }
             ]
         },
         "anchor": {
@@ -248,15 +258,8 @@
             "EnvironmentMonitoringAdjustCamera": "VigorousCisternOriginiumSlugAdjustCamera"
         },
         "next": [
-            "VigorousCisternOriginiumSlugAdjustHeading"
+            "EnvironmentMonitoringTakePhoto"
         ]
-    },
-    "VigorousCisternOriginiumSlugAdjustHeading": {
-        "desc": "充满活力的蓄水源石虫任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": ["EnvironmentMonitoringTakePhoto"]
     },
     "VigorousCisternOriginiumSlugAdjustCamera": {
         "desc": "充满活力的蓄水源石虫任务中调整朝向",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/Waterlamp.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/Waterlamp.json
@@ -256,15 +256,6 @@
             "EnvironmentMonitoringAdjustCamera": "WaterlampAdjustCamera"
         },
         "next": [
-            "WaterlampAdjustHeading"
-        ]
-    },
-    "WaterlampAdjustHeading": {
-        "desc": "水灯虫任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/XiraniteNexus.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/XiraniteNexus.json
@@ -280,15 +280,6 @@
             "EnvironmentMonitoringAdjustCamera": "XiraniteNexusAdjustCamera"
         },
         "next": [
-            "XiraniteNexusAdjustHeading"
-        ]
-    },
-    "XiraniteNexusAdjustHeading": {
-        "desc": "枢壤仪任务无需调整角色朝向",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "rate_limit": 0,
-        "next": [
             "EnvironmentMonitoringTakePhoto"
         ]
     },

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/data.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/data.mjs
@@ -89,35 +89,6 @@ function buildRow(mission, usedIds) {
     ];
     const AfterTrackedNext = route.isAdapted ? [`GoTo${Id}`] : [`${Id}NotAdapted`];
 
-    // 朝向节点：MapTarget 的 Heading 已合并到同一个 MapNavigateAction path；
-    // MapPath / MapGoal 仍需在移动后单独调用 HEADING，未配置 Heading 时退化为透传节点。
-    const AdjustHeadingNodeBody =
-        route.HasHeading && !route.HasNavigationHeading
-            ? {
-                  desc: `${sanitizeDisplayName(missionName)}任务中调整角色朝向`,
-                  pre_delay: 0,
-                  action: "Custom",
-                  custom_action: "MapNavigateAction",
-                  custom_action_param: {
-                      path: [
-                          {
-                              action: "HEADING",
-                              angle: route.Heading,
-                          },
-                      ],
-                  },
-                  post_delay: 0,
-                  rate_limit: 0,
-                  next: ["EnvironmentMonitoringTakePhoto"],
-              }
-            : {
-                  desc: `${sanitizeDisplayName(missionName)}任务无需调整角色朝向`,
-                  pre_delay: 0,
-                  post_delay: 0,
-                  rate_limit: 0,
-                  next: ["EnvironmentMonitoringTakePhoto"],
-              };
-
     return {
         Station,
         Id,
@@ -139,7 +110,6 @@ function buildRow(mission, usedIds) {
         InExpectedText: buildExpectedFromLocaleMap(mission.shotTargetName),
         TrackOrGoToNext,
         AfterTrackedNext,
-        AdjustHeadingNodeBody,
         MapNavigationAction: route.MapNavigationAction,
         MapNavigationParam: route.MapNavigationParam,
     };

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.mjs
@@ -109,16 +109,17 @@ function buildNavigationParams({
     hasMapGoal,
     heading,
 }) {
-    const MapNavigationAction = hasMapTarget ? "MapNavigateAction" : hasMapGoal ? "MapTrackerGoal" : "MapTrackerMove";
+    // 1. Build location assertion node
     const MapAssertRecognition = hasMapTarget ? "MapLocateAssertLocation" : "MapTrackerAssertLocation";
-    const navigationHeading = hasMapTarget && heading.HasHeading;
     const MapAssertParam =
         MapAssertRecognition === "MapLocateAssertLocation"
             ? {
+                  // Using MapLocateAssertLocation
                   zone_id: MapName,
                   target: MapAssert,
               }
             : {
+                  // Using MapTrackerAssertLocation
                   expected: [
                       {
                           map_name: MapName,
@@ -126,16 +127,34 @@ function buildNavigationParams({
                       },
                   ],
               };
+
+    // 2. Build navigation node
+    const MapNavigationAction = hasMapTarget ? "MapNavigateAction" : hasMapGoal ? "MapTrackerGoal" : "MapTrackerMove";
+    const mapTrackerExtraParams = {
+        ...(heading.HasHeading
+            ? {
+                  on_finish: {
+                      action: "Custom",
+                      custom_action: "MapTrackerToward",
+                      custom_action_param: {
+                          angle: heading.Heading,
+                      },
+                  },
+              }
+            : {}),
+        ...(NoEnsureInitialMovementState ? {no_ensure_initial_movement_state: true} : {}),
+    };
     const MapNavigationParam =
         MapNavigationAction === "MapNavigateAction"
             ? {
+                  // Using MapNavigateAction
                   path: [
                       {
                           action: "NAVMESH",
                           target: MapTarget,
                           ...(!isFieldMissing(MapTargetTier) ? {target_tier: MapTargetTier} : {}),
                       },
-                      ...(navigationHeading
+                      ...(heading.HasHeading
                           ? [
                                 {
                                     action: "HEADING",
@@ -147,14 +166,16 @@ function buildNavigationParams({
               }
             : MapNavigationAction === "MapTrackerGoal"
               ? {
+                    // Using MapTrackerGoal
                     map_name: MapName,
                     target: MapGoal,
-                    ...(NoEnsureInitialMovementState ? {no_ensure_initial_movement_state: true} : {}),
+                    ...mapTrackerExtraParams,
                 }
               : {
+                    // Using MapTrackerMove
                     map_name: MapName,
                     path: MapPath,
-                    ...(NoEnsureInitialMovementState ? {no_ensure_initial_movement_state: true} : {}),
+                    ...mapTrackerExtraParams,
                 };
 
     return {
@@ -162,7 +183,6 @@ function buildNavigationParams({
         MapAssertParam,
         MapNavigationAction,
         MapNavigationParam,
-        HasNavigationHeading: navigationHeading,
     };
 }
 

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/template.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/template.json
@@ -217,10 +217,9 @@
             "EnvironmentMonitoringAdjustCamera": "${Id}AdjustCamera"
         },
         "next": [
-            "${Id}AdjustHeading"
+            "EnvironmentMonitoringTakePhoto"
         ]
     },
-    "${Id}AdjustHeading": "${AdjustHeadingNodeBody}",
     "${Id}AdjustCamera": {
         "desc": "${Name}任务中调整朝向",
         "max_hit": "${CameraMaxHit}",


### PR DESCRIPTION
## 概述

此 PR 修改了环境监测任务中，MapTracker 系列的转向行为的实现方式。引入了使用 on_finish 挂钩调用的 MapTrackerToward 节点，以简化流程。

同时重新生成了 pipeline。

## 关联

前置 PR 是 #3830 。

## Summary by Sourcery

通过将 MapTracker 转向行为集成到导航节点中并重新生成流水线，简化 EnvironmentMonitoring 的导航朝向（heading）处理。

增强内容：
- 现在，EnvironmentMonitoring 任务的路径解析会通过 `on_finish MapTrackerToward` 钩子，将朝向调整附加到 MapTracker 导航上，而不是使用单独的朝向节点。
- 从 EnvironmentMonitoring 任务数据中移除专用的 `AdjustHeading` 节点，改为使用新的集成朝向行为。
- 重新生成 EnvironmentMonitoring 的流水线 JSON 资源和模板，以反映更新后的导航与朝向流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify EnvironmentMonitoring navigation heading handling by integrating MapTracker turn behavior into navigation nodes and regenerating the pipelines.

Enhancements:
- Route resolution for EnvironmentMonitoring missions now attaches heading adjustments to MapTracker navigation via an on_finish MapTrackerToward hook instead of separate heading nodes.
- Remove the dedicated AdjustHeading node from EnvironmentMonitoring mission data in favor of the new integrated heading behavior.
- Regenerate EnvironmentMonitoring pipeline JSON assets and template to reflect the updated navigation and heading flow.

</details>