### PR TITLE
fix(EnvironmentMonitoring): 优化倒塌的天师桩路线

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AnnularWaterfall.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AnnularWaterfall.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToAnnularWaterfallMapTrackerMove"
+            "GoToAnnularWaterfallMove"
         ]
     },
     "GoToAnnularWaterfallNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToAnnularWaterfallStartPos"
         ]
     },
-    "GoToAnnularWaterfallMapTrackerMove": {
-        "desc": "前往环形瀑布",
+    "GoToAnnularWaterfallMove": {
+        "desc": "自动寻路前往环形瀑布",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/BambooWaterChimes.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/BambooWaterChimes.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToBambooWaterChimesMapTrackerMove"
+            "GoToBambooWaterChimesMove"
         ]
     },
     "GoToBambooWaterChimesNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToBambooWaterChimesStartPos"
         ]
     },
-    "GoToBambooWaterChimesMapTrackerMove": {
-        "desc": "前往水竹铃",
+    "GoToBambooWaterChimesMove": {
+        "desc": "自动寻路前往水竹铃",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/CloudrestEcoSite.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/CloudrestEcoSite.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToCloudrestEcoSiteMapTrackerMove"
+            "GoToCloudrestEcoSiteMove"
         ]
     },
     "GoToCloudrestEcoSiteNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToCloudrestEcoSiteStartPos"
         ]
     },
-    "GoToCloudrestEcoSiteMapTrackerMove": {
-        "desc": "前往栖云生态点",
+    "GoToCloudrestEcoSiteMove": {
+        "desc": "自动寻路前往栖云生态点",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
@@ -218,7 +218,7 @@
             ]
         },
         "next": [
-            "GoToFloraObservationPointMapTrackerMove"
+            "GoToFloraObservationPointMove"
         ]
     },
     "GoToFloraObservationPointNotAtStartPos": {
@@ -234,8 +234,8 @@
             "GoToFloraObservationPointStartPos"
         ]
     },
-    "GoToFloraObservationPointMapTrackerMove": {
-        "desc": "前往植物观察点",
+    "GoToFloraObservationPointMove": {
+        "desc": "自动寻路前往植物观察点",
         "action": "Custom",
         "custom_action": "MapNavigateAction",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToHangingVinesMapTrackerMove"
+            "GoToHangingVinesMove"
         ]
     },
     "GoToHangingVinesNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToHangingVinesStartPos"
         ]
     },
-    "GoToHangingVinesMapTrackerMove": {
-        "desc": "前往垂藤",
+    "GoToHangingVinesMove": {
+        "desc": "自动寻路前往垂藤",
         "action": "Custom",
         "custom_action": "MapTrackerGoal",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/MysteriousCryptidGraffiti.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/MysteriousCryptidGraffiti.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToMysteriousCryptidGraffitiMapTrackerMove"
+            "GoToMysteriousCryptidGraffitiMove"
         ]
     },
     "GoToMysteriousCryptidGraffitiNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToMysteriousCryptidGraffitiStartPos"
         ]
     },
-    "GoToMysteriousCryptidGraffitiMapTrackerMove": {
-        "desc": "前往谜之生物的涂鸦",
+    "GoToMysteriousCryptidGraffitiMove": {
+        "desc": "自动寻路前往谜之生物的涂鸦",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToPeachTreeAtBabblesSHomeMapTrackerMove"
+            "GoToPeachTreeAtBabblesSHomeMove"
         ]
     },
     "GoToPeachTreeAtBabblesSHomeNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToPeachTreeAtBabblesSHomeStartPos"
         ]
     },
-    "GoToPeachTreeAtBabblesSHomeMapTrackerMove": {
-        "desc": "前往念念家的桃树",
+    "GoToPeachTreeAtBabblesSHomeMove": {
+        "desc": "自动寻路前往念念家的桃树",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Rainbow.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Rainbow.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToRainbowMapTrackerMove"
+            "GoToRainbowMove"
         ]
     },
     "GoToRainbowNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToRainbowStartPos"
         ]
     },
-    "GoToRainbowMapTrackerMove": {
-        "desc": "前往彩虹",
+    "GoToRainbowMove": {
+        "desc": "自动寻路前往彩虹",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToSerenityGardenTianshiPillarMapTrackerMove"
+            "GoToSerenityGardenTianshiPillarMove"
         ]
     },
     "GoToSerenityGardenTianshiPillarNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToSerenityGardenTianshiPillarStartPos"
         ]
     },
