### PR TITLE
chore: add all archs

### DIFF
--- a/.github/workflows/discord-release-notification.yml
+++ b/.github/workflows/discord-release-notification.yml
@@ -43,19 +43,23 @@ jobs:
 
           BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
           WIN64_URL="${BASE_URL}/MaaEnd-win-x86_64-${TAG}.zip"
-          WINARM_URL="${BASE_URL}/MaaEnd-win-aarch64-${TAG}.zip"
-          MAC_URL="${BASE_URL}/MaaEnd-macos-x86_64-${TAG}.dmg"
+          WINAARCH_URL="${BASE_URL}/MaaEnd-win-aarch64-${TAG}.zip"
+          MAC64_URL="${BASE_URL}/MaaEnd-macos-x86_64-${TAG}.dmg"
+          MACAARCH_URL="${BASE_URL}/MaaEnd-macos-aarch64-${TAG}.dmg"
           LIN64_URL="${BASE_URL}/MaaEnd-linux-x86_64-${TAG}.tar.gz"
+          LINAARCH_URL="${BASE_URL}/MaaEnd-linux-aarch64-${TAG}.tar.gz"
 
-          DESCRIPTION=$(printf 'Read the full release note [here](%s).\n\nUpdate available in your MaaEnd client.\nOr, download `MaaEnd %s` for your platform by clicking the buttons below.' "$URL" "$TAG")
+          DESCRIPTION=$(printf 'Read the full release note [here](%s).\n\nUpdate available in your MaaEnd client.\nDownload MaaEnd `%s` for your platform\nby clicking the buttons below.' "$URL" "$TAG")
 
           PAYLOAD=$(jq -n \
             --arg tag "$TAG" \
             --arg description "$DESCRIPTION" \
             --arg win64_url "$WIN64_URL" \
-            --arg winarm_url "$WINARM_URL" \
-            --arg mac_url "$MAC_URL" \
+            --arg winaarch_url "$WINAARCH_URL" \
+            --arg mac64_url "$MAC64_URL" \
+            --arg macaarch_url "$MACAARCH_URL" \
             --arg lin64_url "$LIN64_URL" \
+            --arg linaarch_url "$LINAARCH_URL" \
             '{
               embeds: [{
                 title: ("🎉 New MaaEnd Release:  " + $tag),
@@ -63,9 +67,11 @@ jobs:
                 color: 15844367,
                 fields: [
                   { name: "Windows (x64)", value: ("[↗ Download](" + $win64_url + ")"), inline: true },
-                  { name: "Windows (ARM)", value: ("[↗ Download](" + $winarm_url + ")"), inline: true },
-                  { name: "macOS (x64)", value: ("[↗ Download](" + $mac_url + ")"), inline: true },
-                  { name: "Linux (x64)", value: ("[↗ Download](" + $lin64_url + ")"), inline: true }
+                  { name: "macOS (x64)", value: ("[↗ Download](" + $mac64_url + ")"), inline: true },
+                  { name: "Linux (x64)", value: ("[↗ Download](" + $lin64_url + ")"), inline: true },
+                  { name: "Windows (ARM)", value: ("[↗ Download](" + $winaarch_url + ")"), inline: true },
+                  { name: "macOS (ARM)", value: ("[↗ Download](" + $macaarch_url + ")"), inline: true },
+                  { name: "Linux (ARM)", value: ("[↗ Download](" + $linaarch_url + ")"), inline: true }
                 ]
               }]
             }')

