### PR TITLE
fix(ItemTransfer): 补充库存转移切换界面的繁中支持

### DIFF
--- a/assets/tasks/ItemTransfer.json
+++ b/assets/tasks/ItemTransfer.json
@@ -3974,24 +3974,28 @@
                         "ItemTransferClickOrigin": {
                             "expected": [
                                 "四号谷地",
+                                "四號谷地",
                                 "Valley IV"
                             ]
                         },
                         "ItemTransferClickOriginClicked": {
                             "expected": [
                                 "四号谷地",
+                                "四號谷地",
                                 "Valley IV"
                             ]
                         },
                         "ItemTransferClickOriginReturn": {
                             "expected": [
                                 "四号谷地",
+                                "四號谷地",
                                 "Valley IV"
                             ]
                         },
                         "ItemTransferClickOriginReturnClicked": {
                             "expected": [
                                 "四号谷地",
+                                "四號谷地",
                                 "Valley IV"
                             ]
                         }
@@ -4048,12 +4052,14 @@
                         "ItemTransferClickDestination": {
                             "expected": [
                                 "四号谷地",
+                                "四號谷地",
                                 "Valley IV"
                             ]
                         },
                         "ItemTransferClickDestinationClicked": {
                             "expected": [
                                 "四号谷地",
+                                "四號谷地",
                                 "Valley IV"
                             ]
                         }


### PR DESCRIPTION
修复繁中客户端下库存转移切换仓库失败的问题。

`Valley IV / 四号谷地` 的仓库区域选项补充：

- `四號谷地`

- 修改后也仅支持所有模板匹配的转移需求
- OCR只认简中，看pr里有人在做cv就没改()
Close #4173

## Summary by Sourcery

修復在物品轉移任務配置中，繁體中文客戶端對倉庫切換的支援問題。

錯誤修復：
- 解決在使用繁體中文客戶端時，庫存轉移畫面上的倉庫切換失敗問題。

增強功能：
- 在物品轉移配置中，為「Valley IV / 四號谷地」倉庫區域新增繁體中文選項。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Traditional Chinese client support for warehouse switching in the ItemTransfer task configuration.

Bug Fixes:
- Resolve warehouse switch failures on the inventory transfer screen when using the Traditional Chinese client.

Enhancements:
- Add Traditional Chinese option for the 'Valley IV / 四号谷地' warehouse area in the ItemTransfer configuration.

</details>