### PR TITLE
fix(EnvironmentMonitoring): 修复安思园的天师桩任务

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/SerenityGardenTianshiPillar.json
@@ -31,7 +31,12 @@
             "安思園の天師杭",
             "안사원의 천사장"
         ],
-        "replace": [],
+        "replace": [
+            [
+                "椿",
+                "樁"
+            ]
+        ],
         "order_by": "Vertical"
     },
     "CheckSerenityGardenTianshiPillarIcon": {
@@ -122,7 +127,12 @@
             "安思園の天師杭の写真を撮る",
             "안사원의 천사장을 촬영하기"
         ],
-        "replace": []
+        "replace": [
+            [
+                "椿",
+                "樁"
+            ]
+        ]
     },
     "AcceptSerenityGardenTianshiPillar": {
         "desc": "接取安思园的天师桩委托",
@@ -243,42 +253,12 @@
     "GoToSerenityGardenTianshiPillarMove": {
         "desc": "自动寻路前往安思园的天师桩",
         "action": "Custom",
-        "custom_action": "MapTrackerMove",
+        "custom_action": "MapTrackerGoal",
         "custom_action_param": {
             "map_name": "map02_lv004",
-            "path": [
-                [
-                    418.8,
-                    321.4
-                ],
-                [
-                    418.8,
-                    327.6
-                ],
-                [
-                    415,
-                    327.6
-                ],
-                [
-                    415,
-                    321.3
-                ],
-                [
-                    323.8,
-                    321.3
-                ],
-                [
-                    325,
-                    377.7
-                ],
-                [
-                    324.9,
-                    403.8
-                ],
-                [
-                    295.1,
-                    403.8
-                ]
+            "target": [
+                295.1,
+                403.8
             ],
             "on_finish": {
                 "action": "Custom",

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -869,42 +869,18 @@
             20.8,
             17.4
         ],
-        "MapPath": [
-            [
-                418.8,
-                321.4
-            ],
-            [
-                418.8,
-                327.6
-            ],
-            [
-                415,
-                327.6
-            ],
-            [
-                415,
-                321.3
-            ],
-            [
-                323.8,
-                321.3
-            ],
-            [
-                325,
-                377.7
-            ],
-            [
-                324.9,
-                403.8
-            ],
-            [
-                295.1,
-                403.8
-            ]
+        "MapGoal": [
+            295.1,
+            403.8
         ],
         "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenUp",
         "NoEnsureInitialMovementState": true,
-        "Heading": 270
+        "Heading": 270,
+        "Replace": [
+            [
+                "椿",
+                "樁"
+            ]
+        ]
     }
 ]


### PR DESCRIPTION
使用 MapTrackerGoal 并添加替换规则

fixed #4075

## Summary by Sourcery

修复「静谧花园天始之柱」任务的环境监测流水线配置，以使用正确的追踪设置和路由。

Bug Fixes:
- 更正「静谧花园天始之柱」环境监测任务配置，确保相关任务能够按预期运行。

Enhancements:
- 将环境监测路由生成与更新后的追踪和替换规则对齐，适配「静谧花园天始之柱」任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix environment monitoring pipeline configuration for the Serenity Garden Tianshi Pillar task to use the correct tracking setup and routing.

Bug Fixes:
- Correct the Serenity Garden Tianshi Pillar environment monitoring task configuration so the associated mission functions as expected.

Enhancements:
- Align environment monitoring route generation with the updated tracking and replacement rules for the Serenity Garden Tianshi Pillar task.

</details>