### PR TITLE
fix(map): 修复视角旋转速度计算错误的问题

### DIFF
--- a/agent/go-service/common/charactercontroller/controller.go
+++ b/agent/go-service/common/charactercontroller/controller.go
@@ -2,9 +2,7 @@ package charactercontroller
 
 import (
 	"encoding/json"
-	"math"
 
-	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/control"
 	"github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -37,7 +35,6 @@ type characterControllerRelativeMoveParam struct {
 	Begin []int `json:"begin"`
 }
 
-// on wlroots, dx/dy are compensated by control.WlrootsRelativeMoveScale.
 // When "begin" is specified, dx/dy are computed from begin to arg.Box
 // (resolved from pipeline "target") instead of the explicit dx/dy fields.
 type CharacterControllerRelativeMoveAction struct{}
@@ -68,14 +65,7 @@ func (a *CharacterControllerRelativeMoveAction) Run(ctx *maa.Context, arg *maa.C
 		dy = arg.Box.Y() - params.Begin[1]
 	}
 
-	scaledDX := int32(dx)
-	scaledDY := int32(dy)
-	controlType, _ := control.GetControlType(ctx.GetTasker().GetController())
-	if controlType == control.CONTROL_TYPE_WLROOTS {
-		scaledDX = int32(math.Round(float64(dx) * control.WlrootsRelativeMoveScale))
-		scaledDY = int32(math.Round(float64(dy) * control.WlrootsRelativeMoveScale))
-	}
-	ctx.GetTasker().GetController().PostRelativeMove(scaledDX, scaledDY).Wait()
+	ctx.GetTasker().GetController().PostRelativeMove(int32(dx), int32(dy)).Wait()
 	return true
 }
 

