### PR TITLE
fix: 修复每日任务校验与拍照流程

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,8 @@ on:
       - "assets/**"
       - "!assets/resource/model"
       - "tools/schema/**"
+      - "tools/validate_schema.py"
+      - "tools/pipeline-generate/EnvironmentMonitoring/routes.json"
       - "package.json"
       - "maatools.config.mts"
 
@@ -20,6 +22,8 @@ on:
       - "assets/**"
       - "!assets/resource/model"
       - "tools/schema/**"
+      - "tools/validate_schema.py"
+      - "tools/pipeline-generate/EnvironmentMonitoring/routes.json"
       - "package.json"
       - "maatools.config.mts"
 

--- a/agent/go-service/trialofswordmancy/action_test.go
+++ b/agent/go-service/trialofswordmancy/action_test.go
@@ -1,0 +1,42 @@
+package trialofswordmancy
+
+import (
+	"testing"
+
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/trialofswordmancy/solver"
+)
+
+func TestParseAbandCountExhaustedWithNumber(t *testing.T) {
+	text := "本日放弃次数已用完，继续放弃将会扣除1次奖励演算次数，是否确认放弃？"
+	if got := parseAbandCount(text); got != 0 {
+		t.Fatalf("parseAbandCount() = %d, want 0", got)
+	}
+}
+
+func TestParseFirstInt(t *testing.T) {
+	n, ok := parseFirstInt("abc12de34")
+	if !ok || n != 12 {
+		t.Fatalf("parseFirstInt() = %d, %v; want 12, true", n, ok)
+	}
+
+	if n, ok := parseFirstInt("无数字"); ok || n != 0 {
+		t.Fatalf("parseFirstInt(no digits) = %d, %v; want 0, false", n, ok)
+	}
+}
+
+func TestLoadOverflowModeInvalidFallback(t *testing.T) {
+	got := loadOverflowMode(`{"overflowMode":"OverflowTypo"}`)
+	if got != solver.OverflowNone {
+		t.Fatalf("loadOverflowMode(invalid) = %v, want %v", got, solver.OverflowNone)
+	}
+}
+
+func TestPickDecisionPrefersAbandonWhenCloseToDraw(t *testing.T) {
+	got := pickDecision([]solver.Outcome{
+		{Action: solver.DrawCard, Total: 10},
+		{Action: solver.Abandon, Total: 9.5},
+	})
+	if got != solver.Abandon {
+		t.Fatalf("pickDecision() = %v, want %v", got, solver.Abandon)
+	}
+}

--- a/agent/go-service/trialofswordmancy/action_test.go
+++ b/agent/go-service/trialofswordmancy/action_test.go
@@ -40,3 +40,34 @@ func TestPickDecisionPrefersAbandonWhenCloseToDraw(t *testing.T) {
 		t.Fatalf("pickDecision() = %v, want %v", got, solver.Abandon)
 	}
 }
+
+func TestPickDecisionPrefersAbandonOnTie(t *testing.T) {
+	got := pickDecision([]solver.Outcome{
+		{Action: solver.DrawCard, Total: 10},
+		{Action: solver.Abandon, Total: 10},
+	})
+	if got != solver.Abandon {
+		t.Fatalf("pickDecision(tie) = %v, want %v", got, solver.Abandon)
+	}
+}
+
+func TestPickDecisionPrefersDrawWhenAbandonMuchWorse(t *testing.T) {
+	got := pickDecision([]solver.Outcome{
+		{Action: solver.DrawCard, Total: 10},
+		{Action: solver.Abandon, Total: 5},
+	})
+	if got != solver.DrawCard {
+		t.Fatalf("pickDecision(large gap) = %v, want %v", got, solver.DrawCard)
+	}
+}
+
+func TestPickDecisionWithMultipleOutcomes(t *testing.T) {
+	got := pickDecision([]solver.Outcome{
+		{Action: solver.DrawCard, Total: 10},
+		{Action: solver.Abandon, Total: 9.5},
+		{Action: solver.Calculate, Total: 12},
+	})
+	if got != solver.Calculate {
+		t.Fatalf("pickDecision(multiple outcomes) = %v, want %v", got, solver.Calculate)
+	}
+}

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -1046,6 +1046,7 @@
     "task.BatchUseDetector.option.Category.Compass": "Compass",
     "task.BatchUseDetector.option.Times.label": "Use Count",
     "task.BatchUseDetector.option.Times.input.label": "Count",
