### PR TITLE
fix: 再次提高延迟防止赠送线索动画误判为停止

### DIFF
--- a/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
+++ b/assets/resource/pipeline/DijiangRewards/ReceptionRoom.json
@@ -633,7 +633,7 @@
             "type": "Click"
         },
         "post_wait_freezes": {
-            "time": 200,
+            "time": 500,
             "target": [
                 1065,
                 0,


### PR DESCRIPTION
## Summary by Sourcery

调整接待室奖励流水线的配置，以进一步延后赠品线索动画的停止检测，从而减少错误停止的误判。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust reception room reward pipeline configuration to further delay the stop detection for the giveaway clue animation to reduce false stop misjudgments.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整接待室奖励流水线的配置，以进一步延后赠品线索动画的停止检测，从而减少错误停止的误判。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust reception room reward pipeline configuration to further delay the stop detection for the giveaway clue animation to reduce false stop misjudgments.

</details>

</details>