### PR TITLE
feat: 当颜色检查失败时或有遮挡时,结束整个任务链

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneImageCheck.json
+++ b/assets/resource/pipeline/SceneManager/SceneImageCheck.json
@@ -120,7 +120,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AbortPipelineOnSceneCheckFail"
+            "__SceneCheckAbortPipeline"
         ],
         "focus": {
             "Node.Action.Starting": "$task.SceneManager.focus.color_match_failed_prefix"

--- a/assets/resource/pipeline/SceneManager/SceneImageCheck.json
+++ b/assets/resource/pipeline/SceneManager/SceneImageCheck.json
@@ -114,12 +114,14 @@
         ]
     },
     "__SceneImageCheckAICPlanColorFailedFinish": {
-        "desc": "检查颜色失败",
+        "desc": "检查颜色失败,截图保存到 debug 目录",
         "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "FalseAction",
+        "action": "Screencap",
         "post_delay": 0,
         "rate_limit": 0,
+        "next": [
+            "AbortPipelineOnSceneCheckFail"
+        ],
         "focus": {
             "Node.Action.Starting": "$task.SceneManager.focus.color_match_failed_prefix"
         }

--- a/assets/resource/pipeline/SceneManager/SceneLoading.json
+++ b/assets/resource/pipeline/SceneManager/SceneLoading.json
@@ -210,7 +210,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AbortPipelineOnSceneCheckFail"
+            "__SceneCheckAbortPipeline"
         ]
     },
     "__SceneCheckOSD": {
@@ -247,13 +247,13 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AbortPipelineOnSceneCheckFail"
+            "__SceneCheckAbortPipeline"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">屏幕存在遮挡，请尝试关闭帧率显示</span>"
         }
     },
-    "AbortPipelineOnSceneCheckFail": {
+    "__SceneCheckAbortPipeline": {
         "desc": "运用 poststop 接口停止整个任务链",
         "pre_delay": 0,
         "action": {

--- a/assets/resource/pipeline/SceneManager/SceneLoading.json
+++ b/assets/resource/pipeline/SceneManager/SceneLoading.json
@@ -208,7 +208,10 @@
             "type": "Screencap"
         },
         "post_delay": 0,
-        "rate_limit": 0
+        "rate_limit": 0,
+        "next": [
+            "AbortPipelineOnSceneCheckFail"
+        ]
     },
     "__SceneCheckOSD": {
         "desc": "检查窗口是否有遮挡",
@@ -222,6 +225,7 @@
         ]
     },
     "__SceneCheckOSDFailed": {
+        "desc": "检查遮挡失败时，截图保存到 debug 目录",
         "recognition": "OCR",
         "roi": [
             0,
@@ -239,12 +243,26 @@
             "(?i)\\bload\\b|负载|負載"
         ],
         "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "FalseAction",
+        "action": "Screencap",
         "post_delay": 0,
         "rate_limit": 0,
+        "next": [
+            "AbortPipelineOnSceneCheckFail"
+        ],
         "focus": {
             "Node.Recognition.Succeeded": "<span style=\"color: red; font-weight: bold;\">屏幕存在遮挡，请尝试关闭帧率显示</span>"
         }
+    },
+    "AbortPipelineOnSceneCheckFail": {
+        "desc": "运用 poststop 接口停止整个任务链",
+        "pre_delay": 0,
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PostStop"
+            }
+        },
+        "post_delay": 0,
+        "rate_limit": 0
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

更新场景管理流水线配置，以根据图像颜色检查与遮挡条件调整任务链终止行为。

新功能：
- 添加配置，当场景图像颜色检查失败或检测到遮挡时终止整个任务链。

改进：
- 优化 SceneImageCheck 和 SceneLoading 流水线 JSON 资源，使其与新的任务链终止规则保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update scene management pipeline configurations to adjust task chain termination behavior based on image color checks and occlusion conditions.

New Features:
- Add configuration to end the entire task chain when scene image color checks fail or occlusions are detected.

Enhancements:
- Refine SceneImageCheck and SceneLoading pipeline JSON resources to align with new task chain termination rules.

</details>