### PR TITLE
fix(EnvironmentMonitoring): 修复 FailureCollectorReset 流程错误

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring.json
@@ -1,21 +1,14 @@
 {
     "EnvironmentMonitoringMain": {
         "desc": "环境监测主流程",
-        "next": [
-            "EnvironmentMonitoringReset",
-            "EnvironmentMonitoringLoop",
-            "[JumpBack]SceneEnterMenuRegionalDevelopmentWulingEnvironmentMonitoring"
-        ]
-    },
-    "EnvironmentMonitoringReset": {
-        "desc": "重置环境监测路线执行结果",
         "action": "Custom",
         "custom_action": "FailureCollectorReset",
         "custom_action_param": {
             "key": "EnvironmentMonitoring"
         },
         "next": [
-            "EnvironmentMonitoringLoop"
+            "EnvironmentMonitoringLoop",
+            "[JumpBack]SceneEnterMenuRegionalDevelopmentWulingEnvironmentMonitoring"
         ]
     },
     "EnvironmentMonitoringLoop": {


### PR DESCRIPTION
进入任务就应该执行 FailureCollectorReset，然后才是判断是否进入环境检测循环

## Summary by Sourcery

Bug Fixes:
- 修正 EnvironmentMonitoring 任务流程，使其在进行环境监控循环决策之前执行 `FailureCollectorReset`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the EnvironmentMonitoring task flow to perform FailureCollectorReset prior to the environment monitoring loop decision.

</details>