### PR TITLE
fix: 偶现售卖弹性物资失败

### DIFF
--- a/assets/resource/pipeline/AutoSell/Recognition.json
+++ b/assets/resource/pipeline/AutoSell/Recognition.json
@@ -57,7 +57,7 @@
             54
         ],
         "connected": true,
-        "count": 300
+        "count": 280
     },
     "AutoSellStockRedistributionItemGreenLineRecognition": {
         "desc": "识别物资调度界面中的绿线所在位置，用于定位item宽度",
@@ -80,7 +80,7 @@
             80
         ],
         "connected": true,
-        "count": 400
+        "count": 370
     },
     "AutoSellStockRedistributionItemNameRecRecognition": {
         "desc": "识别物资调度界面中文字所在roi，方便only_rec识别",


### PR DESCRIPTION
close #4138

## 由 Sourcery 提供的摘要

错误修复：
- 通过更正流水线配置中的识别设置，解决弹性材料在自动出售（AutoSell）过程中间歇性失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve intermittent AutoSell failures for elastic materials by correcting recognition settings in the pipeline configuration.

</details>