### PR TITLE
perf: 未勾选自动送货风险知悉改为任务失败

### DIFF
--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobs.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobs.json
@@ -14,11 +14,13 @@
     "SeizeDeliveryJobsGuard": {
         "desc": "自动送委托的风险知悉拦截节点（此节点在 tasks 中跟随全自动送货选项默认开启）",
         "enabled": false,
+        "recognition": "DirectHit",
         "pre_delay": 0,
-        "action": "StopTask",
+        "action": "Custom",
+        "custom_action": "FalseAction",
         "post_delay": 0,
         "focus": {
-            "Node.Action.Starting": "您需要同意知悉可能的后果才能使用自动走路送货功能"
+            "Node.Recognition.Succeeded": "您需要同意知悉可能的后果才能使用自动走路送货功能"
         }
     },
     "SeizeDeliveryJobsReadyToSeize": {


### PR DESCRIPTION
## Summary by Sourcery

更新 SeizeDeliveryJobs 管道配置，将“缺少对自动交付风险的确认”视为任务失败，而不是继续允许其执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update SeizeDeliveryJobs pipeline configuration to treat missing acknowledgement of automatic delivery risk as a task failure instead of allowing it to proceed.

</details>