--- a/.github/workflows/discord-release-notification.yml
+++ b/.github/workflows/discord-release-notification.yml
@@ -66,9 +66,9 @@ jobs:
                 description: $description,
                 color: 15844367,
                 fields: [
-                  { name: "Windows", value: ("[x64](" + $win64_url + ") · [Aarch](" + $winaarch_url + ")"), inline: true },
-                  { name: "macOS", value: ("[x64](" + $mac64_url + ") · [Aarch](" + $macaarch_url + ")"), inline: true },
-                  { name: "Linux", value: ("[x64](" + $lin64_url + ") · [Aarch](" + $linaarch_url + ")"), inline: true }
+                  { name: "Windows", value: ("[↗x64](" + $win64_url + ") · [↗ARM](" + $winaarch_url + ")"), inline: true },
+                  { name: "macOS", value: ("[↗x64](" + $mac64_url + ") · [↗ARM](" + $macaarch_url + ")"), inline: true },
+                  { name: "Linux", value: ("[↗x64](" + $lin64_url + ") · [↗ARM](" + $linaarch_url + ")"), inline: true }
                 ]
               }]
             }')

--- a/.github/workflows/discord-release-notification.yml
+++ b/.github/workflows/discord-release-notification.yml
@@ -49,7 +49,7 @@ jobs:
           LIN64_URL="${BASE_URL}/MaaEnd-linux-x86_64-${TAG}.tar.gz"
           LINAARCH_URL="${BASE_URL}/MaaEnd-linux-aarch64-${TAG}.tar.gz"
 
-          DESCRIPTION=$(printf 'Read the full release note [here](%s).\n\nUpdate available in your MaaEnd client.\nDownload MaaEnd `%s` for your platform\nby clicking the buttons below.' "$URL" "$TAG")
+          DESCRIPTION=$(printf 'Read the full release note [here](%s).\n\nUpdate available in your MaaEnd client.\nDownload MaaEnd `%s` for your platform below.' "$URL" "$TAG")
 
           PAYLOAD=$(jq -n \
             --arg tag "$TAG" \
@@ -66,12 +66,9 @@ jobs:
                 description: $description,
                 color: 15844367,
                 fields: [
-                  { name: "Windows (x64)", value: ("[↗ Download](" + $win64_url + ")"), inline: true },
-                  { name: "macOS (x64)", value: ("[↗ Download](" + $mac64_url + ")"), inline: true },
-                  { name: "Linux (x64)", value: ("[↗ Download](" + $lin64_url + ")"), inline: true },
-                  { name: "Windows (ARM)", value: ("[↗ Download](" + $winaarch_url + ")"), inline: true },
-                  { name: "macOS (ARM)", value: ("[↗ Download](" + $macaarch_url + ")"), inline: true },
-                  { name: "Linux (ARM)", value: ("[↗ Download](" + $linaarch_url + ")"), inline: true }
+                  { name: "Windows", value: ("[x64](" + $win64_url + ") · [ARM](" + $winaarch_url + ")"), inline: true },
+                  { name: "macOS", value: ("[x64](" + $mac64_url + ")"), inline: true },
+                  { name: "Linux", value: ("[x64](" + $lin64_url + ")"), inline: true }
                 ]
               }]
             }')

--- a/.github/workflows/discord-release-notification.yml
+++ b/.github/workflows/discord-release-notification.yml
@@ -66,9 +66,9 @@ jobs:
                 description: $description,
                 color: 15844367,
                 fields: [
-                  { name: "Windows", value: ("[x64](" + $win64_url + ") ⬢ [ARM](" + $winaarch_url + ")"), inline: true },
-                  { name: "macOS", value: ("[x64](" + $mac64_url + ") ⬢ [ARM](" + $macaarch_url + ")"), inline: true },
-                  { name: "Linux", value: ("[x64](" + $lin64_url + ") ⬢ [ARM](" + $linaarch_url + ")"), inline: true }
+                  { name: "Windows", value: ("[x64](" + $win64_url + ") ❘ [ARM](" + $winaarch_url + ")"), inline: true },
+                  { name: "macOS", value: ("[x64](" + $mac64_url + ") | [ARM](" + $macaarch_url + ")"), inline: true },
+                  { name: "Linux", value: ("[x64](" + $lin64_url + ") ▫ [ARM](" + $linaarch_url + ")"), inline: true }
                 ]
               }]
             }')

