### PR TITLE
fix(VisitFriends): 修复优先访问备注好友功能失效

### DIFF
--- a/agent/go-service/visitfriends/select_friend.go
+++ b/agent/go-service/visitfriends/select_friend.go
@@ -42,13 +42,11 @@ func normalizeFriendName(name string) string {
 
 // VisitFriendsSelectFriendRecognition 参考 DailyEventGoToRecognition：
 // 读取 attach.visited，排除已点好友后识别列表项，返回进船按钮框供 Pipeline Click。
+// 优先备注不走 custom param：由任务选项只改 Name OCR 的 expected + order_by=Expected，
+// 本识别器读取该节点 order_by，仅在注入 visited 排除时保持相同 expected 形态。
 type VisitFriendsSelectFriendRecognition struct{}
 
 var _ maa.CustomRecognitionRunner = &VisitFriendsSelectFriendRecognition{}
-
-type selectFriendParam struct {
-	OnlyRemarkFriends bool `json:"only_remark_friends"`
-}
 
 type selectFriendDetail struct {
 	NameText  string `json:"name_text"`
@@ -67,27 +65,27 @@ func (r *VisitFriendsSelectFriendRecognition) Run(ctx *maa.Context, arg *maa.Cus
 		return nil, false
 	}
 
-	var params selectFriendParam
-	if raw := strings.TrimSpace(arg.CustomRecognitionParam); raw != "" {
-		if err := json.Unmarshal([]byte(raw), &params); err != nil {
-			log.Error().Err(err).Str("component", selectFriendRecognitionName).Msg("failed to parse custom_recognition_param")
-			return nil, false
-		}
-	}
-
 	visited, err := loadSelectFriendVisited(ctx, nodeName)
 	if err != nil {
 		log.Error().Err(err).Str("component", selectFriendRecognitionName).Str("node", nodeName).Msg("load attach.visited failed")
 		return nil, false
 	}
 
-	// 与 DailyEventGoTo 一样覆盖 OCR expected，减少已访问命中；
-	// 覆盖 OCR expected 排除已访问；按钮与名字按纵向最近邻配对，不要求数量一致。
-	expected := buildSelectFriendExpected(visited)
+	// 覆盖 OCR expected 排除已访问；同步写回 order_by，避免扁平 override 冲掉备注优先规则。
+	prioritizeRemark, orderBy, err := loadSelectFriendNameOCROrder(ctx)
+	if err != nil {
+		log.Error().Err(err).Str("component", selectFriendRecognitionName).Msg("load name OCR order_by failed")
+		return nil, false
+	}
+	expected := buildSelectFriendExpected(visited, prioritizeRemark)
+	nameOCROverride := map[string]any{
+		"expected": expected,
+	}
+	if orderBy != "" {
+		nameOCROverride["order_by"] = orderBy
+	}
 	if err := ctx.OverridePipeline(map[string]any{
-		selectFriendNameOCRNode: map[string]any{
-			"expected": []string{expected},
-		},
+		selectFriendNameOCRNode: nameOCROverride,
 	}); err != nil {
 		log.Error().Err(err).Str("component", selectFriendRecognitionName).Msg("override name OCR expected failed")
 		return nil, false
@@ -120,10 +118,6 @@ func (r *VisitFriendsSelectFriendRecognition) Run(ctx *maa.Context, arg *maa.Cus
 	for i := range nameHits {
 		rawName := strings.TrimSpace(nameHits[i].Text)
 		if rawName == "" {
-			continue
-		}
-		if params.OnlyRemarkFriends && !friendNameHasRemark(rawName) {
-			log.Debug().Str("component", selectFriendRecognitionName).Str("name", rawName).Msg("no remark, skip")
 			continue
 		}
 
@@ -244,10 +238,6 @@ func selectFriendCombinedDetailJSON(detail *maa.RecognitionDetail, index int, ki
 	return raw, true
 }
 
-func friendNameHasRemark(name string) bool {
-	return strings.Contains(name, "(") || strings.Contains(name, "（")
-}
-
 func hitBoxCenterY(box []int) float64 {
 	if len(box) < 4 {
 		return math.NaN()
@@ -334,7 +324,50 @@ func selectFriendVisitedContains(visited []string, name string) bool {
 	return false
 }
 
-func buildSelectFriendExpected(visited []string) string {
+// loadSelectFriendNameOCROrder 读取 Name OCR 的 order_by。
+// order_by=Expected 表示任务选项开启了优先备注（expected 为「带括号 / 不带括号」两项）。
+func loadSelectFriendNameOCROrder(ctx *maa.Context) (prioritizeRemark bool, orderBy string, err error) {
+	raw, err := ctx.GetNodeJSON(selectFriendNameOCRNode)
+	if err != nil {
+		return false, "", err
+	}
+	orderBy, err = parseOCROrderBy([]byte(raw))
+	if err != nil {
+		return false, "", err
+	}
+	return strings.EqualFold(orderBy, "Expected"), orderBy, nil
+}
+
+func parseOCROrderBy(raw []byte) (string, error) {
+	var flat struct {
+		OrderBy     string          `json:"order_by"`
+		Recognition json.RawMessage `json:"recognition"`
+	}
+	if err := json.Unmarshal(raw, &flat); err != nil {
+		return "", err
+	}
+	if orderBy := strings.TrimSpace(flat.OrderBy); orderBy != "" {
+		return orderBy, nil
+	}
+	if len(flat.Recognition) == 0 {
+		return "", nil
+	}
+	// 扁平："recognition":"OCR"；v2："recognition":{"type":"OCR","param":{"order_by":...}}
+	if flat.Recognition[0] == '"' {
+		return "", nil
+	}
+	var v2 struct {
+		Param struct {
+			OrderBy string `json:"order_by"`
+		} `json:"param"`
+	}
+	if err := json.Unmarshal(flat.Recognition, &v2); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(v2.Param.OrderBy), nil
+}
+
+func buildSelectFriendExpected(visited []string, prioritizeRemark bool) []string {
 	escaped := make([]string, 0, len(visited))
 	for _, name := range visited {
 		trimmed := strings.TrimSpace(name)
@@ -343,9 +376,22 @@ func buildSelectFriendExpected(visited []string) string {
 		}
 		escaped = append(escaped, regexp.QuoteMeta(trimmed))
 	}
-	if len(escaped) == 0 {
-		return ".*#.*"
+
+	// 带备注好友名形如「备注(原名)#xxxx」，用左括号区分。
+	// order_by=Expected 时：先带括号、后不带括号，优先命中备注好友。
+	const withRemark = `.*[（(].*#.*`
+	const anyFriend = `.*#.*`
+
+	prefix := ""
+	if len(escaped) > 0 {
+		// 与 DailyEventGoTo 相同：用负向预测排除已访问；Go 侧仍会再按 normalize 过滤一层。
+		prefix = fmt.Sprintf("^(?!(?:%s)$)", strings.Join(escaped, "|"))
 	}
-	// 与 DailyEventGoTo 相同：用负向预测排除已访问；Go 侧仍会再按 normalize 过滤一层。
-	return fmt.Sprintf("^(?!(?:%s)$).*#.*", strings.Join(escaped, "|"))
+	if prioritizeRemark {
+		return []string{
+			prefix + withRemark,
+			prefix + anyFriend,
+		}
+	}
+	return []string{prefix + anyFriend}
 }

--- a/assets/resource/pipeline/VisitFriends/Exectue.json
+++ b/assets/resource/pipeline/VisitFriends/Exectue.json
@@ -75,6 +75,26 @@
         "key": 89, // Y
         "post_delay": 0,
         "next": [
+            "VisitFriendsEnterShipSuccessClearScrollText"
+        ]
+    },
+    "VisitFriendsEnterShipSuccessClearScrollText": {
+        "desc": "进入好友船后清空列表滚动检测的文字缓存，确保返回列表后重新探测",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "PipelineOverrideAction",
+        "custom_action_param": {
+            "patch": {
+                "VisitFriendsMenuScanScrollList": {
+                    "attach": {
+                        "last_text": ""
+                    }
+                }
+            }
+        },
+        "post_delay": 0,
+        "next": [
             "VisitFriendsEnterMenuTerminalSuccess"
         ]
     },

--- a/assets/resource/pipeline/VisitFriends/MenuScan.json
+++ b/assets/resource/pipeline/VisitFriends/MenuScan.json
@@ -35,12 +35,9 @@
         }
     },
     "VisitFriendsMenuScanTargetFriendOpen": {
-        "desc": "选择下一个好友。only_remark_friends 由任务选项覆盖",
+        "desc": "选择下一个好友（消费性：attach.visited）。优先备注由 Name OCR 的 expected+order_by 独立控制",
         "recognition": "Custom",
         "custom_recognition": "VisitFriendsSelectFriendRecognition",
-        "custom_recognition_param": {
-            "only_remark_friends": false
-        },
         "pre_delay": 0,
         "action": "Click",
         "post_wait_freezes": 200,

--- a/assets/resource/pipeline/VisitFriends/MenuScan.json
+++ b/assets/resource/pipeline/VisitFriends/MenuScan.json
@@ -75,7 +75,7 @@
         }
     },
     "VisitFriendsMenuScanScrollList": {
-        "desc": "好友列表未到底时向下滚动：ListComplete 对比 WithNameForScroll（不检查线索）好友名文字变化",
+        "desc": "好友列表未到底时向下滚动：ListComplete 对比 WithNameForScroll（不检查线索）好友名文字变化。attach.last_text 由 Exectue.json 的 VisitFriendsEnterShipSuccessClearScrollText 进入好友船时清空",
         "recognition": "Custom",
         "custom_recognition": "ListCompleteRecognition",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/VisitFriends/Recognition.json
+++ b/assets/resource/pipeline/VisitFriends/Recognition.json
@@ -36,7 +36,7 @@
         "order_by": "Vertical"
     },
     "VisitFriendsRecognitionItemNameByEnterButton": {
-        "desc": "按进船按钮偏移识别好友名（可由 SelectFriend 覆盖 expected 排除已访问）",
+        "desc": "按进船按钮偏移识别好友名。默认 Vertical；VisitFriendsRemark=Yes 时改为两项 expected + order_by Expected",
         "recognition": {
             "type": "OCR",
             "param": {

--- a/assets/tasks/VisitFriends.json
+++ b/assets/tasks/VisitFriends.json
@@ -29,9 +29,16 @@
                 {
                     "name": "Yes",
                     "pipeline_override": {
-                        "VisitFriendsMenuScanTargetFriendOpen": {
-                            "custom_recognition_param": {
-                                "only_remark_friends": true
+                        // 备注优先独立改 Name OCR：expected 列表顺序 + order_by Expected
+                        "VisitFriendsRecognitionItemNameByEnterButton": {
+                            "recognition": {
+                                "param": {
+                                    "expected": [
+                                        ".*[（(].*#.*",
+                                        ".*#.*"
+                                    ],
+                                    "order_by": "Expected"
+                                }
                             }
                         }
                     }
@@ -39,9 +46,14 @@
                 {
                     "name": "No",
                     "pipeline_override": {
-                        "VisitFriendsMenuScanTargetFriendOpen": {
-                            "custom_recognition_param": {
-                                "only_remark_friends": false
+                        "VisitFriendsRecognitionItemNameByEnterButton": {
+                            "recognition": {
+                                "param": {
+                                    "expected": [
+                                        ".*#.*"
+                                    ],
+                                    "order_by": "Vertical"
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary by Sourcery

在 VisitFriends 流程中，保留并利用 Name OCR 的 `order_by` 配置，以在排除已访问好友的前提下，正确优先处理带备注的好友。

Bug 修复：
- 修复“优先备注好友”任务选项不起作用的回归问题，通过将识别逻辑与 Name OCR 中 `order_by=Expected` 的设置保持一致来解决。

增强功能：
- 移除仅用于备注选择的自定义识别参数，从 Name OCR 节点配置中推导备注优先逻辑。
- 调整好友名称 OCR 的预期匹配模式，以支持对带备注好友的优先匹配，并在此基础上回退到任意好友名称匹配，同时仍然过滤掉已访问的条目。
- 新增辅助工具，用于读取和解析不同流水线 JSON 格式中的 Name OCR 节点 `order_by` 设置，以确保与现有和未来配置的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve and leverage the Name OCR order_by configuration to correctly prioritize remark friends while excluding already visited friends in the VisitFriends flow.

Bug Fixes:
- Fix the regression where the "prioritize remark friends" task option had no effect by aligning the recognition logic with the Name OCR order_by=Expected setting.

Enhancements:
- Remove the custom recognition parameter for remark-only selection and derive remark prioritization from the Name OCR node configuration.
- Adjust the expected patterns for friend name OCR to support prioritized matching of remark friends and fallback to any friend names while still filtering out visited entries.
- Introduce helpers to read and parse the Name OCR node order_by setting across different pipeline JSON formats, ensuring compatibility with existing and future configurations.

</details>