### PR TITLE
chore: 自动pick release分支失败

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -39,9 +39,9 @@ jobs:
             exit 0
           fi
 
-          # 提取中版本号：vX.Y.Z-rc.N → vX.Y，分支名 release/vX.Y
+          # 提取中版本号：vX.Y.Z-rc.N → X.Y，分支名 release/vX.Y
           BASE_VERSION="${BASH_REMATCH[1]}"
-          BRANCH_NAME="release/${BASE_VERSION}"
+          BRANCH_NAME="release/v${BASE_VERSION}"
 
           echo "tag=${TAG}" | tee -a "$GITHUB_OUTPUT"
           echo "branch_name=${BRANCH_NAME}" | tee -a "$GITHUB_OUTPUT"
@@ -100,8 +100,8 @@ jobs:
             exit 0
           fi
 
-          # 提取中版本号：vX.Y.0 → vX.Y，分支名 release/vX.Y
-          CURRENT_BRANCH="release/${BASH_REMATCH[1]}"
+          # 提取中版本号：vX.Y.0 → X.Y，分支名 release/vX.Y
+          CURRENT_BRANCH="release/v${BASH_REMATCH[1]}"
 
           echo "tag=${TAG}" | tee -a "$GITHUB_OUTPUT"
           echo "current_branch=${CURRENT_BRANCH}" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
@ocsin1 
<img width="1076" height="1179" alt="image" src="https://github.com/user-attachments/assets/eaaca696-ce8c-4cb0-912c-a5833c4dfc0f" />

## Summary by Sourcery

CI：
- 修复 `create-release-branch` 工作流中的发布分支名称生成逻辑，使其在分支名称中包含前导的 `v` 前缀。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Fix release branch name generation in the create-release-branch workflow to include the leading 'v' prefix in branch names.

</details>