### PR TITLE
fix:修复从信用点商店中开始任务时,不会领取信用点

### DIFF
--- a/assets/resource/pipeline/CreditShopping/GoToShop.json
+++ b/assets/resource/pipeline/CreditShopping/GoToShop.json
@@ -2,7 +2,7 @@
     "CreditShoppingMain": {
         "desc": "信用点购物主入口",
         "next": [
-            "CreditShoppingShopping",
+            "CreditShoppingInShop",
             "CreditShoppingCheckShopPage",
             "[JumpBack]SceneEnterMenuShop"
         ]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保通过 CreditShopping GoToShop 管道配置从积分商城开始任务时，能够正确授予相应的积分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure starting a task from the credit point shop correctly grants the associated credit points via the CreditShopping GoToShop pipeline configuration.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 确保通过 CreditShopping GoToShop 管道配置从积分商城开始任务时，能够正确授予相应的积分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure starting a task from the credit point shop correctly grants the associated credit points via the CreditShopping GoToShop pipeline configuration.

</details>

</details>