### PR TITLE
perf: 低配电脑转视角

### DIFF
--- a/agent/go-service/common/charactercontroller/controller.go
+++ b/agent/go-service/common/charactercontroller/controller.go
@@ -7,12 +7,40 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	screenW = 1280
+	screenH = 720
+)
+
+// Accumulated hover-cursor offset since last Alt reset (Win32 path).
+// Always restarting from screen center would reverse-delta and bounce the camera.
+var cursorDX, cursorDY int
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
 func rotateView(ctx *maa.Context, dx, dy int) {
-	cx, cy := 1280/2, 720/2
+	cx, cy := screenW/2, screenH/2
+	if absInt(cursorDX) > screenW/4 || absInt(cursorDY) > screenH/4 {
+		ctx.RunAction("__CharacterControllerDeltaAltKeyDownAction",
+			maa.Rect{0, 0, 0, 0}, "", nil)
+		ctx.RunAction("__CharacterControllerDeltaClickCenterAction",
+			maa.Rect{0, 0, 0, 0}, "", nil)
+		ctx.RunAction("__CharacterControllerDeltaAltKeyUpAction",
+			maa.Rect{0, 0, 0, 0}, "", nil)
+		cursorDX, cursorDY = 0, 0
+	}
+
+	fromX, fromY := cx+cursorDX, cy+cursorDY
 	override := map[string]any{
 		"__CharacterControllerDeltaSwipeAction": map[string]any{
-			"begin": maa.Rect{cx, cy, 4, 4},
-			"end":   maa.Rect{cx + dx, cy + dy, 4, 4},
+			"begin": maa.Rect{fromX, fromY, 1, 1},
+			"end":   maa.Rect{fromX + dx, fromY + dy, 1, 1},
+			// wlroots resource remaps this node to RelativeMove; keep dx/dy for that path.
 			"custom_action_param": map[string]any{
 				"dx": dx,
 				"dy": dy,
@@ -21,12 +49,8 @@ func rotateView(ctx *maa.Context, dx, dy int) {
 	}
 	ctx.RunAction("__CharacterControllerDeltaSwipeAction",
 		maa.Rect{0, 0, 0, 0}, "", override)
-	ctx.RunAction("__CharacterControllerDeltaAltKeyDownAction",
-		maa.Rect{0, 0, 0, 0}, "", nil)
-	ctx.RunAction("__CharacterControllerDeltaClickCenterAction",
-		maa.Rect{0, 0, 0, 0}, "", nil)
-	ctx.RunAction("__CharacterControllerDeltaAltKeyUpAction",
-		maa.Rect{0, 0, 0, 0}, "", nil)
+	cursorDX += dx
+	cursorDY += dy
 }
 
 type characterControllerRelativeMoveParam struct {


### PR DESCRIPTION
close #4335

## Summary by Sourcery

改进相机旋转输入处理方式，通过重用累积的光标偏移量而不是每一帧都重置光标位置，以更好地支持低配置机器。

增强内容：
- 追踪累积的光标位移量，仅在光标偏离屏幕中心过远时才将其重置回中心，以减少视角抖动。
- 调整滑动开始/结束区域，并将屏幕尺寸集中为可复用常量，从而实现更一致的相机控制行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve camera rotation input handling to better support low-spec machines by reusing accumulated cursor offsets instead of recentering each frame.

Enhancements:
- Track accumulated cursor deltas and only recenter the cursor when it drifts too far from screen center, reducing view jitter.
- Adjust swipe start/end rectangles and centralize screen dimensions into reusable constants for more consistent camera control behavior.

</details>