### PR TITLE
refactor(map): 统一使用Point结构体表示点

### DIFF
--- a/.agents/skills/go-map-tracker-guide/SKILL.md
+++ b/.agents/skills/go-map-tracker-guide/SKILL.md
@@ -16,7 +16,7 @@ description: MaaEnd MapTracker 相关组件编写指南。为 agent/go-service/m
 当你判断确实正在进行 MapTracker 的开发工作时，*务必无条件地先读取下列文档*以快速了解详细内容：
 
 - docs/zh_cn/developers/components/map-tracker.md 列出了 pipeline JSON 调用方视角下的 MapTracker 的使用方式；
-- docs/zh_cn/developers/components/map-tracker(advanced).md 列出了更具体的有关 MapTracker 维护和开发的细节。
+- docs/zh_cn/developers/components/map-tracker(advanced).md 列出了更具体的有关 MapTracker 维护、开发和测试的细节。
 
 ## 组件概览
 
@@ -24,20 +24,28 @@ description: MaaEnd MapTracker 相关组件编写指南。为 agent/go-service/m
 
 **Go** 代码位于 agent/go-service/maptracker 目录下，主要包含以下子包：
 
-- default 包：主要提供小地图（游戏画面左上角的实时小地图）识别、寻路的功能，属于核心功能；
-    - assert_location：MapTrackerAssetLocation 节点实现；
-    - infer.go：MapTrackerInfer 节点实现；
-    - move.go：MapTrackerMove 节点实现；
+- default 包：主要提供**小地图**（游戏画面左上角的实时小地图）识别、寻路的功能，属于核心功能；
+    - assert_location：MapTrackerAssetLocation 位置条件判断 节点实现；
+    - infer.go：MapTrackerInfer 玩家位置和朝向识别 节点实现；
+    - move.go：MapTrackerMove 依照指定路径移动 节点实现；
+    - goal.go：MapTrackerGoal 依照 NavMesh 移动 节点实现；
+    - 其他节点文件和辅助文件。
+- bigmap 包：主要提供**大地图**（游戏内打开地图页面时显示的大地图）识别的功能；
+    - infer.go：MapTrackerBigMapInfer 视窗位置识别 节点实现；
+    - find_image.go：MapTrackerBigMapFindImage 大地图中的图标识别 节点实现；
+    - zoom.go：MapTrackerBigMapZoom 调节大地图缩放 节点实现；
+    - pick.go：MapTrackerBigMapPick 点击指定大地图点 节点实现；
     - 其他辅助文件。
-- bigmap 包：主要提供大地图（游戏内打开地图页面时显示的大地图）识别的功能；
-    - infer.go：MapTrackerBigMapInfer 节点实现；
-    - pick.go：MapTrackerBigMapPick 节点实现；
-    - 其他辅助文件。
-- internal 包：主要提供一些辅助功能；
-    - resource.go：资源加载辅助。
+- internal 包：主要提供一些辅助和公共功能；
+    - algo.go：二维几何点及相关算法实现；
+    - nav_mesh.go：NavMesh 数据解析实现；
+    - resource.go：资源加载辅助；
+    - 其他辅助文件和测试文件。
 - compatible 包：对 Cpp 方案的兼容层，次要，一般无需维护。
 
 主要的依赖项是 agent/go-service/pkg/minicv 包，提供了定制化的计算机视觉功能，例如模板匹配。
+
+Go 代码的验证主要是通过**编译构建和单元测试**完成的；一般无需使用 pnpm 进行测试（这个是 MaaFW 的测试工具而不是 MapTracker 的）。
 
 ### 工具代码
 
@@ -50,9 +58,18 @@ description: MaaEnd MapTracker 相关组件编写指南。为 agent/go-service/m
     - http_utils.py：下载相关；
     - location_service.py：依赖于 maa_interface.py 提供工具内调用 MapTracker 定位的功能；
     - maa_interface.py：提供了与游戏交互的接口；
+    - nav_mesh.py：提供了 NavMesh 数据解析的功能；
     - pipeline_handler.py：提供了 pipeline JSON 解析的功能；
     - sprite_utils.py：提供了 GUI 中显示图标的能力；
     - zmdmap_schemas.py：提供了 zmdmap 数据解析的功能。
 - map_fetcher.py：提供了从 zmdmap 获取最新地图图片的功能；
 - map_generator.py：提供了基于最新图片来生成优化后的地图图片和数据的功能；
-- map_tracker_editor：向用户提供路线编辑等可视化功能。
+- map_tracker_editor.py：向用户提供路线编辑等可视化功能；
+- map_tracker_tester.py：提供小地图推理功能的集成测试；
+- nav_mesh_editor.py：向用户提供 NavMesh 编辑等可视化功能。
+
+上述工具代码按照功能分类：
+
+- 用于地图图片和数据的拉取（常通过 CI 运行）：fetcher 和 generator；
+- 提供给人类用户使用的可视化工具：两个 editor；
+- 集成测试工具（常通过 CI 运行）：tester。

--- a/agent/go-service/maptracker/compatible/assert_compatible_test.go
+++ b/agent/go-service/maptracker/compatible/assert_compatible_test.go
@@ -2,7 +2,6 @@
 package maptrackercompatible
 
 import (
-	"math"
 	"testing"
 )
 
@@ -29,52 +28,6 @@ func TestMapTrackerAssertLocationCompatibleRejectsInvalidParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if _, err := action.convertParam(&tt.param); err == nil {
 				t.Fatal("expected error")
-			}
-		})
-	}
-}
-
-func TestMapTrackerAssertLocationCompatibleConvertsRegionalSamples(t *testing.T) {
-	chdirCompatibleTestRepoRoot(t)
-
-	tests := []struct {
-		name       string
-		param      mapLocateAssertCompatibleParam
-		expectMap  string
-		expectRect [4]float64
-	}{
-		{
-			name:       "Wuling",
-			param:      mapLocateAssertCompatibleParam{ZoneID: "Wuling_Base", Target: [4]float64{942, 723, 2, 1}},
-			expectMap:  "map02_lv002",
-			expectRect: [4]float64{664.200, 734.200, 2.075, 1.038},
-		},
-		{
-			name:       "OMVBase",
-			param:      mapLocateAssertCompatibleParam{ZoneID: "OMVBase01", Target: [4]float64{187, 131, 1, 10}},
-			expectMap:  "base01_lv003",
-			expectRect: [4]float64{190.200, 132.825, 1.038, 10.375},
-		},
-	}
-
-	action := &MapTrackerAssertLocationCompatible{}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			converted, err := action.convertParam(&tt.param)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(converted.Expected) != 1 {
-				t.Fatalf("got %d conditions, want 1", len(converted.Expected))
-			}
-			condition := converted.Expected[0]
-			if condition.MapName != tt.expectMap {
-				t.Fatalf("got map %q, want %q", condition.MapName, tt.expectMap)
-			}
-			for i, expect := range tt.expectRect {
-				if math.Abs(condition.Target[i]-expect) > 2.0 {
-					t.Fatalf("target[%d] got %.3f, want %.3f", i, condition.Target[i], expect)
-				}
 			}
 		})
 	}

--- a/agent/go-service/maptracker/compatible/convert.go
+++ b/agent/go-service/maptracker/compatible/convert.go
@@ -36,7 +36,7 @@ type compatibleSourcePoint struct {
 
 type compatibleConvertedPath struct {
 	MapName string
-	Path    [][2]float64
+	Path    []maptrackerinternal.Point
 }
 
 type compatibleSourceRect struct {
@@ -108,7 +108,7 @@ func convertCompatiblePoints(preferredMapName string, points []compatibleSourceP
 	}
 
 	mapper := &compatibleCoordinateMapper{preferredMapName: preferredMapName}
-	path := make([][2]float64, 0, len(points))
+	path := make([]maptrackerinternal.Point, 0, len(points))
 	moveMapName := ""
 	for _, sourcePoint := range points {
 		point, err := mapper.mapPoint(sourcePoint.SourceName, sourcePoint.X, sourcePoint.Y)
@@ -121,7 +121,7 @@ func convertCompatiblePoints(preferredMapName string, points []compatibleSourceP
 		} else if moveMapName != rootMapName {
 			return compatibleConvertedPath{}, fmt.Errorf("MapTrackerMove cannot represent route across multiple levels: %s and %s", moveMapName, rootMapName)
 		}
-		path = append(path, [2]float64{point.X, point.Y})
+		path = append(path, maptrackerinternal.Point{X: point.X, Y: point.Y})
 	}
 
 	if moveMapName == "" {

--- a/agent/go-service/maptracker/compatible/move_compatible_test.go
+++ b/agent/go-service/maptracker/compatible/move_compatible_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-
-	internal "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/internal"
 )
 
 func moveCompatibleTestRepoRoot(t *testing.T) string {
@@ -98,80 +96,6 @@ func TestMapTrackerMoveCompatibleRejectsEmptyOrUnknownRoutes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if _, err := (&MapTrackerMoveCompatible{}).convertParam(&tt.param); err == nil {
 				t.Fatal("expected error")
-			}
-		})
-	}
-}
-
-func TestMapTrackerMoveCompatibleConvertsRegionalSamples(t *testing.T) {
-	chdirCompatibleTestRepoRoot(t)
-
-	tests := []struct {
-		name    string
-		param   mapNavigateCompatibleParam
-		expects [][2]float64
-	}{
-		{
-			name: "ValleyIV",
-			param: mapNavigateCompatibleParam{
-				Path: mustRawMessages(t,
-					map[string]any{"action": "ZONE", "zone_id": "ValleyIV_Base"},
-					[]any{532.0, 697.0},
-					[]any{574.0, 735.0},
-				),
-			},
-			expects: [][2]float64{
-				{478.960, 267.960},
-				{524.845, 309.475},
-			},
-		},
-		{
-			name: "Wuling",
-			param: mapNavigateCompatibleParam{
-				MapName: "map02_lv002",
-				Path: mustRawMessages(t,
-					map[string]any{"action": "ZONE", "zone_id": "Wuling_Base"},
-					[]any{942.0, 723.0},
-					[]any{944.0, 723.0},
-				),
-			},
-			expects: [][2]float64{
-				{664.200, 734.200},
-				{666.275, 734.200},
-			},
-		},
-		{
-			name: "OMVBase",
-			param: mapNavigateCompatibleParam{
-				Path: mustRawMessages(t,
-					map[string]any{"action": "ZONE", "zone_id": "OMVBase01"},
-					[]any{187.0, 141.0},
-					[]any{187.0, 131.0},
-				),
-			},
-			expects: [][2]float64{
-				{190.200, 143.200},
-				{190.200, 132.825},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			converted, err := (&MapTrackerMoveCompatible{}).convertParam(&tt.param)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(converted.Path) != len(tt.expects) {
-				t.Fatalf("got %d points, want %d", len(converted.Path), len(tt.expects))
-			}
-			for i, expect := range tt.expects {
-				got := converted.Path[i]
-				expectPoint := internal.Point{X: expect[0], Y: expect[1]}
-				dist := got.DistanceTo(expectPoint)
-				if dist > 2.0 {
-					t.Fatalf("point %d got [%.3f, %.3f], want [%.3f, %.3f], dist %.3f", i, got.X, got.Y, expect[0], expect[1], dist)
-				}
 			}
 		})
 	}

--- a/agent/go-service/maptracker/compatible/move_compatible_test.go
+++ b/agent/go-service/maptracker/compatible/move_compatible_test.go
@@ -3,11 +3,12 @@ package maptrackercompatible
 
 import (
 	"encoding/json"
-	"math"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	internal "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/internal"
 )
 
 func moveCompatibleTestRepoRoot(t *testing.T) string {
@@ -166,9 +167,10 @@ func TestMapTrackerMoveCompatibleConvertsRegionalSamples(t *testing.T) {
 			}
 			for i, expect := range tt.expects {
 				got := converted.Path[i]
-				dist := math.Hypot(got[0]-expect[0], got[1]-expect[1])
+				expectPoint := internal.Point{X: expect[0], Y: expect[1]}
+				dist := got.DistanceTo(expectPoint)
 				if dist > 2.0 {
-					t.Fatalf("point %d got [%.3f, %.3f], want [%.3f, %.3f], dist %.3f", i, got[0], got[1], expect[0], expect[1], dist)
+					t.Fatalf("point %d got [%.3f, %.3f], want [%.3f, %.3f], dist %.3f", i, got.X, got.Y, expect[0], expect[1], dist)
 				}
 			}
 		})

