### PR TITLE
fix: 修改文案提示错误

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -161,7 +161,7 @@
     "option.DiscardUnmatched.label": "Discard Unmatched",
     "option.DiscardUnmatched.description": "When enabled, matrices that don't match target skill combinations will be discarded instead of skipped",
     "option.ExportCalculatorScript.label": "Recommend Pre-inscription Plans",
-    "option.ExportCalculatorScript.description": "After filtering, lists pre-inscription plans by ungraduated needs, logs recommendations, and saves EssencePlan.html in the working directory",
+    "option.ExportCalculatorScript.description": "After filtering, lists pre-inscription plans by ungraduated needs, logs recommendations, and saves EssencePlan.html in the working directory.",
     "task.AutoEssence.label": "🎱Essence Farm",
     "task.AutoEssence.description": "Automatically challenge heavily accumulated points.\n## WARNING:\n- Please make sure to enable the **Global Hotkey** option in **[Settings] - [Hotkey]**, and remember the **End Task** key. When the program fails, long-press this key to stop.",
     "option.AutoEssenceDoOverride.label": "Use Inscription Vouchers",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -161,7 +161,7 @@
     "option.DiscardUnmatched.label": "未匹配时废弃",
     "option.DiscardUnmatched.description": "开启后，未匹配到目标技能组合的基质将被废弃而非跳过",
     "option.ExportCalculatorScript.label": "推荐预刻写方案",
-    "option.ExportCalculatorScript.description": "筛选结束后，枚举所有预刻写方案，按能满足的未毕业武器数量降序，直接在日志中输出推荐方案，并且保存到工作目录下的 EssencePlan.html",
+    "option.ExportCalculatorScript.description": "筛选结束后，枚举所有预刻写方案，按能满足的未毕业武器数量降序，直接在日志中输出推荐方案，并且保存到工作目录下的 EssencePlan.html。",
     "task.AutoEssence.label": "🎱基质刷取",
     "task.AutoEssence.description": "自动挑战重度淤积点\n## 警告：\n- 请务必在 **[设置] - [快捷键]** 中开启 **全局快捷键** 选项，并牢记 **结束任务** 的按键。当程序出现故障时，长按该按键即可停止。",
     "option.AutoEssenceDoOverride.label": "使用刻写券",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -161,7 +161,7 @@
     "option.DiscardUnmatched.label": "未匹配時廢棄",
     "option.DiscardUnmatched.description": "開啟後，未匹配到目標技能組合的基質將被廢棄而非跳過",
     "option.ExportCalculatorScript.label": "推薦預刻寫方案",
-    "option.ExportCalculatorScript.description": "篩選結束後，枚舉所有預刻寫方案，按能滿足的未畢業武器數量降序，直接在日誌中輸出推薦方案，並儲存到工作目錄下的 EssencePlan.html",
+    "option.ExportCalculatorScript.description": "篩選結束後，枚舉所有預刻寫方案，按能滿足的未畢業武器數量降序，直接在日誌中輸出推薦方案，並儲存到工作目錄下的 EssencePlan.html。",
     "task.AutoEssence.label": "🎱基質刷取",
     "task.AutoEssence.description": "自動挑戰重度淤積點\n## 警告：\n- 請務必在 **[設置] - [快捷鍵]** 中開啟 **全域快捷鍵** 選項，並牢記 **結束任務** 的按鍵。當程序出現故障時，長按該按鍵即可停止。",
     "option.AutoEssenceDoOverride.label": "使用刻寫券",


### PR DESCRIPTION
close #2555

## Summary by Sourcery

错误修复：
- 更正 en_us、zh_cn 和 zh_tw 界面本地化资源中具有误导性或不准确的文本字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct misleading or inaccurate text strings in en_us, zh_cn, and zh_tw interface locale resources.

</details>