--- a/agent/go-service/maptracker/default/const.go
+++ b/agent/go-service/maptracker/default/const.go
@@ -9,7 +9,7 @@ const (
 // Move action configuration
 const (
 	INFER_INTERVAL_MS              = 100
-	ROTATION_MAX_SPEED             = 10.0
+	ROTATION_MAX_SPEED             = 6.0
 	ROTATION_DEFAULT_SPEED         = 2.0
 	ROTATION_DEFAULT_SPEED_WLROOTS = 5.0
 	ROTATION_MIN_SPEED             = 1.0

--- a/agent/go-service/maptracker/default/const.go
+++ b/agent/go-service/maptracker/default/const.go
@@ -8,10 +8,11 @@ const (
 
 // Move action configuration
 const (
-	INFER_INTERVAL_MS      = 100
-	ROTATION_MAX_SPEED     = 10.0
-	ROTATION_DEFAULT_SPEED = 2.0
-	ROTATION_MIN_SPEED     = 1.0
+	INFER_INTERVAL_MS              = 100
+	ROTATION_MAX_SPEED             = 10.0
+	ROTATION_DEFAULT_SPEED         = 2.0
+	ROTATION_DEFAULT_SPEED_WLROOTS = 5.0
+	ROTATION_MIN_SPEED             = 1.0
 )
 
 // Misc

--- a/agent/go-service/maptracker/default/const.go
+++ b/agent/go-service/maptracker/default/const.go
@@ -8,11 +8,10 @@ const (
 
 // Move action configuration
 const (
-	INFER_INTERVAL_MS              = 100
-	ROTATION_MAX_SPEED             = 6.0
-	ROTATION_DEFAULT_SPEED         = 2.0
-	ROTATION_DEFAULT_SPEED_WLROOTS = 5.0
-	ROTATION_MIN_SPEED             = 1.0
+	INFER_INTERVAL_MS      = 100
+	ROTATION_MAX_SPEED     = 5.0
+	ROTATION_DEFAULT_SPEED = 2.5
+	ROTATION_MIN_SPEED     = 1.0
 )
 
 // Misc

--- a/agent/go-service/maptracker/default/const.go
+++ b/agent/go-service/maptracker/default/const.go
@@ -9,7 +9,7 @@ const (
 // Move action configuration
 const (
 	INFER_INTERVAL_MS      = 100
-	ROTATION_MAX_SPEED     = 4.0
+	ROTATION_MAX_SPEED     = 10.0
 	ROTATION_DEFAULT_SPEED = 2.0
 	ROTATION_MIN_SPEED     = 1.0
 )

--- a/agent/go-service/maptracker/default/move.go
+++ b/agent/go-service/maptracker/default/move.go
@@ -117,6 +117,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 	}
 
 	ctrl := ctx.GetTasker().GetController()
+	ctrlType, _ := control.GetControlType(ctrl)
 	ca, err := control.NewControlAdaptor(ctx, ctrl, WORK_W, WORK_H)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create control adaptor")
@@ -156,6 +157,9 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 
 	// Adaptive rotation sensitivity local state
 	rotationSpeed := ROTATION_DEFAULT_SPEED
+	if ctrlType == control.CONTROL_TYPE_WLROOTS {
+		rotationSpeed = ROTATION_DEFAULT_SPEED_WLROOTS
+	}
 	var rotAdjState, rotAdjStateCache *PlayerRotationAdjustmentState
 
 	// For each target point

--- a/agent/go-service/maptracker/default/move.go
+++ b/agent/go-service/maptracker/default/move.go
@@ -157,9 +157,6 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 
 	// Adaptive rotation sensitivity local state
 	rotationSpeed := ROTATION_DEFAULT_SPEED
-	if ctrlType == control.CONTROL_TYPE_WLROOTS {
-		rotationSpeed = ROTATION_DEFAULT_SPEED_WLROOTS
-	}
 	var rotAdjState, rotAdjStateCache *PlayerRotationAdjustmentState
 
 	// For each target point
@@ -317,10 +314,10 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					if distTravel > control.MovementWalk.DistanceDuring(rotAdjState.expectedElapsed) {
 						// Check if rotation difference is sufficient to consider adjusting rotation speed
 						actualDeltaRot := calcDeltaRotation(rotAdjState.fromRot, rot)
-						if math.Abs(float64(actualDeltaRot))+math.Abs(rotAdjState.deltaRot) > param.RotationLowerThreshold {
+						if math.Abs(float64(actualDeltaRot)) > param.RotationLowerThreshold && math.Abs(rotAdjState.deltaRot) > param.RotationLowerThreshold {
 							idealRotSpeed := rotationSpeed * rotAdjState.deltaRot / (float64(actualDeltaRot) + 1e-6)
 							if idealRotSpeed >= ROTATION_MIN_SPEED && idealRotSpeed <= ROTATION_MAX_SPEED {
-								rotationSpeed = rotationSpeed*0.618 + idealRotSpeed*0.382
+								rotationSpeed = rotationSpeed*0.865 + idealRotSpeed*0.135 // 1/e^2
 								rotAdjStateCache = rotAdjState
 								log.Debug().
 									Float64("idealRotSpeed", idealRotSpeed).

--- a/agent/go-service/maptracker/default/move.go
+++ b/agent/go-service/maptracker/default/move.go
@@ -117,7 +117,6 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 	}
 
 	ctrl := ctx.GetTasker().GetController()
-	ctrlType, _ := control.GetControlType(ctrl)
 	ca, err := control.NewControlAdaptor(ctx, ctrl, WORK_W, WORK_H)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create control adaptor")

--- a/agent/go-service/maptracker/default/move.go
+++ b/agent/go-service/maptracker/default/move.go
@@ -314,7 +314,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 						// Check if rotation difference is sufficient to consider adjusting rotation speed
 						actualDeltaRot := calcDeltaRotation(rotAdjState.fromRot, rot)
 						if math.Abs(float64(actualDeltaRot))+math.Abs(rotAdjState.deltaRot) > param.RotationLowerThreshold {
-							idealRotSpeed := rotAdjState.deltaRot / (float64(actualDeltaRot) + 1e-6)
+							idealRotSpeed := rotationSpeed * rotAdjState.deltaRot / (float64(actualDeltaRot) + 1e-6)
 							if idealRotSpeed >= ROTATION_MIN_SPEED && idealRotSpeed <= ROTATION_MAX_SPEED {
 								rotationSpeed = rotationSpeed*0.618 + idealRotSpeed*0.382
 								rotAdjStateCache = rotAdjState

--- a/agent/go-service/pkg/control/adaptor_wlroots.go
+++ b/agent/go-service/pkg/control/adaptor_wlroots.go
@@ -2,16 +2,10 @@
 package control
 
 import (
-	"math"
 	"time"
 
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 )
-
-// WlrootsRelativeMoveScale compensates for the sensitivity difference between
-// the wlroots relative-move path and the default desktop hover-swipe path.
-// Empirically derived from the previous per-call ratio 2.6 / 2.0 = 1.3.
-const WlrootsRelativeMoveScale = 1.3
 
 // wlrootsControlAdaptor reuses desktop key/movement behavior while overriding
 // camera interaction to use relative mouse movement.
@@ -25,20 +19,9 @@ func newWlrootsControlAdaptor(ctx *maa.Context, ctrl *maa.Controller, w, h int) 
 	}
 }
 
-// SwipeHover on wlroots is implemented via relative mouse movement, so the
-// absolute anchor (contact/x/y) is ignored and only dx/dy are honored.
-// dx/dy are scaled by WlrootsRelativeMoveScale so callers can share the same
-// sensitivity baseline with desktop controllers.
-func (wca *wlrootsControlAdaptor) SwipeHover(_ /*contact*/, _ /*x*/, _ /*y*/, dx, dy int, durationMillis, delayMillis int) {
-	scaledDX := int32(math.Round(float64(dx) * WlrootsRelativeMoveScale))
-	scaledDY := int32(math.Round(float64(dy) * WlrootsRelativeMoveScale))
-	wca.ctrl.PostRelativeMove(scaledDX, scaledDY).Wait()
-	time.Sleep(time.Duration(durationMillis+delayMillis) * time.Millisecond)
-}
-
 func (wca *wlrootsControlAdaptor) RotateCamera(dx, dy int) {
-	// No screen-center anchor: wlroots SwipeHover ignores x/y and sends a relative move.
-	wca.SwipeHover(0, 0, 0, dx, dy, defaultDesktopKeyActionDelayMillis*3, defaultDesktopKeyActionDelayMillis)
+	wca.ctrl.PostRelativeMove(int32(dx), int32(dy)).Wait()
+	time.Sleep(defaultDesktopKeyActionDelayMillis * time.Millisecond)
 }
 
 func (wca *wlrootsControlAdaptor) ResetCursor(_ CursorResetPolicy) {


### PR DESCRIPTION
修正错误的自适应旋转速度计算公式

## Summary by Sourcery

通过移除通用的 wlroots 移动缩放，并为 wlroots 引入与控制器类型相关的分段旋转速度，同时禁用针对 wlroots 控制器的自适应旋转调节，从而优化 MapTracker 的摄像机旋转行为。

Bug Fixes（缺陷修复）:
- 统一 wlroots 相对鼠标移动与角色控制器行为，使其与其他控制器保持一致，避免重复缩放和旋转灵敏度不一致的问题。

Enhancements（增强改进）:
- 为 wlroots 基于角度距离引入分段旋转速度选择，以改善在 MapTracker 及相关流程中的摄像机旋转控制。
- 将旋转速度计算集中到一个共享的辅助函数中，该函数被移动（move）、滑索（zipline）和朝向（toward）等 MapTracker 动作共用。
- 通过移除依赖控制器类型的缩放，简化 wlroots 控制适配器和角色控制器的相对移动逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine MapTracker camera rotation behavior by removing generic wlroots movement scaling and introducing controller-aware, segmented rotation speed for wlroots while disabling adaptive rotation tuning for wlroots controllers.

Bug Fixes:
- Align wlroots relative mouse movement and character controller behavior with other controllers to avoid double scaling and inconsistent rotation sensitivity.

Enhancements:
- Introduce segmented rotation speed selection for wlroots based on angular distance to improve camera rotation control in MapTracker and related flows.
- Centralize rotation speed calculation in a shared helper used by move, zipline, and toward MapTracker actions.
- Simplify wlroots control adaptor and character controller relative move logic by removing controller-type-dependent scaling.

</details>