### PR TITLE
fix(VisitFriends): 进入好友船时清空滚动检测last_text,避免误判列表到底

### DIFF
--- a/agent/go-service/common/listcomplete/recognition.go
+++ b/agent/go-service/common/listcomplete/recognition.go
@@ -3,6 +3,7 @@ package listcomplete
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/recogtarget"
@@ -13,18 +14,23 @@ import (
 const (
 	componentName  = "ListCompleteRecognition"
 	attachLastText = "last_text"
+	// fingerprintSep 拼接整屏 OCR 文本；选不会出现在好友名中的分隔符。
+	fingerprintSep = "\n"
 )
 
 var _ maa.CustomRecognitionRunner = &Recognition{}
 
-// Recognition 是通用的列表完成识别器：通过 OCR 文本是否变化判断列表是否仍在滚动/更新。
+// Recognition 是通用的列表完成识别器：通过 OCR 指纹是否变化判断列表是否仍在滚动/更新。
 //
-// 首次命中（当前节点 attach.last_text 为空）时，只要 OCR 成功即返回 true，并写入文字与框；
-// 之后若文字与 attach.last_text 一致则返回 false（视为列表已到底/未变化），
+// 指纹取自目标 OCR 节点的整屏命中（优先 Filtered，否则 All），按纵向（再按横向）排序后
+// 用换行拼接，避免只比 Best 时顶部名字不变、下方已滚动仍被误判到底。
+//
+// 首次命中（当前节点 attach.last_text 为空）时，只要能抽出指纹即返回 true，并写入指纹与框；
+// 之后若指纹与 attach.last_text 一致则返回 false（视为列表已到底/未变化），
 // 不一致则更新 attach 并返回 true。
 //
 // node 可为 OCR 节点，或 And 节点。对 And 节点，按节点自身 box_index（默认 0）
-// 从 CombinedResult 中选取子识别结果，再从该结果提取 OCR 文本与框——目标解析复用 recogtarget。
+// 从 CombinedResult 中选取子识别结果，再从该结果提取 OCR——目标解析复用 recogtarget。
 type Recognition struct{}
 
 type params struct {
@@ -90,13 +96,13 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 		return nil, false
 	}
 
-	hit, err := extractOCRHitFromNode(ctx, p.Node, detail)
+	hit, err := extractOCRFingerprintFromNode(ctx, p.Node, detail)
 	if err != nil {
 		log.Error().
 			Err(err).
 			Str("component", componentName).
 			Str("node", p.Node).
-			Msg("failed to extract OCR from recognition result")
+			Msg("failed to extract OCR fingerprint from recognition result")
 		return nil, false
 	}
 
@@ -115,7 +121,7 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 			Str("component", componentName).
 			Str("node", p.Node).
 			Str("text", hit.Text).
-			Msg("OCR text unchanged, list complete")
+			Msg("OCR fingerprint unchanged, list complete")
 		return nil, false
 	}
 
@@ -142,7 +148,7 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 		Str("text", hit.Text).
 		Str("last_text", lastText).
 		Bool("first_run", lastText == "").
