### PR TITLE
fix: 偶现无法进入菜单列表 (#3890)

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -94,6 +94,10 @@
                 "green_mask": true
             }
         },
+        "pre_wait_freezes": {
+            "time": 100,
+            "timeout": 1000
+        },
         "pre_delay": 0,
         "action": {
             "type": "Custom",


### PR DESCRIPTION
close #3870

## Summary by Sourcery

Bug Fixes:
- 调整 SceneMenu 场景配置，以确保菜单列表始终可以进入，避免间歇性失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust SceneMenu scene configuration so the menu list can always be entered without intermittent failures.

</details>

## Summary by Sourcery

错误修复：
- 调整 SceneMenu 配置，确保菜单列表场景能够稳定打开，避免偶发性的访问问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust SceneMenu configuration so the menu list scene consistently opens without sporadic access issues.

</details>