### PR TITLE
ci: 重构 cherry-pick 创建pr的body和标题逻辑

### DIFF
--- a/.github/workflows/cherry-pick-to-v2.yml
+++ b/.github/workflows/cherry-pick-to-v2.yml
@@ -30,6 +30,7 @@ jobs:
         id: pr
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
 
@@ -43,11 +44,17 @@ jobs:
           echo "release_branch=${RELEASE_BRANCH}" | tee -a "$GITHUB_OUTPUT"
           echo "fix_branch=${FIX_BRANCH}" | tee -a "$GITHUB_OUTPUT"
 
-          # PR_TITLE 通过 env 传递避免 shell 注入；多行安全写入 GITHUB_OUTPUT
+          # PR_TITLE / PR_BODY 通过 env 传递避免 shell 注入；多行安全写入 GITHUB_OUTPUT
           {
             echo "pr_title<<PRTITLE_EOF"
             echo "$PR_TITLE"
             echo "PRTITLE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "pr_body<<PRBODY_EOF"
+            echo "$PR_BODY"
+            echo "PRBODY_EOF"
           } >> "$GITHUB_OUTPUT"
 
           echo "Processing PR #${PR_NUMBER}: '${PR_TITLE}'"
@@ -123,6 +130,7 @@ jobs:
           FIX_BRANCH: ${{ steps.pr.outputs.fix_branch }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           PR_TITLE: ${{ steps.pr.outputs.pr_title }}
+          PR_BODY: ${{ steps.pr.outputs.pr_body }}
           RELEASE_BRANCH: ${{ steps.pr.outputs.release_branch }}
         run: |
           set -euo pipefail
@@ -134,29 +142,22 @@ jobs:
             exit 0
           fi
 
-          # 用 python 做模板替换，避免 sed 注入（| & 等特殊字符）
+          # 用 python 拼接原 PR body + footer，避免 shell 注入
           PR_BODY="$(python3 -c "
           import os
-          body = '''## Summary
-          - This PR automatically cherry-picks the fix merged into a release branch (\`__RELEASE_BRANCH__\`) back to the main development branch (\`v2\`).
-          - Original PR: #__PR_NUMBER__
-          - Original title: __PR_TITLE__
-
-          ## Why
-          The fix was first applied to a release branch. This PR ensures the same fix is also available in the main development branch (v2).
-
-          ## Auto-generated
-          This PR was created automatically by the \`cherry-pick-to-v2\` workflow.
-          [skip changelog]
-          '''
-          body = body.replace('__RELEASE_BRANCH__', os.environ['RELEASE_BRANCH'])
-          body = body.replace('__PR_NUMBER__',     os.environ['PR_NUMBER'])
-          body = body.replace('__PR_TITLE__',      os.environ['PR_TITLE'])
-          print(body)
+          original = os.environ.get('PR_BODY', '') or ''
+          n = os.environ['PR_NUMBER']
+          r = os.environ['RELEASE_BRANCH']
+          footer = (
+              '\n\n---\n\n'
+              f'> Cherry-pick of #{n} from \`{r}\` to \`v2\`.\n'
+              '[skip changelog]'
+          )
+          print(original.rstrip() + footer)
           ")"
 
           gh pr create \
             --base v2 \
             --head "$FIX_BRANCH" \
-            --title "fix: cherry-pick #${PR_NUMBER} from ${RELEASE_BRANCH} to v2" \
+            --title "${PR_TITLE} (cherry-pick of #${PR_NUMBER})" \
             --body "$PR_BODY"


### PR DESCRIPTION
测试效果:
https://github.com/ocsin1/ci-test/actions/runs/29108790555?pr=17
https://github.com/ocsin1/ci-test/pull/18

## Summary by Sourcery

优化 cherry-pick 工作流：在创建 v2 cherry-pick PR 时复用原始 PR 的标题和正文，并追加自动生成的页脚，以增强可追溯性和安全性。

New Features:
- 在 cherry-pick PR 中保留原始拉取请求的正文，并在其后附加描述 cherry-pick 上下文的页脚。

Enhancements:
- 在创建 cherry-pick PR 时复用原始拉取请求的标题，并在新标题中明确说明与源 PR 的关系。
- 提高工作流的健壮性，通过环境变量传递 PR 标题和正文，并在 GitHub Actions 输出中安全地处理多行内容。

CI:
- 更新 `cherry-pick-to-v2` GitHub Actions 工作流，根据源 PR 的元数据构建 PR 标题和正文，而不是使用固定模板。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the cherry-pick workflow to reuse the original PR title and body when creating v2 cherry-pick PRs, appending an auto-generated footer for traceability and safety.

New Features:
- Preserve the original pull request body in cherry-pick PRs with an appended footer describing the cherry-pick context.

Enhancements:
- Reuse the original pull request title when creating cherry-pick PRs, clarifying the relationship to the source PR in the new title.
- Improve workflow robustness by passing PR title and body via environment variables and handling multi-line content safely in GitHub Actions outputs.

CI:
- Update the cherry-pick-to-v2 GitHub Actions workflow to construct PR titles and bodies based on the source PR metadata instead of a fixed template.

</details>