### PR TITLE
修复环境监测拍照目标未达成后的重试流程

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
@@ -85,7 +85,8 @@
         "next": [
             "EnvironmentMonitoringShutterButtonHighlighted",
             "EnvironmentMonitoringShutterButtonPhotographyTarget",
-            "[JumpBack][Anchor]EnvironmentMonitoringAdjustCamera"
+            "[JumpBack][Anchor]EnvironmentMonitoringAdjustCamera",
+            "EnvironmentMonitoringTakePhoto"
         ]
     },
     "EnvironmentMonitoringCheckPhotographyTarget": {


### PR DESCRIPTION
## 变更内容
- 在环境监测拍照等待节点中，目标未达成且回到调整相机仍未命中时，重新进入拍照流程。

## 影响
- 只改环境监测拍照流程，不包含选剑演武、schema 或文案改动。

## 验证
- pnpm run check
- git diff --check

## Summary by Sourcery

Bug Fixes:
- 确保在从相机调整界面返回后，当目标仍未满足时，环境监测拍照流程能正确重试拍摄过程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the environment monitoring photo flow correctly retries the shooting process when the target remains unmet after returning from camera adjustment.

</details>