### PR TITLE
ci: 修复 sync_schema_files 下载失败时终止并报错

### DIFF
--- a/.github/workflows/sync_schema_files.yml
+++ b/.github/workflows/sync_schema_files.yml
@@ -44,19 +44,13 @@ jobs:
           mkdir -p tools/schema
 
           # 下载JSON schema文件
-          curl -s -o tools/schema/interface.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/interface.schema.json || echo "Failed to download interface.schema.json"
-          curl -s -o tools/schema/interface_config.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/interface_config.schema.json || echo "Failed to download interface_config.schema.json"
-          curl -s -o tools/schema/interface_import.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/interface_import.schema.json || echo "Failed to download interface_import.schema.json"
-          curl -s -o tools/schema/pipeline.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/pipeline.schema.json || echo "Failed to download pipeline.schema.json"
+          curl -sfS -o tools/schema/interface.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/interface.schema.json || { echo "::error::Failed to download interface.schema.json"; exit 1; }
+          curl -sfS -o tools/schema/interface_config.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/interface_config.schema.json || { echo "::error::Failed to download interface_config.schema.json"; exit 1; }
+          curl -sfS -o tools/schema/interface_import.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/interface_import.schema.json || { echo "::error::Failed to download interface_import.schema.json"; exit 1; }
+          curl -sfS -o tools/schema/pipeline.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/pipeline.schema.json || { echo "::error::Failed to download pipeline.schema.json"; exit 1; }
 
-          # 检查文件是否成功下载
-          echo "Checking downloaded files:"
-          if compgen -G "tools/schema/*.schema.json" > /dev/null; then
-            ls -la tools/schema/*.schema.json
-          else
-            echo "No schema files downloaded"
-            exit 1
-          fi
+          echo "Downloaded files:"
+          ls -la tools/schema/*.schema.json
 
       - name: Check for changes with git status
         id: check_status

--- a/tools/schema/interface_config.schema.json
+++ b/tools/schema/interface_config.schema.json
@@ -1,2 +1,104 @@
-429: Too Many Requests
-For more on scraping GitHub and how it may affect your rights, please review our Terms of Service (https://docs.github.com/en/site-policy/github-terms/github-terms-of-service).
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "controller": {
+            "title": "激活的控制器",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "控制器名",
+                    "type": "string"
+                },
+                "type": {
+                    "title": "控制器类型",
+                    "type": "string",
+                    "enum": ["Adb", "Win32", "PlayCover", "WlRoots"]
+                }
+            }
+        },
+        "adb": {
+            "title": "ADB配置",
+            "type": "object",
+            "properties": {
+                "adb_path": {
+                    "title": "ADB路径参数",
+                    "type": "string"
+                },
+                "address": {
+                    "title": "ADB连接参数",
+                    "type": "string"
+                },
+                "config": {
+                    "title": "额外配置参数",
+                    "type": "object"
+                }
+            }
+        },
+        "win32": {
+            "title": "Win32配置",
+            "type": "object"
+        },
+        "playcover": {
+            "title": "PlayCover配置",
+            "type": "object",
+            "properties": {
+                "address": {
+                    "title": "服务地址",
+                    "type": "string"
+                },
+                "uuid": {
+                    "title": "Bundle Identifier",
+                    "type": "string"
+                }
+            }
+        },
+        "wlroots": {
+            "title": "WlRoots配置",
+            "type": "object",
+            "properties": {
+                "wlr_socket_path": {
+                    "title": "Wayland Socket路径",
+                    "type": "string"
+                }
+            }
+        },
+        "resource": {
+            "title": "激活的资源",
+            "type": "string"
+        },
+        "task": {
+            "title": "激活的任务",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "title": "任务名",
+                        "type": "string"
+                    },
+                    "option": {
+                        "title": "任务选项",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "title": "选项名",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "title": "选项值",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["name", "value"]
+                        }
+                    }
+                },
+                "required": ["name"]
+            }
+        }
+    },
+    "required": ["controller", "resource", "task"]
+}


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 更新 `sync_schema_files` 工作流，将模式下载失败视为错误并停止该作业。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update sync_schema_files workflow to treat failed schema downloads as errors that stop the job.

</details>