### PR TITLE
refactor:调整信用点商店和稳定物资的颜色识别,尝试使用灰度来兼容更宽幅的颜色范围

### DIFF
--- a/assets/resource/pipeline/AutoStockStaple/General/Item.json
+++ b/assets/resource/pipeline/AutoStockStaple/General/Item.json
@@ -57,18 +57,16 @@
                     88,
                     22
                 ],
+                "method": 6,
                 "lower": [
-                    50,
-                    50,
-                    50
+                    0
                 ],
                 "upper": [
-                    130,
-                    130,
-                    130
+                    180
                 ],
                 "connected": true,
-                "count": 1500
+                "count": 1500,
+                "order_by": "Area"
             }
         }
     },

--- a/assets/resource/pipeline/CreditShopping/Credit/Reserve.json
+++ b/assets/resource/pipeline/CreditShopping/Credit/Reserve.json
@@ -27,18 +27,18 @@
         }
     },
     "CreditShoppingPriority1ReserveCreditGate": {
-        "desc": "优先购买的保留信用点准入判断",
+        "desc": "优先购买1的保留信用点准入判断",
         "recognition": "DirectHit"
     },
     "CreditShoppingPriority2ReserveCreditGate": {
-        "desc": "普通购买1的保留信用点准入判断",
+        "desc": "优先购买2的保留信用点准入判断",
         "recognition": "And",
         "all_of": [
             "CreditShoppingReserveCreditSatisfied"
         ]
     },
     "CreditShoppingPriority3ReserveCreditGate": {
-        "desc": "普通购买2的保留信用点准入判断",
+        "desc": "优先购买3的保留信用点准入判断",
         "recognition": "And",
         "all_of": [
             "CreditShoppingReserveCreditSatisfied"

--- a/assets/resource/pipeline/CreditShopping/Item/Blacklist.json
+++ b/assets/resource/pipeline/CreditShopping/Item/Blacklist.json
@@ -11,18 +11,16 @@
                     118,
                     25
                 ],
+                "method": 6,
                 "lower": [
-                    60,
-                    60,
-                    60
+                    0
                 ],
                 "upper": [
-                    70,
-                    70,
-                    70
+                    180
                 ],
                 "connected": true,
-                "count": 10
+                "count": 1500,
+                "order_by": "Area"
             }
         }
     },
@@ -31,15 +29,11 @@
             "type": "ColorMatch",
             "param": {
                 "roi": "BlacklistOCRLabelColor",
-                "method": 40,
+                "method": 6,
                 "lower": [
-                    0,
-                    0,
-                    0
+                    200
                 ],
                 "upper": [
-                    0,
-                    1,
                     255
                 ],
                 "count": 10

--- a/assets/resource/pipeline/CreditShopping/Item/Priority1.json
+++ b/assets/resource/pipeline/CreditShopping/Item/Priority1.json
@@ -11,18 +11,16 @@
                     118,
                     25
                 ],
+                "method": 6,
                 "lower": [
-                    50,
-                    50,
-                    50
+                    0
                 ],
                 "upper": [
-                    130,
-                    130,
-                    130
+                    180
                 ],
                 "connected": true,
-                "count": 1500
+                "count": 1500,
+                "order_by": "Area"
             }
         }
     },
@@ -31,15 +29,11 @@
             "type": "ColorMatch",
             "param": {
                 "roi": "BuyFirstOCRLabelColor",
-                "method": 40,
+                "method": 6,
                 "lower": [
-                    0,
-                    0,
-                    0
+                    200
                 ],
                 "upper": [
-                    0,
-                    1,
                     255
                 ],
                 "count": 10
@@ -81,18 +75,16 @@
                     118,
                     25
                 ],
+                "method": 6,
                 "lower": [
-                    60,
-                    60,
-                    60
+                    0
                 ],
                 "upper": [
-                    70,
-                    70,
-                    70
+                    180
                 ],
                 "connected": true,