-    "GoToSerenityGardenTianshiPillarMapTrackerMove": {
-        "desc": "前往安思园的天师桩",
+    "GoToSerenityGardenTianshiPillarMove": {
+        "desc": "自动寻路前往安思园的天师桩",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/TreeOfTheOldCourtyard.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/TreeOfTheOldCourtyard.json
@@ -218,7 +218,7 @@
             ]
         },
         "next": [
-            "GoToTreeOfTheOldCourtyardMapTrackerMove"
+            "GoToTreeOfTheOldCourtyardMove"
         ]
     },
     "GoToTreeOfTheOldCourtyardNotAtStartPos": {
@@ -234,8 +234,8 @@
             "GoToTreeOfTheOldCourtyardStartPos"
         ]
     },
-    "GoToTreeOfTheOldCourtyardMapTrackerMove": {
-        "desc": "前往旧庭树",
+    "GoToTreeOfTheOldCourtyardMove": {
+        "desc": "自动寻路前往旧庭树",
         "action": "Custom",
         "custom_action": "MapNavigateAction",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WaterTemperatureController.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WaterTemperatureController.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToWaterTemperatureControllerMapTrackerMove"
+            "GoToWaterTemperatureControllerMove"
         ]
     },
     "GoToWaterTemperatureControllerNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToWaterTemperatureControllerStartPos"
         ]
     },
-    "GoToWaterTemperatureControllerMapTrackerMove": {
-        "desc": "前往净水温控装置",
+    "GoToWaterTemperatureControllerMove": {
+        "desc": "自动寻路前往净水温控装置",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WitheredBranches.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/WitheredBranches.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToWitheredBranchesMapTrackerMove"
+            "GoToWitheredBranchesMove"
         ]
     },
     "GoToWitheredBranchesNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToWitheredBranchesStartPos"
         ]
     },
-    "GoToWitheredBranchesMapTrackerMove": {
-        "desc": "前往枯枝",
+    "GoToWitheredBranchesMove": {
+        "desc": "自动寻路前往枯枝",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/AncientTree.json
@@ -218,7 +218,7 @@
             ]
         },
         "next": [
-            "GoToAncientTreeMapTrackerMove"
+            "GoToAncientTreeMove"
         ]
     },
     "GoToAncientTreeNotAtStartPos": {
@@ -234,8 +234,8 @@
             "GoToAncientTreeStartPos"
         ]
     },
-    "GoToAncientTreeMapTrackerMove": {
-        "desc": "前往古树",
+    "GoToAncientTreeMove": {
+        "desc": "自动寻路前往古树",
         "action": "Custom",
         "custom_action": "MapNavigateAction",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInTheBlightTide.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/BeaconDamagedInTheBlightTide.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToBeaconDamagedInTheBlightTideMapTrackerMove"
+            "GoToBeaconDamagedInTheBlightTideMove"
         ]
     },
     "GoToBeaconDamagedInTheBlightTideNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToBeaconDamagedInTheBlightTideStartPos"
         ]
     },
-    "GoToBeaconDamagedInTheBlightTideMapTrackerMove": {
-        "desc": "前往侵蚀潮中损坏的信标",
+    "GoToBeaconDamagedInTheBlightTideMove": {
+        "desc": "自动寻路前往侵蚀潮中损坏的信标",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CisternOriginiumSlugs.json
@@ -218,7 +218,7 @@
             ]
         },
         "next": [
-            "GoToCisternOriginiumSlugsMapTrackerMove"
+            "GoToCisternOriginiumSlugsMove"
         ]
     },
     "GoToCisternOriginiumSlugsNotAtStartPos": {
@@ -234,8 +234,8 @@
             "GoToCisternOriginiumSlugsStartPos"
         ]
     },
-    "GoToCisternOriginiumSlugsMapTrackerMove": {
-        "desc": "前往蓄水源石虫",
+    "GoToCisternOriginiumSlugsMove": {
+        "desc": "自动寻路前往蓄水源石虫",
         "action": "Custom",
         "custom_action": "MapNavigateAction",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToCleansingJadeMapTrackerMove"
+            "GoToCleansingJadeMove"
         ]
     },
     "GoToCleansingJadeNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToCleansingJadeStartPos"
         ]
     },
