### PR TITLE
fix: 移除多余的 box_index 属性以简化确认按钮识别逻辑

### DIFF
--- a/assets/resource/pipeline/DijiangRewards/Manufacturing.json
+++ b/assets/resource/pipeline/DijiangRewards/Manufacturing.json
@@ -139,8 +139,7 @@
                 "all_of": [
                     "YellowConfirmButtonType1",
                     "MFGCabinNeedTakeText"
-                ],
-                "box_index": 1
+                ]
             }
         },
         "pre_delay": 0,
@@ -246,8 +245,7 @@
                 "all_of": [
                     "YellowConfirmButtonType1",
                     "UseAssistText"
-                ],
-                "box_index": 1
+                ]
             }
         },
         "pre_wait_freezes": {
@@ -332,8 +330,7 @@
                 "all_of": [
                     "YellowConfirmButtonType1",
                     "YellowButtonConfirmText"
-                ],
-                "box_index": 1
+                ]
             }
         },
         "pre_wait_freezes": {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 从 DijiangRewards 制造流水线中移除多余的 `box_index` 配置，以防止错误或含糊的确认按钮识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove redundant box_index configuration from the DijiangRewards Manufacturing pipeline to prevent incorrect or ambiguous confirmation button recognition.

</details>
- 从 DijiangRewards 制造流水线中移除多余的 `box_index` 配置，以防止对确认按钮的识别出现错误或歧义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 从 DijiangRewards 制造流水线中移除多余的 `box_index` 配置，以防止错误或含糊的确认按钮识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove redundant box_index configuration from the DijiangRewards Manufacturing pipeline to prevent incorrect or ambiguous confirmation button recognition.

</details>

</details>