### PR TITLE
feat(EnvironmentMonitoring): 支持“小池荷”

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PoolLotus.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PoolLotus.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "PoolLotusNotAdapted"
+            "GoToPoolLotus"
         ]
     },
     "AlreadyTrackedPoolLotus": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "PoolLotusNotAdapted"
+            "GoToPoolLotus"
         ]
     },
     "PoolLotusOpenTrackedMissionMap": {
@@ -340,12 +340,12 @@
         "custom_recognition_param": {
             "expected": [
                 {
-                    "map_name": "^map\\d+_lv\\d+$",
+                    "map_name": "map02_lv004",
                     "target": [
-                        0,
-                        0,
-                        1,
-                        1
+                        602.8,
+                        325,
+                        9.7,
+                        8.1
                     ]
                 }
             ]
@@ -364,7 +364,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneAnyEnterWorld"
+                "SceneEnterWorldWulingMarkerStone3"
             ]
         },
         "post_delay": 0,
@@ -377,15 +377,20 @@
         "desc": "自动寻路前往小池荷",
         "pre_delay": 0,
         "action": "Custom",
-        "custom_action": "MapTrackerMove",
+        "custom_action": "MapTrackerGoal",
         "custom_action_param": {
-            "map_name": "^map\\d+_lv\\d+$",
-            "path": [
-                [
-                    0,
-                    0
-                ]
-            ]
+            "map_name": "map02_lv004",
+            "target": [
+                594.4,
+                324.1
+            ],
+            "on_finish": {
+                "action": "Custom",
+                "custom_action": "MapTrackerToward",
+                "custom_action_param": {
+                    "angle": 334
+                }
+            }
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -408,12 +413,12 @@
     },
     "PoolLotusAdjustCamera": {
         "desc": "小池荷任务中调整朝向",
-        "max_hit": 2,
+        "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "EnvironmentMonitoringSwipeScreenUp"
+            "EnvironmentMonitoringSwipeScreenRight"
         ]
     }
 }

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -886,7 +886,22 @@
     {
         "MissionId": "m1m69",
         "Name": "“小池荷”",
-        "Id": "PoolLotus"
+        "Id": "PoolLotus",
+        "EnterMap": "SceneEnterWorldWulingMarkerStone3",
+        "MapName": "map02_lv004",
+        "MapAssert": [
+            602.8,
+            325,
+            9.7,
+            8.1
+        ],
+        "MapGoal": [
+            594.4,
+            324.1
+        ],
+        "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenRight",
+        "CameraMaxHit": 1,
+        "Heading": 334
     },
     {
         "MissionId": "m1m70",


### PR DESCRIPTION
## Summary
增加首墩环境终端 “小池荷”任务适配

## 由 Sourcery 提供的摘要

在 EnvironmentMonitoring 流水线配置中新增对“小池荷”（PoolLotus）环境监测终端的支持。

新增功能：
- 为“小池荷” MarkerStone 环境监测终端定义流水线配置。
- 在 EnvironmentMonitoring 流水线生成路由中注册“小池荷”（PoolLotus）路由。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for the "小池荷" (PoolLotus) environment monitoring terminal in the EnvironmentMonitoring pipeline configuration.

New Features:
- Define pipeline configuration for the "小池荷" MarkerStone environment monitoring terminal.
- Register the "小池荷" (PoolLotus) route in the EnvironmentMonitoring pipeline generation routes.

</details>