### PR TITLE
feat(EnvironmentMonitoring): 增加金秋时适配

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AutumnGold.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/AutumnGold.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutumnGoldNotAdapted"
+            "GoToAutumnGold"
         ]
     },
     "AlreadyTrackedAutumnGold": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutumnGoldNotAdapted"
+            "GoToAutumnGold"
         ]
     },
     "AutumnGoldNotAdapted": {
@@ -266,12 +266,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "^map\\d+_lv\\d+$",
+                    "map_name": "map02_lv004",
                     "target": [
-                        0,
-                        0,
-                        1,
-                        1
+                        402.4,
+                        313.4,
+                        20.8,
+                        17.4
                     ]
                 }
             ]
@@ -284,34 +284,40 @@
         ]
     },
     "GoToAutumnGoldNotAtStartPos": {
-        "desc": "不在金秋时任务开始位置附近，先传送再检查落点",
+        "desc": "不在金秋时任务开始位置附近，先传送再继续寻路",
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneAnyEnterWorld"
+                "SceneEnterWorldWulingMarkerStone2"
             ]
         },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToAutumnGoldStartPos"
+            "GoToAutumnGoldMove"
         ]
     },
     "GoToAutumnGoldMove": {
         "desc": "自动寻路前往金秋时",
         "pre_delay": 0,
         "action": "Custom",
-        "custom_action": "MapTrackerMove",
+        "custom_action": "MapTrackerGoal",
         "custom_action_param": {
-            "map_name": "^map\\d+_lv\\d+$",
-            "path": [
-                [
-                    0,
-                    0
-                ]
-            ]
+            "map_name": "map02_lv004",
+            "target": [
+                299.5,
+                386.5
+            ],
+            "on_finish": {
+                "action": "Custom",
+                "custom_action": "MapTrackerToward",
+                "custom_action_param": {
+                    "angle": 270
+                }
+            },
+            "no_ensure_initial_movement_state": true
         },
         "anchor": {
             "EnvironmentMonitoringBackToTerminal": "EnvironmentMonitoringGoToMarkerStoneMonitoringTerminal",
@@ -325,12 +331,12 @@
     },
     "AutumnGoldAdjustCamera": {
         "desc": "金秋时任务中调整朝向",
-        "max_hit": 2,
+        "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "EnvironmentMonitoringSwipeScreenUp"
+            "EnvironmentMonitoringSwipeScreenDown"
         ]
     }
 }

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -891,7 +891,23 @@
     {
         "MissionId": "m1m70",
         "Name": "“金秋时”",
-        "Id": "AutumnGold"
+        "Id": "AutumnGold",
+        "EnterMap": "SceneEnterWorldWulingMarkerStone2",
+        "MapName": "map02_lv004",
+        "MapAssert": [
+            402.4,
+            313.4,
+            20.8,
+            17.4
+        ],
+        "MapGoal": [
+            299.5,
+            386.5
+        ],
+        "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenDown",
+        "CameraMaxHit": 1,
+        "NoEnsureInitialMovementState": true,
+        "Heading": 270
     },
     {
         "MissionId": "m1m71",


### PR DESCRIPTION
## Summary
- 新增环境监测任务“金秋时”（`m1m70`）的完整路线配置
- 使用首墟监测终端传送点进入 `map02_lv004`
- 使用 `MapTrackerGoal` 移动至目标点 `[299.5, 386.5]`
- 到达后将朝向调整为 `270°`
- 调整相机视角为向下滑动，最多执行 1 次

Close #4312 

## Summary by Sourcery

为“金秋时 (Autumn Gold)”任务新增环境监测路线配置，使用“界桩监测终端”管线。

新增功能：
- 为“金秋时 (Autumn Gold, m1m70)”环境监测任务引入完整路线配置，包括通过“界桩监测终端”进入，以及移动至指定目标位置的路径。

增强内容：
- 更新环境监测路线生成元数据，将“金秋时 (Autumn Gold, m1m70)”路线纳入其中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new environment monitoring route configuration for the Autumn Gold (金秋时) task using the Marker Stone Monitoring Terminal pipeline.

New Features:
- Introduce full route configuration for the Autumn Gold (金秋时, m1m70) environment monitoring task, including entry via the Marker Stone Monitoring Terminal and movement to the specified target location.

Enhancements:
- Update environment monitoring route generation metadata to include the Autumn Gold (金秋时, m1m70) route.

</details>