### PR TITLE
fix(MapNavigator): web 工具 Agent IPC 端点唯一化 定位点 tier/base 帧换算

### DIFF
--- a/tools/MapNavigator/recording_service.py
+++ b/tools/MapNavigator/recording_service.py
@@ -11,7 +11,7 @@ from connection_models import RecordingSessionConfig
 from connectors import build_recording_connector
 import key_listener
 from model import ActionType, PathPoint, PathRecorder, normalize_zone_id
-from runtime import AGENT_DIR, CPP_AGENT_EXE, MAAFW_BIN_DIR, MaaRuntime, get_agent_env
+from runtime import AGENT_DIR, CPP_AGENT_EXE, MAAFW_BIN_DIR, MaaRuntime, get_agent_env, new_agent_id
 
 
 StatusCallback = Callable[[str, str], None]
@@ -114,7 +114,7 @@ class RecordingService:
             if self._session_config is None:
                 raise RuntimeError("录制会话配置缺失。")
 
-            agent_id = f"MapLocatorAgent_{int(time.time())}"
+            agent_id = new_agent_id("MapLocatorAgent")
             if not CPP_AGENT_EXE.exists():
                 raise FileNotFoundError(f"找不到 Agent 可执行文件: {CPP_AGENT_EXE}")
 

--- a/tools/MapNavigator/runtime.py
+++ b/tools/MapNavigator/runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,15 @@ def _resolve_cpp_agent_executable() -> Path:
 
 
 CPP_AGENT_EXE = _resolve_cpp_agent_executable()
+
+
+def new_agent_id(prefix: str) -> str:
+    """生成全局唯一的 Agent id。
+
+    id 即 AgentClient 的 IPC 端点名: 重名时后到者轻则 connect() 永久挂死, 重则
+    zmq 抛出未捕获异常 abort 掉宿主进程。曾用 int(time.time()), 同秒即撞。
+    """
+    return f"{prefix}_{os.getpid()}_{uuid.uuid4().hex[:8]}"
 
 
 def get_agent_env() -> dict[str, str]:

--- a/tools/MapNavigator/web/serve.py
+++ b/tools/MapNavigator/web/serve.py
@@ -50,6 +50,7 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 import webbrowser
 from contextlib import asynccontextmanager
 from dataclasses import asdict