--- a/.github/workflows/discord-release-notification.yml
+++ b/.github/workflows/discord-release-notification.yml
@@ -66,9 +66,9 @@ jobs:
                 description: $description,
                 color: 15844367,
                 fields: [
-                  { name: "Windows", value: ("[↗x64](" + $win64_url + ") · [↗ARM](" + $winaarch_url + ")"), inline: true },
-                  { name: "macOS", value: ("[↗x64](" + $mac64_url + ") · [↗ARM](" + $macaarch_url + ")"), inline: true },
-                  { name: "Linux", value: ("[↗x64](" + $lin64_url + ") · [↗ARM](" + $linaarch_url + ")"), inline: true }
+                  { name: "Windows", value: ("[x64](" + $win64_url + ") ⬢ [ARM](" + $winaarch_url + ")"), inline: true },
+                  { name: "macOS", value: ("[x64](" + $mac64_url + ") ⬢ [ARM](" + $macaarch_url + ")"), inline: true },
+                  { name: "Linux", value: ("[x64](" + $lin64_url + ") ⬢ [ARM](" + $linaarch_url + ")"), inline: true }
                 ]
               }]
             }')

--- a/.github/workflows/discord-release-notification.yml
+++ b/.github/workflows/discord-release-notification.yml
@@ -43,11 +43,11 @@ jobs:
 
           BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
           WIN64_URL="${BASE_URL}/MaaEnd-win-x86_64-${TAG}.zip"
-          WINAARCH_URL="${BASE_URL}/MaaEnd-win-aarch64-${TAG}.zip"
+          WINARM_URL="${BASE_URL}/MaaEnd-win-aarch64-${TAG}.zip"
           MAC64_URL="${BASE_URL}/MaaEnd-macos-x86_64-${TAG}.dmg"
-          MACAARCH_URL="${BASE_URL}/MaaEnd-macos-aarch64-${TAG}.dmg"
+          MACARM_URL="${BASE_URL}/MaaEnd-macos-aarch64-${TAG}.dmg"
           LIN64_URL="${BASE_URL}/MaaEnd-linux-x86_64-${TAG}.tar.gz"
-          LINAARCH_URL="${BASE_URL}/MaaEnd-linux-aarch64-${TAG}.tar.gz"
+          LINARM_URL="${BASE_URL}/MaaEnd-linux-aarch64-${TAG}.tar.gz"
 
           DESCRIPTION=$(printf 'Read the full release note [here](%s).\n\nUpdate available in your MaaEnd client.\nDownload MaaEnd `%s` for your platform below.' "$URL" "$TAG")
 
@@ -55,20 +55,20 @@ jobs:
             --arg tag "$TAG" \
             --arg description "$DESCRIPTION" \
             --arg win64_url "$WIN64_URL" \
-            --arg winaarch_url "$WINAARCH_URL" \
+            --arg winarm_url "$WINARM_URL" \
             --arg mac64_url "$MAC64_URL" \
-            --arg macaarch_url "$MACAARCH_URL" \
+            --arg macarm_url "$MACARM_URL" \
             --arg lin64_url "$LIN64_URL" \
-            --arg linaarch_url "$LINAARCH_URL" \
+            --arg linarm_url "$LINARM_URL" \
             '{
               embeds: [{
                 title: ("🎉 New MaaEnd Release:  " + $tag),
                 description: $description,
                 color: 15844367,
                 fields: [
-                  { name: "Windows", value: ("[x64](" + $win64_url + ") ❘ [ARM](" + $winaarch_url + ")"), inline: true },
-                  { name: "macOS", value: ("[x64](" + $mac64_url + ") ❘ [ARM](" + $macaarch_url + ")"), inline: true },
-                  { name: "Linux", value: ("[x64](" + $lin64_url + ") ❘ [ARM](" + $linaarch_url + ")"), inline: true }
+                  { name: "Windows", value: ("[x64](" + $win64_url + ") ❘ [ARM](" + $winarm_url + ")"), inline: true },
+                  { name: "macOS", value: ("[x64](" + $mac64_url + ") ❘ [ARM](" + $macarm_url + ")"), inline: true },
+                  { name: "Linux", value: ("[x64](" + $lin64_url + ") ❘ [ARM](" + $linarm_url + ")"), inline: true }
                 ]
               }]
             }')

