### PR TITLE
perf: 选剑演武 go 内捕获 err 进行 focus 输出

### DIFF
--- a/agent/go-service/trialofswordmancy/action.go
+++ b/agent/go-service/trialofswordmancy/action.go
@@ -105,20 +105,13 @@ func (a *DecideAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 	// 复刻 TS 计算器（trial-of-swordmancy-strategy.vue）的推荐规则：抽牌与放弃总价值差 <1 时优先放弃。
 	best := pickDecision(outcomes)
 
-	// 不可达：识别产出了不在 MDP 状态空间的局面（识别 ROI/模板未校准、读错、或手牌超牌库等）。
-	// 这是错误，不是「奖励耗尽」—— 奖励耗尽由 pipeline 在进 Decide 前就识别并走 Finish。
-	// 这里直接让动作失败（return false），任务以错误中止，不冒充正常结束。
+	// 不可达：识别产出了不在 MDP 状态空间的局面（ROI/模板未校准、读错、手牌超牌库等），是错误而非
+	// 「奖励耗尽」（耗尽由 pipeline 在进 Decide 前就走 Finish）。用 focus 给用户一份局面速览（复用
+	// formatFocus，决策行显示「状态不可达」），并整体标红以醒目；不写 log.Error——否则 zerolog 的 ERR
+	// 会直接刷到用户界面；任务仍以错误中止。排查所需状态字段已在 recognition 的 "game state recognized" 日志里。
 	if outcomes == nil || best == solver.ActionNone {
-		log.Error().
-			Str("component", component).
-			Ints("hand", gs.State.Hand[:]).
-			Int("remainCalc", gs.State.RemainCalc).
-			Int("remainAband", gs.State.RemainAband).
-			Int("remainDouble", gs.State.RemainDouble).
-			Bool("isDoubled", gs.State.IsDoubled).
-			Ints("deck", gs.Config.Deck[:]).
-			Msg("unreachable state: recognition produced a state outside the MDP space; aborting")
-		maafocus.Print(ctx, i18n.T("trialofswordmancy.recognition_failed"))
+		red := "<span style=\"color:#ff4d4f;\">" + strings.ReplaceAll(formatFocus(gs, solver.ActionNone), "\n", "<br/>") + "</span>"
+		maafocus.Print(ctx, red)
 		return false
 	}
 
@@ -264,7 +257,7 @@ func actionFocusLabel(action solver.Action) string {
 	case solver.Double:
 		return i18n.T("trialofswordmancy.action.double")
 	default:
-		return i18n.T("trialofswordmancy.action.unknown")
+		return i18n.T("trialofswordmancy.action.unreachable")
 	}
 }
 

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -185,7 +185,7 @@
     "trialofswordmancy.action.abandon": "Abandon round",
     "trialofswordmancy.action.calculate": "Calculate",
     "trialofswordmancy.action.double": "Take double",
-    "trialofswordmancy.action.unknown": "Unknown",
+    "trialofswordmancy.action.unreachable": "unreachable state",
     "trialofswordmancy.hand_empty": "empty",
     "trialofswordmancy.doubled": "Doubled",
     "trialofswordmancy.undoubled": "Not doubled",

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -185,7 +185,7 @@
     "trialofswordmancy.action.abandon": "Abandon round",
     "trialofswordmancy.action.calculate": "Calculate",
     "trialofswordmancy.action.double": "Take double",
-    "trialofswordmancy.action.unreachable": "unreachable state",
+    "trialofswordmancy.action.unreachable": "Unreachable state",
     "trialofswordmancy.hand_empty": "empty",
     "trialofswordmancy.doubled": "Doubled",
     "trialofswordmancy.undoubled": "Not doubled",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -185,7 +185,7 @@
     "trialofswordmancy.action.abandon": "放棄",
     "trialofswordmancy.action.calculate": "演算開始",
     "trialofswordmancy.action.double": "ダブル選択",
-    "trialofswordmancy.action.unknown": "不明",
+    "trialofswordmancy.action.unreachable": "到達不能状態",
     "trialofswordmancy.hand_empty": "空",
     "trialofswordmancy.doubled": "ダブル中",
     "trialofswordmancy.undoubled": "ダブルなし",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -185,7 +185,7 @@
     "trialofswordmancy.action.abandon": "포기",
     "trialofswordmancy.action.calculate": "연산",
     "trialofswordmancy.action.double": "더블 선택",
-    "trialofswordmancy.action.unknown": "알 수 없음",
+    "trialofswordmancy.action.unreachable": "상태 도달 불가",
     "trialofswordmancy.hand_empty": "없음",
     "trialofswordmancy.doubled": "더블됨",
     "trialofswordmancy.undoubled": "더블 아님",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -185,7 +185,7 @@
     "trialofswordmancy.action.abandon": "放弃本局",
     "trialofswordmancy.action.calculate": "开始演算",
     "trialofswordmancy.action.double": "选择翻倍",
-    "trialofswordmancy.action.unknown": "未知决策",
+    "trialofswordmancy.action.unreachable": "状态不可达",
     "trialofswordmancy.hand_empty": "空",
     "trialofswordmancy.doubled": "已翻倍",
     "trialofswordmancy.undoubled": "未翻倍",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -185,7 +185,7 @@
     "trialofswordmancy.action.abandon": "放棄本局",
     "trialofswordmancy.action.calculate": "開始演算",
     "trialofswordmancy.action.double": "選擇翻倍",
-    "trialofswordmancy.action.unknown": "未知決策",
+    "trialofswordmancy.action.unreachable": "狀態不可達",
     "trialofswordmancy.hand_empty": "空",
     "trialofswordmancy.doubled": "已翻倍",
     "trialofswordmancy.undoubled": "未翻倍",


### PR DESCRIPTION
## Summary by Sourcery

通过向用户展示聚焦且可见的摘要来处理无法到达的 Trial of Swordmancy 状态，而不是记录内部错误日志。

New Features:
- 当识别结果产生超出空间（out-of-space）状态时，渲染一个 HTML 格式的聚焦视图，将无法到达的游戏状态突出展示给用户。

Enhancements:
- 将意外求解器动作的默认操作标签改为指示“无法到达的状态”，而不是“未知动作”。
- 避免为无法到达的 Trial of Swordmancy 状态发出 zerolog 错误日志，以防止产生噪声式的用户可见错误输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle unreachable Trial of Swordmancy states by surfacing a focused, user-visible summary instead of logging an internal error.

New Features:
- Render an HTML-formatted focus view highlighting unreachable game states to the user when recognition produces an out-of-space state.

Enhancements:
- Change the default action label for unexpected solver actions to indicate an unreachable state rather than an unknown action.
- Avoid emitting zerolog error logs for unreachable Trial of Swordmancy states to prevent noisy user-facing error output.

</details>