### PR TITLE
fix: 偶现地图菜单退出到大世界失败

### DIFF
--- a/assets/resource/pipeline/Interface/InScene/Region.json
+++ b/assets/resource/pipeline/Interface/InScene/Region.json
@@ -13,7 +13,8 @@
                 ],
                 "template": [
                     "SceneManager/MapMind.png"
-                ]
+                ],
+                "method": 10001 // 默认5时，当弹出右侧面板，此图片依然能匹配上
             },
             {
                 "recognition": "TemplateMatch",


### PR DESCRIPTION
close #4062

## Summary by Sourcery

Bug Fixes:
- 解决从场景内的区域/地图菜单退出并返回主世界视图时偶发失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve intermittent failures when exiting from the in-scene region/map menu back to the main world view.

</details>