### PR TITLE
fix: 库存转移改为点击 UI 打开背包

### DIFF
--- a/assets/resource/pipeline/ItemTransfer.json
+++ b/assets/resource/pipeline/ItemTransfer.json
@@ -57,27 +57,138 @@
         ]
     },
     "ItemTransferStartOpenRepo": {
-        "action": "ClickKey",
-        "key": 66, // B
-        "post_wait_freezes": 400,
+        "desc": "直接打开背包而非通过快捷键",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    {
+                        "recognition": {
+                            "type": "TemplateMatch",
+                            "param": {
+                                "roi": [
+                                    -250,
+                                    0,
+                                    200,
+                                    200
+                                ],
+                                "template": [
+                                    "SceneManager/Backpack.png"
+                                ],
+                                "green_mask": true
+                            }
+                        }
+                    },
+                    {
+                        "recognition": {
+                            "type": "TemplateMatch",
+                            "param": {
+                                "roi": [
+                                    0,
+                                    0,
+                                    400,
+                                    80
+                                ],
+                                "template": [
+                                    "SceneManager/WorldDijiangMenu.png"
+                                ],
+                                "green_mask": true
+                            }
+                        }
+                    },
+                    {
+                        "recognition": {
+                            "type": "TemplateMatch",
+                            "param": {
+                                "roi": [
+                                    -200,
+                                    0,
+                                    200,
+                                    200
+                                ],
+                                "template": [
+                                    "SceneManager/WorldMenu.png"
+                                ],
+                                "green_mask": true
+                            }
+                        }
+                    }
+                ],
+                "box_index": 0
+            }
+        },
+        "pre_wait_freezes": {
+            "time": 400,
+            "target": [
+                900,
+                100,
+                250,
+                160
+            ]
+        },
+        "pre_delay": 0,
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "AutoAltClickAction"
+            }
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "ItemTransferStartOpenRepoSuccess"
+        ]
+    },
+    "ItemTransferStartOpenRepoSuccess": {
+        "recognition": "And",
+        "all_of": [
+            "InBackpack"
+        ],
+        "pre_wait_freezes": 200,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "ItemTransferInBackpack"
         ]
     },
     "ItemTransferInBackpack": {
         "desc": "当前在背包界面，开始转移任务",
+        "recognition": "And",
+        "all_of": [
+            "InBackpack"
+        ],
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "StashBackpackSubTask"
+                "ItemTransferStashBackpackSubTask"
             ]
         },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
             "ItemTransferSwitchRepoToOrigin"
+        ]
+    },
+    "ItemTransferStashBackpackSubTask": {
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "ItemTransferStashBackpackMain",
+            "EmptyNode"
+        ]
+    },
+    "ItemTransferStashBackpackMain": {
+        "desc": "保留整理背包功能，不复用通用整理背包传送兜底",
+        "enabled": false,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "StashBackpackEnterSuccess"
         ]
     },
     "ItemTransferSwitchRepoToOrigin": {

--- a/assets/tasks/ItemTransfer.json
+++ b/assets/tasks/ItemTransfer.json
@@ -3909,7 +3909,7 @@
                 {
                     "name": "Yes",
                     "pipeline_override": {
-                        "StashBackpackMain": {
+                        "ItemTransferStashBackpackMain": {
                             "enabled": true
                         }
                     },


### PR DESCRIPTION
## 概要
- 将库存转移开始阶段的背包入口从 `B` 快捷键改为识别并点击界面背包按钮。
- 进入库存转移的背包内流程前，增加 `InBackpack` 确认。
- 为库存转移拆出专用的整理背包入口，避免复用通用 `StashBackpackMain` 时触发传送兜底，从而导致存放结束后转移时不在会客室。

close #4007

## Summary by Sourcery

调整物品传输流程，通过 UI 交互打开背包，并添加状态校验，确保传输操作在正确的“身处背包界面”的上下文中执行。同时，将物品传输时使用的背包入口与通用的仓库背包入口区分开来，以避免不必要的传送保护机制被触发。

New Features:
- 引入一个专用的背包入口，用于通过点击 UI 背包按钮触发的物品传输操作，而不是使用快捷键 B。

Bug Fixes:
- 防止物品传输复用通用的仓库背包入口，以免触发传送回退逻辑，导致玩家在完成存储后被留在接待室之外。

Enhancements:
- 在物品传输流程进入背包逻辑之前，增加一个 InBackpack 确认步骤，以确保只有在玩家确实处于背包 UI 时，才会运行该流程管线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust item transfer flow to open the backpack via UI interaction and add state validation to ensure transfers occur from the correct in-backpack context, while separating the backpack entry used during item transfer from the generic stash backpack entry to avoid unintended teleport safeguards.

New Features:
- Introduce a dedicated backpack entry for item transfer operations triggered by clicking the UI backpack button instead of using the B hotkey.

Bug Fixes:
- Prevent item transfer from reusing the generic stash backpack entry that could trigger teleport fallbacks and leave the player outside the reception room after storage is completed.

Enhancements:
- Add an InBackpack confirmation step before entering the backpack flow during item transfer to ensure the pipeline runs only when the player is actually in the backpack UI.

</details>