### PR TITLE
feat: 抢委托送货支持快捷选点传送

### DIFF
--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobs.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobs.json
@@ -177,8 +177,8 @@
             "__SeizeDeliveryJobsFindTarget16_3"
         ],
         "action": "Click",
-        "post_wait_freezes": 500,
         "timeout": 10000, // 断言能在短时间内弹出接取成功动画
+        "rate_limit": 250, // 加速等待
         "next": [
             "SeizeDeliveryJobsIsSeizeSuccess"
         ],

--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobs.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobs.json
@@ -40,6 +40,8 @@
         "all_of": [
             "__SeizeDeliveryJobsRecoViewCurrentJob"
         ],
+        "pre_delay": 0,
+        "post_delay": 0,
         "next": [
             // 已接过单，且开启了后处理，就会跳转后续处理
             "SeizeDeliveryJobsPostProcessingEntry",
@@ -72,6 +74,8 @@
         ],
         "template": "SeizeDeliveryJobs/DepotNodePage/JobExhausted.png",
         "order_by": "Score",
+        "pre_delay": 0,
+        "post_delay": 0,
         "next": [
             // 视作任务结束
         ],
@@ -173,16 +177,8 @@
             "__SeizeDeliveryJobsFindTarget16_3"
         ],
         "action": "Click",
-        "post_wait_freezes": {
-            "time": 2000,
-            "target": [
-                2,
-                164,
-                264,
-                103
-            ]
-        },
-        "timeout": 5000, // 断言能在短时间内弹出接取成功动画
+        "post_wait_freezes": 500,
+        "timeout": 10000, // 断言能在短时间内弹出接取成功动画
         "next": [
             "SeizeDeliveryJobsIsSeizeSuccess"
         ],
@@ -205,7 +201,7 @@
         ],
         "template": "SeizeDeliveryJobs/DepotNodePage/JobSeized.png",
         "order_by": "Score",
-        "pre_wait_freezes": 1000, // 等待接取动画结束
+        "pre_wait_freezes": 250,
         "action": "Click",
         "post_delay": 500, // 点击后，等待界面回到大世界
         "next": [

--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsCommon.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsCommon.json
@@ -189,8 +189,7 @@
         }
     },
     "__SeizeDeliveryJobsStartTrackingTask": {
-        "desc": "在任务详情页面，若没找到定位按钮，此时需要先点击开始追踪任务按钮",
-        "max_hit": 5, // 此为回环节点，防死循环
+        "desc": "在任务详情页面，若没找到定位按钮，则点击开始追踪任务按钮",
         "recognition": "TemplateMatch",
         "roi": [
             1070,
@@ -201,9 +200,10 @@
         "template": "Common/Button/WhiteConfirmButtonType1.png",
         "order_by": "Score",
         "action": "Click",
+        "rate_limit": 500, // 加速等待大地图弹出
         "next": [
-            // 追踪任务后，界面会切换到大世界，此时需要回环执行前述流程
-            "SeizeDeliveryJobsEnterWulingJobList"
+            // 自游戏 1.4 版本开始，追踪任务按钮会直接打开大地图查看目的地，而非返回大世界
+            "__SeizeDeliveryJobsInDestinationMap"
         ],
         "focus": {
             "Node.Action.Starting": "点击开始追踪任务"

--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsCommon.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsCommon.json
@@ -222,26 +222,10 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "__SeizeDeliveryJobsPurifyDestinationMap"
+            "[Anchor]SeizeDeliveryJobsAfterEnterDestinationMap" // 外部调用者需要覆写此锚点的所指
         ],
         "focus": {
             "Node.Recognition.Succeeded": "正在查看任务位置"
         }
-    },
-    "__SeizeDeliveryJobsPurifyDestinationMap": {
-        "desc": "在目的地地图界面，清理地图图标遮挡",
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "MapTrackerBigMap_FilterNone"
-            ]
-        },
-        "anchor": {
-            "SeizeDeliveryAfterEnterWulingJobList": "" // 任务结束，置空锚点以防止误用
-        },
-        "next": [
-            "[Anchor]SeizeDeliveryJobsAfterEnterDestinationMap" // 外部调用者需要覆写此锚点的所指
-        ]
     }
 }

