### PR TITLE
fix:修复赠送线索后的延迟太短导致识别到上一帧结果

### DIFF
--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -629,13 +629,18 @@
                 ]
             }
         },
-        "pre_delay": 0,
         "action": {
             "type": "Click"
         },
-        "post_wait_freezes": 200,
-        "post_delay": 0,
-        "rate_limit": 0
+        "post_wait_freezes": {
+            "time": 200,
+            "target": [
+                1065,
+                0,
+                179,
+                41
+            ]
+        }
     },
     "ReceptionRoomSendCluesSelectFriend": {
         "desc": "[会客室·线索] 先识别缺失线索的好友",


### PR DESCRIPTION
## Summary by Sourcery

改进：
- 调整帝江接待室奖励流水线中的时间参数，以避免误将上一帧的结果识别为当前帧的结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Tune timing parameters in the Dijiang reception room reward pipeline to avoid misidentifying results from the previous frame.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进：
- 调整帝江接待室奖励流水线中的时间参数，以避免误将上一帧的结果识别为当前帧的结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Tune timing parameters in the Dijiang reception room reward pipeline to avoid misidentifying results from the previous frame.

</details>

</details>