### PR TITLE
fix(EnvironmentMonitoring): 调整垂藤拍照点坐标与朝向

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
@@ -307,14 +307,14 @@
         "custom_action_param": {
             "map_name": "map02_lv004",
             "target": [
-                579.2,
-                253.7
+                520,
+                288
             ],
             "on_finish": {
                 "action": "Custom",
                 "custom_action": "MapTrackerToward",
                 "custom_action_param": {
-                    "angle": 90
+                    "angle": 0
                 }
             }
         },

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -650,12 +650,12 @@
             8.1
         ],
         "MapGoal": [
-            579.2,
-            253.7
+            520,
+            288
         ],
         "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenUp",
         "CameraMaxHit": 3,
-        "Heading": 90
+        "Heading": 0
     },
     {
         "MissionId": "m1m63",


### PR DESCRIPTION
将 MapGoal 改为 (520, 288)，Heading 改为 0，提升垂藤任务到达与对准稳定性。
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/f3a11263-0107-4864-a551-4f705ce67913" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/02c26405-2a56-45cd-a842-e48101927033" />

## Summary by Sourcery

调整 EnvironmentMonitoring 中悬挂藤蔓照片采集的位置和朝向，以提升任务对准的稳定性。

改进内容：
- 更新 HangingVines 流水线配置，使用新的地图目标坐标和朝向，以提高到达和定位的可靠性。
- 将 EnvironmentMonitoring 路线生成配置与更新后的 HangingVines 任务参数对齐。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust EnvironmentMonitoring hanging vines photo capture position and heading to improve task alignment stability.

Enhancements:
- Update HangingVines pipeline configuration with new map goal coordinates and heading for more reliable arrival and orientation.
- Align EnvironmentMonitoring route generation config with the updated HangingVines task parameters.

</details>