### PR TITLE
fix: GH token needed

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -453,6 +453,8 @@ jobs:
     if: ${{ needs.meta.outputs.is_release == 'true' }}
     needs: [meta, package_linux_tarball, package_macos_dmg, package_win_zip, changelog]
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/download-artifact@v7
         with:
@@ -513,8 +515,6 @@ jobs:
         run: |
           gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release.yml -f tag=${{ needs.meta.outputs.tag }}
           gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release_note.yml -f tag=${{ needs.meta.outputs.tag }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Send Discord release notification
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -453,8 +453,6 @@ jobs:
     if: ${{ needs.meta.outputs.is_release == 'true' }}
     needs: [meta, package_linux_tarball, package_macos_dmg, package_win_zip, changelog]
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/download-artifact@v7
         with:
@@ -512,11 +510,15 @@ jobs:
       - name: Trigger MirrorChyanUploading
         if: ${{ github.repository_owner == 'MaaEnd' }}
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release.yml -f tag=${{ needs.meta.outputs.tag }}
           gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release_note.yml -f tag=${{ needs.meta.outputs.tag }}
 
       - name: Send Discord release notification
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run --repo $GITHUB_REPOSITORY discord-release-notification.yml \
             -f release_tag="${{ needs.meta.outputs.tag }}"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 在发布工作流中，将 `GH_TOKEN` 从 `GITHUB_TOKEN` 机密的配置位置从单个步骤提升到作业级别进行配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Configure GH_TOKEN from GITHUB_TOKEN secret at the job level instead of within a single step in the release workflow.

</details>