### PR TITLE
fix(EnvironmentMonitoring): 释放拍照模式 R 键

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
@@ -64,12 +64,12 @@
         "threshold": 0.8,
         "action": "Click",
         "next": [
-            "EnterCameraModeKeyDown"
+            "EnterCameraModeKeyUp"
         ]
     },
-    "EnterCameraModeKeyDown": {
+    "EnterCameraModeKeyUp": {
         "desc": "进入拍照模式，退出按键",
-        "action": "KeyDown",
+        "action": "KeyUp",
         "key": 82, // R 0x52
         "next": [
             "EnvironmentMonitoringWaitShutterButton"

--- a/assets/resource_adb/pipeline/EnvironmentMonitoring/TakePhoto.json
+++ b/assets/resource_adb/pipeline/EnvironmentMonitoring/TakePhoto.json
@@ -23,7 +23,7 @@
             23
         ]
     },
-    "EnterCameraModeKeyDown": {
+    "EnterCameraModeKeyUp": {
         "action": "TouchUp"
     }
 }


### PR DESCRIPTION
## 变更内容

修复环境监测拍照流程中进入拍照模式后的 R 键释放逻辑：

- 将 `EnterCameraModeKeyDown` 重命名为 `EnterCameraModeKeyUp`
- 将对应动作从 `KeyDown` 改为 `KeyUp`
- 同步更新 `EnterCameraModeChooseCamera.next` 引用

## 原因

长按 R 打开拍照模式并选择相机后，后续节点仍执行 `KeyDown`，会造成按键语义错误，存在 R 键持续占用风险。

## 验证

- `pnpm exec prettier --write assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json`
- `pnpm check`
- 环境监测相关 Win32 / ADB 节点测试单独通过

## Summary by Sourcery

调整 EnvironmentMonitoring 拍照流水线，以在进入摄像模式时正确处理 R 键释放事件。

Bug Fixes:
- 通过将进入摄像模式的动作从按键按下触发改为按键抬起触发，修复 EnvironmentMonitoring 拍照流程中错误的 R 键事件。

Enhancements:
- 重命名进入摄像模式的节点以体现按键抬起语义，并更新拍照流水线配置中下游引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust EnvironmentMonitoring take-photo pipeline to correctly handle R key release when entering camera mode.

Bug Fixes:
- Fix incorrect R key event in the EnvironmentMonitoring take-photo flow by switching the enter-camera-mode action to trigger on key up instead of key down.

Enhancements:
- Rename the enter-camera-mode node to reflect key-up semantics and update downstream references in the take-photo pipeline configuration.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整 EnvironmentMonitoring 拍照流水线，以在进入摄像模式时正确处理 R 键释放事件。

Bug Fixes:
- 通过将进入摄像模式的动作从按键按下触发改为按键抬起触发，修复 EnvironmentMonitoring 拍照流程中错误的 R 键事件。

Enhancements:
- 重命名进入摄像模式的节点以体现按键抬起语义，并更新拍照流水线配置中下游引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust EnvironmentMonitoring take-photo pipeline to correctly handle R key release when entering camera mode.

Bug Fixes:
- Fix incorrect R key event in the EnvironmentMonitoring take-photo flow by switching the enter-camera-mode action to trigger on key up instead of key down.

Enhancements:
- Rename the enter-camera-mode node to reflect key-up semantics and update downstream references in the take-photo pipeline configuration.

</details>

</details>