### PR TITLE
feat: 大世界队伍切换

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -186,6 +186,8 @@
     "task.AutoEssence.focus.essence_filter_after_battle_start": "Essence detected. Start filtering and locking useful ones.",
     "task.AutoEssence.focus.essence_filter_after_battle_init_succeeded": "Initialization completed.",
     "task.PuzzleSolver.label": "🧩 Solve Puzzle",
+    "task.SwitchTeam.label": "🔄 Switch Team",
+    "option.SwitchTeamTeamChoose.label": "Select Team",
     "task.PuzzleSolver.description": "Automatically solve puzzle mini-games for you. No need to think anymore!",
     "task.PullCountCalculator.label": "🧮 Pull Count Calculator",
     "task.PullCountCalculator.description": "Read the top resource bar on the Operator Recruitment screen, then scan recruitment vouchers in Valuables to estimate current and next-version pulls. Switch to the target recruitment page first.",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -182,6 +182,8 @@
     "task.AutoEssence.focus.essence_filter_after_battle_start": "基質を検出。有用な基質の絞り込みとロックを開始します。",
     "task.AutoEssence.focus.essence_filter_after_battle_init_succeeded": "初期化が完了しました。",
     "task.PuzzleSolver.label": "🧩 パズル解決",
+    "task.SwitchTeam.label": "🔄 編成切替",
+    "option.SwitchTeamTeamChoose.label": "チーム選択",
     "task.PuzzleSolver.description": "パズルミニゲームを自動で解決します。もう考える必要はありません！",
     "task.PullCountCalculator.label": "🧮 スカウト回数計算",
     "task.PullCountCalculator.description": "オペレーター募集画面の上部リソース欄を読み取り、貴重品庫のスカウト券もスキャンして、現在と次バージョンのスカウト回数を見積もります。先に対象の募集ページへ移動してください。",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -182,6 +182,8 @@
     "task.AutoEssence.focus.essence_filter_after_battle_start": "기질을 인식했습니다. 유효한 기질 필터링 및 잠금을 시작합니다.",
     "task.AutoEssence.focus.essence_filter_after_battle_init_succeeded": "초기화가 완료되었습니다.",
     "task.PuzzleSolver.label": "🧩 퍼즐 해결",
+    "task.SwitchTeam.label": "🔄 편성 전환",
+    "option.SwitchTeamTeamChoose.label": "팀 선택",
     "task.PuzzleSolver.description": "퍼즐 미니게임을 자동으로 해결해 줍니다. 더 이상 생각할 필요가 없습니다!",
     "task.PullCountCalculator.label": "🧮 모집 횟수 계산",
     "task.PullCountCalculator.description": "오퍼레이터 모집 화면의 상단 자원 바를 읽고 귀중품 보관함의 모집권도 스캔해 현재 풀과 다음 버전 풀 모집 횟수를 계산합니다. 먼저 대상 모집 화면으로 이동해 주세요.",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -186,6 +186,8 @@
     "task.AutoEssence.focus.essence_filter_after_battle_start": "识别到基质，开始筛选并锁定有用的",
     "task.AutoEssence.focus.essence_filter_after_battle_init_succeeded": "初始化完成",
     "task.PuzzleSolver.label": "🧩解拼图",
+    "task.SwitchTeam.label": "🔄切换编队",
+    "option.SwitchTeamTeamChoose.label": "选择队伍",
     "task.PuzzleSolver.description": "自动帮你通关拼图小游戏，太好了不用自己动脑子了.jpg",
     "task.PullCountCalculator.label": "🧮抽数计算",
     "task.PullCountCalculator.description": "从干员寻访界面读取顶部资源栏，再进入贵重品库扫描寻访券，估算当前池和下版本池子抽数。请先手动切到目标寻访页面。",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -186,6 +186,8 @@
     "task.AutoEssence.focus.essence_filter_after_battle_start": "識別到基質，開始篩選並鎖定有用的",
     "task.AutoEssence.focus.essence_filter_after_battle_init_succeeded": "初始化完成",
     "task.PuzzleSolver.label": "🧩解拼圖",
+    "task.SwitchTeam.label": "🔄切換編隊",
+    "option.SwitchTeamTeamChoose.label": "選擇隊伍",
     "task.PuzzleSolver.description": "自動幫你通關拼圖小遊戲，太好了不用自己動腦子了.jpg",
     "task.PullCountCalculator.label": "🧮抽數計算",
     "task.PullCountCalculator.description": "從幹員尋訪介面讀取頂部資源欄，再進入貴重品庫掃描尋訪券，估算目前池與下版本池子抽數。請先手動切到目標尋訪頁面。",

