### PR TITLE
perf: minicv亚像素模板匹配精度优化

### DIFF
--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	_ "image/png"
+	"math"
 	"os"
 	"runtime"
 	"sync"
@@ -118,19 +119,22 @@ func runMatchWorkers(workerCount int, fn func(workerID int)) {
 	wg.Wait()
 }
 
-func subpixelOffset(neg, pos float64) float64 {
-	wn := max(0.0, neg)
-	wp := max(0.0, pos)
-	wn2 := wn * wn
-	wp2 := wp * wp
-
-	sum := wn2 + wp2
-	if sum < 1e-12 {
+func subpixelOffset(neg, pivot, pos float64) float64 {
+	if pivot <= 0 || neg <= 0 || pos <= 0 {
 		return 0.0
 	}
 
-	offset := (wp2 - wn2) / sum
-	return min(1.0, max(-1.0, offset))
+	lnNeg := math.Log(neg)
+	lnCenter := math.Log(pivot)
+	lnPos := math.Log(pos)
+
+	// Gaussian interpolation
+	denom := 2.0 * (lnNeg + lnPos - 2.0*lnCenter)
+	if denom > -1e-12 {
+		return 0.0
+	}
+
+	return -(lnPos - lnNeg) / denom
 }
 
 // MatchTemplate performs template matching on the whole image,
@@ -244,10 +248,7 @@ func MatchTemplateInArea(
 		rightNCC = ComputeNCC(img, imgIntArr, tpl, tplStats, fx+1, fy)
 	}
 
-	subX := float64(fx) + subpixelOffset(leftNCC, rightNCC)
-	subY := float64(fy) + subpixelOffset(upNCC, downNCC)
-
-	return subX, subY, fm
+	return float64(fx) + subpixelOffset(leftNCC, fm, rightNCC), float64(fy) + subpixelOffset(upNCC, fm, downNCC), fm
 }
 
 // MatchTemplateInAreaWithMask performs template matching in a rectangular search area while ignoring template pixels of the mask color.
@@ -343,10 +344,7 @@ func MatchTemplateInAreaWithMask(
 	leftNCC := evalOr(fx-1, fy, fm)
 	rightNCC := evalOr(fx+1, fy, fm)
 
-	subX := float64(fx) + subpixelOffset(leftNCC, rightNCC)
-	subY := float64(fy) + subpixelOffset(upNCC, downNCC)
-
-	return subX, subY, fm
+	return float64(fx) + subpixelOffset(leftNCC, fm, rightNCC), float64(fy) + subpixelOffset(upNCC, fm, downNCC), fm
 }
 
 // BuildCircleMaskTemplate creates a template whose pixels outside the circle are filled with the mask color.
@@ -613,7 +611,7 @@ func subpixelNCCInMatrix(matrix [][]float64, x, y int, val float64) (float64, fl
 	if y+1 < len(matrix) {
 		downNCC = matrix[y+1][x]
 	}
-	return float64(x) + subpixelOffset(leftNCC, rightNCC), float64(y) + subpixelOffset(upNCC, downNCC)
+	return float64(x) + subpixelOffset(leftNCC, val, rightNCC), float64(y) + subpixelOffset(upNCC, val, downNCC)
 }
 
 func suppressNCCMatrix(matrix [][]float64, x, y, w, h int) {

--- a/agent/go-service/pkg/minicv/match_template.go
+++ b/agent/go-service/pkg/minicv/match_template.go
@@ -120,7 +120,7 @@ func runMatchWorkers(workerCount int, fn func(workerID int)) {
 }
 
 func subpixelOffset(neg, pivot, pos float64) float64 {
-	if pivot <= 0 || neg <= 0 || pos <= 0 {
+	if pivot <= 0 || neg <= 0 || pos <= 0 || neg > pivot || pos > pivot {
 		return 0.0
 	}
 


### PR DESCRIPTION
## 概要

此 PR 调整了 minicv 包中的亚像素模板匹配计算方法。从“左右邻居加权偏移”改成了“基于 NCC 峰值的 Gaussian 三点插值”。

**更改前：**

整数模板匹配先找到 NCC 最大的整数坐标 `(x, y)`，然后分别看左右/上下相邻点的 NCC 值来估计小数偏移。

设某一轴上 `C-` 是左侧或上侧邻点 NCC，`C+` 是右侧或下侧邻点 NCC。旧算法不使用中心点 NCC，只用两侧邻点：

```text
w- = max(0, C-)
w+ = max(0, C+)

delta = (w+^2 - w-^2) / (w+^2 + w-^2)
delta = clamp(delta, -1, 1)
```

最终坐标：

```text
x' = x + delta_x
y' = y + delta_y
```

这个算法的含义是：哪一侧邻点 NCC 更高，就把坐标往哪一侧推；差距越大，偏移越大。

**更改后：**

新算法使用三点 Gaussian 插值。仍然先找到整数峰值 `(x, y)`，但某一轴上会使用：`C-` 左侧或上侧邻点 NCC、`C0` 中心整数峰值 NCC、`C+` 右侧或下侧邻点 NCC。

假设 NCC 峰值局部近似为 Gaussian：

```text
C(t) = A * exp(-a(t - mu)^2)
```

对两边取对数后：

```text
ln C(t) = ln A - a(t - mu)^2
```

也就是一个二次函数。因此可以用 `t = -1, 0, 1` 三个点拟合一条抛物线，然后取抛物线顶点作为亚像素偏移。设：

```text
L- = ln(C-)
L0 = ln(C0)
L+ = ln(C+)
```

拟合二次函数：

```text
L(t) = a t^2 + b t + c
```

三点可推出：

```text
a = (L- + L+ - 2L0) / 2
b = (L+ - L-) / 2
```

顶点位置：

```text
delta = -b / (2a)
```

代入后得到当前实现中的公式：

```text
delta = -(L+ - L-) / (2 * (L- + L+ - 2L0))
```

最终坐标同样是：

```text
x' = x + delta_x
y' = y + delta_y
```

**核心差异：**

旧算法是“邻点强弱比例偏移”，数学上更像启发式权重；新算法是“局部峰值模型拟合”，数学上是在 log-NCC 空间拟合二次峰。

新算法使用中心点 `C0`，能感知峰值曲率，因此偏移更符合 NCC 峰的位置；同时在整数峰值切换时，Gaussian 插值通常能给出更连续的小数坐标，减少跳变。

## 测试

此更改主要影响到的业务是 MapTracker 系列的识别精度。

先前版本的 MapTrackerInfer，在不同缩放（precision）下，亚像素小数位的分布情况会发生显著改变，甚至在某些 precision 下，小数位的分布倾向于某些固定值（例如 0.5）。

更改后的亚像素算法，经归一化信息熵测试，不同 precision 下，X、Y 轴小数位的熵值普遍 >0.8（1.0 最高，越高越符合均匀分布），说明算法效果良好。

测试样本来自于 https://github.com/MaaEnd/MaaEndTestset/commit/1626e57db1229f7c296f80bc10e280f266ef75f6

## Summary by Sourcery

将 minicv 中的子像素模板匹配方式，从启发式的邻域加权偏移，切换为在 NCC 峰值附近进行高斯插值，以提升子像素精度。

Enhancements:
- 使用对数域的三点高斯插值细化子像素偏移计算，并将整数峰值的 NCC 值纳入插值过程。
- 更新模板匹配辅助函数，在无掩码和带掩码的匹配路径中，均传递 NCC 峰值作为插值的基准点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch subpixel template matching in minicv from heuristic neighbor-weight offset to Gaussian interpolation around the NCC peak for improved subpixel accuracy.

Enhancements:
- Refine subpixel offset computation using log-domain three-point Gaussian interpolation that incorporates the integer-peak NCC value.
- Update template matching helpers to pass the NCC peak as the interpolation pivot in both unmasked and masked matching paths.

</details>