### PR TITLE
feat: 自动战斗排轴增加 不等待连携技冷却选项

### DIFF
--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -31,6 +31,7 @@ type autoFightAttach struct {
 	EnableLockTarget             bool   `json:"enable_lock_target"`
 	ReserveSkillLevel            int    `json:"reserve_skill_level"`
 	EndAxisTimelineCode          string `json:"end_axis_timeline_code"`
+	SkipComboCooldown            bool   `json:"skip_combo_cooldown"`
 }
 
 var screenAnalyzer = NewScreenAnalyzer()
@@ -573,7 +574,7 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 		} else {
 			if hasEnemyTarget && timeline.ActionFinish() {
 				maafocus.PrintThrottle(ctx, 3*time.Second, i18n.T("autofight.endaxis.retry_timeline"))
-				timeline.SelectScenario(ctx, characterCount, comboFull, endSkillFull, energyLevel)
+				timeline.SelectScenario(ctx, characterCount, comboFull, endSkillFull, energyLevel, params.SkipComboCooldown)
 			}
 
 			if screenAnalyzer.GetCharacterComboActive() && !timeline.ActionFinish() {

--- a/agent/go-service/autofight/endaxistimeline.go
+++ b/agent/go-service/autofight/endaxistimeline.go
@@ -75,7 +75,7 @@ type timelineRootRaw struct {
 //
 //	t := NewEndAxisTimeline()
 //	t.SetTimelineCode(code)
-//	if t.SelectScenario(comboFull, endSkillFull, energy) {
+//	if t.SelectScenario(ctx, characterCount, comboFull, endSkillFull, energy, skipComboCooldown) {
 //	    for !t.ActionFinish() {
 //	        if a, ok := t.FrontAction(); ok {
 //	            // ... 在外部执行该动作 ...
@@ -181,11 +181,13 @@ func decodeEndAxisShareCode(code string) ([]byte, error) {
 //   - characterComboFull：连携已就绪的角色编号列表（1..characterCount 中的子集），
 //     例如 [1, 3] 表示 1 号、3 号角色连携满；
 //   - endSkillFull：终结技已充能完毕的角色编号列表（1..characterCount 中的子集）；
-//   - energyLevel：当前能量条等级，目前仅作为状态保留，未参与匹配。
+//   - energyLevel：当前能量条等级，目前仅作为状态保留，未参与匹配；
+//   - skipComboCooldown：为 true 时跳过全员连携就绪检测，轴完立刻尝试匹配下一 scenario。
 //
 // 匹配规则：
-//  1. 1..characterCount 任一角色不在 characterComboFull 中（即有人连携没满），直接返回
-//     false，不进入 scenario 匹配，并通过 maafocus.PrintThrottle（3s）输出"等待连携技冷却完成"的提示；
+//  1. 若 skipComboCooldown 为 false，且 1..characterCount 任一角色不在 characterComboFull 中
+//     （即有人连携没满），直接返回 false，不进入 scenario 匹配，并通过 maafocus.PrintThrottle（3s）
+//     输出"等待连携技冷却完成"的提示；
 //  2. 对每个 scenario，逐个 track i ∈ [0, characterCount) 检查：若该 track 含 type==ultimate
 //     的 action，则对应角色编号 i+1 必须在 endSkillFull 列表中；任一项不满足则跳过该
 //     scenario，并通过 maafocus.PrintThrottle（3s）输出"终结技未充能完毕"的提示；
@@ -194,22 +196,24 @@ func decodeEndAxisShareCode(code string) ([]byte, error) {
 //  4. 所有 scenario 都不满足时返回 false。
 //
 // 选中 scenario 时通过 maafocus.Print 输出多语言提示；跳过提示限频，ctx 为 nil 时仅记录日志。
-func (t *EndAxisTimeline) SelectScenario(ctx *maa.Context, characterCount int, characterComboFull, endSkillFull []int, energyLevel int) bool {
+func (t *EndAxisTimeline) SelectScenario(ctx *maa.Context, characterCount int, characterComboFull, endSkillFull []int, energyLevel int, skipComboCooldown bool) bool {
 	t.reset()
 
 	if t.root == nil {
 		return false
 	}
 
-	for op := 1; op <= characterCount; op++ {
-		if !slices.Contains(characterComboFull, op) {
-			log.Debug().
-				Str("component", "EndAxisTimeline").
-				Str("step", "SelectScenario").
-				Int("waitingOperator", op).
-				Msg("combo not ready for all operators")
-			maafocus.PrintThrottle(ctx, 3*time.Second, i18n.T("autofight.endaxis.waiting_combo_cooldown"))
-			return false
+	if !skipComboCooldown {
+		for op := 1; op <= characterCount; op++ {
+			if !slices.Contains(characterComboFull, op) {
+				log.Debug().
+					Str("component", "EndAxisTimeline").
+					Str("step", "SelectScenario").
+					Int("waitingOperator", op).
+					Msg("combo not ready for all operators")
+				maafocus.PrintThrottle(ctx, 3*time.Second, i18n.T("autofight.endaxis.waiting_combo_cooldown"))
+				return false
+			}
 		}
 	}
 

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -149,6 +149,8 @@
     "option.AutoFightAxisData.description": "- Open www.end-axis.com to create a timeline, or browse www.end-axis.com/shares (sharing plaza) for timelines shared by others.\n- Add operators, skills, and ultimate skill release timing in the timeline; extra elements are not read.\n- On the site, click + in the top-left corner and add at least one plan without ultimate skills to ensure looping.\n- Internally selects one timeline plan automatically based on ultimate skill charge state.",
     "option.AutoFightAxisCodeString.label": "Data code",
     "option.AutoFightAxisCodeString.description": "Select a timeline plan on the site, then Export (top-right) → Copy Data Code, and paste it here.",
+    "option.AutoFightAxisSkipComboCooldown.label": "Skip link skill cooldown wait",
+    "option.AutoFightAxisSkipComboCooldown.description": "When enabled, start the next timeline round immediately after one finishes. When disabled, wait until all link skills are ready before starting the next round.",
     "option.AutoPick.label": "Auto Pick Up",
     "option.QuickTeleport.label": "Quick Teleport",
     "option.QuickTeleport.description": "When selecting a teleport point on the world map (or from a list), automatically click Teleport.",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -147,6 +147,8 @@
     "option.AutoFightAxisData.description": "- www.end-axis.com を開いて排軸を作成するか、www.end-axis.com/shares の排軸共有広場で他人が共有した排軸を使用してください。\n- 排軸にオペレーター、戦技、終結技の発動タイミングを追加すれば十分です。余分な要素は読み取られません。\n- サイト左上の + から終結技なしの方案を少なくとも1つ追加し、ループできるようにすることを推奨します。\n- 内部で終結技の状態に応じて、排軸方案のいずれかを自動選択します。",
     "option.AutoFightAxisCodeString.label": "データコード",
     "option.AutoFightAxisCodeString.description": "サイトで排軸方案を選び、右上のエクスポート→データコードをコピーして、ここに貼り付けてください。",
+    "option.AutoFightAxisSkipComboCooldown.label": "連携技クールダウン待機をスキップ",
+    "option.AutoFightAxisSkipComboCooldown.description": "有効時、1セットの排軸終了後すぐに次のラウンドを試行します。無効時は全員の連携技が準備できてから次のラウンドを試行します。",
     "option.AutoPick.label": "自動拾取",
     "option.QuickTeleport.label": "クイックテレポート",
     "option.QuickTeleport.description": "ワールドマップ（または一覧）で転送地点を選択した時に、転送を自動でクリックします。",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -147,6 +147,8 @@
     "option.AutoFightAxisData.description": "- www.end-axis.com 에서 타임라인을 만들거나, www.end-axis.com/shares 공유 광장에서 다른 사람이 공유한 타임라인을 사용하세요.\n- 타임라인에 오퍼레이터, 전술 스킬, 필살기 사용 시점을 추가하면 됩니다. 불필요한 요소는 읽지 않습니다.\n- 사이트 좌측 상단 + 를 눌러 종결기 없는 방안을 최소 1개 추가해 순환 가능하도록 하는 것을 권장합니다.\n- 내부에서 필살기 충전 상태에 따라 타임라인 방안 중 하나를 자동으로 선택합니다.",
     "option.AutoFightAxisCodeString.label": "데이터 코드",
     "option.AutoFightAxisCodeString.description": "사이트에서 타임라인 방안을 선택한 뒤, 우측 상단 내보내기→데이터 코드 복사 후 여기에 붙여넣으세요.",
+    "option.AutoFightAxisSkipComboCooldown.label": "연계기 쿨다운 대기 생략",
+    "option.AutoFightAxisSkipComboCooldown.description": "켜면 타임라인 한 세트가 끝난 뒤 바로 다음 라운드를 시도합니다. 끄면 전원 연계기가 준비된 뒤에야 다음 라운드를 시도합니다.",
     "option.AutoPick.label": "자동 줍기",
     "option.QuickTeleport.label": "빠른 텔레포트",
     "option.QuickTeleport.description": "월드맵(또는 목록)에서 텔레포트 지점을 선택할 때 텔레포트를 자동으로 클릭합니다.",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -149,6 +149,8 @@
     "option.AutoFightAxisData.description": "- 打开 www.end-axis.com 创建排轴，或在 www.end-axis.com/shares 排轴分享广场使用他人分享的排轴。\n- 在排轴中添加干员、添加战技、终结技释放时机即可，多余元素不会读取。\n- 建议在网站中点击左上角 + 至少添加一个无终结技方案以保证可循环。\n- 内部将根据终结技状态自动选择其中一个排轴方案。",
     "option.AutoFightAxisCodeString.label": "数据码",
     "option.AutoFightAxisCodeString.description": "在网站中选择一个排轴方案，点击右上角导出-复制数据码，然后粘贴到这里",
+    "option.AutoFightAxisSkipComboCooldown.label": "不等待连携技冷却",
+    "option.AutoFightAxisSkipComboCooldown.description": "开启后，一套排轴打完立即尝试下一轮。关闭后，全员连携就绪后再尝试下一轮。",
     "option.AutoPick.label": "自动拾取",
     "option.QuickTeleport.label": "快速传送",
     "option.QuickTeleport.description": "在大地图上点击传送点（或列表中有传送点）时，自动点击传送",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -149,6 +149,8 @@
     "option.AutoFightAxisData.description": "- 打開 www.end-axis.com 建立排軸，或在 www.end-axis.com/shares 排軸分享廣場使用他人分享的排軸。\n- 在排軸中添加幹員、添加戰技、終結技釋放時機即可，多餘元素不會讀取。\n- 建議在網站中點擊左上角 + 至少添加一個無終結技方案以保證可循環。\n- 內部將依終結技狀態自動選擇其中一個排軸方案。",
     "option.AutoFightAxisCodeString.label": "資料碼",
     "option.AutoFightAxisCodeString.description": "在網站中選擇一個排軸方案，點擊右上角匯出-複製資料碼，然後貼到這裡",
+    "option.AutoFightAxisSkipComboCooldown.label": "不等待連攜技冷卻",
+    "option.AutoFightAxisSkipComboCooldown.description": "開啟後，一套排軸打完立即嘗試下一輪。關閉後，全員連攜就緒後再嘗試下一輪。",
     "option.AutoPick.label": "自動拾取",
     "option.QuickTeleport.label": "快速傳送",
     "option.QuickTeleport.description": "在大地圖上點擊傳送點（或列表中有傳送點）時，自動點擊傳送",

--- a/assets/resource/pipeline/Interface/AutoFight.json
+++ b/assets/resource/pipeline/Interface/AutoFight.json
@@ -21,7 +21,8 @@
             "reserve_skill_level": 1,
             "enable_end_skill": true,
             "enable_lock_target": true,
-            "end_axis_timeline_code": ""
+            "end_axis_timeline_code": "",
+            "skip_combo_cooldown": false
         }
     }
 }

--- a/assets/tasks/RealTimeTask.json
+++ b/assets/tasks/RealTimeTask.json
@@ -611,7 +611,8 @@
                 {
                     "name": "Yes",
                     "option": [
-                        "AutoFightAxisData"
+                        "AutoFightAxisData",
+                        "AutoFightAxisSkipComboCooldown"
                     ]
                 },
                 {
@@ -630,7 +631,8 @@
                 {
                     "name": "Yes",
                     "option": [
-                        "AutoFightAxisData"
+                        "AutoFightAxisData",
+                        "AutoFightAxisSkipComboCooldown"
                     ]
                 },
                 {
@@ -663,6 +665,34 @@
                     }
                 }
             }
+        },
+        "AutoFightAxisSkipComboCooldown": {
+            "label": "$option.AutoFightAxisSkipComboCooldown.label",
+            "description": "$option.AutoFightAxisSkipComboCooldown.description",
+            "type": "switch",
+            "default_case": "No",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "AutoFight": {
+                            "attach": {
+                                "skip_combo_cooldown": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "No",
+                    "pipeline_override": {
+                        "AutoFight": {
+                            "attach": {
+                                "skip_combo_cooldown": false
+                            }
+                        }
+                    }
+                }
+            ]
         },
         "AutoFightSkill": {
             "label": "$option.AutoFightSkill.label",


### PR DESCRIPTION
close #4192

## Summary by Sourcery

在自动战斗中添加一个选项，使其在选择终轴时间线方案时可以跳过等待所有连携技就绪的过程。

新功能：
- 引入 `skip-combo-cooldown` 标志，使自动战斗在进行终轴时间线选择时，无需等待所有角色的连携技能全部就绪即可继续。

增强内容：
- 扩展终轴方案选择逻辑以及 UI/本地化资源，以支持新的 `skip-combo-cooldown` 选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an option to skip waiting for all combo skills to be ready before selecting an end-axis timeline scenario in auto-fight.

New Features:
- Introduce a skip-combo-cooldown flag to allow auto-fight to proceed with end-axis timeline selection without requiring all characters' combo skills to be ready.

Enhancements:
- Extend end-axis scenario selection logic and UI/localization resources to support the new skip-combo-cooldown option.

</details>