### PR TITLE
feat(MapNavigator): 基于 NavMesh 的自动绕障

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -91,6 +91,16 @@ constexpr int32_t kDynamicRecoveryTotalTimeoutMs = 30000;
 constexpr int32_t kRecoveryJumpAttemptsBeforeDetour = 2;
 constexpr double kDynamicRecoveryResetDistance = 2.0;
 constexpr double kCloseGoalDetourSuppressSlack = 6.0;
+constexpr int32_t kRecoveryDetourAttemptsBeforeUnstick = 1;
+constexpr double kUnstickSampleStepM = 0.5;        // per-ray on/off scan resolution (world units)
+constexpr double kUnstickMaxRockCrossingM = 2.0;   // tolerate this much off-mesh (the rock) before solid ground; longer = water => reject bearing
+constexpr double kUnstickMeshMarginM = 1.0;        // step this far past the mesh edge so we land ON solid ground
+constexpr double kUnstickMinDistanceM = 2.5;       // shortest committed dislodge step
+constexpr double kUnstickMaxDistanceM = 6.0;       // ray-scan reach / longest dislodge step
+constexpr int32_t kUnstickPulseMs = 270;           // per forward pulse after turning to the escape bearing
+constexpr int32_t kUnstickMaxPulses = 8;           // committed-walk cap; displacement exit usually ends it sooner
+constexpr double kUnstickResetDistanceM = 2.0;     // relocated this far from the unstick origin => reset bearing rotation
+constexpr double kUnstickSuccessFraction = 0.6;    // displacement >= this * planned dist => a real dislodge step
 // When the locator yields no usable fix for a sustained period (e.g. the agent was shoved across a
 // zone boundary into a sub-zone the active route was not planned in, so every fix fails zone
 // validation), stop holding forward into the obstacle, hop periodically to dislodge, and fail-fast
@@ -110,6 +120,20 @@ constexpr int32_t kRiverFallRecoveryPulseMs = kPostHeadingForwardPulseMs;       
 constexpr int32_t kOffRouteWedgeReplanMs = 6000;
 constexpr int32_t kOffRouteWedgeReplanCooldownMs = 4000;
 constexpr int32_t kOffRouteWedgeFailMs = 12000;
+
+// Cross-tier escape (wrong-tier fall): plan ONE navmesh corridor from a walkable FLOORED-tier fix back to the
+// nearest reachable authored waypoint and follow it as a fixed corridor (riding the legitimate tier<->base
+// oscillation). Exit needs BOTH arrival distance AND a floor-blind (base) zone — a shaft's lower loops pass under
+// the rim in (x,y), so distance alone fires early on the tier.
+constexpr double kCrossTierEscapeArrivalM = 3.0;
+// Escape fast-fail (mode B: escape stays active but the corridor is walled/unfollowable). Keyed on the
+// hard-progress clock, which mid-escape overlay re-applies cannot reset, so it measures genuine no-corridor-
+// progress. Progress-aware: a long-but-advancing escape is never killed early; only a continuously stuck one trips.
+constexpr int32_t kCrossTierEscapeHardStallMs = 12000;
+// Wrong-tier thrash fast-fail (mode A: recover<->re-lose storm). Every global re-acquire resets every progress/
+// loss clock, so no timeout fires; instead count consecutive global re-acquires since the last waypoint advance
+// and fail here. Normal travel sees 0-1 transient losses per leg, so this many with zero advance is pathological.
+constexpr int32_t kLocalizationThrashFailCount = 5;
 
 // --- NavRunController (RUN corridor follower) ---
 constexpr double kNavRunLookaheadLowSpeedM = 2.5;

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -124,6 +124,23 @@ struct RiverFallRecoveryState
     }
 };
 
+// Physical lateral-bypass escalation. Deliberately persists across recovery.Reset() so consecutive bypasses
+// at the same stuck spot grow the step and alternate sides; cleared only on genuine progress (waypoint
+// advance / new navigation) or once the agent has moved away from `origin`.
+struct LateralBypassState
+{
+    NaviPosition origin {};
+    int count = 0;
+    bool active = false;
+
+    void Reset()
+    {
+        origin = {};
+        count = 0;
+        active = false;
+    }
+};
+
 // Previous-tick heading, used to estimate the agent's own turn rate for the steering damping term. Only the
 // physical heading is tracked here; the rate is gated at the call site on the elapsed gap and on plausibility,
 // so a stale entry after a recovery / relocation pause simply yields a zero rate that tick rather than a spike.
@@ -160,6 +177,30 @@ struct OffRouteWedgeState
     }
 };
 
