### PR TITLE
fix(SellProduct): 修复盈天台建设站未能售卖的问题

### DIFF
--- a/assets/resource/pipeline/SellProduct/Sell.json
+++ b/assets/resource/pipeline/SellProduct/Sell.json
@@ -36,6 +36,7 @@
         "next": [
             "[JumpBack]SellProductSkyKingFlatsConstructionSite",
             "[JumpBack]SellProductCardiacRemediationStation",
+            "[JumpBack]SellProductXiranflowCloudseederStation",
             "SellProductLoop",
             "[JumpBack]SceneEnterMenuRegionalDevelopment"
         ]

--- a/tools/pipeline-generate/SellProduct/README.md
+++ b/tools/pipeline-generate/SellProduct/README.md
@@ -2,10 +2,11 @@
 
 据点数据通过 zmdmap API 获取，存储在 `tools/pipeline-generate/data/` 目录。
 
-`model.mjs` 统一维护据点命名、排序和国际化键；三个模板各自消费最小数据投影：
+`model.mjs` 统一维护据点命名、排序和国际化键；四类模板各自消费最小数据投影：
 
 - `pipeline-data.mjs`：Win32 Pipeline 据点与识别框；
 - `pipeline-adb-data.mjs`：ADB Pipeline 据点与识别框；
+- `sell-data.mjs`：区域售卖入口与区域内据点列表；
 - `task-data.mjs`：Task 中的物品、保留数量和干员选项。
 
 据点 `LocationId` 由 zmdmap 英文名称自动派生；只有存在实际 OCR 误识证据时才在 `model.mjs` 追加兼容候选。某个模板独有的参数留在对应投影文件中。
@@ -22,6 +23,7 @@ node tools/pipeline-generate/SellProduct/sync-locales.mjs
 
 # 等价于在当前目录运行
 npx @joebao/maa-pipeline-generate --config pipeline-config.json
+npx @joebao/maa-pipeline-generate --config sell-config.json
 npx @joebao/maa-pipeline-generate --config task-config.json
 # 需要生成安卓端（ADB）专用流水线时使用
 npx @joebao/maa-pipeline-generate --config pipeline-adb-config.json

--- a/tools/pipeline-generate/SellProduct/data.test.mjs
+++ b/tools/pipeline-generate/SellProduct/data.test.mjs
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {sellProductLocations, settlementData, toPascalCase} from "./model.mjs";
+import {sellProductLocations, sellProductRegions, settlementData, toPascalCase} from "./model.mjs";
 import sellProductAdbRows from "./pipeline-adb-data.mjs";
 import sellProductPipelineRows from "./pipeline-data.mjs";
+import sellProductSellRows from "./sell-data.mjs";
 import {buildOperatorCaseEntry, sellProductTaskRows} from "./task-data.mjs";
 
 function sortedKeys(value) {
@@ -50,6 +51,24 @@ test("SellProduct templates consume separate minimal projections of the shared l
         "TargetOperatorCases",
         "TargetOperatorDefaultCase",
     ]);
+});
+
+test("SellProduct region entry rows contain every generated location", () => {
+    assert.deepEqual(
+        sellProductSellRows.map((row) => row.RegionPrefix),
+        sellProductRegions.map((region) => region.RegionPrefix),
+    );
+
+    for (const row of sellProductSellRows) {
+        const region = sellProductRegions.find((entry) => entry.RegionPrefix === row.RegionPrefix);
+        assert.deepEqual(
+            row.Next,
+            region.LocationIds.map((locationId) => `[JumpBack]SellProduct${locationId}`).concat(
+                "SellProductLoop",
+                "[JumpBack]SceneEnterMenuRegionalDevelopment",
+            ),
+        );
+    }
 });
 
 test("SellProduct location IDs are derived from the current upstream English names", () => {

--- a/tools/pipeline-generate/SellProduct/model.mjs
+++ b/tools/pipeline-generate/SellProduct/model.mjs
@@ -60,11 +60,17 @@ const SETTLEMENT_OCR_ALIASES = {
     ],
 };
 
-// domainId → RegionPrefix 默认映射。新 domain 接入时若沿用「英文区域名」命名约定，加一行即可；
+// domainId → 区域信息。新 domain 接入时若沿用「英文区域名」命名约定，只需在此补充展示名；
 // 不在表中的 domain 会回退到 toPascalCase(domainId)。
-const DOMAIN_REGION_PREFIX = {
-    domain_1: "ValleyIV",
-    domain_2: "Wuling",
+const DOMAIN_REGION = {
+    domain_1: {
+        RegionPrefix: "ValleyIV",
+        RegionDesc: "四号谷地",
+    },
+    domain_2: {
+        RegionPrefix: "Wuling",
+        RegionDesc: "武陵",
+    },
 };
 
 // 生成据点入口 OCR 候选：先加入数据源多语言全文，再追加额外 OCR 候选。
@@ -103,7 +109,7 @@ export const sellProductLocations = Object.entries(settlementData.settlements)
             SettlementId,
             settlement,
         ]) => {
-            const RegionPrefix = DOMAIN_REGION_PREFIX[settlement.domainId] || toPascalCase(settlement.domainId);
+            const RegionPrefix = DOMAIN_REGION[settlement.domainId]?.RegionPrefix || toPascalCase(settlement.domainId);
             const LocationId = toPascalCase(settlement.settlementName.EN || SettlementId);
 
             return {
@@ -115,6 +121,22 @@ export const sellProductLocations = Object.entries(settlementData.settlements)
             };
         },
     );