-		Msg("OCR text accepted")
+		Msg("OCR fingerprint accepted")
 
 	return &maa.CustomRecognitionResult{
 		Box:    hit.Box,
@@ -177,60 +183,84 @@ func ensureNodeContainsOCR(ctx *maa.Context, nodeName string) error {
 	return nil
 }
 
-// extractOCRHitFromNode 先用 recogtarget 按 box_index 选中目标子结果，再提取 OCR 文本与框。
-func extractOCRHitFromNode(ctx *maa.Context, nodeName string, detail *maa.RecognitionDetail) (ocrHit, error) {
+// extractOCRFingerprintFromNode 先用 recogtarget 按 box_index 选中目标子结果，
+// 再收集整屏 OCR 命中并生成指纹（纵向排序后 join）。
+func extractOCRFingerprintFromNode(ctx *maa.Context, nodeName string, detail *maa.RecognitionDetail) (ocrHit, error) {
 	selected, err := recogtarget.SelectDetail(ctx, nodeName, detail)
 	if err != nil {
 		return ocrHit{}, err
 	}
-	hit, ok := ocrHitFromResults(selected)
+	hit, ok := fingerprintFromOCRResults(selected)
 	if !ok {
 		return ocrHit{}, fmt.Errorf("no ocr result found")
 	}
 	return hit, nil
 }
 
-func ocrHitFromResults(detail *maa.RecognitionDetail) (ocrHit, bool) {
-	if detail == nil || detail.Results == nil {
+// fingerprintFromOCRResults 收集 Filtered（空则 All）中全部 OCR 文本，
+// 按 box 纵向再横向排序后拼接为指纹；Box 取最上方一条。
+func fingerprintFromOCRResults(detail *maa.RecognitionDetail) (ocrHit, bool) {
+	hits := collectOCRHits(detail)
+	if len(hits) == 0 {
 		return ocrHit{}, false
 	}
+	return buildFingerprint(hits), true
+}
 
-	try := func(result *maa.RecognitionResult) (ocrHit, bool) {
+func collectOCRHits(detail *maa.RecognitionDetail) []ocrHit {
+	if detail == nil || detail.Results == nil {
+		return nil
+	}
+
+	results := detail.Results.Filtered
+	if len(results) == 0 {
+		results = detail.Results.All
+	}
+
+	hits := make([]ocrHit, 0, len(results))
+	for _, result := range results {
 		if result == nil {
-			return ocrHit{}, false
+			continue
 		}
 		ocrResult, ok := result.AsOCR()
 		if !ok {
-			return ocrHit{}, false
+			continue
 		}
 		text := strings.TrimSpace(ocrResult.Text)
 		if text == "" {
-			return ocrHit{}, false
+			continue
 		}
 		box := ocrResult.Box
 		if !rectValid(box) && rectValid(detail.Box) {
 			box = detail.Box
 		}
 		if !rectValid(box) {
-			return ocrHit{}, false
+			continue
 		}
-		return ocrHit{Text: text, Box: box}, true
+		hits = append(hits, ocrHit{Text: text, Box: box})
 	}
+	return hits
+}
 
-	if hit, ok := try(detail.Results.Best); ok {
-		return hit, true
-	}
-	for _, result := range detail.Results.Filtered {
-		if hit, ok := try(result); ok {
-			return hit, true
+func buildFingerprint(hits []ocrHit) ocrHit {
+	sorted := append([]ocrHit(nil), hits...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		yi := sorted[i].Box[1]
+		yj := sorted[j].Box[1]
+		if yi != yj {
+			return yi < yj
 		}
+		return sorted[i].Box[0] < sorted[j].Box[0]
+	})
+
+	texts := make([]string, 0, len(sorted))
+	for _, h := range sorted {
+		texts = append(texts, h.Text)
 	}
-	for _, result := range detail.Results.All {
-		if hit, ok := try(result); ok {
-			return hit, true
-		}
+	return ocrHit{
+		Text: strings.Join(texts, fingerprintSep),
+		Box:  sorted[0].Box,
 	}
-	return ocrHit{}, false
 }
 
 func rectValid(box maa.Rect) bool {

--- a/agent/go-service/common/listcomplete/recognition.go
+++ b/agent/go-service/common/listcomplete/recognition.go
@@ -22,8 +22,9 @@ var _ maa.CustomRecognitionRunner = &Recognition{}
 
 // Recognition 是通用的列表完成识别器：通过 OCR 指纹是否变化判断列表是否仍在滚动/更新。
 //
-// 指纹取自目标 OCR 节点的整屏命中（优先 Filtered，否则 All），按纵向（再按横向）排序后
-// 用换行拼接，避免只比 Best 时顶部名字不变、下方已滚动仍被误判到底。
+// 指纹取自目标 OCR 节点命中（优先 Filtered，否则 All）：按纵向（再按横向）排序后
+// 只取首尾两条用换行拼接（仅一条时用该条）。比只用 Best 更能发现「顶不变、底已滚」；
+// 比整屏 join 更耐中间项 OCR 抖动。
 //
 // 首次命中（当前节点 attach.last_text 为空）时，只要能抽出指纹即返回 true，并写入指纹与框；
 // 之后若指纹与 attach.last_text 一致则返回 false（视为列表已到底/未变化），
@@ -197,8 +198,8 @@ func extractOCRFingerprintFromNode(ctx *maa.Context, nodeName string, detail *ma
 	return hit, nil
 }
 
-// fingerprintFromOCRResults 收集 Filtered（空则 All）中全部 OCR 文本，
-// 按 box 纵向再横向排序后拼接为指纹；Box 取最上方一条。
+// fingerprintFromOCRResults 收集 Filtered（空则 All）中 OCR 命中，
+// 按 box 纵向再横向排序后取首尾生成指纹；Box 取最上方一条。
 func fingerprintFromOCRResults(detail *maa.RecognitionDetail) (ocrHit, bool) {
 	hits := collectOCRHits(detail)
 	if len(hits) == 0 {
@@ -253,9 +254,10 @@ func buildFingerprint(hits []ocrHit) ocrHit {
 		return sorted[i].Box[0] < sorted[j].Box[0]
 	})
 
-	texts := make([]string, 0, len(sorted))
-	for _, h := range sorted {
-		texts = append(texts, h.Text)
+	// 只取首尾：中间漏检/多检不影响；底部换人仍能与 Best-only 区分开。
+	texts := []string{sorted[0].Text}
+	if last := sorted[len(sorted)-1]; len(sorted) > 1 {
+		texts = append(texts, last.Text)
 	}
 	return ocrHit{
 		Text: strings.Join(texts, fingerprintSep),

--- a/agent/go-service/common/listcomplete/recognition_test.go
+++ b/agent/go-service/common/listcomplete/recognition_test.go
@@ -60,22 +60,22 @@ func TestBuildFingerprintDetectsPartialScroll(t *testing.T) {
 
 	// 顶部名字不变、底部换人：旧 Best-only 会误判到底，首尾指纹应不同。
 	before := buildFingerprint([]ocrHit{
-		{Text: "苏墨#0514", Box: maa.Rect{135, 221, 147, 26}},
-		{Text: "daddy#8190", Box: maa.Rect{137, 328, 157, 22}},
-		{Text: "Astel#1915", Box: maa.Rect{137, 434, 84, 19}},
-		{Text: "心宿二#4702", Box: maa.Rect{136, 534, 161, 26}},
+		{Text: "Alpha#1001", Box: maa.Rect{135, 221, 147, 26}},
+		{Text: "Bravo#2002", Box: maa.Rect{137, 328, 157, 22}},
+		{Text: "Charlie#3003", Box: maa.Rect{137, 434, 84, 19}},
+		{Text: "Delta#4004", Box: maa.Rect{136, 534, 161, 26}},
 	})
 	after := buildFingerprint([]ocrHit{
-		{Text: "苏墨#0514", Box: maa.Rect{135, 221, 147, 26}},
-		{Text: "daddy#8190", Box: maa.Rect{137, 328, 157, 22}},
-		{Text: "Astel#1915", Box: maa.Rect{137, 434, 84, 19}},
-		{Text: "乘风#9587", Box: maa.Rect{136, 534, 120, 26}},
+		{Text: "Alpha#1001", Box: maa.Rect{135, 221, 147, 26}},
+		{Text: "Bravo#2002", Box: maa.Rect{137, 328, 157, 22}},
+		{Text: "Charlie#3003", Box: maa.Rect{137, 434, 84, 19}},
+		{Text: "Echo#5005", Box: maa.Rect{136, 534, 120, 26}},
 	})
 	if before.Text == after.Text {
 		t.Fatalf("partial scroll fingerprints collided: %q", before.Text)
 	}
-	wantBefore := "苏墨#0514" + fingerprintSep + "心宿二#4702"
-	wantAfter := "苏墨#0514" + fingerprintSep + "乘风#9587"
+	wantBefore := "Alpha#1001" + fingerprintSep + "Delta#4004"
+	wantAfter := "Alpha#1001" + fingerprintSep + "Echo#5005"
 	if before.Text != wantBefore {
 		t.Fatalf("before = %q, want %q", before.Text, wantBefore)
 	}

--- a/agent/go-service/common/listcomplete/recognition_test.go
+++ b/agent/go-service/common/listcomplete/recognition_test.go
@@ -2,6 +2,8 @@ package listcomplete
 
 import (
 	"testing"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
 )
 
 func TestParseParams(t *testing.T) {
@@ -20,5 +22,48 @@ func TestParseParams(t *testing.T) {
 	}
 	if _, err := parseParams(""); err == nil {
 		t.Fatal("expected error for empty param")
+	}
+}
+
+func TestBuildFingerprintSortsByVerticalThenHorizontal(t *testing.T) {
+	t.Parallel()
+
+	hit := buildFingerprint([]ocrHit{
+		{Text: "B", Box: maa.Rect{10, 200, 20, 10}},
+		{Text: "A", Box: maa.Rect{10, 100, 20, 10}},
+		{Text: "C-left", Box: maa.Rect{5, 300, 20, 10}},
+		{Text: "C-right", Box: maa.Rect{50, 300, 20, 10}},
+	})
+
+	wantText := "A" + fingerprintSep + "B" + fingerprintSep + "C-left" + fingerprintSep + "C-right"
+	if hit.Text != wantText {
+		t.Fatalf("fingerprint = %q, want %q", hit.Text, wantText)
+	}
+	if hit.Box != (maa.Rect{10, 100, 20, 10}) {
+		t.Fatalf("box = %v, want topmost A box", hit.Box)
+	}
+}
+
+func TestBuildFingerprintDetectsPartialScroll(t *testing.T) {
+	t.Parallel()
+
+	// 顶部名字不变、底部换人：旧 Best-only 会误判到底，整屏指纹应不同。
+	before := buildFingerprint([]ocrHit{
+		{Text: "苏墨#0514", Box: maa.Rect{135, 221, 147, 26}},
+		{Text: "daddy#8190", Box: maa.Rect{137, 328, 157, 22}},
+		{Text: "Astel#1915", Box: maa.Rect{137, 434, 84, 19}},
+		{Text: "心宿二#4702", Box: maa.Rect{136, 534, 161, 26}},
+	})
+	after := buildFingerprint([]ocrHit{
+		{Text: "苏墨#0514", Box: maa.Rect{135, 221, 147, 26}},
+		{Text: "daddy#8190", Box: maa.Rect{137, 328, 157, 22}},
+		{Text: "Astel#1915", Box: maa.Rect{137, 434, 84, 19}},
+		{Text: "乘风#9587", Box: maa.Rect{136, 534, 120, 26}},
+	})
+	if before.Text == after.Text {
+		t.Fatalf("partial scroll fingerprints collided: %q", before.Text)
+	}
+	if before.Box != after.Box {
+		t.Fatalf("top box should stay same when only bottom changes: before=%v after=%v", before.Box, after.Box)
 	}
 }

--- a/agent/go-service/common/listcomplete/recognition_test.go
+++ b/agent/go-service/common/listcomplete/recognition_test.go
@@ -25,7 +25,7 @@ func TestParseParams(t *testing.T) {
 	}
 }
 
-func TestBuildFingerprintSortsByVerticalThenHorizontal(t *testing.T) {
+func TestBuildFingerprintUsesFirstAndLastOnly(t *testing.T) {
 	t.Parallel()
 
 	hit := buildFingerprint([]ocrHit{
@@ -35,7 +35,7 @@ func TestBuildFingerprintSortsByVerticalThenHorizontal(t *testing.T) {
 		{Text: "C-right", Box: maa.Rect{50, 300, 20, 10}},
 	})
 
-	wantText := "A" + fingerprintSep + "B" + fingerprintSep + "C-left" + fingerprintSep + "C-right"
+	wantText := "A" + fingerprintSep + "C-right"
 	if hit.Text != wantText {
 		t.Fatalf("fingerprint = %q, want %q", hit.Text, wantText)
 	}
@@ -44,10 +44,21 @@ func TestBuildFingerprintSortsByVerticalThenHorizontal(t *testing.T) {
 	}
 }
 
+func TestBuildFingerprintSingleHit(t *testing.T) {
+	t.Parallel()
+
+	hit := buildFingerprint([]ocrHit{
+		{Text: "only", Box: maa.Rect{10, 100, 20, 10}},
+	})
+	if hit.Text != "only" {
+		t.Fatalf("fingerprint = %q, want only", hit.Text)
+	}
+}
+
 func TestBuildFingerprintDetectsPartialScroll(t *testing.T) {
 	t.Parallel()
 
-	// 顶部名字不变、底部换人：旧 Best-only 会误判到底，整屏指纹应不同。
+	// 顶部名字不变、底部换人：旧 Best-only 会误判到底，首尾指纹应不同。
 	before := buildFingerprint([]ocrHit{
 		{Text: "苏墨#0514", Box: maa.Rect{135, 221, 147, 26}},
 		{Text: "daddy#8190", Box: maa.Rect{137, 328, 157, 22}},
@@ -63,7 +74,29 @@ func TestBuildFingerprintDetectsPartialScroll(t *testing.T) {
 	if before.Text == after.Text {
 		t.Fatalf("partial scroll fingerprints collided: %q", before.Text)
 	}
-	if before.Box != after.Box {
-		t.Fatalf("top box should stay same when only bottom changes: before=%v after=%v", before.Box, after.Box)
+	wantBefore := "苏墨#0514" + fingerprintSep + "心宿二#4702"
+	wantAfter := "苏墨#0514" + fingerprintSep + "乘风#9587"
+	if before.Text != wantBefore {
+		t.Fatalf("before = %q, want %q", before.Text, wantBefore)
+	}
+	if after.Text != wantAfter {
+		t.Fatalf("after = %q, want %q", after.Text, wantAfter)
+	}
+}
+
+func TestBuildFingerprintIgnoresMiddleOCRJitter(t *testing.T) {
+	t.Parallel()
+
+	stable := buildFingerprint([]ocrHit{
+		{Text: "top", Box: maa.Rect{10, 100, 20, 10}},
+		{Text: "mid-a", Box: maa.Rect{10, 200, 20, 10}},
+		{Text: "bottom", Box: maa.Rect{10, 300, 20, 10}},
+	})
+	jitter := buildFingerprint([]ocrHit{
+		{Text: "top", Box: maa.Rect{10, 100, 20, 10}},
+		{Text: "bottom", Box: maa.Rect{10, 300, 20, 10}},
+	})
+	if stable.Text != jitter.Text {
+		t.Fatalf("middle miss should not change first/last fingerprint: %q vs %q", stable.Text, jitter.Text)
 	}
 }

--- a/assets/resource/pipeline/Interface/Example/ListCompleteRecognition.json
+++ b/assets/resource/pipeline/Interface/Example/ListCompleteRecognition.json
@@ -1,6 +1,6 @@
 {
     "ListCompleteRecognitionExampleGate": {
-        "desc": "ListCompleteRecognition 示例：OCR 文本首次命中或发生变化时返回 true，文本不变时返回 false",
+        "desc": "ListCompleteRecognition 示例：整屏 OCR 指纹首次命中或发生变化时返回 true，指纹不变时返回 false",
         "recognition": {
             "type": "Custom",
             "param": {

--- a/assets/resource/pipeline/Interface/Example/ListCompleteRecognition.json
+++ b/assets/resource/pipeline/Interface/Example/ListCompleteRecognition.json
@@ -1,6 +1,6 @@
 {
     "ListCompleteRecognitionExampleGate": {
-        "desc": "ListCompleteRecognition 示例：整屏 OCR 指纹首次命中或发生变化时返回 true，指纹不变时返回 false",
+        "desc": "ListCompleteRecognition 示例：OCR 首尾指纹首次命中或发生变化时返回 true，指纹不变时返回 false",
         "recognition": {
             "type": "Custom",
             "param": {

--- a/assets/resource/pipeline/VisitFriends/Exectue.json
+++ b/assets/resource/pipeline/VisitFriends/Exectue.json
@@ -75,26 +75,6 @@
         "key": 89, // Y
         "post_delay": 0,
         "next": [
-            "VisitFriendsEnterShipSuccessClearScrollText"
-        ]
-    },
-    "VisitFriendsEnterShipSuccessClearScrollText": {
-        "desc": "进入好友船后清空列表滚动检测的文字缓存，确保返回列表后重新探测",
-        "recognition": "DirectHit",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "PipelineOverrideAction",
-        "custom_action_param": {
-            "patch": {
-                "VisitFriendsMenuScanScrollList": {
-                    "attach": {
-                        "last_text": ""
-                    }
-                }
-            }
-        },
-        "post_delay": 0,
-        "next": [
             "VisitFriendsEnterMenuTerminalSuccess"
         ]
     },

--- a/assets/resource/pipeline/VisitFriends/Exectue.json
+++ b/assets/resource/pipeline/VisitFriends/Exectue.json
@@ -75,6 +75,26 @@
         "key": 89, // Y
         "post_delay": 0,
         "next": [
+            "VisitFriendsEnterShipSuccessClearScrollText"
+        ]
+    },
+    "VisitFriendsEnterShipSuccessClearScrollText": {
+        "desc": "进入好友船后清空列表滚动检测的文字缓存，确保返回列表后重新探测",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "PipelineOverrideAction",
+        "custom_action_param": {
+            "patch": {
+                "VisitFriendsMenuScanScrollList": {
+                    "attach": {
+                        "last_text": ""
+                    }
+                }
+            }
+        },
+        "post_delay": 0,
+        "next": [
             "VisitFriendsEnterMenuTerminalSuccess"
         ]
     },

--- a/assets/resource/pipeline/VisitFriends/MenuScan.json
+++ b/assets/resource/pipeline/VisitFriends/MenuScan.json
@@ -75,7 +75,7 @@
         }
     },
     "VisitFriendsMenuScanScrollList": {
-        "desc": "好友列表未到底时向下滚动：ListComplete 对比 WithNameForScroll（不检查线索）好友名文字变化",
+        "desc": "好友列表未到底时向下滚动：ListComplete 对比 WithNameForScroll（不检查线索）好友名文字变化。attach.last_text 由 Exectue.json 的 VisitFriendsEnterShipSuccessClearScrollText 进入好友船时清空",
         "recognition": "Custom",
         "custom_recognition": "ListCompleteRecognition",
         "custom_recognition_param": {

--- a/docs/en_us/developers/custom.md
+++ b/docs/en_us/developers/custom.md
@@ -256,7 +256,7 @@ Parameters:
 Behavior:
 
 1. Run recognition on `node`; return no match if it misses or no OCR text can be extracted.
-2. Collect all OCR hits from the target result (`Filtered`, else `All`), sort by vertical then horizontal position, and join with newlines as the fingerprint; the returned box is the topmost hit. Do not use `Best` alone, or a partial scroll that keeps the top name unchanged can be misread as list-complete.
+2. Collect OCR hits from the target result (`Filtered`, else `All`), sort by vertical then horizontal position, and fingerprint only the first and last hits joined with a newline (or the single hit if there is only one); the returned box is the topmost hit. This still detects “top unchanged, bottom scrolled” better than `Best` alone, while staying more stable than joining every on-screen string.
 3. Read `attach.last_text` from the current custom recognition node itself.
 4. If `last_text` is empty (first success): return a match and write the current fingerprint into `attach.last_text`.
 5. If the current fingerprint equals `last_text`: return no match (treat as list complete / unchanged).
@@ -284,7 +284,7 @@ Notes:
 
 - State is stored in `attach.last_text` on the **current Custom recognition node**, not on the OCR/`And` node referenced by `node`.
 - To restart a list scan, clear that Custom node's `attach.last_text` (for example via `PipelineOverride`).
-- This recognizer only answers "did the full-screen OCR fingerprint change"; scrolling/clicking still belong in Pipeline.
+- This recognizer only answers "did the first/last OCR fingerprint change"; scrolling/clicking still belong in Pipeline.
 
 ### ScheduleRecognition
 

--- a/docs/en_us/developers/custom.md
+++ b/docs/en_us/developers/custom.md
@@ -247,7 +247,7 @@ Important Notes:
 
 ### ListCompleteRecognition
 
-The `ListCompleteRecognition` implementation is located in `agent/go-service/common/listcomplete`. It detects whether a list is still updating by checking whether OCR text has changed (commonly used to detect when a scrollable list has reached the end).
+The `ListCompleteRecognition` implementation is located in `agent/go-service/common/listcomplete`. It detects whether a list is still updating by checking whether an OCR fingerprint has changed (commonly used to detect when a scrollable list has reached the end).
 
 Parameters:
 
@@ -256,12 +256,13 @@ Parameters:
 Behavior:
 
 1. Run recognition on `node`; return no match if it misses or no OCR text can be extracted.
-2. Read `attach.last_text` from the current custom recognition node itself.
-3. If `last_text` is empty (first success): return a match, with the box set to the OCR text position, and write the current text into `attach.last_text`.
-4. If the current text equals `last_text`: return no match (treat as list complete / unchanged).
-5. If the current text differs from `last_text`: update `attach.last_text` and return a match.
+2. Collect all OCR hits from the target result (`Filtered`, else `All`), sort by vertical then horizontal position, and join with newlines as the fingerprint; the returned box is the topmost hit. Do not use `Best` alone, or a partial scroll that keeps the top name unchanged can be misread as list-complete.
+3. Read `attach.last_text` from the current custom recognition node itself.
+4. If `last_text` is empty (first success): return a match and write the current fingerprint into `attach.last_text`.
+5. If the current fingerprint equals `last_text`: return no match (treat as list complete / unchanged).
+6. If the current fingerprint differs from `last_text`: update `attach.last_text` and return a match.
 
-For `And` nodes, target resolution is shared with `ExpressionRecognition` via `pkg/recogtarget`: first run the `And` node itself, then read the corresponding sub-recognition result from this run's `CombinedResult` using that node's native `box_index` (default `0`), and extract OCR text/box from that selected child. Node definition validation also requires the `box_index` target to contain OCR.
+For `And` nodes, target resolution is shared with `ExpressionRecognition` via `pkg/recogtarget`: first run the `And` node itself, then read the corresponding sub-recognition result from this run's `CombinedResult` using that node's native `box_index` (default `0`), and extract OCR from that selected child. Node definition validation also requires the `box_index` target to contain OCR.
 
 Example file: [`ListCompleteRecognition.json`](../../../assets/resource/pipeline/Interface/Example/ListCompleteRecognition.json)
 
@@ -283,7 +284,7 @@ Notes:
 
 - State is stored in `attach.last_text` on the **current Custom recognition node**, not on the OCR/`And` node referenced by `node`.
 - To restart a list scan, clear that Custom node's `attach.last_text` (for example via `PipelineOverride`).
-- This recognizer only answers "did the text change"; scrolling/clicking still belong in Pipeline.
+- This recognizer only answers "did the full-screen OCR fingerprint change"; scrolling/clicking still belong in Pipeline.
 
 ### ScheduleRecognition
 

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -249,7 +249,7 @@ Recognition 节点用于执行自定义识别。常见写法如下：
 
 ### ListCompleteRecognition
 
-`ListCompleteRecognition` 实现位于 `agent/go-service/common/listcomplete`，用于通过 OCR 文本是否变化判断列表是否仍在更新（常见于滑动列表到底检测）。
+`ListCompleteRecognition` 实现位于 `agent/go-service/common/listcomplete`，用于通过 OCR 指纹是否变化判断列表是否仍在更新（常见于滑动列表到底检测）。
 
 参数：
 
@@ -258,12 +258,13 @@ Recognition 节点用于执行自定义识别。常见写法如下：
 行为：
 
 1. 执行 `node` 识别；未命中或无法提取 OCR 文字时返回未命中。
-2. 读取当前自定义识别节点自身的 `attach.last_text`。
-3. 若 `last_text` 为空（首次成功）：返回命中，框为 OCR 文字位置，并把当前文字写入 `attach.last_text`。
-4. 若当前文字与 `last_text` 一致：返回未命中（视为列表已到底/未变化）。
-5. 若当前文字与 `last_text` 不一致：更新 `attach.last_text` 并返回命中。
+2. 从目标 OCR 结果收集整屏命中（优先 `Filtered`，否则 `All`），按纵向（再按横向）排序后用换行拼接为指纹；返回框取最上方一条。不要只用 `Best`，以免顶部名字不变、下方已滚动时误判到底。
+3. 读取当前自定义识别节点自身的 `attach.last_text`。
+4. 若 `last_text` 为空（首次成功）：返回命中，并把当前指纹写入 `attach.last_text`。
+5. 若当前指纹与 `last_text` 一致：返回未命中（视为列表已到底/未变化）。
+6. 若当前指纹与 `last_text` 不一致：更新 `attach.last_text` 并返回命中。
 
-对 `And` 节点，目标解析与 `ExpressionRecognition` 共用 `pkg/recogtarget`：先执行该 `And` 节点本身，再按其原生 `box_index`（默认 `0`）从本次 `CombinedResult` 中选取对应子识别结果，并从该子结果提取 OCR 文本与框。节点定义阶段也会校验 `box_index` 目标含 OCR。
+对 `And` 节点，目标解析与 `ExpressionRecognition` 共用 `pkg/recogtarget`：先执行该 `And` 节点本身，再按其原生 `box_index`（默认 `0`）从本次 `CombinedResult` 中选取对应子识别结果，并从该子结果提取 OCR。节点定义阶段也会校验 `box_index` 目标含 OCR。
 
 示例文件：[`ListCompleteRecognition.json`](../../../assets/resource/pipeline/Interface/Example/ListCompleteRecognition.json)
 
@@ -285,7 +286,7 @@ Recognition 节点用于执行自定义识别。常见写法如下：
 
 - 状态保存在**当前 Custom 识别节点**的 `attach.last_text`，不是 `node` 指向的 OCR/`And` 节点。
 - 需要重新开始一轮列表扫描时，应清空该 Custom 节点的 `attach.last_text`（例如通过 `PipelineOverride`）。
-- 该识别器只负责“文本是否变化”，滑动、点击等流程仍由 Pipeline 组织。
+- 该识别器只负责“整屏 OCR 指纹是否变化”，滑动、点击等流程仍由 Pipeline 组织。
 
 ### ScheduleRecognition
 

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -258,7 +258,7 @@ Recognition 节点用于执行自定义识别。常见写法如下：
 行为：
 
 1. 执行 `node` 识别；未命中或无法提取 OCR 文字时返回未命中。
-2. 从目标 OCR 结果收集整屏命中（优先 `Filtered`，否则 `All`），按纵向（再按横向）排序后用换行拼接为指纹；返回框取最上方一条。不要只用 `Best`，以免顶部名字不变、下方已滚动时误判到底。
+2. 从目标 OCR 结果收集命中（优先 `Filtered`，否则 `All`），按纵向（再按横向）排序后只取首尾两条用换行拼接为指纹（仅一条时用该条）；返回框取最上方一条。比只用 `Best` 更能发现「顶不变、底已滚」；比整屏 join 更耐中间 OCR 抖动。
 3. 读取当前自定义识别节点自身的 `attach.last_text`。
 4. 若 `last_text` 为空（首次成功）：返回命中，并把当前指纹写入 `attach.last_text`。
 5. 若当前指纹与 `last_text` 一致：返回未命中（视为列表已到底/未变化）。
@@ -286,7 +286,7 @@ Recognition 节点用于执行自定义识别。常见写法如下：
 
 - 状态保存在**当前 Custom 识别节点**的 `attach.last_text`，不是 `node` 指向的 OCR/`And` 节点。
 - 需要重新开始一轮列表扫描时，应清空该 Custom 节点的 `attach.last_text`（例如通过 `PipelineOverride`）。
-- 该识别器只负责“整屏 OCR 指纹是否变化”，滑动、点击等流程仍由 Pipeline 组织。
+- 该识别器只负责“OCR 首尾指纹是否变化”，滑动、点击等流程仍由 Pipeline 组织。
 
 ### ScheduleRecognition
 


### PR DESCRIPTION
我没有测试次数了，得别人测测(

## Summary by Sourcery

通过基于首个和最后一个 OCR 命中的“OCR 指纹”而非单一 OCR 文本值，提升列表完成检测的鲁棒性。

增强点：
- 修改 `ListCompleteRecognition`，通过计算并比较由最上方和最下方 OCR 命中构建的 OCR 指纹，来判断列表是否仍在更新。
- 优化 OCR 命中结果的收集逻辑：优先使用过滤后的结果，其次回退到全部结果；在构建指纹时忽略无效或空的 OCR 条目。

文档：
- 在英文和中文开发者指南中记录 `ListCompleteRecognition` 基于 OCR 指纹的全新行为，包括指纹在 `attach.last_text` 中的构造方式及其使用方法。

测试：
- 新增覆盖指纹构造的单元测试，包括顺序、单一命中行为、部分滚动检测，以及在中间项 OCR 抖动情况下的鲁棒性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve list completion detection robustness by basing it on an OCR fingerprint derived from the first and last hits instead of a single OCR text value.

Enhancements:
- Change ListCompleteRecognition to compute and compare an OCR fingerprint built from the topmost and bottommost OCR hits to decide if a list is still updating.
- Refine OCR hit collection to prioritize filtered results, fall back to all results, and ignore invalid or empty OCR entries when building the fingerprint.

Documentation:
- Document the new OCR fingerprint–based behavior of ListCompleteRecognition in both English and Chinese developer guides, including how fingerprints are constructed and used in attach.last_text.

Tests:
- Add unit tests covering fingerprint construction, including ordering, single-hit behavior, partial scroll detection, and robustness against middle-item OCR jitter.

</details>