### PR TITLE
修正 SellProduct 英文维护文档的自检路径

### DIFF
--- a/docs/en_us/developers/tasks/sell-product-maintain.md
+++ b/docs/en_us/developers/tasks/sell-product-maintain.md
@@ -491,7 +491,7 @@ After modifying the generator or data, it is recommended to execute:
 
 ```shell
 pnpm generate:SellProduct
-pnpm prettier --write "docs/zh_cn/developers/tasks/sell-product-maintain.md" "docs/zh_cn/developers/README.md"
+pnpm prettier --write "docs/en_us/developers/tasks/sell-product-maintain.md" "docs/en_us/developers/README.md"
 ```
 
 If the Go matching logic was modified:


### PR DESCRIPTION
## 变更内容
- 将英文 SellProduct 维护文档自检命令中的 docs/zh_cn 路径改为 docs/en_us 路径。

## 影响
- docs-only，不改变程序逻辑。

## 验证
- node_modules/.bin/prettier.cmd --check docs/en_us/developers/tasks/sell-product-maintain.md
- git diff --check

## Summary by Sourcery

文档：
- 更正 SellProduct 英文维护指南中的 Prettier 命令路径，将 `docs/zh_cn` 改为 `docs/en_us`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the Prettier command paths in the SellProduct English maintenance guide to use docs/en_us instead of docs/zh_cn.

</details>