### PR TITLE
fix(pipeline-generate): 在 CI 中绕过 zmdmap 缓存

### DIFF
--- a/tools/pipeline-generate/fetch-data.mjs
+++ b/tools/pipeline-generate/fetch-data.mjs
@@ -4,7 +4,7 @@
 //
 // 用法：node tools/pipeline-generate/fetch-data.mjs [--force] [--cache-bust]
 //   --force  忽略本地版本缓存，强制重新下载
-//   --cache-bust  下载数据文件时追加时间戳参数，绕过远端缓存
+//   --cache-bust  等价于 --force，并在下载数据文件时追加时间戳参数，绕过远端缓存
 
 import {mkdirSync, readFileSync, writeFileSync} from "node:fs";
 import {resolve} from "node:path";

--- a/tools/pipeline-generate/fetch-data.mjs
+++ b/tools/pipeline-generate/fetch-data.mjs
@@ -2,8 +2,9 @@
 // 从 zmdmap API 获取最新版本，下载数据文件到 tools/pipeline-generate/data/ 目录。
 // 若本地已是最新版本则跳过下载。
 //
-// 用法：node tools/pipeline-generate/fetch-data.mjs [--force]
+// 用法：node tools/pipeline-generate/fetch-data.mjs [--force] [--cache-bust]
 //   --force  忽略本地版本缓存，强制重新下载
+//   --cache-bust  下载数据文件时追加时间戳参数，绕过远端缓存
 
 import {mkdirSync, readFileSync, writeFileSync} from "node:fs";
 import {resolve} from "node:path";
@@ -18,7 +19,10 @@ const DATA_FILES = [
 ];
 
 const VERSION_FILE = "version.txt";
-const force = process.argv.includes("--force");
+const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
+const shouldCacheBust = process.argv.includes("--cache-bust") || isGitHubActions;
+const force = process.argv.includes("--force") || shouldCacheBust;
+const cacheBustToken = shouldCacheBust ? Date.now().toString() : null;
 
 function readCachedVersion() {
     try {
@@ -56,7 +60,11 @@ async function fetchAndCache(version) {
     mkdirSync(dataDir, {recursive: true});
 
     for (const file of DATA_FILES) {
-        const url = `${DATA_BASE_URL}/${file}?ver=${encodeURIComponent(version)}`;
+        const url = new URL(`${DATA_BASE_URL}/${file}`);
+        url.searchParams.set("ver", version);
+        if (cacheBustToken) {
+            url.searchParams.set("t", cacheBustToken);
+        }
         console.log(`[fetch-data] 下载 ${url}`);
         const res = await fetch(url);
         if (!res.ok) {


### PR DESCRIPTION
## 概要

- 在 GitHub Actions 中运行 `fetch-data.mjs` 时强制重新下载 zmdmap 生成数据
- 下载 `settlement_trade.json` 与 `kite_station_i18n.json` 时追加 `t=<时间戳>` 查询参数，绕过远端缓存
- 保留本地默认行为：非 CI 环境仍会优先使用版本缓存，除非显式传入 `--force` 或 `--cache-bust`

## 背景

同一个 zmdmap 大版本号下如果继续补充数据，原逻辑会因为 `version.txt` 未变化而直接跳过下载，导致 pipeline-generate 产物无法同步到最新数据。

## 验证

- `pnpm exec prettier --check tools/pipeline-generate/fetch-data.mjs`
- `node --check tools/pipeline-generate/fetch-data.mjs`
- `git diff --check origin/v2..HEAD`

## Summary by Sourcery

调整流水线数据获取方式，在本地保持对缓存友好的默认行为的同时，在 CI 中始终绕过已缓存的 zmdmap 数据。

Enhancements:
- 新增可选的 `--cache-bust` 标志，用于强制重新获取数据，并在下载 zmdmap 数据文件时追加时间戳查询参数。
- 在 GitHub Actions 环境下自动启用缓存失效和强制重新获取，这样 CI 流水线始终会使用最新的 zmdmap 数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust pipeline data fetching to always bypass cached zmdmap data in CI while keeping cache-friendly defaults locally.

Enhancements:
- Add an optional --cache-bust flag to force data refetching and append a timestamp query parameter when downloading zmdmap data files.
- Automatically enable cache busting and forced refetching when running under GitHub Actions so CI pipelines always use the latest zmdmap data.

</details>