+// Cross-tier escape. The agent fell onto a wrong FLOORED tier (one the route never planned for); we plan ONE
+// navmesh corridor from that tier fix back to a reachable authored waypoint and follow it, tolerating the
+// open-air shaft's tier<->base oscillation as a live guard rather than re-planning on every flip. Everything is
+// gated on `active`: when false the navigator and the real-loss handling are byte-for-byte unchanged.
+// `anchor_zone` is the tier we fell into; it defines the same-geometry span we tolerate flipping within. `goal_*`
+// is the base-pixel rejoin waypoint (arrival exits the mode). A continuously-stuck escape is bounded at the call
+// site by the hard-progress stall clock (no field needed here); a recover<->re-lose thrash is bounded by the
+// top-level re-acquire streak below.
+struct CrossTierEscapeState
+{
+    bool active = false;
+    std::string anchor_zone;
+    double goal_x = 0.0;
+    double goal_y = 0.0;
+
+    void Reset()
+    {
+        active = false;
+        anchor_zone.clear();
+        goal_x = 0.0;
+        goal_y = 0.0;
+    }
+};
+
 struct NavigationRuntimeState
 {
     RouteTrackerState route;
@@ -168,8 +209,15 @@ struct NavigationRuntimeState
     DynamicRecoveryState recovery;
     LocalizationLossState localization_loss;
     RiverFallRecoveryState river_fall;
+    LateralBypassState bypass;
     SteeringRateState steering_rate;
     OffRouteWedgeState offroute;
+    CrossTierEscapeState cross_tier_escape;
+    // Consecutive global re-acquires (the navigation_state_machine "recovered via global re-acquire" path) since
+    // the last genuine waypoint advance. Top-level on purpose: the loss/escape/overlay Resets that fire all through
+    // a wrong-tier thrash storm never clear it — only real forward progress does — so it is the one storm-proof
+    // fast-fail signal. Reset in OnWaypointAdvance / BeginNavigation only.
+    int global_reacquire_streak = 0;
     bool dynamic_replan_requested = false;
     bool nav_run_dirty = true;
 
@@ -190,8 +238,11 @@ struct NavigationRuntimeState
         recovery.Reset();
         localization_loss.Reset();
         river_fall.Reset();
+        bypass.Reset();
         steering_rate.Reset();
         offroute.Reset();
+        cross_tier_escape.Reset();
+        global_reacquire_streak = 0;
         dynamic_replan_requested = false;
         nav_run_dirty = true;
         flow.navigate_started_at = now;
@@ -203,7 +254,9 @@ struct NavigationRuntimeState
         route.ResetTracking();
         recovery.Reset();
         river_fall.Reset();
+        bypass.Reset();
         offroute.Reset();
+        global_reacquire_streak = 0;
         dynamic_replan_requested = false;
         nav_run_dirty = true;
         flow.last_auto_sprint_time = {};

--- a/agent/cpp-algo/source/MapNavigator/navigation_session.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_session.cpp
@@ -323,7 +323,8 @@ void NavigationSession::ResetHardProgress()
     hard_progress_initialized_ = false;
 }
 