--- a/assets/resource/pipeline/Interface/InScene/Team.json
+++ b/assets/resource/pipeline/Interface/InScene/Team.json
@@ -1,0 +1,20 @@
+{
+    "InTeam": {
+        "desc": "在编队菜单",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    0,
+                    0,
+                    100,
+                    100
+                ],
+                "template": [
+                    "ProtocolSpace/TeamChooseIcon.png"
+                ],
+                "threshold": 0.9
+            }
+        }
+    }
+}

--- a/assets/resource/pipeline/Interface/SceneMenu.json
+++ b/assets/resource/pipeline/Interface/SceneMenu.json
@@ -70,6 +70,16 @@
             "[JumpBack]SceneAnyEnterWorld"
         ]
     },
+    "SceneEnterMenuTeam": {
+        "desc": "从任意界面进入编队菜单",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateWorldEnterMenuTeam",
+            "[JumpBack]SceneAnyEnterWorld"
+        ]
+    },
     "SceneEnterMenuProtocolPass": {
         "desc": "从任意界面进入通行证菜单",
         "pre_delay": 0,

--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -1001,6 +1001,86 @@
         "pre_delay": 0,
         "post_delay": 0
     },
+    "__ScenePrivateWorldEnterMenuTeam": {
+        "desc": "从大世界进入编队菜单",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "InWorld"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateMenuListEnterMenuTeam",
+            "[JumpBack]__ScenePrivateWorldEnterMenuList"
+        ]
+    },
+    "__ScenePrivateMenuListEnterMenuTeam": {
+        "desc": "从菜单列表进入编队菜单",
+        "recognition": "And",
+        "all_of": [
+            "InMenuList",
+            {
+                "recognition": {
+                    "type": "OCR",
+                    "param": {
+                        "roi": [
+                            -400,
+                            0,
+                            400,
+                            720
+                        ],
+                        "expected": [
+                            "编队",
+                            "編隊",
+                            "(?i)Team",
+                            "編成",
+                            "편성"
+                        ]
+                    }
+                }
+            }
+        ],
+        "box_index": 1,
+        "pre_delay": 0,
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "SceneManagerMenuListClickItemAction"
+            }
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateAnyEnterMenuTeamSuccess"
+        ]
+    },
+    "__ScenePrivateAnyEnterMenuTeamSuccess": {
+        "desc": "成功进入编队菜单",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "InTeam"
+                ]
+            }
+        },
+        "pre_wait_freezes": {
+            "time": 200,
+            "target": [
+                0,
+                0,
+                100,
+                200
+            ]
+        },
+        "pre_delay": 0,
+        "post_delay": 0
+    },
     "__ScenePrivateWorldEnterMenuProtocolPass": {
         "desc": "从大世界进入通行证菜单",
         "recognition": {

--- a/assets/resource/pipeline/SwitchTeam.json
+++ b/assets/resource/pipeline/SwitchTeam.json
@@ -1,0 +1,139 @@
+{
+    "SwitchTeamMain": {
+        "desc": "切换编队入口",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterMenuTeam"
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SwitchTeamIn"
+        ]
+    },
+    "SwitchTeamIn": {
+        "desc": "已进入编队菜单，准备切换队伍",
+        "recognition": "And",
+        "all_of": [
+            "InTeam"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SwitchTeamChooseNeed",
+            "SwitchTeamChooseNotNeed"
+        ]
+    },
+    "SwitchTeamChooseTextRecognition": {
+        "desc": "识别协议空间队伍",
+        "recognition": "OCR",
+        "roi": [
+            0,
+            -60,
+            500,
+            35
+        ],
+        "expected": [
+            "01"
+        ]
+    },
+    "SwitchTeamChooseNeed": {
+        "desc": "选择协议空间队伍",
+        "recognition": "And",
+        "all_of": [
+            "SwitchTeamChooseTextRecognition",
+            {
+                "recognition": "ColorMatch",
+                "roi": "SwitchTeamChooseTextRecognition",
+                "roi_offset": [
+                    -30,
+                    0,
+                    10,
+                    0
+                ],
+                "lower": [
+                    0,
+                    0,
+                    0
+                ],
+                "upper": [
+                    45,
+                    45,
+                    45
+                ],
+                "connected": true,
+                "count": 200
+            }
+        ],
+        "pre_delay": 0,
+        "action": "Click",
+        "post_wait_freezes": 200,
+        "post_delay": 0,
+        "next": [
+            "SwitchTeamConfirm"
+        ]
+    },
+    "SwitchTeamChooseNotNeed": {
+        "desc": "选择协议空间队伍",
+        "recognition": "And",
+        "all_of": [
+            "SwitchTeamChooseTextRecognition",
+            {
+                "recognition": "ColorMatch",
+                "roi": "SwitchTeamChooseTextRecognition",
+                "roi_offset": [
+                    -30,
+                    0,
+                    10,
+                    0
+                ],
+                "lower": [
+                    200,
+                    200,
+                    200
+                ],
+                "upper": [
+                    255,
+                    255,
+                    255
+                ],
+                "connected": true,
+                "count": 200
+            }
+        ],
+        "pre_delay": 0,
+        "post_wait_freezes": 200,
+        "post_delay": 0
+    },
+    "SwitchTeamConfirm": {
+        "desc": "确认切换编队",
+        "recognition": "Or",
+        "any_of": [
+            "YellowConfirmButtonType2"
+        ],
+        "pre_wait_freezes": 200,
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SwitchTeamConfirmSuccess"
+        ]
+    },
+    "SwitchTeamConfirmSuccess": {
+        "desc": "切换编队成功",
+        "recognition": "And",
+        "all_of": [
+            "WhiteConfirmButtonType2"
+        ],
+        "pre_wait_freezes": 200,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    }
+}

