### PR TITLE
fix: 相伴赠礼领取武器失败

### DIFF
--- a/assets/resource/pipeline/DailyRewards/Event/GiftEvent.json
+++ b/assets/resource/pipeline/DailyRewards/Event/GiftEvent.json
@@ -47,8 +47,28 @@
         "action": "Click",
         "post_delay": 0,
         "next": [
+            "[JumpBack]DailyEventUnreadGiftEventClickNew",
             "SceneNoticeRewardsConfirm"
         ]
+    },
+    "DailyEventUnreadGiftEventClickNew": {
+        "desc": "点击获得界面右下角 NEW",
+        "recognition": "OCR",
+        "roi": [
+            900,
+            400,
+            250,
+            150
+        ],
+        "expected": [
+            // 武器领取的NEW
+            // @i18n-skip
+            "NEW"
+        ],
+        "pre_delay": 1000, // 防止动画一直在动
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0
     },
     "DailyEventUnreadGiftEventFinish": {
         "desc": "领取完了",


### PR DESCRIPTION
close #4286

## Summary by Sourcery

Bug Fixes:
- 通过修正 GiftEvent 的每日奖励配置，解决在领取伙伴赠礼活动武器时出现的失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve failure when claiming companion gift event weapons by correcting the GiftEvent daily rewards configuration.

</details>