### PR TITLE
feat:自动囤货支持滑动

### DIFF
--- a/agent/go-service/autostockpile/goods_scan.go
+++ b/agent/go-service/autostockpile/goods_scan.go
@@ -45,6 +45,165 @@ func runGoodsTemplateMatch(ctx *maa.Context, img image.Image, templatePath strin
 	return ctx.RunRecognition(locateGoodsNodeName, img, nil)
 }
 
+// scanGoodsOnImage 对单帧截图执行 OCR 绑价与模板补全，返回本页识别到的商品列表。
+func scanGoodsOnImage(ctx *maa.Context, img image.Image, region string, itemMap *ItemMap) ([]GoodsItem, AbortReason, error) {
+	if ctx == nil || img == nil {
+		return nil, AbortReasonGoodsOCRUnavailableWarn, fmt.Errorf("ctx or image is nil")
+	}
+	if err := validateItemMap(itemMap); err != nil {
+		return nil, AbortReasonNone, err
+	}
+
+	goodsROI := resolveGoodsRecognitionROI(ctx, img)
+	prices, ocrNames, goodsOCRAbortReason, goodsOCRErr := runGoodsOCR(ctx, img, goodsROI, itemMap)
+	if goodsOCRAbortReason != AbortReasonNone {
+		return nil, goodsOCRAbortReason, goodsOCRErr
+	}
+	log.Info().
+		Str("component", autoStockpileComponent).
+		Str("step", "scan_page").
+		Str("region", region).
+		Int("price_count", len(prices)).
+		Int("ocr_name_count", len(ocrNames)).
+		Msg("goods ocr finished")
+
+	boundIDs := make(map[string]bool)
+	usedPrice := make([]bool, len(prices))
+	pass1Goods := make([]GoodsItem, 0, len(ocrNames))
+	pass1Success := 0
+	pass1Failed := 0
+
+	sort.Slice(ocrNames, func(i, j int) bool {
+		if ocrNames[i].box.Y() != ocrNames[j].box.Y() {
+			return ocrNames[i].box.Y() < ocrNames[j].box.Y()
+		}
+		return ocrNames[i].box.X() < ocrNames[j].box.X()
+	})
+
+	for _, name := range ocrNames {
+		boundPrice, ok := bindPriceToOCRGoods(name, prices, usedPrice)
+		if !ok {
+			pass1Failed++
+			log.Warn().
+				Str("component", autoStockpileComponent).
+				Str("bind_pass", "ocr").
+				Str("goods_id", name.id).
+				Str("goods_name", name.name).
+				Str("tier", name.tier).
+				Int("goods_x", name.box.X()).
+				Int("goods_y", name.box.Y()).
+				Msg("failed to bind price for goods")
+			continue
+		}
+
+		pass1Goods = append(pass1Goods, GoodsItem{
+			ID:    name.id,
+			Name:  name.name,
+			Tier:  name.tier,
+			Price: boundPrice,
+		})
+		boundIDs[name.id] = true
+		pass1Success++
+	}
+
+	log.Info().
+		Str("component", autoStockpileComponent).
+		Str("bind_pass", "ocr").
+		Int("bind_success", pass1Success).
+		Int("bind_failed", pass1Failed).
+		Msg("goods-price binding finished")
+
+	candidateIDs := listUnboundRegionItemIDs(itemMap, region, boundIDs)
+	log.Info().
+		Str("component", autoStockpileComponent).
+		Str("region", region).
+		Str("template_source", "item_map").
+		Int("template_count", len(candidateIDs)).
+		Msg("goods template candidates loaded")
+
+	goods := make([]goodsCandidate, 0, len(candidateIDs))
+	for _, id := range candidateIDs {
+		templatePath := BuildTemplatePath(id)
+
+		detail, recErr := runGoodsTemplateMatch(ctx, img, templatePath, goodsROI)
+		if recErr != nil {
+			log.Warn().
+				Err(recErr).
+				Str("component", autoStockpileComponent).
+				Str("template", templatePath).
+				Msg("template match failed")
+			continue
+		}
+
+		box, hit := bestTemplateHit(detail)
+		if !hit {
+			continue
+		}
+
+		itemName := itemMap.IDToName[id]
+		tier := ParseTierFromID(id)
+
+		goods = append(goods, goodsCandidate{
+			item: GoodsItem{
+				ID:    id,
+				Name:  itemName,
+				Tier:  tier,
+				Price: 0,
+			},
+			box: box,
+		})
+	}
+
+	log.Info().
+		Str("component", autoStockpileComponent).
+		Int("template_hits", len(goods)).
+		Msg("template matching finished")
+
+	sort.Slice(goods, func(i, j int) bool {
+		if goods[i].box.Y() == goods[j].box.Y() {
+			return goods[i].box.X() < goods[j].box.X()
+		}
+		return goods[i].box.Y() < goods[j].box.Y()
+	})
+
+	resultGoods := make([]GoodsItem, 0, len(pass1Goods)+len(goods))
+	resultGoods = append(resultGoods, pass1Goods...)
+	bindingSuccess := 0
+	bindingFailed := 0
+
+	for _, g := range goods {
+		boundPrice, ok := bindPriceToGoods(g, prices, usedPrice)
+		item := g.item
+		if ok {
+			item.Price = boundPrice
+			bindingSuccess++
+		} else {
+			bindingFailed++
+			log.Warn().
+				Str("component", autoStockpileComponent).
+				Str("bind_pass", "template").
+				Str("goods_id", g.item.ID).
+				Str("goods_name", g.item.Name).
+				Str("tier", g.item.Tier).
+				Int("price", item.Price).
+				Int("goods_x", g.box.X()).
+				Int("goods_y", g.box.Y()).
+				Msg("failed to bind price for goods, skipping")
+			continue
+		}
+		resultGoods = append(resultGoods, item)
+	}
+
+	log.Info().
+		Str("component", autoStockpileComponent).
+		Str("bind_pass", "template").
+		Int("bind_success", bindingSuccess).
+		Int("bind_failed", bindingFailed).
+		Msg("goods-price binding finished")
+
+	return resultGoods, AbortReasonNone, nil
+}
+
 func resolveGoodsRecognitionROI(ctx *maa.Context, img image.Image) []int {
 	baseROI := []int{63, 162, 1177, 553}
 	marketMarkBox, found, err := runFindMarketMark(ctx, img)

--- a/agent/go-service/autostockpile/merge.go
+++ b/agent/go-service/autostockpile/merge.go
@@ -1,0 +1,33 @@
+package autostockpile
+
+// mergeGoodsByID 合并两页商品：保留首屏条目，仅追加次屏新 ID，并返回仅次屏出现的 ID 列表。
+func mergeGoodsByID(page0, page1 []GoodsItem) (goods []GoodsItem, page1OnlyIDs []string) {
+	seen := make(map[string]struct{}, len(page0)+len(page1))
+	goods = make([]GoodsItem, 0, len(page0)+len(page1))
+	page1OnlyIDs = make([]string, 0)
+
+	for _, item := range page0 {
+		if item.ID == "" {
+			continue
+		}
+		if _, ok := seen[item.ID]; ok {
+			continue
+		}
+		seen[item.ID] = struct{}{}
+		goods = append(goods, item)
+	}
+
+	for _, item := range page1 {
+		if item.ID == "" {
+			continue
+		}
+		if _, ok := seen[item.ID]; ok {
+			continue
+		}
+		seen[item.ID] = struct{}{}
+		goods = append(goods, item)
+		page1OnlyIDs = append(page1OnlyIDs, item.ID)
+	}
+
+	return goods, page1OnlyIDs
+}

--- a/agent/go-service/autostockpile/merge_test.go
+++ b/agent/go-service/autostockpile/merge_test.go
@@ -1,0 +1,78 @@
+package autostockpile
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeGoodsByID(t *testing.T) {
+	t.Parallel()
+
+	page0 := []GoodsItem{
+		{ID: "A", Name: "a", Price: 100},
+		{ID: "B", Name: "b", Price: 200},
+	}
+	page1 := []GoodsItem{
+		{ID: "B", Name: "b-dup", Price: 210},
+		{ID: "Z", Name: "z", Price: 50},
+	}
+
+	goods, page1Only := mergeGoodsByID(page0, page1)
+
+	wantGoods := []GoodsItem{
+		{ID: "A", Name: "a", Price: 100},
+		{ID: "B", Name: "b", Price: 200},
+		{ID: "Z", Name: "z", Price: 50},
+	}
+	if !reflect.DeepEqual(goods, wantGoods) {
+		t.Fatalf("goods = %#v, want %#v", goods, wantGoods)
+	}
+	wantPage1Only := []string{"Z"}
+	if !reflect.DeepEqual(page1Only, wantPage1Only) {
+		t.Fatalf("page1Only = %#v, want %#v", page1Only, wantPage1Only)
+	}
+}
+
+func TestMergeGoodsByIDEmptyPages(t *testing.T) {
+	t.Parallel()
+
+	goods, page1Only := mergeGoodsByID(nil, nil)
+	if len(goods) != 0 || len(page1Only) != 0 {
+		t.Fatalf("expected empty merge, got goods=%#v page1Only=%#v", goods, page1Only)
+	}
+
+	page1 := []GoodsItem{{ID: "Z", Name: "z", Price: 1}}
+	goods, page1Only = mergeGoodsByID(nil, page1)
+	if len(goods) != 1 || goods[0].ID != "Z" {
+		t.Fatalf("unexpected goods %#v", goods)
+	}
+	if !reflect.DeepEqual(page1Only, []string{"Z"}) {
+		t.Fatalf("unexpected page1Only %#v", page1Only)
+	}
+}
+
+func TestMergeGoodsByIDSkipsEmptyID(t *testing.T) {
+	t.Parallel()
+
+	page0 := []GoodsItem{{ID: "", Name: "bad"}, {ID: "A", Name: "a"}}
+	page1 := []GoodsItem{{ID: "", Name: "bad2"}, {ID: "B", Name: "b"}}
+	goods, page1Only := mergeGoodsByID(page0, page1)
+	if len(goods) != 2 || goods[0].ID != "A" || goods[1].ID != "B" {
+		t.Fatalf("unexpected goods %#v", goods)
+	}
+	if !reflect.DeepEqual(page1Only, []string{"B"}) {
+		t.Fatalf("unexpected page1Only %#v", page1Only)
+	}
+}
+
+func TestIsPage1OnlyID(t *testing.T) {
+	t.Parallel()
+
+	data := RecognitionData{Page1OnlyIDs: []string{"Z", "Y"}}
+	if !isPage1OnlyID(data, "Z") {
+		t.Fatal("expected Z to be page1-only")
+	}
+	if isPage1OnlyID(data, "A") {
+		t.Fatal("expected A not to be page1-only")
+	}
+}

--- a/agent/go-service/autostockpile/nodes.go
+++ b/agent/go-service/autostockpile/nodes.go
@@ -19,4 +19,6 @@ const (
 	overflowQuotaAdditionNodeName  = "AutoStockpileGetQuotaAddition"
 	locateGoodsNodeName            = "AutoStockpileLocateGoods"
 	goodsPriceNodeName             = "AutoStockpileGetGoods"
+	swipeShelfDownNodeName         = "AutoStockpileSwipeShelfDown"
+	swipeShelfUpNodeName           = "AutoStockpileSwipeShelfUp"
 )

--- a/agent/go-service/autostockpile/recognition.go
+++ b/agent/go-service/autostockpile/recognition.go
@@ -2,7 +2,6 @@ package autostockpile
 
 import (
 	"encoding/json"
-	"sort"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
@@ -90,156 +89,24 @@ func (r *ItemValueChangeRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogn
 		return nil, false
 	}
 
-	goodsROI := resolveGoodsRecognitionROI(ctx, arg.Img)
-	prices, ocrNames, goodsOCRAbortReason, goodsOCRErr := runGoodsOCR(ctx, arg.Img, goodsROI, itemMap)
-	if goodsOCRAbortReason != AbortReasonNone {
+	resultGoods, page1OnlyIDs, goodsAbortReason, scanErr := scanGoodsWithOptionalSecondPage(ctx, arg.Img, region, itemMap)
+	if goodsAbortReason != AbortReasonNone {
 		log.Warn().
-			Err(goodsOCRErr).
+			Err(scanErr).
 			Str("component", autoStockpileComponent).
-			Str("step", "goods_ocr").
-			Str("abort_reason", string(goodsOCRAbortReason)).
-			Msg("goods ocr unavailable")
-		return buildAbortedRecognitionResult(arg, goodsOCRAbortReason)
+			Str("step", "scan_goods").
+			Str("abort_reason", string(goodsAbortReason)).
+			Msg("goods scan unavailable")
+		return buildAbortedRecognitionResult(arg, goodsAbortReason)
 	}
-	log.Info().
-		Str("component", autoStockpileComponent).
-		Int("price_count", len(prices)).
-		Int("ocr_name_count", len(ocrNames)).
-		Msg("goods ocr finished")
-
-	boundIDs := make(map[string]bool)
-	usedPrice := make([]bool, len(prices))
-	pass1Goods := make([]GoodsItem, 0, len(ocrNames))
-	pass1Success := 0
-	pass1Failed := 0
-
-	sort.Slice(ocrNames, func(i, j int) bool {
-		if ocrNames[i].box.Y() != ocrNames[j].box.Y() {
-			return ocrNames[i].box.Y() < ocrNames[j].box.Y()
-		}
-		return ocrNames[i].box.X() < ocrNames[j].box.X()
-	})
-
-	for _, name := range ocrNames {
-		boundPrice, ok := bindPriceToOCRGoods(name, prices, usedPrice)
-		if !ok {
-			pass1Failed++
-			log.Warn().
-				Str("component", autoStockpileComponent).
-				Str("bind_pass", "ocr").
-				Str("goods_id", name.id).
-				Str("goods_name", name.name).
-				Str("tier", name.tier).
-				Int("goods_x", name.box.X()).
-				Int("goods_y", name.box.Y()).
-				Msg("failed to bind price for goods")
-			continue
-		}
-
-		pass1Goods = append(pass1Goods, GoodsItem{
-			ID:    name.id,
-			Name:  name.name,
-			Tier:  name.tier,
-			Price: boundPrice,
-		})
-		boundIDs[name.id] = true
-		pass1Success++
+	if scanErr != nil {
+		log.Error().
+			Err(scanErr).
+			Str("component", autoStockpileComponent).
+			Str("step", "scan_goods").
+			Msg("goods scan failed")
+		return nil, false
 	}
-
-	log.Info().
-		Str("component", autoStockpileComponent).
-		Str("bind_pass", "ocr").
-		Int("bind_success", pass1Success).
-		Int("bind_failed", pass1Failed).
-		Msg("goods-price binding finished")
-
-	candidateIDs := listUnboundRegionItemIDs(itemMap, region, boundIDs)
-	log.Info().
-		Str("component", autoStockpileComponent).
-		Str("region", region).
-		Str("template_source", "item_map").
-		Int("template_count", len(candidateIDs)).
-		Msg("goods template candidates loaded")
-
-	goods := make([]goodsCandidate, 0, len(candidateIDs))
-	for _, id := range candidateIDs {
-		templatePath := BuildTemplatePath(id)
-
-		detail, recErr := runGoodsTemplateMatch(ctx, arg.Img, templatePath, goodsROI)
-		if recErr != nil {
-			log.Warn().
-				Err(recErr).
-				Str("component", autoStockpileComponent).
-				Str("template", templatePath).
-				Msg("template match failed")
-			continue
-		}
-
-		box, hit := bestTemplateHit(detail)
-		if !hit {
-			continue
-		}
-
-		itemName := itemMap.IDToName[id]
-		tier := ParseTierFromID(id)
-
-		goods = append(goods, goodsCandidate{
-			item: GoodsItem{
-				ID:    id,
-				Name:  itemName,
-				Tier:  tier,
-				Price: 0,
-			},
-			box: box,
-		})
-	}
-
-	log.Info().
-		Str("component", autoStockpileComponent).
-		Int("template_hits", len(goods)).
-		Msg("template matching finished")
-
-	sort.Slice(goods, func(i, j int) bool {
-		if goods[i].box.Y() == goods[j].box.Y() {
-			return goods[i].box.X() < goods[j].box.X()
-		}
-		return goods[i].box.Y() < goods[j].box.Y()
-	})
-
-	resultGoods := make([]GoodsItem, 0, len(pass1Goods)+len(goods))
-	resultGoods = append(resultGoods, pass1Goods...)
-	bindingSuccess := 0
-	bindingFailed := 0
-
-	for _, g := range goods {
-		boundPrice, ok := bindPriceToGoods(g, prices, usedPrice)
-		item := g.item
-		if ok {
-			item.Price = boundPrice
-			bindingSuccess++
-		} else {
-			bindingFailed++
-			log.Warn().
-				Str("component", autoStockpileComponent).
-				Str("bind_pass", "template").
-				Str("goods_id", g.item.ID).
-				Str("goods_name", g.item.Name).
-				Str("tier", g.item.Tier).
-				Int("price", item.Price).
-				Int("goods_x", g.box.X()).
-				Int("goods_y", g.box.Y()).
-				Msg("failed to bind price for goods, skipping")
-			continue
-		}
-		resultGoods = append(resultGoods, item)
-	}
-
-	log.Info().
-		Str("component", autoStockpileComponent).
-		Str("bind_pass", "template").
-		Int("bind_success", bindingSuccess).
-		Int("bind_failed", bindingFailed).
-		Msg("goods-price binding finished")
 
 	if err := validateRecognizedGoodsTiers(resultGoods); err != nil {
 		log.Error().
@@ -258,7 +125,8 @@ func (r *ItemValueChangeRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogn
 				Current:  overflowCurrent,
 				Overflow: overflowAmount,
 			},
-			Goods: resultGoods,
+			Goods:        resultGoods,
+			Page1OnlyIDs: page1OnlyIDs,
 		},
 		AbortReason: AbortReasonNone,
 	}
@@ -279,6 +147,7 @@ func (r *ItemValueChangeRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogn
 		Bool("overflow", resultPayload.hasOverflow()).
 		Str("abort_reason", string(resultPayload.AbortReason)).
 		Int("goods_count", len(resultPayload.Data.Goods)).
+		Int("page1_only_count", len(resultPayload.Data.Page1OnlyIDs)).
 		Msg("custom recognition finished")
 	maafocus.Print(ctx, i18n.T("autostockpile.recognition_done", len(resultPayload.Data.Goods)))
 

--- a/agent/go-service/autostockpile/selector.go
+++ b/agent/go-service/autostockpile/selector.go
@@ -167,6 +167,23 @@ func (a *SelectItemAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 		return true
 	}
 
+	if isPage1OnlyID(*data, selection.ProductID) {
+		log.Info().
+			Str("component", "autostockpile").
+			Str("product_id", selection.ProductID).
+			Str("product_name", selection.ProductName).
+			Msg("selected goods only on second page, swipe shelf down before click")
+		if swipeErr := swipeShelfDown(ctx); swipeErr != nil {
+			log.Error().
+				Err(swipeErr).
+				Str("component", "autostockpile").
+				Str("product_id", selection.ProductID).
+				Str("step", "shelf_swipe_down_before_click").
+				Msg("failed to reveal page1-only goods before click")
+			return false
+		}
+	}
+
 	override, err := buildSelectionPipelineOverride(ctx, selection, quantityDecision)
 	if err != nil {
 		log.Error().

--- a/agent/go-service/autostockpile/shelf_swipe.go
+++ b/agent/go-service/autostockpile/shelf_swipe.go
@@ -1,0 +1,136 @@
+package autostockpile
+
+import (
+	"fmt"
+	"image"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+func runShelfSwipe(ctx *maa.Context, nodeName string) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+
+	_, err := ctx.RunAction(nodeName, maa.Rect{0, 0, 0, 0}, "", nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func swipeShelfDown(ctx *maa.Context) error {
+	return runShelfSwipe(ctx, swipeShelfDownNodeName)
+}
+
+func swipeShelfUp(ctx *maa.Context) error {
+	return runShelfSwipe(ctx, swipeShelfUpNodeName)
+}
+
+func screencapShelf(ctx *maa.Context) (image.Image, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is nil")
+	}
+	tasker := ctx.GetTasker()
+	if tasker == nil {
+		return nil, fmt.Errorf("tasker is nil")
+	}
+	ctrl := tasker.GetController()
+	if ctrl == nil {
+		return nil, fmt.Errorf("controller is nil")
+	}
+
+	ctrl.PostScreencap().Wait()
+	img, err := ctrl.CacheImage()
+	if err != nil {
+		return nil, err
+	}
+	if img == nil {
+		return nil, fmt.Errorf("cached image is nil")
+	}
+	return img, nil
+}
+
+// scanGoodsWithOptionalSecondPage 首屏扫描后下滑一次再扫次屏，按 ID 合并，并尽量滑回首屏。
+func scanGoodsWithOptionalSecondPage(
+	ctx *maa.Context,
+	firstImg image.Image,
+	region string,
+	itemMap *ItemMap,
+) (goods []GoodsItem, page1OnlyIDs []string, abortReason AbortReason, err error) {
+	page0, abortReason, err := scanGoodsOnImage(ctx, firstImg, region, itemMap)
+	if abortReason != AbortReasonNone || err != nil {
+		return nil, nil, abortReason, err
+	}
+
+	if swipeErr := swipeShelfDown(ctx); swipeErr != nil {
+		log.Warn().
+			Err(swipeErr).
+			Str("component", autoStockpileComponent).
+			Str("step", "shelf_swipe_down").
+			Int("page0_count", len(page0)).
+			Msg("shelf swipe down failed, keep first page only")
+		return page0, nil, AbortReasonNone, nil
+	}
+
+	restored := false
+	defer func() {
+		if restored {
+			return
+		}
+		if upErr := swipeShelfUp(ctx); upErr != nil {
+			log.Warn().
+				Err(upErr).
+				Str("component", autoStockpileComponent).
+				Str("step", "shelf_swipe_up").
+				Msg("failed to restore shelf to first page")
+		}
+	}()
+
+	secondImg, capErr := screencapShelf(ctx)
+	if capErr != nil {
+		log.Warn().
+			Err(capErr).
+			Str("component", autoStockpileComponent).
+			Str("step", "shelf_screencap").
+			Int("page0_count", len(page0)).
+			Msg("second page screencap failed, keep first page only")
+		return page0, nil, AbortReasonNone, nil
+	}
+
+	page1, page1Abort, page1Err := scanGoodsOnImage(ctx, secondImg, region, itemMap)
+	if page1Abort != AbortReasonNone || page1Err != nil {
+		log.Warn().
+			Err(page1Err).
+			Str("component", autoStockpileComponent).
+			Str("step", "scan_page1").
+			Str("abort_reason", string(page1Abort)).
+			Int("page0_count", len(page0)).
+			Msg("second page scan failed, keep first page only")
+		return page0, nil, AbortReasonNone, nil
+	}
+
+	goods, page1OnlyIDs = mergeGoodsByID(page0, page1)
+	log.Info().
+		Str("component", autoStockpileComponent).
+		Str("step", "merge_pages").
+		Int("page0_count", len(page0)).
+		Int("page1_count", len(page1)).
+		Int("merged_count", len(goods)).
+		Int("page1_only_count", len(page1OnlyIDs)).
+		Strs("page1_only_ids", page1OnlyIDs).
+		Msg("dual-page goods scan merged")
+
+	if upErr := swipeShelfUp(ctx); upErr != nil {
+		log.Warn().
+			Err(upErr).
+			Str("component", autoStockpileComponent).
+			Str("step", "shelf_swipe_up").
+			Msg("failed to restore shelf to first page after merge")
+	} else {
+		restored = true
+	}
+
+	return goods, page1OnlyIDs, AbortReasonNone, nil
+}

--- a/agent/go-service/autostockpile/state.go
+++ b/agent/go-service/autostockpile/state.go
@@ -24,7 +24,17 @@ var (
 func copyRecognitionData(src RecognitionData) RecognitionData {
 	dst := src
 	dst.Goods = append([]GoodsItem(nil), src.Goods...)
+	dst.Page1OnlyIDs = append([]string(nil), src.Page1OnlyIDs...)
 	return dst
+}
+
+func isPage1OnlyID(data RecognitionData, productID string) bool {
+	for _, id := range data.Page1OnlyIDs {
+		if id == productID {
+			return true
+		}
+	}
+	return false
 }
 
 // getDecisionState returns nil if no state has been set; otherwise returns a deep copy.

--- a/agent/go-service/autostockpile/types.go
+++ b/agent/go-service/autostockpile/types.go
@@ -57,8 +57,9 @@ type RecognitionResult struct {
 
 // RecognitionData 表示识别成功时传递给消费端的原始数据。
 type RecognitionData struct {
-	Quota QuotaInfo   `json:"Quota"`
-	Goods []GoodsItem `json:"Goods"`
+	Quota        QuotaInfo   `json:"Quota"`
+	Goods        []GoodsItem `json:"Goods"`
+	Page1OnlyIDs []string    `json:"Page1OnlyIDs,omitempty"`
 }
 
 // QuotaInfo 表示额度识别结果。

--- a/assets/resource/pipeline/AutoStockpile/Helper.json
+++ b/assets/resource/pipeline/AutoStockpile/Helper.json
@@ -177,5 +177,77 @@
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0
+    },
+    "AutoStockpileSwipeShelfDown": {
+        "desc": "货架向下滑动一页，露出下方商品",
+        "recognition": {
+            "type": "DirectHit",
+            "param": {}
+        },
+        "pre_delay": 0,
+        "action": {
+            "type": "Swipe",
+            "param": {
+                "begin": [
+                    640,
+                    520
+                ],
+                "end": [
+                    [
+                        640,
+                        320
+                    ]
+                ],
+                "end_hold": 200
+            }
+        },
+        "post_wait_freezes": {
+            "time": 300,
+            "target": [
+                63,
+                162,
+                400,
+                400
+            ],
+            "threshold": 0.98
+        },
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "AutoStockpileSwipeShelfUp": {
+        "desc": "货架向上滑动一页，恢复到首屏",
+        "recognition": {
+            "type": "DirectHit",
+            "param": {}
+        },
+        "pre_delay": 0,
+        "action": {
+            "type": "Swipe",
+            "param": {
+                "begin": [
+                    640,
+                    320
+                ],
+                "end": [
+                    [
+                        640,
+                        520
+                    ]
+                ],
+                "end_hold": 200
+            }
+        },
+        "post_wait_freezes": {
+            "time": 300,
+            "target": [
+                63,
+                162,
+                400,
+                400
+            ],
+            "threshold": 0.98
+        },
+        "post_delay": 0,
+        "rate_limit": 0
     }
 }

--- a/docs/en_us/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/en_us/developers/tasks/auto-stockpile-maintain.md
@@ -177,3 +177,22 @@ Language files to update: `zh_cn.json`, `en_us.json`, `ja_jp.json`, `ko_kr.json`
 File: `docs/zh_cn/protocol/autostockpile-daily-storage/daily_storage.schema.json` (and the corresponding `en_us` version)
 
 Add the new region identifier (e.g., `"NewRegion"`) to the `enum` list of the `region` field to ensure third-party tools can validate data for the new region via the Schema.
+
+## Dual-page Shelf Scan
+
+Recognition scans the elastic goods shelf for **at most two pages** so items below the fold are not missed:
+
+1. OCR + template match on the first-page screenshot.
+2. Run `AutoStockpileSwipeShelfDown` once (`post_wait_freezes` waits for list settle).
+3. Screencap and scan the second page.
+4. Merge by goods **ID** (keep first-page entry on duplicates; IDs only on page 2 go into `Page1OnlyIDs`).
+5. Run `AutoStockpileSwipeShelfUp` to restore the first page.
+
+If swipe/second-page scan fails, fall back to first-page results without aborting.
+
+After selection:
+
+- If the chosen ID is in `Page1OnlyIDs`, swipe down once more before `AutoStockpileSelectedGoodsClick`.
+- If the item was already on page 1, click without an extra swipe.
+
+Swipe nodes live in `assets/resource/pipeline/AutoStockpile/Helper.json` (720p). Tune `begin` / `end` and `post_wait_freezes.target` if real devices miss or over-scroll.

--- a/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
+++ b/docs/zh_cn/developers/tasks/auto-stockpile-maintain.md
@@ -177,3 +177,22 @@ var regionBases = map[string]int{
 文件：`docs/zh_cn/protocol/autostockpile-daily-storage/daily_storage.schema.json`（以及对应 `en_us` 版本）
 
 在 `region` 字段的 `enum` 列表中加入新地区标识（如 `"NewRegion"`），确保第三方工具能通过 Schema 校验新增地区的数据。
+
+## 货架双页扫描
+
+识别阶段会对弹性货架做**最多两页**扫描，避免清单超出一屏时漏价：
+
+1. 对首屏截图执行 OCR + 模板匹配。
+2. 调用 `AutoStockpileSwipeShelfDown` 下滑一次（`post_wait_freezes` 等待列表稳定）。
+3. 再截图扫描次屏。
+4. 按商品 **ID 去重合并**（同 ID 保留首屏结果；仅次屏出现的 ID 记入 `Page1OnlyIDs`）。
+5. 调用 `AutoStockpileSwipeShelfUp` 滑回首屏。
+
+任一滑动/次屏扫描失败时降级为仅首屏结果，不中断任务。
+
+选中商品后：
+
+- 若商品 ID 在 `Page1OnlyIDs` 中（例如最后一排只在次屏可见），点击前会再执行一次 `AutoStockpileSwipeShelfDown`，再交给 `AutoStockpileSelectedGoodsClick` 做模板点击。
+- 若首屏已有该商品，则不额外滑动。
+
+滑动节点定义在 `assets/resource/pipeline/AutoStockpile/Helper.json`。坐标基于 720p，实机若漏扫或过量重复，优先微调 `begin` / `end` 与 `post_wait_freezes.target`。


### PR DESCRIPTION
## Summary by Sourcery

添加支持双页自动囤货货架扫描及滑动操作，并将其集成到识别与选取流程中。

New Features:
- 支持通过滑动扫描自动囤货货架最多两页的商品，将按 ID 识别出的商品进行合并，并向下游使用方暴露仅存在于第二页的商品 ID。

Enhancements:
- 将商品识别逻辑重构为可复用的按图片扫描和双页扫描编排工具，包括货架滑动与截屏工具方法。
- 扩展选取逻辑，根据识别元数据在点击前自动滑动货架，以展示仅存在于第二页的商品。
- 增强识别数据与日志，增加仅存在于第二页的商品追踪与计数，以提升可观测性。

Documentation:
- 在自动囤货维护的英文和中文开发文档中，记录双页货架扫描行为、滑动节点以及调优指导。

Tests:
- 添加单元测试，覆盖多页商品合并行为与仅第一页 ID 检测相关的逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add dual-page auto-stockpile shelf scanning with swipe support and integrate it into recognition and selection flows.

New Features:
- Support scanning up to two pages of the auto-stockpile goods shelf by swiping, merging recognized items by ID and exposing second-page-only IDs to consumers.

Enhancements:
- Refactor goods recognition into reusable per-image scanning and dual-page scan orchestration helpers, including shelf swipe and screencap utilities.
- Extend selection logic to automatically reveal second-page-only goods with a pre-click shelf swipe based on recognition metadata.
- Augment recognition data and logging with second-page-only item tracking and counts for better observability.

Documentation:
- Document the dual-page shelf scan behavior, swipe nodes, and tuning guidance in both English and Chinese developer docs for auto-stockpile maintenance.

Tests:
- Add unit tests covering multi-page goods merging behavior and page1-only ID detection.

</details>