### PR TITLE
Revert "chore: update interface_config schema files from MaaFramework"

### DIFF
--- a/tools/schema/interface_config.schema.json
+++ b/tools/schema/interface_config.schema.json
@@ -1,2 +1,104 @@
-429: Too Many Requests
-For more on scraping GitHub and how it may affect your rights, please review our Terms of Service (https://docs.github.com/en/site-policy/github-terms/github-terms-of-service).
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "controller": {
+            "title": "激活的控制器",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "控制器名",
+                    "type": "string"
+                },
+                "type": {
+                    "title": "控制器类型",
+                    "type": "string",
+                    "enum": ["Adb", "Win32", "PlayCover", "WlRoots"]
+                }
+            }
+        },
+        "adb": {
+            "title": "ADB配置",
+            "type": "object",
+            "properties": {
+                "adb_path": {
+                    "title": "ADB路径参数",
+                    "type": "string"
+                },
+                "address": {
+                    "title": "ADB连接参数",
+                    "type": "string"
+                },
+                "config": {
+                    "title": "额外配置参数",
+                    "type": "object"
+                }
+            }
+        },
+        "win32": {
+            "title": "Win32配置",
+            "type": "object"
+        },
+        "playcover": {
+            "title": "PlayCover配置",
+            "type": "object",
+            "properties": {
+                "address": {
+                    "title": "服务地址",
+                    "type": "string"
+                },
+                "uuid": {
+                    "title": "Bundle Identifier",
+                    "type": "string"
+                }
+            }
+        },
+        "wlroots": {
+            "title": "WlRoots配置",
+            "type": "object",
+            "properties": {
+                "wlr_socket_path": {
+                    "title": "Wayland Socket路径",
+                    "type": "string"
+                }
+            }
+        },
+        "resource": {
+            "title": "激活的资源",
+            "type": "string"
+        },
+        "task": {
+            "title": "激活的任务",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "title": "任务名",
+                        "type": "string"
+                    },
+                    "option": {
+                        "title": "任务选项",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "title": "选项名",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "title": "选项值",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["name", "value"]
+                        }
+                    }
+                },
+                "required": ["name"]
+            }
+        }
+    },
+    "required": ["controller", "resource", "task"]
+}


### PR DESCRIPTION
This reverts commit 31250a7a15169da0b8bf9682d6c78e93b61ce0ab.

## Summary by Sourcery

增强功能：
- 恢复先前的 `interface_config.schema.json` 定义，移除由 MaaFramework 架构更新引入的更改。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Restore the prior interface_config.schema.json definition, removing changes introduced by the MaaFramework schema update.

</details>