### PR TITLE
fix: 选剑演武结束前等待画面稳定

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -25,6 +25,10 @@
     // 奖励耗尽 → 结束（CheckRewardMode 见非奖励模式 / Fight.json 战后 RewardExhausted 汇入）
     "TrialOfSwordmancyDailyFinish": {
         "desc": "演算结束",
+        "recognition": "And",
+        "all_of": [
+            "TrialOfSwordmancyDrawCard"
+        ],
         "pre_delay": 0,
         "post_delay": 0,
         "focus": {


### PR DESCRIPTION
fix #4179
不等待会导致下一任务开始时误识别到 InWorld

## Summary by Sourcery

Bug Fixes:
- 通过在退出 `TrialOfSwordmancy` 之前添加一个稳定等待时间，防止在下一项任务开始时错误地将游戏识别为处于 InWorld 状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent misidentifying the game as being InWorld at the start of the next task by adding a stabilization wait before exiting TrialOfSwordmancy.

</details>