### PR TITLE
feat(MapLocator): 在日志中输出每轮定位结果

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/position_provider.cpp
+++ b/agent/cpp-algo/source/MapNavigator/position_provider.cpp
@@ -1,5 +1,7 @@
 #include <chrono>
 
+#include <MaaUtils/Logger.h>
+
 #include "../utils.h"
 #include "MapNavigator/controller_info_utils.h"
 #include "controller_type_utils.h"
@@ -88,6 +90,16 @@ bool PositionProvider::Capture(NaviPosition* out_pos, bool force_global_search, 
     options.expected_zone_id = expected_zone_id;
 
     const auto locate_result = locator_->locate(minimap, options);
+    const int status = static_cast<int>(locate_result.status);
+    if (locate_result.position) {
+        const auto& position = *locate_result.position;
+        LogInfo << "MapLocator" << VAR(status) << VAR(locate_result.debugMessage) << VAR(position.zoneId) << VAR(position.x)
+                << VAR(position.y) << VAR(position.score) << VAR(position.sliceIndex) << VAR(position.scale) << VAR(position.angle)
+                << VAR(position.latencyMs) << VAR(position.isHeld);
+    }
+    else {
+        LogInfo << "MapLocator" << VAR(status) << VAR(locate_result.debugMessage) << "position=null";
+    }
     if (locate_result.status != maplocator::LocateStatus::Success || !locate_result.position) {
         last_capture_was_held_ = false;
         held_fix_streak_ = 0;


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- 添加对 MapLocator `locate` 结果的结构化日志记录，包括状态、调试消息，以及位置信息详情（或在不可用时为 `null`）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add structured logging of MapLocator locate results, including status, debug message, and position details or null when unavailable.

</details>