### PR TITLE
fix: 拜访好友误识别单个好友

### DIFF
--- a/assets/resource/pipeline/VisitFriends/MenuScan.json
+++ b/assets/resource/pipeline/VisitFriends/MenuScan.json
@@ -98,6 +98,7 @@
                             0
                         ],
                         "expected": [
+                            // @i18n-skip
                             "(^|[^\\d])1(?!\\d)"
                         ],
                         "only_rec": true

--- a/assets/resource/pipeline/VisitFriends/MenuScan.json
+++ b/assets/resource/pipeline/VisitFriends/MenuScan.json
@@ -66,6 +66,7 @@
         "recognition": "And",
         "all_of": [
             {
+                "sub_name": "_CanVisitText",
                 "recognition": {
                     "type": "OCR",
                     "param": {
@@ -76,13 +77,30 @@
                             203
                         ],
                         "expected": [
-                            // 可拜访的好友
-                            // @i18n-skip
-                            "好友1",
-                            "好友1",
-                            "Friends 1",
-                            "レンド1"
+                            "可拜访的好友",
+                            "可拜訪的好友",
+                            "Visitable Friends",
+                            "訪問できるフレンド",
+                            "可拜访"
                         ]
+                    }
+                }
+            },
+            {
+                "recognition": {
+                    "type": "OCR",
+                    "param": {
+                        "roi": "_CanVisitText",
+                        "roi_offset": [
+                            0,
+                            0,
+                            15,
+                            0
+                        ],
+                        "expected": [
+                            "(^|[^\\d])1(?!\\d)"
+                        ],
+                        "only_rec": true
                     }
                 }
             }


### PR DESCRIPTION
close #4008

## Summary by Sourcery

Bug Fixes:
- 解决在扫描“访问好友”菜单时对单个好友识别不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect recognition of single friends when scanning the visit friends menu.

</details>