-    "GoToCleansingJadeMapTrackerMove": {
-        "desc": "前往漱玉",
+    "GoToCleansingJadeMove": {
+        "desc": "自动寻路前往漱玉",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
@@ -218,7 +218,7 @@
             ]
         },
         "next": [
-            "GoToCollapsedTianshiPillarMapTrackerMove"
+            "GoToCollapsedTianshiPillarMove"
         ]
     },
     "GoToCollapsedTianshiPillarNotAtStartPos": {
@@ -234,8 +234,8 @@
             "GoToCollapsedTianshiPillarStartPos"
         ]
     },
-    "GoToCollapsedTianshiPillarMapTrackerMove": {
-        "desc": "前往倒塌的天师桩",
+    "GoToCollapsedTianshiPillarMove": {
+        "desc": "自动寻路前往倒塌的天师桩",
         "action": "Custom",
         "custom_action": "MapNavigateAction",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CollapsedTianshiPillar.json
@@ -207,18 +207,14 @@
     "GoToCollapsedTianshiPillarStartPos": {
         "desc": "在倒塌的天师桩任务开始位置附近",
         "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition": "MapLocateAssertLocation",
         "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv001",
-                    "target": [
-                        210,
-                        635,
-                        15,
-                        15
-                    ]
-                }
+            "zone_id": "Wuling_Base",
+            "target": [
+                671.75,
+                1564.08,
+                46.31,
+                54.57
             ]
         },
         "next": [
@@ -241,34 +237,21 @@
     "GoToCollapsedTianshiPillarMapTrackerMove": {
         "desc": "前往倒塌的天师桩",
         "action": "Custom",
-        "custom_action": "MapTrackerMove",
+        "custom_action": "MapNavigateAction",
         "custom_action_param": {
-            "map_name": "map02_lv001",
             "path": [
-                [
-                    213,
-                    632
-                ],
-                [
-                    191,
-                    616
-                ],
-                [
-                    186,
-                    621
-                ],
-                [
-                    180,
-                    618
-                ]
-            ],
-            "on_finish": {
-                "action": "Custom",
-                "custom_action": "MapTrackerToward",
-                "custom_action_param": {
-                    "angle": 300
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        644.99,
+                        1561.89
+                    ]
+                },
+                {
+                    "action": "HEADING",
+                    "angle": 290
                 }
-            }
+            ]
         },
         "anchor": {
             "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToOutskirtsMonitoringTerminal",

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove"
+            "GoToEcologyNearTheFieldLogisticsDepotMove"
         ]
     },
     "GoToEcologyNearTheFieldLogisticsDepotNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToEcologyNearTheFieldLogisticsDepotStartPos"
         ]
     },
-    "GoToEcologyNearTheFieldLogisticsDepotMapTrackerMove": {
-        "desc": "前往储备站周围的生态环境",
+    "GoToEcologyNearTheFieldLogisticsDepotMove": {
+        "desc": "自动寻路前往储备站周围的生态环境",
         "action": "Custom",
         "custom_action": "MapTrackerGoal",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToEternalSunsetMapTrackerMove"
+            "GoToEternalSunsetMove"
         ]
     },
     "GoToEternalSunsetNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToEternalSunsetStartPos"
         ]
     },
-    "GoToEternalSunsetMapTrackerMove": {
-        "desc": "前往栖霞驻影",
+    "GoToEternalSunsetMove": {
+        "desc": "自动寻路前往栖霞驻影",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/IndoorCrops.json
@@ -218,7 +218,7 @@
             ]
         },
         "next": [
-            "GoToIndoorCropsMapTrackerMove"
+            "GoToIndoorCropsMove"
         ]
     },
     "GoToIndoorCropsNotAtStartPos": {
@@ -234,8 +234,8 @@
             "GoToIndoorCropsStartPos"
         ]
     },
-    "GoToIndoorCropsMapTrackerMove": {
-        "desc": "前往室内作物",
+    "GoToIndoorCropsMove": {
+        "desc": "自动寻路前往室内作物",
         "action": "Custom",
         "custom_action": "MapNavigateAction",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/InflatedAndGlowingBugspittingLankybeast.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove"
+            "GoToInflatedAndGlowingBugspittingLankybeastMove"
         ]
     },
     "GoToInflatedAndGlowingBugspittingLankybeastNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToInflatedAndGlowingBugspittingLankybeastStartPos"
         ]
     },
