### PR TITLE
fix(ItemTransfer): 补充覆盖项中的 max_distance 参数

### DIFF
--- a/assets/tasks/ItemTransfer.json
+++ b/assets/tasks/ItemTransfer.json
@@ -144,17 +144,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 103
+                                "target_class": 103,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 103
+                                "target_class": 103,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 103
+                                "target_class": 103,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -186,17 +189,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 74,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 74
+                                "target_class": 74,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 74
+                                "target_class": 74,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -219,17 +225,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 14
+                                "target_class": 14,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 14
+                                "target_class": 14,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 14
+                                "target_class": 14,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -252,17 +261,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 166
+                                "target_class": 166,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 166
+                                "target_class": 166,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 166
+                                "target_class": 166,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -285,17 +297,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 86
+                                "target_class": 86,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 86
+                                "target_class": 86,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 86
+                                "target_class": 86,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -318,17 +333,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 126
+                                "target_class": 126,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 126
+                                "target_class": 126,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 126
+                                "target_class": 126,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -351,17 +369,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 76
+                                "target_class": 76,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 76
+                                "target_class": 76,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 76
+                                "target_class": 76,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -384,17 +405,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 165
+                                "target_class": 165,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 165
+                                "target_class": 165,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 165
+                                "target_class": 165,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -417,17 +441,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 85
+                                "target_class": 85,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 85
+                                "target_class": 85,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 85
+                                "target_class": 85,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -450,17 +477,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 125
+                                "target_class": 125,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 125
+                                "target_class": 125,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 125
+                                "target_class": 125,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -483,17 +513,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 75
+                                "target_class": 75,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 75
+                                "target_class": 75,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 75
+                                "target_class": 75,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -516,17 +549,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 128
+                                "target_class": 128,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 128
+                                "target_class": 128,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 128
+                                "target_class": 128,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -549,17 +585,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 144
+                                "target_class": 144,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 144
+                                "target_class": 144,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 144
+                                "target_class": 144,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -582,17 +621,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 122
+                                "target_class": 122,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 122
+                                "target_class": 122,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 122
+                                "target_class": 122,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -615,17 +657,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 119
+                                "target_class": 119,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 119
+                                "target_class": 119,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 119
+                                "target_class": 119,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -648,17 +693,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 175
+                                "target_class": 175,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 175
+                                "target_class": 175,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 175
+                                "target_class": 175,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -681,17 +729,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 172
+                                "target_class": 172,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 172
+                                "target_class": 172,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 172
+                                "target_class": 172,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -714,17 +765,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 160
+                                "target_class": 160,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 160
+                                "target_class": 160,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 160
+                                "target_class": 160,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -747,17 +801,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 161
+                                "target_class": 161,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 161
+                                "target_class": 161,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 161
+                                "target_class": 161,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -780,17 +837,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 89
+                                "target_class": 89,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 89
+                                "target_class": 89,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 89
+                                "target_class": 89,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -813,17 +873,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 88
+                                "target_class": 88,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 88
+                                "target_class": 88,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 88
+                                "target_class": 88,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -846,17 +909,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 191
+                                "target_class": 191,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 191
+                                "target_class": 191,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 191
+                                "target_class": 191,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -879,17 +945,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 58
+                                "target_class": 58,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 58
+                                "target_class": 58,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 58
+                                "target_class": 58,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -912,17 +981,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 56
+                                "target_class": 56,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 56
+                                "target_class": 56,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 56
+                                "target_class": 56,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -945,17 +1017,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 51
+                                "target_class": 51,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 51
+                                "target_class": 51,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 51
+                                "target_class": 51,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -978,17 +1053,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 134
+                                "target_class": 134,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 134
+                                "target_class": 134,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 134
+                                "target_class": 134,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1011,17 +1089,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 133
+                                "target_class": 133,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 133
+                                "target_class": 133,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 133
+                                "target_class": 133,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1061,17 +1142,20 @@
                         },
                         "ItemTransferFindItemWithOCR": {
                             "custom_action_param": {
-                                "item_name": "壤晶"
+                                "item_name": "壤晶",
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemWithOCRBag": {
                             "custom_action_param": {
-                                "item_name": "壤晶"
+                                "item_name": "壤晶",
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemWithOCRBagReturn": {
                             "custom_action_param": {
-                                "item_name": "壤晶"
+                                "item_name": "壤晶",
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1259,17 +1343,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 169
+                                "target_class": 169,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 169
+                                "target_class": 169,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 169
+                                "target_class": 169,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1501,17 +1588,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 28
+                                "target_class": 28,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 28
+                                "target_class": 28,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 28
+                                "target_class": 28,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1543,17 +1633,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 96,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 96
+                                "target_class": 96,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 96
+                                "target_class": 96,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1576,17 +1669,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 111
+                                "target_class": 111,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 111
+                                "target_class": 111,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 111
+                                "target_class": 111,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1609,17 +1705,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 112
+                                "target_class": 112,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 112
+                                "target_class": 112,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 112
+                                "target_class": 112,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1642,17 +1741,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 118
+                                "target_class": 118,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 118
+                                "target_class": 118,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 118
+                                "target_class": 118,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1708,17 +1810,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 115
+                                "target_class": 115,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 115
+                                "target_class": 115,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 115
+                                "target_class": 115,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1741,17 +1846,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 117
+                                "target_class": 117,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 117
+                                "target_class": 117,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 117
+                                "target_class": 117,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1774,17 +1882,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 116
+                                "target_class": 116,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 116
+                                "target_class": 116,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 116
+                                "target_class": 116,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1807,17 +1918,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 162
+                                "target_class": 162,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 162
+                                "target_class": 162,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 162
+                                "target_class": 162,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1840,17 +1954,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 90
+                                "target_class": 90,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 90
+                                "target_class": 90,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 90
+                                "target_class": 90,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1884,17 +2001,20 @@
                         },
                         "ItemTransferFindItemWithOCR": {
                             "custom_action_param": {
-                                "item_name": "赤铜粉末"
+                                "item_name": "赤铜粉末",
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemWithOCRBag": {
                             "custom_action_param": {
-                                "item_name": "赤铜粉末"
+                                "item_name": "赤铜粉末",
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemWithOCRBagReturn": {
                             "custom_action_param": {
-                                "item_name": "赤铜粉末"
+                                "item_name": "赤铜粉末",
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1917,17 +2037,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 142
+                                "target_class": 142,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 142
+                                "target_class": 142,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 142
+                                "target_class": 142,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -1983,17 +2106,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 53
+                                "target_class": 53,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 53
+                                "target_class": 53,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 53
+                                "target_class": 53,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -2025,17 +2151,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 93,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 93
+                                "target_class": 93,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 93
+                                "target_class": 93,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -2058,17 +2187,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 73
+                                "target_class": 73,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 73
+                                "target_class": 73,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 73
+                                "target_class": 73,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -2217,17 +2349,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 52,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 52
+                                "target_class": 52,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 52
+                                "target_class": 52,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -2403,17 +2538,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 42,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 42
+                                "target_class": 42,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 42
+                                "target_class": 42,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -2487,17 +2625,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 143,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 143
+                                "target_class": 143,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 143
+                                "target_class": 143,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3051,17 +3192,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 129
+                                "target_class": 129,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 129
+                                "target_class": 129,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 129
+                                "target_class": 129,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3084,17 +3228,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 145
+                                "target_class": 145,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 145
+                                "target_class": 145,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 145
+                                "target_class": 145,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3117,17 +3264,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 123
+                                "target_class": 123,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 123
+                                "target_class": 123,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 123
+                                "target_class": 123,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3150,17 +3300,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 176
+                                "target_class": 176,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 176
+                                "target_class": 176,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 176
+                                "target_class": 176,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3183,17 +3336,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 59
+                                "target_class": 59,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 59
+                                "target_class": 59,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 59
+                                "target_class": 59,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3216,17 +3372,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 135
+                                "target_class": 135,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 135
+                                "target_class": 135,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 135
+                                "target_class": 135,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3249,17 +3408,20 @@
                         },
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
-                                "target_class": 36
+                                "target_class": 36,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 36
+                                "target_class": 36,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 36
+                                "target_class": 36,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3293,17 +3455,20 @@
                         },
                         "ItemTransferFindItemWithOCR": {
                             "custom_action_param": {
-                                "item_name": "回响秘剂"
+                                "item_name": "回响秘剂",
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemWithOCRBag": {
                             "custom_action_param": {
-                                "item_name": "回响秘剂"
+                                "item_name": "回响秘剂",
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemWithOCRBagReturn": {
                             "custom_action_param": {
-                                "item_name": "回响秘剂"
+                                "item_name": "回响秘剂",
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3344,17 +3509,20 @@
                         "ItemTransferFindItemWithOCR": {
                             "custom_action_param": {
                                 "item_name": "优质芽针针剂",
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemWithOCRBag": {
                             "custom_action_param": {
-                                "item_name": "优质芽针针剂"
+                                "item_name": "优质芽针针剂",
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemWithOCRBagReturn": {
                             "custom_action_param": {
-                                "item_name": "优质芽针针剂"
+                                "item_name": "优质芽针针剂",
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3386,17 +3554,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 124,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 124
+                                "target_class": 124,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 124
+                                "target_class": 124,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3428,17 +3599,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 102,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 102
+                                "target_class": 102,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 102
+                                "target_class": 102,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3470,17 +3644,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 6,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 6
+                                "target_class": 6,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 6
+                                "target_class": 6,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3512,17 +3689,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 131,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 131
+                                "target_class": 131,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 131
+                                "target_class": 131,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3563,17 +3743,20 @@
                         "ItemTransferFindItemWithOCR": {
                             "custom_action_param": {
                                 "item_name": "优质锦草软饮",
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemWithOCRBag": {
                             "custom_action_param": {
-                                "item_name": "优质锦草软饮"
+                                "item_name": "优质锦草软饮",
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemWithOCRBagReturn": {
                             "custom_action_param": {
-                                "item_name": "优质锦草软饮"
+                                "item_name": "优质锦草软饮",
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3605,17 +3788,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 177,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 177
+                                "target_class": 177,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 177
+                                "target_class": 177,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3647,17 +3833,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 100,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 100
+                                "target_class": 100,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 100
+                                "target_class": 100,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3689,17 +3878,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 5,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 5
+                                "target_class": 5,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 5
+                                "target_class": 5,
+                                "max_distance": 1
                             }
                         }
                     }
@@ -3731,17 +3923,20 @@
                         "ItemTransferFindItemFallback": {
                             "custom_action_param": {
                                 "target_class": 60,
-                                "descending": true
+                                "descending": true,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBag": {
                             "custom_action_param": {
-                                "target_class": 60
+                                "target_class": 60,
+                                "max_distance": 1
                             }
                         },
                         "ItemTransferFindItemFallbackBagReturn": {
                             "custom_action_param": {
-                                "target_class": 60
+                                "target_class": 60,
+                                "max_distance": 1
                             }
                         }
                     }


### PR DESCRIPTION
## 概要

- 修复 ItemTransfer 物品级 `pipeline_override` 覆盖 `custom_action_param` 后丢失 `max_distance` 的问题
- 为无编辑距离 <= 1 相邻物品风险的查找覆盖项补充 `max_distance: 1`
- 避免 OCR/fallback 查找时因覆盖行为未回退到默认距离=1（实际为0），导致因OCR识别误差，进一步导致物品未匹配
- 存在距离=1物品不做此次补充，避免OCR误匹配

## 未修改物品
赤铜矿 <-> 赤铜瓶 <-> 赤铜块 <-> 赫铜块 <-> 赫铜瓶
蓝铁矿 <-> 蓝铁瓶 <-> 蓝铁块
重息壤 <-> 息壤
高晶质瓶 <-> 紫晶质瓶
钢块 <-> 碳块
高晶纤维 <-> 紫晶纤维
高晶粉末 <-> 紫晶粉末
赫铜装备原件 <-> 赤铜装备原件
高晶装备原件 <-> 紫晶装备原件
赫铜零件 <-> 赤铜零件
钢制零件 <-> 铁制零件
高晶零件 <-> 紫晶零件
中容武陵电池 <-> 低容武陵电池
高容谷地电池 <-> 中容谷地电池 <-> 低容谷地电池


Close #3869 
Close #3205 

## Summary by Sourcery

调整 ItemTransfer 任务配置，以恢复并统一针对被重写的物品转移规则中 `max_distance` 的处理方式。

Bug 修复：
- 修复在 `ItemTransfer` 中 `pipeline_override` 覆盖 `custom_action_param` 时导致 `max_distance` 丢失的问题，该问题会阻止 OCR 相关查询中的正确回退匹配。

功能增强：
- 为部分 `ItemTransfer` 覆盖条目显式添加 `max_distance: 1`，以支持近距离匹配；同时保持已知存在歧义的条目不变，以避免 OCR 误匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust ItemTransfer task configuration to restore and standardize max_distance handling for overridden item transfer rules.

Bug Fixes:
- Fix loss of max_distance when ItemTransfer pipeline_override overwrites custom_action_param, preventing correct fallback matching in OCR-related lookups.

Enhancements:
- Add explicit max_distance: 1 to selected ItemTransfer override entries that should allow near-distance matching while leaving known ambiguous items unchanged to avoid OCR mis-matches.

</details>