### PR TITLE
feat: 启动选剑默认自动战斗

### DIFF
--- a/assets/tasks/TrialOfSwordmancy.json
+++ b/assets/tasks/TrialOfSwordmancy.json
@@ -119,7 +119,7 @@
         "TrialOfSwordmancyAutoFight": {
             "type": "switch",
             "label": "$option.TrialOfSwordmancyAutoFight.label",
-            "default_case": "No",
+            "default_case": "Yes",
             "cases": [
                 {
                     "name": "No",


### PR DESCRIPTION
应该都能打得过，省的用户问为什么没这个功能

## Summary by Sourcery

新功能：
- 在默认启用自动战斗的情况下开始「Swordmancy」遭遇的试用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Start Trial of Swordmancy encounters with auto-battle enabled by default.

</details>