### PR TITLE
fix(MapNavigator): 移除对预制菜的神秘判定

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
@@ -240,50 +240,6 @@ int64_t ElapsedMs(std::chrono::steady_clock::time_point from, std::chrono::stead
     return std::chrono::duration_cast<std::chrono::milliseconds>(to - from).count();
 }
 
-double PointToSegmentDistance(const navmesh::WorldPoint& p, const navmesh::WorldPoint& a, const navmesh::WorldPoint& b)
-{
-    const double dx = b.x - a.x;
-    const double dy = b.y - a.y;
-    const double len_sq = dx * dx + dy * dy;
-    if (len_sq <= std::numeric_limits<double>::epsilon()) {
-        return std::hypot(p.x - a.x, p.y - a.y);
-    }
-    const double t = std::clamp(((p.x - a.x) * dx + (p.y - a.y) * dy) / len_sq, 0.0, 1.0);
-    return std::hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy));
-}
-
-double PointToPolylineDistance(const navmesh::WorldPoint& p, const std::vector<navmesh::WorldPoint>& poly)
-{
-    double best = std::numeric_limits<double>::infinity();
-    for (size_t i = 0; i + 1 < poly.size(); ++i) {
-        best = std::min(best, PointToSegmentDistance(p, poly[i], poly[i + 1]));
-    }
-    return best;
-}
-
-// Fraction of the corridor (resampled every ~`step` world units) within `eps` of the authored line:
-// ~1.0 when it tracks the line, ~0 when it detours (route3 ~0.05). 1.0 on degenerate input.
-double CorridorCoincidence(
-    const navmesh::WorldPath& corridor,
-    const std::vector<navmesh::WorldPoint>& authored,
-    double eps,
-    double step)
-{
-    if (corridor.points.size() < 2 || authored.size() < 2) {
-        return 1.0;
-    }
-    size_t total = 0;
-    size_t coincident = 0;
-    const auto tally = [&](const navmesh::WorldPoint& p) {
-        ++total;
-        if (PointToPolylineDistance(p, authored) <= eps) {
-            ++coincident;
-        }
-    };
-    ForEachResampledPoint(corridor.points, step, tally);
-    return total == 0 ? 1.0 : static_cast<double>(coincident) / static_cast<double>(total);
-}
-
 // The authored line from the current waypoint up to and including the anchor. Returns empty unless the
 // anchor is actually reached (a control node or path end first truncates the span), so the caller falls
 // back to the navmesh corridor instead of trusting a line that stops short of the anchor.
@@ -340,14 +296,8 @@ bool NavRunController::buildPlan(
         plan_.planned_at = now;
     };
 
-    // The literal-vs-navmesh choice is per anchor span: decide once, reuse across soft replans.
-    // invalidate() (anchor/zone change, or recovery's nav_run_dirty) resets plan_ for a fresh decision.
-    const bool same_span = plan_.valid && plan_.anchor_index == anchor_index;
     std::vector<navmesh::WorldPoint> authored = BuildAuthoredSpanPolyline(session, anchor_index);