-void NavigationSession::ApplyDynamicOverlay(std::vector<Waypoint> generated_prefix, size_t continue_index, const NaviPosition& pos)
+void NavigationSession::ApplyDynamicOverlay(std::vector<Waypoint> generated_prefix, size_t continue_index, const NaviPosition& pos,
+                                            bool reset_hard_progress)
 {
     assert(continue_index <= original_path_.size() && "Dynamic overlay continue index is out of range.");
     current_path_ = std::move(generated_prefix);
@@ -335,7 +336,12 @@ void NavigationSession::ApplyDynamicOverlay(std::vector<Waypoint> generated_pref
     current_node_idx_ = 0;
     current_zone_id_ = pos.zone_id;
     ResetProgress();
-    ResetHardProgress();
+    // Skipped by the unstick replan: it re-applies to the SAME waypoint every recovery retry, so clearing the
+    // hard clock here would keep re-arming it and defeat the recovery timeout. A genuine waypoint change is
+    // re-baselined by ObserveHardProgress on its own, so the clock still tracks real progress either way.
+    if (reset_hard_progress) {
+        ResetHardProgress();
+    }
     LogInfo << "Dynamic route overlay applied." << VAR(generated_count) << VAR(continue_index) << VAR(current_path_.size())
             << VAR(pos.x) << VAR(pos.y) << VAR(pos.zone_id);
 }

--- a/agent/cpp-algo/source/MapNavigator/navigation_session.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_session.h
@@ -65,7 +65,8 @@ struct NavigationSession
     int64_t HardStalledMs(const std::chrono::steady_clock::time_point& now) const;
     void ResetHardProgress();
 
-    void ApplyDynamicOverlay(std::vector<Waypoint> generated_prefix, size_t continue_index, const NaviPosition& pos);
+    void ApplyDynamicOverlay(std::vector<Waypoint> generated_prefix, size_t continue_index, const NaviPosition& pos,
+                             bool reset_hard_progress = true);
 
     NaviPhase phase() const;
     void UpdatePhase(NaviPhase next_phase, const char* reason);

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -548,13 +548,44 @@ bool NavigationStateMachine::HandleLocalizationLoss()
         last_global_relocalize_at_ = now;
         const std::string prior_zone = session_->current_zone_id();
         if (position_provider_->Capture(position_, /*force_global_search=*/true, /*expected_zone_id=*/std::string())) {
-            if (!position_->zone_id.empty() && position_->zone_id != prior_zone) {
+            const bool zone_changed = !position_->zone_id.empty() && position_->zone_id != prior_zone;
+
+            if (runtime_state_.cross_tier_escape.active) {
+                if (NavmeshZonesShareGeometry(param_, runtime_state_.cross_tier_escape.anchor_zone, position_->zone_id)) {
+                    LogInfo << "Cross-tier escape rode a zone flip; preserving the corridor." << VAR(prior_zone)
+                            << VAR(position_->zone_id) << VAR(position_->x) << VAR(position_->y);
+                    if (zone_changed) {
+                        session_->UpdateCurrentZone(position_->zone_id);
+                    }
+                    loss.Reset();
+                    return true;
+                }
+                LogInfo << "Cross-tier escape: re-acquired zone left the pit span; reverting to loss handling."
+                        << VAR(prior_zone) << VAR(position_->zone_id);
+                runtime_state_.cross_tier_escape.Reset();
+            }
+            else if (zone_changed && TryEnterCrossTierEscape()) {
+                loss.Reset();
+                return true;
+            }
+
+            if (zone_changed) {
                 // Pin subsequent tracking ticks to the zone we actually re-acquired in, else the next
                 // CaptureCurrentPosition(false) would re-impose the stale expected_zone and fail again.
                 session_->UpdateCurrentZone(position_->zone_id);
             }
+            if (++runtime_state_.global_reacquire_streak >= kLocalizationThrashFailCount) {
+                return FailNavigation(
+                    "localization_thrash",
+                    "Re-acquired the route repeatedly without advancing a waypoint (wrong-tier fall thrashing "
+                    "recover<->re-lose); terminating so the pipeline can retry.",
+                    0.0,
+                    0.0,
+                    0);
+            }
             LogInfo << "Localization recovered via global re-acquire; resuming navigation." << VAR(loss_elapsed.count())
-                    << VAR(prior_zone) << VAR(position_->zone_id) << VAR(position_->x) << VAR(position_->y);
+                    << VAR(prior_zone) << VAR(position_->zone_id) << VAR(position_->x) << VAR(position_->y)
+                    << VAR(runtime_state_.global_reacquire_streak);
             ArmRiverFallRecoveryIfBlackScreenLoss("global_reacquire");
             loss.Reset();
             runtime_state_.route.ResetTracking();
@@ -602,7 +633,9 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
     size_t continue_index,
     const Waypoint& anchor,
     bool use_detour,
-    double route_heading)
+    double route_heading,
+    bool emit_interior_corners,
+    bool reset_hard_progress)
 {
     if (!anchor.HasPosition()) {
         LogWarn << "Dynamic navmesh overlay skipped: anchor has no position." << VAR(reason) << VAR(continue_index);
@@ -623,7 +656,7 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
         generated_prefix.emplace_back(detour_vertex.x, detour_vertex.y, ActionType::RUN);
         generated_prefix.back().strict_arrival = true;
     }
-    else if (!AppendGeneratedNavmeshWaypoints(route->path, generated_prefix, false)) {
+    else if (!AppendGeneratedNavmeshWaypoints(route->path, generated_prefix, false, emit_interior_corners)) {
         LogWarn << "Dynamic navmesh overlay skipped: generated path is unusable." << VAR(reason) << VAR(continue_index)
                 << VAR(route->path.points.size());
         return false;
@@ -635,7 +668,7 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
                 << VAR(continue_index) << VAR(position_->x) << VAR(position_->y);
     }
     const size_t generated_count = generated_prefix.size();
-    session_->ApplyDynamicOverlay(std::move(generated_prefix), continue_index, *position_);
+    session_->ApplyDynamicOverlay(std::move(generated_prefix), continue_index, *position_, reset_hard_progress);
     runtime_state_.route.Reset();
     runtime_state_.nav_run_dirty = true;
     if (generated_count == 0 && std::hypot(anchor.x - position_->x, anchor.y - position_->y) <= ArrivalBandForStartupBypass(anchor)) {
@@ -649,7 +682,8 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
     return true;
 }
 
-bool NavigationStateMachine::TryApplyDynamicOverlayToNextAnchor(const char* reason, bool use_detour, double route_heading)
+bool NavigationStateMachine::TryApplyDynamicOverlayToNextAnchor(const char* reason, bool use_detour, double route_heading,
+                                                               bool reset_hard_progress)
 {
     const std::optional<DynamicAnchor> anchor = ResolveCurrentAnchor(session_, *position_);
     if (!anchor) {
@@ -658,7 +692,8 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToNextAnchor(const char* reas
                 << VAR(position_->zone_id);
         return false;
     }
-    return TryApplyDynamicOverlayToAnchor(reason, anchor->first, anchor->second, use_detour, route_heading);
+    return TryApplyDynamicOverlayToAnchor(reason, anchor->first, anchor->second, use_detour, route_heading,
+                                          /*emit_interior_corners=*/false, reset_hard_progress);
 }
 
 bool NavigationStateMachine::HandleDynamicReplanRequest(const char* reason)
@@ -676,6 +711,128 @@ bool NavigationStateMachine::HandleDynamicReplanRequest(const char* reason)
     LogWarn << "Dynamic navmesh replan unavailable; falling back to current route." << VAR(reason) << VAR(position_->x)
             << VAR(position_->y) << VAR(position_->zone_id);
     SelectPhaseForCurrentWaypoint("dynamic_replan_fallback");
+    return true;
+}
+
+bool NavigationStateMachine::PlanCrossTierEscapeCorridorFromHere(const char* reason)
+{
+    const double heading = NaviMath::NormalizeAngle(position_->angle);
+    const std::vector<Waypoint>& path = session_->current_path();
+    for (size_t index = session_->current_node_idx(); index < path.size(); ++index) {
+        const Waypoint& candidate = session_->CurrentPathAt(index);
+        if (!candidate.HasPosition()) {
+            continue;
+        }
+        const std::optional<size_t> continue_index = session_->CanonicalIndexAtCurrentPath(index);
+        if (!continue_index) {
+            continue;  // a generated overlay waypoint (no canonical index) is not a rejoin target
+        }
+        if (TryApplyDynamicOverlayToAnchor(reason, *continue_index, candidate, /*use_detour=*/false, heading,
+                                           /*emit_interior_corners=*/true)) {
+            runtime_state_.cross_tier_escape.goal_x = candidate.x;
+            runtime_state_.cross_tier_escape.goal_y = candidate.y;
+            LogInfo << "Cross-tier escape corridor planned." << VAR(reason) << VAR(position_->zone_id)
+                    << VAR(position_->x) << VAR(position_->y) << VAR(*continue_index) << VAR(candidate.x)
+                    << VAR(candidate.y);
+            return true;
+        }
+    }
+    LogInfo << "Cross-tier escape: on a wrong tier but no reachable authored waypoint." << VAR(reason)
+            << VAR(position_->zone_id) << VAR(position_->x) << VAR(position_->y);
+    return false;
+}
+
+bool NavigationStateMachine::TryEnterCrossTierEscape()
+{
+    // Positive-ID: the fresh fix must sit on a real FLOORED tier (not a geometry / "…_Base" overview zone).
+    const float tier_floor = NavmeshFloorYForZone(param_, position_->zone_id);
+    if (tier_floor <= navmesh::kBaseNavFloorYValidMin) {
+        LogInfo << "Cross-tier escape declined: zone is not a floored tier." << VAR(position_->zone_id)
+                << VAR(tier_floor) << VAR(position_->x) << VAR(position_->y);
+        return false;
+    }
+    if (ResolveCurrentAnchor(session_, *position_)) {
+        LogInfo << "Cross-tier escape declined: route has a zone-compatible anchor here (normal travel)."
+                << VAR(position_->zone_id) << VAR(position_->x) << VAR(position_->y);
+        return false;
+    }
+
+    if (!PlanCrossTierEscapeCorridorFromHere("crosstier_escape")) {
+        return false;  // on a wrong tier but no reachable authored waypoint; defer to loss handling
+    }
+    runtime_state_.cross_tier_escape.active = true;
+    runtime_state_.cross_tier_escape.anchor_zone = position_->zone_id;
+    LogInfo << "Cross-tier escape engaged: routing out of a wrong tier via navmesh." << VAR(position_->zone_id)
+            << VAR(position_->x) << VAR(position_->y) << VAR(runtime_state_.cross_tier_escape.goal_x)
+            << VAR(runtime_state_.cross_tier_escape.goal_y);
+    return true;
+}
+
+bool NavigationStateMachine::ExecutePhysicalUnstick(double stuck_heading)
+{
+    LateralBypassState& unstick = runtime_state_.bypass;
+    // Relocated since the last unstick => a new spot; restart the bearing rotation.
+    if (unstick.active && std::hypot(position_->x - unstick.origin.x, position_->y - unstick.origin.y) > kUnstickResetDistanceM) {
+        unstick.Reset();
+    }
+    if (!unstick.active) {
+        unstick.active = true;
+        unstick.origin = *position_;
+        unstick.count = 0;
+    }
+
+    double distance = kUnstickMinDistanceM;
+    const std::optional<navmesh::WorldPoint> target =
+        PlanUnstickTarget(param_, *position_, stuck_heading, unstick.count, &distance);
+    if (!target) {
+        ++unstick.count;
+        LogWarn << "Physical unstick: no on-mesh escape bearing found." << VAR(stuck_heading) << VAR(unstick.count);
+        return false;
+    }
+
+    const double target_heading = NaviMath::CalcTargetRotation(position_->x, position_->y, target->x, target->y);
+    const double heading_delta = NaviMath::CalcDeltaRotation(position_->angle, target_heading);
+    motion_controller_->SetForwardState(false);
+    utils::SleepFor(kStopWaitMs);
+    int units = static_cast<int>(std::lround(heading_delta * action_wrapper_->DefaultTurnUnitsPerDegree()));
+    if (units == 0) {
+        units = heading_delta > 0.0 ? 1 : -1;
+    }
+    action_wrapper_->SendViewDeltaSync(units, 0);
+
+    const NaviPosition step_start = *position_;
+    double moved = 0.0;
+    for (int pulse = 0; pulse < kUnstickMaxPulses; ++pulse) {
+        action_wrapper_->PulseForwardSync(kUnstickPulseMs);
+        // Stop the moment tracking goes blind (held / black screen = a likely river fall) so we don't keep
+        // driving forward into the water; the next tick's loss handling takes over.
+        if (!CaptureCurrentPosition(false) || position_provider_->LastCaptureWasHeld()
+            || position_provider_->LastCaptureWasBlackScreen() || !position_->valid) {
+            break;
+        }
+        moved = std::hypot(position_->x - step_start.x, position_->y - step_start.y);
+        if (moved >= distance * kUnstickSuccessFraction) {
+            break;
+        }
+    }
+    motion_controller_->SetForwardState(false);
+    ++unstick.count;
+    const bool dislodged = moved >= distance * kUnstickSuccessFraction;
+    LogInfo << "Physical unstick step executed." << VAR(distance) << VAR(moved) << VAR(dislodged) << VAR(unstick.count)
+            << VAR(target_heading) << VAR(target->x) << VAR(target->y);
+
+    // Refresh the route from the new spot but keep the hard-progress clock: this replan re-fires every recovery
+    // retry while stuck, and resetting the clock each time would defeat the 30s recovery timeout (livelock).
+    if (TryApplyDynamicOverlayToNextAnchor("recovery_unstick_replan", false, 0.0, /*reset_hard_progress=*/false)) {
+        session_->ResetProgress();
+        SelectPhaseForCurrentWaypoint("recovery_unstick_replan");
+        return true;
+    }
+    runtime_state_.route.ResetTracking();
+    runtime_state_.dynamic_replan_requested = false;
+    runtime_state_.nav_run_dirty = true;
+    session_->ResetProgress();
+    SelectPhaseForCurrentWaypoint("recovery_physical_unstick");
     return true;
 }
 
@@ -724,6 +881,18 @@ bool NavigationStateMachine::TickNavigate()
             }
         } else {
             loss.Reset();
+        }
+    }
+
+    if (runtime_state_.cross_tier_escape.active) {
+        const double distance_to_goal = std::hypot(position_->x - runtime_state_.cross_tier_escape.goal_x,
+                                                    position_->y - runtime_state_.cross_tier_escape.goal_y);
+        const bool on_floorless_zone =
+            NavmeshFloorYForZone(param_, position_->zone_id) <= navmesh::kBaseNavFloorYValidMin;
+        if (distance_to_goal <= kCrossTierEscapeArrivalM && on_floorless_zone) {
+            LogInfo << "Cross-tier escape reached the rejoin point on the base floor; resuming authored route."
+                    << VAR(distance_to_goal) << VAR(position_->zone_id) << VAR(position_->x) << VAR(position_->y);
+            runtime_state_.cross_tier_escape.Reset();
         }
     }
 
