### PR TITLE
fix(map): 卡住缓解流水线的若干等待与稳定判别的修复

### DIFF
--- a/assets/resource/pipeline/MapTracker/StuckMitigator.json
+++ b/assets/resource/pipeline/MapTracker/StuckMitigator.json
@@ -3,7 +3,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractReco",
+            "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractPre",
             "__MapTrackerStuckMitigator_MoveOrDeleteDevice_NoHit"
         ]
     },
@@ -14,7 +14,7 @@
             // Finish pipeline execution
         ]
     },
-    "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractReco": {
+    "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractPre": {
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -30,11 +30,6 @@
                 "order_by": "Score"
             }
         },
-        "next": [
-            "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractPre"
-        ]
-    },
-    "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractPre": {
         "action": {
             "type": "KeyDown",
             "param": {
@@ -49,7 +44,7 @@
         "action": {
             "type": "Click",
             "param": {
-                "target": "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractReco"
+                "target": "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractPre"
             }
         },
         "next": [

--- a/assets/resource/pipeline/MapTracker/StuckMitigator.json
+++ b/assets/resource/pipeline/MapTracker/StuckMitigator.json
@@ -293,7 +293,7 @@
         "action": {
             "type": "Click"
         },
-        "post_delay": 250,
+        "post_delay": 300,
         "next": [
             "__MapTrackerStuckMitigator_MoveOrDeleteDevice_CancelMove"
         ]

--- a/assets/resource/pipeline/MapTracker/StuckMitigator.json
+++ b/assets/resource/pipeline/MapTracker/StuckMitigator.json
@@ -2,10 +2,16 @@
     "MapTrackerStuckMitigator_MoveOrDeleteDevice": {
         "pre_delay": 0,
         "post_delay": 0,
-        "timeout": 5000,
         "next": [
-            "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractReco"
-            //"__MapTrackerStuckMitigator_MoveOrDeleteDevice_NoHit"
+            "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractReco",
+            "__MapTrackerStuckMitigator_MoveOrDeleteDevice_NoHit"
+        ]
+    },
+    "__MapTrackerStuckMitigator_MoveOrDeleteDevice_NoHit": {
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            // Finish pipeline execution
         ]
     },
     "__MapTrackerStuckMitigator_MoveOrDeleteDevice_InteractReco": {
@@ -58,6 +64,7 @@
             }
         },
         "timeout": 5000,
+        "rate_limit": 500,
         "next": [
             "__MapTrackerStuckMitigator_MoveOrDeleteDevice_DeleteDevice",
             "__MapTrackerStuckMitigator_MoveOrDeleteDevice_MoveDevice",
@@ -65,12 +72,7 @@
             "__MapTrackerStuckMitigator_MoveOrDeleteDevice_SkipChat",
             "__MapTrackerStuckMitigator_MoveOrDeleteDevice_CloseBagDialog",
             "__MapTrackerStuckMitigator_MoveOrDeleteDevice_CloseUnknownDeviceDialog"
-            //"__MapTrackerStuckMitigator_MoveOrDeleteDevice_NoHit"
         ]
-    },
-    "__MapTrackerStuckMitigator_MoveOrDeleteDevice_NoHit": {
-        "pre_delay": 0,
-        "post_delay": 0
     },
     "__MapTrackerInternal_IsInFactoryDeviceDialog": {
         "recognition": {

--- a/assets/resource/pipeline/MapTracker/StuckMitigator.json
+++ b/assets/resource/pipeline/MapTracker/StuckMitigator.json
@@ -243,7 +243,16 @@
         "action": {
             "type": "Click"
         },
-        "post_wait_freezes": 500,
+        "post_wait_freezes": {
+            "target": [
+                520,
+                300,
+                240,
+                120
+            ],
+            "time": 500,
+            "timeout": 10000
+        },
         "next": [
             "__MapTrackerStuckMitigator_MoveOrDeleteDevice_DeleteDeviceConfirm"
         ]
@@ -330,7 +339,16 @@
         "action": {
             "type": "Click"
         },
-        "post_wait_freezes": 500,
+        "post_wait_freezes": {
+            "target": [
+                520,
+                300,
+                240,
+                120
+            ],
+            "time": 500,
+            "timeout": 10000
+        },
         "next": [
             "__MapTrackerStuckMitigator_MoveOrDeleteDevice_SkipChatConfirm"
         ]


### PR DESCRIPTION
## 概要

此 PR 基于实践经验：

1. 回滚了 MapTracker StuckMitigator 中的一处不当的 NoHit 节点移除；
2. 修复了两处未设置正确 target 区域的 `post_wait_freezes`；
3. 微调了移动普通设备的等待时间。

## 关联

1. 问题引入于 #3752 。将会修复：

Fix #3907 
Fix #3990

2. 将修复：

Fix #3931

## Summary by Sourcery

调整 MapTracker 卡住缓解管线，以改进对无命中节点的处理以及设备移动等待行为。

Bug Fixes:
- 在 StuckMitigator 中恢复之前被移除的无命中节点处理，以防止在卡住缓解过程中错误地移除节点。
- 更正 MapTracker 管线中 `post_wait_freezes` 的目标区域，确保等待逻辑应用到预期的区域。

Enhancements:
- 重新调整 MapTracker 管线中普通移动设备的等待时长，以提升卡住检测和缓解的稳定性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust MapTracker stuck mitigation pipeline to improve handling of no-hit nodes and device movement wait behavior.

Bug Fixes:
- Restore previously removed no-hit node handling in StuckMitigator to prevent incorrect node removal in stuck mitigation.
- Correct target regions for post_wait_freezes in the MapTracker pipeline to ensure waits apply to the intended areas.

Enhancements:
- Retune wait durations for moving normal devices in the MapTracker pipeline to improve stability of stuck detection and mitigation.

</details>