### PR TITLE
fix: 放宽制造装备识别器颜色阈值

### DIFF
--- a/assets/resource/pipeline/GearAssembly/Region.json
+++ b/assets/resource/pipeline/GearAssembly/Region.json
@@ -6,27 +6,23 @@
             "param": {
                 "roi": [
                     35,
-                    50,
                     100,
-                    590
+                    100,
+                    500
                 ],
+                "method": 6,
                 "lower": [
                     [
-                        20,
-                        20,
                         20
                     ]
                 ],
                 "upper": [
                     [
-                        50,
-                        50,
-                        50
+                        55
                     ]
                 ],
                 "connected": true,
-                "count": 2000,
-                "order_by": "Vertical"
+                "count": 2000
             }
         }
     },


### PR DESCRIPTION
## Summary by Sourcery

增强：
- 调整 GearAssembly 区域配置参数，使基于颜色的设备识别条件不那么严格。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust GearAssembly region configuration parameters to make color-based equipment recognition less strict.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

增强：
- 调整 GearAssembly 区域配置参数，使基于颜色的设备识别条件不那么严格。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust GearAssembly region configuration parameters to make color-based equipment recognition less strict.

</details>

</details>