-                "count": 10
+                "count": 1500,
+                "order_by": "Area"
             }
         }
     },
@@ -101,15 +93,11 @@
             "type": "ColorMatch",
             "param": {
                 "roi": "BuyFirstOCR_CanNotAfford_LabelColor",
-                "method": 40,
+                "method": 6,
                 "lower": [
-                    0,
-                    0,
-                    0
+                    200
                 ],
                 "upper": [
-                    0,
-                    1,
                     255
                 ],
                 "count": 10

--- a/assets/resource/pipeline/CreditShopping/Item/Priority2.json
+++ b/assets/resource/pipeline/CreditShopping/Item/Priority2.json
@@ -11,18 +11,16 @@
                     118,
                     25
                 ],
+                "method": 6,
                 "lower": [
-                    60,
-                    60,
-                    60
+                    0
                 ],
                 "upper": [
-                    70,
-                    70,
-                    70
+                    180
                 ],
                 "connected": true,
-                "count": 10
+                "count": 1500,
+                "order_by": "Area"
             }
         }
     },
@@ -31,15 +29,11 @@
             "type": "ColorMatch",
             "param": {
                 "roi": "Priority2OCRLabelColor",
-                "method": 40,
+                "method": 6,
                 "lower": [
-                    0,
-                    0,
-                    0
+                    200
                 ],
                 "upper": [
-                    0,
-                    1,
                     255
                 ],
                 "count": 10
@@ -81,18 +75,16 @@
                     118,
                     25
                 ],
+                "method": 6,
                 "lower": [
-                    60,
-                    60,
-                    60
+                    0
                 ],
                 "upper": [
-                    70,
-                    70,
-                    70
+                    180
                 ],
                 "connected": true,
-                "count": 10
+                "count": 1500,
+                "order_by": "Area"
             }
         }
     },
@@ -101,15 +93,11 @@
             "type": "ColorMatch",
             "param": {
                 "roi": "Priority2OCR_CanNotAfford_LabelColor",
-                "method": 40,
+                "method": 6,
                 "lower": [
-                    0,
-                    0,
-                    0
+                    200
                 ],
                 "upper": [
-                    0,
-                    1,
                     255
                 ],
                 "count": 10

--- a/assets/resource/pipeline/CreditShopping/Item/Priority3.json
+++ b/assets/resource/pipeline/CreditShopping/Item/Priority3.json
@@ -11,18 +11,16 @@
                     118,
                     25
                 ],
+                "method": 6,
                 "lower": [
-                    60,
-                    60,
-                    60
+                    0
                 ],
                 "upper": [
-                    70,
-                    70,
-                    70
+                    180
                 ],
                 "connected": true,
-                "count": 10
+                "count": 1500,
+                "order_by": "Area"
             }
         }
     },
@@ -31,15 +29,11 @@
             "type": "ColorMatch",
             "param": {
                 "roi": "Priority3OCRLabelColor",
-                "method": 40,
+                "method": 6,
                 "lower": [
-                    0,
-                    0,
-                    0
+                    200
                 ],
                 "upper": [
-                    0,
-                    1,
                     255
                 ],
                 "count": 10
@@ -81,18 +75,16 @@
                     118,
                     25
                 ],
+                "method": 6,
                 "lower": [
-                    60,
-                    60,
-                    60
+                    0
                 ],
                 "upper": [
-                    70,
-                    70,
-                    70
+                    180
                 ],
                 "connected": true,
-                "count": 10
+                "count": 1500,
+                "order_by": "Area"
             }
         }
     },
