### PR TITLE
fix(MapLocator): 双策略不一致时用运动连续性裁判放行

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -877,6 +877,26 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
                 .debugMessage = "Dual-Mode Tracking Success",
             };
         }
+        if (motionTracker->getLastPos().has_value()) {
+            const double predX = motionTracker->getPredictedX(now);
+            const double predY = motionTracker->getPredictedY(now);
+            const double distPrimaryToPred = std::hypot(rawPrimaryPos.x - predX, rawPrimaryPos.y - predY);
+            const double distFallbackToPred = std::hypot(rawFallbackPos.x - predX, rawFallbackPos.y - predY);
+            const bool primaryCloser = distPrimaryToPred <= distFallbackToPred;
+            MapPosition arbitrated = primaryCloser ? rawPrimaryPos : rawFallbackPos;
+            const double arbitratedDistToPred = primaryCloser ? distPrimaryToPred : distFallbackToPred;
+            if (arbitratedDistToPred <= kTrackingOutlierDistance) {
+                arbitrated.isHeld = false;
+                LogInfo << "Dual-Mode arbitrated by motion continuity" << VAR(distPrimaryToPred) << VAR(distFallbackToPred)
+                        << VAR(arbitrated.x) << VAR(arbitrated.y) << VAR(arbitrated.score) << VAR(dist);
+                MapPosition accepted = acceptPosition(arbitrated, now);
+                return LocateResult {
+                    .status = LocateStatus::Success,
+                    .position = accepted,
+                    .debugMessage = "Dual-Mode Motion Arbitrated",
+                };
+            }
+        }
         LogInfo << "Dual-Mode Tracking rejected" << VAR(rawPrimaryPos.score) << VAR(rawPrimaryPos.x) << VAR(rawPrimaryPos.y)
                 << VAR(rawFallbackPos.score) << VAR(rawFallbackPos.x) << VAR(rawFallbackPos.y) << VAR(dist);
     }


### PR DESCRIPTION
- fix #4197

## Summary by Sourcery

错误修复：
- 通过使用运动跟踪器的预测在主位置与回退位置存在冲突时进行选择，解决对有效的双模跟踪结果被错误拒绝的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect rejection of valid dual-mode tracking results by using motion tracker prediction to choose between conflicting primary and fallback positions.

</details>