### PR TITLE
fix(pipeline-generate): 格式化下载的 zmdmap JSON

### DIFF
--- a/tools/pipeline-generate/fetch-data.mjs
+++ b/tools/pipeline-generate/fetch-data.mjs
@@ -71,8 +71,13 @@ async function fetchAndCache(version) {
             throw new Error(`下载 ${file} 失败: ${res.status} ${res.statusText}`);
         }
         const text = await res.text();
-        writeFileSync(resolve(dataDir, file), text, "utf8");
-        console.log(`[fetch-data] 已缓存 ${file} (${(Buffer.byteLength(text) / 1024).toFixed(0)} KB)`);
+        // 保留超出 Number 安全范围的 ID 原始字面量，避免格式化时发生精度丢失。
+        const data = JSON.parse(text, (_key, value, context) =>
+            typeof value === "number" ? JSON.rawJSON(context.source) : value,
+        );
+        const formattedData = `${JSON.stringify(data, null, 2)}\n`;
+        writeFileSync(resolve(dataDir, file), formattedData, "utf8");
+        console.log(`[fetch-data] 已缓存 ${file} (${(Buffer.byteLength(formattedData) / 1024).toFixed(0)} KB)`);
     }
 
     writeFileSync(resolve(dataDir, VERSION_FILE), version, "utf8");


### PR DESCRIPTION
## 修改内容

- 下载 zmdmap JSON 后统一使用 2 空格缩进和末尾换行格式化保存。
- 格式化时保留超出 JavaScript 安全整数范围的原始数字字面量，避免数据精度损失。

## 原因

#4344 中的同步任务直接保存了上游响应体。上游 JSON 改为单行压缩格式后，生成的 PR 出现整文件压缩和大量无意义 diff。

## 影响

后续同步生成的 JSON 将保持稳定、可审查的排版，同时不会因为 JavaScript Number 精度限制而静默修改上游 ID。

## 验证

- `pnpm check`
- `pnpm test`（595/595）
- 使用实际单行上游数据验证格式化输出和超大整数保真
- `git diff --check`

## Summary by Sourcery

对缓存的 zmdmap JSON 响应进行稳定的美化格式化，同时保留超过 JavaScript 安全整数范围的大数值 ID。

Bug Fixes:
- 防止在缓存的 zmdmap JSON 中，对于超过 JavaScript 安全整数范围的 ID 发生无提示的精度丢失。

Enhancements:
- 始终以 2 个空格缩进并带有结尾换行符的方式美化打印缓存的 zmdmap JSON，从而避免因上游压缩数据而产生嘈杂的差异。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Format cached zmdmap JSON responses with stable pretty-printing while preserving large numeric IDs beyond JavaScript’s safe integer range.

Bug Fixes:
- Prevent silent precision loss for IDs in cached zmdmap JSON that exceed JavaScript’s safe integer range.

Enhancements:
- Always pretty-print cached zmdmap JSON with 2-space indentation and a trailing newline to avoid noisy diffs from compressed upstream data.

</details>

Bug Fixes（缺陷修复）：
- 当缓存下载的 zmdmap JSON 时，对于超过 JavaScript 安全整数范围的 ID，防止出现无提示的精度丢失问题。

Enhancements（增强改进）：
- 确保缓存的 zmdmap JSON 始终以 2 空格缩进并带有结尾换行的方式进行美化打印，从而避免由于上游响应数据被压缩而导致的多余差异。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

对缓存的 zmdmap JSON 响应进行稳定的美化格式化，同时保留超过 JavaScript 安全整数范围的大数值 ID。

Bug Fixes:
- 防止在缓存的 zmdmap JSON 中，对于超过 JavaScript 安全整数范围的 ID 发生无提示的精度丢失。

Enhancements:
- 始终以 2 个空格缩进并带有结尾换行符的方式美化打印缓存的 zmdmap JSON，从而避免因上游压缩数据而产生嘈杂的差异。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Format cached zmdmap JSON responses with stable pretty-printing while preserving large numeric IDs beyond JavaScript’s safe integer range.

Bug Fixes:
- Prevent silent precision loss for IDs in cached zmdmap JSON that exceed JavaScript’s safe integer range.

Enhancements:
- Always pretty-print cached zmdmap JSON with 2-space indentation and a trailing newline to avoid noisy diffs from compressed upstream data.

</details>

</details>