+
+// 区域级售卖入口消费的最小模型，区域和据点顺序与 sellProductLocations 保持一致。
+export const sellProductRegions = Object.values(
+    sellProductLocations.reduce((regions, location) => {
+        if (!regions[location.RegionPrefix]) {
+            const region = DOMAIN_REGION[settlementData.settlements[location.SettlementId].domainId];
+            regions[location.RegionPrefix] = {
+                RegionPrefix: location.RegionPrefix,
+                RegionDesc: region?.RegionDesc || location.RegionPrefix,
+                LocationIds: [],
+            };
+        }
+        regions[location.RegionPrefix].LocationIds.push(location.LocationId);
+        return regions;
+    }, {}),
+);
 
 // 国际化同步器消费的最小数据视图。命名规则与所有模板共享同一模型。
 export const sellProductLocaleEntries = {

--- a/tools/pipeline-generate/SellProduct/sell-config.json
+++ b/tools/pipeline-generate/SellProduct/sell-config.json
@@ -1,0 +1,8 @@
+{
+    "template": "sell-template.jsonc",
+    "data": "sell-data.mjs",
+    "outputDir": "../../../assets/resource/pipeline/SellProduct",
+    "outputFile": "Sell.json",
+    "format": true,
+    "merged": true
+}

--- a/tools/pipeline-generate/SellProduct/sell-data.mjs
+++ b/tools/pipeline-generate/SellProduct/sell-data.mjs
@@ -1,0 +1,12 @@
+import {sellProductRegions} from "./model.mjs";
+
+export const sellProductSellRows = sellProductRegions.map((region) => ({
+    RegionPrefix: region.RegionPrefix,
+    RegionDesc: region.RegionDesc,
+    Next: region.LocationIds.map((locationId) => `[JumpBack]SellProduct${locationId}`).concat(
+        "SellProductLoop",
+        "[JumpBack]SceneEnterMenuRegionalDevelopment",
+    ),
+}));
+
+export default sellProductSellRows;

--- a/tools/pipeline-generate/SellProduct/sell-template.jsonc
+++ b/tools/pipeline-generate/SellProduct/sell-template.jsonc
@@ -1,0 +1,17 @@
+{
+    "SellProduct${RegionPrefix}Sell": {
+        "desc": "在${RegionDesc}售卖",
+        "max_hit": 1,
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneEnterMenuRegionalDevelopment${RegionPrefix}OutpostManagement"
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": "${Next}"
+    }
+}


### PR DESCRIPTION
## 问题

盈天台建设站的据点 Pipeline 已生成，但区域售卖入口 `Sell.json` 仍由人工维护，新增据点后没有同步加入武陵售卖流程，导致该建设站无法执行售卖。

## 修复方法

- 将 `assets/resource/pipeline/SellProduct/Sell.json` 接入 `pipeline-generate`
- 从 SellProduct 共享据点模型生成区域售卖入口和区域内据点列表
- 重新生成产物，将 `SellProductXiranflowCloudseederStation` 加入武陵售卖流程
- 补充生成数据单测和维护文档，避免后续新增据点时再次遗漏

## 影响

武陵区域售卖流程现在会正确处理盈天台建设站；后续据点数据更新时，区域入口清单会随其他 SellProduct 产物一同生成。

## 验证

- `node --test tools/pipeline-generate/SellProduct/data.test.mjs tools/pipeline-generate/SellProduct/sync-locales.test.mjs`
- `pnpm check`
- `pnpm test`
- `node tools/pipeline-generate/run-all.mjs SellProduct`
- `git diff --check`

## Summary by Sourcery

将区域级别的 SellProduct 销售条目集成到管道生成器中，以使各区域的销售流程与共享结算数据保持同步。

New Features:
- 直接从共享结算模型生成区域级别的 SellProduct 销售条目以及区域到地点的映射。
- 引入专用的 SellProduct 销售数据模板和配置，用于自动化生成 `Sell.json`。

Enhancements:
- 扩展 SellProduct 模型，为各域增加结构化的区域元数据，包括显示名称。
- 更新 SellProduct 文档，描述新的销售数据投影方式及生成命令。

Tests:
- 增加测试，确保生成的区域销售行覆盖所有地点，并与预期的导航顺序一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate SellProduct region-level sell entries into the pipeline generator to keep regional sell flows in sync with shared settlement data.

New Features:
- Generate region-level SellProduct sell entries and region-to-location mappings directly from the shared settlement model.
- Introduce dedicated SellProduct sell-data templates and config for automated Sell.json generation.

Enhancements:
- Extend the SellProduct model with structured region metadata, including display names, for domains.
- Update SellProduct documentation to describe the new sell-data projection and generation commands.

Tests:
- Add tests ensuring generated region sell rows cover all locations and match the expected navigation sequence.

</details>