@@ -816,6 +985,10 @@ bool NavigationStateMachine::TickNavigate()
             // leave nav_run_dirty clear and just recompute the serial projection for the new
             // current waypoint, keeping the arrival gate below consistent within this tick.
             runtime_state_.recovery.Reset();
+            // Passing corridor waypoints is discrete forward progress the thrash fast-fail must honour: a
+            // long leg with several transient losses would otherwise reach the re-acquire cap and wrongly
+            // fail. A stationary recover<->re-lose storm passes none, so it stays storm-proof.
+            runtime_state_.global_reacquire_streak = 0;
             route = RouteTracker::Update(session_, &runtime_state_.route, *position_);
         }
     }
@@ -831,6 +1004,21 @@ bool NavigationStateMachine::TickNavigate()
         // Feed the same signal to the hard watchdog, which recovery escapes can never reset (they only clear
         // the ordinary ObserveProgress clock). This is what lets the recovery timeout below actually fire.
         session_->ObserveHardProgress(session_->current_node_idx(), effective_progress, now);
+    }
+    // Cross-tier escape: follow the ONE planned corridor (arrival above is the success exit). Fast-fail when the
+    // corridor makes no genuine progress for too long. Keys on the hard-progress clock, which the escape's own
+    // overlay re-applies can't reset, so it trips only on a continuously stuck (walled/unfollowable) escape, never
+    // a slow-but-advancing one. The orthogonal recover<->re-lose thrash is caught by the re-acquire streak above.
+    if (runtime_state_.cross_tier_escape.active && session_->HardStalledMs(now) >= kCrossTierEscapeHardStallMs) {
+        const double goal_dist = std::hypot(position_->x - runtime_state_.cross_tier_escape.goal_x,
+                                            position_->y - runtime_state_.cross_tier_escape.goal_y);
+        runtime_state_.cross_tier_escape.Reset();
+        return FailNavigation(
+            "crosstier_escape_stalled",
+            "Cross-tier escape made no corridor progress (walled or unfollowable); terminating so the pipeline can retry.",
+            goal_dist,
+            0.0,
+            session_->HardStalledMs(now));
     }
     // An OffCorridor replan rebuilds a genuinely different (usually longer) corridor, so reset the stall
     // counter to not penalize the new route. A ProgressRegression replan, by contrast, fires *because* the