-    const bool authored_usable = authored.size() >= 2;
-
-    // Already literal this span: rebuild from the advanced waypoint, skip the A* (it would detour again).
-    if (same_span && plan_.literal && authored_usable) {
+    if (authored.size() >= 2) {
         navmesh::WorldPath literal_path;
         literal_path.points = std::move(authored);
         commit(std::move(literal_path), true);
@@ -362,36 +312,7 @@ bool NavRunController::buildPlan(
                  << VAR(position.zone_id);
         return false;
     }
-
-    bool literal = same_span && plan_.literal;
-    if (!same_span && authored_usable) {
-        // Fresh span: go literal iff the corridor barely coincides (detoured) AND the line really crosses
-        // water. off_mesh is sampled only after the cheap coincidence gate passes; -1 = not evaluated.
-        const double coincidence =
-            CorridorCoincidence(route->path, authored, kCorridorLiteralFidelityEpsilonM, kCorridorLiteralSampleStepM);
-        double off_mesh = -1.0;
-        if (coincidence < kCorridorLiteralMinCoincidence) {
-            off_mesh = NavmeshOffMeshFraction(param, position.zone_id, authored, kCorridorLiteralSampleStepM);
-            literal = off_mesh > kCorridorLiteralMinOffMeshFraction;
-        }
-        // Log both outcomes so the decision is diagnosable on-device (route3: coincidence ~0.05,
-        // off_mesh ~0.63, authored.size 21).
-        LogDebug << "NavRunController corridor-source decision." << VAR(anchor_index) << VAR(literal)
-                 << VAR(coincidence) << VAR(off_mesh) << VAR(route->path.points.size()) << VAR(authored.size());
-        if (literal) {
-            LogInfo << "NavRunController trusting authored RUN line (corridor detours off-mesh)."
-                    << VAR(anchor_index) << VAR(coincidence) << VAR(off_mesh) << VAR(authored.size());
-        }
-    }
-
-    if (literal && authored_usable) {
-        navmesh::WorldPath literal_path;
-        literal_path.points = std::move(authored);
-        commit(std::move(literal_path), true);
-    }
-    else {
-        commit(std::move(route->path), false);
-    }
+    commit(std::move(route->path), false);
     return true;
 }
 

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -125,11 +125,6 @@ constexpr int32_t kNavRunSoftReplanCooldownMs = 1200;
 constexpr int32_t kNavRunSoftReplanMaxPerAnchor = 3;
 constexpr int32_t kNavRunProgressRegressionMs = 800;
 
-constexpr double kCorridorLiteralFidelityEpsilonM = 2.0;     // corridor sample within this of the line "coincides"
-constexpr double kCorridorLiteralMinCoincidence = 0.5;       // coincidence below this => corridor detoured (route3 ~0.05)
-constexpr double kCorridorLiteralMinOffMeshFraction = 0.15;  // span must be this much off-mesh to qualify (route3 ~0.43)
-constexpr double kCorridorLiteralSampleStepM = 1.0;          // resample step (world units)
-
 // --- Zone / Portal / Transfer Constants ---
 constexpr int32_t kZoneConfirmRetryIntervalMs = 120;
 constexpr int32_t kZoneConfirmTimeoutMs = 12000;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -628,6 +628,12 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
                 << VAR(route->path.points.size());
         return false;
     }
+    if (generated_prefix.empty()
+        && std::hypot(anchor.x - position_->x, anchor.y - position_->y) > ArrivalBandForStartupBypass(anchor)) {
+        generated_prefix.emplace_back(position_->x, position_->y, ActionType::RUN);
+        LogInfo << "Dynamic overlay seeded leading node to avoid single-point path." << VAR(reason)
+                << VAR(continue_index) << VAR(position_->x) << VAR(position_->y);
+    }
     const size_t generated_count = generated_prefix.size();
     session_->ApplyDynamicOverlay(std::move(generated_prefix), continue_index, *position_);
     runtime_state_.route.Reset();

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -33,8 +33,8 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(
     const navmesh::WorldPoint& goal,
     const std::vector<uint32_t>& blocked_triangles = {});
 // Resample `poly` at ~`step` world units (clamped to >=0.1) and invoke `fn` on the leading vertex and
-// every resampled point. Shared by NavmeshOffMeshFraction and NavRunController's CorridorCoincidence so
-// both sampling passes stay identical. Caller guards poly.size() >= 2 for a meaningful result.
+// every resampled point. Used by NavmeshOffMeshFraction. Caller guards poly.size() >= 2 for a
+// meaningful result.
 template <typename Fn>
 void ForEachResampledPoint(const std::vector<navmesh::WorldPoint>& poly, double step, Fn&& fn)
 {


### PR DESCRIPTION
- close #3860
- close #3910
- close #3741
- close #3576
- close #3734

## Summary by Sourcery

简化导航运行路径选择，并改进针对锚点的动态覆盖处理，以解决导航中的边缘情况。

Bug 修复：
- 在可用时始终使用原始编写的运行线，而不是在有条件的情况下优先选择绕行的导航网格走廊，以避免路径行为不一致。
- 当从距离锚点较远的位置开始时，在动态覆盖中预先加入一个前导的 RUN 节点，以防止生成仅有单点的路线。

增强功能：
- 移除未使用的走廊重合和离网启发式逻辑，以及相关的数学辅助函数和配置常量，以获得更可预测的导航运行行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify nav run path selection and improve dynamic overlay handling for anchors to address navigation edge cases.

Bug Fixes:
- Always use the authored run line when available instead of conditionally preferring a detoured navmesh corridor to avoid inconsistent path behavior.
- Seed a leading RUN node in dynamic overlays when starting far from the anchor to prevent generation of single-point routes.

Enhancements:
- Remove unused corridor coincidence and off-mesh heuristics along with related math helpers and configuration constants for more predictable nav run behavior.

</details>