### PR TITLE
fix(MapNavigator): 走廊路点消费对齐起步门控

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
@@ -447,8 +447,15 @@ NavRunTickResult NavRunController::tick(
     result.remaining_to_anchor = remaining;
     result.upcoming_turn_deg = upcoming_turn;
     const double character_arc = CorridorArcLengthTo(plan_.path, plan_.corridor_arc_prefix, *projection);
-    result.passed_run_waypoints =
+    const size_t corridor_passed =
         CountCorridorPassedRunWaypoints(*session, plan_.path, plan_.corridor_arc_prefix, anchor_index, character_arc);
+    if (route.startup_motion_confirmed) {
+        result.passed_run_waypoints = corridor_passed;
+    }
+    else if (corridor_passed > 0) {
+        LogDebug << "Corridor passed advance blocked before startup movement confirmed." << VAR(corridor_passed)
+                 << VAR(session->current_node_idx()) << VAR(character_arc);
+    }
     return result;
 }
 


### PR DESCRIPTION
- fix #4144

## Summary by Sourcery

Bug Fixes:
- 在启动运动被确认之前，防止走廊运行航路点提前推进，以避免过早推进。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent corridor run waypoint advancement before startup motion is confirmed to avoid premature progression.

</details>