### PR TITLE
refactor(pipeline): 将主流程移出 subtask

### DIFF
--- a/assets/resource/pipeline/AutoEcoFarm.json
+++ b/assets/resource/pipeline/AutoEcoFarm.json
@@ -6,12 +6,14 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "StashBackpackSubTask",
-                "AutoEcoFarmMain"
+                "StashBackpackSubTask"
             ]
         },
         "post_delay": 0,
-        "rate_limit": 0
+        "rate_limit": 0,
+        "next": [
+            "AutoEcoFarmMain"
+        ]
     },
     "AutoEcoFarmMain": {
         "desc": "自动生态农场主入口",

--- a/assets/resource/pipeline/ItemTransfer.json
+++ b/assets/resource/pipeline/ItemTransfer.json
@@ -71,12 +71,14 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "StashBackpackSubTask",
-                "ItemTransferSwitchRepoToOrigin"
+                "StashBackpackSubTask"
             ]
         },
         "post_delay": 0,
-        "rate_limit": 0
+        "rate_limit": 0,
+        "next": [
+            "ItemTransferSwitchRepoToOrigin"
+        ]
     },
     "ItemTransferSwitchRepoToOrigin": {
         "recognition": "OCR",


### PR DESCRIPTION
这是为了避免日志工具仅显示一个节点。

<img width="782" height="574" alt="05e1bace5190734ffb047634936db4e8" src="https://github.com/user-attachments/assets/4e99abb3-4c1a-4622-be83-cfbb2fba3e87" />

<img width="2430" height="1590" alt="b70a410002101229dc6b82f1e42ac6d4" src="https://github.com/user-attachments/assets/9d59ec01-7342-4f44-a84f-70f7126c032c" />


## 变更内容

- 将 `AutoEcoFarmTask` 的主流程入口 `AutoEcoFarmMain` 从 `SubTask` 的 `sub` 列表移到节点 `next`。
- 将 `ItemTransferInBackpack` 的后续流程 `ItemTransferSwitchRepoToOrigin` 从 `SubTask` 的 `sub` 列表移到节点 `next`。

## 变更原因

`SubTask` 适合顺序执行真正的子任务或准备动作。当前入口节点先执行可选的 `StashBackpackSubTask` 后，应回到 Pipeline 外层流转继续进入主流程，避免把业务主流程嵌进 `SubTask` 动作里，导致 action 成败语义和后续跳转耦合。

## 影响

- 生态农场和物品转交在可选收纳背包后，都会通过外层 `next` 进入自己的主流程。
- 未改变识别 ROI、模板、任务选项和用户配置入口。

## 验证

- `pnpm exec prettier --write assets/resource/pipeline/AutoEcoFarm.json assets/resource/pipeline/ItemTransfer.json`
- `pnpm check`
- `pnpm test`

## Summary by Sourcery

将主流水线流程与可选的背包储物（backpack-stash）子任务解耦，以便在执行完可选存储操作后，核心的 AutoEcoFarm 和物品转移过程能够通过外层的 next 节点继续运行。

Bug Fixes:
- 修正 AutoEcoFarm 和 ItemTransfer 流水线在执行可选背包储物子任务后的主流程跳转，避免将主要逻辑嵌入到子任务链中。

Enhancements:
- 通过将 AutoEcoFarm 和 ItemTransfer 的主续接节点从子任务列表移动到外层的 next 节点来统一流水线结构，从而使控制流程更加清晰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple main pipeline flows from optional backpack-stash subtasks so that core AutoEcoFarm and item transfer processes resume via outer next nodes after optional storage actions.

Bug Fixes:
- Correct main flow transitions for AutoEcoFarm and ItemTransfer pipelines after optional backpack stash subtasks to avoid main logic being embedded inside subtask chains.

Enhancements:
- Align pipeline structure by moving primary AutoEcoFarm and ItemTransfer continuation nodes from subtask lists to next nodes for clearer control flow.

</details>

## Summary by Sourcery

将主流水线流程从可选的背包存储子任务中解耦，使执行能够通过外层的 next 节点继续，而不是一直嵌套在子任务链中。

Bug Fixes:
- 修正 AutoEcoFarm 和 ItemTransfer 流水线在可选背包存储子任务之后的主流程跳转，使核心逻辑不再停留在子任务列表内部。

Enhancements:
- 通过将主流程的后续执行统一路由到顶层的 next 节点，对齐 AutoEcoFarm 和 ItemTransfer 流水线结构，从而实现更清晰且更一致的控制流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple main pipeline flows from optional backpack stash subtasks so execution resumes via outer next nodes instead of remaining nested within subtask chains.

Bug Fixes:
- Correct main flow transitions for AutoEcoFarm and ItemTransfer pipelines after optional backpack stash subtasks so core logic no longer resides inside subtask lists.

Enhancements:
- Align AutoEcoFarm and ItemTransfer pipeline structures by routing main continuations through top-level next nodes for clearer and more consistent control flow.

</details>