### PR TITLE
补充自定义动作参数的静态校验

### DIFF
--- a/tools/schema/components/map_tracker.schema.json
+++ b/tools/schema/components/map_tracker.schema.json
@@ -38,6 +38,178 @@
             "maxItems": 4,
             "items": false
         },
+        "MapNavigateActionType": {
+            "type": "string",
+            "description": "Semantic action tokens accepted by MapNavigateAction waypoints.",
+            "enum": [
+                "RUN",
+                "SPRINT",
+                "JUMP",
+                "FIGHT",
+                "INTERACT",
+                "TRANSFER",
+                "PORTAL",
+                "HEADING",
+                "NAVMESH",
+                "ZONE",
+                "COLLECT",
+                "DIG"
+            ]
+        },
+        "MapNavigateActionList": {
+            "anyOf": [
+                { "$ref": "#/$defs/MapNavigateActionType" },
+                {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "$ref": "#/$defs/MapNavigateActionType" }
+                }
+            ]
+        },
+        "MapNavigateWaypointArray": {
+            "type": "array",
+            "description": "MapNavigateAction tuple waypoint: [x, y, optional actions / strict flag / zone id].",
+            "prefixItems": [
+                { "type": "number" },
+                { "type": "number" }
+            ],
+            "minItems": 2,
+            "items": {
+                "anyOf": [
+                    { "$ref": "#/$defs/MapNavigateActionList" },
+                    { "type": "boolean" },
+                    { "type": "string" }
+                ]
+            }
+        },
+        "MapNavigateWaypointObject": {
+            "type": "object",
+            "description": "MapNavigateAction object waypoint, including ZONE, HEADING and NAVMESH semantic nodes.",
+            "additionalProperties": false,
+            "properties": {
+                "action": { "$ref": "#/$defs/MapNavigateActionType" },
+                "actions": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "$ref": "#/$defs/MapNavigateActionType" }
+                },
+                "zone_id": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "zoneId": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "zone": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "map_name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "mapName": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "target_tier": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "targetTier": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "strict": { "type": "boolean" },
+                "strict_arrival": { "type": "boolean" },
+                "strictArrival": { "type": "boolean" },
+                "x": { "type": "number" },
+                "y": { "type": "number" },
+                "angle": { "type": "number" },
+                "heading": { "type": "number" },
+                "yaw": { "type": "number" },
+                "target": { "$ref": "#/$defs/Coordinate2D" }
+            },
+            "anyOf": [
+                { "required": [ "action" ] },
+                { "required": [ "actions" ] },
+                { "required": [ "x", "y" ] },
+                { "required": [ "angle" ] },
+                { "required": [ "heading" ] },
+                { "required": [ "yaw" ] },
+                { "required": [ "target" ] },
+                { "required": [ "zone_id" ] },
+                { "required": [ "zoneId" ] },
+                { "required": [ "zone" ] },
+                { "required": [ "map_name" ] },
+                { "required": [ "mapName" ] }
+            ]
+        },
+        "MapNavigateParam": {
+            "type": "object",
+            "description": "Parameters for MapNavigateAction, parsed by agent/cpp-algo/source/MapNavigator/navi_param_parser.cpp.",
+            "additionalProperties": false,
+            "properties": {
+                "map_name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "path": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "anyOf": [
+                            { "$ref": "#/$defs/MapNavigateWaypointArray" },
+                            { "$ref": "#/$defs/MapNavigateWaypointObject" }
+                        ]
+                    }
+                },
+                "arrival_timeout": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 60000
+                },
+                "sprint_threshold": {
+                    "type": "number",
+                    "minimum": 0,
+                    "default": 16
+                },
+                "enable_local_driver": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "navmesh_file": { "type": "string" },
+                "nav_file": { "type": "string" },
+                "navmesh_snap_radius": {
+                    "type": "number",
+                    "minimum": 0,
+                    "default": 5
+                },
+                "snap_radius": {
+                    "type": "number",
+                    "minimum": 0,
+                    "default": 5
+                },
+                "navmesh_max_cost": {
+                    "type": "number",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "action": { "$ref": "#/$defs/MapNavigateActionType" },
+                "actions": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "$ref": "#/$defs/MapNavigateActionType" }
+                },
+                "x": { "type": "number" },
+                "y": { "type": "number" },
+                "angle": { "type": "number" },
+                "heading": { "type": "number" },
+                "yaw": { "type": "number" },
+                "target": { "$ref": "#/$defs/Coordinate2D" }
+            }
+        },
         "LocationCondition": {
             "type": "object",
             "description": "A single map location condition: map_name + bounding box.",

--- a/tools/schema/custom.action.schema.json
+++ b/tools/schema/custom.action.schema.json
@@ -91,6 +91,44 @@
             ]
         }
     },
+    "allOf": [
+        {
+            "if": {
+                "type": "object",
+                "required": [ "custom_action" ],
+                "properties": { "custom_action": { "const": "MapNavigateAction" } }
+            },
+            "then": {
+                "type": "object",
+                "required": [ "custom_action_param" ],
+                "properties": { "custom_action_param": { "$ref": "./components/map_tracker.schema.json#/$defs/MapNavigateParam" } }
+            }
+        },
+        {
+            "if": {
+                "type": "object",
+                "required": [ "custom_action" ],
+                "properties": { "custom_action": { "const": "ClearHitCount" } }
+            },
+            "then": {
+                "type": "object",
+                "required": [ "custom_action_param" ],
+                "properties": {
+                    "custom_action_param": {
+                        "type": "object",
+                        "required": [ "nodes" ],
+                        "properties": {
+                            "nodes": {
+                                "type": "array",
+                                "items": { "type": "string" }
+                            },
+                            "strict": { "type": "boolean" }
+                        }
+                    }
+                }
+            }
+        }
+    ],
     "if": {
         "type": "object",
         "required": [ "custom_action" ],


### PR DESCRIPTION
## 变更内容
- 为 MapNavigateAction 增加 custom_action_param 的 schema 定义，覆盖 path、单点参数、导航动作、navmesh 和超时等字段。
- 为 ClearHitCount 增加 nodes / strict 参数校验。

## 影响
- 不改变运行逻辑，只让现有 pipeline 的参数形状能在静态校验阶段被检查。

## 验证
- python -m json.tool tools/schema/custom.action.schema.json
- python -m json.tool tools/schema/components/map_tracker.schema.json
- git diff --check
- tools/validate_schema.py --resource-dirs assets/resource assets/resource_adb --exclude-dirs assets/resource/gamedata assets/resource/image assets/resource/model assets/resource_adb/image assets/resource_adb/model --task-dirs assets/tasks

## Summary by Sourcery

为地图导航和命中次数清零组件中的自定义动作参数添加静态模式验证。

新功能：
- 为 `MapNavigateAction.custom_action_param` 定义模式，涵盖路径、单点参数、导航动作、导航网格（navmesh）以及超时字段。

增强：
- 通过为节点和严格选项添加模式检查，收紧对 `ClearHitCount` 的参数验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add static schema validation for custom action parameters in map navigation and hit count clearing components.

New Features:
- Define schema for MapNavigateAction.custom_action_param covering path, single-point parameters, navigation actions, navmesh and timeout fields.

Enhancements:
- Tighten parameter validation for ClearHitCount by adding schema checks for nodes and strict options.

</details>