-    "GoToInflatedAndGlowingBugspittingLankybeastMapTrackerMove": {
-        "desc": "前往肚子鼓气后发光的吐虫长股兽",
+    "GoToInflatedAndGlowingBugspittingLankybeastMove": {
+        "desc": "自动寻路前往肚子鼓气后发光的吐虫长股兽",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToMiniShellbeastMapTrackerMove"
+            "GoToMiniShellbeastMove"
         ]
     },
     "GoToMiniShellbeastNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToMiniShellbeastStartPos"
         ]
     },
-    "GoToMiniShellbeastMapTrackerMove": {
-        "desc": "前往小壳兽",
+    "GoToMiniShellbeastMove": {
+        "desc": "自动寻路前往小壳兽",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToObservantSableChestedFowlbeastMapTrackerMove"
+            "GoToObservantSableChestedFowlbeastMove"
         ]
     },
     "GoToObservantSableChestedFowlbeastNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToObservantSableChestedFowlbeastStartPos"
         ]
     },
-    "GoToObservantSableChestedFowlbeastMapTrackerMove": {
-        "desc": "前往东张西望的黑腹雉羽兽",
+    "GoToObservantSableChestedFowlbeastMove": {
+        "desc": "自动寻路前往东张西望的黑腹雉羽兽",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/PierWaterwheel.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/PierWaterwheel.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToPierWaterwheelMapTrackerMove"
+            "GoToPierWaterwheelMove"
         ]
     },
     "GoToPierWaterwheelNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToPierWaterwheelStartPos"
         ]
     },
-    "GoToPierWaterwheelMapTrackerMove": {
-        "desc": "前往码头水车",
+    "GoToPierWaterwheelMove": {
+        "desc": "自动寻路前往码头水车",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/RainbowFin.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToRainbowFinMapTrackerMove"
+            "GoToRainbowFinMove"
         ]
     },
     "GoToRainbowFinNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToRainbowFinStartPos"
         ]
     },
-    "GoToRainbowFinMapTrackerMove": {
-        "desc": "前往七彩鳞",
+    "GoToRainbowFinMove": {
+        "desc": "自动寻路前往七彩鳞",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/VigorousCisternOriginiumSlug.json
@@ -218,7 +218,7 @@
             ]
         },
         "next": [
-            "GoToVigorousCisternOriginiumSlugMapTrackerMove"
+            "GoToVigorousCisternOriginiumSlugMove"
         ]
     },
     "GoToVigorousCisternOriginiumSlugNotAtStartPos": {
@@ -234,8 +234,8 @@
             "GoToVigorousCisternOriginiumSlugStartPos"
         ]
     },
-    "GoToVigorousCisternOriginiumSlugMapTrackerMove": {
-        "desc": "前往充满活力的蓄水源石虫",
+    "GoToVigorousCisternOriginiumSlugMove": {
+        "desc": "自动寻路前往充满活力的蓄水源石虫",
         "action": "Custom",
         "custom_action": "MapNavigateAction",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/Waterlamp.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/Waterlamp.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToWaterlampMapTrackerMove"
+            "GoToWaterlampMove"
         ]
     },
     "GoToWaterlampNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToWaterlampStartPos"
         ]
     },
-    "GoToWaterlampMapTrackerMove": {
-        "desc": "前往水灯虫",
+    "GoToWaterlampMove": {
+        "desc": "自动寻路前往水灯虫",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/XiraniteNexus.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/XiraniteNexus.json
@@ -222,7 +222,7 @@
             ]
         },
         "next": [
-            "GoToXiraniteNexusMapTrackerMove"
+            "GoToXiraniteNexusMove"
         ]
     },
     "GoToXiraniteNexusNotAtStartPos": {
@@ -238,8 +238,8 @@
             "GoToXiraniteNexusStartPos"
         ]
     },
