### PR TITLE
补充选剑演武决策辅助测试

### DIFF
--- a/agent/go-service/trialofswordmancy/action_test.go
+++ b/agent/go-service/trialofswordmancy/action_test.go
@@ -1,0 +1,73 @@
+package trialofswordmancy
+
+import (
+	"testing"
+
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/trialofswordmancy/solver"
+)
+
+func TestParseAbandCountExhaustedWithNumber(t *testing.T) {
+	text := "本日放弃次数已用完，继续放弃将会扣除1次奖励演算次数，是否确认放弃？"
+	if got := parseAbandCount(text); got != 0 {
+		t.Fatalf("parseAbandCount() = %d, want 0", got)
+	}
+}
+
+func TestParseFirstInt(t *testing.T) {
+	n, ok := parseFirstInt("abc12de34")
+	if !ok || n != 12 {
+		t.Fatalf("parseFirstInt() = %d, %v; want 12, true", n, ok)
+	}
+
+	if n, ok := parseFirstInt("无数字"); ok || n != 0 {
+		t.Fatalf("parseFirstInt(no digits) = %d, %v; want 0, false", n, ok)
+	}
+}
+
+func TestLoadOverflowModeInvalidFallback(t *testing.T) {
+	got := loadOverflowMode(`{"overflowMode":"OverflowTypo"}`)
+	if got != solver.OverflowNone {
+		t.Fatalf("loadOverflowMode(invalid) = %v, want %v", got, solver.OverflowNone)
+	}
+}
+
+func TestPickDecisionPrefersAbandonWhenCloseToDraw(t *testing.T) {
+	got := pickDecision([]solver.Outcome{
+		{Action: solver.DrawCard, Total: 10},
+		{Action: solver.Abandon, Total: 9.5},
+	})
+	if got != solver.Abandon {
+		t.Fatalf("pickDecision() = %v, want %v", got, solver.Abandon)
+	}
+}
+
+func TestPickDecisionPrefersAbandonOnTie(t *testing.T) {
+	got := pickDecision([]solver.Outcome{
+		{Action: solver.DrawCard, Total: 10},
+		{Action: solver.Abandon, Total: 10},
+	})
+	if got != solver.Abandon {
+		t.Fatalf("pickDecision(tie) = %v, want %v", got, solver.Abandon)
+	}
+}
+
+func TestPickDecisionPrefersDrawWhenAbandonMuchWorse(t *testing.T) {
+	got := pickDecision([]solver.Outcome{
+		{Action: solver.DrawCard, Total: 10},
+		{Action: solver.Abandon, Total: 5},
+	})
+	if got != solver.DrawCard {
+		t.Fatalf("pickDecision(large gap) = %v, want %v", got, solver.DrawCard)
+	}
+}
+
+func TestPickDecisionWithMultipleOutcomes(t *testing.T) {
+	got := pickDecision([]solver.Outcome{
+		{Action: solver.DrawCard, Total: 10},
+		{Action: solver.Abandon, Total: 9.5},
+		{Action: solver.Calculate, Total: 12},
+	})
+	if got != solver.Calculate {
+		t.Fatalf("pickDecision(multiple outcomes) = %v, want %v", got, solver.Calculate)
+	}
+}


### PR DESCRIPTION
## 背景

选剑演武里有几段容易被误改的辅助逻辑：放弃次数文字解析、非法 `overflowMode` 的回退，以及“抽牌/放弃/开始演算”的选择规则。

这个 PR 只补测试，把现有行为固定下来。

## 改动

- 覆盖“放弃次数已用完”提示的解析结果。
- 覆盖文本取第一个数字的行为。
- 覆盖非法 `overflowMode` 回退到默认值。
- 覆盖现有决策规则：接近或并列时放弃，抽牌明显更好时抽牌，演算明显更好时演算。

## 验证

- `pnpm run check`
- `tools/validate_schema.py --resource-dirs assets/resource --exclude-dirs assets/resource/gamedata assets/resource/image assets/resource/model --task-dirs assets/tasks`
- `go test ./trialofswordmancy`
- `git diff --check`
