### PR TITLE
docs(gift-operator): 补充新增干员时遗漏的 next 数组接线步骤

### DIFF
--- a/docs/en_us/developers/tasks/gift-operator-maintain.md
+++ b/docs/en_us/developers/tasks/gift-operator-maintain.md
@@ -1,7 +1,7 @@
 # Developer Guide — Gift Operator Maintenance
 
 This document describes the file layout of `GiftOperator` and its two execution routes.  
-Last updated June 6, 2026.
+Last updated June 28, 2026.
 
 ## File overview
 
@@ -23,7 +23,7 @@ Last updated June 6, 2026.
 
 ## Paths to update when adding an operator
 
-When adding a new operator, update at least these 5 places (`<Name>` is the operator identifier and must match the template filename and option case name):
+When adding a new operator, update at least these 6 places (`<Name>` is the operator identifier and must match the template filename and option case name):
 
 | #   | Path                                                               | Description                                                                                                    |
 | --- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
@@ -31,7 +31,8 @@ When adding a new operator, update at least these 5 places (`<Name>` is the oper
 | 2   | `assets/resource_adb/image/GiftOperator/Operators/<Name>.png`      | ADB operator portrait template; same processing as above                                                       |
 | 3   | `assets/tasks/GiftOperator.json` → `SelectOperator`                | Add a case for UI selection and to supply operator info for the receive-only route                             |
 | 4   | `assets/resource/pipeline/GiftOperator/Operator/Operator.json`     | Per-operator OCR recognition and whitelist in receive-only mode                                                |
-| 5   | `assets/locales/interface/*.json` → `operator.<Name>`              | Localized operator display names                                                                               |
+| 5   | `assets/resource/pipeline/GiftOperator/GiftOperatorContact.json` → `GiftOperatorSelectGiftOp.next` | Append `GiftOperatorSelect_<Name>` to the `next` array, or the receive-only route never triggers the new operator node |
+| 6   | `assets/locales/interface/*.json` → `operator.<Name>`              | Localized operator display names                                                                               |
 
 ## Route 1: Default (give + receive)
 

--- a/docs/zh_cn/developers/tasks/gift-operator-maintain.md
+++ b/docs/zh_cn/developers/tasks/gift-operator-maintain.md
@@ -1,7 +1,7 @@
 # 开发手册 - 赠送干员礼物维护文档
 
 本文说明 `GiftOperator` 的文件分布与两条执行路线。  
-该文档更新于 2026 年 6 月 6 日。
+该文档更新于 2026 年 6 月 28 日。
 
 ## 文件路径
 
@@ -23,7 +23,7 @@
 
 ## 新增干员时需改的路径
 
-新增一名干员时，至少需同步以下 5 处（`<Name>` 为干员标识，与模板文件名、option case 名保持一致）：
+新增一名干员时，至少需同步以下 6 处（`<Name>` 为干员标识，与模板文件名、option case 名保持一致）：
 
 | #   | 路径                                                               | 说明                                                                                      |
 | --- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
@@ -31,7 +31,8 @@
 | 2   | `assets/resource_adb/image/GiftOperator/Operators/<Name>.png`      | ADB 干员头像模板；同上处理                                                                |
 | 3   | `assets/tasks/GiftOperator.json` → `SelectOperator`                | 新增 case，在 UI 提供可选干员，并为「只收礼物」路线提供干员信息                           |
 | 4   | `assets/resource/pipeline/GiftOperator/Operator/Operator.json`     | 「只收礼物」模式下各干员的 OCR 识别与白名单                                               |
-| 5   | `assets/locales/interface/*.json` → `operator.<Name>`              | 各语言干员显示名称                                                                        |
+| 5   | `assets/resource/pipeline/GiftOperator/GiftOperatorContact.json` → `GiftOperatorSelectGiftOp.next` | 在「只收礼物」选人节点的 `next` 数组追加 `GiftOperatorSelect_<Name>`，否则该干员节点不会被触发 |
+| 6   | `assets/locales/interface/*.json` → `operator.<Name>`              | 各语言干员显示名称                                                                        |
 
 ## 路线一：默认（送礼 + 收礼）
 


### PR DESCRIPTION
## 背景

`GiftOperator`（赠送礼物）任务的新增干员维护文档 `docs/zh_cn/developers/tasks/gift-operator-maintain.md`（及英文对应 `docs/en_us/...`）在「新增干员时需改的路径」表格中列出了 5 处需同步的位置，但遗漏了关键的 `next` 数组接线步骤。

## 问题

「只收礼物」路线下，`GiftOperatorSelectGiftOp` 节点（`assets/resource/pipeline/GiftOperator/GiftOperatorContact.json`）的 `next` 数组**显式枚举**了所有 `GiftOperatorSelect_<Name>` 节点名：

<https://github.com/MaaEnd/MaaEnd/blob/4fff8e33702dd46e7cbb757b5ecc9e1e3d3373dd/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json#L130-L158>

该节点先用 Gift.png 模板定位「带礼物的行」，再 next 逐个尝试各干员头像进行二次匹配。若新增干员时只建了 Operator/Operator.json 里的 GiftOperatorSelect_<Name> 节点，却没把它加进这个 next 数组，该节点永远不会被触发——「只收礼物」路线下该干员无法被识别选中，即使头像模板与 OCR 白名单都已配好。

这条接线步骤在原维护文档中缺失，需交叉阅读两个 pipeline 文件才能发现。

## 改动

中英文维护文档同步：

- 在「新增干员时需改的路径」表格插入第 5 行，说明需在 GiftOperatorSelectGiftOp.next 数组追加 GiftOperatorSelect_<Name>
- 原 locale 行编号由 5 改为 6
- 首部条目数「5 处 / 5 places」改为「6 处 / 6 places」
- 更新文档日期

## 影响范围

仅文档变更，不涉及代码与任务行为。

## Summary by Sourcery

记录在添加新运营商时所需的额外 GiftOperator `next` 数组接线步骤，以确保仅接收路由能够识别该运营商。

文档：
- 更新英文和中文的 GiftOperator 维护指南，在添加运营商时列出六个必需的更新路径，包括将新运营商节点接入 `GiftOperatorSelectGiftOp.next`。
- 将两份 GiftOperator 维护文档中的“最后更新日期”刷新为 2026 年 6 月 28 日。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the additional GiftOperator next-array wiring step required when adding a new operator to ensure the receive-only route recognizes the operator.

Documentation:
- Update the English and Chinese GiftOperator maintenance guides to list six required update paths when adding an operator, including wiring the new operator node into GiftOperatorSelectGiftOp.next.
- Refresh the last-updated dates in both GiftOperator maintenance documents to June 28, 2026.

</details>