### PR TITLE
fix(SceneManager): 修复意外回到大世界的问题

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneImageCheck.json
+++ b/assets/resource/pipeline/SceneManager/SceneImageCheck.json
@@ -12,8 +12,8 @@
         "pre_delay": 0,
         "action": "Click",
         "target": [
-            30,
-            -60,
+            60,
+            -100,
             10,
             10
         ],


### PR DESCRIPTION
在菜单列表中如果单击过于靠近左下角会直接退出到大世界中。

fixed #3195

## Summary by Sourcery

Bug Fixes:
- 修复在菜单列表左下区域附近点击时会意外退出到主世界的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix accidental exit to the overworld when clicking near the bottom-left area of the menu list.

</details>