### PR TITLE
fix(MapNavigator): 修复动态 overlay 桥接折角的锚点与可走性

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -134,6 +134,8 @@ bool IsZoneCompatible(const Waypoint& waypoint, const std::string& current_zone_
     return current_zone_id.empty() || waypoint.zone_id.empty() || waypoint.zone_id == current_zone_id;
 }
 
+constexpr size_t kUnaddressableAnchorIndex = std::numeric_limits<size_t>::max();
+
 bool IsRequiredSemanticAnchor(const Waypoint& waypoint)
 {
     if (!waypoint.HasPosition()) {
@@ -656,7 +658,9 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
         generated_prefix.emplace_back(detour_vertex.x, detour_vertex.y, ActionType::RUN);
         generated_prefix.back().strict_arrival = true;
     }
-    else if (!AppendGeneratedNavmeshWaypoints(route->path, generated_prefix, false, emit_interior_corners)) {
+    else if (!AppendGeneratedNavmeshWaypoints(param_, position_->zone_id, *route, generated_prefix,
+                                              /*include_goal=*/false, emit_interior_corners,
+                                              /*strict_segment_breaks=*/false)) {
         LogWarn << "Dynamic navmesh overlay skipped: generated path is unusable." << VAR(reason) << VAR(continue_index)
                 << VAR(route->path.points.size());
         return false;
@@ -944,7 +948,8 @@ bool NavigationStateMachine::TickNavigate()
             // continuous RUN can lookahead through to the next semantic anchor.
             std::optional<DynamicAnchor> nav_run_anchor;
             if (current_waypoint.RequiresStrictArrival()) {
-                nav_run_anchor = DynamicAnchor { session_->current_node_idx(), current_waypoint };
+                nav_run_anchor = DynamicAnchor { session_->CanonicalIndexAtCurrent().value_or(kUnaddressableAnchorIndex),
+                                                 current_waypoint };
             }
             else {
                 nav_run_anchor = ResolveCurrentAnchor(session_, *position_);

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -946,7 +946,8 @@ std::optional<navmesh::WorldPoint> PlanUnstickTarget(
 
 bool AppendGeneratedNavmeshWaypoints(
     const navmesh::WorldPath& world_path, std::vector<Waypoint>& out_path, bool include_goal,
-    bool emit_interior_corners, const navmesh::BaseNavPlanner* drivability_planner, uint16_t drivable_zone_id)
+    bool emit_interior_corners, const navmesh::BaseNavPlanner* drivability_planner, uint16_t drivable_zone_id,
+    bool strict_segment_breaks)
 {
     if (world_path.points.empty()) {
         return false;
@@ -971,15 +972,19 @@ bool AppendGeneratedNavmeshWaypoints(
     }
 
     size_t prev = 0; // the driven line starts at points[0] — the route origin / character's current position
-    const auto flush_leg_to = [&](size_t anchor, bool strict_arrival) {
-        if (drivability_planner != nullptr && anchor > prev + 1
-            && !drivability_planner->isRouteSegmentDrivable(
+    const auto restore_corners_to = [&](size_t anchor) {
+        if (drivability_planner == nullptr || anchor <= prev + 1
+            || drivability_planner->isRouteSegmentDrivable(
                 drivable_zone_id, world_path.points[prev], world_path.points[anchor])) {
-            for (size_t corner = prev + 1; corner < anchor; ++corner) {
-                out_path.emplace_back(world_path.points[corner].x, world_path.points[corner].y, ActionType::RUN);
-                out_path.back().strict_arrival = false;
-            }
+            return;
         }
+        for (size_t corner = prev + 1; corner < anchor; ++corner) {
+            out_path.emplace_back(world_path.points[corner].x, world_path.points[corner].y, ActionType::RUN);
+            out_path.back().strict_arrival = false;
+        }
+    };
+    const auto flush_leg_to = [&](size_t anchor, bool strict_arrival) {
+        restore_corners_to(anchor);
         out_path.emplace_back(world_path.points[anchor].x, world_path.points[anchor].y, ActionType::RUN);
         out_path.back().strict_arrival = strict_arrival;
         prev = anchor;
@@ -993,14 +998,38 @@ bool AppendGeneratedNavmeshWaypoints(
         if (emit_idx == 0) {
             continue;
         }
-        flush_leg_to(emit_idx, true);
+        flush_leg_to(emit_idx, strict_segment_breaks);
     }
 
-    if (include_goal && total >= 2) {
-        flush_leg_to(total - 1, true);
+    if (total >= 2) {
+        if (include_goal) {
+            flush_leg_to(total - 1, true);
+        }
+        else {
+            restore_corners_to(total - 1);
+        }
     }
 
     return true;
+}
+
+bool AppendGeneratedNavmeshWaypoints(
+    const NaviParam& param, const std::string& locator_zone, const navmesh::BaseNavRouteResult& route,
+    std::vector<Waypoint>& out_path, bool include_goal, bool emit_interior_corners, bool strict_segment_breaks)
+{
+    const std::string navmesh_zone = InferBaseNavZone(locator_zone, param.map_name);
+    const std::shared_ptr<CachedNavmesh> navmesh =
+        navmesh_zone.empty() ? nullptr : LoadCachedNavmesh(ResolveNavmeshFile(param.navmesh_file), navmesh_zone);
+    if (!navmesh) {
+        LogWarn << "Generated navmesh waypoints emitted without a drivability check." << VAR(locator_zone)
+                << VAR(navmesh_zone);
+        return AppendGeneratedNavmeshWaypoints(route.path, out_path, include_goal, emit_interior_corners, nullptr, 0,
+                                               strict_segment_breaks);
+    }
+    const uint16_t drivable_zone =
+        route.triangles.empty() ? route.path.zone_id : navmesh->planner.triangleZone(route.triangles.front());
+    return AppendGeneratedNavmeshWaypoints(route.path, out_path, include_goal, emit_interior_corners, &navmesh->planner,
+                                           drivable_zone, strict_segment_breaks);
 }
 
 } // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -80,6 +80,9 @@ std::optional<navmesh::WorldPoint> PlanUnstickTarget(
 bool AppendGeneratedNavmeshWaypoints(
     const navmesh::WorldPath& world_path, std::vector<Waypoint>& out_path, bool include_goal,
     bool emit_interior_corners = false, const navmesh::BaseNavPlanner* drivability_planner = nullptr,
-    uint16_t drivable_zone_id = 0);
+    uint16_t drivable_zone_id = 0, bool strict_segment_breaks = true);
+bool AppendGeneratedNavmeshWaypoints(
+    const NaviParam& param, const std::string& locator_zone, const navmesh::BaseNavRouteResult& route,
+    std::vector<Waypoint>& out_path, bool include_goal, bool emit_interior_corners, bool strict_segment_breaks);
 
 } // namespace mapnavigator


### PR DESCRIPTION
- fix #4158

## Summary by Sourcery

调整生成的导航网格路径点和动态覆盖层处理方式，在防止临时覆盖层锚点变成不可寻址的严格语义锚点的同时，保持桥面拐角可通行。

New Features:
- 添加 `AppendGeneratedNavmeshWaypoints` 的一个重载版本，使用 `NaviParam` 和 `BaseNavRouteResult` 进行基于导航网格的可通行性检查。

Bug Fixes:
- 确保在动态生成的覆盖路径中，非可通行的直线路段能够恢复内部拐角，以便绕障碍物的绕行路径保持可遍历。
- 防止动态覆盖层中的桥面点被视为具有无效规范索引的严格语义锚点，从而避免光标停滞在不可寻址的锚点上。

Enhancements:
- 引入可配置的 `strict_segment_breaks` 标志，用于控制生成的路径段终点是否被标记为严格到达点。
- 为在没有可用规范索引时的动态锚点使用哨兵锚点索引，将覆盖层索引与人工编写的路径索引区分开来。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust generated navmesh waypoints and dynamic overlay handling to keep bridge corners drivable while preventing temporary overlay anchors from becoming unaddressable strict semantic anchors.

New Features:
- Add an overload of AppendGeneratedNavmeshWaypoints that performs navmesh-based drivability checks using NaviParam and BaseNavRouteResult.

Bug Fixes:
- Ensure non-drivable straight segments in dynamically generated overlay paths restore interior corners so detour routes around obstacles remain traversable.
- Prevent dynamic overlay bridge points from being treated as strict semantic anchors with invalid canonical indices, avoiding cursor stalls on unaddressable anchors.

Enhancements:
- Introduce a configurable strict_segment_breaks flag to control whether generated segment endpoints are marked as strict arrivals.
- Use a sentinel anchor index for dynamic anchors when no canonical index is available, separating overlay indices from authored route indices.

</details>