### PR TITLE
让格式检查覆盖 jsonc 文件

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "format": "prettier --write \"**/*.{json,jsonc,yml,yaml,md}\"",
         "format:aggressive": "prettier --print-width 20 --write \"assets/resource/pipeline/**/*.json\" && prettier --write \"assets/resource/pipeline/**/*.json\"",
-        "format:check": "prettier --check \"**/*.{json,yml,yaml,md}\"",
+        "format:check": "prettier --check \"**/*.{json,jsonc,yml,yaml,md}\"",
         "format:go": "cd agent/go-service && go fmt ./...",
         "format:all": "pnpm format && pnpm format:go",
         "check": "maa-tools check",


### PR DESCRIPTION
## 变更内容
- 将 package.json 里的 format:check 范围从 json/yml/yaml/md 扩展为 json/jsonc/yml/yaml/md。

## 原因
- format 脚本已经覆盖 jsonc，但 format:check 没覆盖。
- 仓库中存在 tools/pipeline-generate/SellProduct/*.jsonc 模板文件。

## 影响
- 不改变程序逻辑，只让检查命令覆盖现有 jsonc 模板。

## 验证
- git diff --check
- node_modules/.bin/prettier.cmd --write package.json
- pnpm run format:check