+    "task.BatchUseDetector.option.Times.input.error": "Enter a valid count.",
     "task.ResourceRecycleStation.label": "🦉Resource Recycle Station",
     "task.ResourceRecycleStation.description": "Automatically collect resources from Resource Recycle Stations in Wuling and Valley IV",
     "option.ResourceRecycleStationRegion.label": "Collect Region",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -1046,6 +1046,7 @@
     "task.BatchUseDetector.option.Category.Compass": "コンパス",
     "task.BatchUseDetector.option.Times.label": "使用回数",
     "task.BatchUseDetector.option.Times.input.label": "回数",
+    "task.BatchUseDetector.option.Times.input.error": "有効な回数を入力してください。",
     "task.ResourceRecycleStation.label": "🦉資源回収ステーション",
     "task.ResourceRecycleStation.description": "武陵と四号谷地の資源回収ステーションから自動的に収集します",
     "option.ResourceRecycleStationRegion.label": "収集地域",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -1046,6 +1046,7 @@
     "task.BatchUseDetector.option.Category.Compass": "나침반",
     "task.BatchUseDetector.option.Times.label": "사용 횟수",
     "task.BatchUseDetector.option.Times.input.label": "횟수",
+    "task.BatchUseDetector.option.Times.input.error": "유효한 횟수를 입력하세요.",
     "task.ResourceRecycleStation.label": "🦉자원 재활용 스테이션",
     "task.ResourceRecycleStation.description": "무릉과 4호 계곡의 자원 재활용 스테이션에서 자동으로 수집합니다",
     "option.ResourceRecycleStationRegion.label": "수집 지역",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -1046,6 +1046,7 @@
     "task.BatchUseDetector.option.Category.Compass": "罗盘",
     "task.BatchUseDetector.option.Times.label": "使用次数",
     "task.BatchUseDetector.option.Times.input.label": "次数",
+    "task.BatchUseDetector.option.Times.input.error": "请输入有效次数。",
     "task.ResourceRecycleStation.label": "🦉资源回收站",
     "task.ResourceRecycleStation.description": "自动收取武陵和四号谷地的资源回收站物资",
     "option.ResourceRecycleStationRegion.label": "收取地区",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -1046,6 +1046,7 @@
     "task.BatchUseDetector.option.Category.Compass": "羅盤",
     "task.BatchUseDetector.option.Times.label": "使用次數",
     "task.BatchUseDetector.option.Times.input.label": "次數",
+    "task.BatchUseDetector.option.Times.input.error": "請輸入有效次數。",
     "task.ResourceRecycleStation.label": "🦉資源回收站",
     "task.ResourceRecycleStation.description": "自動收取武陵和四號谷地的資源回收站物資",
     "option.ResourceRecycleStationRegion.label": "收取地區",