--- a/assets/tasks/SwitchTeam.json
+++ b/assets/tasks/SwitchTeam.json
@@ -1,0 +1,85 @@
+{
+    "task": [
+        {
+            "name": "SwitchTeam",
+            "label": "$task.SwitchTeam.label",
+            "entry": "SwitchTeamMain",
+            "option": [
+                "SwitchTeamTeamChoose"
+            ],
+            "controller": [
+                "Win32-Front",
+                "ADB",
+                "PlayCover",
+                "Wlroots"
+            ],
+            "group": [
+                "open_world"
+            ]
+        }
+    ],
+    "option": {
+        "SwitchTeamTeamChoose": {
+            "type": "select",
+            "label": "$option.SwitchTeamTeamChoose.label",
+            "default_case": "SwitchTeamTeamChoose01",
+            "cases": [
+                {
+                    "name": "SwitchTeamTeamChoose01",
+                    "label": "01",
+                    "pipeline_override": {
+                        "SwitchTeamChooseTextRecognition": {
+                            "expected": [
+                                "01"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "SwitchTeamTeamChoose02",
+                    "label": "02",
+                    "pipeline_override": {
+                        "SwitchTeamChooseTextRecognition": {
+                            "expected": [
+                                "02"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "SwitchTeamTeamChoose03",
+                    "label": "03",
+                    "pipeline_override": {
+                        "SwitchTeamChooseTextRecognition": {
+                            "expected": [
+                                "03"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "SwitchTeamTeamChoose04",
+                    "label": "04",
+                    "pipeline_override": {
+                        "SwitchTeamChooseTextRecognition": {
+                            "expected": [
+                                "04"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "SwitchTeamTeamChoose05",
+                    "label": "05",
+                    "pipeline_override": {
+                        "SwitchTeamChooseTextRecognition": {
+                            "expected": [
+                                "05"
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
close #4051

## Summary by Sourcery

在场景内菜单中添加直接切换队伍的支持，并将其接入场景管理流水线。

新功能：
- 引入场景内队伍切换界面以及相关的场景流水线配置。

改进：
- 更新场景菜单和场景管理器的流水线配置，以整合新的队伍切换流程。

文档：
- 为新的队伍切换界面在所有支持的语言中扩展 UI 本地化条目。

杂项：
- 在游戏流水线中为队伍切换操作添加任务配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for switching teams directly in the in‑scene menu and wire it into the scene management pipeline.

New Features:
- Introduce an in‑scene team switch interface and associated scene pipeline configuration.

Enhancements:
- Update scene menu and scene manager pipeline configs to integrate the new team switching flow.

Documentation:
- Extend UI localization entries across all supported languages for the new team switching interface.

Chores:
- Add task configuration for the team switching operation in the game pipeline.

</details>