### PR TITLE
fix: 无法领取活动相伴赠礼 (cherry-pick of #4279)

### DIFF
--- a/assets/resource/pipeline/DailyRewards/Event.json
+++ b/assets/resource/pipeline/DailyRewards/Event.json
@@ -77,6 +77,7 @@
             "DailyEventUnreadChallengeEvent",
             "DailyEventUnreadSpaceExplorationEvent",
             "DailyEventUnreadLimitedTimeEvent",
+            "DailyEventUnreadGiftEvent",
             "DailyEventUnreadUnknown"
         ]
     },
@@ -129,7 +130,7 @@
             "param": {
                 "roi": [
                     21,
-                    124,
+                    100,
                     211,
                     530
                 ],
@@ -154,7 +155,7 @@
         "recognition": "OCR",
         "roi": [
             21,
-            124,
+            100,
             211,
             530
         ],

--- a/assets/resource/pipeline/DailyRewards/Event/GiftEvent.json
+++ b/assets/resource/pipeline/DailyRewards/Event/GiftEvent.json
@@ -1,0 +1,93 @@
+{
+    "DailyEventUnreadGiftEvent": {
+        "desc": "处理赠礼活动",
+        "recognition": "And",
+        "all_of": [
+            "DailyEventUnreadGiftEventColor",
+            "DailyEventUnreadGiftEventTitle"
+        ],
+        "pre_wait_freezes": {
+            "target": [
+                -200,
+                0,
+                200,
+                200
+            ],
+            "time": 200
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "DailyEventUnreadGiftEventPickAll",
+            "DailyEventUnreadGiftEventFinish"
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "进入赠礼活动"
+        }
+    },
+    "DailyEventUnreadGiftEventPickAll": {
+        "desc": "赠礼活动内一键领取",
+        "recognition": "OCR",
+        "roi": [
+            -160,
+            -440,
+            160,
+            200
+        ],
+        "expected": [
+            // 一键领取
+            // @i18n-skip
+            "键领取",
+            "快速領取",
+            "(?i)Claim\\s*All",
+            "一括受取",
+            "일괄 획득"
+        ],
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "next": [
+            "SceneNoticeRewardsConfirm"
+        ]
+    },
+    "DailyEventUnreadGiftEventFinish": {
+        "desc": "领取完了",
+        "pre_delay": 0,
+        "post_delay": 0
+    },
+    "DailyEventUnreadGiftEventColor": {
+        "desc": "赠礼活动详情标题黄字区域",
+        "recognition": "ColorMatch",
+        "roi": [
+            -200,
+            0,
+            200,
+            200
+        ],
+        "lower": [
+            230,
+            230,
+            0
+        ],
+        "upper": [
+            255,
+            255,
+            13
+        ],
+        "connected": true,
+        "count": 200
+    },
+    "DailyEventUnreadGiftEventTitle": {
+        "desc": "赠礼活动详情标题",
+        "recognition": "OCR",
+        "roi": "DailyEventUnreadGiftEventColor",
+        "expected": [
+            "赠礼活动",
+            "贈禮活動",
+            "Gift Event",
+            "ギフトイベント",
+            "선물 이벤트"
+        ],
+        "only_rec": true
+    }
+}

--- a/assets/resource/pipeline/Interface/InScene/Region.json
+++ b/assets/resource/pipeline/Interface/InScene/Region.json
@@ -337,8 +337,7 @@
                     "InScene/NoticeRewardsIcon.png",
                     "InScene/NoticeRewardsIcon2.png",
                     "InScene/NoticeRewardsIcon3.png"
-                ],
-                "threshold": 0.9
+                ]
             }
         }
     },


### PR DESCRIPTION
## 由 Sourcery 提供的总结

修复每日奖励活动礼物的配置，使关联的促销礼物可以被正确领取。

新功能：
- 引入单独的每日奖励活动礼物 `GiftEvent` 配置资源，以支持对关联促销奖励的正确处理。

错误修复：
- 解决由于活动配置不正确导致在每日奖励流程中无法领取活动伴随礼物的问题。

改进：
- 调整每日奖励活动和场景内区域的配置，使礼物事件能够正确接入现有的奖励管线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix configuration for daily rewards event gifts so that associated promotional gifts can be claimed correctly.

New Features:
- Introduce a separate GiftEvent configuration resource for daily rewards event gifts to support proper handling of associated promotional rewards.

Bug Fixes:
- Resolve issue where event companion gifts in the daily rewards flow could not be claimed due to incorrect event configuration.

Enhancements:
- Adjust daily rewards event and in-scene region configuration to correctly wire gift events into the existing rewards pipeline.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

修复每日奖励活动礼物的配置，使关联的促销礼物可以被正确领取。

新功能：
- 引入单独的每日奖励活动礼物 `GiftEvent` 配置资源，以支持对关联促销奖励的正确处理。

错误修复：
- 解决由于活动配置不正确导致在每日奖励流程中无法领取活动伴随礼物的问题。

改进：
- 调整每日奖励活动和场景内区域的配置，使礼物事件能够正确接入现有的奖励管线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix configuration for daily rewards event gifts so that associated promotional gifts can be claimed correctly.

New Features:
- Introduce a separate GiftEvent configuration resource for daily rewards event gifts to support proper handling of associated promotional rewards.

Bug Fixes:
- Resolve issue where event companion gifts in the daily rewards flow could not be claimed due to incorrect event configuration.

Enhancements:
- Adjust daily rewards event and in-scene region configuration to correctly wire gift events into the existing rewards pipeline.

</details>

</details>

---

> Cherry-pick of #4279 from `release/v2.20` to `v2`.
[skip changelog]