@@ -954,7 +1142,7 @@ bool NavigationStateMachine::TickNavigate()
     // where on_route is meaningful; the stall clocks above are fed corridor progress and miss a pinned-off-route
     // cursor. Fed straight-line distance, so the timer only grows while genuinely off-route with no inward gain.
     if (session_->phase() == NaviPhase::Navigate && waypoint.action == ActionType::RUN && !waypoint.RequiresStrictArrival()
-        && !route.on_route) {
+        && !route.on_route && !runtime_state_.cross_tier_escape.active) {
         OffRouteWedgeState& wedge = runtime_state_.offroute;
         const double progress_epsilon = std::max(kNoProgressDistanceEpsilon, kMeasurementDefaultPositionQuantum);
         if (!wedge.active || route.progress_distance + progress_epsilon < wedge.best_distance) {
@@ -992,7 +1180,8 @@ bool NavigationStateMachine::TickNavigate()
     const bool near_strict_goal = waypoint.RequiresStrictArrival()
         && route.waypoint_distance <= arrival_distance + kCloseGoalDetourSuppressSlack;
     const bool should_try_recovery = session_->phase() == NaviPhase::Navigate && stalled_ms >= kObstacleRecoveryMinTriggerMs
-                                     && (route.progress_distance > kNoProgressMinDistance || waypoint.RequiresStrictArrival());
+                                     && (route.progress_distance > kNoProgressMinDistance || waypoint.RequiresStrictArrival())
+                                     && !runtime_state_.cross_tier_escape.active;
     if (should_try_recovery) {
         const std::optional<DynamicAnchor> anchor = ResolveCurrentAnchor(session_, *position_);
         if (anchor) {
@@ -1026,6 +1215,13 @@ bool NavigationStateMachine::TickNavigate()
                                                    < kDynamicRecoveryRetryIntervalMs;
             if (!retry_cooling_down) {
                 recovery.last_replan_at = now;
+
+                if (!near_strict_goal && recovery.detour_attempt_count >= kRecoveryDetourAttemptsBeforeUnstick) {
+                    if (ExecutePhysicalUnstick(route.route_heading)) {
+                        return true;
+                    }
+                }
+
                 ++recovery.jump_attempt_count;
                 const NaviPosition jump_start = *position_;
                 LogInfo << "Dynamic recovery jump pulse issued." << VAR(recovery.jump_attempt_count)
@@ -1094,10 +1290,9 @@ bool NavigationStateMachine::TickNavigate()
                         SelectPhaseForCurrentWaypoint("recovery_navmesh_detour");
                         return true;
                     }
-
-                    LogWarn << "Dynamic recovery detour attempt failed." << VAR(recovery.detour_attempt_count)
-                            << VAR(recovery.jump_attempt_count) << VAR(post_jump_anchor->first)
-                            << VAR(route.progress_distance) << VAR(stalled_ms);
+                    LogWarn << "Dynamic recovery detour attempt failed; switching to physical unstick."
+                            << VAR(recovery.detour_attempt_count) << VAR(recovery.jump_attempt_count)
+                            << VAR(post_jump_anchor->first) << VAR(route.progress_distance) << VAR(stalled_ms);
                 }
                 utils::SleepFor(kTargetTickMs);
                 return true;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -49,9 +49,15 @@ private:
         size_t continue_index,
         const Waypoint& anchor,
         bool use_detour,
-        double route_heading = 0.0);
-    bool TryApplyDynamicOverlayToNextAnchor(const char* reason, bool use_detour, double route_heading = 0.0);
+        double route_heading = 0.0,
+        bool emit_interior_corners = false,
+        bool reset_hard_progress = true);
+    bool TryApplyDynamicOverlayToNextAnchor(const char* reason, bool use_detour, double route_heading = 0.0,
+                                            bool reset_hard_progress = true);
     bool HandleDynamicReplanRequest(const char* reason);
+    bool TryEnterCrossTierEscape();
+    bool PlanCrossTierEscapeCorridorFromHere(const char* reason);
+    bool ExecutePhysicalUnstick(double stuck_heading);
     void SelectPhaseForCurrentWaypoint(const char* reason);
     void StopMotion();
     bool FailNavigation(const char* reason, const char* log_message, double current_distance, double yaw_error, int64_t stalled_ms);

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -706,6 +706,49 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(
     return route_result;
 }
 
+float NavmeshFloorYForZone(const NaviParam& param, const std::string& locator_zone)
+{
+    if (locator_zone.empty()) {
+        return navmesh::kBaseNavFloorYNone;
+    }
+    const std::string navmesh_zone = InferBaseNavZone(locator_zone, param.map_name);
+    if (navmesh_zone.empty()) {
+        return navmesh::kBaseNavFloorYNone;
+    }
+    const auto navmesh = LoadCachedNavmesh(ResolveNavmeshFile(param.navmesh_file), navmesh_zone);
+    if (!navmesh) {
+        return navmesh::kBaseNavFloorYNone;
+    }
+    return navmesh->pack.floorYForZoneName(locator_zone);
+}
+
+bool NavmeshZonesShareGeometry(const NaviParam& param, const std::string& zone_a, const std::string& zone_b)
+{
+    if (zone_a.empty() || zone_b.empty()) {
+        return false;
+    }
+    if (zone_a == zone_b) {
+        return true;
+    }
+    const std::string navmesh_zone = InferBaseNavZone(zone_a, param.map_name);
+    if (navmesh_zone.empty()) {
+        return false;
+    }
+    const auto navmesh = LoadCachedNavmesh(ResolveNavmeshFile(param.navmesh_file), navmesh_zone);
+    if (!navmesh) {
+        return false;
+    }
+    const auto geometry_id = [&navmesh](const std::string& name) -> int {
+        const navmesh::BaseNavZone* zone = navmesh->pack.findZoneByName(name);
+        if (zone == nullptr) {
+            return -1;
+        }
+        return navmesh::IsTierZone(*zone) ? static_cast<int>(zone->component_count) : static_cast<int>(zone->zone_id);
+    };
+    const int geom_a = geometry_id(zone_a);
+    return geom_a >= 0 && geom_a == geometry_id(zone_b);
+}
+
 double NavmeshOffMeshFraction(
     const NaviParam& param,
     const std::string& locator_zone,
@@ -840,7 +883,65 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshDetourRoute(
     return best;
 }
 
-bool AppendGeneratedNavmeshWaypoints(const navmesh::WorldPath& world_path, std::vector<Waypoint>& out_path, bool include_goal)
+std::optional<navmesh::WorldPoint> PlanUnstickTarget(
+    const NaviParam& param,
+    const NaviPosition& position,
+    double stuck_heading,
+    int attempt_index,
+    double* out_distance)
+{
+    const std::string navmesh_zone = InferBaseNavZone(position.zone_id, param.map_name);
+    if (navmesh_zone.empty()) {
+        return std::nullopt;
+    }
+    const std::filesystem::path navmesh_path = ResolveNavmeshFile(param.navmesh_file);
+    const auto navmesh = LoadCachedNavmesh(navmesh_path, navmesh_zone);
+    if (!navmesh) {
+        return std::nullopt;
+    }
+    const auto on_mesh = [&](const navmesh::WorldPoint& p) {
+        const auto proj = navmesh->pack.projectToBase(navmesh_zone, p.x, p.y);
+        if (!proj || proj->geometry_zone == nullptr) {
+            return true;
+        }
+        return navmesh->planner.pointOnMesh(proj->geometry_zone->zone_id, { .x = proj->x, .y = proj->y });
+    };
+
+    static constexpr double kFan[] = { 180.0, -135.0, 135.0, -90.0, 90.0 };
+    constexpr int kFanCount = static_cast<int>(sizeof(kFan) / sizeof(kFan[0]));
+    const int rot = ((attempt_index % kFanCount) + kFanCount) % kFanCount;
+
+    for (int i = 0; i < kFanCount; ++i) {
+        const double bearing = NaviMath::NormalizeHeading(stuck_heading + kFan[(i + rot) % kFanCount]);
+        double run = 0.0;
+        double longest = 0.0;
+        double solid_start = -1.0;  // distance where the trailing contiguous on-mesh stretch begins
+        for (double d = kUnstickSampleStepM; d <= kUnstickMaxDistanceM + 1e-9; d += kUnstickSampleStepM) {
+            if (on_mesh(OffsetPoint(position, bearing, d))) {
+                if (solid_start < 0.0) {
+                    solid_start = d;
+                }
+                run = 0.0;
+            }
+            else {
+                solid_start = -1.0;
+                run += kUnstickSampleStepM;
+                longest = std::max(longest, run);
+            }
+        }
+        if (solid_start >= 0.0 && longest <= kUnstickMaxRockCrossingM) {
+            const double dist = std::clamp(solid_start + kUnstickMeshMarginM, kUnstickMinDistanceM, kUnstickMaxDistanceM);
+            if (out_distance != nullptr) {
+                *out_distance = dist;
+            }
+            return OffsetPoint(position, bearing, dist);
+        }
+    }
+    return std::nullopt;
+}
+
+bool AppendGeneratedNavmeshWaypoints(
+    const navmesh::WorldPath& world_path, std::vector<Waypoint>& out_path, bool include_goal, bool emit_interior_corners)
 {
     if (world_path.points.empty()) {
         return false;
@@ -851,6 +952,12 @@ bool AppendGeneratedNavmeshWaypoints(const navmesh::WorldPath& world_path, std::
     const size_t loop_end = include_goal ? total : (total > 0 ? total - 1 : 0);
 
     for (size_t index = 1; index < loop_end; ++index) {
+        if (emit_interior_corners) {
+            const navmesh::WorldPoint& point = world_path.points[index];
+            out_path.emplace_back(point.x, point.y, ActionType::RUN);
+            out_path.back().strict_arrival = false;
+            continue;
+        }
         if (!segment_breaks.contains(index)) {
             continue;
         }

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -32,6 +32,8 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(
     const navmesh::WorldPoint& start,
     const navmesh::WorldPoint& goal,
     const std::vector<uint32_t>& blocked_triangles = {});
+float NavmeshFloorYForZone(const NaviParam& param, const std::string& locator_zone);
+bool NavmeshZonesShareGeometry(const NaviParam& param, const std::string& zone_a, const std::string& zone_b);
 // Resample `poly` at ~`step` world units (clamped to >=0.1) and invoke `fn` on the leading vertex and
 // every resampled point. Used by NavmeshOffMeshFraction. Caller guards poly.size() >= 2 for a
 // meaningful result.
@@ -69,6 +71,13 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshDetourRoute(
     const Waypoint& anchor,
     double route_heading,
     navmesh::WorldPoint* out_detour_vertex = nullptr);
-bool AppendGeneratedNavmeshWaypoints(const navmesh::WorldPath& world_path, std::vector<Waypoint>& out_path, bool include_goal);
+std::optional<navmesh::WorldPoint> PlanUnstickTarget(
+    const NaviParam& param,
+    const NaviPosition& position,
+    double stuck_heading,
+    int attempt_index,
+    double* out_distance = nullptr);
+bool AppendGeneratedNavmeshWaypoints(
+    const navmesh::WorldPath& world_path, std::vector<Waypoint>& out_path, bool include_goal, bool emit_interior_corners = false);
 
 } // namespace mapnavigator


### PR DESCRIPTION
## Sourcery 总结

引入基于导航网格（navmesh）的跨层（cross-tier）逃逸和物理脱困机制，以提升导航过程中的自动避障与恢复鲁棒性。

新功能：
- 新增跨层逃逸模式，从错误楼层（wrong floored tier）规划一条导航网格走廊（navmesh corridor），将其连接到可达的预设路点（authored waypoint），并在层级/底座（tier/base）反复切换中沿该走廊前进。
- 新增物理脱困流程，当动态绕行（dynamic detours）无法使智能体脱困时，主动转向并沿安全的导航网格方位行走。

缺陷修复：
- 在跨层逃逸激活期间，防止偏离路线与恢复逻辑相互干扰，从而减少错误的恢复触发。
- 为定位抖动（localization thrashing）和停滞的跨层逃逸增加快速失败条件，避免陷入无休止的恢复/失去循环。

增强改进：
- 扩展动态覆盖（dynamic overlay）的应用，可选地保留“硬进度”计时，并为逃逸走廊输出内部导航网格拐点。
- 追踪导航网格楼层高度以及区域间共享几何信息，以更好地分类楼层层级并容忍安全区域的切换。
- 优化恢复流程的升级顺序，从跳跃脉冲（jump pulses）到导航网格绕行，再到物理脱困，并改进日志记录与状态追踪。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce navmesh-based cross-tier escape and physical unstick mechanisms to improve automatic obstacle avoidance and recovery robustness during navigation.

New Features:
- Add cross-tier escape mode that plans a single navmesh corridor from a wrong floored tier back to a reachable authored waypoint and follows it through tier/base oscillations.
- Add a physical unstick routine that actively turns and walks along safe navmesh bearings when dynamic detours cannot dislodge the agent.

Bug Fixes:
- Prevent off-route and recovery logic from interfering while cross-tier escape is active, reducing erroneous recovery triggers.
- Add fast-fail conditions for localization thrashing and stalled cross-tier escapes to avoid endless recover/relose loops.

Enhancements:
- Extend dynamic overlay application to optionally keep hard-progress timing and to emit interior navmesh corners for escape corridors.
- Track navmesh floor height and shared geometry between zones to better classify floored tiers and tolerate safe zone flips.
- Refine recovery sequencing to escalate from jump pulses to navmesh detours and finally to physical unstick, with improved logging and state tracking.

</details>