--- a/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
@@ -85,7 +85,8 @@
         "next": [
             "EnvironmentMonitoringShutterButtonHighlighted",
             "EnvironmentMonitoringShutterButtonPhotographyTarget",
-            "[JumpBack][Anchor]EnvironmentMonitoringAdjustCamera"
+            "[JumpBack][Anchor]EnvironmentMonitoringAdjustCamera",
+            "EnvironmentMonitoringTakePhoto"
         ]
     },
     "EnvironmentMonitoringCheckPhotographyTarget": {

--- a/tools/schema/custom.action.schema.json
+++ b/tools/schema/custom.action.schema.json
@@ -193,6 +193,32 @@
                                     "properties": {
                                         "custom_action_param": { "$ref": "./components/auto_alt.schema.json#/$defs/AutoAltSwipeParam" }
                                     }
+                                },
+                                "else": {
+                                    "if": {
+                                        "type": "object",
+                                        "required": [ "custom_action" ],
+                                        "properties": { "custom_action": { "const": "TrialOfSwordmancy.Decide" } }
+                                    },
+                                    "then": {
+                                        "type": "object",
+                                        "required": [ "custom_action_param" ],
+                                        "properties": {
+                                            "custom_action_param": {
+                                                "type": "object",
+                                                "required": [ "overflowMode" ],
+                                                "properties": {
+                                                    "overflowMode": {
+                                                        "enum": [
+                                                            "OverflowNone",
+                                                            "OverflowOnce",
+                                                            "OverflowTwice"
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/tools/validate_schema.py
+++ b/tools/validate_schema.py
@@ -245,6 +245,13 @@ def main():
         default=[],
         help="Directories containing task files to validate against interface_import.schema.json (default: none)",
     )
+    parser.add_argument(
+        "--environment-monitoring-routes-files",
+        type=str,
+        nargs="*",
+        default=["tools/pipeline-generate/EnvironmentMonitoring/routes.json"],
+        help="Path to EnvironmentMonitoring routes.json files (default: tools/pipeline-generate/EnvironmentMonitoring/routes.json)",
+    )
 
     args = parser.parse_args()
 
@@ -369,6 +376,30 @@ def main():
         else:
             print(
                 f"Warning: Task schema {task_schema_path} does not exist, skipping task validation..."
+            )
+
+    if args.environment_monitoring_routes_files:
+        print("\nValidating EnvironmentMonitoring routes files...")
+        routes_schema_path = schema_dir / "environment_monitoring_routes.schema.json"
+        if routes_schema_path.exists():
+            routes_schema = load_jsonc(routes_schema_path)
+            routes_schema_uri = routes_schema_path.as_uri()
+            schema_store[routes_schema_uri] = routes_schema
+
+            routes_validator = create_validator(routes_schema, schema_store)
+
+            for routes_file in args.environment_monitoring_routes_files:
+                routes_path = Path(routes_file)
+                if routes_path.exists():
+                    if not validate_file(routes_path, routes_validator):
+                        all_valid = False
+                else:
+                    print(
+                        f"Warning: EnvironmentMonitoring routes file {routes_file} does not exist, skipping..."
+                    )
+        else:
+            print(
+                f"Warning: EnvironmentMonitoring routes schema {routes_schema_path} does not exist, skipping routes validation..."
             )
 
     if all_valid:

--- a/tools/validate_schema.py
+++ b/tools/validate_schema.py
@@ -248,9 +248,9 @@ def main():
     parser.add_argument(
         "--environment-monitoring-routes-files",
         type=str,
-        nargs="*",
+        nargs="+",
         default=["tools/pipeline-generate/EnvironmentMonitoring/routes.json"],
-        help="Path to EnvironmentMonitoring routes.json files (default: tools/pipeline-generate/EnvironmentMonitoring/routes.json)",
+        help="Path(s) to EnvironmentMonitoring routes.json files (default: tools/pipeline-generate/EnvironmentMonitoring/routes.json)",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## 概要
- 修正环境监测进入拍照模式的按键释放节点，并在等待快门失败时回到已有拍照入口流程兜底。
- 为 `TrialOfSwordmancy.Decide` 补充 `overflowMode` 参数 schema，并增加选剑演武解析/决策边界测试。
- 将环境监测 `routes.json` 接入 schema 校验；同时补齐 BatchUseDetector 次数输入错误文案。

## 验证
- `go test ./trialofswordmancy`
- `node --test tools/pipeline-generate/SellProduct/data.test.mjs`
- `python tools/validate_schema.py --resource-dirs assets/resource assets/resource_adb --exclude-dirs assets/resource/gamedata assets/resource/image assets/resource/model assets/resource_adb/image assets/resource_adb/model --task-dirs assets/tasks`
- `gofmt -l agent/go-service/trialofswordmancy/action_test.go`
- `git diff --check`
- 已打本地 Windows 验证包，并实际运行今日任务通过。

## 说明
- 本 PR 不改变选剑演武的抽牌/放弃策略，只补 schema 与测试覆盖。