### PR TITLE
fix: 协议空间避免死循环 (cherry-pick of #4269)

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -451,8 +451,7 @@
             "InProtocolSpace"
         ],
         "next": [
-            "ProtocolSpaceFightStartSuccess",
-            "ProtocolSpaceFightStartWait"
+            "ProtocolSpaceFightStartSuccess"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "等待战斗开始"


### PR DESCRIPTION
close #4259

## Summary

将 release/v2.20 上的协议空间死循环修复手动 cherry-pick 到 v2。

自动 cherry-pick 工作流在 `Fetch PR title and body` 步骤失败，未生成 fix/pr-4269 分支。

---

> Cherry-pick of #4269 from `release/v2.20` to `v2`.
[skip changelog]

## Summary by Sourcery

Bug Fixes:
- 解决 ProtocolSpace InSpace 管道配置中的潜在无限循环问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve a potential infinite loop in the ProtocolSpace InSpace pipeline configuration.

</details>