### PR TITLE
fix: 选剑演武残局直接放弃

### DIFF
--- a/agent/go-service/trialofswordmancy/action.go
+++ b/agent/go-service/trialofswordmancy/action.go
@@ -17,6 +17,11 @@ import (
 
 var _ maa.CustomActionRunner = &DecideAction{}
 
+// remainCalcEndgame 标志跨天残局：求解器态空间 RemainCalc 上界 3（每日演算上限），
+// recognition 用 OCR+1 还原后，残局那局 OCR 读到 3 → RemainCalc=4，超出态空间。残局不求解，
+// Decide 直接放弃这局（见 DecideAction.Run）。
+const remainCalcEndgame = 4
+
 // DecideAction 反序列化 recognition 产出的 GameState，调 solver.Decide 取最优单步决策，
 // 按决策用 OverrideNext 路由到执行节点。
 //
@@ -47,6 +52,23 @@ func (a *DecideAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 	if err := json.Unmarshal([]byte(detailJSON), &gs); err != nil {
 		log.Error().Err(err).Str("component", component).Msg("failed to parse game state")
 		return false
+	}
+
+	// 跨天残局：recognition 读出 RemainCalc=4（OCR=3，超出求解器态空间上界 3=每日演算上限）。
+	// 残局那局白送、且放弃只扣放弃次数不扣演算次数——跳过求解，直接放弃这局，回到主入口开正常的 3 局。
+	// （求解器态空间不支持 4 层；故残局直接放弃，不在 recognition 钳制近似。）
+	if gs.State.RemainCalc == remainCalcEndgame {
+		resetAband() // 放弃扣 1 次放弃次数，缓存失效，下回合首步重新探测
+		if err := routeDecision(ctx, arg.CurrentTaskName, solver.Abandon); err != nil {
+			log.Error().Err(err).Str("component", component).Msg("failed to route endgame give-up")
+			return false
+		}
+		log.Info().
+			Str("component", component).
+			Int("remainCalc", gs.State.RemainCalc).
+			Msg("cross-day endgame (RemainCalc=4): skip solver, give up the free run")
+		maafocus.Print(ctx, "选剑演武\n跨天残局\n→ 放弃本局")
+		return true
 	}
 
 	// 配置：牌库/手牌/剩余次数/翻倍态来自 recognition 截图识别；溢出模式是玩家策略选项，

--- a/agent/go-service/trialofswordmancy/recognition.go
+++ b/agent/go-service/trialofswordmancy/recognition.go
@@ -76,15 +76,11 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 		}
 	}
 
-	// 屏幕的「本日剩余奖励演算次数」显示的是「当前进行中这局之外的剩余」——抽取第一张手牌时扣 1，
-	// 故 solver = OCR + 1（态空间 RemainCalc 1..3，对应 OCR 0..2）。仅演算次数有此偏移：放弃/翻倍次数
-	// 界面显示即真实值，直接用。走到这里 calcOK 必为真。
-	//
-	// 跨天残局：当天实际 4 次演算（残局这局白送），放弃/双倍不受影响、照常读；
-	// 求解器态空间上界 3，钳制 RemainCalc 到 3 喂入。
-	remainCalcSolver := min(remainCalc+1, 3)
+	// 屏幕的「本日剩余奖励演算次数」显示的是「当前进行中这局之外的剩余」——进入抽牌界面即扣 1，
+	// 而求解器把进行中这局也算作可用 → solver = OCR + 1（solver 态空间 RemainCalc 1..3，对应 OCR 0..2）。
+	// 仅演算次数有此偏移：放弃/翻倍次数界面显示的就是真实值，直接用。走到这里 calcOK 必为真。
 	state := solver.State{
-		RemainCalc:   remainCalcSolver,
+		RemainCalc:   remainCalc + 1,
 		RemainAband:  remainAband,
 		RemainDouble: remainDouble,
 		IsDoubled:    isDoubled,

--- a/agent/go-service/trialofswordmancy/recognition.go
+++ b/agent/go-service/trialofswordmancy/recognition.go
@@ -79,6 +79,7 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 	// 屏幕的「本日剩余奖励演算次数」显示的是「当前进行中这局之外的剩余」——进入抽牌界面即扣 1，
 	// 而求解器把进行中这局也算作可用 → solver = OCR + 1（solver 态空间 RemainCalc 1..3，对应 OCR 0..2）。
 	// 仅演算次数有此偏移：放弃/翻倍次数界面显示的就是真实值，直接用。走到这里 calcOK 必为真。
+	// 跨天残局那局白送：OCR 读到 3 → RemainCalc=4，超出态空间上界——本处不钳制，原样交给 Decide 直接放弃。
 	state := solver.State{
 		RemainCalc:   remainCalc + 1,
 		RemainAband:  remainAband,


### PR DESCRIPTION
| 奖励 | 放弃 | 双倍 |
| ---- | ---- | ---- |
| 4    | 3    | 2    |
| 3    | x    | 1    |

以上两种情况在计算器内都是不可达状态

暂时决定不处理残局

## Summary by Sourcery

在「Trial of Swordmancy」中处理跨天终局运行时，将 `RemainCalc=4` 视为自动放弃的情况，而不是将其传入求解器。

Bug Fixes:
- 当跨天终局给予一次额外计算时，通过绕过求解器并直接放弃该次运行，防止出现无效的求解器状态。

Enhancements:
- 调整识别逻辑，将原始偏移的 `RemainCalc` 数值（包括终局运行中的 4）传递给决策逻辑，而不是将其限定在求解器的上限范围内。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle cross-day endgame runs in Trial of Swordmancy by treating RemainCalc=4 as an auto-abandon case instead of feeding it into the solver.

Bug Fixes:
- Prevent invalid solver states when a cross-day endgame grants an extra calculation by bypassing the solver and directly abandoning that run.

Enhancements:
- Adjust recognition to pass the raw offset RemainCalc value (including 4 for endgame runs) to the decision logic instead of clamping it to the solver limit.

</details>