### PR TITLE
perf: 游戏分辨率过大时提示减小

### DIFF
--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -192,6 +192,15 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		fullScreen, _ := gamesetting.GetVideoFullScreen()
 		if fullScreen == 1 {
 			c.stopWithWarning(tasker, controllerDisplay, int(width), int(height), i18n.T("tasker.aspect_ratio_warning.full_screen_illegal"))
+		} else if runtime.GOOS == "windows" {
+			registryWidth, wErr := gamesetting.GetVideoResolutionWidth()
+			registryHeight, hErr := gamesetting.GetVideoResolutionHeight()
+			if wErr == nil && hErr == nil && registryWidth > 0 && registryHeight > 0 &&
+				(int(width) != int(registryWidth) || int(height) != int(registryHeight)) {
+				c.stopWithWarning(tasker, controllerDisplay, int(width), int(height), i18n.T("tasker.aspect_ratio_warning.requirement_ratio_window_mismatch"))
+			} else {
+				c.stopWithWarning(tasker, controllerDisplay, int(width), int(height), i18n.T("tasker.aspect_ratio_warning.requirement_ratio"))
+			}
 		} else {
 			c.stopWithWarning(tasker, controllerDisplay, int(width), int(height), i18n.T("tasker.aspect_ratio_warning.requirement_ratio"))
 		}

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -159,6 +159,7 @@
     "tasker.aspect_ratio_warning.requirement_label": "Required:",
     "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 aspect ratio and at least 1280x720; for example 3840x2160, 2560x1440, 1920x1080, 1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio_window_mismatch": "16:9 aspect ratio with the window not exceeding monitor edges; try switching the game to a smaller 16:9 resolution",
     "tasker.aspect_ratio_warning.full_screen_illegal": "Windowed mode; fullscreen requires a physical 16:9 monitor, which your current display does not meet.",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",
     "maptracker.emergency_stop.desc": "Navigation aborted.",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -159,6 +159,7 @@
     "tasker.aspect_ratio_warning.requirement_label": "必要条件：",
     "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比率かつ 1280x720 以上。例: 3840x2160、2560x1440、1920x1080、1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio_window_mismatch": "16:9 比率で、ウィンドウがモニター端を超えないこと。より小さい 16:9 解像度への切り替えをお試しください",
     "tasker.aspect_ratio_warning.full_screen_illegal": "ウィンドウモード；全画面モードでは物理的に 16:9 のディスプレイが必要ですが、現在のディスプレイは条件を満たしません。",
     "maptracker.emergency_stop.title": "🚨 緊急停止",
     "maptracker.emergency_stop.desc": "ナビゲーションを中止しました。",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -159,6 +159,7 @@
     "tasker.aspect_ratio_warning.requirement_label": "요구 사항:",
     "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 비율이고 최소 1280x720 이상이어야 합니다; 예: 3840x2160, 2560x1440, 1920x1080, 1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio_window_mismatch": "16:9 비율이며 창이 모니터 가장자리를 넘지 않아야 합니다. 더 작은 16:9 해상도로 전환해 보세요",
     "tasker.aspect_ratio_warning.full_screen_illegal": "창 모드; 전체 화면 모드는 물리적으로 16:9 해상도 모니터가 필요하며 현재 디스플레이는 조건에 맞지 않습니다.",
     "maptracker.emergency_stop.title": "🚨 긴급 정지",
     "maptracker.emergency_stop.desc": "길찾기가 중단되었습니다.",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -159,6 +159,7 @@
     "tasker.aspect_ratio_warning.requirement_label": "目标要求：",
     "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例且不低于 1280x720；例如 3840x2160、2560x1440、1920x1080、1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio_window_mismatch": "16:9 比例且窗口不超过显示器边缘，可尝试将游戏切换至更小的 16:9 比例",
     "tasker.aspect_ratio_warning.full_screen_illegal": "窗口模式；全屏模式需使用物理分辨率16:9的显示器，当前显示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",
     "maptracker.emergency_stop.desc": "寻路已中止。",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -159,6 +159,7 @@
     "tasker.aspect_ratio_warning.requirement_label": "目標要求：",
     "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
     "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例且不低於 1280x720；例如 3840x2160、2560x1440、1920x1080、1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio_window_mismatch": "16:9 比例且視窗不超過顯示器邊緣，可嘗試將遊戲切換至更小的 16:9 比例",
     "tasker.aspect_ratio_warning.full_screen_illegal": "視窗模式；全螢幕模式需使用物理解析度 16:9 的顯示器，目前顯示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",
     "maptracker.emergency_stop.desc": "尋路已中止。",


### PR DESCRIPTION
close #3689

## Summary by Sourcery

调整纵横比检查逻辑，当在 Windows 上以窗口模式运行时，如果游戏分辨率过大或不匹配，提供更具体的警告信息。

New Features:
- 在 Windows 窗口模式下添加分辨率不匹配检测功能，当控制器报告的分辨率与配置的游戏分辨率不一致时提示用户。

Enhancements:
- 更新所有受支持语言中的本地化警告信息，用以区分通用分辨率要求与窗口模式下的分辨率不匹配情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust aspect ratio checks to provide more specific warnings when game resolution is too large or mismatched in windowed mode on Windows.

New Features:
- Add resolution mismatch detection for windowed mode on Windows to prompt users when the controller-reported resolution differs from the configured game resolution.

Enhancements:
- Update localized warning messages across all supported languages to distinguish between generic resolution requirements and windowed-mode resolution mismatches.

</details>