--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsPost.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsPost.json
@@ -4,7 +4,7 @@
         "enabled": false,
         "pre_delay": 0,
         "anchor": {
-            "SeizeDeliveryJobsAfterEnterDestinationMap": "SeizeDeliveryJobsWhereIsTheDestination"
+            "SeizeDeliveryJobsAfterEnterDestinationMap": "SeizeDeliveryJobsQuickTeleportSelect"
         },
         "post_delay": 0,
         "next": [
@@ -14,102 +14,136 @@
             "Node.Recognition.Succeeded": "**进入抢单后处理流程**"
         }
     },
-    "SeizeDeliveryJobsWhereIsTheDestination": {
-        "desc": "在目的地地图界面，开始判断任务所在的地区",
+    "SeizeDeliveryJobsQuickTeleportSelect": {
+        "desc": "在目的地地图界面，使用游戏自带的前往传送功能选中仓储节点附近的传送点",
+        "recognition": "TemplateMatch",
+        "roi": [
+            950,
+            540,
+            210,
+            160
+        ],
+        "template": [
+            "Common/Button/WhiteConfirmButtonType1.png",
+            "Common/Button/WhiteConfirmButtonType1Hover.png"
+        ],
+        "order_by": "Score",
+        "action": "Click",
+        "post_wait_freezes": 500, // 等待地图视窗移动到传送点
+        "next": [
+            "SeizeDeliveryJobsQuickTeleport"
+        ],
+        "focus": {
+            "Node.Action.Starting": "点击前往传送按钮"
+        }
+    },
+    "SeizeDeliveryJobsQuickTeleport": {
+        "desc": "在目的地地图界面，且已选中了传送点，直接点击传送",
+        "recognition": "TemplateMatch",
+        "roi": [
+            1110,
+            540,
+            150,
+            160
+        ],
+        "template": [
+            "Common/Button/WhiteConfirmButtonType1.png",
+            "Common/Button/WhiteConfirmButtonType1Hover.png"
+        ],
+        "order_by": "Score",
+        "action": "Click",
+        "next": [
+            "SeizeDeliveryJobsQuickTeleportDone",
+            "[JumpBack]SceneAnyEnterWorld"
+        ],
+        "focus": {
+            "Node.Action.Starting": "点击传送按钮"
+        }
+    },
+    "SeizeDeliveryJobsQuickTeleportDone": {
+        "desc": "已在大世界中，表明传送结束，准备根据当前位置以选择前往何处的仓储节点",
+        "recognition": "And",
+        "all_of": [
+            "InWorld"
+        ],
         "pre_delay": 0,
         "post_delay": 0,
         "timeout": 5000, // 断言在短时间内可以命中任一 next
         "next": [
-            "SeizeDeliveryJobsWillGoToWulingCity",
-            "SeizeDeliveryJobsWillGoToTestArea"
+            "SeizeDeliveryJobsSuccessTeleportDone",
+            "SeizeDeliveryJobsTargetDepotNodeIsWulingCity",
+            "SeizeDeliveryJobsTargetDepotNodeIsTestArea"
         ],
         "on_error": [
             "SeizeDeliveryJobsFatalCannotDetermineDestination"
         ]
     },
-    "SeizeDeliveryJobsWillGoToWulingCity": {
-        "desc": "判断任务位于武陵城",
+    "SeizeDeliveryJobsTargetDepotNodeIsWulingCity": {
+        "desc": "判断当前是武陵城的送货任务",
         "recognition": "Custom",
-        "custom_recognition": "MapTrackerBigMapFindImage",
+        "custom_recognition": "MapTrackerAssertLocation",
         "custom_recognition_param": {
-            "template": "image/SeizeDeliveryJobs/BlueTaskLocation.png",
-            "expected": {
-                "map_name": "map02_lv002",
-                "target": [
-                    0,
-                    0,
-                    9999,
-                    9999
-                ]
-            },
-            "threshold": 0.325, // 主要是看地图匹配，故任务标点阈值无需过高
-            "green_mask": true,
-            "zoom_value": 0.325
+            "expected": [
+                {
+                    "map_name": "map02_lv002",
+                    "target": [
+                        642.0,
+                        715.0,
+                        54.0,
+                        91.0
+                    ]
+                }
+            ]
         },
         "pre_delay": 0,
         "anchor": {
-            "SeizeDeliveryJobsTeleportPre": "SeizeDeliveryJobsTeleportWulingCity"
+            "SeizeDeliveryJobsWalkToDepotNode": "SeizeDeliveryJobsWalkToDepotNodeWulingCity"
         },
         "post_delay": 0,
         "next": [
-            "SeizeDeliveryJobsCheckCarryingGoodsPre"
+            "SeizeDeliveryJobsCheckCarryingGoods"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "判断任务地点是武陵城"
         }
     },
-    "SeizeDeliveryJobsWillGoToTestArea": {
-        "desc": "判断任务位于试验园区",
+    "SeizeDeliveryJobsTargetDepotNodeIsTestArea": {
+        "desc": "判断当前是试验园区的送货任务",
         "recognition": "Custom",
-        "custom_recognition": "MapTrackerBigMapFindImage",
+        "custom_recognition": "MapTrackerAssertLocation",
         "custom_recognition_param": {
-            "template": "image/SeizeDeliveryJobs/BlueTaskLocation2.png",
-            "expected": {
-                "map_name": "map02_lv005",
-                "target": [
-                    0,
-                    0,
-                    9999,
-                    9999
-                ]
-            },
-            "threshold": 0.325,
-            "green_mask": true,
-            "zoom_value": 0.325
+            "expected": [
+                {
+                    "map_name": "map02_lv005",
+                    "target": [
+                        280.0,
+                        387.0,
+                        65.0,
+                        45.0
+                    ]
+                }
+            ]
         },
         "pre_delay": 0,
         "anchor": {
-            "SeizeDeliveryJobsTeleportPre": "SeizeDeliveryJobsTeleportTestArea"
+            "SeizeDeliveryJobsWalkToDepotNode": "SeizeDeliveryJobsWalkToDepotNodeTestArea"
         },
         "post_delay": 0,
         "next": [
-            "SeizeDeliveryJobsCheckCarryingGoodsPre"
+            "SeizeDeliveryJobsCheckCarryingGoods"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "判断任务地点是试验园区"
         }
     },
-    "SeizeDeliveryJobsCheckCarryingGoodsPre": {
+    "SeizeDeliveryJobsCheckCarryingGoods": {
         "desc": "返回大世界，检查是否已携带了货物",
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "[JumpBack]__SeizeDeliveryJobsEnsureInWorld",
             "SeizeDeliveryJobsIsCarryingGoods",
-            "SeizeDeliveryJobsNotCarryingGoods"
-        ]
-    },
-    "__SeizeDeliveryJobsEnsureInWorld": {
-        "desc": "确保返回大世界（需 jumpback 调用）",
-        "recognition": "And",
-        "all_of": [
-            "InWorld"
-        ],
-        "inverse": true, // 如果不在大世界界面则命中
-        "pre_delay": 0,
-        "post_delay": 0,
-        "next": [
-            "SceneAnyEnterWorld"
+            "[Anchor]SeizeDeliveryJobsWalkToDepotNode", // 没有携带货物，则正常去走到仓储节点
+            "SeizeDeliveryJobsFatalCannotDetermineDestination" // 兜底报错回显，以防 Anchor 未被赋值
         ]
     },
     "SeizeDeliveryJobsIsCarryingGoods": {
@@ -132,58 +166,7 @@
             "Node.Recognition.Succeeded": "已经携带货物"
         }
     },
-    "SeizeDeliveryJobsNotCarryingGoods": {
-        "desc": "未发现携带货物，走正常传送流程（传送点由 anchor 控制）",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "next": [
-            "[Anchor]SeizeDeliveryJobsTeleportPre"
-        ],
-        "focus": {
-            "Node.Recognition.Succeeded": "正在传送到建议位置"
-        }
-    },
     // ===== 武陵城部分 =====
-    "SeizeDeliveryJobsTeleportWulingCity": {
-        "desc": "传送到武陵城仓储节点锚点（北侧锚点）",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingWulingCity5"
-            ]
-        },
-        "post_delay": 0,
-        "timeout": 10000,
-        "next": [
-            "SeizeDeliveryJobsSuccessTeleportDone",
-            "SeizeDeliveryJobsCanWalkToDepotNodeWulingCity"
-        ]
-    },
-    "SeizeDeliveryJobsCanWalkToDepotNodeWulingCity": {
-        "desc": "确认当前位于武陵城仓储节点附近区域",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv002",
-                    "target": [
-                        574.2,
-                        721.3,
-                        133.1,
-                        125.5
-                    ]
-                }
-            ]
-        },
-        "pre_delay": 0,
-        "post_delay": 0,
-        "next": [
-            "SeizeDeliveryJobsWalkToDepotNodeWulingCity"
-        ]
-    },
     "SeizeDeliveryJobsWalkToDepotNodeWulingCity": {
         "desc": "走到武陵城仓储节点",
         "pre_delay": 0,
@@ -233,46 +216,6 @@
         }
     },
     // ===== 试验园区部分 =====
