### PR TITLE
feat(MapNavigator): 起点位于 off-mesh 时先盲走到最近网格点

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -80,6 +80,10 @@ constexpr double kBlindTargetFallbackSnapRadius = 12.0;
 constexpr double kBlindTargetMaxExtension = 30.0;
 constexpr double kBlindTargetProbeStep = 2.0;
 
+// Start recovery: how far we are willing to walk unguided to get back onto the mesh. Covers the whole
+// off-mesh band measured along the base-exit corridor, where the blind walk out of the base drops us.
+constexpr double kStartRecoveryMaxBlindWalk = 32.0;
+
 bool IsNavmeshWaypoint(const Waypoint& waypoint)
 {
     return waypoint.action == ActionType::NAVMESH && waypoint.HasPosition();
@@ -505,6 +509,39 @@ bool AppendBlindTargetFallback(
     return true;
 }
 
+bool AppendStartRecovery(
+    const NaviParam& param,
+    const CachedNavmesh& navmesh,
+    const navmesh::BaseNavRouteRequest& request,
+    NavmeshExpansionState& state,
+    std::vector<Waypoint>& out_path)
+{
+    const navmesh::BaseNavZone* zone = navmesh.pack.findZoneByName(state.navmesh_zone);
+    if (zone == nullptr) {
+        return false;
+    }
+    const double radius = std::max(param.navmesh_snap_radius, kStartRecoveryMaxBlindWalk);
+    const auto entry = navmesh.planner.snap(zone->zone_id, request.start, radius, request.start_floor_y);
+    if (!entry) {
+        LogWarn << "NAVMESH start recovery rejected: no mesh point within the blind-walk budget."
+                << VAR(state.navmesh_zone) << VAR(state.current_zone) << VAR(request.start.x) << VAR(request.start.y)
+                << VAR(radius);
+        return false;
+    }
+
+    if (entry->distance <= kWaypointArrivalSlack) {
+        return false;
+    }
+
+    out_path.emplace_back(entry->point.x, entry->point.y, ActionType::RUN);
+    out_path.back().strict_arrival = false;
+    state.route_start = entry->point;
+    LogInfo << "NAVMESH start off mesh; walking onto the nearest mesh point first." << VAR(state.navmesh_zone)
+            << VAR(state.current_zone) << VAR(request.start.x) << VAR(request.start.y) << VAR(entry->point.x)
+            << VAR(entry->point.y) << VAR(entry->distance);
+    return true;
+}
+
 bool AppendNavmeshWaypoint(
     const NaviParam& param,
     const CachedNavmesh& navmesh,
@@ -513,9 +550,13 @@ bool AppendNavmeshWaypoint(
     std::vector<Waypoint>& out_path)
 {
     const ProjectedTarget target = ResolveProjectedTarget(navmesh.pack, waypoint);
-    const navmesh::BaseNavRouteRequest request = BuildRouteRequest(
+    navmesh::BaseNavRouteRequest request = BuildRouteRequest(
         param, navmesh.pack, state.current_zone, state.navmesh_zone, state.route_start, target.point, {}, target.floor_y);
-    const auto route_result = navmesh.planner.findPath(request);
+    auto route_result = navmesh.planner.findPath(request);
+    if (!route_result.ok() && AppendStartRecovery(param, navmesh, request, state, out_path)) {
+        request.start = state.route_start;
+        route_result = navmesh.planner.findPath(request);
+    }
     if (!route_result.ok()) {
         LogWarn << "NAVMESH waypoint not directly reachable; attempting blind-target fallback." << VAR(state.navmesh_zone)
                 << VAR(state.current_zone) << VAR(target.point.x) << VAR(target.point.y)

--- a/tools/MapNavigator/web/serve.py
+++ b/tools/MapNavigator/web/serve.py
@@ -24,7 +24,7 @@
   GET  /basemap-by-zone       -> 任意 zone 字符串 -> 解析后的底图 PNG (resolve_zone_image)
   GET  /api/zone-ids          -> assert 模式 zone 下拉可选值 (list_available_zone_ids)
   GET  /mesh/{zone_id}        -> 某几何区的 NMSH 二进制网格缓冲 (application/octet-stream)
-  POST /api/route             -> A* 预览路线 (basenav_preview.find_route)
+  POST /api/route             -> A* 预览路线 (basenav_preview.find_route); 起点/终点离网时镜像运行时的盲走补全
   GET  /api/settings          -> 读取 ~/.maaend/mapnavigator.json
   PUT  /api/settings          -> 写入 ~/.maaend/mapnavigator.json
   GET  /api/adb/devices       -> adb devices -l 枚举 (容错)
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import os
 import socket
 import struct
@@ -106,6 +107,13 @@ NAVMESH_DIR = RESOURCE_DIR / "model" / "map" / "navmesh"
 NAVMESH_GZ = NAVMESH_DIR / "base.nav.gz"
 NAVMESH_RAW = NAVMESH_DIR / "base.nav"
 STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+# 起点/终点不在可走网格上时,运行时会盲走一段直线补上 (cpp-algo navmesh_path_expander.cpp 的同名常量)。
+START_RECOVERY_MAX_BLIND_WALK = 32.0
+WAYPOINT_ARRIVAL_SLACK = 0.5
+BLIND_TARGET_FALLBACK_SNAP = 12.0
+BLIND_TARGET_MAX_EXTENSION = 30.0
+BLIND_TARGET_PROBE_STEP = 2.0
 
 # NMSH 二进制网格缓冲 (小端), 见 DESIGN §2.4
 NMSH_MAGIC = b"NMSH"
@@ -416,6 +424,113 @@ async def api_mesh(zone_id: int) -> Response:
     return Response(content=data, media_type="application/octet-stream")
 
 
+def _blind_target_fallback(
+    field: Any,
+    geom_zone_id: int,
+    start: tuple[float, float],
+    goal: tuple[float, float],
+    floor_y: float | None,
+) -> tuple[Any, dict[str, Any]] | None:
+    """终点不在可走网格上时,运行时怎么走 (cpp-algo AppendBlindTargetFallback,即 #3505)。
+
+    从终点沿直线往起点方向逐点回探,第一个能规划到的点就是最近的连通网格点:规划到那里,剩下
+    的一小段直线盲走过去。残差超上限就放弃。
+    """
+    total = math.hypot(goal[0] - start[0], goal[1] - start[1])
+    if total < 1e-6:
+        return None
+
+    probe_limit = min(total, BLIND_TARGET_MAX_EXTENSION + BLIND_TARGET_FALLBACK_SNAP)
+    offset = 0.0
+    while offset <= probe_limit + 1e-6:
+        t = min(offset / total, 1.0)
+        probe = (goal[0] + (start[0] - goal[0]) * t, goal[1] + (start[1] - goal[1]) * t)
+        offset += BLIND_TARGET_PROBE_STEP
+        try:
+            route = field.find_route(geom_zone_id, start, probe, BLIND_TARGET_FALLBACK_SNAP, floor_y)
+        except ValueError:
+            continue
+        if not len(route.points):
+            continue
+        reached = route.points[-1]
+        gap = math.hypot(goal[0] - reached[0], goal[1] - reached[1])
+        if gap > BLIND_TARGET_MAX_EXTENSION:
+            return None
+        return route, {"gap": float(gap), "reached": [float(reached[0]), float(reached[1])]}
+    return None
+
+
+def _offmesh_probe(
+    field: Any,
+    geom_zone_id: int,
+    point: tuple[float, float],
+    snap_radius: float,
+    floor_y: float | None,
+    budget: float | None = None,
+) -> dict[str, Any] | None:
+    """点不在可走网格上吗? 不在的话,最近的网格点在哪、有多远。在网格上则返回 None。
+
+    判据直接用运行时的第一步:以 navmesh_snap_radius 吸附。吸得上,运行时会悄悄吸过去,什么
+    都不会发生(实测 404 个 case:半径内的点无一触发盲走),所以不该报;吸不上,梯子才出手。
+
+    budget 是这个位置上运行时肯盲走的上限(起点 32 / 终点 30),由调用方按角色给——探针本身不
+    知道点是起点还是终点,不填就不下"超不超上限"的判断。
+    """
+    if field.snap(geom_zone_id, point, snap_radius, floor_y) is not None:
+        return None
+    nearest = field.snap(geom_zone_id, point, START_RECOVERY_MAX_BLIND_WALK, floor_y)
+    if nearest is None:
+        return {"distance": None, "nearest": None, "budget": budget}
+    return {
+        "distance": float(nearest.distance),
+        "nearest": [float(nearest.point[0]), float(nearest.point[1])],
+        "budget": budget,
+    }
+
+
+def _blind_walk_reason(field: Any, geom_zone_id: int, point: tuple[float, float]) -> str:
+    """运行时为什么非盲走不可:点压根不在网格上,还是点脚下有网格、但那一块跟目的地连不过去?
+
+    两种毛病差得很远(一个是点标错地方,一个是网格本身碎成了互不连通的块),提示里不能混为一谈。
+    这里判"脚下有没有三角面"用纯几何的 _point_on_mesh:不带半径、不做小岛降权,问的就是这一件事。
+    """
+    return "off_mesh" if not field._point_on_mesh(geom_zone_id, point) else "disconnected"
+
+
+class OffMeshProbeRequest(BaseModel):
+    zone_id: int
+    points: list[list[float]]
+    snap_radius: float = 5.0
+    floor_y: float | None = None
+
+
+@app.post("/api/offmesh-probe")
+async def api_offmesh_probe(req: OffMeshProbeRequest) -> dict[str, Any]:
+    """批量问:这些点在可走网格上吗? 给没有起终点上下文的点用(编辑模式的路径点、刚点下的孤点)。
+
+    只答几何事实(在/不在、最近网格多远)。盲走究竟走多远是跟起点有关的(终点盲走要朝起点回探),
+    那个数只有 /api/route 给得出,别拿这里的距离冒充。
+    """
+
+    def _compute() -> dict[str, Any]:
+        try:
+            field = field_manager.get()
+        except RuntimeError as exc:
+            return {"ok": False, "error": f"navmesh 尚未就绪: {exc}"}
+
+        geom_zone_id = int(field.geometry_zone_id(req.zone_id))
+        results: list[dict[str, Any] | None] = []
+        for raw in req.points:
+            if len(raw) < 2:
+                results.append(None)
+                continue
+            point = (float(raw[0]), float(raw[1]))
+            results.append(_offmesh_probe(field, geom_zone_id, point, req.snap_radius, req.floor_y))
+        return {"ok": True, "results": results}
+
+    return await run_in_threadpool(_compute)
+
+
 @app.post("/api/route")
 async def api_route(req: RouteRequest) -> dict[str, Any]:
     def _compute() -> dict[str, Any]:
@@ -430,15 +545,67 @@ async def api_route(req: RouteRequest) -> dict[str, Any]:
         geom_zone_id = int(field.geometry_zone_id(req.zone_id))
         start = (float(req.start[0]), float(req.start[1]))
         goal = (float(req.goal[0]), float(req.goal[1]))
+
+        blind_start: dict[str, Any] | None = None
+        blind_target: dict[str, Any] | None = None
+        route: Any = None
+        plan_start = start
         try:
             route = field.find_route(geom_zone_id, start, goal, req.snap_radius, req.floor_y)
         except ValueError as exc:
-            return {"ok": False, "error": str(exc)}
+            error = str(exc)
+            entry = field.snap(geom_zone_id, start, START_RECOVERY_MAX_BLIND_WALK, req.floor_y)
+            if entry is not None and entry.distance > WAYPOINT_ARRIVAL_SLACK:
+                plan_start = (float(entry.point[0]), float(entry.point[1]))
+                blind_start = {"entry": [plan_start[0], plan_start[1]], "distance": float(entry.distance)}
+                try:
+                    route = field.find_route(geom_zone_id, plan_start, goal, req.snap_radius, req.floor_y)
+                except ValueError as exc2:
+                    error = str(exc2)
+            if route is None:
+                fallback = _blind_target_fallback(field, geom_zone_id, plan_start, goal, req.floor_y)
+                if fallback is None:
+                    # 规划失败时把起终点的离网情况一并带回去 —— 不然前端只有一句"寻路失败",
+                    # 看不出到底是点掉在网格外, 还是两点根本不连通。
+                    return {
+                        "ok": False,
+                        "error": error,
+                        "off_mesh": {
+                            "start": _offmesh_probe(
+                                field, geom_zone_id, start, req.snap_radius, req.floor_y,
+                                budget=START_RECOVERY_MAX_BLIND_WALK,
+                            ),
+                            "goal": _offmesh_probe(
+                                field, geom_zone_id, goal, req.snap_radius, req.floor_y,
+                                budget=BLIND_TARGET_MAX_EXTENSION,
+                            ),
+                        },
+                    }
+                route, blind_target = fallback
+
+        # 盲走确实会发生, 但成因有两种(点离网 / 网格不连通)。前端要照实说, 所以这里分清楚。
+        if blind_start is not None:
+            blind_start["reason"] = _blind_walk_reason(field, geom_zone_id, start)
+        if blind_target is not None:
+            blind_target["reason"] = _blind_walk_reason(field, geom_zone_id, goal)
+
+        points = [[float(p[0]), float(p[1])] for p in route.points]
+        breaks = [int(b) for b in (route.segment_breaks or [])]
+        if blind_start is not None:
+            # 盲走段插在最前面,故所有 break 下标 +1。points[0] 仍是本段请求的起点,前端的
+            # 多段合并(丢掉后续段的首点)因此照常成立。
+            points.insert(0, [float(req.start[0]), float(req.start[1])])
+            breaks = [b + 1 for b in breaks]
+        if blind_target is not None and blind_target["gap"] > WAYPOINT_ARRIVAL_SLACK:
+            points.append([goal[0], goal[1]])
+
         return {
             "ok": True,
-            "points": [[float(p[0]), float(p[1])] for p in route.points],
-            "segment_breaks": [int(b) for b in (route.segment_breaks or [])],
+            "points": points,
+            "segment_breaks": breaks,
             "cost": float(route.cost),
+            "blind_start": blind_start,
+            "blind_target": blind_target,
         }
 
     return await run_in_threadpool(_compute)

--- a/tools/MapNavigator/web/static/js/gl/overlay.js
+++ b/tools/MapNavigator/web/static/js/gl/overlay.js
@@ -28,6 +28,10 @@ const ASSERT_LABEL_FILL = '#fff1f2';
 
 const SELECTION_RECT_STROKE = '#38bdf8';
 
+// Off-mesh warnings share the amber of the hint marker — "look here", never "blocked".
+const OFFMESH_COLOR = '#ffaa00';
+const OFFMESH_DIM = 'rgba(255, 170, 0, 0.55)';
+
 export class Overlay {
   /**
    * @param {HTMLCanvasElement} canvas the transparent 2D overlay canvas
@@ -71,6 +75,8 @@ export class Overlay {
    *   @param {?number[]} [vm.assertLocateHint] `[x,y]` 游戏当前位置 marker (assert mode)
    *   @param {?Array<{x:number,y:number,label:string}>} [vm.astarLocateHints] preview markers (astar mode)
    *   @param {Object} [vm.astar] see {@link Overlay#_drawAstarPreview}
+   *   @param {Array<Object>} [vm.offMeshMarks] points off the walkable mesh — see
+   *     {@link Overlay#_drawOffMeshMarks} (drawn in every mode)
    *   @param {?Object} [vm.selectionRect] `{x0,y0,x1,y1}` canvas-px drag box, or null
    * @returns {void}
    */
@@ -99,9 +105,183 @@ export class Overlay {
         this._drawAstarPreview(camera, vm.astar);
       }
     }
+    // Topmost: a point sitting off the walkable mesh is the one thing that must never be
+    // hidden under a route line.
+    this._drawOffMeshMarks(camera, vm.offMeshMarks || []);
     if (vm.selectionRect) {
       this._drawSelectionRect(vm.selectionRect);
     }
+  }
+
+  /**
+   * Straight lines the runtime walks with no navmesh under it (amber, dashed, hollow ring
+   * where the mesh takes over). Drawn over the neon route, which otherwise renders these
+   * exactly like a normal planned leg and hides the fact that nothing was planned at all.
+   * @param {Camera} camera
+   * @param {Array<{off:number[], mesh:number[]}>} walks display-frame world coords
+   * @returns {void}
+   */
+  _drawBlindWalks(camera, walks) {
+    if (!walks.length) return;
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.lineCap = 'round';
+
+    for (const walk of walks) {
+      const [ox, oy] = camera.worldToCanvas(walk.off[0], walk.off[1]);
+      const [mx, my] = camera.worldToCanvas(walk.mesh[0], walk.mesh[1]);
+
+      ctx.beginPath();
+      ctx.moveTo(ox, oy);
+      ctx.lineTo(mx, my);
+      ctx.setLineDash([]);
+      ctx.strokeStyle = 'rgba(0, 0, 0, 0.45)';
+      ctx.lineWidth = 6.0;
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.moveTo(ox, oy);
+      ctx.lineTo(mx, my);
+      ctx.setLineDash([7, 5]);
+      ctx.strokeStyle = OFFMESH_COLOR;
+      ctx.lineWidth = 3.0;
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.arc(mx, my, 4.5, 0, Math.PI * 2);
+      ctx.setLineDash([]);
+      ctx.fillStyle = '#0b1220';
+      ctx.fill();
+      ctx.strokeStyle = OFFMESH_COLOR;
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  /**
+   * Off-mesh badge: a dashed amber ring around the point plus a one-line caption. Purely
+   * informational — the developer decides whether the straight line is walkable.
+   *
+   * `exact` marks a distance the backend measured on a real route (the blind walk the
+   * runtime performs). Otherwise it is the straight-line distance to the nearest mesh,
+   * which is *not* the same number, and the caption says so rather than implying it is.
+   *
+   * @param {Camera} camera
+   * @param {Array<{point:number[], nearest:?number[], distance:?number, budget:?number,
+   *   exact:boolean, label:string}>} marks display-frame world coords
+   * @returns {void}
+   */
+  _drawOffMeshMarks(camera, marks) {
+    if (!marks.length) return;
+    const ctx = this.ctx;
+
+    for (const mark of marks) {
+      const [cx, cy] = camera.worldToCanvas(mark.point[0], mark.point[1]);
+      if (!Number.isFinite(cx) || !Number.isFinite(cy)) continue;
+      ctx.save();
+
+      // A probe has no blind-walk line of its own — show where the mesh actually starts.
+      if (!mark.exact && mark.nearest) {
+        const [nx, ny] = camera.worldToCanvas(mark.nearest[0], mark.nearest[1]);
+        ctx.beginPath();
+        ctx.moveTo(cx, cy);
+        ctx.lineTo(nx, ny);
+        ctx.setLineDash([4, 4]);
+        ctx.strokeStyle = OFFMESH_DIM;
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+
+        ctx.beginPath();
+        ctx.arc(nx, ny, 4, 0, Math.PI * 2);
+        ctx.setLineDash([]);
+        ctx.strokeStyle = OFFMESH_DIM;
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+      }
+
+      ctx.beginPath();
+      ctx.arc(cx, cy, 18, 0, Math.PI * 2);
+      ctx.setLineDash([4, 4]);
+      ctx.strokeStyle = OFFMESH_COLOR;
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+
+      // Glyph rides the ring's upper-right; the caption clears it (the plate is opaque and
+      // would otherwise paint straight over it).
+      this._drawWarningGlyph(cx + 20, cy - 20);
+      this._drawCaption(cx, cy - 40, this._offMeshCaption(mark));
+      ctx.restore();
+    }
+  }
+
+  /**
+   * Caption for an off-mesh badge.
+   *
+   * A blind walk has two very different causes and the caption must not conflate them: the
+   * point is off the mesh, or it stands *on* mesh that simply can't reach the destination
+   * (a small disconnected island). Saying "不在网格上" about an on-mesh point would be a lie.
+   * @param {Object} mark @returns {string}
+   */
+  _offMeshCaption(mark) {
+    const where = mark.reason === 'disconnected' ? '网格不连通' : '不在网格上';
+    if (mark.distance === null || mark.distance === undefined) {
+      return `${where} · 附近无网格`;
+    }
+    const d = mark.distance.toFixed(1);
+    if (mark.exact) return `${where} · 盲走 ${d} 格`;
+    const over = mark.budget && mark.distance > mark.budget ? `（超上限 ${mark.budget}）` : '';
+    return `${where} · 最近网格 ${d} 格${over}`;
+  }
+
+  /** Small filled warning triangle. @param {number} cx @param {number} cy @returns {void} */
+  _drawWarningGlyph(cx, cy) {
+    const ctx = this.ctx;
+    const r = 8;
+    ctx.save();
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - r);
+    ctx.lineTo(cx + r * 0.9, cy + r * 0.65);
+    ctx.lineTo(cx - r * 0.9, cy + r * 0.65);
+    ctx.closePath();
+    ctx.fillStyle = OFFMESH_COLOR;
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(0, 0, 0, 0.55)';
+    ctx.lineWidth = 1;
+    ctx.stroke();
+
+    ctx.fillStyle = '#1a1200';
+    ctx.font = `bold 9px ${MONO}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('!', cx, cy + r * 0.1);
+    ctx.restore();
+  }
+
+  /** Amber caption on a dark plate, centered at (cx, cy). @returns {void} */
+  _drawCaption(cx, cy, text) {
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.setLineDash([]);
+    ctx.font = `bold 10px ${MONO}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    const padX = 5;
+    const w = ctx.measureText(text).width + padX * 2;
+    const h = 15;
+    ctx.fillStyle = 'rgba(11, 18, 32, 0.85)';
+    ctx.strokeStyle = OFFMESH_COLOR;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.rect(cx - w / 2, cy - h / 2, w, h);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.fillStyle = OFFMESH_COLOR;
+    ctx.fillText(text, cx, cy);
+    ctx.restore();
   }
 
   /**
@@ -281,6 +461,8 @@ export class Overlay {
    *   @param {boolean} astar.hasRoute false → previewPoints is a straight placeholder
    *   @param {?number[]} [astar.goalOnly] `[x,y]` goal marker while no route yet
    *   @param {number[][]} [astar.waypoints] multi-leg click points (S, 2..n-1, G badges)
+   *   @param {Array<Object>} [astar.blindWalks] straight lines the runtime walks off-mesh —
+   *     see {@link Overlay#_drawBlindWalks}
    * @returns {void}
    */
   _drawAstarPreview(camera, astar) {
@@ -313,6 +495,8 @@ export class Overlay {
       this._drawFlowingParticle(camera, segments);
       ctx.restore();
     }
+
+    this._drawBlindWalks(camera, astar.blindWalks || []);
 
     if (astar.segmentBreaks && astar.segmentBreaks.length) {
       const breakRadius = Math.max(1.5, Math.min(4, 2 * camera.viewScale));

--- a/tools/MapNavigator/web/static/js/main.js
+++ b/tools/MapNavigator/web/static/js/main.js
@@ -37,6 +37,7 @@ import {
   getZoneIds,
   basemapByZoneUrl,
   postRoute,
+  postOffMeshProbe,
   exportPath,
   exportAssert,
   locateOnce,
@@ -103,6 +104,33 @@ class MapNavigatorApp {
     this.astarPoints = [];
     /** @type {?{points:number[][], segment_breaks:number[], cost:number}} */
     this.astarRoute = null;
+    /**
+     * Straight lines the runtime walks with no navmesh under it, base px: `off` is the
+     * point outside the mesh, `mesh` where the mesh takes over. Taken from the backend's
+     * actual ladder result, so this is what the character does — not an estimate.
+     * @type {Array<{off:number[], mesh:number[], distance:number, kind:string}>}
+     */
+    this.astarBlindWalks = [];
+    /**
+     * Off-mesh points to badge, base px. `exact` marks the ones whose distance came from a
+     * real route (a blind walk); the rest are geometric nearest-mesh probes — a *goal*'s
+     * blind walk depends on the start, so those two numbers are not interchangeable.
+     * @type {Array<{point:number[], distance:?number, nearest:?number[], exact:boolean, label:string}>}
+     */
+    this.offMeshMarks = [];
+    /**
+     * EDIT-mode off-mesh badges, in the points' own zone frame. Same shape as
+     * {@link offMeshMarks} but always `exact:false` — a waypoint is a *goal*, and the
+     * runtime's blind walk to a goal depends on where it starts from.
+     * @type {Array<Object>}
+     */
+    this.editOffMeshMarks = [];
+    /** Guards against a stale probe response overwriting a newer one. @type {number} */
+    this._probeToken = 0;
+    /** @type {?string} NAVMESH-waypoint signature the edit-mode badges were probed for. */
+    this._offMeshSig = null;
+    /** @type {?number} debounce handle for the edit-mode probe. */
+    this._offMeshTimer = null;
 
     // --- basemap texture bookkeeping (async <img> load) ---
     /** @type {?string} zone name currently uploaded to the renderer basemap. */
@@ -733,6 +761,8 @@ class MapNavigatorApp {
     if (mode === Mode.EDIT) overlayPoints = this._currentSegmentPoints();
     else if (mode === Mode.ASSERT) overlayPoints = this._displayRealPoints();
 
+    if (mode === Mode.EDIT) this._scheduleEditOffMeshProbe();
+
     let displayAssertLocateHint = null;
     if (mode === Mode.ASSERT && this.assertLocateHint) {
       displayAssertLocateHint = this._baseToDisplay(this.assertLocateHint[0], this.assertLocateHint[1]);
@@ -754,11 +784,13 @@ class MapNavigatorApp {
               hasRoute: !!this.astarRoute,
               goalOnly: this.astarGoal && !this.astarRoute ? this.astarGoal : null,
               waypoints: this.astarPoints,
+              blindWalks: this._blindWalksForDisplay(),
             }
           : null,
       selectionRect: this.selectionRect,
       assertLocateHint: displayAssertLocateHint,
       astarLocateHints: displayAstarLocateHints,
+      offMeshMarks: this._offMeshForMode(mode),
     };
     this.renderer.requestRender(this.camera);
     this.overlay.render(this.camera, vm);
@@ -874,6 +906,130 @@ class MapNavigatorApp {
     if (this.astarRoute) return this._routeDisplayPoints();
     if (this.astarStart) return [this.astarStart];
     return [];
+  }
+
+  /** The runtime's blind-walk lines, base px → display frame. @returns {Array<Object>} */
+  _blindWalksForDisplay() {
+    return this.astarBlindWalks.map((w) => ({
+      ...w,
+      off: this._baseToDisplay(w.off[0], w.off[1]),
+      mesh: this._baseToDisplay(w.mesh[0], w.mesh[1]),
+    }));
+  }
+
+  /** Off-mesh badges, base px → display frame. @returns {Array<Object>} */
+  _offMeshMarksForDisplay() {
+    return this.offMeshMarks.map((m) => ({
+      ...m,
+      point: this._baseToDisplay(m.point[0], m.point[1]),
+      nearest: m.nearest ? this._baseToDisplay(m.nearest[0], m.nearest[1]) : null,
+    }));
+  }
+
+  /**
+   * Off-mesh badges for the active mode. EDIT badges its NAVMESH waypoints (already in the
+   * edit zone's own frame — no projection); A* badges its clicked points. ASSERT shows the
+   * real route read-only and owns no badges of its own.
+   * @param {string} mode @returns {Array<Object>}
+   */
+  _offMeshForMode(mode) {
+    if (mode === Mode.EDIT) return this.editOffMeshMarks;
+    if (mode === Mode.ASTAR) return this._offMeshMarksForDisplay();
+    return [];
+  }
+
+  /**
+   * The NAVMESH waypoints of the current edit segment, with their base-px coords.
+   *
+   * Only NAVMESH: those are the ones the runtime pathfinds to, so landing off the mesh
+   * changes what it does. A RUN waypoint off the mesh is not a defect — the runtime walks
+   * the recorded line as authored, mesh or no mesh — so badging those would be pure noise.
+   * @returns {Array<{idx:number, base:number[], own:number[]}>}
+   */
+  _editNavmeshPoints() {
+    if (!this.field) return [];
+    const out = [];
+    const points = this._currentSegmentPoints();
+    for (let i = 0; i < points.length; i += 1) {
+      const point = points[i];
+      if (!getPointActions(point).includes(ActionType.NAVMESH)) continue;
+      const zoneId = this._resolveZoneId(point.zone);
+      if (Number.isNaN(zoneId)) continue;
+      out.push({ idx: i, base: this._pointToBase(zoneId, point.x, point.y), own: [point.x, point.y], zoneId });
+    }
+    return out;
+  }
+
+  /**
+   * Re-probe the edit segment's NAVMESH waypoints when they change. Called from every
+   * paint, so it short-circuits on an unchanged signature (a pan or zoom must not hit the
+   * backend) and debounces the ones that do change (dragging a node fires per mousemove).
+   * @returns {void}
+   */
+  _scheduleEditOffMeshProbe() {
+    const targets = this._editNavmeshPoints();
+    const sig = targets.map((t) => `${t.zoneId}:${t.own[0]},${t.own[1]}`).join('|');
+    if (sig === this._offMeshSig) return;
+    this._offMeshSig = sig;
+
+    if (!targets.length) {
+      this.editOffMeshMarks = [];
+      return;
+    }
+    clearTimeout(this._offMeshTimer);
+    this._offMeshTimer = setTimeout(() => this._probeEditNavmeshPoints(targets), 150);
+  }
+
+  /**
+   * Badge whichever NAVMESH waypoints sit off the walkable mesh.
+   *
+   * The distance shown is the straight line to the nearest mesh — *not* the blind walk the
+   * runtime performs, which depends on where the character comes from (it probes back along
+   * the goal→start line). The badge says "最近网格", never "盲走"; A* mode is where the
+   * runtime's real number lives.
+   * @param {Array<Object>} targets from {@link _editNavmeshPoints}
+   * @returns {Promise<void>}
+   */
+  async _probeEditNavmeshPoints(targets) {
+    const token = ++this._probeToken;
+    const zoneId = this._resolveZoneId(this.state.currentZone());
+    if (!this.field || Number.isNaN(zoneId) || !targets.length) return;
+
+    let res;
+    try {
+      res = await postOffMeshProbe({
+        zone_id: this.field.geometryZoneId(zoneId),
+        points: targets.map((t) => t.base),
+        snap_radius: ASTAR_PREVIEW_SNAP_RADIUS,
+        floor_y: this.field.floorYFor(zoneId),
+      });
+    } catch {
+      return; // 探针只是提示, 失败就静默放过, 别打断编辑
+    }
+    if (token !== this._probeToken || !res || !res.ok) return;
+
+    const marks = [];
+    (res.results || []).forEach((probe, i) => {
+      if (!probe || !targets[i]) return;
+      const target = targets[i];
+      marks.push({
+        point: target.own,
+        // nearest 是基准图坐标, 点在自己的分层坐标系里 —— 换算回来才画得到一起。
+        nearest: probe.nearest ? this._baseToOwn(target.zoneId, probe.nearest) : null,
+        distance: probe.distance,
+        budget: null, // 路点是终点, 真实盲走距离跟起点有关, 这里不下上限判断
+        exact: false,
+        label: `#${target.idx}`, // 跟节点圆圈上的编号一致 (0 基)
+      });
+    });
+    this.editOffMeshMarks = marks;
+    this._paint();
+  }
+
+  /** base px → a point's own zone frame (inverse of {@link _pointToBase}). */
+  _baseToOwn(zoneId, base) {
+    if (!this.field || Number.isNaN(zoneId) || !this.field.isTier(zoneId)) return base;
+    return this.field.baseToTier(zoneId, base[0], base[1]);
   }
 
   /** Sorted-rect `[x,y,w,h]` in display-frame world for the assert overlay (unrounded). */
@@ -1390,24 +1546,67 @@ class MapNavigatorApp {
         this.astarPoints = [[wx, wy]];
         this.astarRoute = null;
         setStatus(`A* 起点: [${wx.toFixed(1)}, ${wy.toFixed(1)}]，再点击终点。`, '#3b82f6');
+        // 探针/路线的同步开头会清掉上一轮的离网徽标, 所以先调它们、再 _paint(),
+        // 免得这一帧还画着上一条路线的警示环。
+        this._probeLoneAstarPoint();
         this._paint();
         return;
       }
       this.astarPoints.push([wx, wy]);
       setStatus('正在计算 A* 路径...', '#eab308');
-      this._paint();
       this._calculateAstarPreview();
+      this._paint();
     } else {
       this.astarPoints.push([wx, wy]);
       if (this.astarPoints.length < 2) {
         setStatus('已设置 A* 起点，请继续点击后续路点以串联多段路径。', '#3b82f6');
+        this._probeLoneAstarPoint();
         this._paint();
       } else {
         setStatus(`正在计算第 ${this.astarPoints.length - 1} 段 A* 路径...`, '#eab308');
-        this._paint();
         this._calculateAstarPreview();
+        this._paint();
       }
     }
+  }
+
+  /**
+   * Badge the lone A* point when it sits off the walkable mesh. With ≥2 points the route
+   * owns the badges (it carries the runtime's real blind-walk numbers); this covers the
+   * moment before any route exists, when a point clicked off the mesh looks no different
+   * from one on it. Geometry only — see {@link postOffMeshProbe}.
+   * @returns {Promise<void>}
+   */
+  async _probeLoneAstarPoint() {
+    this._resetOffMeshOverlays();
+    const token = this._probeToken;
+    if (!this.field || this.astarPoints.length !== 1) return;
+
+    const displayZoneId = this._astarZoneId();
+    if (Number.isNaN(displayZoneId)) return;
+    const tierId = this._activeDisplayTierId();
+    const [px, py] = this.astarPoints[0];
+    const base = tierId !== null ? this.field.tierToBase(tierId, px, py) : [px, py];
+
+    let res;
+    try {
+      res = await postOffMeshProbe({
+        zone_id: this.field.geometryZoneId(displayZoneId),
+        points: [base],
+        snap_radius: ASTAR_PREVIEW_SNAP_RADIUS,
+        floor_y: this.field.floorYFor(displayZoneId),
+      });
+    } catch {
+      return; // 探针只是提示, 失败就静默放过, 别打断编辑
+    }
+    if (token !== this._probeToken) return; // 期间点变了, 丢弃这次结果
+
+    const probe = res && res.ok && res.results ? res.results[0] : null;
+    if (!probe) return;
+    this._addOffMeshMark(base, 'S', { ...probe, exact: false });
+    const d = probe.distance === null ? '附近无网格' : `最近网格 ${probe.distance.toFixed(1)} 格`;
+    setStatus(`⚠ 该点不在可走网格上（${d}）——运行时会直线盲走过去，请自行确认这条直线走得通。`, '#f59e0b');
+    this._paint();
   }
 
   /**
@@ -1419,6 +1618,9 @@ class MapNavigatorApp {
    * @returns {Promise<void>}
    */
   async _calculateAstarPreview() {
+    // 先同步清干净(并作废在途探针) —— 调用方随后 _paint() 时就不会再画着上一次的残留徽标,
+    // 而点起点时发出的孤点探针也不会在路线算完之后才回来、盖掉路线自己的那行提示。
+    this._resetOffMeshOverlays();
     if (!this.field || this.astarPoints.length < 2) return;
     const displayZoneId = this._astarZoneId();
     const geomId = this.field.geometryZoneId(displayZoneId);
@@ -1435,16 +1637,42 @@ class MapNavigatorApp {
       let totalCost = 0;
 
       for (let i = 0; i < basePoints.length - 1; i++) {
+        const legStart = basePoints[i];
+        const legGoal = basePoints[i + 1];
         const res = await postRoute({
           zone_id: geomId,
-          start: basePoints[i],
-          goal: basePoints[i + 1],
+          start: legStart,
+          goal: legGoal,
           snap_radius: ASTAR_PREVIEW_SNAP_RADIUS,
           floor_y: floorY,
         });
 
         if (!res || !res.ok) {
+          this._markFailedLeg(res && res.off_mesh, legStart, legGoal, i, basePoints.length);
           throw new Error(res?.error || `第 ${i + 1} 段 A* 寻路失败`);
+        }
+
+        // The runtime blind-walks a straight line onto the mesh (off-mesh start) or off it
+        // (off-mesh goal). These are its real numbers, so draw the actual lines it walks.
+        if (res.blind_start) {
+          const { entry, distance, reason } = res.blind_start;
+          this.astarBlindWalks.push({ off: legStart, mesh: entry, distance, kind: '起点' });
+          this._addOffMeshMark(legStart, this._astarBadgeLabel(i, basePoints.length), {
+            nearest: entry,
+            distance,
+            reason,
+            exact: true,
+          });
+        }
+        if (res.blind_target) {
+          const { reached, gap, reason } = res.blind_target;
+          this.astarBlindWalks.push({ off: legGoal, mesh: reached, distance: gap, kind: '终点' });
+          this._addOffMeshMark(legGoal, this._astarBadgeLabel(i + 1, basePoints.length), {
+            nearest: reached,
+            distance: gap,
+            reason,
+            exact: true,
+          });
         }
 
         const segmentPts = res.points || [];
@@ -1463,14 +1691,100 @@ class MapNavigatorApp {
         segment_breaks: combinedBreaks,
         cost: totalCost,
       };
-      setStatus(`A* 路线已生成：共 ${this.astarPoints.length} 个关键点，包含 ${this.astarRoute.points.length} 个坐标。`, '#10b981');
+      const summary = `A* 路线已生成：共 ${this.astarPoints.length} 个关键点，包含 ${this.astarRoute.points.length} 个坐标。`;
+      if (this.astarBlindWalks.length > 0) {
+        const worst = Math.max(...this.astarBlindWalks.map((b) => b.distance)).toFixed(1);
+        const kinds = [...new Set(this.astarBlindWalks.map((b) => b.kind))].join('/');
+        // "接不上网格" 两种成因都覆盖(点离网 / 脚下网格不连通); 具体是哪种, 徽标上写着。
+        setStatus(
+          `${summary} ⚠ ${this.astarBlindWalks.length} 处盲走：${kinds}接不上网格，运行时会沿橙色虚线直着走过去（最长 ${worst} 格）——请自行确认这条直线走得通。`,
+          '#f59e0b',
+        );
+      } else {
+        setStatus(summary, '#10b981');
+      }
       this._paint();
     } catch (err) {
       this.astarRoute = null;
+      this.astarBlindWalks = [];
       const msg = err && err.message ? err.message : err;
-      setStatus(`A* 寻路失败: ${msg}`, '#ef4444');
+      setStatus(`A* 寻路失败: ${msg}${this._offMeshHint()}`, '#ef4444');
       this._paint();
     }
+  }
+
+  /** Badge letter for A* waypoint `i` of `n` (matches the overlay's S / 2..n-1 / G). */
+  _astarBadgeLabel(i, n) {
+    if (i === 0) return 'S';
+    if (i === n - 1) return 'G';
+    return String(i + 1);
+  }
+
+  /**
+   * Record an off-mesh point to badge. A waypoint shared by two legs is reported by both
+   * (once as a goal, once as a start), so keep only the first badge per point — the two
+   * blind-walk *lines* are both real and stay.
+   * @param {number[]} point base px
+   * @param {string} label badge letter the point already wears (S / 2..n-1 / G)
+   * @param {{nearest:?number[], distance:?number, budget:?number, reason:?string,
+   *   exact:boolean}} info `reason` is 'off_mesh' (the point is outside the mesh) or
+   *   'disconnected' (it stands on mesh the destination can't be reached from)
+   * @returns {void}
+   */
+  _addOffMeshMark(point, label, info) {
+    const key = (p) => `${p[0].toFixed(2)},${p[1].toFixed(2)}`;
+    if (this.offMeshMarks.some((m) => key(m.point) === key(point))) return;
+    this.offMeshMarks.push({
+      point,
+      label,
+      nearest: info.nearest || null,
+      distance: info.distance === undefined ? null : info.distance,
+      budget: info.budget || null,
+      reason: info.reason || 'off_mesh',
+      exact: !!info.exact,
+    });
+  }
+
+  /**
+   * Badge whichever endpoints of a failed leg are off the mesh, using the backend's probe.
+   * Nothing badged means both endpoints sit on the mesh and the leg failed for another
+   * reason (the two are on disconnected pieces of it) — a different problem, said plainly
+   * rather than mislabeled "off-mesh".
+   * @param {?{start:?Object, goal:?Object}} offMesh @param {number[]} legStart
+   * @param {number[]} legGoal @param {number} i leg index @param {number} n waypoint count
+   * @returns {void}
+   */
+  _markFailedLeg(offMesh, legStart, legGoal, i, n) {
+    if (!offMesh) return;
+    if (offMesh.start) this._addOffMeshMark(legStart, this._astarBadgeLabel(i, n), { ...offMesh.start, exact: false });
+    if (offMesh.goal) this._addOffMeshMark(legGoal, this._astarBadgeLabel(i + 1, n), { ...offMesh.goal, exact: false });
+  }
+
+  /** Trailing clause for a failed-route status line, naming the off-mesh endpoints. @returns {string} */
+  _offMeshHint() {
+    if (!this.offMeshMarks.length) {
+      return '（起终点都在网格上——多半是两点分属互不连通的网格块）';
+    }
+    const parts = this.offMeshMarks.map((m) => {
+      if (m.distance === null || m.distance === undefined) return `${m.label} 附近没有可走网格`;
+      // budget = 这个位置上运行时肯盲走的上限, 由后端按起点/终点的角色给。
+      const over = m.budget && m.distance > m.budget ? `，超出盲走上限 ${m.budget} 格` : '';
+      return `${m.label} 离网格 ${m.distance.toFixed(1)} 格${over}`;
+    });
+    return `（${parts.join('；')}）`;
+  }
+
+  /**
+   * Drop the off-mesh overlays and void any probe still in flight, so a response that
+   * arrives late can no longer re-add a badge for a point that has since changed.
+   *
+   * Synchronous on purpose: callers paint right after, and must paint the cleared state.
+   * @returns {void}
+   */
+  _resetOffMeshOverlays() {
+    this.astarBlindWalks = [];
+    this.offMeshMarks = [];
+    this._probeToken += 1;
   }
 
   /** Drop all A* click points, the computed route, and the preview markers. @returns {void} */
@@ -1478,6 +1792,7 @@ class MapNavigatorApp {
     this.astarPoints = [];
     this.astarRoute = null;
     this.astarLocateHints = [];
+    this._resetOffMeshOverlays();
   }
 
   /** Reset A* view state on a zone change. @returns {void} */
@@ -1997,6 +2312,7 @@ class MapNavigatorApp {
             } else {
               setStatus('A* 点已清空。', '#3b82f6');
             }
+            this._probeLoneAstarPoint();
             this._paint();
           }
           e.preventDefault();

--- a/tools/MapNavigator/web/static/js/rpc.js
+++ b/tools/MapNavigator/web/static/js/rpc.js
@@ -171,14 +171,52 @@ export function getZoneIds() {
 /**
  * Request an A* preview route. Resolves the backend payload verbatim, including the
  * `{ok:false, error}` "unreachable" case (see module note).
+ *
+ * `blind_start` / `blind_target` describe the straight lines the runtime walks with no
+ * navmesh under it (they are the actual ladder result, not an estimate). Their `reason` is
+ * `'off_mesh'` when the endpoint lies outside the mesh, `'disconnected'` when it stands on
+ * mesh the other end simply cannot be reached from — do not report the second as the first.
+ *
+ * `off_mesh` rides along on the `ok:false` case so a failure can say *why* — an endpoint
+ * outside the mesh reads very differently from two endpoints on disconnected pieces.
+ *
  * @param {{zone_id:number, start:number[], goal:number[], snap_radius?:number, floor_y?:?number}} req
- * @returns {Promise<{ok:boolean, points?:number[][], segment_breaks?:number[], cost?:number, error?:string}>}
+ * @returns {Promise<{ok:boolean, points?:number[][], segment_breaks?:number[], cost?:number,
+ *   blind_start?:?{entry:number[], distance:number, reason:string},
+ *   blind_target?:?{reached:number[], gap:number, reason:string},
+ *   off_mesh?:{start:?OffMeshProbe, goal:?OffMeshProbe}, error?:string}>}
  */
 export function postRoute(req) {
   return sendJson('/api/route', {
     zone_id: req.zone_id,
     start: req.start,
     goal: req.goal,
+    snap_radius: req.snap_radius === undefined ? 5.0 : req.snap_radius,
+    floor_y: req.floor_y === undefined ? null : req.floor_y,
+  });
+}
+
+/**
+ * @typedef {{distance:?number, nearest:?number[]}} OffMeshProbe a point off the walkable
+ *   mesh: how far the nearest mesh point is and where it lies (both null when there is no
+ *   mesh at all within the runtime's blind-walk budget).
+ */
+
+/**
+ * Ask which of `points` lie off the walkable mesh. Resolves one entry per input point,
+ * `null` meaning "on the mesh" (the runtime snaps it silently — nothing to report).
+ *
+ * Geometry only. How far the runtime actually blind-walks to a *goal* depends on the start
+ * (it probes back along the goal→start line), so that number comes from {@link postRoute}
+ * alone — never present a `distance` from here as the blind walk.
+ *
+ * @param {{zone_id:number, points:number[][], snap_radius?:number, floor_y?:?number}} req
+ * @returns {Promise<{ok:boolean, results?:Array<?OffMeshProbe>, error?:string}>}
+ */
+export function postOffMeshProbe(req) {
+  return sendJson('/api/offmesh-probe', {
+    zone_id: req.zone_id,
+    points: req.points,
     snap_radius: req.snap_radius === undefined ? 5.0 : req.snap_radius,
     floor_y: req.floor_y === undefined ? null : req.floor_y,
   });

--- a/tools/MapNavigator/web/static/js/rpc.js
+++ b/tools/MapNavigator/web/static/js/rpc.js
@@ -197,9 +197,11 @@ export function postRoute(req) {
 }
 
 /**
- * @typedef {{distance:?number, nearest:?number[]}} OffMeshProbe a point off the walkable
- *   mesh: how far the nearest mesh point is and where it lies (both null when there is no
- *   mesh at all within the runtime's blind-walk budget).
+ * @typedef {{distance:?number, nearest:?number[], budget:?number}} OffMeshProbe a point off the
+ *   walkable mesh: how far the nearest mesh point is and where it lies (both null when there is
+ *   no mesh at all within the runtime's blind-walk budget). `budget` is how far the runtime will
+ *   blind-walk at that endpoint's role, so only {@link postRoute} fills it in — a bare point does
+ *   not say whether it is a start or a goal, and the batch probe below leaves it null.
  */
 
 /**


### PR DESCRIPTION
- resolve #3666

<img width="715" height="886" alt="fig1_start_offmesh" src="https://github.com/user-attachments/assets/171650c3-ad34-4ce4-8bf4-18efa735c804" />
<img width="616" height="921" alt="fig2_goal_offmesh_pen" src="https://github.com/user-attachments/assets/724686a2-7091-4e91-a925-9259f031aec9" />
<img width="1492" height="894" alt="fig3_criterion" src="https://github.com/user-attachments/assets/8c64da9f-1a46-4b81-848d-4a2e42173435" />

## Summary by Sourcery

在 A* 的起点/终点不在导航网格（navmesh）上时，暴露并可视化运行时的盲走（blind-walk）行为，并添加基于几何的探针，用于在 A* 和编辑模式中警示离网格的路径点。

新功能：
- 添加 `/api/offmesh-probe` 端点和前端 RPC，用于检测位于可行走网格之外的点，并报告最近网格的距离。
- 在 MapNavigator 叠加层中显示离网格警告，包括徽标、说明文字，以及在 A* 预览中对运行时盲走显示虚线。
- 在编辑模式中对 NAVMESH 路径点进行探测和标记，并对孤立的 A* 点进行标记，以指示在尚未存在完整路径之前它们是否位于网格之外。

增强改进：
- 扩展 `/api/route` 和 A* 预览处理，使其反映运行时针对离网格起点/终点的盲走恢复行为，并将这些信息暴露给 UI。
- 更新 cpp 导航网格路径扩展逻辑，对离网格的 NAVMESH 路径点执行起点恢复，使编辑器预览与运行时行为保持一致。
- 改进 A* 失败消息，加入详细的离网格诊断信息（到网格的距离、盲走预算、连接性提示）。

文档：
- 在 JS RPC 模块注释中记录新的路线响应字段（`blind_start`、`blind_target`、`off_mesh`）以及离网格探针的语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose and visualize runtime blind-walk behaviour when A* start/goal are off the navmesh, and add geometry-based probes to warn about off-mesh waypoints in both A* and edit modes.

New Features:
- Add /api/offmesh-probe endpoint and frontend RPC to detect points that lie off the walkable mesh and report nearest mesh distances.
- Show off-mesh warnings in MapNavigator overlay, including badges, captions, and dashed lines for runtime blind walks on A* previews.
- Probe and badge NAVMESH waypoints in edit mode and lone A* points to indicate when they sit off the mesh before a route exists.

Enhancements:
- Extend /api/route and A* preview handling to mirror runtime blind-walk recovery for off-mesh starts/goals and surface this information to the UI.
- Update cpp navmesh path expansion to perform start recovery on off-mesh NAVMESH waypoints, aligning editor previews with runtime behaviour.
- Improve A* failure messages with detailed off-mesh diagnostics (distance to mesh, blind-walk budgets, connectivity hints).

Documentation:
- Document new route response fields (blind_start, blind_target, off_mesh) and off-mesh probe semantics in the JS RPC module comments.

</details>