### PR TITLE
feat(skill): 新增 MaaEnd 测试图片维护技能

### DIFF
--- a/.agents/skills/maaend-test-image/SKILL.md
+++ b/.agents/skills/maaend-test-image/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: maaend-test-image
+description: 为 MaaEnd 添加、导入或补充节点识别测试截图，并按仓库约定脱敏图片、放入 tests/MaaEndTestset、维护 tests/**/test_*.json 和运行 pnpm check/pnpm test 验证。用户提到“添加测试图片/截图”“把截图加入 ADB 或 Win32 测试集”“给节点补正例或反例”“更新 hits/box”“UID 打码后提交测试图”时使用；即使用户只说把某张游戏截图放进 MaaEnd 测试，也要用本技能避免未脱敏原图进入仓库。
+---
+
+# MaaEnd 测试图片维护
+
+## 目标
+
+把原始游戏截图安全地加入 MaaEnd 的节点测试。最终同时满足：
+
+- 仓库内只出现脱敏后的 PNG，不先复制未打码原图；
+- 图片位于 `tests/MaaEndTestset/<controller>/<resource>/`；
+- 对应 `tests/**/test_*.json` 使用正确的 `controller`、`resource`、图片文件名和 `hits`；
+- JSON、图片引用、`pnpm check` 和 `pnpm test` 通过；
+- 不改动无关图片、用例或用户已有工作。
+
+本技能适用于已有固定 ROI 的 `ADB` 和 `Win32`。`PlayCover` 或新分辨率没有可靠遮盖坐标时，先向用户确认脱敏规则，不要套用其它平台坐标。
+
+## 开始前确认上下文
+
+1. 定位 MaaEnd 根目录；应同时存在 `maatools.config.mts`、`tests/MaaEndTestset/`、`tests/scripts/loader.mts` 和 `assets/resource/model/ocr/`。
+2. 运行 `git status --short`，记录已有修改和未跟踪文件。它们属于用户，不要批量处理测试截图。
+3. 阅读 `docs/zh_cn/developers/node-testing.md`，再查看语义最接近的图片和 `tests/**/test_*.json`。以当前文档、schema 和 `maatools.config.mts` 为准，不沿用旧测试集格式。
+4. 从用户输入或目标路径确定：
+    - 原始截图路径；
+    - `controller`：`ADB` 或 `Win32`；
+    - `resource`：当前官服目录为 `Official_CN`，测试配置写 `官服`；
+    - 无扩展名图片名和目标 `test_*.json`；
+    - 期望命中节点 `hits`，以及确需校验时的 `box`。
+
+只有缺失信息会改变图片落盘位置或测试含义时才追问。不要猜测节点名、正负例结果或精确 `box`。
+
+## 路径和命名
+
+图片使用：
+
+```text
+tests/MaaEndTestset/<controller>/<resource>/<图片名>.png
+```
+
+测试文件使用：
+
+```text
+tests/<功能或组件>/test_<测试主题>.json
+```
+
+`image` 只写文件名，必须显式包含 `.png`，不能包含目录：
+
+```json
+{
+    "configs": {
+        "name": "(Win32/ADB-官服)自动转交送货任务",
+        "resource": [
+            "官服"
+        ],
+        "controller": [
+            "Win32",
+            "ADB"
+        ]
+    },
+    "cases": [
+        {
+            "image": "四号谷地_地区建设_仓储节点_送货任务_确认转交.png",
+            "hits": [
+                "DeliveryJobsConfirmTaskTransfer"
+            ]
+        }
+    ]
+}
+```
+
+优先追加到语义匹配的现有文件。只有没有合适测试主题时才新建文件，并仿照相邻测试。若 `controller` 或 `resource` 是数组，`tests/scripts/loader.mts` 会展开笛卡尔积；每种组合都必须有同名图片。同一张图可按不同测试目的出现在多个测试文件中。
+
+## 脱敏并导入图片
+
+使用本技能的单图脚本，从仓库外的原图直接生成目标文件：
+
+```powershell
+uv run .agents/skills/maaend-test-image/scripts/redact_test_image.py `
+  "C:\path\raw.png" `
+  "tests\MaaEndTestset\ADB\Official_CN\四号谷地_确认转交.png"
+```
+
+脚本使用 MaaEnd 自带的 OCR 模型并执行：
+
+1. 校验截图为 1280×720；
+2. 用纯绿色 `RGB(0, 255, 0)` 覆盖 ADB 固定 ROI `[84, 690, 114, 18]` 或 Win32 固定 ROI `[70, 696, 90, 13]`；
+3. 用 `assets/resource/model/ocr/` 查找包含 `UID` 或 `#` 的区域；
+4. 用同样的纯绿色覆盖 OCR 命中框；
+5. 原子写入目标 PNG，外部原图不会先进入仓库。
+
+如果 OCR 漏掉其它私人信息，添加可重复的额外 ROI，格式为 `x,y,w,h`：
+
+```powershell
+uv run .agents/skills/maaend-test-image/scripts/redact_test_image.py `
+  "C:\path\raw.png" `
+  "tests\MaaEndTestset\Win32\Official_CN\功能_画面.png" `
+  --extra-roi 1100,20,160,40 `
+  --extra-roi 20,620,240,60
+```
+
+目标已存在时，只有用户明确要求替换才加 `--force`。原图本来就在目标路径且需要原地脱敏时也必须加 `--force`；脚本会先写临时文件再替换。
+
+处理后必须查看最终图片，确认：
+
+- UID、账号编号、昵称或其它私人信息均已完全遮住；
+- 绿色块没有遮挡本次要测试的识别目标；
+- 图片内容、方向和 1280×720 分辨率未被改变；
+- 仓库中没有原始副本或 `.redacting-*` 临时文件。
+
+OCR 只是辅助检查，视觉复核才是隐私安全的最终门槛。无法确认脱敏完整时，不要把图片加入测试或提交。
+
+## 编写测试用例
+
+### `hits` 写法
+
+只验证命中节点：
+
+```json
+"hits": [
+    "NodeName"
+]
+```
+
+验证命中节点和固定识别框：
+
+```json
+"hits": [
+    {
+        "node": "NodeName",
+        "box": [
+            91,
+            587,
+            274,
+            48
+        ]
+    }
+]
+```
+
+不同控制器使用不同识别框：
+
+```json
+"box": {
+    "ADB": [
+        91,
+        587,
+        274,
+        48
+    ],
+    "Win32": [
+        100,
+        600,
+        250,
+        50
+    ]
+}
+```
+
+反例：
+
+```json
+"hits": []
+```
+
+`box` 使用 `[x, y, width, height]` 的非负整数。只有用户提供了预期框，或实际测试输出给出了可确认的框时才写，不要从截图肉眼猜精确值。
+
+### 修改规则
+
+- `configs.controller` 与图片目录一致，可写字符串或数组。
+- `configs.resource` 与 `tests/scripts/loader.mts` 的映射一致；当前官服写 `官服`。
+- 不手写 `imageRoot`；loader 会根据矩阵自动生成。
+- `image` 必须是实际文件名并带 `.png`，不得包含 `/` 或 `\`。
+- `hits` 必须存在，允许空数组。
+- 同一文件内不要重复添加相同 `image`；需要增加节点时合并到已有用例。
+- 测试文件允许 JSONC 注释，格式必须遵循仓库 Prettier（通常为 4 空格）。
+- 只编辑目标测试文件，不顺手修正其它已有测试。
+
+## 验证
+
+先做本次变更的直接检查：
+
+```powershell
+pnpm exec prettier --write "tests\功能\test_xxx.json"
+pnpm check
+pnpm test
+```
+
+随后确认：
+
+1. 每个新增 `image` 在对应 controller/resource 的目录下都存在；
+2. `tests/maatools/error_details.json` 没有本次用例的错误；
+3. `git diff --check` 没有文本问题；
+4. `git status --short` 和目标文件 diff 只包含预期变更。
+
+若 `pnpm test` 失败，先区分：
+
+- 图片路径、矩阵或配置错误：修正测试定义；
+- `hits` 与实际画面不符：依据真实测试目的修正，不能为了变绿而删除必要断言；
+- MaaEnd 节点本身识别失败：报告节点、ROI 或模板问题。除非用户同时要求修改 Pipeline，否则不要扩大范围。
+
+## 交付
+
+简要说明新增或替换了哪些脱敏图片、更新了哪些测试文件与预期命中、额外遮盖区域，以及 `pnpm check`、`pnpm test` 的结果。不要声称图片“已安全脱敏”，除非已实际查看最终图片。

--- a/.agents/skills/maaend-test-image/evals/evals.json
+++ b/.agents/skills/maaend-test-image/evals/evals.json
@@ -1,0 +1,23 @@
+{
+    "skill_name": "maaend-test-image",
+    "evals": [
+        {
+            "id": 1,
+            "prompt": "把 C:\\Screenshots\\确认转交.png 加到 MaaEnd 的 ADB 官服自动转交送货任务测试里，图片名用 四号谷地_确认转交_二测.png，预期命中 DeliveryJobsConfirmTaskTransfer。原图有 UID，记得打码。",
+            "expected_output": "从仓库外原图直接生成 tests/MaaEndTestset/ADB/Official_CN/四号谷地_确认转交_二测.png 的脱敏版本，在语义匹配的 tests/DeliveryJobs/test_transfer_job.json 中添加带 .png 的 image 和指定 hits，并运行 pnpm check 与 pnpm test。",
+            "files": []
+        },
+        {
+            "id": 2,
+            "prompt": "Win32 的 C:\\Temp\\wrong-level.png 是升级武器按钮的反例，请作为 WrongUpLevelButton_2.png 加进 MaaEnd 现有通用按钮测试。右上角昵称 OCR 没识别出来，需要再遮住 1100,20,160,40。",
+            "expected_output": "用 Win32 固定 ROI、UID/# OCR 和额外 ROI 生成 tests/MaaEndTestset/Win32/Official_CN/WrongUpLevelButton_2.png，把用例追加到语义匹配的 tests/Common/Button/test_*.json，hits 为空数组，目视复核后运行 pnpm check 与 pnpm test。",
+            "files": []
+        },
+        {
+            "id": 3,
+            "prompt": "把 downloads 里的 new-shot.png 加成一个 MaaEnd 节点识别测试，预期框大概在按钮附近。",
+            "expected_output": "平台、目标测试主题、节点名和精确 box 都不足以安全推断；先检查 MaaEnd 本地上下文，仍无法确定时只追问会影响落盘位置和测试语义的必要信息，不猜测 box，也不把未脱敏原图复制进 tests/MaaEndTestset。",
+            "files": []
+        }
+    ]
+}

--- a/.agents/skills/maaend-test-image/scripts/redact_test_image.py
+++ b/.agents/skills/maaend-test-image/scripts/redact_test_image.py
@@ -1,0 +1,292 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "maafw>=5.9.0",
+#     "numpy>=2.0",
+#     "opencv-python-headless>=4.10",
+#     "pillow>=11",
+# ]
+# ///
+
+"""Import one MaaEnd test screenshot after redacting private information."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+import uuid
+
+import cv2
+from maa.controller import CustomController
+from maa.pipeline import JOCR
+from maa.resource import Resource
+from maa.tasker import Tasker
+from maa.toolkit import Toolkit
+import numpy as np
+from PIL import Image as PILImage
+
+
+SUPPORTED_CONTROLLERS = {"adb": "ADB", "win32": "Win32"}
+FIXED_ROIS = {
+    "ADB": [84, 690, 114, 18],
+    "Win32": [70, 696, 90, 13],
+}
+EXPECTED_SIZE = (1280, 720)
+
+
+class OfflineOcrController(CustomController):
+    """Provide the no-op controller required by MaaFramework offline OCR."""
+
+    def connect(self) -> bool:
+        return True
+
+    def request_uuid(self) -> str:
+        return "maaend-test-image-offline-ocr"
+
+    def start_app(self, intent: str) -> bool:
+        return True
+
+    def stop_app(self, intent: str) -> bool:
+        return True
+
+    def screencap(self) -> np.ndarray:
+        return np.zeros((1, 1, 3), dtype=np.uint8)
+
+    def click(self, x: int, y: int) -> bool:
+        return True
+
+    def swipe(self, x1: int, y1: int, x2: int, y2: int, duration: int) -> bool:
+        return True
+
+    def touch_down(self, contact: int, x: int, y: int, pressure: int) -> bool:
+        return True
+
+    def touch_move(self, contact: int, x: int, y: int, pressure: int) -> bool:
+        return True
+
+    def touch_up(self, contact: int) -> bool:
+        return True
+
+    def click_key(self, keycode: int) -> bool:
+        return True
+
+    def input_text(self, text: str) -> bool:
+        return True
+
+    def key_down(self, keycode: int) -> bool:
+        return True
+
+    def key_up(self, keycode: int) -> bool:
+        return True
+
+    def scroll(self, dx: int, dy: int) -> bool:
+        return True
+
+    def get_custom_info(self) -> dict[str, str]:
+        return {"mode": "offline-ocr", "platform": sys.platform}
+
+
+def find_repo_root(explicit: Path | None) -> Path:
+    """Find a MaaEnd checkout containing the in-repository test set."""
+    if explicit is not None:
+        candidates = [explicit]
+    else:
+        script_repo = Path(__file__).resolve().parents[4]
+        cwd = Path.cwd().resolve()
+        candidates = [cwd, *cwd.parents, script_repo]
+
+    for candidate in candidates:
+        root = candidate.expanduser().resolve()
+        markers = (
+            root / "maatools.config.mts",
+            root / "tests" / "MaaEndTestset",
+            root / "assets" / "resource" / "model" / "ocr",
+        )
+        if all(marker.exists() for marker in markers):
+            return root
+    raise SystemExit("找不到 MaaEnd 根目录；请在仓库内运行，或使用 --repo 指定。")
+
+
+def parse_roi(raw: str) -> list[int]:
+    """Parse x,y,w,h into a validated ROI."""
+    try:
+        values = [int(part.strip()) for part in raw.split(",")]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("ROI 必须是整数 x,y,w,h") from exc
+    if len(values) != 4 or any(value < 0 for value in values):
+        raise argparse.ArgumentTypeError("ROI 必须是四个非负整数 x,y,w,h")
+    if values[2] == 0 or values[3] == 0:
+        raise argparse.ArgumentTypeError("ROI 的宽和高必须大于 0")
+    return values
+
+
+def controller_from_destination(repo: Path, destination: Path) -> str:
+    """Validate the MaaEnd test-set path and infer its controller."""
+    testset = (repo / "tests" / "MaaEndTestset").resolve()
+    try:
+        relative = destination.resolve().relative_to(testset)
+    except ValueError as exc:
+        raise SystemExit("目标图片必须位于 tests/MaaEndTestset/ 内。") from exc
+
+    if len(relative.parts) != 3:
+        raise SystemExit(
+            "目标图片必须使用 tests/MaaEndTestset/<controller>/<resource>/<文件名>.png。"
+        )
+    controller = SUPPORTED_CONTROLLERS.get(relative.parts[0].casefold())
+    if controller is None:
+        raise SystemExit("目标图片必须位于 ADB/ 或 Win32/ 目录中。")
+    return controller
+
+
+def read_image(path: Path) -> np.ndarray:
+    """Read an image from a path that may contain non-ASCII characters."""
+    image_bytes = np.fromfile(path, dtype=np.uint8)
+    image = cv2.imdecode(image_bytes, cv2.IMREAD_COLOR)
+    if image is None:
+        raise SystemExit(f"无法读取图片：{path}")
+    return image
+
+
+def validate_image_and_rois(image: np.ndarray, rois: list[list[int]]) -> None:
+    """Require MaaEnd's 720p baseline and in-bounds redaction rectangles."""
+    height, width = image.shape[:2]
+    if (width, height) != EXPECTED_SIZE:
+        raise SystemExit(
+            f"截图必须为 {EXPECTED_SIZE[0]}x{EXPECTED_SIZE[1]}，实际为 {width}x{height}。"
+        )
+    for x, y, roi_width, roi_height in rois:
+        if x + roi_width > width or y + roi_height > height:
+            raise SystemExit(
+                "打码 ROI 超出图片范围："
+                f"[{x}, {y}, {roi_width}, {roi_height}]，图片尺寸为 {width}x{height}。"
+            )
+
+
+def fill_roi(image: np.ndarray, roi: list[int]) -> None:
+    """Fill an ROI with pure green in OpenCV BGR order."""
+    x, y, width, height = roi
+    image[y : y + height, x : x + width] = [0, 255, 0]
+
+
+def build_tasker(repo: Path) -> tuple[Tasker, Resource, OfflineOcrController]:
+    """Create an offline OCR tasker backed by MaaEnd's bundled OCR model."""
+    runtime_path = repo / ".cache" / "maaend-test-image"
+    runtime_path.mkdir(parents=True, exist_ok=True)
+    Toolkit.init_option(runtime_path)
+
+    controller = OfflineOcrController()
+    controller.post_connection().wait()
+
+    resource = Resource()
+    resource.post_bundle(repo / "assets" / "resource").wait()
+    tasker = Tasker()
+    if not tasker.bind(resource, controller) or not tasker.inited:
+        raise SystemExit("MaaFramework OCR 初始化失败。")
+    return tasker, resource, controller
+
+
+def find_private_rois(tasker: Tasker, image: np.ndarray) -> list[list[int]]:
+    """Return OCR boxes containing UID markers."""
+    detail = tasker.post_recognition("OCR", JOCR(expected=["UID", "#"]), image).wait().get()
+    nodes = getattr(detail, "nodes", [])
+    if not nodes:
+        return []
+    recognition = getattr(nodes[0], "recognition", None)
+    results = getattr(recognition, "filtered_results", []) if recognition else []
+    return [[int(value) for value in result.box] for result in results]
+
+
+def save_png(image: np.ndarray, destination: Path) -> None:
+    """Save a BGR OpenCV image as PNG through Pillow."""
+    image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+    PILImage.fromarray(image_rgb).save(destination, "PNG")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="使用 MaaEnd 固定 ROI + UID/# OCR 脱敏并导入单张节点测试截图。"
+    )
+    parser.add_argument("source", type=Path, help="仓库外原始截图路径")
+    parser.add_argument(
+        "destination",
+        type=Path,
+        help="tests/MaaEndTestset/<controller>/<resource>/ 下的目标 PNG",
+    )
+    parser.add_argument(
+        "--controller",
+        choices=("ADB", "Win32"),
+        help="可选；默认从目标路径推断，并校验两者一致",
+    )
+    parser.add_argument(
+        "--extra-roi",
+        action="append",
+        default=[],
+        type=parse_roi,
+        metavar="X,Y,W,H",
+        help="额外纯绿色遮盖区域，可重复传入",
+    )
+    parser.add_argument("--force", action="store_true", help="允许替换已有目标图片")
+    parser.add_argument("--repo", type=Path, help="MaaEnd 仓库根目录")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    repo = find_repo_root(args.repo)
+    source = args.source.expanduser().resolve()
+    destination = args.destination.expanduser()
+    if not destination.is_absolute():
+        destination = repo / destination
+    destination = destination.resolve()
+
+    if not source.is_file():
+        raise SystemExit(f"原始截图不存在：{source}")
+    if destination.suffix.casefold() != ".png":
+        raise SystemExit("目标图片必须使用 .png 扩展名。")
+
+    inferred_controller = controller_from_destination(repo, destination)
+    if args.controller is not None and args.controller != inferred_controller:
+        raise SystemExit(
+            f"--controller={args.controller} 与目标路径平台 {inferred_controller} 不一致。"
+        )
+    controller = args.controller or inferred_controller
+
+    same_file = source == destination
+    if destination.exists() and not args.force:
+        raise SystemExit(f"目标已存在：{destination}；确认替换时使用 --force。")
+
+    image = read_image(source)
+    fixed_roi = FIXED_ROIS[controller]
+    validate_image_and_rois(image, [fixed_roi, *args.extra_roi])
+    fill_roi(image, fixed_roi)
+
+    tasker, resource, ocr_controller = build_tasker(repo)
+    ocr_rois = find_private_rois(tasker, image)
+    del tasker, resource, ocr_controller
+    validate_image_and_rois(image, ocr_rois)
+    for roi in [*ocr_rois, *args.extra_roi]:
+        fill_roi(image, roi)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(
+        f".{destination.stem}.redacting-{uuid.uuid4().hex}.png"
+    )
+    try:
+        save_png(image, temporary)
+        temporary.replace(destination)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+    mode = "原地替换" if same_file else "导入"
+    print(f"已{mode}并打码：{destination}")
+    print(f"平台：{controller}；固定 ROI：{fixed_roi}")
+    print(f"OCR ROI：{ocr_rois}")
+    if args.extra_roi:
+        print(f"额外 ROI：{args.extra_roi}")
+    print("请目视检查最终图片，确认没有 OCR 漏掉的私人信息。")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 变更内容

- 新增项目级 `maaend-test-image` 技能，规范 MaaEnd 节点测试截图的导入、命名、用例维护与验证流程。
- 提供单图脱敏脚本，直接使用 MaaEnd 自带 OCR 模型，支持 Win32/ADB 固定 UID 区域与额外 ROI 遮盖。
- 添加 3 个评测场景，覆盖正例、反例与信息不足时的安全处理。

## 变更原因

MaaEnd 的节点测试截图现已维护在 `tests/MaaEndTestset`，需要一套与当前 `maatools.config.mts`、测试 schema 和 `pnpm test` 流程一致的技能，避免沿用旧测试集路径或将未脱敏截图加入仓库。

## 影响

仅新增 `.agents/skills/maaend-test-image` 下的技能文件，不修改 Pipeline、任务配置或运行时资源。

## 验证

- 技能结构校验通过。
- 脱敏脚本使用现有 1280×720 ADB 截图完成实际冒烟测试，并目视确认输出。
- `pnpm check` 通过。
- `pnpm test` 通过（521/521）。

## 由 Sourcery 总结

添加一个新的 MaaEnd 测试图像维护技能，包括一个用于安全编辑和导入节点测试截图的脚本，以及在现有 MaaEnd 测试工作流程中使用该技能的文档。

新功能：
- 引入一个 `maaend-test-image` 项目级技能，用于标准化在仓库中添加和维护 MaaEnd 节点测试截图的方式。
- 添加一个编辑脚本，使用 MaaEnd 内置的 OCR 在将单张测试截图导入 `tests/MaaEndTestset` 之前移除其中的隐私信息。
- 提供技能文档，说明路径、命名规则、测试模式（schema）的使用方式以及将新截图集成到 MaaEnd 测试中的验证步骤。

增强：
- 使 MaaEnd 测试图像处理与现有的 `maatools` 配置和测试工作流程保持一致，防止未编辑或放置错误的截图进入仓库。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个新的 MaaEnd 项目级技能，用于通过仓库内的工具和文档安全地导入和维护节点识别测试截图。

新功能：
- 引入 `maaend-test-image` 技能，用于规范在 `tests/MaaEndTestset` 中添加、打码和维护 MaaEnd 节点测试截图。
- 提供一个 Python 脚本，使用 MaaEnd 自带的 OCR，在将单张截图导入测试集之前，对 UID 和其他敏感区域进行打码处理。
- 文档化端到端工作流程，包括放置已打码图片、配置测试 JSON 文件，以及使用 `pnpm check` 和 `pnpm test` 进行验证。

测试：
- 为 `maaend-test-image` 技能新增评估配置，以覆盖典型使用场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new MaaEnd project-level skill for safely importing and maintaining node recognition test screenshots with in-repo tooling and documentation.

New Features:
- Introduce a maaend-test-image skill to standardize adding, redacting, and maintaining MaaEnd node test screenshots in tests/MaaEndTestset.
- Provide a Python script that uses MaaEnd’s bundled OCR to redact UID and other sensitive regions from single screenshots before importing them into the test set.
- Document the end-to-end workflow for placing redacted images, configuring test JSON files, and validating with pnpm check and pnpm test.

Tests:
- Add evaluation configuration for the maaend-test-image skill to cover typical usage scenarios.

</details>

</details>