### PR TITLE
fix: 修复领取邮箱奖励时小概率失败

### DIFF
--- a/assets/resource/pipeline/DailyRewards/Emails.json
+++ b/assets/resource/pipeline/DailyRewards/Emails.json
@@ -246,7 +246,14 @@
         },
         "action": {
             "type": "Click",
-            "param": {}
+            "param": {
+                "target_offset": [
+                    0,
+                    4,
+                    0,
+                    -4
+                ]
+            }
         },
         "next": [
             "DailyEmailNoEmailRewards",


### PR DESCRIPTION
<img width="931" height="725" alt="3461c180dfa3b736368d239b5e0b548e" src="https://github.com/user-attachments/assets/4d8f287b-8420-44c7-9798-039e12e990a8" />

box可能会出现这种情况,此时如果点击最上部,会点击失效
<img width="347" height="510" alt="QQ_1783822613397" src="https://github.com/user-attachments/assets/d6f1fc3f-f786-4f88-a1cf-0c06490e93d7" />

## Summary by Sourcery

调整邮件每日奖励的配置，以防止在从最上方箱体区域领取奖励时偶发的失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust email daily rewards configuration to prevent rare failures when claiming rewards from the topmost box area.

</details>