-    "SeizeDeliveryJobsTeleportTestArea": {
-        "desc": "传送到试验园区仓储节点附近锚点",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "SceneEnterWorldWulingTestArea1"
-            ]
-        },
-        "post_delay": 0,
-        "timeout": 10000,
-        "next": [
-            "SeizeDeliveryJobsSuccessTeleportDone",
-            "SeizeDeliveryJobsCanWalkToDepotNodeTestArea"
-        ]
-    },
-    "SeizeDeliveryJobsCanWalkToDepotNodeTestArea": {
-        "desc": "确认当前位于试验园区",
-        "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
-        "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "map02_lv005",
-                    "target": [
-                        286.3,
-                        377.0,
-                        59.4,
-                        45.3
-                    ]
-                }
-            ]
-        },
-        "pre_delay": 0,
-        "post_delay": 0,
-        "next": [
-            "SeizeDeliveryJobsWalkToDepotNodeTestArea"
-        ]
-    },
     "SeizeDeliveryJobsWalkToDepotNodeTestArea": {
         "desc": "走到试验园区仓储节点",
         "pre_delay": 0,

--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsPostDeparture.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsPostDeparture.json
@@ -4,7 +4,7 @@
         "enabled": false,
         "pre_delay": 0,
         "anchor": {
-            "SeizeDeliveryJobsAfterEnterDestinationMap": "SeizeDeliveryJobsRunDeparture"
+            "SeizeDeliveryJobsAfterEnterDestinationMap": "SeizeDeliveryJobsPostPurifyDestinationMap"
         },
         "post_delay": 0,
         "next": [
@@ -13,6 +13,22 @@
         "focus": {
             "Node.Action.Starting": "**进入自动送货流程**"
         }
+    },
+    "SeizeDeliveryJobsPostPurifyDestinationMap": {
+        "desc": "在目的地地图界面，清理地图图标遮挡",
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "MapTrackerBigMap_FilterNone"
+            ]
+        },
+        "anchor": {
+            "SeizeDeliveryJobsAfterEnterWulingJobList": "" // 任务结束，置空锚点以防止误用
+        },
+        "next": [
+            "SeizeDeliveryJobsRunDeparture"
+        ]
     },
     "SeizeDeliveryJobsRunDeparture": {
         "desc": "在目的地地图界面，调用 custom 进行自动送货流程",


### PR DESCRIPTION
## 概要

此 PR 适配了终末地 1.4 版本更新引入的自动选择传送点的功能，据此简化了抢委托送货任务的选点逻辑。

<img width="582" height="220" alt="image" src="https://github.com/user-attachments/assets/0e773e2c-5537-48a4-b430-352007eb6f25" />

## Summary by Sourcery

增强功能：
- 更新 SeizeDeliveryJobs 流水线，以利用自动传送点选择机制，替代自定义的点选逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update SeizeDeliveryJobs pipelines to leverage automatic teleport point selection instead of custom point-picking logic.

</details>