### PR TITLE
fix(选剑演武): 修复演算开始时角色在演算区域外会卡死的问题

### DIFF
--- a/assets/resource/pipeline/Interface/Scene.json
+++ b/assets/resource/pipeline/Interface/Scene.json
@@ -178,5 +178,36 @@
             "SceneWaitLoadingExit",
             "__ScenePrivateNextTrue"
         ]
+    },
+    "SceneWaitBlackScreenLoadingExit": {
+        "desc": "判断当前场景在加载界面（黑屏），什么都不做，用于等待加载界面消失",
+        "recognition": "ColorMatch",
+        "roi": [
+            0,
+            0,
+            200,
+            200
+        ],
+        "lower": [
+            0,
+            0,
+            0
+        ],
+        "upper": [
+            10,
+            10,
+            10
+        ],
+        "count": 40000,
+        "pre_delay": 0,
+        "post_delay": 500,
+        "next": [
+            // "[JumpBack]__SceneCheckOSD",
+            // "[JumpBack]__SceneCheckYellowColor",
+            // "[JumpBack]__SceneCheckTealColor",
+            // "[JumpBack]__SceneCheckPurpleColor",
+            "SceneWaitBlackScreenLoadingExit",
+            "__ScenePrivateNextTrue"
+        ]
     }
 }

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
@@ -54,6 +54,43 @@
         "post_delay": 0,
         "next": [
             "[JumpBack]SceneWaitBlackScreenLoadingExit",
+            "TrialOfSwordmancyLoadingExit"
+        ]
+    },
+    "TrialOfSwordmancyLoadingExit": {
+        "desc": "加载完毕",
+        "recognition": "And",
+        "all_of": [
+            "InWorld"
+        ],
+        "pre_delay": 0,
+        "post_wait_freezes": 200,
+        "post_delay": 0,
+        "next": [
+            "TrialOfSwordmancyEnterTrialTarget",
+            "TrialOfSwordmancyOutOfBounds"
+        ]
+    },
+    "TrialOfSwordmancyOutOfBounds": {
+        "desc": "加载完但未出现挑战目标界面，说明开始演算时角色在演算区域外",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "arrival_timeout": 10000,
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1863,
+                        1789
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "on_error": [
+            // 本次寻路必定失败
             "TrialOfSwordmancyEnterTrialTarget"
         ]
     },

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
@@ -53,7 +53,7 @@
         "action": "Click",
         "post_delay": 0,
         "next": [
-            "[JumpBack]SceneWaitLoadingExit",
+            "[JumpBack]SceneWaitBlackScreenLoadingExit",
             "TrialOfSwordmancyEnterTrialTarget"
         ]
     },


### PR DESCRIPTION
fix #3935

## Summary by Sourcery

Bug Fixes:
- 解决在 TrialOfSwordmancy 模式中，如果计算在角色位于战斗区域之外时开始，角色可能会被卡住导致软锁的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve a soft-lock issue where the character could become stuck if the calculation began while they were outside the combat region in the TrialOfSwordmancy mode.

</details>