@@ -86,6 +87,7 @@ from runtime import (  # noqa: E402
     configure_runtime_env,
     get_agent_env,
     load_maa_runtime,
+    new_agent_id,
 )
 from settings_store import (  # noqa: E402
     CONNECTION_KINDS,
@@ -100,6 +102,7 @@ from fastapi.concurrency import run_in_threadpool  # noqa: E402
 from fastapi.responses import FileResponse, JSONResponse, Response  # noqa: E402
 from fastapi.staticfiles import StaticFiles  # noqa: E402
 from pydantic import BaseModel  # noqa: E402
+from starlette.datastructures import MutableHeaders  # noqa: E402
 
 
 # --- 常量 -----------------------------------------------------------------------------
@@ -362,6 +365,36 @@ async def lifespan(_app: FastAPI):
 
 
 app = FastAPI(title="MapNavigator Web Backend", lifespan=lifespan)
+
+
+class NoStoreMiddleware:
+    """给所有 HTTP 响应打 Cache-Control: no-store。
+
+    这是给别的开发者用的工具, 底图/数据包/前端 JS 都可能被就地替换。浏览器默认对没有
+    Cache-Control 的 FileResponse 走启发式缓存, 会拿旧底图旧代码却毫无提示 —— 非本模块
+    开发者根本察觉不到。localhost 每次重取代价为零, 宁可不缓存也不让任何人踩到隐形旧图。
+
+    纯 ASGI 实现: 只在 http.response.start 时补一个响应头, 不缓冲 FileResponse 响应体
+    (BaseHTTPMiddleware 会缓冲, 破坏大文件与 range), 也不碰 websocket。
+    """
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_no_store(message: Any) -> None:
+            if message["type"] == "http.response.start":
+                MutableHeaders(scope=message)["Cache-Control"] = "no-store"
+            await send(message)
+
+        await self.app(scope, receive, send_no_store)
+
+
+app.add_middleware(NoStoreMiddleware)
 
 
 class RouteRequest(BaseModel):
@@ -1185,7 +1218,7 @@ def do_locate_once(runtime: Any, session_config: Any) -> dict[str, Any]:
     """
     agent_process = None
     try:
-        agent_id = f"MapLocatorOnceAgent_{int(time.time())}"
+        agent_id = new_agent_id("MapLocatorOnceAgent")
         if not CPP_AGENT_EXE.exists():
             raise FileNotFoundError(f"找不到 Agent 可执行文件: {CPP_AGENT_EXE}")
 
@@ -1274,7 +1307,8 @@ async def api_locate_once(payload: dict[str, Any] = Body(default_factory=dict)) 
         res = await run_in_threadpool(do_locate_once, runtime, session_config)
         return res
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"定位执行失败: {exc}")
+        _log(f"定位失败:\n{traceback.format_exc()}")
+        raise HTTPException(status_code=500, detail=f"定位执行失败: {exc}") from exc
 
 
 # 静态站点挂在最后, 使显式 API 路由优先匹配。空目录也不会崩 (已在 lifespan 中 mkdir)。

--- a/tools/MapNavigator/web/static/js/main.js
+++ b/tools/MapNavigator/web/static/js/main.js
@@ -1839,7 +1839,9 @@ class MapNavigatorApp {
               if (this._selectDisplayZoneById(zoneIdNum)) this._onAstarZoneChanged(false);
             }
 
-            this._addAstarHint(x, y, '游戏当前位置');
+            // 定位给的是所在 zone 自己的帧(tier 上即 tier px), 预览点存 base px。
+            const [bx, by] = this._pointToBase(zoneIdNum, x, y);
+            this._addAstarHint(bx, by, '游戏当前位置');
             setStatus(`已标记 A* 定位预览点: [${x.toFixed(1)}, ${y.toFixed(1)}]。当前有 ${this.astarLocateHints.length} 个预览点。`, '#10b981');
             this._focusAstarHints();
           }
@@ -1853,7 +1855,8 @@ class MapNavigatorApp {
               this.els.assertZoneCombo.value = numericIdStr;
               this._onAssertZoneChanged();
             }
-            this.assertLocateHint = [x, y];
+            // 定位给的是所在 zone 自己的帧(tier 上即 tier px), 提示点存 base px。
+            this.assertLocateHint = zoneObj ? this._pointToBase(zoneObj.zone_id, x, y) : [x, y];
             this._fitView();
             setStatus(`已定位到游戏当前位置 [${x.toFixed(1)}, ${y.toFixed(1)}]，请在此提示点周围拖拽鼠标来画出断言矩形。`, '#10b981');
             this._paint();
@@ -1872,8 +1875,8 @@ class MapNavigatorApp {
   // ==================================================================================
 
   /**
-   * Append an A* preview marker. Coords are **base px** — the frame locate fixes and
-   * exported NAVMESH targets use; `_paint` projects them into the display frame.
+   * Append an A* preview marker. Coords are **base px** (callers convert from the point's
+   * own zone frame); `_paint` projects them into the display frame.
    * @param {number} x @param {number} y @param {string} label caption drawn under the marker
    * @returns {void}
    */
@@ -2188,10 +2191,11 @@ class MapNavigatorApp {
             tierName = zone.name;
           }
         }
-        // Preview markers are already base px (locate fixes / hand-entered coords).
+        // 预览点存的是 base px; 带 target_tier 时运行时按 tier px 解读 target, 所以反投回去。
+        const target = tierName ? this.field.baseToTier(tierId, hint.x, hint.y) : [hint.x, hint.y];
         const payload = {
           action: 'NAVMESH',
-          target: [compactNumber(hint.x), compactNumber(hint.y)]
+          target: [compactNumber(target[0]), compactNumber(target[1])]
         };
         if (tierName) {
           payload.target_tier = tierName;
@@ -2219,10 +2223,11 @@ class MapNavigatorApp {
     const targets = [];
     for (let i = 1; i < this.astarPoints.length; i++) {
       const pt = this.astarPoints[i];
-      const basePt = tierId !== null ? this.field.tierToBase(tierId, pt[0], pt[1]) : pt;
+      // 画的点本就是显示帧 px(有 tier 时即 tier px), 正是 target_tier 要的帧; 不带 tier 才转 base px。
+      const target = tierName ? pt : tierId !== null ? this.field.tierToBase(tierId, pt[0], pt[1]) : pt;
       const payload = {
         action: 'NAVMESH',
-        target: [compactNumber(basePt[0]), compactNumber(basePt[1])]
+        target: [compactNumber(target[0]), compactNumber(target[1])]
       };
       if (tierName) {
         payload.target_tier = tierName;

--- a/tools/MapNavigator/web/static/js/rpc.js
+++ b/tools/MapNavigator/web/static/js/rpc.js
@@ -125,13 +125,24 @@ export function getLoadStatus() {
 export async function getMesh(zoneId) {
   let res;
   try {
-    res = await fetch(`/mesh/${encodeURIComponent(String(zoneId))}`);
+    res = await fetch(`/mesh/${encodeURIComponent(String(zoneId))}`, { cache: 'no-store' });
   } catch (err) {
     throw new RpcError(`网络请求失败: /mesh/${zoneId} (${err && err.message ? err.message : err})`, 0);
   }
   if (res.status === 404) return null;
   if (!res.ok) throw new RpcError(await errorMessage(res), res.status);
   return res.arrayBuffer();
+}
+
+/**
+ * 追加一次性 query 参数。底图走 `new Image().src`，浏览器对这类脚本发起的请求在硬刷新时
+ * 也常直接命中旧缓存条目、根本不回源，于是更新了模板图仍显示旧图。变一下 URL 就没有可命中
+ * 的条目，必然回源；配合服务端 no-store，之后每次都是最新。
+ * @param {string} url
+ * @returns {string}
+ */
+function withCacheBust(url) {
+  return `${url}${url.includes('?') ? '&' : '?'}_=${Date.now()}`;
 }
 
 /**
@@ -144,7 +155,7 @@ export function basemapUrl(imagePath) {
   const parts = String(imagePath)
     .split('/')
     .map((seg) => encodeURIComponent(seg));
-  return `/basemap/${parts.join('/')}`;
+  return withCacheBust(`/basemap/${parts.join('/')}`);
 }
 
 /**
@@ -156,7 +167,7 @@ export function basemapUrl(imagePath) {
  * @returns {string}
  */
 export function basemapByZoneUrl(zoneId) {
-  return `/basemap-by-zone?zone_id=${encodeURIComponent(String(zoneId))}`;
+  return withCacheBust(`/basemap-by-zone?zone_id=${encodeURIComponent(String(zoneId))}`);
 }
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

确保 MapNavigator 的 Web 后端和前端在定位和录制流程中使用对缓存安全的资源，并为代理的 IPC 端点分配唯一标识。

Bug 修复：
- 生成全局唯一的代理 ID，防止 IPC 端点冲突导致进程挂起或崩溃。
- 修正 A* 预览标记、断言以及 NAVMESH 请求中分层坐标系与基础坐标系之间的坐标转换。

功能增强：
- 禁用 HTTP 响应缓存，并为底图和网格资源添加 cache-busting 机制，确保开发者在本地开发时始终看到最新资源。
- 在一次性定位失败时记录完整堆栈跟踪，以便调试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure MapNavigator web backend and frontend use cache-safe resources and unique agent IPC endpoints for location and recording flows.

Bug Fixes:
- Generate globally unique agent IDs to prevent IPC endpoint collisions that could hang or crash processes.
- Correct coordinate frame conversions between tier and base frames for A* preview markers, assertions, and NAVMESH requests.

Enhancements:
- Disable HTTP response caching and add cache-busting for basemap and mesh resources so developers always see the latest assets during local development.
- Log full stack traces on locate-once failures to aid debugging.

</details>