@@ -101,15 +93,11 @@
             "type": "ColorMatch",
             "param": {
                 "roi": "Priority3OCR_CanNotAfford_LabelColor",
-                "method": 40,
+                "method": 6,
                 "lower": [
-                    0,
-                    0,
-                    0
+                    200
                 ],
                 "upper": [
-                    0,
-                    1,
                     255
                 ],
                 "count": 10

--- a/assets/resource/pipeline/CreditShopping/Item/ShelfBase.json
+++ b/assets/resource/pipeline/CreditShopping/Item/ShelfBase.json
@@ -42,20 +42,20 @@
             -147
         ],
         "lower": [
-            255,
-            131,
-            131
+            200,
+            0,
+            0
         ],
         "upper": [
             255,
-            192,
-            192
+            150,
+            150
         ],
         "count": 20,
         "order_by": "Vertical"
     },
     "CanAfford": {
-        "desc": "买得起（价格不是红色）",
+        "desc": "买得起（价格是黑色）",
         "recognition": "ColorMatch",
         "roi": "NotSoldOut",
         "roi_offset": [
@@ -64,18 +64,14 @@
             -94,
             -147
         ],
+        "method": 6,
         "lower": [
-            76,
-            76,
-            76
+            0
         ],
         "upper": [
-            108,
-            108,
-            108
+            90
         ],
-        "connected": true,
-        "count": 10,
+        "count": 25,
         "order_by": "Vertical"
     }
 }

--- a/assets/resource/pipeline/CreditShopping/record.json
+++ b/assets/resource/pipeline/CreditShopping/record.json
@@ -11,19 +11,16 @@
                     130,
                     28
                 ],
+                "method": 6,
                 "lower": [
-                    50,
-                    50,
-                    50
+                    0
                 ],
                 "upper": [
-                    130,
-                    130,
-                    130
+                    180
                 ],
                 "connected": true,
                 "count": 1500,
-                "order_by": "Vertical"
+                "order_by": "Area"
             }
         }
     },
@@ -33,15 +30,11 @@
             "type": "ColorMatch",
             "param": {
                 "roi": "ItemNameOCRLabelColor",
-                "method": 40,
+                "method": 6,
                 "lower": [
-                    0,
-                    0,
-                    0
+                    200
                 ],
                 "upper": [
-                    0,
-                    1,
                     255
                 ],
                 "count": 10,


### PR DESCRIPTION
## Summary by Sourcery

优化自动库存常备品和信用商店的商品配置，使其与更灵活的基于颜色的识别方案保持一致。

增强内容：
- 放宽 AutoStockStaple 配置中针对常备品的基于颜色的识别规则，以支持更广泛的视觉变体。
- 更新信用商店商品配置，包括库存预留、黑名单、优先级、货架基线和记录等，以适配新的、支持灰度的颜色识别机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine item configuration for auto stock staples and credit shopping to align with a more flexible color-based recognition scheme.

Enhancements:
- Relax color-based identification rules for staple items in AutoStockStaple configuration to support a wider range of visual variants.
- Update credit shop item configurations, including reserves, blacklists, priorities, shelf baselines, and records, to match the new grayscale-compatible color recognition.

</details>

增强内容：
- 优化 AutoStockStaple 商品配置，使基于颜色的稳定物资识别更加灵活。
- 修订信用购物商品配置（预留、黑名单、优先级、货架基准以及记录），以符合更新后的颜色识别规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化自动库存常备品和信用商店的商品配置，使其与更灵活的基于颜色的识别方案保持一致。

增强内容：
- 放宽 AutoStockStaple 配置中针对常备品的基于颜色的识别规则，以支持更广泛的视觉变体。
- 更新信用商店商品配置，包括库存预留、黑名单、优先级、货架基线和记录等，以适配新的、支持灰度的颜色识别机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine item configuration for auto stock staples and credit shopping to align with a more flexible color-based recognition scheme.

Enhancements:
- Relax color-based identification rules for staple items in AutoStockStaple configuration to support a wider range of visual variants.
- Update credit shop item configurations, including reserves, blacklists, priorities, shelf baselines, and records, to match the new grayscale-compatible color recognition.

</details>

</details>