### PR TITLE
fix: 相伴赠礼卡死

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneLogin.json
+++ b/assets/resource/pipeline/SceneManager/SceneLogin.json
@@ -76,6 +76,7 @@
             "[JumpBack]SceneWaitLoadingExit",
             "[JumpBack]__ScenePrivateLoginMonthlyPassConfirm",
             "[JumpBack]__ScenePrivateLoginPristineMonthlyPassConfirm",
+            "[JumpBack]__ScenePrivateLoginCompanionGiftConfirm",
             "__ScenePrivateLoginSuccess",
             "[JumpBack]__ScenePrivateLoginCloseDialog"
         ]
@@ -157,6 +158,28 @@
                     "今日月卡奖励",
                     "今日月卡獎勵",
                     "(?i)Daily\\s*Monthly\\s*Pass\\s*Rewards"
+                ]
+            }
+        },
+        "pre_delay": 1200, // 3d移动，pre_wait_freeze不生效
+        "action": {
+            "type": "Click"
+        }
+    },
+    "__ScenePrivateLoginCompanionGiftConfirm": {
+        "desc": "相伴赠礼，无法跳过必须领取",
+        "max_hit": 1, // 3d移动不好判断什么时候结束，因此只点一次防止影响到下一层弹窗
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    -500,
+                    -300,
+                    500,
+                    300
+                ],
+                "expected": [
+                    "点击领取奖励"
                 ]
             }
         },


### PR DESCRIPTION
## Summary by Sourcery

调整 SceneLogin 管线配置，以解决与伙伴礼物功能相关的卡死问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust SceneLogin pipeline configuration to resolve a freeze related to the companion gift feature.

</details>