--- a/.github/workflows/discord-release-notification.yml
+++ b/.github/workflows/discord-release-notification.yml
@@ -67,8 +67,8 @@ jobs:
                 color: 15844367,
                 fields: [
                   { name: "Windows", value: ("[x64](" + $win64_url + ") ❘ [ARM](" + $winaarch_url + ")"), inline: true },
-                  { name: "macOS", value: ("[x64](" + $mac64_url + ") | [ARM](" + $macaarch_url + ")"), inline: true },
-                  { name: "Linux", value: ("[x64](" + $lin64_url + ") ▫ [ARM](" + $linaarch_url + ")"), inline: true }
+                  { name: "macOS", value: ("[x64](" + $mac64_url + ") ❘ [ARM](" + $macaarch_url + ")"), inline: true },
+                  { name: "Linux", value: ("[x64](" + $lin64_url + ") ❘ [ARM](" + $linaarch_url + ")"), inline: true }
                 ]
               }]
             }')

--- a/.github/workflows/discord-release-notification.yml
+++ b/.github/workflows/discord-release-notification.yml
@@ -66,9 +66,9 @@ jobs:
                 description: $description,
                 color: 15844367,
                 fields: [
-                  { name: "Windows", value: ("[x64](" + $win64_url + ") · [ARM](" + $winaarch_url + ")"), inline: true },
-                  { name: "macOS", value: ("[x64](" + $mac64_url + ")"), inline: true },
-                  { name: "Linux", value: ("[x64](" + $lin64_url + ")"), inline: true }
+                  { name: "Windows", value: ("[x64](" + $win64_url + ") · [Aarch](" + $winaarch_url + ")"), inline: true },
+                  { name: "macOS", value: ("[x64](" + $mac64_url + ") · [Aarch](" + $macaarch_url + ")"), inline: true },
+                  { name: "Linux", value: ("[x64](" + $lin64_url + ") · [Aarch](" + $linaarch_url + ")"), inline: true }
                 ]
               }]
             }')


### PR DESCRIPTION
## Summary by Sourcery

更新 Discord 发布通知，以包含所有平台架构，并简化各平台的下载链接。

新功能：
- 在 Discord 发布通知中添加 macOS ARM64 和 Linux ARM64 下载链接。

增强内容：
- 将按架构划分的下载按钮合并为单一的 Windows、macOS 和 Linux 字段，在其中列出 x64 和 ARM 版本。
- 优化 Discord 发布说明文本，以强调多平台下载支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Discord release notification to include all platform architectures and streamline download links per platform.

New Features:
- Add macOS ARM64 and Linux ARM64 download links to Discord release notifications.

Enhancements:
- Consolidate per-architecture download buttons into single Windows, macOS, and Linux fields listing x64 and ARM variants.
- Refine Discord release description text to emphasize multi-platform downloads.

</details>

新功能：
- 在 Discord 发布通知中加入 macOS 和 Linux ARM64 下载链接。
- 将按架构划分的独立下载按钮整合为单个平台字段，在其中列出 x64 和 ARM 版本。

增强：
- 调整 Discord 通知中的发布说明文案，以更好地体现多平台下载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 Discord 发布通知，以包含所有平台架构，并简化各平台的下载链接。

新功能：
- 在 Discord 发布通知中添加 macOS ARM64 和 Linux ARM64 下载链接。

增强内容：
- 将按架构划分的下载按钮合并为单一的 Windows、macOS 和 Linux 字段，在其中列出 x64 和 ARM 版本。
- 优化 Discord 发布说明文本，以强调多平台下载支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Discord release notification to include all platform architectures and streamline download links per platform.

New Features:
- Add macOS ARM64 and Linux ARM64 download links to Discord release notifications.

Enhancements:
- Consolidate per-architecture download buttons into single Windows, macOS, and Linux fields listing x64 and ARM variants.
- Refine Discord release description text to emphasize multi-platform downloads.

</details>

</details>