--- a/agent/go-service/maptracker/default/assert_location.go
+++ b/agent/go-service/maptracker/default/assert_location.go
@@ -86,7 +86,7 @@ func (r *MapTrackerAssertLocation) Run(ctx *maa.Context, arg *maa.CustomRecognit
 	for _, condition := range param.Expected {
 		if result.MapName == condition.MapName {
 			x, y, w, h := condition.Target[0], condition.Target[1], condition.Target[2], condition.Target[3]
-			if result.X >= x && result.X < x+w && result.Y >= y && result.Y < y+h {
+			if result.Loc.X >= x && result.Loc.X < x+w && result.Loc.Y >= y && result.Loc.Y < y+h {
 				log.Info().
 					Interface("condition", condition).
 					Msg("Location assertion satisfied")
@@ -101,14 +101,13 @@ func (r *MapTrackerAssertLocation) Run(ctx *maa.Context, arg *maa.CustomRecognit
 
 	log.Info().
 		Str("mapName", result.MapName).
-		Float64("x", result.X).
-		Float64("y", result.Y).
+		Interface("current", result.Loc).
 		Interface("expected", param.Expected).
 		Msg("Location assertion not satisfied, no conditions met")
 
 	return &maa.CustomRecognitionResult{
 		Box:    arg.Roi,
-		Detail: fmt.Sprintf("Expected hit one of %v, but got map_name=%s, x=%.1f, y=%.1f", param.Expected, result.MapName, result.X, result.Y),
+		Detail: fmt.Sprintf("Expected hit one of %v, but got map_name=%s, x=%.1f, y=%.1f", param.Expected, result.MapName, result.Loc.X, result.Loc.Y),
 	}, false
 }
 

--- a/agent/go-service/maptracker/default/assert_location.go
+++ b/agent/go-service/maptracker/default/assert_location.go
@@ -86,7 +86,7 @@ func (r *MapTrackerAssertLocation) Run(ctx *maa.Context, arg *maa.CustomRecognit
 	for _, condition := range param.Expected {
 		if result.MapName == condition.MapName {
 			x, y, w, h := condition.Target[0], condition.Target[1], condition.Target[2], condition.Target[3]
-			if result.Loc.X >= x && result.Loc.X < x+w && result.Loc.Y >= y && result.Loc.Y < y+h {
+			if result.Loc.InRect(x, y, w, h) {
 				log.Info().
 					Interface("condition", condition).
 					Msg("Location assertion satisfied")

--- a/agent/go-service/maptracker/default/goal.go
+++ b/agent/go-service/maptracker/default/goal.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"image/color"
-	"math"
 	"time"
 
 	maptrackerbigmap "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/bigmap"
@@ -46,9 +45,9 @@ const (
 // MapTrackerGoalParam represents the custom_action_param for MapTrackerGoal.
 type MapTrackerGoalParam struct {
 	MapTrackerMoveParam
-	Target        *[2]float64 `json:"target,omitempty"`
-	EntityID      *int64      `json:"entity_id,omitempty"`
-	ZiplinePolicy string      `json:"zipline_policy,omitempty"`
+	Target        *internal.Point `json:"target,omitempty"`
+	EntityID      *int64          `json:"entity_id,omitempty"`
+	ZiplinePolicy string          `json:"zipline_policy,omitempty"`
 }
 
 type goalContext struct {
@@ -57,7 +56,7 @@ type goalContext struct {
 	param  *MapTrackerGoalParam
 	ctrl   *maa.Controller
 	mesh   *internal.NavMesh
-	target [2]float64
+	target internal.Point
 }
 
 type ziplinePolicy struct {
@@ -147,7 +146,7 @@ func (a *MapTrackerGoal) parseParam(paramStr string) (*MapTrackerGoalParam, erro
 		return nil, fmt.Errorf("entity_id must be positive")
 	}
 	if param.Target != nil {
-		if math.IsNaN(param.Target[0]) || math.IsInf(param.Target[0], 0) || math.IsNaN(param.Target[1]) || math.IsInf(param.Target[1], 0) {
+		if !param.Target.IsValid() {
 			return nil, fmt.Errorf("target contains invalid coordinate")
 		}
 	}
@@ -160,7 +159,7 @@ func (a *MapTrackerGoal) parseParam(paramStr string) (*MapTrackerGoalParam, erro
 	return &param, nil
 }
 
-func (a *MapTrackerGoal) prepare(ctx *maa.Context, ctrl *maa.Controller, param *MapTrackerGoalParam) (*MapTrackerInferResult, *internal.NavMesh, [2]float64, error) {
+func (a *MapTrackerGoal) prepare(ctx *maa.Context, ctrl *maa.Controller, param *MapTrackerGoalParam) (*MapTrackerInferResult, *internal.NavMesh, internal.Point, error) {
 	inferMoveParam := &MapTrackerMoveParam{
 		MapName:          param.MapName,
 		MapNameMatchRule: param.MapNameMatchRule,
@@ -171,41 +170,41 @@ func (a *MapTrackerGoal) prepare(ctx *maa.Context, ctrl *maa.Controller, param *
 
 	inferResult, err := doInfer(ctx, ctrl, inferMoveParam)
 	if err != nil {
-		return nil, nil, [2]float64{}, fmt.Errorf("failed to infer current location for MapTrackerGoal: %w", err)
+		return nil, nil, internal.Point{}, fmt.Errorf("failed to infer current location for MapTrackerGoal: %w", err)
 	}
 	if !isMapNameCoreMatch(inferResult.MapName, param.MapName) {
-		return nil, nil, [2]float64{}, fmt.Errorf("current map %q does not match target map %q", inferResult.MapName, param.MapName)
+		return nil, nil, internal.Point{}, fmt.Errorf("current map %q does not match target map %q", inferResult.MapName, param.MapName)
 	}
 
 	mesh, err := internal.LoadNavMesh(param.MapName)
 	if err != nil {
-		return nil, nil, [2]float64{}, fmt.Errorf("failed to load NavMesh for MapTrackerGoal: %w", err)
+		return nil, nil, internal.Point{}, fmt.Errorf("failed to load NavMesh for MapTrackerGoal: %w", err)
 	}
 
 	target, err := a.resolveTarget(mesh, param)
 	if err != nil {
-		return nil, nil, [2]float64{}, fmt.Errorf("failed to resolve MapTrackerGoal target: %w", err)
+		return nil, nil, internal.Point{}, fmt.Errorf("failed to resolve MapTrackerGoal target: %w", err)
 	}
 	return inferResult, mesh, target, nil
 }
 
-func (a *MapTrackerGoal) resolveTarget(mesh *internal.NavMesh, param *MapTrackerGoalParam) ([2]float64, error) {
+func (a *MapTrackerGoal) resolveTarget(mesh *internal.NavMesh, param *MapTrackerGoalParam) (internal.Point, error) {
 	if param.Target != nil {
 		return *param.Target, nil
 	}
 	vertex, ok := mesh.FindVertexByEntityID(*param.EntityID)
 	if !ok {
-		return [2]float64{}, fmt.Errorf("entity_id %d not found in NavMesh", *param.EntityID)
+		return internal.Point{}, fmt.Errorf("entity_id %d not found in NavMesh", *param.EntityID)
 	}
-	return [2]float64{vertex.X, vertex.Y}, nil
+	return vertex.Pos, nil
 }
 
 func (a *MapTrackerGoal) runOrdinaryGoal(goalCtx *goalContext, inferResult *MapTrackerInferResult) bool {
 	mesh := goalCtx.mesh
 	mesh.ClearTemporaryVertex()
 	defer mesh.ClearTemporaryVertex()
-	startID, _ := mesh.AddTemporaryVertex(inferResult.X, inferResult.Y, startPointCostFactor, startPointMCD)
-	targetID, _ := mesh.AddTemporaryVertex(goalCtx.target[0], goalCtx.target[1], endPointCostFactor, endPointMCD)
+	startID, _ := mesh.AddTemporaryVertex(inferResult.Loc, startPointCostFactor, startPointMCD)
+	targetID, _ := mesh.AddTemporaryVertex(goalCtx.target, endPointCostFactor, endPointMCD)
 	path, err := mesh.FindPath(startID, targetID)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to find NavMesh path for MapTrackerGoal")
@@ -213,10 +212,10 @@ func (a *MapTrackerGoal) runOrdinaryGoal(goalCtx *goalContext, inferResult *MapT
 	}
 
 	log.Info().Str("map", goalCtx.param.MapName).
-		Float64("startX", inferResult.X).
-		Float64("startY", inferResult.Y).
-		Float64("targetX", goalCtx.target[0]).
-		Float64("targetY", goalCtx.target[1]).
+		Float64("startX", inferResult.Loc.X).
+		Float64("startY", inferResult.Loc.Y).
+		Float64("targetX", goalCtx.target.X).
+		Float64("targetY", goalCtx.target.Y).
 		Int("pathCount", len(path)).
 		Msg("MapTrackerGoal path generated")
 
@@ -224,11 +223,11 @@ func (a *MapTrackerGoal) runOrdinaryGoal(goalCtx *goalContext, inferResult *MapT
 }
 
 func (a *MapTrackerGoal) runZiplineGoal(goalCtx *goalContext, inferResult *MapTrackerInferResult) bool {
-	ordinaryPath, err := a.findOrdinaryPathFromLocation(goalCtx, inferResult.X, inferResult.Y)
+	ordinaryPath, err := a.findOrdinaryPathFromLocation(goalCtx, inferResult.Loc)
 	var mustSeePoints [][2]int
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to find ordinary path before zipline search, using fallback must-see points")
-		mustSeePoints = fallbackMustSeePoints([2]float64{inferResult.X, inferResult.Y}, goalCtx.target)
+		mustSeePoints = fallbackMustSeePoints(inferResult.Loc, goalCtx.target)
 	} else {
 		ordinaryDistance := internal.PathTotalDistance(ordinaryPath)
 		policy := mapTrackerGoalZiplinePolicies[goalCtx.param.ZiplinePolicy]
@@ -261,7 +260,7 @@ func (a *MapTrackerGoal) runZiplineGoal(goalCtx *goalContext, inferResult *MapTr
 			return false
 		}
 
-		pathIDs, path, err := a.findPathFromLocation(goalCtx, current.X, current.Y)
+		pathIDs, path, err := a.findPathFromLocation(goalCtx, current.Loc)
 		if err != nil {
 			log.Warn().Err(err).Int("replan", replan).Msg("Zipline-aware path search failed")
 			return false
@@ -311,9 +310,9 @@ func (a *MapTrackerGoal) handlePathWithoutZiplineEdge(
 	goalCtx *goalContext,
 	onZipline *bool,
 	current **MapTrackerInferResult,
-	path [][2]float64,
+	path []internal.Point,
 	replan int,
-) (shouldRunMove bool, movePath [][2]float64) {
+) (shouldRunMove bool, movePath []internal.Point) {
 	if *onZipline {
 		*onZipline = false
 		*current = a.inferAndGetOffZipline(goalCtx, *current)
@@ -336,7 +335,7 @@ func (a *MapTrackerGoal) approachAndMountZipline(
 	destID int,
 ) bool {
 	sourcePoint, _ := goalCtx.mesh.VertexPoint(sourceID)
-	alreadyAtSource := *onZipline && math.Hypot((*current).X-sourcePoint[0], (*current).Y-sourcePoint[1]) <= ZIPLINE_EXPECTED_DISTANCE
+	alreadyAtSource := *onZipline && (*current).Loc.DistanceTo(sourcePoint) <= ZIPLINE_EXPECTED_DISTANCE
 	if alreadyAtSource {
 		_, ok := goalCtx.mesh.IsZiplineEdge(sourceID, destID)
 		if !ok {
@@ -391,15 +390,15 @@ func (a *MapTrackerGoal) validateZiplineArrival(
 	pathIDs []int,
 	ziplineIndex int,
 	destID int,
-	destPoint [2]float64,
+	destPoint internal.Point,
 ) bool {
 	*current = a.inferOrFallback(goalCtx, *current)
-	if math.Hypot((*current).X-destPoint[0], (*current).Y-destPoint[1]) > ZIPLINE_EXPECTED_DISTANCE {
+	if (*current).Loc.DistanceTo(destPoint) > ZIPLINE_EXPECTED_DISTANCE {
 		goalCtx.mesh.DisableVertex(destID)
 		log.Warn().
 			Int("vertex", destID).
-			Float64("curX", (*current).X).Float64("curY", (*current).Y).
-			Float64("targetX", destPoint[0]).Float64("targetY", destPoint[1]).
+			Float64("curX", (*current).Loc.X).Float64("curY", (*current).Loc.Y).
+			Float64("targetX", destPoint.X).Float64("targetY", destPoint.Y).
 			Msg("Zipline arrived at unexpected point, disabling expected point")
 		*onZipline = false
 		*current = a.inferAndGetOffZipline(goalCtx, *current)
@@ -419,7 +418,7 @@ func (a *MapTrackerGoal) validateZiplineArrival(
 	return true
 }
 
-func (a *MapTrackerGoal) runZipline(goalCtx *goalContext, target [2]float64) bool {
+func (a *MapTrackerGoal) runZipline(goalCtx *goalContext, target internal.Point) bool {
 	param := MapTrackerZiplineParam{
 		MapName:          goalCtx.param.MapName,
 		Target:           &target,
@@ -440,10 +439,10 @@ func (a *MapTrackerGoal) runZipline(goalCtx *goalContext, target [2]float64) boo
 	})
 }
 
-func (a *MapTrackerGoal) findPathFromLocation(goalCtx *goalContext, x, y float64) ([]int, [][2]float64, error) {
+func (a *MapTrackerGoal) findPathFromLocation(goalCtx *goalContext, loc internal.Point) ([]int, []internal.Point, error) {
 	goalCtx.mesh.ClearTemporaryVertex()
-	startID, _ := goalCtx.mesh.AddTemporaryVertex(x, y, startPointCostFactor, startPointMCD)
-	targetID, _ := goalCtx.mesh.AddTemporaryVertex(goalCtx.target[0], goalCtx.target[1], endPointCostFactor, endPointMCD)
+	startID, _ := goalCtx.mesh.AddTemporaryVertex(loc, startPointCostFactor, startPointMCD)
+	targetID, _ := goalCtx.mesh.AddTemporaryVertex(goalCtx.target, endPointCostFactor, endPointMCD)
 	pathIDs, err := goalCtx.mesh.FindPathIDs(startID, targetID)
 	if err != nil {
 		return nil, nil, err
@@ -455,15 +454,15 @@ func (a *MapTrackerGoal) findPathFromLocation(goalCtx *goalContext, x, y float64
 	return pathIDs, path, nil
 }
 
-func (a *MapTrackerGoal) findOrdinaryPathFromLocation(goalCtx *goalContext, x, y float64) ([][2]float64, error) {
+func (a *MapTrackerGoal) findOrdinaryPathFromLocation(goalCtx *goalContext, loc internal.Point) ([]internal.Point, error) {
 	goalCtx.mesh.ClearTemporaryVertex()
 	defer goalCtx.mesh.ClearTemporaryVertex()
-	startID, _ := goalCtx.mesh.AddTemporaryVertex(x, y, startPointCostFactor, startPointMCD)
-	targetID, _ := goalCtx.mesh.AddTemporaryVertex(goalCtx.target[0], goalCtx.target[1], endPointCostFactor, endPointMCD)
+	startID, _ := goalCtx.mesh.AddTemporaryVertex(loc, startPointCostFactor, startPointMCD)
+	targetID, _ := goalCtx.mesh.AddTemporaryVertex(goalCtx.target, endPointCostFactor, endPointMCD)
 	return goalCtx.mesh.FindPath(startID, targetID)
 }
 
-func (a *MapTrackerGoal) runFinalGoalMove(goalCtx *goalContext, path [][2]float64) bool {
+func (a *MapTrackerGoal) runFinalGoalMove(goalCtx *goalContext, path []internal.Point) bool {
 	moveParam := goalCtx.param.MapTrackerMoveParam
 	moveParam.Path = path
 	moveParam.MapName = goalCtx.param.MapName
@@ -553,7 +552,7 @@ func (a *MapTrackerGoal) loadRuntimeZiplines(goalCtx *goalContext, mustSeePoints
 
 	ids := make([]int, 0, len(matches))
 	for _, match := range matches {
-		id, _ := goalCtx.mesh.AddRuntimeVertex(match.MapX, match.MapY, 0, 0, internal.NavMeshVertexFlagZipline)
+		id, _ := goalCtx.mesh.AddRuntimeVertex(internal.Point{X: match.MapX, Y: match.MapY}, 0, 0, internal.NavMeshVertexFlagZipline)
 		ids = append(ids, id)
 	}
 	policy := mapTrackerGoalZiplinePolicies[goalCtx.param.ZiplinePolicy]
@@ -616,7 +615,7 @@ func (a *MapTrackerGoal) findBigMapZiplines(goalCtx *goalContext, mustSeePoints 
 	return matches, nil
 }
 
-func (a *MapTrackerGoal) saveDebugImage(goalCtx *goalContext, pathIDs []int, path [][2]float64, ziplineIDs []int, current *MapTrackerInferResult, replan int) {
+func (a *MapTrackerGoal) saveDebugImage(goalCtx *goalContext, pathIDs []int, path []internal.Point, ziplineIDs []int, current *MapTrackerInferResult, replan int) {
 	mapRGBA, err := getCachedPreviewMapRGBA(goalCtx.param.MapName)
 	if err != nil {
 		log.Debug().Err(err).Str("map", goalCtx.param.MapName).Msg("Failed to load map image for MapTrackerGoal debug image")
@@ -632,20 +631,14 @@ func (a *MapTrackerGoal) saveDebugImage(goalCtx *goalContext, pathIDs []int, pat
 	colorCurrent := color.RGBA{0x27, 0xce, 0x60, 0xff}
 	colorTarget := color.RGBA{0xdb, 0x39, 0x2b, 0xff}
 
-	toPixel := func(point [2]float64) (int, int) {
-		return int(math.Round(point[0])), int(math.Round(point[1]))
-	}
-
 	for i := 0; i+1 < len(path); i++ {
-		x1, y1 := toPixel(path[i])
-		x2, y2 := toPixel(path[i+1])
 		lineColor := colorPath
 		if i+1 < len(pathIDs) {
 			if _, ok := goalCtx.mesh.IsZiplineEdge(pathIDs[i], pathIDs[i+1]); ok {
 				lineColor = colorPathZipline
 			}
 		}
-		minicv.ImageDrawLine(canvas, x1, y1, x2, y2, lineColor, 3)
+		minicv.ImageDrawLine(canvas, path[i].IntX(), path[i].IntY(), path[i+1].IntX(), path[i+1].IntY(), lineColor, 3)
 	}
 
 	for _, id := range ziplineIDs {
@@ -656,21 +649,17 @@ func (a *MapTrackerGoal) saveDebugImage(goalCtx *goalContext, pathIDs []int, pat
 		if !ok {
 			continue
 		}
-		x, y := toPixel(point)
-		minicv.ImageDrawFilledCircle(canvas, x, y, 5, colorZipline)
+		minicv.ImageDrawFilledCircle(canvas, point.IntX(), point.IntY(), 5, colorZipline)
 	}
 
 	for _, point := range path {
-		x, y := toPixel(point)
-		minicv.ImageDrawFilledCircle(canvas, x, y, 3, colorPoint)
+		minicv.ImageDrawFilledCircle(canvas, point.IntX(), point.IntY(), 3, colorPoint)
 	}
 
 	if current != nil {
-		x, y := toPixel([2]float64{current.X, current.Y})
-		minicv.ImageDrawFilledCircle(canvas, x, y, 6, colorCurrent)
+		minicv.ImageDrawFilledCircle(canvas, current.Loc.IntX(), current.Loc.IntY(), 6, colorCurrent)
 	}
-	targetX, targetY := toPixel(goalCtx.target)
-	minicv.ImageDrawFilledCircle(canvas, targetX, targetY, 6, colorTarget)
+	minicv.ImageDrawFilledCircle(canvas, goalCtx.target.IntX(), goalCtx.target.IntY(), 6, colorTarget)
 
 	if err := minicv.ImageSaveDebug(canvas, mapTrackerGoalDebugDir, "MapTrackerGoal", 4); err != nil {
 		log.Debug().Err(err).Str("path", mapTrackerGoalDebugDir).Msg("Failed to save MapTrackerGoal debug image")
@@ -679,15 +668,15 @@ func (a *MapTrackerGoal) saveDebugImage(goalCtx *goalContext, pathIDs []int, pat
 	log.Debug().Int("replan", replan).Str("path", mapTrackerGoalDebugDir).Msg("MapTrackerGoal debug image saved")
 }
 
-func fallbackMustSeePoints(start, target [2]float64) [][2]int {
-	mid := [2]float64{(start[0] + target[0]) / 2, (start[1] + target[1]) / 2}
-	return pathToMustSeePoints([][2]float64{start, mid, target})
+func fallbackMustSeePoints(start, target internal.Point) [][2]int {
+	mid := internal.Point{X: (start.X + target.X) / 2, Y: (start.Y + target.Y) / 2}
+	return pathToMustSeePoints([]internal.Point{start, mid, target})
 }
 
-func pathToMustSeePoints(path [][2]float64) [][2]int {
+func pathToMustSeePoints(path []internal.Point) [][2]int {
 	points := make([][2]int, 0, len(path))
 	for _, point := range path {
-		converted := [2]int{int(math.Round(point[0])), int(math.Round(point[1]))}
+		converted := [2]int{point.IntX(), point.IntY()}
 		if len(points) > 0 && points[len(points)-1] == converted {
 			continue
 		}
@@ -718,7 +707,7 @@ func connectRuntimeZiplines(mesh *internal.NavMesh, ziplineIDs []int, firstEdgeI
 			if vertex.Flags&internal.NavMeshVertexFlagHidden != 0 {
 				continue
 			}
-			dist := math.Hypot(vertex.X-ziplinePoint[0], vertex.Y-ziplinePoint[1])
+			dist := ziplinePoint.DistanceTo(vertex.Pos)
 			if dist < ziplineConnectDistance {
 				mesh.AddRuntimeEdge(nextID(), id, ziplineID, false, factors.ToVertex*dist, 0)
 				mesh.AddRuntimeEdge(nextID(), ziplineID, id, false, factors.FromVertex*dist, 0)
@@ -729,7 +718,7 @@ func connectRuntimeZiplines(mesh *internal.NavMesh, ziplineIDs []int, firstEdgeI
 		left, _ := mesh.VertexPoint(ziplineIDs[i])
 		for j := i + 1; j < len(ziplineIDs); j++ {
 			right, _ := mesh.VertexPoint(ziplineIDs[j])
-			dist := math.Hypot(left[0]-right[0], left[1]-right[1])
+			dist := left.DistanceTo(right)
 			if dist <= ziplineMaxDistance {
 				mesh.AddRuntimeEdge(nextID(), ziplineIDs[i], ziplineIDs[j], true, factors.BetweenVertex*dist, internal.NavMeshEdgeFlagZipline)
 			}

--- a/agent/go-service/maptracker/default/goal.go
+++ b/agent/go-service/maptracker/default/goal.go
@@ -212,10 +212,8 @@ func (a *MapTrackerGoal) runOrdinaryGoal(goalCtx *goalContext, inferResult *MapT
 	}
 
 	log.Info().Str("map", goalCtx.param.MapName).
-		Float64("startX", inferResult.Loc.X).
-		Float64("startY", inferResult.Loc.Y).
-		Float64("targetX", goalCtx.target.X).
-		Float64("targetY", goalCtx.target.Y).
+		Object("start", inferResult.Loc).
+		Object("target", goalCtx.target).
 		Int("pathCount", len(path)).
 		Msg("MapTrackerGoal path generated")
 
@@ -397,8 +395,8 @@ func (a *MapTrackerGoal) validateZiplineArrival(
 		goalCtx.mesh.DisableVertex(destID)
 		log.Warn().
 			Int("vertex", destID).
-			Float64("curX", (*current).Loc.X).Float64("curY", (*current).Loc.Y).
-			Float64("targetX", destPoint.X).Float64("targetY", destPoint.Y).
+			Object("current", (*current).Loc).
+			Object("target", destPoint).
 			Msg("Zipline arrived at unexpected point, disabling expected point")
 		*onZipline = false
 		*current = a.inferAndGetOffZipline(goalCtx, *current)

--- a/agent/go-service/maptracker/default/infer.go
+++ b/agent/go-service/maptracker/default/infer.go
@@ -215,7 +215,8 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 	log.Info().Str("InferMode", result.InferMode).
 		Int64("InferTimeMs", result.InferTimeMs).
 		Str("MapName", result.MapName).
-		Float64("X", result.Loc.X).Float64("Y", result.Loc.Y).
+		Float64("X", result.Loc.X).Float64("Y", result.Loc.Y). // Reserved for backward compatibility
+		Object("LOC", result.Loc).
 		Int("Rot", result.Rot).
 		Float64("LocConf", result.LocConf).
 		Float64("RotConf", result.RotConf).

--- a/agent/go-service/maptracker/default/infer.go
+++ b/agent/go-service/maptracker/default/infer.go
@@ -20,16 +20,17 @@ import (
 
 // MapTrackerInferResult represents the result of map tracking inference
 type MapTrackerInferResult struct {
-	MapName     string  `json:"mapName"`     // Map name
-	X           float64 `json:"x"`           // X coordinate on the map
-	Y           float64 `json:"y"`           // Y coordinate on the map
-	Rot         int     `json:"rot"`         // Rotation angle (0-359 degrees)
-	LocConf     float64 `json:"locConf"`     // Location confidence
-	RotConf     float64 `json:"rotConf"`     // Rotation confidence
-	LocTimeMs   int64   `json:"locTimeMs"`   // Location inference time in ms
-	RotTimeMs   int64   `json:"rotTimeMs"`   // Rotation inference time in ms
-	InferMode   string  `json:"inferMode"`   // Inference mode ("FullSearchHit", "FastSearchHit")
-	InferTimeMs int64   `json:"inferTimeMs"` // Total inference time in ms
+	MapName     string         `json:"mapName"`     // Map name
+	X           float64        `json:"x"`           // X coordinate on the map (backward capability)
+	Y           float64        `json:"y"`           // Y coordinate on the map (backward capability)
+	Loc         internal.Point `json:"point"`       // Point struct for X/Y coordinates
+	Rot         int            `json:"rot"`         // Rotation angle (0-359 degrees)
+	LocConf     float64        `json:"locConf"`     // Location confidence
+	RotConf     float64        `json:"rotConf"`     // Rotation confidence
+	LocTimeMs   int64          `json:"locTimeMs"`   // Location inference time in ms
+	RotTimeMs   int64          `json:"rotTimeMs"`   // Rotation inference time in ms
+	InferMode   string         `json:"inferMode"`   // Inference mode ("FullSearchHit", "FastSearchHit")
+	InferTimeMs int64          `json:"inferTimeMs"` // Total inference time in ms
 }
 
 // MapTrackerInferParam represents the custom_recognition_param for MapTrackerInfer
@@ -67,8 +68,7 @@ type MapTrackerInfer struct {
 // InferLocationRawResult represents the raw result of location inference
 type InferLocationRawResult struct {
 	MapName       string
-	X             float64
-	Y             float64
+	Loc           internal.Point
 	Conf          float64
 	Source        InferLocationHitMode
 	ElapsedTimeMs int64
@@ -143,7 +143,7 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 
 		} else if globalInferState.IsCloseToPending(loc) {
 			// This hit is close to the pending location
-			globalInferState.UpdatePending(loc.X, loc.Y)
+			globalInferState.UpdatePending(loc.Loc)
 
 			if globalInferState.ShouldTakeoverPending() {
 				// Do takeover (replace convinced with pending)
@@ -193,8 +193,9 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 	// Build hit result
 	result := MapTrackerInferResult{
 		MapName:     finalLoc.MapName,
-		X:           finalLoc.X,
-		Y:           finalLoc.Y,
+		X:           finalLoc.Loc.X,
+		Y:           finalLoc.Loc.Y,
+		Loc:         finalLoc.Loc,
 		Rot:         finalRot.Rot,
 		LocConf:     finalLoc.Conf,
 		RotConf:     finalRot.Conf,
@@ -214,7 +215,7 @@ func (i *MapTrackerInfer) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (
 	log.Info().Str("InferMode", result.InferMode).
 		Int64("InferTimeMs", result.InferTimeMs).
 		Str("MapName", result.MapName).
-		Float64("X", result.X).Float64("Y", result.Y).
+		Float64("X", result.Loc.X).Float64("Y", result.Loc.Y).
 		Int("Rot", result.Rot).
 		Float64("LocConf", result.LocConf).
 		Float64("RotConf", result.RotConf).
@@ -314,8 +315,7 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 	globalInferState.Lock()
 
 	stableConvincedMapName := globalInferState.convinced.MapName
-	stableLocX := globalInferState.convinced.X
-	stableLocY := globalInferState.convinced.Y
+	stableLoc := globalInferState.convinced.Loc
 	isInTime := globalInferState.IsConvincedValid()
 
 	globalInferState.Unlock()
@@ -335,7 +335,7 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 	// Try fast search if stable
 	if param.AllowedModes&INFER_MODE_FAST_SEARCH != 0 && isStable() {
 		fastBestVal := -1.0
-		fastBestX, fastBestY := 0.0, 0.0
+		fastBestLoc := internal.Point{}
 		fastBestMapName := ""
 
 		for idx := range scaledMaps {
@@ -344,8 +344,9 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 				continue
 			}
 
-			expectedCenterX := int(math.Round((stableLocX - float64(mapData.OffsetX)) * scale))
-			expectedCenterY := int(math.Round((stableLocY - float64(mapData.OffsetY)) * scale))
+			expectedCenter := mapData.PixelTransform(scale).Apply(stableLoc)
+			expectedCenterX := expectedCenter.IntX()
+			expectedCenterY := expectedCenter.IntY()
 			searchRadius := max(int(float64(CONVINCED_DISTANCE_THRESHOLD)*scale), 1)
 			searchArea := [4]int{
 				expectedCenterX - searchRadius,
@@ -358,8 +359,12 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 
 			if matchVal > fastBestVal {
 				fastBestVal = matchVal
-				fastBestX = roundTo1Decimal((matchX+miniMapHalfW)/scale + float64(mapData.OffsetX))
-				fastBestY = roundTo1Decimal((matchY+miniMapHalfH)/scale + float64(mapData.OffsetY))
+				pixel := internal.Point{X: matchX + miniMapHalfW, Y: matchY + miniMapHalfH}
+				loc := mapData.PixelTransform(scale).Inverse(pixel)
+				fastBestLoc = internal.Point{
+					X: roundTo1Decimal(loc.X),
+					Y: roundTo1Decimal(loc.Y),
+				}
 				fastBestMapName = mapData.Name
 			}
 		}
@@ -368,15 +373,14 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 			elapsedTimeMs := time.Since(t0).Milliseconds()
 			log.Debug().Float64("conf", fastBestVal).
 				Str("map", fastBestMapName).
-				Float64("X", fastBestX).
-				Float64("Y", fastBestY).
+				Float64("X", fastBestLoc.X).
+				Float64("Y", fastBestLoc.Y).
 				Int64("elapsedTimeMs", elapsedTimeMs).
 				Msg("Internal fast search location inference completed")
 
 			return &InferLocationRawResult{
 				MapName:       fastBestMapName,
-				X:             fastBestX,
-				Y:             fastBestY,
+				Loc:           fastBestLoc,
 				Conf:          fastBestVal,
 				Source:        FAST_SEARCH_HIT,
 				ElapsedTimeMs: elapsedTimeMs,
@@ -389,12 +393,12 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 	// Match against all maps in parallel
 	type mapResult struct {
 		val     float64
-		x, y    float64
+		loc     internal.Point
 		mapName string
 	}
 
 	bestVal := -1.0
-	bestX, bestY := 0.0, 0.0
+	bestLoc := internal.Point{}
 	bestMapName := ""
 	triedCount := 0
 
@@ -415,8 +419,12 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 	if singleMapToTry != nil {
 		matchX, matchY, matchVal := minicv.MatchTemplate(singleMapToTry.Img, singleMapToTry.GetIntegralArray(), miniMap, miniStats)
 		bestVal = matchVal
-		bestX = roundTo1Decimal((matchX+miniMapHalfW)/scale + float64(singleMapToTry.OffsetX))
-		bestY = roundTo1Decimal((matchY+miniMapHalfH)/scale + float64(singleMapToTry.OffsetY))
+		pixel := internal.Point{X: matchX + miniMapHalfW, Y: matchY + miniMapHalfH}
+		loc := singleMapToTry.PixelTransform(scale).Inverse(pixel)
+		bestLoc = internal.Point{
+			X: roundTo1Decimal(loc.X),
+			Y: roundTo1Decimal(loc.Y),
+		}
 		bestMapName = singleMapToTry.Name
 	} else if triedCount > 1 {
 		resChan := make(chan mapResult, triedCount)
@@ -432,9 +440,16 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 			go func(m *internal.MapCache) {
 				defer wg.Done()
 				matchX, matchY, matchVal := minicv.MatchTemplate(m.Img, m.GetIntegralArray(), miniMap, miniStats)
-				mx := roundTo1Decimal((matchX+miniMapHalfW)/scale + float64(m.OffsetX))
-				my := roundTo1Decimal((matchY+miniMapHalfH)/scale + float64(m.OffsetY))
-				resChan <- mapResult{matchVal, mx, my, m.Name}
+				pixel := internal.Point{X: matchX + miniMapHalfW, Y: matchY + miniMapHalfH}
+				loc := m.PixelTransform(scale).Inverse(pixel)
+				resChan <- mapResult{
+					val: matchVal,
+					loc: internal.Point{
+						X: roundTo1Decimal(loc.X),
+						Y: roundTo1Decimal(loc.Y),
+					},
+					mapName: m.Name,
+				}
 			}(mapData)
 		}
 
@@ -446,8 +461,7 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 		for res := range resChan {
 			if res.val > bestVal {
 				bestVal = res.val
-				bestX = res.x
-				bestY = res.y
+				bestLoc = res.loc
 				bestMapName = res.mapName
 			}
 		}
@@ -461,15 +475,14 @@ func (i *MapTrackerInfer) inferLocation(ctrlType string, screenImg *image.RGBA, 
 	log.Debug().Int("triedMaps", triedCount).
 		Float64("bestConf", bestVal).
 		Str("bestMap", bestMapName).
-		Float64("X", bestX).
-		Float64("Y", bestY).
+		Float64("X", bestLoc.X).
+		Float64("Y", bestLoc.Y).
 		Int64("elapsedTimeMs", elapsedTimeMs).
 		Msg("Internal location inference completed")
 
 	return &InferLocationRawResult{
 		MapName:       bestMapName,
-		X:             bestX,
-		Y:             bestY,
+		Loc:           bestLoc,
 		Conf:          bestVal,
 		Source:        FULL_SEARCH_HIT,
 		ElapsedTimeMs: time.Since(t0).Milliseconds(),

--- a/agent/go-service/maptracker/default/infer_state.go
+++ b/agent/go-service/maptracker/default/infer_state.go
@@ -2,9 +2,10 @@
 package maptrackerdefault
 
 import (
-	"math"
 	"sync"
 	"time"
+
+	internal "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/internal"
 )
 
 // InferLocationHitMode represents the mode of location inference hit
@@ -76,10 +77,9 @@ func (s *InferState) SetPending(loc InferLocationRawResult) {
 }
 
 // UpdatePending updates the pending location and increments hit count
-func (s *InferState) UpdatePending(x, y float64) {
+func (s *InferState) UpdatePending(loc internal.Point) {
 	_ = s.getLockTime()
-	s.pending.X = x
-	s.pending.Y = y
+	s.pending.Loc = loc
 	s.pendingHitCount++
 }
 
@@ -112,9 +112,7 @@ func (s *InferState) IsCloseToConvinced(loc *InferLocationRawResult) bool {
 	if !isMapNameCoreMatch(s.convinced.MapName, loc.MapName) {
 		return false
 	}
-	dx := s.convinced.X - loc.X
-	dy := s.convinced.Y - loc.Y
-	return math.Hypot(dx, dy) < CONVINCED_DISTANCE_THRESHOLD
+	return s.convinced.Loc.DistanceTo(loc.Loc) < CONVINCED_DISTANCE_THRESHOLD
 }
 
 // IsCloseToPending checks if a location is close to the pending location
@@ -122,9 +120,7 @@ func (s *InferState) IsCloseToPending(loc *InferLocationRawResult) bool {
 	if !isMapNameCoreMatch(s.pending.MapName, loc.MapName) {
 		return false
 	}
-	dx := s.pending.X - loc.X
-	dy := s.pending.Y - loc.Y
-	return math.Hypot(dx, dy) < CONVINCED_DISTANCE_THRESHOLD
+	return s.pending.Loc.DistanceTo(loc.Loc) < CONVINCED_DISTANCE_THRESHOLD
 }
 
 // ShouldTakeoverPending checks if pending should be promoted to convinced

--- a/agent/go-service/maptracker/default/move.go
+++ b/agent/go-service/maptracker/default/move.go
@@ -238,7 +238,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 
 			// Calculate rotation difference
 			targetRot := int(math.Round(curLoc.AngleTo(targetLoc)))
-			rawDeltaRot := calcDeltaRotation(curRot, targetRot)
+			rawDeltaRot := internal.DeltaRotation(curRot, targetRot)
 			absRawDeltaRot := math.Abs(float64(rawDeltaRot))
 
 			// Check arrival
@@ -246,7 +246,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				if i < len(param.Path)-1 {
 					// Foresee rotation adjustment for the next but not final target
 					nextTargetRot := int(math.Round(loc.AngleTo(param.Path[i+1])))
-					nextDeltaRot := calcDeltaRotation(rot, nextTargetRot)
+					nextDeltaRot := internal.DeltaRotation(rot, nextTargetRot)
 					if math.Abs(float64(nextDeltaRot)) > param.RotationUpperThreshold {
 						ca.SetPlayerMovement(control.MovementWalk, control.PolicyDefault)
 					}
@@ -263,7 +263,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					log.Info().Int("index", i).Float64("dist", dist).Msg("Target point reached (fine approach)")
 					finishCurrentTarget(curLoc, curRot)
 					break
-				} else if math.Abs(float64(calcDeltaRotation(targetRot, initRot))) > 90.0 {
+				} else if math.Abs(float64(internal.DeltaRotation(targetRot, initRot))) > 90.0 {
 					log.Info().Int("index", i).Float64("dist", dist).Int("targetRot", targetRot).Int("initRot", initRot).Msg("Target point reached (fine approach, guessed by rotation)")
 					finishCurrentTarget(curLoc, curRot)
 					break
@@ -281,7 +281,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 						finishCurrentTarget(curLoc, curRot)
 						break
 					}
-				} else if math.Abs(float64(calcDeltaRotation(targetRot, initRot))) > 90.0 {
+				} else if math.Abs(float64(internal.DeltaRotation(targetRot, initRot))) > 90.0 {
 					log.Info().Int("index", i).Float64("dist", dist).Int("targetRot", targetRot).Int("initRot", initRot).Msg("Target point reached (ordinary approach, guessed by rotation)")
 					finishCurrentTarget(curLoc, curRot)
 					break
@@ -320,7 +320,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					distTravel := curLoc.DistanceTo(rotAdjState.fromPos)
 					if distTravel > control.MovementWalk.DistanceDuring(rotAdjState.expectedElapsed) {
 						// Check if rotation difference is sufficient to consider adjusting rotation speed
-						actualDeltaRot := calcDeltaRotation(rotAdjState.fromRot, curRot)
+						actualDeltaRot := internal.DeltaRotation(rotAdjState.fromRot, curRot)
 						if math.Abs(float64(actualDeltaRot)) > param.RotationLowerThreshold && math.Abs(rotAdjState.deltaRot) > param.RotationLowerThreshold {
 							idealRotSpeed := rotationSpeed * rotAdjState.deltaRot / (float64(actualDeltaRot) + 1e-6)
 							if idealRotSpeed >= ROTATION_MIN_SPEED && idealRotSpeed <= ROTATION_MAX_SPEED {
@@ -659,18 +659,6 @@ func buildMapNameRegex(rule string, mapName string) string {
 	return rule
 }
 
-// calcDeltaRotation calculates min difference between two angles [-180, 180]
-func calcDeltaRotation(current, target int) int {
-	diff := target - current
-	for diff > 180 {
-		diff -= 360
-	}
-	for diff < -180 {
-		diff += 360
-	}
-	return diff
-}
-
 func (a *MapTrackerMove) buildNavigationMovingHTML(
 	param *MapTrackerMoveParam, targetIndex int, current internal.Point, target internal.Point,
 ) string {
@@ -852,21 +840,13 @@ func calcNavigationPreviewGeometry(focusPoints []internal.Point, current interna
 	minSpan := float64(minSize)
 	maxSpan := float64(maxSize)
 
-	minX, minY := math.Inf(1), math.Inf(1)
-	maxX, maxY := math.Inf(-1), math.Inf(-1)
-	update := func(p internal.Point) {
-		if !p.IsValid() {
-			return
-		}
-		minX = math.Min(minX, p.X)
-		minY = math.Min(minY, p.Y)
-		maxX = math.Max(maxX, p.X)
-		maxY = math.Max(maxY, p.Y)
+	minX, minY, maxX, maxY := internal.PathBounds(focusPoints)
+	if current.IsValid() {
+		minX = math.Min(minX, current.X)
+		minY = math.Min(minY, current.Y)
+		maxX = math.Max(maxX, current.X)
+		maxY = math.Max(maxY, current.Y)
 	}
-	for _, p := range focusPoints {
-		update(p)
-	}
-	update(current)
 
 	if math.IsNaN(minX) || math.IsInf(minX, 0) ||
 		math.IsNaN(minY) || math.IsInf(minY, 0) ||

--- a/agent/go-service/maptracker/default/move.go
+++ b/agent/go-service/maptracker/default/move.go
@@ -34,7 +34,7 @@ type MapTrackerMoveParam struct {
 	// MapName is the name of the map to navigate (required).
 	MapName string `json:"map_name"`
 	// Path is a sequence of [x, y] coordinate points to follow (required).
-	Path [][2]float64 `json:"path"`
+	Path []internal.Point `json:"path"`
 	// NoPrint controls whether to suppress printing navigation status to the GUI.
 	NoPrint bool `json:"no_print,omitempty"`
 	// PathTrim trims the path to start from the nearest point to the current location when enabled.
@@ -98,11 +98,11 @@ var mapTrackerInferParamForMove = MapTrackerInferParam{
 
 // PlayerRotationAdjustmentState keeps track of one rotation adjustment
 type PlayerRotationAdjustmentState struct {
-	fromPos         [2]float64    // Last position where rotation adjustment started to apply
-	fromRot         int           // Last rotation when rotation adjustment started to apply
-	deltaRot        float64       // Last rotation difference to apply
-	startTime       time.Time     // Last time when rotation adjustment started to apply
-	expectedElapsed time.Duration // Expected time for this rotation adjustment to take effect
+	fromPos         internal.Point // Last position where rotation adjustment started to apply
+	fromRot         int            // Last rotation when rotation adjustment started to apply
+	deltaRot        float64        // Last rotation difference to apply
+	startTime       time.Time      // Last time when rotation adjustment started to apply
+	expectedElapsed time.Duration  // Expected time for this rotation adjustment to take effect
 }
 
 var previewMapCache = struct {
@@ -137,7 +137,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 			closestIdx := 0
 			minDist := math.MaxFloat64
 			for i, p := range param.Path {
-				dist := math.Hypot(initRes.X-p[0], initRes.Y-p[1])
+				dist := initRes.Loc.DistanceTo(p)
 				if dist < minDist {
 					minDist = dist
 					closestIdx = i
@@ -169,19 +169,18 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 	var rotAdjState, rotAdjStateCache *PlayerRotationAdjustmentState
 
 	// For each target point
-	for i, target := range param.Path {
-		targetX, targetY := target[0], target[1]
+	for i, targetLoc := range param.Path {
 		enableFineApproach := (param.FineApproach == FINE_APPROACH_ALL_TARGETS) ||
 			(param.FineApproach == FINE_APPROACH_FINAL_TARGET && i == len(param.Path)-1)
-		log.Info().Int("index", i).Float64("targetX", targetX).Float64("targetY", targetY).Msg("Navigating to next target point")
+		log.Info().Int("index", i).Interface("target", targetLoc).Msg("Navigating to next target point")
 
 		// Show navigation UI
 		var initRot int
 		if initResult, err := doInfer(ctx, ctrl, param); err == nil && initResult != nil {
-			initRot = calcTargetRotation(initResult.X, initResult.Y, targetX, targetY)
+			initRot = int(initResult.Loc.AngleTo(targetLoc))
 			if !param.NoPrint {
 				maafocus.PrintLargeContentTrimNewline(
-					a.buildNavigationMovingHTML(param, i, initResult.X, initResult.Y, targetX, targetY),
+					a.buildNavigationMovingHTML(param, i, initResult.Loc, targetLoc),
 				)
 			}
 		} else if err != nil {
@@ -192,7 +191,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 			lastLoopTime                = time.Time{}
 			lastArrivalTime             = time.Now()
 			prevLocationTime            = time.Time{}
-			prevLocation                *[2]float64
+			prevLocation                *internal.Point
 			fineApproachOngoing         = false
 			fineApproachExpectedEndTime = time.Time{}
 			stuckMitigatorIdx           = 0
@@ -234,20 +233,19 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				ca.SetPlayerMovement(control.MovementStop, control.PolicyDefault)
 				continue
 			}
-			curX, curY := result.X, result.Y
-			rot := result.Rot
+			curLoc := result.Loc
+			curRot := result.Rot
 
 			// Calculate rotation difference
-			targetRot := calcTargetRotation(curX, curY, targetX, targetY)
-			rawDeltaRot := calcDeltaRotation(rot, targetRot)
+			targetRot := int(math.Round(curLoc.AngleTo(targetLoc)))
+			rawDeltaRot := calcDeltaRotation(curRot, targetRot)
 			absRawDeltaRot := math.Abs(float64(rawDeltaRot))
 
 			// Check arrival
-			finishCurrentTarget := func(curX, curY float64, rot int) {
+			finishCurrentTarget := func(loc internal.Point, rot int) {
 				if i < len(param.Path)-1 {
 					// Foresee rotation adjustment for the next but not final target
-					nextX, nextY := param.Path[i+1][0], param.Path[i+1][1]
-					nextTargetRot := calcTargetRotation(curX, curY, nextX, nextY)
+					nextTargetRot := int(math.Round(loc.AngleTo(param.Path[i+1])))
 					nextDeltaRot := calcDeltaRotation(rot, nextTargetRot)
 					if math.Abs(float64(nextDeltaRot)) > param.RotationUpperThreshold {
 						ca.SetPlayerMovement(control.MovementWalk, control.PolicyDefault)
@@ -259,15 +257,15 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				}
 			}
 
-			dist := math.Hypot(curX-targetX, curY-targetY)
+			dist := curLoc.DistanceTo(targetLoc)
 			if fineApproachOngoing {
 				if loopStartTime.After(fineApproachExpectedEndTime) || dist < FINE_APPROACH_COMPLETE_THRESHOLD {
 					log.Info().Int("index", i).Float64("dist", dist).Msg("Target point reached (fine approach)")
-					finishCurrentTarget(curX, curY, rot)
+					finishCurrentTarget(curLoc, curRot)
 					break
 				} else if math.Abs(float64(calcDeltaRotation(targetRot, initRot))) > 90.0 {
 					log.Info().Int("index", i).Float64("dist", dist).Int("targetRot", targetRot).Int("initRot", initRot).Msg("Target point reached (fine approach, guessed by rotation)")
-					finishCurrentTarget(curX, curY, rot)
+					finishCurrentTarget(curLoc, curRot)
 					break
 				}
 			} else {
@@ -279,21 +277,21 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 						ca.SetPlayerMovement(control.MovementWalk, control.PolicyDefault)
 						log.Info().Int("index", i).Float64("dist", dist).Dur("expectedElapsed", fineApproachExpectedElapsed).Msg("Entering fine approach")
 					} else {
-						log.Info().Int("index", i).Float64("x", curX).Float64("y", curY).Msg("Target point reached (ordinary approach)")
-						finishCurrentTarget(curX, curY, rot)
+						log.Info().Int("index", i).Float64("x", curLoc.X).Float64("y", curLoc.Y).Msg("Target point reached (ordinary approach)")
+						finishCurrentTarget(curLoc, curRot)
 						break
 					}
 				} else if math.Abs(float64(calcDeltaRotation(targetRot, initRot))) > 90.0 {
 					log.Info().Int("index", i).Float64("dist", dist).Int("targetRot", targetRot).Int("initRot", initRot).Msg("Target point reached (ordinary approach, guessed by rotation)")
-					finishCurrentTarget(curX, curY, rot)
+					finishCurrentTarget(curLoc, curRot)
 					break
 				}
 			}
 
-			log.Debug().Float64("curX", curX).Float64("curY", curY).Int("curRot", rot).Float64("dist", dist).Int("targetRot", targetRot).Msg("Navigating to target")
+			log.Debug().Float64("curX", curLoc.X).Float64("curY", curLoc.Y).Int("curRot", curRot).Float64("dist", dist).Int("targetRot", targetRot).Msg("Navigating to target")
 
 			// Check stuck
-			if prevLocation != nil && math.Hypot(prevLocation[0]-curX, prevLocation[1]-curY) < 2.0 {
+			if prevLocation != nil && prevLocation.DistanceTo(curLoc) < 2.0 {
 				deltaLocationMs := loopStartTime.Sub(prevLocationTime).Milliseconds()
 				if deltaLocationMs > param.StuckTimeout {
 					log.Error().Msg("Stuck for too long, stopping task")
@@ -310,7 +308,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					}
 				}
 			} else {
-				prevLocation = &[2]float64{curX, curY}
+				prevLocation = &curLoc
 				prevLocationTime = loopStartTime
 			}
 
@@ -319,10 +317,10 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				// Check if last rotation adjustment is completed
 				if loopStartTime.Sub(rotAdjState.startTime) > rotAdjState.expectedElapsed {
 					// Check if player is moving and rotating sufficiently to trust rotation measurement
-					distTravel := math.Hypot(curX-rotAdjState.fromPos[0], curY-rotAdjState.fromPos[1])
+					distTravel := curLoc.DistanceTo(rotAdjState.fromPos)
 					if distTravel > control.MovementWalk.DistanceDuring(rotAdjState.expectedElapsed) {
 						// Check if rotation difference is sufficient to consider adjusting rotation speed
-						actualDeltaRot := calcDeltaRotation(rotAdjState.fromRot, rot)
+						actualDeltaRot := calcDeltaRotation(rotAdjState.fromRot, curRot)
 						if math.Abs(float64(actualDeltaRot)) > param.RotationLowerThreshold && math.Abs(rotAdjState.deltaRot) > param.RotationLowerThreshold {
 							idealRotSpeed := rotationSpeed * rotAdjState.deltaRot / (float64(actualDeltaRot) + 1e-6)
 							if idealRotSpeed >= ROTATION_MIN_SPEED && idealRotSpeed <= ROTATION_MAX_SPEED {
@@ -391,8 +389,8 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 
 					// Update adaptive rotation state
 					rotAdjState = &PlayerRotationAdjustmentState{
-						fromPos:         [2]float64{curX, curY},
-						fromRot:         rot,
+						fromPos:         curLoc,
+						fromRot:         curRot,
 						deltaRot:        finalDeltaRot,
 						startTime:       time.Now(),
 						expectedElapsed: ca.GetPlayerMovement().EtaOfRotation(math.Abs(finalDeltaRot)),
@@ -409,15 +407,15 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 
 	// Show finished UI summary
 	if !param.NoPrint {
-		finishedX, finishedY := 0.0, 0.0
+		finished := internal.Point{X: 0.0, Y: 0.0}
 		if len(param.Path) > 0 {
-			finishedX, finishedY = param.Path[len(param.Path)-1][0], param.Path[len(param.Path)-1][1]
+			finished = param.Path[len(param.Path)-1]
 		}
 		if finalInfer, err := doInfer(ctx, ctrl, param); err == nil && finalInfer != nil {
-			finishedX, finishedY = finalInfer.X, finalInfer.Y
+			finished = finalInfer.Loc
 		}
 		maafocus.PrintLargeContentTrimNewline(
-			a.buildNavigationFinishedHTML(param, finishedX, finishedY),
+			a.buildNavigationFinishedHTML(param, finished),
 		)
 	}
 
@@ -447,8 +445,8 @@ func (a *MapTrackerMove) parseParam(paramStr string) (*MapTrackerMoveParam, erro
 	if len(param.Path) == 0 {
 		return nil, fmt.Errorf("path is required in parameters, got empty")
 	}
-	for i, point := range param.Path {
-		if math.IsNaN(point[0]) || math.IsInf(point[0], 0) || math.IsNaN(point[1]) || math.IsInf(point[1], 0) {
+	for i, p := range param.Path {
+		if !p.IsValid() {
 			return nil, fmt.Errorf("path[%d] contains invalid coordinate", i)
 		}
 	}
@@ -661,21 +659,6 @@ func buildMapNameRegex(rule string, mapName string) string {
 	return rule
 }
 
-// calcTargetRotation calculates the angle from (fromX, fromY) to (toX, toY).
-// 0 degrees is North (negative Y), increasing clockwise.
-func calcTargetRotation(fromX, fromY, toX, toY float64) int {
-	dx := toX - fromX
-	dy := toY - fromY
-	angleRad := math.Atan2(dx, -dy)
-	angleDeg := angleRad * 180.0 / math.Pi
-
-	// Normalize to [0, 360)
-	if angleDeg < 0 {
-		angleDeg += 360
-	}
-	return int(math.Round(angleDeg)) % 360
-}
-
 // calcDeltaRotation calculates min difference between two angles [-180, 180]
 func calcDeltaRotation(current, target int) int {
 	diff := target - current
@@ -689,47 +672,42 @@ func calcDeltaRotation(current, target int) int {
 }
 
 func (a *MapTrackerMove) buildNavigationMovingHTML(
-	param *MapTrackerMoveParam,
-	targetIndex int,
-	currentX float64,
-	currentY float64,
-	targetX float64,
-	targetY float64,
+	param *MapTrackerMoveParam, targetIndex int, current internal.Point, target internal.Point,
 ) string {
-	previewImageURL := buildNavigationPreviewDataURL(param.Path, targetIndex, param.MapName, currentX, currentY, targetX, targetY)
+	previewImageURL := buildNavigationPreviewDataURL(param.Path, targetIndex, param.MapName, current, target)
 
 	return i18n.RenderHTML("maptracker.navigation_moving", map[string]any{
 		"CurrentIdx": targetIndex + 1,
 		"Total":      len(param.Path),
-		"CurX":       currentX,
-		"CurY":       currentY,
-		"TgtX":       targetX,
-		"TgtY":       targetY,
+		"CurX":       current.X,
+		"CurY":       current.Y,
+		"TgtX":       target.X,
+		"TgtY":       target.Y,
 		"PreviewURL": previewImageURL,
 	})
 }
 
-func (a *MapTrackerMove) buildNavigationFinishedHTML(param *MapTrackerMoveParam, currentX, currentY float64) string {
-	targetX, targetY := currentX, currentY
+func (a *MapTrackerMove) buildNavigationFinishedHTML(param *MapTrackerMoveParam, current internal.Point) string {
+	target := internal.Point{X: current.X, Y: current.Y}
 	targetIndex := 0
 	if len(param.Path) > 0 {
 		targetIndex = len(param.Path) - 1
-		targetX = param.Path[targetIndex][0]
-		targetY = param.Path[targetIndex][1]
+		target.X = param.Path[targetIndex].X
+		target.Y = param.Path[targetIndex].Y
 	}
 
-	previewImageURL := buildNavigationPreviewDataURL(param.Path, targetIndex, param.MapName, currentX, currentY, targetX, targetY)
+	previewImageURL := buildNavigationPreviewDataURL(param.Path, targetIndex, param.MapName, current, target)
 
 	return i18n.RenderHTML("maptracker.navigation_finished", map[string]any{
 		"CurrentIdx": len(param.Path),
 		"Total":      len(param.Path),
-		"CurX":       currentX,
-		"CurY":       currentY,
+		"CurX":       current.X,
+		"CurY":       current.Y,
 		"PreviewURL": previewImageURL,
 	})
 }
 
-func buildNavigationPreviewDataURL(path [][2]float64, targetIndex int, mapName string, currentX, currentY, targetX, targetY float64) string {
+func buildNavigationPreviewDataURL(path []internal.Point, targetIndex int, mapName string, current, target internal.Point) string {
 	// Prepare map image
 	mapRGBA, err := getCachedPreviewMapRGBA(mapName)
 	if err != nil {
@@ -738,14 +716,14 @@ func buildNavigationPreviewDataURL(path [][2]float64, targetIndex int, mapName s
 	}
 
 	// Prepare points to focus on
-	focusPoints := make([][2]float64, 0, 9)
+	focusPoints := make([]internal.Point, 0, 9)
 	if len(path) > 0 {
 		start := max(0, targetIndex-4)
 		end := min(len(path)-1, targetIndex+4)
 		focusPoints = append(focusPoints, path[start:end+1]...)
 	}
 	if len(focusPoints) == 0 {
-		focusPoints = append(focusPoints, [2]float64{targetX, targetY})
+		focusPoints = append(focusPoints, internal.Point{X: target.X, Y: target.Y})
 	}
 
 	drawPath := path
@@ -756,20 +734,23 @@ func buildNavigationPreviewDataURL(path [][2]float64, targetIndex int, mapName s
 	// Calculate geometry and crop map image
 	const canvasSize = 192
 
-	scale, offsetX, offsetY,
-		currentViewX, currentViewY := calcNavigationPreviewGeometry(focusPoints, currentX, currentY, canvasSize, 96, 192)
-	if scale <= 0 {
-		scale = 1.0
+	viewTransform, currentView := calcNavigationPreviewGeometry(focusPoints, current, canvasSize, 96, 192)
+	if viewTransform.ScaleX <= 0 || viewTransform.ScaleY <= 0 || viewTransform.ScaleX != viewTransform.ScaleY {
+		viewTransform = internal.LinearTransform{ScaleX: 1.0, ScaleY: 1.0}
+		currentView = viewTransform.Apply(current)
 	}
+	scale := viewTransform.ScaleX
 
 	canvas := image.NewRGBA(image.Rect(0, 0, canvasSize, canvasSize))
 	draw.Draw(canvas, canvas.Bounds(), &image.Uniform{C: color.RGBA{0xf7, 0xfb, 0xff, 0xff}}, image.Point{}, draw.Src)
 
 	b := mapRGBA.Bounds()
-	srcMinX := int(math.Floor((-offsetX) / scale))
-	srcMinY := int(math.Floor((-offsetY) / scale))
-	srcMaxX := int(math.Ceil((float64(canvasSize) - offsetX) / scale))
-	srcMaxY := int(math.Ceil((float64(canvasSize) - offsetY) / scale))
+	topLeft := viewTransform.Inverse(internal.Point{X: 0, Y: 0})
+	bottomRight := viewTransform.Inverse(internal.Point{X: canvasSize, Y: canvasSize})
+	srcMinX := int(math.Floor(topLeft.X))
+	srcMinY := int(math.Floor(topLeft.Y))
+	srcMaxX := int(math.Ceil(bottomRight.X))
+	srcMaxY := int(math.Ceil(bottomRight.Y))
 	srcMinX = max(b.Min.X, srcMinX)
 	srcMinY = max(b.Min.Y, srcMinY)
 	srcMaxX = min(b.Max.X, srcMaxX)
@@ -782,8 +763,9 @@ func buildNavigationPreviewDataURL(path [][2]float64, targetIndex int, mapName s
 	srcRect := image.Rect(srcMinX, srcMinY, srcMaxX, srcMaxY)
 	cropped := minicv.ImageCropRect(mapRGBA, srcRect)
 	scaledCrop := minicv.ImageScale(cropped, scale)
-	dstMinX := int(math.Round(offsetX + float64(srcRect.Min.X)*scale))
-	dstMinY := int(math.Round(offsetY + float64(srcRect.Min.Y)*scale))
+	dstMin := viewTransform.Apply(internal.Point{X: float64(srcRect.Min.X), Y: float64(srcRect.Min.Y)})
+	dstMinX := dstMin.IntX()
+	dstMinY := dstMin.IntY()
 	dstRect := image.Rect(dstMinX, dstMinY, dstMinX+scaledCrop.Bounds().Dx(), dstMinY+scaledCrop.Bounds().Dy())
 	draw.Draw(canvas, dstRect, scaledCrop, image.Point{}, draw.Over)
 
@@ -795,26 +777,20 @@ func buildNavigationPreviewDataURL(path [][2]float64, targetIndex int, mapName s
 	)
 
 	for i := 0; i+1 < len(drawPath); i++ {
-		x1 := int(math.Round(drawPath[i][0]*scale + offsetX))
-		y1 := int(math.Round(drawPath[i][1]*scale + offsetY))
-		x2 := int(math.Round(drawPath[i+1][0]*scale + offsetX))
-		y2 := int(math.Round(drawPath[i+1][1]*scale + offsetY))
-		minicv.ImageDrawLine(canvas, x1, y1, x2, y2, colorBlue, 3)
+		p1 := viewTransform.Apply(drawPath[i])
+		p2 := viewTransform.Apply(drawPath[i+1])
+		minicv.ImageDrawLine(canvas, p1.IntX(), p1.IntY(), p2.IntX(), p2.IntY(), colorBlue, 3)
 	}
 
 	for _, p := range drawPath {
-		x := int(math.Round(p[0]*scale + offsetX))
-		y := int(math.Round(p[1]*scale + offsetY))
-		minicv.ImageDrawFilledCircle(canvas, x, y, 4, colorBlue)
+		p_ := viewTransform.Apply(p)
+		minicv.ImageDrawFilledCircle(canvas, p_.IntX(), p_.IntY(), 4, colorBlue)
 	}
 
-	curX := int(math.Round(currentViewX))
-	curY := int(math.Round(currentViewY))
-	tgtX := int(math.Round(targetX*scale + offsetX))
-	tgtY := int(math.Round(targetY*scale + offsetY))
-	minicv.ImageDrawLine(canvas, curX, curY, tgtX, tgtY, colorRed, 3)
-	minicv.ImageDrawFilledCircle(canvas, tgtX, tgtY, 5, colorRed)
-	minicv.ImageDrawFilledCircle(canvas, curX, curY, 5, colorGreen)
+	target_ := viewTransform.Apply(target)
+	minicv.ImageDrawLine(canvas, currentView.IntX(), currentView.IntY(), target_.IntX(), target_.IntY(), colorRed, 3)
+	minicv.ImageDrawFilledCircle(canvas, target_.IntX(), target_.IntY(), 5, colorRed)
+	minicv.ImageDrawFilledCircle(canvas, currentView.IntX(), currentView.IntY(), 5, colorGreen)
 
 	// Return as base64 data URL
 	base64JPEG, err := minicv.ImageToBase64JPEG(canvas, 90)
@@ -859,9 +835,8 @@ func getCachedPreviewMapRGBA(mapName string) (*image.RGBA, error) {
 	return img, nil
 }
 
-func calcNavigationPreviewGeometry(focusPoints [][2]float64, currentX, currentY float64, canvasSize int, minSize int, maxSize int) (
-	scale, offsetX, offsetY,
-	currentViewX, currentViewY float64,
+func calcNavigationPreviewGeometry(focusPoints []internal.Point, current internal.Point, canvasSize int, minSize int, maxSize int) (
+	viewTransform internal.LinearTransform, currentView internal.Point,
 ) {
 	if canvasSize < 1 {
 		canvasSize = 1
@@ -879,19 +854,19 @@ func calcNavigationPreviewGeometry(focusPoints [][2]float64, currentX, currentY 
 
 	minX, minY := math.Inf(1), math.Inf(1)
 	maxX, maxY := math.Inf(-1), math.Inf(-1)
-	update := func(x, y float64) {
-		if math.IsNaN(x) || math.IsInf(x, 0) || math.IsNaN(y) || math.IsInf(y, 0) {
+	update := func(p internal.Point) {
+		if !p.IsValid() {
 			return
 		}
-		minX = math.Min(minX, x)
-		minY = math.Min(minY, y)
-		maxX = math.Max(maxX, x)
-		maxY = math.Max(maxY, y)
+		minX = math.Min(minX, p.X)
+		minY = math.Min(minY, p.Y)
+		maxX = math.Max(maxX, p.X)
+		maxY = math.Max(maxY, p.Y)
 	}
 	for _, p := range focusPoints {
-		update(p[0], p[1])
+		update(p)
 	}
-	update(currentX, currentY)
+	update(current)
 
 	if math.IsNaN(minX) || math.IsInf(minX, 0) ||
 		math.IsNaN(minY) || math.IsInf(minY, 0) ||
@@ -903,15 +878,14 @@ func calcNavigationPreviewGeometry(focusPoints [][2]float64, currentX, currentY 
 
 	spanX := min(max(maxX-minX, minSpan), maxSpan)
 	spanY := min(max(maxY-minY, minSpan), maxSpan)
-	scale = math.Min(previewSize/spanX, previewSize/spanY)
+	scale := math.Min(previewSize/spanX, previewSize/spanY)
 
 	centerX := (minX + maxX) * 0.5
 	centerY := (minY + maxY) * 0.5
-	offsetX = previewSize*0.5 - centerX*scale
-	offsetY = previewSize*0.5 - centerY*scale
+	offsetX := previewSize*0.5 - centerX*scale
+	offsetY := previewSize*0.5 - centerY*scale
 
-	currentViewX = currentX*scale + offsetX
-	currentViewY = currentY*scale + offsetY
-
+	viewTransform = internal.LinearTransform{ScaleX: scale, ScaleY: scale, OffsetX: offsetX, OffsetY: offsetY}
+	currentView = viewTransform.Apply(current)
 	return
 }

--- a/agent/go-service/maptracker/default/move.go
+++ b/agent/go-service/maptracker/default/move.go
@@ -277,7 +277,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 						ca.SetPlayerMovement(control.MovementWalk, control.PolicyDefault)
 						log.Info().Int("index", i).Float64("dist", dist).Dur("expectedElapsed", fineApproachExpectedElapsed).Msg("Entering fine approach")
 					} else {
-						log.Info().Int("index", i).Float64("x", curLoc.X).Float64("y", curLoc.Y).Msg("Target point reached (ordinary approach)")
+						log.Info().Int("index", i).Float64("dist", dist).Object("pos", curLoc).Msg("Target point reached (ordinary approach)")
 						finishCurrentTarget(curLoc, curRot)
 						break
 					}
@@ -288,7 +288,7 @@ func (a *MapTrackerMove) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 				}
 			}
 
-			log.Debug().Float64("curX", curLoc.X).Float64("curY", curLoc.Y).Int("curRot", curRot).Float64("dist", dist).Int("targetRot", targetRot).Msg("Navigating to target")
+			log.Debug().Object("cur", curLoc).Int("curRot", curRot).Float64("dist", dist).Int("targetRot", targetRot).Msg("Navigating to target")
 
 			// Check stuck
 			if prevLocation != nil && prevLocation.DistanceTo(curLoc) < 2.0 {

--- a/agent/go-service/maptracker/default/toward.go
+++ b/agent/go-service/maptracker/default/toward.go
@@ -142,7 +142,7 @@ func (a *MapTrackerToward) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			}
 		}
 
-		deltaRot := calcDeltaRotation(curRot, targetRot)
+		deltaRot := internal.DeltaRotation(curRot, targetRot)
 		absDeltaRot := math.Abs(float64(deltaRot))
 		log.Debug().Int("curRot", curRot).Int("targetRot", targetRot).Float64("deltaRot", float64(deltaRot)).Msg("Adjusting orientation")
 

--- a/agent/go-service/maptracker/default/toward.go
+++ b/agent/go-service/maptracker/default/toward.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"time"
 
+	internal "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/internal"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/control"
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
@@ -26,7 +27,7 @@ type MapTrackerTowardParam struct {
 	MapName string `json:"map_name,omitempty"`
 	// Target is the map coordinate the player should face toward.
 	// At least one of Angle and Target must be provided.
-	Target *[2]float64 `json:"target,omitempty"`
+	Target *internal.Point `json:"target,omitempty"`
 	// RotationThreshold is the maximum allowed angle difference in degrees to treat the player as
 	// already facing the target orientation.
 	RotationThreshold float64 `json:"rotation_threshold,omitempty"`
@@ -137,7 +138,7 @@ func (a *MapTrackerToward) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			if param.Angle != nil {
 				targetRot = ((int(math.Round(*param.Angle)) % 360) + 360) % 360
 			} else {
-				targetRot = calcTargetRotation(result.X, result.Y, param.Target[0], param.Target[1])
+				targetRot = int(math.Round(result.Loc.AngleTo(*param.Target)))
 			}
 		}
 
@@ -188,7 +189,7 @@ func (a *MapTrackerToward) parseParam(paramStr string) (*MapTrackerTowardParam, 
 		return nil, fmt.Errorf("angle contains invalid value")
 	}
 	if param.Target != nil {
-		if math.IsNaN(param.Target[0]) || math.IsInf(param.Target[0], 0) || math.IsNaN(param.Target[1]) || math.IsInf(param.Target[1], 0) {
+		if !param.Target.IsValid() {
 			return nil, fmt.Errorf("target contains invalid coordinate")
 		}
 	}

--- a/agent/go-service/maptracker/default/zipline.go
+++ b/agent/go-service/maptracker/default/zipline.go
@@ -79,10 +79,8 @@ func (a *MapTrackerZipline) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool
 
 	distance := result.Loc.DistanceTo(*param.Target)
 	log.Info().
-		Float64("curX", result.Loc.X).
-		Float64("curY", result.Loc.Y).
-		Float64("targetX", param.Target.X).
-		Float64("targetY", param.Target.Y).
+		Object("current", result.Loc).
+		Object("target", param.Target).
 		Float64("distance", distance).
 		Msg("Current location and target for MapTrackerZipline")
 

--- a/agent/go-service/maptracker/default/zipline.go
+++ b/agent/go-service/maptracker/default/zipline.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"time"
 
+	internal "github.com/MaaXYZ/MaaEnd/agent/go-service/maptracker/internal"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/control"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv"
@@ -24,7 +25,7 @@ type MapTrackerZiplineParam struct {
 	// MapName has the same definition as [MapTrackerMoveParam.MapName].
 	MapName string `json:"map_name"`
 	// Target is the map coordinate of the destination zipline.
-	Target *[2]float64 `json:"target"`
+	Target *internal.Point `json:"target"`
 	// RotationThreshold is the maximum allowed angle difference to treat the player as
 	// already facing the right direction to the destination zipline.
 	RotationThreshold float64 `json:"rotation_threshold,omitempty"`
@@ -76,12 +77,12 @@ func (a *MapTrackerZipline) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool
 		return false
 	}
 
-	distance := math.Hypot(result.X-param.Target[0], result.Y-param.Target[1])
+	distance := result.Loc.DistanceTo(*param.Target)
 	log.Info().
-		Float64("curX", result.X).
-		Float64("curY", result.Y).
-		Float64("targetX", param.Target[0]).
-		Float64("targetY", param.Target[1]).
+		Float64("curX", result.Loc.X).
+		Float64("curY", result.Loc.Y).
+		Float64("targetX", param.Target.X).
+		Float64("targetY", param.Target.Y).
 		Float64("distance", distance).
 		Msg("Current location and target for MapTrackerZipline")
 
@@ -162,7 +163,7 @@ func (a *MapTrackerZipline) parseParam(paramStr string) (*MapTrackerZiplineParam
 	if param.Target == nil {
 		return nil, fmt.Errorf("target is required in parameters")
 	}
-	if math.IsNaN(param.Target[0]) || math.IsInf(param.Target[0], 0) || math.IsNaN(param.Target[1]) || math.IsInf(param.Target[1], 0) {
+	if !param.Target.IsValid() {
 		return nil, fmt.Errorf("target contains invalid coordinate")
 	}
 	if param.RotationThreshold == 0 {
@@ -198,7 +199,7 @@ func (a *MapTrackerZipline) rotateTowardTarget(ctx *maa.Context, ctrl *maa.Contr
 			time.Sleep(rotationInterval)
 			continue
 		}
-		targetRot := calcTargetRotation(result.X, result.Y, param.Target[0], param.Target[1])
+		targetRot := int(math.Round(result.Loc.AngleTo(*param.Target)))
 		deltaRot := calcDeltaRotation(result.Rot, targetRot)
 		absDeltaRot := math.Abs(float64(deltaRot))
 		log.Debug().Int("curRot", result.Rot).Int("targetRot", targetRot).Float64("deltaRot", float64(deltaRot)).Msg("Rotating toward zipline")

--- a/agent/go-service/maptracker/default/zipline.go
+++ b/agent/go-service/maptracker/default/zipline.go
@@ -200,7 +200,7 @@ func (a *MapTrackerZipline) rotateTowardTarget(ctx *maa.Context, ctrl *maa.Contr
 			continue
 		}
 		targetRot := int(math.Round(result.Loc.AngleTo(*param.Target)))
-		deltaRot := calcDeltaRotation(result.Rot, targetRot)
+		deltaRot := internal.DeltaRotation(result.Rot, targetRot)
 		absDeltaRot := math.Abs(float64(deltaRot))
 		log.Debug().Int("curRot", result.Rot).Int("targetRot", targetRot).Float64("deltaRot", float64(deltaRot)).Msg("Rotating toward zipline")
 		if absDeltaRot <= param.RotationThreshold {

--- a/agent/go-service/maptracker/internal/algo.go
+++ b/agent/go-service/maptracker/internal/algo.go
@@ -102,7 +102,24 @@ func (lt LinearTransform) Inverse(p Point) Point {
 	}
 }
 
-/* ******** Path ******** */
+/* ******** Misc ******** */
+
+// PathBounds returns the min and max X/Y of all valid points in path.
+// Returns (+Inf, +Inf, -Inf, -Inf) when no valid points are present.
+func PathBounds(path []Point) (minX, minY, maxX, maxY float64) {
+	minX, minY = math.Inf(1), math.Inf(1)
+	maxX, maxY = math.Inf(-1), math.Inf(-1)
+	for _, p := range path {
+		if !p.IsValid() {
+			continue
+		}
+		minX = math.Min(minX, p.X)
+		minY = math.Min(minY, p.Y)
+		maxX = math.Max(maxX, p.X)
+		maxY = math.Max(maxY, p.Y)
+	}
+	return
+}
 
 // PathTotalDistance returns the cumulative Euclidean distance along a coordinate path.
 func PathTotalDistance(path []Point) float64 {
@@ -111,6 +128,18 @@ func PathTotalDistance(path []Point) float64 {
 		distance += path[i].DistanceTo(path[i-1])
 	}
 	return distance
+}
+
+// DeltaRotation returns the minimum signed angle difference from current to target in [-180, 180].
+func DeltaRotation(current, target int) int {
+	diff := target - current
+	for diff > 180 {
+		diff -= 360
+	}
+	for diff < -180 {
+		diff += 360
+	}
+	return diff
 }
 
 /* ******** Graph searching algorithms ******** */

--- a/agent/go-service/maptracker/internal/algo.go
+++ b/agent/go-service/maptracker/internal/algo.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+
+	"github.com/rs/zerolog"
 )
 
 /* ******** Point ******** */
@@ -17,6 +19,11 @@ type Point struct {
 
 func (p Point) Clone() Point {
 	return Point{X: p.X, Y: p.Y}
+}
+
+// MarshalZerologObject serializes the point as zerolog sub-fields X and Y.
+func (p Point) MarshalZerologObject(e *zerolog.Event) {
+	e.Float64("X", p.X).Float64("Y", p.Y)
 }
 
 func (p Point) MarshalJSON() ([]byte, error) {
@@ -52,6 +59,11 @@ func (p Point) IsInf() bool {
 
 func (p Point) IsValid() bool {
 	return !p.IsNaN() && !p.IsInf()
+}
+
+// InRect reports whether p lies within the axis-aligned rectangle [x, x+w) x [y, y+h).
+func (p Point) InRect(x, y, w, h float64) bool {
+	return p.X >= x && p.X < x+w && p.Y >= y && p.Y < y+h
 }
 
 // DistanceTo returns the Euclidean distance from this point to another point.

--- a/agent/go-service/maptracker/internal/algo.go
+++ b/agent/go-service/maptracker/internal/algo.go
@@ -3,27 +3,117 @@ package maptrackerinternal
 
 import (
 	"container/heap"
+	"encoding/json"
 	"fmt"
 	"math"
 )
 
-/* ******** Reusable utilities ******** */
+/* ******** Point ******** */
+
+type Point struct {
+	X float64
+	Y float64
+}
+
+func (p Point) Clone() Point {
+	return Point{X: p.X, Y: p.Y}
+}
+
+func (p Point) MarshalJSON() ([]byte, error) {
+	return json.Marshal([2]float64{p.X, p.Y})
+}
+
+func (p *Point) UnmarshalJSON(data []byte) error {
+	var arr [2]float64
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+
+	p.X = arr[0]
+	p.Y = arr[1]
+	return nil
+}
+
+func (p Point) IntX() int {
+	return int(math.Round(p.X))
+}
+
+func (p Point) IntY() int {
+	return int(math.Round(p.Y))
+}
+
+func (p Point) IsNaN() bool {
+	return math.IsNaN(p.X) || math.IsNaN(p.Y)
+}
+
+func (p Point) IsInf() bool {
+	return math.IsInf(p.X, 0) || math.IsInf(p.Y, 0)
+}
+
+func (p Point) IsValid() bool {
+	return !p.IsNaN() && !p.IsInf()
+}
+
+// DistanceTo returns the Euclidean distance from this point to another point.
+func (p Point) DistanceTo(other Point) float64 {
+	return math.Hypot(p.X-other.X, p.Y-other.Y)
+}
+
+// ManhattanDistanceTo returns the Manhattan distance from this point to another point.
+func (p Point) ManhattanDistanceTo(other Point) float64 {
+	return math.Abs(p.X-other.X) + math.Abs(p.Y-other.Y)
+}
+
+// AngleTo returns the angle in degrees [0, 360) from this point to another point,
+// where 0° is up (negative Y direction), and angles increase clockwise.
+func (p Point) AngleTo(other Point) float64 {
+	dx := other.X - p.X
+	dy := other.Y - p.Y
+
+	// 0° is up (-Y), increasing clockwise
+	angle := math.Atan2(dx, -dy) * 180 / math.Pi
+
+	// Normalize to [0, 360)
+	angle = math.Mod(angle+360, 360)
+
+	return angle
+}
+
+/* ******** Linear Transformation ******** */
+
+type LinearTransform struct {
+	ScaleX  float64
+	ScaleY  float64
+	OffsetX float64
+	OffsetY float64
+}
+
+func (lt LinearTransform) Apply(p Point) Point {
+	return Point{
+		X: p.X*lt.ScaleX + lt.OffsetX,
+		Y: p.Y*lt.ScaleY + lt.OffsetY,
+	}
+}
+
+func (lt LinearTransform) Inverse(p Point) Point {
+	return Point{
+		X: (p.X - lt.OffsetX) / lt.ScaleX,
+		Y: (p.Y - lt.OffsetY) / lt.ScaleY,
+	}
+}
+
+/* ******** Path ******** */
 
 // PathTotalDistance returns the cumulative Euclidean distance along a coordinate path.
-func PathTotalDistance(path [][2]float64) float64 {
+func PathTotalDistance(path []Point) float64 {
 	distance := 0.0
 	for i := 1; i < len(path); i++ {
-		distance += math.Hypot(path[i][0]-path[i-1][0], path[i][1]-path[i-1][1])
+		distance += path[i].DistanceTo(path[i-1])
 	}
 	return distance
 }
 
 /* ******** Graph searching algorithms ******** */
-
-type algoPoint struct {
-	x float64
-	y float64
-}
 
 type algoEdge struct {
 	to   int

--- a/agent/go-service/maptracker/internal/algo_test.go
+++ b/agent/go-service/maptracker/internal/algo_test.go
@@ -95,7 +95,7 @@ func benchmarkDijkstraPathPairs(b *testing.B, adjacency map[int][]algoEdge, pair
 	}
 }
 
-func loadBenchmarkMap02Lv002Graph(tb testing.TB) (map[int]algoPoint, map[int][]algoEdge) {
+func loadBenchmarkMap02Lv002Graph(tb testing.TB) (map[int]Point, map[int][]algoEdge) {
 	tb.Helper()
 	file, err := os.Open(filepath.Join("..", "..", "..", "..", "assets", "data", "MapTrackerNavMesh", "map02_lv002.mtnm"))
 	if err != nil {
@@ -110,7 +110,7 @@ func loadBenchmarkMap02Lv002Graph(tb testing.TB) (map[int]algoPoint, map[int][]a
 	return mesh.buildPathGraph()
 }
 
-func benchmarkReachablePathPairs(tb testing.TB, points map[int]algoPoint, adjacency map[int][]algoEdge, count int) []benchmarkPathPair {
+func benchmarkReachablePathPairs(tb testing.TB, points map[int]Point, adjacency map[int][]algoEdge, count int) []benchmarkPathPair {
 	tb.Helper()
 	ids := make([]int, 0, len(points))
 	for id := range points {

--- a/agent/go-service/maptracker/internal/nav_mesh.go
+++ b/agent/go-service/maptracker/internal/nav_mesh.go
@@ -69,8 +69,7 @@ type NavMeshMeta struct {
 // NavMeshVertex represents a vertex in a MapTracker NavMesh.
 type NavMeshVertex struct {
 	ID       int
-	X        float64
-	Y        float64
+	Pos      Point
 	TierID   int
 	EntityID int64
 	Flags    int
@@ -89,8 +88,7 @@ type NavMeshEdge struct {
 // NavMeshTemporaryVertex represents a runtime-only vertex injected into a NavMesh.
 type NavMeshTemporaryVertex struct {
 	ID                 int
-	X                  float64
-	Y                  float64
+	Pos                Point
 	CostFactor         float64
 	MaxConnectDistance float64
 }
@@ -241,7 +239,7 @@ func ParseNavMesh(r io.Reader) (*NavMesh, error) {
 }
 
 // AddTemporaryVertex injects a runtime-only vertex with a negative ID.
-func (m *NavMesh) AddTemporaryVertex(x, y, costFactor, maxConnectDistance float64) (int, NavMeshTemporaryVertex) {
+func (m *NavMesh) AddTemporaryVertex(pos Point, costFactor, maxConnectDistance float64) (int, NavMeshTemporaryVertex) {
 	if m.TemporaryVertices == nil {
 		m.TemporaryVertices = map[int]NavMeshTemporaryVertex{}
 	}
@@ -252,7 +250,7 @@ func (m *NavMesh) AddTemporaryVertex(x, y, costFactor, maxConnectDistance float6
 		}
 		id += navMeshTemporaryIDOffset
 	}
-	vertex := NavMeshTemporaryVertex{ID: id, X: x, Y: y, CostFactor: costFactor, MaxConnectDistance: maxConnectDistance}
+	vertex := NavMeshTemporaryVertex{ID: id, Pos: pos, CostFactor: costFactor, MaxConnectDistance: maxConnectDistance}
 	m.TemporaryVertices[id] = vertex
 	return id, vertex
 }
@@ -263,7 +261,7 @@ func (m *NavMesh) ClearTemporaryVertex() {
 }
 
 // AddRuntimeVertex injects a runtime-only graph vertex with a negative ID.
-func (m *NavMesh) AddRuntimeVertex(x, y float64, tierID int, entityID int64, flags int) (int, NavMeshVertex) {
+func (m *NavMesh) AddRuntimeVertex(pos Point, tierID int, entityID int64, flags int) (int, NavMeshVertex) {
 	if m.RuntimeVertices == nil {
 		m.RuntimeVertices = map[int]NavMeshVertex{}
 	}
@@ -274,7 +272,7 @@ func (m *NavMesh) AddRuntimeVertex(x, y float64, tierID int, entityID int64, fla
 		}
 		id += navMeshRuntimeIDOffset
 	}
-	vertex := NavMeshVertex{ID: id, X: roundNavMeshCoord(x), Y: roundNavMeshCoord(y), TierID: tierID, EntityID: entityID, Flags: flags}
+	vertex := NavMeshVertex{ID: id, Pos: Point{X: roundNavMeshCoord(pos.X), Y: roundNavMeshCoord(pos.Y)}, TierID: tierID, EntityID: entityID, Flags: flags}
 	m.RuntimeVertices[id] = vertex
 	return id, vertex
 }
@@ -334,19 +332,19 @@ func (m *NavMesh) IsZiplineEdge(fromID, toID int) (NavMeshEdge, bool) {
 }
 
 // VertexPoint returns a vertex coordinate by ID.
-func (m *NavMesh) VertexPoint(id int) ([2]float64, bool) {
+func (m *NavMesh) VertexPoint(id int) (Point, bool) {
 	vertex, ok := m.vertexByID(id)
 	if ok {
-		return [2]float64{vertex.X, vertex.Y}, true
+		return vertex.Pos, true
 	}
 	if temporary, ok := m.TemporaryVertices[id]; ok {
-		return [2]float64{temporary.X, temporary.Y}, true
+		return temporary.Pos, true
 	}
-	return [2]float64{}, false
+	return Point{}, false
 }
 
 // FindPath finds a coordinate path between vertices through this NavMesh.
-func (m *NavMesh) FindPath(startID, targetID int) ([][2]float64, error) {
+func (m *NavMesh) FindPath(startID, targetID int) ([]Point, error) {
 	pathIDs, err := m.FindPathIDs(startID, targetID)
 	if err != nil {
 		return nil, err
@@ -389,17 +387,17 @@ func (m *NavMesh) FindPathIDs(startID, targetID int) ([]int, error) {
 }
 
 // PathIDsToPoints converts a vertex ID path to a coordinate path.
-func (m *NavMesh) PathIDsToPoints(pathIDs []int) ([][2]float64, error) {
+func (m *NavMesh) PathIDsToPoints(pathIDs []int) ([]Point, error) {
 	if len(pathIDs) == 0 {
 		return nil, fmt.Errorf("path is empty")
 	}
-	path := make([][2]float64, 0, len(pathIDs))
+	path := make([]Point, 0, len(pathIDs))
 	for _, id := range pathIDs {
 		point, ok := m.VertexPoint(id)
 		if !ok {
 			return nil, fmt.Errorf("path vertex %d not found", id)
 		}
-		if len(path) > 0 && math.Hypot(path[len(path)-1][0]-point[0], path[len(path)-1][1]-point[1]) < 1e-6 {
+		if len(path) > 0 && path[len(path)-1].DistanceTo(point) < 1e-6 {
 			continue
 		}
 		path = append(path, point)
@@ -554,7 +552,7 @@ func parseNavMeshVertex(line string) (NavMeshVertex, error) {
 		return NavMeshVertex{}, err
 	}
 
-	return NavMeshVertex{ID: id, X: roundNavMeshCoord(x), Y: roundNavMeshCoord(y), TierID: tierID, EntityID: entityID, Flags: flags}, nil
+	return NavMeshVertex{ID: id, Pos: Point{X: roundNavMeshCoord(x), Y: roundNavMeshCoord(y)}, TierID: tierID, EntityID: entityID, Flags: flags}, nil
 }
 
 func parseNavMeshEdge(line string) (NavMeshEdge, error) {
@@ -629,30 +627,30 @@ func roundNavMeshCoord(value float64) float64 {
 	return math.Round(value*1000) / 1000
 }
 
-func (m *NavMesh) buildPathGraph() (map[int]algoPoint, map[int][]algoEdge) {
-	points := map[int]algoPoint{}
+func (m *NavMesh) buildPathGraph() (map[int]Point, map[int][]algoEdge) {
+	points := map[int]Point{}
 	adjacency := map[int][]algoEdge{}
 	for id, vertex := range m.Vertices {
 		if m.DisabledVertices[id] || vertex.Flags&NavMeshVertexFlagHidden != 0 {
 			continue
 		}
-		points[id] = algoPoint{x: vertex.X, y: vertex.Y}
+		points[id] = vertex.Pos
 	}
 	for id, vertex := range m.RuntimeVertices {
 		if m.DisabledVertices[id] || vertex.Flags&NavMeshVertexFlagHidden != 0 {
 			continue
 		}
-		points[id] = algoPoint{x: vertex.X, y: vertex.Y}
+		points[id] = vertex.Pos
 	}
 	for id, vertex := range m.TemporaryVertices {
-		points[id] = algoPoint{x: vertex.X, y: vertex.Y}
+		points[id] = vertex.Pos
 	}
 	m.appendPathGraphEdges(points, adjacency, m.Edges)
 	m.appendPathGraphEdges(points, adjacency, m.RuntimeEdges)
 	return points, adjacency
 }
 
-func (m *NavMesh) appendPathGraphEdges(points map[int]algoPoint, adjacency map[int][]algoEdge, edges map[int]NavMeshEdge) {
+func (m *NavMesh) appendPathGraphEdges(points map[int]Point, adjacency map[int][]algoEdge, edges map[int]NavMeshEdge) {
 	for _, edge := range edges {
 		if m.DisabledEdges[edge.ID] || m.DisabledVertices[edge.SourceID] || m.DisabledVertices[edge.DestinationID] {
 			continue
@@ -724,7 +722,7 @@ func (m *NavMesh) appendPathConnectCandidates(candidates *[]navMeshConnectCandid
 		if m.DisabledVertices[id] || vertex.Flags&NavMeshVertexFlagHidden != 0 {
 			continue
 		}
-		dist := math.Hypot(vertex.X-temporaryVertex.X, vertex.Y-temporaryVertex.Y)
+		dist := temporaryVertex.Pos.DistanceTo(vertex.Pos)
 		if dist < temporaryVertex.MaxConnectDistance {
 			*candidates = append(*candidates, navMeshConnectCandidate{id: id, dist: dist, cost: temporaryVertex.CostFactor * dist})
 		}
@@ -748,21 +746,21 @@ func (m *NavMesh) temporaryEdgeCost(fromID, toID int) float64 {
 	fromTemporary, fromOK := m.TemporaryVertices[fromID]
 	toTemporary, toOK := m.TemporaryVertices[toID]
 	if fromOK && toOK {
-		return math.Max(fromTemporary.CostFactor, toTemporary.CostFactor) * math.Hypot(fromTemporary.X-toTemporary.X, fromTemporary.Y-toTemporary.Y)
+		return math.Max(fromTemporary.CostFactor, toTemporary.CostFactor) * fromTemporary.Pos.DistanceTo(toTemporary.Pos)
 	}
 	if fromOK {
 		vertex, ok := m.vertexByID(toID)
 		if !ok {
 			return 0
 		}
-		return fromTemporary.CostFactor * math.Hypot(fromTemporary.X-vertex.X, fromTemporary.Y-vertex.Y)
+		return fromTemporary.CostFactor * fromTemporary.Pos.DistanceTo(vertex.Pos)
 	}
 	if toOK {
 		vertex, ok := m.vertexByID(fromID)
 		if !ok {
 			return 0
 		}
-		return toTemporary.CostFactor * math.Hypot(toTemporary.X-vertex.X, toTemporary.Y-vertex.Y)
+		return toTemporary.CostFactor * toTemporary.Pos.DistanceTo(vertex.Pos)
 	}
 	return 0
 }

--- a/agent/go-service/maptracker/internal/nav_mesh_test.go
+++ b/agent/go-service/maptracker/internal/nav_mesh_test.go
@@ -53,17 +53,17 @@ func TestFindPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseNavMesh() error = %v", err)
 	}
-	path, err := findTemporaryPath(mesh, [2]float64{-1, 0}, [2]float64{11, 0})
+	path, err := findTemporaryPath(mesh, Point{X: -1, Y: 0}, Point{X: 11, Y: 0})
 	if err != nil {
 		t.Fatalf("FindPath() error = %v", err)
 	}
 	if len(path) < 3 {
 		t.Fatalf("len(path) = %d, path = %+v", len(path), path)
 	}
-	if path[0] != [2]float64{-1, 0} {
+	if path[0] != (Point{X: -1, Y: 0}) {
 		t.Fatalf("path[0] = %+v", path[0])
 	}
-	if path[len(path)-1] != [2]float64{11, 0} {
+	if path[len(path)-1] != (Point{X: 11, Y: 0}) {
 		t.Fatalf("path last = %+v", path[len(path)-1])
 	}
 }
@@ -73,11 +73,11 @@ func TestFindPathUsesTemporaryVertexConnection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseNavMesh() error = %v", err)
 	}
-	path, err := findTemporaryPath(mesh, [2]float64{0, 0}, [2]float64{5, 5})
+	path, err := findTemporaryPath(mesh, Point{X: 0, Y: 0}, Point{X: 5, Y: 5})
 	if err != nil {
 		t.Fatalf("FindPath() error = %v", err)
 	}
-	assertNavMeshPath(t, path, [][2]float64{{0, 0}, {5, 5}})
+	assertNavMeshPath(t, path, []Point{{X: 0, Y: 0}, {X: 5, Y: 5}})
 }
 
 func TestFindPathRejectsFarConnectPoints(t *testing.T) {
@@ -85,7 +85,7 @@ func TestFindPathRejectsFarConnectPoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseNavMesh() error = %v", err)
 	}
-	if _, err := findTemporaryPath(mesh, [2]float64{-100, 0}, [2]float64{11, 0}); err == nil {
+	if _, err := findTemporaryPath(mesh, Point{X: -100, Y: 0}, Point{X: 11, Y: 0}); err == nil {
 		t.Fatalf("FindPath() error = nil")
 	}
 }
@@ -95,8 +95,8 @@ func TestTemporaryVertexIDsAreNegative(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseNavMesh() error = %v", err)
 	}
-	firstID, first := mesh.AddTemporaryVertex(1, 2, 1.05, 20)
-	secondID, second := mesh.AddTemporaryVertex(3, 4, 1.05, 20)
+	firstID, first := mesh.AddTemporaryVertex(Point{X: 1, Y: 2}, 1.05, 20)
+	secondID, second := mesh.AddTemporaryVertex(Point{X: 3, Y: 4}, 1.05, 20)
 	if firstID != -1 || first.ID != -1 || secondID != -2 || second.ID != -2 {
 		t.Fatalf("unexpected temporary vertices: firstID=%d first=%+v secondID=%d second=%+v", firstID, first, secondID, second)
 	}
@@ -111,9 +111,9 @@ func TestPathConnectPlansSupportThreeTemporaryVertices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseNavMesh() error = %v", err)
 	}
-	mesh.AddTemporaryVertex(0, 0, 1.05, 20)
-	mesh.AddTemporaryVertex(10, 0, 1.05, 20)
-	mesh.AddTemporaryVertex(11, 0, 1.05, 20)
+	mesh.AddTemporaryVertex(Point{X: 0, Y: 0}, 1.05, 20)
+	mesh.AddTemporaryVertex(Point{X: 10, Y: 0}, 1.05, 20)
+	mesh.AddTemporaryVertex(Point{X: 11, Y: 0}, 1.05, 20)
 	plans := mesh.pathConnectPlans()
 	if len(plans) == 0 {
 		t.Fatalf("pathConnectPlans() returned no plans")
@@ -128,8 +128,8 @@ func TestTemporaryEdgeCostUsesMaxCostFactorBetweenTemporaryVertices(t *testing.T
 	if err != nil {
 		t.Fatalf("ParseNavMesh() error = %v", err)
 	}
-	leftID, _ := mesh.AddTemporaryVertex(0, 0, 1.05, 20)
-	rightID, _ := mesh.AddTemporaryVertex(3, 4, 2.0, 20)
+	leftID, _ := mesh.AddTemporaryVertex(Point{X: 0, Y: 0}, 1.05, 20)
+	rightID, _ := mesh.AddTemporaryVertex(Point{X: 3, Y: 4}, 2.0, 20)
 	if cost := mesh.temporaryEdgeCost(leftID, rightID); cost != 10 {
 		t.Fatalf("temporaryEdgeCost() = %v", cost)
 	}
@@ -160,8 +160,8 @@ E3=S3,D4,B1,C10,F()
 	if err != nil {
 		t.Fatalf("ParseNavMesh() error = %v", err)
 	}
-	leftID, _ := mesh.AddRuntimeVertex(0, 0, 0, 0, NavMeshVertexFlagZipline)
-	rightID, _ := mesh.AddRuntimeVertex(30, 0, 0, 0, NavMeshVertexFlagZipline)
+	leftID, _ := mesh.AddRuntimeVertex(Point{X: 0, Y: 0}, 0, 0, NavMeshVertexFlagZipline)
+	rightID, _ := mesh.AddRuntimeVertex(Point{X: 30, Y: 0}, 0, 0, NavMeshVertexFlagZipline)
 	mesh.AddRuntimeEdge(-100, leftID, 1, true, 0.1, 0)
 	mesh.AddRuntimeEdge(-101, rightID, 4, true, 0.1, 0)
 	mesh.AddRuntimeEdge(-102, leftID, rightID, true, 1, NavMeshEdgeFlagZipline)
@@ -189,7 +189,7 @@ func TestDisableRuntimeZiplineVertex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseNavMesh() error = %v", err)
 	}
-	ziplineID, _ := mesh.AddRuntimeVertex(5, 0, 0, 0, NavMeshVertexFlagZipline)
+	ziplineID, _ := mesh.AddRuntimeVertex(Point{X: 5, Y: 0}, 0, 0, NavMeshVertexFlagZipline)
 	mesh.AddRuntimeEdge(-100, 1, ziplineID, true, 1, 0)
 	mesh.AddRuntimeEdge(-101, ziplineID, 2, true, 1, 0)
 	mesh.DisableVertex(ziplineID)
@@ -229,14 +229,14 @@ func TestParseNavMeshRejectsInvalidData(t *testing.T) {
 	}
 }
 
-func findTemporaryPath(mesh *NavMesh, start [2]float64, target [2]float64) ([][2]float64, error) {
+func findTemporaryPath(mesh *NavMesh, start, target Point) ([]Point, error) {
 	mesh.ClearTemporaryVertex()
-	startID, _ := mesh.AddTemporaryVertex(start[0], start[1], 1.05, 20)
-	targetID, _ := mesh.AddTemporaryVertex(target[0], target[1], 1.05, 20)
+	startID, _ := mesh.AddTemporaryVertex(start, 1.05, 20)
+	targetID, _ := mesh.AddTemporaryVertex(target, 1.05, 20)
 	return mesh.FindPath(startID, targetID)
 }
 
-func assertNavMeshPath(t *testing.T, actual [][2]float64, expected [][2]float64) {
+func assertNavMeshPath(t *testing.T, actual []Point, expected []Point) {
 	t.Helper()
 	if len(actual) != len(expected) {
 		t.Fatalf("len(path) = %d, path = %+v, expected = %+v", len(actual), actual, expected)
@@ -281,7 +281,7 @@ func TestParseRealNavMesh(t *testing.T) {
 	if !ok {
 		t.Fatalf("known entity vertex not found")
 	}
-	path, err := findTemporaryPath(mesh, [2]float64{vertex.X, vertex.Y}, [2]float64{vertex.X + 1, vertex.Y + 1})
+	path, err := findTemporaryPath(mesh, vertex.Pos, Point{X: vertex.Pos.X + 1, Y: vertex.Pos.Y + 1})
 	if err != nil {
 		t.Fatalf("FindPath() on real navmesh error = %v", err)
 	}

--- a/agent/go-service/maptracker/internal/resource.go
+++ b/agent/go-service/maptracker/internal/resource.go
@@ -72,6 +72,17 @@ func (m *MapCache) GetIntegralArray() minicv.IntegralArray {
 	return *m.cachedIntegralArray
 }
 
+// PixelTransform returns the coordinate transform that maps map coordinates
+// to pixel positions in the scaled map image at the given scale.
+func (m MapCache) PixelTransform(scale float64) LinearTransform {
+	return LinearTransform{
+		ScaleX:  scale,
+		ScaleY:  scale,
+		OffsetX: -float64(m.OffsetX) * scale,
+		OffsetY: -float64(m.OffsetY) * scale,
+	}
+}
+
 // InitRawMaps initializes global raw maps cache exactly once.
 func (r *MapTrackerResource) InitRawMaps(ctx *maa.Context) {
 	r.RawMapsOnce.Do(func() {


### PR DESCRIPTION
## 概要

此 PR 对 MapTracker 模块代码进行了重构。主要的内容是统一使用 Point 结构体表示点，同时提取了多个公共函数、简化了部分日志。

此外移除了某些弃用的测试、更新了 SKILL 文档。

## Summary by Sourcery

重构 MapTracker 模块以采用统一的 Point 结构体表示坐标，并将几何工具集中管理。

Enhancements:
- 在移动、目标、滑索（zipline）、朝向（toward）以及导航预览逻辑中，用内部 `Point` 类型替换原有的 `[2]float64` 原始坐标数组。
- 在 internal 包中引入可复用的几何辅助工具，包括 Point 运算、线性变换、路径边界计算以及旋转增量（rotation delta）计算。
- 更新 NavMesh 结构和路径规划逻辑，使其基于 `Point` 类型的顶点坐标和路径工作，从而简化距离计算和绘制逻辑。
- 调整日志与 JSON 序列化，用 `Point` 类型表示位置信息，同时在推理结果中保持向后兼容性。

Tests:
- 更新 NavMesh 路径规划测试以适配基于 `Point` 的路径，并移除已过时的兼容性测试（这些测试曾验证特定区域坐标转换逻辑）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the MapTracker module to adopt a unified Point struct for coordinates and centralize geometry utilities.

Enhancements:
- Replace raw [2]float64 coordinate arrays with an internal Point type across movement, goal, zipline, toward, and navigation preview logic.
- Introduce reusable geometry helpers in the internal package, including Point operations, linear transforms, path bounds, and rotation delta computation.
- Update NavMesh structures and pathfinding to work with Point-based vertex positions and paths, simplifying distance and drawing calculations.
- Adjust logging and JSON serialization to represent positions via the Point type while preserving backward compatibility in inference results.

Tests:
- Update NavMesh pathfinding tests to work with Point-based paths and remove outdated compatibility tests that asserted specific regional coordinate conversions.

</details>