### PR TITLE
fix: 拜访好友提前退出

### DIFF
--- a/assets/resource/pipeline/VisitFriends/MenuScan.json
+++ b/assets/resource/pipeline/VisitFriends/MenuScan.json
@@ -66,7 +66,6 @@
         "recognition": "And",
         "all_of": [
             {
-                "sub_name": "_CanVisitText",
                 "recognition": {
                     "type": "OCR",
                     "param": {
@@ -77,30 +76,13 @@
                             203
                         ],
                         "expected": [
-                            "可拜访的好友",
-                            "可拜訪的好友",
-                            "Visitable Friends",
-                            "訪問できるフレンド",
-                            "可拜访"
+                            // 可拜访的好友
+                            // @i18n-skip
+                            "好友1",
+                            "好友1",
+                            "Friends 1",
+                            "レンド1"
                         ]
-                    }
-                }
-            },
-            {
-                "recognition": {
-                    "type": "OCR",
-                    "param": {
-                        "roi": "_CanVisitText",
-                        "roi_offset": [
-                            0,
-                            0,
-                            15,
-                            0
-                        ],
-                        "expected": [
-                            "1$"
-                        ],
-                        "only_rec": true
                     }
                 }
             }


### PR DESCRIPTION
close #4002

## Summary by Sourcery

错误修复：
- 防止在“VisitFriends”菜单中执行好友访问扫描时过早退出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent premature exit when performing friend visit scans in the VisitFriends menu.

</details>