-    "GoToXiraniteNexusMapTrackerMove": {
-        "desc": "前往枢壤仪",
+    "GoToXiraniteNexusMove": {
+        "desc": "自动寻路前往枢壤仪",
         "action": "Custom",
         "custom_action": "MapTrackerMove",
         "custom_action_param": {

--- a/docs/en_us/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/en_us/developers/tasks/environment-monitoring-maintain.md
@@ -71,7 +71,7 @@ The internal chain for each observation point `{Id}Job` (rendered by `template.j
                       └─ GoTo{Id}NotAtStartPos
                            └─ SubTask: ${EnterMap}            (Teleport)
                                 └─ GoTo{Id}StartPos           (Check if already near the mission start position)
-                                     └─ GoTo{Id}MapTrackerMove
+                                     └─ GoTo{Id}Move
                                           ├─ anchor: EnvironmentMonitoringBackToTerminal → ${GoToMonitoringTerminal}
                                           ├─ anchor: EnvironmentMonitoringAdjustCamera   → ${Id}AdjustCamera
                                           └─ next:   EnvironmentMonitoringTakePhoto

--- a/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
@@ -71,7 +71,7 @@ EnvironmentMonitoringMain
                       └─ GoTo{Id}NotAtStartPos
                            └─ SubTask: ${EnterMap}            （传送）
                                 └─ GoTo{Id}StartPos           （检查是否已到任务开始位置附近）
-                                     └─ GoTo{Id}MapTrackerMove
+                                     └─ GoTo{Id}Move
                                           ├─ anchor: EnvironmentMonitoringBackToTerminal → ${GoToMonitoringTerminal}
                                           ├─ anchor: EnvironmentMonitoringAdjustCamera   → ${Id}AdjustCamera
                                           └─ next:   EnvironmentMonitoringTakePhoto

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/data.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/data.mjs
@@ -54,6 +54,13 @@ function buildExpectedFromLocaleMap(localeMap) {
     }).filter(Boolean);
 }
 
+function rawJson(value) {
+    return {
+        value,
+        raw: JSON.stringify(value, null, 4),
+    };
+}
+
 const routeResolver = createRouteResolver(ROUTE_CONFIG);
 
 function buildStationName(terminalId) {
@@ -103,15 +110,15 @@ function buildRow(mission, usedIds) {
         MapTargetTier: route.MapTargetTier,
         MapGoal: route.MapGoal,
         MapAssertRecognition: route.MapAssertRecognition,
-        MapAssertParam: route.MapAssertParam,
+        MapAssertParam: rawJson(route.MapAssertParam),
         CameraSwipeDirection: route.CameraSwipeDirection,
         CameraMaxHit: route.CameraMaxHit,
         ExpectedText: buildExpectedFromLocaleMap(mission.name),
         InExpectedText: buildExpectedFromLocaleMap(mission.shotTargetName),
-        TrackOrGoToNext,
-        AfterTrackedNext,
+        TrackOrGoToNext: rawJson(TrackOrGoToNext),
+        AfterTrackedNext: rawJson(AfterTrackedNext),
         MapNavigationAction: route.MapNavigationAction,
-        MapNavigationParam: route.MapNavigationParam,
+        MapNavigationParam: rawJson(route.MapNavigationParam),
     };
 }
 

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/template.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/template.json
@@ -191,7 +191,7 @@
         "custom_recognition": "${MapAssertRecognition}",
         "custom_recognition_param": "${MapAssertParam}",
         "next": [
-            "GoTo${Id}MapTrackerMove"
+            "GoTo${Id}Move"
         ]
     },
     "GoTo${Id}NotAtStartPos": {
@@ -207,8 +207,8 @@
             "GoTo${Id}StartPos"
         ]
     },
-    "GoTo${Id}MapTrackerMove": {
-        "desc": "前往${Name}",
+    "GoTo${Id}Move": {
+        "desc": "自动寻路前往${Name}",
         "action": "Custom",
         "custom_action": "${MapNavigationAction}",
         "custom_action_param": "${MapNavigationParam}",

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -169,33 +169,19 @@
         "Name": "倒塌的天师桩",
         "Id": "CollapsedTianshiPillar",
         "EnterMap": "SceneEnterWorldWulingJingyuValley8",
-        "MapName": "map02_lv001",
+        "MapName": "Wuling_Base",
         "MapAssert": [
-            210,
-            635,
-            15,
-            15
+            671.75,
+            1564.08,
+            46.31,
+            54.57
         ],
-        "MapPath": [
-            [
-                213,
-                632
-            ],
-            [
-                191,
-                616
-            ],
-            [
-                186,
-                621
-            ],
-            [
-                180,
-                618
-            ]
+        "MapTarget": [
+            644.99,
+            1561.89
         ],
         "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenUp",
-        "Heading": 300
+        "Heading": 290
     },
     {
         "MissionId": "m1m32",


### PR DESCRIPTION
## 变更内容

- 优化“倒塌的天师桩”路线：从 `MapPath` 录点跟走切换为 `MapTarget` / `MapNavigateAction` 自动寻路，并更新落点断言与最终朝向，避免拍摄目标被角色遮挡。
- 顺便将环境监测生成模板中的 `GoTo${Id}MapTrackerMove` 统一改为 `GoTo${Id}Move`，适配现在同时支持 MapTracker 与 MapNavigate 两种导航方式。
- 重新生成 28 个环境监测观察点 Pipeline，保持引用、节点定义和描述一致。
- 将自动寻路节点描述改为“自动寻路前往...”，避免暗示只支持 MapTrackerMove。
- 同步更新中英文 EnvironmentMonitoring 维护文档中的流程节点名。

Fixes #3823

## 验证

- `pnpm format`
- `pnpm check`
- `pnpm test`

## Summary by Sourcery

更新 EnvironmentMonitoring 自动导航数据模型，并重新生成流水线，以使用统一的移动节点命名和原始 JSON 导航元数据。

增强功能：
- 在 EnvironmentMonitoring 流水线生成器中，将路线和导航相关字段封装为原始 JSON 元数据，以便模板一致地使用。
- 在所有生成的流水线和生成器模板中，将移动节点名称从 `GoTo{Id}MapTrackerMove` 统一规范为 `GoTo{Id}Move`。

文档：
- 将英文和中文的 EnvironmentMonitoring 维护文档与新的 `GoTo{Id}Move` 节点名称及更新后的自动导航描述保持一致。

杂项：
- 重新生成 EnvironmentMonitoring 观测点流水线，以匹配更新后的导航模式和节点命名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update EnvironmentMonitoring auto-navigation data model and regenerate pipelines to use unified movement node naming and raw JSON navigation metadata.

Enhancements:
- Wrap route and navigation-related fields in the EnvironmentMonitoring pipeline generator as raw JSON metadata for consistent template consumption.
- Standardize the GoTo{Id} movement node name from GoTo{Id}MapTrackerMove to GoTo{Id}Move across generated pipelines and generator templates.

Documentation:
- Align English and Chinese EnvironmentMonitoring maintenance docs with the new GoTo{Id}Move node name and updated auto-navigation descriptions.

Chores:
- Regenerate EnvironmentMonitoring observation point pipelines to match the updated navigation schema and node naming.

</details>

增强内容：
- 在环境监控流水线生成器中，将路由和导航相关字段包装为原始 JSON 元数据，以便模板使用更加一致。
- 重新生成环境监控流水线，使其与更新后的自动导航节点命名方案和生成器输出保持一致。

文档：
- 更新英文和中文的环境监控维护文档，使用新的自动导航节点名称，并对其描述进行进一步说明和澄清。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 EnvironmentMonitoring 自动导航数据模型，并重新生成流水线，以使用统一的移动节点命名和原始 JSON 导航元数据。

增强功能：
- 在 EnvironmentMonitoring 流水线生成器中，将路线和导航相关字段封装为原始 JSON 元数据，以便模板一致地使用。
- 在所有生成的流水线和生成器模板中，将移动节点名称从 `GoTo{Id}MapTrackerMove` 统一规范为 `GoTo{Id}Move`。

文档：
- 将英文和中文的 EnvironmentMonitoring 维护文档与新的 `GoTo{Id}Move` 节点名称及更新后的自动导航描述保持一致。

杂项：
- 重新生成 EnvironmentMonitoring 观测点流水线，以匹配更新后的导航模式和节点命名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update EnvironmentMonitoring auto-navigation data model and regenerate pipelines to use unified movement node naming and raw JSON navigation metadata.

Enhancements:
- Wrap route and navigation-related fields in the EnvironmentMonitoring pipeline generator as raw JSON metadata for consistent template consumption.
- Standardize the GoTo{Id} movement node name from GoTo{Id}MapTrackerMove to GoTo{Id}Move across generated pipelines and generator templates.

Documentation:
- Align English and Chinese EnvironmentMonitoring maintenance docs with the new GoTo{Id}Move node name and updated auto-navigation descriptions.

Chores:
- Regenerate EnvironmentMonitoring observation point pipelines to match the updated navigation schema and node naming.

</details>

</details>