### PR TITLE
修复 SubTask 继续执行时可能访问空结果

### DIFF
--- a/agent/go-service/common/subtask/action.go
+++ b/agent/go-service/common/subtask/action.go
@@ -117,6 +117,7 @@ func (a *SubTaskAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 			if !continueOnSubFailure {
 				break
 			}
+			continue
 		}
 
 		if !detail.Status.Success() {


### PR DESCRIPTION
## 变更内容
- 当 SubTask 子任务运行失败且 detail 为空时，如果配置了 continue: true，记录失败后直接进入下一个子任务。

## 原因
- 原代码在 err != nil 或 detail == nil 后，continue: true 的场景会继续执行 detail.Status.Success()；detail 为空时可能触发空指针访问。

## 影响
- 不改变 SubTask 的成功/失败判定，只避免已经失败的空结果继续被读取。

## 验证
- gofmt -w common/subtask/action.go
- go test ./common/subtask（使用仓库内 GOCACHE）
- git diff --check

## Summary by Sourcery

当启用了在子任务失败后继续执行下一子任务的功能时，通过在记录到失败子任务后跳过后续处理，避免在失败后访问子任务执行结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Avoid accessing subtask execution results after a failure when continuing to the next subtask is enabled by skipping further processing once a failed subtask is recorded.

</details>