### PR TITLE
perf: 优化选剑演武识别速度

### DIFF
--- a/agent/go-service/trialofswordmancy/abandstate.go
+++ b/agent/go-service/trialofswordmancy/abandstate.go
@@ -1,21 +1,77 @@
 package trialofswordmancy
 
-import "sync"
+import (
+	"strconv"
+	"sync"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+var _ maa.CustomRecognitionRunner = &AbandRecognition{}
+
+// AbandRecognition 从当前截图中已显示的放弃确认文本识别剩余放弃次数。
+// 它只读取文本并更新缓存，不负责打开弹窗、等待界面或关闭弹窗。
+type AbandRecognition struct{}
+
+// Run 识别放弃确认弹窗文本，并将剩余放弃次数写入总成识别使用的缓存。
+func (r *AbandRecognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa.CustomRecognitionResult, bool) {
+	if arg == nil || arg.Img == nil {
+		log.Error().Str("component", component).Msg("aband recognition arg or image is nil")
+		return nil, false
+	}
+
+	count := 0
+	text := ""
+	exhausted, ok := recognizeAbandExhausted(ctx, arg)
+	if !ok {
+		return nil, false
+	}
+	if !exhausted {
+		var ok bool
+		text, ok = ocrNodeText(ctx, arg.Img, nodeAbandPopup)
+		if !ok {
+			log.Warn().Str("component", component).Msg("aband popup OCR failed")
+			return nil, false
+		}
+
+		var parsed bool
+		count, parsed = parseFirstInt(text)
+		if !parsed {
+			log.Warn().Str("component", component).Str("ocr", text).Msg("failed to parse remaining aband count")
+			return nil, false
+		}
+	}
+
+	setAband(count)
+	log.Info().Str("component", component).Int("aband", count).Str("ocr", text).Msg("remaining aband count recognized")
+
+	return &maa.CustomRecognitionResult{Box: arg.Roi, Detail: strconv.Itoa(count)}, true
+}
+
+func recognizeAbandExhausted(ctx *maa.Context, arg *maa.CustomRecognitionArg) (bool, bool) {
+	detail, err := ctx.RunRecognition(nodeAbandExhausted, arg.Img, nil)
+	if err != nil || detail == nil {
+		log.Warn().Err(err).Str("component", component).Msg("aband exhausted ColorMatch failed")
+		return false, false
+	}
+	return detail.Hit, true
+}
 
 // 剩余放弃次数的持久化（唯一带状态的字段）。
 //
 // 为何这一项要持久化、不能像其它字段那样每步从截图读：界面上不直接显示剩余放弃次数，
 // 只有点击「放弃」后弹出的确认框里才写（「本日剩余放弃次数x次」/「已用完」）。
-// 所以采用「探测-缓存」：未知(-1)时点一下放弃、OCR 弹窗、点取消回到正常界面，拿到次数并缓存；
-// 之后步骤直接读缓存。
+// 所以由 Pipeline 负责打开和关闭放弃弹窗，RecognizeAband 只识别当前弹窗文本并缓存次数；
+// 之后总成识别直接读缓存。
 //
 // 生命周期：
 //   - 进程内初始化为 -1（未知）。
 //   - 路由到 放弃(Abandon) 或 开始演算(Calculate) 时重置为 -1——前者因为放弃会扣 1 次（缓存失效），
-//     后者作为回合结束的统一兜底，下回合首步重新探测。
+//     后者作为回合结束的统一兜底，下回合重新识别。
 var (
 	abandMu    sync.Mutex
-	abandCount = -1 // -1 = 未知，需探测
+	abandCount = -1 // -1 = 未知，需从放弃弹窗识别
 )
 
 func getAband() int {
@@ -30,7 +86,7 @@ func setAband(n int) {
 	abandCount = n
 }
 
-// resetAband 把缓存的剩余放弃次数置为 -1（未知），下次 recognition 会重新探测。
+// resetAband 把缓存的剩余放弃次数置为 -1（未知），等待 RecognizeAband 重新识别。
 func resetAband() {
 	abandMu.Lock()
 	defer abandMu.Unlock()

--- a/agent/go-service/trialofswordmancy/nodes.go
+++ b/agent/go-service/trialofswordmancy/nodes.go
@@ -4,8 +4,9 @@ package trialofswordmancy
 const (
 	component = "trialofswordmancy"
 
-	recognitionName = "TrialOfSwordmancy.Recognize" // pipeline 节点的 custom_recognition
-	decideName      = "TrialOfSwordmancy.Decide"    // pipeline 节点的 custom_action
+	recognitionName      = "TrialOfSwordmancy.Recognize"      // pipeline 节点的 custom_recognition
+	abandRecognitionName = "TrialOfSwordmancy.RecognizeAband" // 放弃弹窗文本 custom_recognition
+	decideName           = "TrialOfSwordmancy.Decide"         // pipeline 节点的 custom_action
 )
 
 // pipeline 节点名常量。
@@ -27,20 +28,16 @@ const (
 	nodeGiveUp     = "TrialOfSwordmancyDailyGiveUp" // 放弃本局 → 确认 → 重置寻路 → 回主入口
 	nodeStartTrial = "TrialOfSwordmancyStartTrial"  // 开始演算 → 编队 → 战斗 → 领奖
 
-	// 探测剩余放弃次数的两段子链入口（节点定义在 TrialOfSwordmancyCommon.json，go 经 ctx.RunTask 触发）：
-	//   - ClickGiveUp：点放弃 → 轮询等弹窗（弹窗留屏，go 夹在中间读 OCR）。
-	//   - ClickCancel：点取消 → 轮询等回抽牌页 → freeze。
-	nodeAbandProbeClickGiveUp = "TrialOfSwordmancyAbandProbeClickGiveUp"
-	nodeAbandProbeClickCancel = "TrialOfSwordmancyAbandProbeClickCancel"
 )
 
 // go-service 专用识别节点名（定义在 TrialOfSwordmancyCommon.json 的 [go] 区，ROI/模板都在 JSON 里）。
 // Go 经 ctx.RunRecognition 按名调用并解析结果，不硬编码坐标。
 const (
-	nodeRemainCalc   = "TrialOfSwordmancyRemainCalc"   // OCR：本日剩余演算次数
-	nodeRemainDouble = "TrialOfSwordmancyRemainDouble" // OCR：剩余翻倍次数
-	nodeAbandPopup   = "TrialOfSwordmancyAbandPopup"   // OCR：放弃确认弹窗文本
-	nodeIsDoubled    = "TrialOfSwordmancyIsDoubled"    // 模板：已翻倍指示
+	nodeRemainCalc     = "TrialOfSwordmancyRemainCalc"     // OCR：本日剩余演算次数
+	nodeRemainDouble   = "TrialOfSwordmancyRemainDouble"   // OCR：剩余翻倍次数
+	nodeAbandPopup     = "TrialOfSwordmancyAbandPopup"     // OCR：放弃确认弹窗文本
+	nodeAbandExhausted = "TrialOfSwordmancyAbandExhausted" // ColorMatch：放弃次数耗尽时的红色文本
+	nodeIsDoubled      = "TrialOfSwordmancyIsDoubled"      // 模板：已翻倍指示
 
 	nodeDeck               = "TrialOfSwordmancyDeck"         // OCR：牌库整列库存数
 	nodeDeckCountPrefix    = "TrialOfSwordmancyDeckCount"    // + "1".."5"：牌库各点数库存数 OCR

--- a/agent/go-service/trialofswordmancy/nodes.go
+++ b/agent/go-service/trialofswordmancy/nodes.go
@@ -44,6 +44,7 @@ const (
 	nodeAbandPopup   = "TrialOfSwordmancyAbandPopup"   // OCR：放弃确认弹窗文本
 	nodeIsDoubled    = "TrialOfSwordmancyIsDoubled"    // 模板：已翻倍指示
 
+	nodeDeck            = "TrialOfSwordmancyDeck"      // OCR：牌库整列库存数
 	nodeDeckCountPrefix = "TrialOfSwordmancyDeckCount" // + "1".."5"：牌库各点数库存数 OCR
 	nodeHandPointPrefix = "TrialOfSwordmancyHandPoint" // + "1".."5"：手牌各槽点数位（模板，运行时 override template）
 )

--- a/agent/go-service/trialofswordmancy/nodes.go
+++ b/agent/go-service/trialofswordmancy/nodes.go
@@ -14,8 +14,6 @@ const (
 	decideNode = "TrialOfSwordmancyDecide"
 
 	// 抽牌界面通用识别节点（定义在 TrialOfSwordmancyCommon.json）。
-	nodeRewardMode          = "TrialOfSwordmancyRewardMode"          // 奖励演算模式标志
-	nodeDrawCard            = "TrialOfSwordmancyDrawCard"            // 抽牌按钮
 	nodeDoubleReward        = "TrialOfSwordmancyDoubleReward"        // 翻倍按钮
 	nodeOverflowExclamation = "TrialOfSwordmancyOverflowExclamation" // 溢出（爆表）叹号
 

--- a/agent/go-service/trialofswordmancy/nodes.go
+++ b/agent/go-service/trialofswordmancy/nodes.go
@@ -44,12 +44,8 @@ const (
 	nodeAbandPopup   = "TrialOfSwordmancyAbandPopup"   // OCR：放弃确认弹窗文本
 	nodeIsDoubled    = "TrialOfSwordmancyIsDoubled"    // 模板：已翻倍指示
 
-	nodeDeck            = "TrialOfSwordmancyDeck"      // OCR：牌库整列库存数
-	nodeDeckCountPrefix = "TrialOfSwordmancyDeckCount" // + "1".."5"：牌库各点数库存数 OCR
-	nodeHandPointPrefix = "TrialOfSwordmancyHandPoint" // + "1".."5"：手牌各槽点数位（模板，运行时 override template）
+	nodeDeck               = "TrialOfSwordmancyDeck"         // OCR：牌库整列库存数
+	nodeDeckCountPrefix    = "TrialOfSwordmancyDeckCount"    // + "1".."5"：牌库各点数库存数 OCR
+	nodeHandPointPrefix    = "TrialOfSwordmancyHandPoint"    // + "1".."5"：各点数模板整行匹配
+	nodeHandPositionPrefix = "TrialOfSwordmancyHandPosition" // + "1".."5"：手牌槽位 ROI
 )
-
-// Point 模板路径前缀：Point1.png … Point5.png。
-// recognizePointValue 运行时把对应模板 override 到 TrialOfSwordmancyHandPoint{slot} 上（roi 由该节点定），
-// 取各点数最高分得该槽点数。
-const pointTemplatePrefix = "TrialOfSwordmancy/Point"

--- a/agent/go-service/trialofswordmancy/recognition.go
+++ b/agent/go-service/trialofswordmancy/recognition.go
@@ -2,7 +2,6 @@ package trialofswordmancy
 
 import (
 	"encoding/json"
-	"fmt"
 	"image"
 	"strconv"
 	"strings"
@@ -22,7 +21,7 @@ var _ maa.CustomRecognitionRunner = &Recognition{}
 //
 // 各字段来源（ROI/模板都在 TrialOfSwordmancyCommon.json 的 [go] 节点里，Go 按名调用 maafw）：
 //   - 屏幕态：RewardMode / DrawCard 在场 → 处于抽牌界面。
-//   - Hand：5 个手牌位（HandPoint1-5）匹配 Point1-5.png，命中即该槽点数+在场。
+//   - Hand：HandPoint1-5 分别整行匹配 Point1-5.png，按 HandPosition1-5 ROI 归槽。
 //   - Deck：牌库「剩余库存」整列 OCR（Deck，按 DeckCount1-5 ROI 分组，抽牌递减）；总牌量 = 剩余 + 手牌。
 //   - RemainCalc / RemainDouble：OCR（RemainCalc / RemainDouble 节点）。
 //   - RemainAband：持久化缓存；未知(-1)时探测（点放弃→OCR 弹窗→取消）。
@@ -139,18 +138,46 @@ func (r *Recognition) detectOverflow(ctx *maa.Context, img image.Image) bool {
 	return runTemplateHit(ctx, img, nodeOverflowExclamation)
 }
 
-// recognizeHand 识别 5 个手牌位置的点数。每个位置（HandPoint1-5 节点）上匹配 Point1-5.png，
-// 最高分模板即该牌点数，同时表示该槽有牌；都没中 → 空槽。
+// recognizeHand 跑 HandPoint1-5 五个整行模板节点，再按 HandPosition1-5 ROI 筛选各槽点数。
+// 同一槽命中多个点数模板时取最高分；都没中则为空槽。
 func (r *Recognition) recognizeHand(ctx *maa.Context, img image.Image) (handCounts [5]int, handRaw [5]int) {
-	for slot := 0; slot < 5; slot++ {
-		point, hit := recognizePointValue(ctx, img, slot)
-		if !hit {
+	var rois [5]maa.Rect
+	for i := range rois {
+		roi, err := nodeROI(ctx, nodeHandPositionPrefix+strconv.Itoa(i+1))
+		if err != nil {
+			return handCounts, handRaw
+		}
+		rois[i] = roi
+	}
+
+	var bestScores [5]float64
+	for point := 1; point <= 5; point++ {
+		detail, err := ctx.RunRecognition(nodeHandPointPrefix+strconv.Itoa(point), img, nil)
+		if err != nil || detail == nil || detail.Results == nil {
 			continue
 		}
-		if point >= 1 && point <= 5 {
+		for _, result := range detail.Results.Filtered {
+			if result == nil {
+				continue
+			}
+			tm, ok := result.AsTemplateMatch()
+			if !ok || tm == nil {
+				continue
+			}
+			for slot, roi := range rois {
+				if rectContains(roi, tm.Box) && tm.Score > bestScores[slot] {
+					bestScores[slot] = tm.Score
+					handRaw[slot] = point
+					break
+				}
+			}
+		}
+	}
+
+	for _, point := range handRaw {
+		if point != 0 {
 			handCounts[point-1]++
 		}
-		handRaw[slot] = point
 	}
 	return handCounts, handRaw
 }
@@ -329,67 +356,6 @@ func runTemplateHit(ctx *maa.Context, img image.Image, nodeName string) bool {
 		return false
 	}
 	return detail.Hit
-}
-
-// recognizePointValue 在第 slot 个手牌位上匹配 Point1-5.png，返回最高分的点数（1-5）。
-// 槽位 roi 由 HandPoint{slot+1} 节点定，Go 只 override template 逐点取分。
-func recognizePointValue(ctx *maa.Context, img image.Image, slot int) (int, bool) {
-	nodeName := nodeHandPointPrefix + strconv.Itoa(slot+1)
-	bestPoint := 0
-	bestScore := 0.0
-	for point := 1; point <= 5; point++ {
-		tpl := fmt.Sprintf("%s%d.png", pointTemplatePrefix, point)
-		score, hit := runHandPointScore(ctx, img, nodeName, tpl)
-		if !hit {
-			continue
-		}
-		if score > bestScore {
-			bestScore = score
-			bestPoint = point
-		}
-	}
-	return bestPoint, bestPoint != 0
-}
-
-// runHandPointScore 把 HandPoint 节点的 template override 成指定模板后跑识别，返回 (score, hit)。
-func runHandPointScore(ctx *maa.Context, img image.Image, nodeName, templatePath string) (float64, bool) {
-	if err := overrideTemplate(ctx, nodeName, templatePath); err != nil {
-		log.Warn().Err(err).Str("component", component).Str("template", templatePath).Msg("override hand-point template 失败")
-		return 0, false
-	}
-	detail, err := ctx.RunRecognition(nodeName, img, nil)
-	if err != nil || detail == nil || !detail.Hit {
-		return 0, false
-	}
-	return bestTemplateScore(detail)
-}
-
-// overrideTemplate 把某节点的 template（运行时）覆盖成指定模板路径，roi 等保持节点原定义。
-func overrideTemplate(ctx *maa.Context, nodeName, templatePath string) error {
-	if ctx == nil {
-		return fmt.Errorf("context is nil")
-	}
-	return ctx.OverridePipeline(map[string]any{
-		nodeName: map[string]any{
-			"recognition": map[string]any{
-				"param": map[string]any{
-					"template": []string{templatePath},
-				},
-			},
-		},
-	})
-}
-
-// bestTemplateScore 取模板匹配最佳结果的分数。
-func bestTemplateScore(detail *maa.RecognitionDetail) (float64, bool) {
-	if detail == nil || detail.Results == nil || detail.Results.Best == nil {
-		return 0, false
-	}
-	tm, ok := detail.Results.Best.AsTemplateMatch()
-	if !ok {
-		return 0, false
-	}
-	return tm.Score, true
 }
 
 // allOCRText 拼接一个识别节点全部 OCR 框的文本（优先 Filtered，空则退回 All），用空串连接。

--- a/agent/go-service/trialofswordmancy/recognition.go
+++ b/agent/go-service/trialofswordmancy/recognition.go
@@ -43,7 +43,6 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 		return nil, r.recognitionFailed(ctx, "牌库 OCR 失败")
 	}
 
-	onCardScreen := r.detectCardScreen(ctx, arg.Img)
 	overflow := r.detectOverflow(ctx, arg.Img)
 	handCounts, handRaw := r.recognizeHand(ctx, arg.Img)
 
@@ -87,11 +86,10 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 		Hand:         handCounts,
 	}
 	gs := GameState{
-		State:        state,
-		Config:       cfg,
-		HandRaw:      handRaw,
-		OnCardScreen: onCardScreen,
-		Overflow:     overflow,
+		State:    state,
+		Config:   cfg,
+		HandRaw:  handRaw,
+		Overflow: overflow,
 	}
 
 	detailBytes, err := json.Marshal(gs)
@@ -108,7 +106,6 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 		Bool("isDoubled", state.IsDoubled).
 		Ints("hand", state.Hand[:]).
 		Ints("handRaw", handRaw[:]).
-		Bool("onCardScreen", onCardScreen).
 		Bool("overflow", overflow).
 		Str("overflowMode", cfg.OverflowMode.String()).
 		Msg("game state recognized")
@@ -123,14 +120,6 @@ func (r *Recognition) recognitionFailed(ctx *maa.Context, reason string) bool {
 	log.Warn().Str("component", component).Str("reason", reason).Msg("recognition failed, aborting task")
 	maafocus.Print(ctx, "选剑演武：识别失败")
 	return false
-}
-
-// detectCardScreen 判定是否处于抽牌界面：RewardMode 或 DrawCard 在场。
-func (r *Recognition) detectCardScreen(ctx *maa.Context, img image.Image) bool {
-	if runTemplateHit(ctx, img, nodeRewardMode) {
-		return true
-	}
-	return runTemplateHit(ctx, img, nodeDrawCard)
 }
 
 // detectOverflow 判定是否识别到溢出叹号（爆表）。

--- a/agent/go-service/trialofswordmancy/recognition.go
+++ b/agent/go-service/trialofswordmancy/recognition.go
@@ -17,14 +17,14 @@ var _ maa.CustomRecognitionRunner = &Recognition{}
 // Recognition 是选剑演武总成识别器：取一张截图 arg.Img，识别当前局面的各状态字段，
 // 组装 GameState 后序列化进 CustomRecognitionResult.Detail 交给 Decide 动作。
 //
-// 几乎无状态——除剩余放弃次数外（界面不显示，持久化+探测），其余字段每步都从当前截图重读。
+// 几乎无状态——除剩余放弃次数外（界面不显示，由 RecognizeAband 识别后缓存），其余字段每步都从当前截图重读。
 //
 // 各字段来源（ROI/模板都在 TrialOfSwordmancyCommon.json 的 [go] 节点里，Go 按名调用 maafw）：
 //   - 屏幕态：RewardMode / DrawCard 在场 → 处于抽牌界面。
 //   - Hand：HandPoint1-5 分别整行匹配 Point1-5.png，按 HandPosition1-5 ROI 归槽。
 //   - Deck：牌库「剩余库存」整列 OCR（Deck，按 DeckCount1-5 ROI 分组，抽牌递减）；总牌量 = 剩余 + 手牌。
 //   - RemainCalc / RemainDouble：OCR（RemainCalc / RemainDouble 节点）。
-//   - RemainAband：持久化缓存；未知(-1)时探测（点放弃→OCR 弹窗→取消）。
+//   - RemainAband：RecognizeAband 从放弃弹窗识别后写入的持久化缓存。
 //   - IsDoubled：模板匹配（IsDoubled 节点）。
 //   - Overflow：OverflowExclamation 在场（观测字段，不参与求解）。
 type Recognition struct{}
@@ -63,16 +63,9 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 	}
 	isDoubled := recognizeIsDoubled(ctx, arg.Img)
 
-	// 剩余放弃次数：持久化缓存；未知(-1)则探测（有副作用，故放最后）。
-	// 探测失败不在此 return false——否则 Decide 节点的 20s 识别超时内会反复点击放弃/取消；
-	// 改为留 -1 → 求解器判不可达 → Decide 动作 return false（一次性中止，不重试）。
+	// 剩余放弃次数由独立的 RecognizeAband 从放弃弹窗识别并缓存。
+	// 缓存仍未知时保留 -1，交给求解器判不可达并中止，不在总成识别中执行任何界面操作。
 	remainAband := getAband()
-	if remainAband < 0 {
-		if n := r.probeAband(ctx); n >= 0 {
-			remainAband = n
-			setAband(n)
-		}
-	}
 
 	// 屏幕的「本日剩余奖励演算次数」显示的是「当前进行中这局之外的剩余」——进入抽牌界面即扣 1，
 	// 而求解器把进行中这局也算作可用 → solver = OCR + 1（solver 态空间 RemainCalc 1..3，对应 OCR 0..2）。
@@ -115,7 +108,7 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 
 // recognitionFailed 关键字段识别失败的统一出口：记日志 + focus「识别失败」+ 返回 false。
 // 任一关键字段（牌库/演算次数/翻倍次数）读不到都走这里——读不到就不在错误信息上做决策，让任务中止。
-// （放奔次数探测失败不在此中止，见 Run 内注释。）
+// （放弃次数缓存未知不在此中止，见 Run 内注释。）
 func (r *Recognition) recognitionFailed(ctx *maa.Context, reason string) bool {
 	log.Warn().Str("component", component).Str("reason", reason).Msg("recognition failed, aborting task")
 	maafocus.Print(ctx, "选剑演武：识别失败")
@@ -255,51 +248,6 @@ func recognizeIsDoubled(ctx *maa.Context, img image.Image) bool {
 	return runTemplateHit(ctx, img, nodeIsDoubled)
 }
 
-// probeAband 探测剩余放弃次数：跑两段 pipeline 子链，go 在中间读一次放弃弹窗 OCR。
-//
-// 子链定义在 TrialOfSwordmancyCommon.json（TrialOfSwordmancyAbandProbe*）：
-//   - ① 点放弃 → 轮询等放弃确认弹窗出现（弹窗留在屏上，子链结束）；
-//   - ② 点取消 → 轮询等回抽牌页（EnemyCard1）→ freeze。
-//
-// 交互/等待/点击全在 pipeline 里——pipeline 的 next 本身就是带重试的轮询（MaaFramework
-// PipelineTask::run_next：截图→识别 next 候选→没中就 sleep rate_limit 重试，直到 timeout），
-// 等价于以前 go 手写的两个轮询循环。go 只负责触发子链 + 在两段之间取一次 OCR 文本。
-// 返回读到的次数（0-3），读不到返回 -1。仅在 getAband()<0 时调用一次。
-func (r *Recognition) probeAband(ctx *maa.Context) int {
-	// ① 点放弃 → 等弹窗。RunTask 返回即弹窗已在屏上（WaitPopup 命中 CancelButton 后子链结束、空 next）。
-	if _, err := ctx.RunTask(nodeAbandProbeClickGiveUp); err != nil {
-		log.Warn().Err(err).Str("component", component).Msg("probeAband: 点放弃/等弹窗失败")
-		return -1
-	}
-
-	// go 取 OCR：弹窗在屏上，截一张图跑放弃弹窗 OCR。
-	ctrl := ctx.GetTasker().GetController()
-	if ctrl == nil {
-		log.Warn().Str("component", component).Msg("probeAband: controller 为空")
-		return -1
-	}
-	ctrl.PostScreencap().Wait()
-	img, err := ctrl.CacheImage()
-	if err != nil || img == nil {
-		log.Warn().Err(err).Str("component", component).Msg("probeAband: 截屏失败")
-		return -1
-	}
-	text, _ := ocrNodeText(ctx, img, nodeAbandPopup)
-	count := parseAbandCount(text)
-
-	// ② 点取消 → 等回抽牌页 → freeze。失败只记日志（次数已读到，界面若残留由上游兜底）。
-	if _, err := ctx.RunTask(nodeAbandProbeClickCancel); err != nil {
-		log.Warn().Err(err).Str("component", component).Msg("probeAband: 点取消/等回抽牌页失败，界面可能残留")
-	}
-
-	if count < 0 {
-		log.Warn().Str("component", component).Str("ocr", text).Msg("probeAband: 未能解析放弃次数")
-	} else {
-		log.Info().Str("component", component).Int("aband", count).Str("ocr", text).Msg("probeAband: 探测到剩余放弃次数")
-	}
-	return count
-}
-
 // ocrNodeText 跑一个 OCR 节点，返回该 ROI 内所有识别框文本的拼接。
 // ppocrv5 常把一行文本切成多个识别框（标点、数字往往单独成框），只取 Best 会丢掉关键数字/关键词，
 // 故此处拼接全部框，调用方再自行 parseFirstInt / 子串判断。
@@ -309,33 +257,6 @@ func ocrNodeText(ctx *maa.Context, img image.Image, nodeName string) (string, bo
 		return "", false
 	}
 	return allOCRText(detail)
-}
-
-// 放弃确认弹窗两种形态（原文）：
-//   - 有次数：「本日剩余放弃次数x次，放弃将扣除，但不会扣除奖励演算次数，是否确认放弃？」（x ∈ 1..3）
-//   - 已耗尽：「本日放弃次数已用完，继续放弃将会扣除1次奖励演算次数，是否确认放弃？」
-//
-// 两种都含数字、都含「奖励演算次数」「扣除」「是否确认放弃」——这些词无法区分两态。
-// 只有「用完 / 继续放弃 / 将会扣除」是耗尽态独有，拿来做耗尽判定。
-// 关键陷阱：耗尽态的「1」是「扣除几次奖励演算次数」，不是放弃次数 → 必须先用耗尽标记拦截，
-// 否则 parseFirstInt 会把那个「1」误当放弃次数。
-var abandExhaustedMarkers = []string{"用完", "继续放弃", "将会扣除"}
-
-// parseAbandCount 从放弃弹窗的拼接文本解析剩余次数。
-//   - 耗尽标记命中 → 0
-//   - 否则取首段数字（有次数态的唯一数字即放弃次数 x）
-//   - 无标记也无数字 → 未知 -1（例如有次数态的数字被 OCR 切错）。不臆断为 0/耗尽：
-//     返回 0 会被 setAband 缓存，污染整局决策；返回 -1 由上游留作未知、求解器判不可达中止。
-func parseAbandCount(text string) int {
-	for _, m := range abandExhaustedMarkers {
-		if strings.Contains(text, m) {
-			return 0
-		}
-	}
-	if n, ok := parseFirstInt(text); ok {
-		return n
-	}
-	return -1
 }
 
 // runTemplateHit 跑一个 TemplateMatch 节点，返回是否命中。

--- a/agent/go-service/trialofswordmancy/recognition.go
+++ b/agent/go-service/trialofswordmancy/recognition.go
@@ -23,7 +23,7 @@ var _ maa.CustomRecognitionRunner = &Recognition{}
 // 各字段来源（ROI/模板都在 TrialOfSwordmancyCommon.json 的 [go] 节点里，Go 按名调用 maafw）：
 //   - 屏幕态：RewardMode / DrawCard 在场 → 处于抽牌界面。
 //   - Hand：5 个手牌位（HandPoint1-5）匹配 Point1-5.png，命中即该槽点数+在场。
-//   - Deck：牌库「剩余库存」OCR（DeckCount1-5，抽牌递减）；总牌量 = 剩余 + 手牌。
+//   - Deck：牌库「剩余库存」整列 OCR（Deck，按 DeckCount1-5 ROI 分组，抽牌递减）；总牌量 = 剩余 + 手牌。
 //   - RemainCalc / RemainDouble：OCR（RemainCalc / RemainDouble 节点）。
 //   - RemainAband：持久化缓存；未知(-1)时探测（点放弃→OCR 弹窗→取消）。
 //   - IsDoubled：模板匹配（IsDoubled 节点）。
@@ -164,18 +164,74 @@ func recognizeCount(ctx *maa.Context, img image.Image, nodeName string) (int, bo
 	return parseFirstInt(text)
 }
 
-// recognizeDeck 跑 DeckCount1-5 五个 OCR 节点读牌库「剩余库存」（抽一张递减一次）；任一读不到则整体失败。
-// 返回的是剩余量，调用方需 + hand 还原总牌量（求解器吃总牌量）。
+// recognizeDeck 跑一次 Deck OCR 读牌库整列，再按 DeckCount1-5 的 ROI 筛选各点数「剩余库存」。
+// 任一 ROI 读不到数字则整体失败。
 func recognizeDeck(ctx *maa.Context, img image.Image) ([5]int, bool) {
+	detail, err := ctx.RunRecognition(nodeDeck, img, nil)
+	if err != nil || detail == nil || detail.Results == nil {
+		return [5]int{}, false
+	}
+
+	var rois [5]maa.Rect
+	for i := range rois {
+		roi, err := nodeROI(ctx, nodeDeckCountPrefix+strconv.Itoa(i+1))
+		if err != nil {
+			return [5]int{}, false
+		}
+		rois[i] = roi
+	}
+
+	var texts [5]strings.Builder
+	for _, result := range detail.Results.Filtered {
+		if result == nil {
+			continue
+		}
+		ocr, ok := result.AsOCR()
+		if !ok || ocr == nil {
+			continue
+		}
+		for i, roi := range rois {
+			if rectContains(roi, ocr.Box) {
+				texts[i].WriteString(strings.TrimSpace(ocr.Text))
+				break
+			}
+		}
+	}
+
 	var deck [5]int
-	for i := 0; i < 5; i++ {
-		n, ok := recognizeCount(ctx, img, nodeDeckCountPrefix+strconv.Itoa(i+1))
+	for i := range deck {
+		n, ok := parseFirstInt(texts[i].String())
 		if !ok {
 			return [5]int{}, false
 		}
 		deck[i] = n
 	}
 	return deck, true
+}
+
+func nodeROI(ctx *maa.Context, nodeName string) (maa.Rect, error) {
+	raw, err := ctx.GetNodeJSON(nodeName)
+	if err != nil {
+		return maa.Rect{}, err
+	}
+	var node struct {
+		Recognition struct {
+			Param struct {
+				ROI maa.Rect `json:"roi"`
+			} `json:"param"`
+		} `json:"recognition"`
+	}
+	if err := json.Unmarshal([]byte(raw), &node); err != nil {
+		return maa.Rect{}, err
+	}
+	return node.Recognition.Param.ROI, nil
+}
+
+func rectContains(outer, inner maa.Rect) bool {
+	return inner.X() >= outer.X() &&
+		inner.Y() >= outer.Y() &&
+		inner.X()+inner.Width() <= outer.X()+outer.Width() &&
+		inner.Y()+inner.Height() <= outer.Y()+outer.Height()
 }
 
 // recognizeIsDoubled 跑 IsDoubled 模板节点，命中即本局已翻倍。

--- a/agent/go-service/trialofswordmancy/register.go
+++ b/agent/go-service/trialofswordmancy/register.go
@@ -7,10 +7,12 @@ import (
 
 // Register 注册选剑演武包提供的自定义识别器与动作。
 //
-//   - TrialOfSwordmancy.Recognize：总成识别（一图多位置 → GameState；放弃次数持久化+探测）。
+//   - TrialOfSwordmancy.Recognize：总成识别（一图多位置 → GameState；读取已缓存的放弃次数）。
+//   - TrialOfSwordmancy.RecognizeAband：从放弃弹窗文本识别并缓存剩余放弃次数。
 //   - TrialOfSwordmancy.Decide：MDP 单步决策 → OverrideNext 路由执行。
 func Register() {
 	maa.AgentServerRegisterCustomRecognition(recognitionName, &Recognition{})
+	maa.AgentServerRegisterCustomRecognition(abandRecognitionName, &AbandRecognition{})
 	maa.AgentServerRegisterCustomAction(decideName, &DecideAction{})
 
 	log.Info().

--- a/agent/go-service/trialofswordmancy/types.go
+++ b/agent/go-service/trialofswordmancy/types.go
@@ -14,7 +14,6 @@ type GameState struct {
 	Config solver.Config `json:"config"`
 
 	// 以下为识别原始字段，供日志/调试观测（写进 detail JSON），action 不读、不参与 MDP 求解。
-	HandRaw      [5]int `json:"handRaw"`      // 各槽位识别到的点数（下标=槽位，0=空槽）
-	OnCardScreen bool   `json:"onCardScreen"` // 是否处于奖励演算（抽牌）界面
-	Overflow     bool   `json:"overflow"`     // 是否识别到溢出叹号（爆表）
+	HandRaw  [5]int `json:"handRaw"`  // 各槽位识别到的点数（下标=槽位，0=空槽）
+	Overflow bool   `json:"overflow"` // 是否识别到溢出叹号（爆表）
 }

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCommon.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCommon.json
@@ -384,61 +384,106 @@
         ],
         "template": "TrialOfSwordmancy/DoubleRewardSelected.png"
     },
-    // —— 手牌 5 槽点数位（模板匹配；Go 运行时把 template override 成 Point1-5.png 取最高分得点数）——
+    // —— 手牌点数识别（模板匹配）——
     "TrialOfSwordmancyHandPoint1": {
-        "desc": "[go] 手牌槽1点数位",
+        "desc": "[go] 手牌点数1",
         "recognition": "TemplateMatch",
         "roi": [
             173,
             123,
-            74,
+            875,
             80
         ],
         "template": "TrialOfSwordmancy/Point1.png"
     },
     "TrialOfSwordmancyHandPoint2": {
-        "desc": "[go] 手牌槽2点数位",
+        "desc": "[go] 手牌点数2",
         "recognition": "TemplateMatch",
+        "roi": [
+            173,
+            123,
+            875,
+            80
+        ],
+        "template": "TrialOfSwordmancy/Point2.png"
+    },
+    "TrialOfSwordmancyHandPoint3": {
+        "desc": "[go] 手牌点数3",
+        "recognition": "TemplateMatch",
+        "roi": [
+            173,
+            123,
+            875,
+            80
+        ],
+        "template": "TrialOfSwordmancy/Point3.png"
+    },
+    "TrialOfSwordmancyHandPoint4": {
+        "desc": "[go] 手牌点数4",
+        "recognition": "TemplateMatch",
+        "roi": [
+            173,
+            123,
+            875,
+            80
+        ],
+        "template": "TrialOfSwordmancy/Point4.png"
+    },
+    "TrialOfSwordmancyHandPoint5": {
+        "desc": "[go] 手牌点数5",
+        "recognition": "TemplateMatch",
+        "roi": [
+            173,
+            123,
+            875,
+            80
+        ],
+        "template": "TrialOfSwordmancy/Point5.png"
+    },
+    "TrialOfSwordmancyHandPosition1": {
+        "desc": "[go] 手牌槽1位置",
+        "roi": [
+            173,
+            123,
+            74,
+            80
+        ]
+    },
+    "TrialOfSwordmancyHandPosition2": {
+        "desc": "[go] 手牌槽2位置",
         "roi": [
             373,
             123,
             74,
             80
-        ],
-        "template": "TrialOfSwordmancy/Point1.png"
+        ]
     },
-    "TrialOfSwordmancyHandPoint3": {
-        "desc": "[go] 手牌槽3点数位",
-        "recognition": "TemplateMatch",
+    "TrialOfSwordmancyHandPosition3": {
+        "desc": "[go] 手牌槽3位置",
         "roi": [
             573,
             123,
             74,
             80
-        ],
-        "template": "TrialOfSwordmancy/Point1.png"
+        ]
     },
-    "TrialOfSwordmancyHandPoint4": {
-        "desc": "[go] 手牌槽4点数位",
-        "recognition": "TemplateMatch",
+    "TrialOfSwordmancyHandPosition4": {
+        "desc": "[go] 手牌槽4位置",
         "roi": [
             773,
             123,
             74,
             80
-        ],
-        "template": "TrialOfSwordmancy/Point1.png"
+        ]
     },
-    "TrialOfSwordmancyHandPoint5": {
-        "desc": "[go] 手牌槽5点数位",
-        "recognition": "TemplateMatch",
+    "TrialOfSwordmancyHandPosition5": {
+        "desc": "[go] 手牌槽5位置",
         "roi": [
             973,
             123,
             74,
             80
-        ],
-        "template": "TrialOfSwordmancy/Point1.png"
+        ]
     },
     // —— 溢出叹号（爆表，观测字段）——
     "TrialOfSwordmancyOverflowExclamation": {

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCommon.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCommon.json
@@ -4,7 +4,6 @@
     // ===========================================================================
     // 下半部分（见分隔线后）：仅 go-service（recognition.go）运行时通过 ctx.RunRecognition
     // 调用、pipeline 流程不直接引用的节点（[go] 前缀标注）。节点名仍全文件共享同一命名空间。
-
     // 第1-5张卡牌 Lv（在场判定）。EnsureFirstCard 用 EnemyCard1 判是否已抽牌；Coating 用 1-5 全部。
     "TrialOfSwordmancyEnemyCard1": {
         "desc": "第1张卡牌 Lv",
@@ -283,12 +282,10 @@
         "template": "TrialOfSwordmancy/ChallengeBackground.png",
         "green_mask": true
     },
-
     // ===========================================================================
     // 以下节点仅供 go-service 经 ctx.RunRecognition 调用（pipeline 流程不直接引用）。
     // ROI/模板均在此定义，Go 侧不硬编码坐标；Go 按名字调用并解析结果。
     // ===========================================================================
-
     // —— 抽牌界面信息位 OCR（读文本，Go 侧 parseFirstInt 取数字）——
     "TrialOfSwordmancyRemainCalc": {
         "desc": "[go] 本日剩余奖励演算次数（OCR，值 2/1/0）",
@@ -310,9 +307,18 @@
             71
         ]
     },
-    "TrialOfSwordmancyDeckCount1": {
-        "desc": "[go] 牌库点数1库存数（OCR）",
+    "TrialOfSwordmancyDeck": {
+        "desc": "[go] 牌库",
         "recognition": "OCR",
+        "roi": [
+            1220,
+            116,
+            27,
+            227
+        ]
+    },
+    "TrialOfSwordmancyDeckCount1": {
+        "desc": "[go] 牌库点数1库存数",
         "roi": [
             1220,
             116,
@@ -321,8 +327,7 @@
         ]
     },
     "TrialOfSwordmancyDeckCount2": {
-        "desc": "[go] 牌库点数2库存数（OCR）",
-        "recognition": "OCR",
+        "desc": "[go] 牌库点数2库存数",
         "roi": [
             1219,
             168,
@@ -331,8 +336,7 @@
         ]
     },
     "TrialOfSwordmancyDeckCount3": {
-        "desc": "[go] 牌库点数3库存数（OCR）",
-        "recognition": "OCR",
+        "desc": "[go] 牌库点数3库存数",
         "roi": [
             1218,
             215,
@@ -341,8 +345,7 @@
         ]
     },
     "TrialOfSwordmancyDeckCount4": {
-        "desc": "[go] 牌库点数4库存数（OCR）",
-        "recognition": "OCR",
+        "desc": "[go] 牌库点数4库存数",
         "roi": [
             1219,
             265,
@@ -351,8 +354,7 @@
         ]
     },
     "TrialOfSwordmancyDeckCount5": {
-        "desc": "[go] 牌库点数5库存数（OCR）",
-        "recognition": "OCR",
+        "desc": "[go] 牌库点数5库存数",
         "roi": [
             1219,
             312,
@@ -370,7 +372,6 @@
             58
         ]
     },
-
     // —— 已翻倍指示（DoubleReward 按钮选中态，模板匹配）——
     "TrialOfSwordmancyIsDoubled": {
         "desc": "[go] 已翻倍指示",
@@ -383,7 +384,6 @@
         ],
         "template": "TrialOfSwordmancy/DoubleRewardSelected.png"
     },
-
     // —— 手牌 5 槽点数位（模板匹配；Go 运行时把 template override 成 Point1-5.png 取最高分得点数）——
     "TrialOfSwordmancyHandPoint1": {
         "desc": "[go] 手牌槽1点数位",
@@ -440,7 +440,6 @@
         ],
         "template": "TrialOfSwordmancy/Point1.png"
     },
-
     // —— 溢出叹号（爆表，观测字段）——
     "TrialOfSwordmancyOverflowExclamation": {
         "desc": "[go] 溢出叹号（爆表）",
@@ -453,7 +452,6 @@
         ],
         "template": "TrialOfSwordmancy/OverflowExclamation.png"
     },
-
     // ===========================================================================
     // 探测剩余放弃次数子链（go 经 ctx.RunTask 触发，见 recognition.go 的 probeAband）。
     // 交互/等待/点击全在此；go 只触发子链 + 在两段之间取一次放弃弹窗 OCR。
@@ -463,7 +461,6 @@
     // 这类时序等待无需 go 手写循环。rate_limit/timeout 设在「点击」节点上——它同时管「本节点识别命中」
     // 与「点完后等下一个节点出现」两段轮询（run_next 用当前节点的 timing 去轮询其 next）。
     // ===========================================================================
-
     // 子链①：点放弃 → 轮询等放弃确认弹窗出现。命中 CancelButton 后子链结束（空 next），弹窗留在屏上供 go OCR。
     "TrialOfSwordmancyAbandProbeClickGiveUp": {
         "desc": "[go] 探测放弃次数①：点放弃按钮（并以其 timing 轮询等弹窗）",

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCommon.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCommon.json
@@ -363,7 +363,7 @@
         ]
     },
     "TrialOfSwordmancyAbandPopup": {
-        "desc": "[go] 放弃确认弹窗文本（OCR：『剩余放弃次数x次』或『已用完』）",
+        "desc": "[go] 放弃确认弹窗文本（OCR：『剩余放弃次数x次』）",
         "recognition": "OCR",
         "roi": [
             276,
@@ -371,6 +371,27 @@
             784,
             58
         ]
+    },
+    "TrialOfSwordmancyAbandExhausted": {
+        "desc": "[go] 放弃次数耗尽时的红色文本",
+        "recognition": "ColorMatch",
+        "roi": [
+            303,
+            344,
+            674,
+            18
+        ],
+        "lower": [
+            235,
+            0,
+            0
+        ],
+        "upper": [
+            255,
+            80,
+            80
+        ],
+        "count": 400
     },
     // —— 已翻倍指示（DoubleReward 按钮选中态，模板匹配）——
     "TrialOfSwordmancyIsDoubled": {
@@ -496,67 +517,5 @@
             47
         ],
         "template": "TrialOfSwordmancy/OverflowExclamation.png"
-    },
-    // ===========================================================================
-    // 探测剩余放弃次数子链（go 经 ctx.RunTask 触发，见 recognition.go 的 probeAband）。
-    // 交互/等待/点击全在此；go 只触发子链 + 在两段之间取一次放弃弹窗 OCR。
-    //
-    // 关键：pipeline 的 next 本身就是带重试的轮询（MaaFramework PipelineTask::run_next：
-    // 截图→识别 next 候选→没中就 sleep rate_limit 重试，直到 timeout）。故「等弹窗出现」「等回抽牌页」
-    // 这类时序等待无需 go 手写循环。rate_limit/timeout 设在「点击」节点上——它同时管「本节点识别命中」
-    // 与「点完后等下一个节点出现」两段轮询（run_next 用当前节点的 timing 去轮询其 next）。
-    // ===========================================================================
-    // 子链①：点放弃 → 轮询等放弃确认弹窗出现。命中 CancelButton 后子链结束（空 next），弹窗留在屏上供 go OCR。
-    "TrialOfSwordmancyAbandProbeClickGiveUp": {
-        "desc": "[go] 探测放弃次数①：点放弃按钮（并以其 timing 轮询等弹窗）",
-        "recognition": "And",
-        "all_of": [
-            "TrialOfSwordmancyGiveUp"
-        ],
-        "action": "Click",
-        "timeout": 10000,
-        "rate_limit": 300,
-        "next": [
-            "TrialOfSwordmancyAbandProbeWaitPopup"
-        ]
-    },
-    "TrialOfSwordmancyAbandProbeWaitPopup": {
-        "desc": "[go] 探测放弃次数①：等放弃确认弹窗出现（命中即子链结束，弹窗留屏供 go OCR）",
-        "recognition": "And",
-        "all_of": [
-            "CancelButton"
-        ],
-        "next": []
-    },
-    // 子链②：点取消 → 轮询等回抽牌页（EnemyCard1 在场）→ freeze（roi 沿用抽牌 freeze 的 [62,146,1191,289]）。
-    "TrialOfSwordmancyAbandProbeClickCancel": {
-        "desc": "[go] 探测放弃次数②：点取消按钮（并以其 timing 轮询等回抽牌页）",
-        "recognition": "And",
-        "all_of": [
-            "CancelButton"
-        ],
-        "action": "Click",
-        "timeout": 10000,
-        "rate_limit": 300,
-        "next": [
-            "TrialOfSwordmancyAbandProbeWaitBackFreeze"
-        ]
-    },
-    "TrialOfSwordmancyAbandProbeWaitBackFreeze": {
-        "desc": "[go] 探测放弃次数②：等回抽牌页并 freeze",
-        "recognition": "And",
-        "all_of": [
-            "TrialOfSwordmancyEnemyCard1"
-        ],
-        "post_wait_freezes": {
-            "time": 200,
-            "target": [
-                62,
-                146,
-                1191,
-                289
-            ]
-        },
-        "next": []
     }
 }

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -206,15 +206,6 @@
         "all_of": [
             "TrialOfSwordmancyDrawCard"
         ],
-        "pre_wait_freezes": {
-            "time": 200,
-            "target": [
-                62,
-                146,
-                1191,
-                289
-            ]
-        },
         "pre_delay": 0,
         "post_wait_freezes": {
             "time": 200,
@@ -225,7 +216,7 @@
                 289
             ]
         },
-        "post_delay": 500, // 即使动画结束，抽牌按钮仍有一定时间不可用
+        "post_delay": 400, // 即使动画结束，抽牌按钮仍有一定时间不可用
         "next": [
             "TrialOfSwordmancyDecide"
         ]

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -45,10 +45,10 @@
         "post_delay": 0,
         "next": [
             "TrialOfSwordmancyEnsureFirstCard",
-            "TrialOfSwordmancyDecide"
+            "TrialOfSwordmancyAbandProbeClickGiveUp"
         ]
     },
-    // 若尚未抽牌（第1张 Lv 不在）则先抽一张，保证探测放弃次数时有牌；已有牌则 fall through 到 Decide
+    // 若尚未抽牌（第1张 Lv 不在）则先抽一张，保证探测放弃次数时有牌；已有牌则 fall through 到 AbandProbe
     "TrialOfSwordmancyEnsureFirstCard": {
         "desc": "空手则先抽一张",
         "recognition": "And",
@@ -61,7 +61,100 @@
         "target": "TrialOfSwordmancyDrawCard",
         "post_delay": 400,
         "next": [
-            "TrialOfSwordmancyDoWaitDrawCardFreezes"
+            "TrialOfSwordmancyDrawFirstCardSuccess"
+        ]
+    },
+    "TrialOfSwordmancyDrawFirstCardSuccess": {
+        "desc": "抽取第一张牌成功",
+        "recognition": "And",
+        "all_of": [
+            "TrialOfSwordmancyEnemyCard1"
+        ],
+        "pre_delay": 0,
+        "post_delay": 400,
+        "post_wait_freezes": {
+            "time": 200,
+            "target": [
+                62,
+                146,
+                173,
+                289
+            ]
+        },
+        "next": [
+            "TrialOfSwordmancyAbandProbeClickGiveUp"
+        ]
+    },
+    // 探测放弃次数 → 回 Decide（同局继续）
+    "TrialOfSwordmancyAbandProbeClickGiveUp": {
+        "desc": "探测放弃次数①：点放弃按钮",
+        "recognition": "And",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "all_of": [
+            "TrialOfSwordmancyGiveUp"
+        ],
+        "action": "Click",
+        "next": [
+            "TrialOfSwordmancyAbandProbeWaitPopup"
+        ]
+    },
+    "TrialOfSwordmancyAbandProbeWaitPopup": {
+        "desc": "探测放弃次数①：等放弃确认弹窗出现",
+        "recognition": "And",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "all_of": [
+            "CancelButton",
+            "YellowConfirmButtonType1"
+        ],
+        "post_wait_freezes": {
+            "time": 100,
+            "target": [
+                303,
+                344,
+                674,
+                18
+            ]
+        },
+        "next": [
+            "TrialOfSwordmancyAbandProbeRecognize"
+        ]
+    },
+    "TrialOfSwordmancyAbandProbeRecognize": {
+        "desc": "识别放弃次数",
+        "recognition": "Custom",
+        "custom_recognition": "TrialOfSwordmancy.RecognizeAband",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "TrialOfSwordmancyAbandProbeClickCancel"
+        ]
+    },
+    "TrialOfSwordmancyAbandProbeClickCancel": {
+        "desc": "探测放弃次数②：点取消按钮",
+        "recognition": "And",
+        "all_of": [
+            "CancelButton"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "action": "Click",
+        "next": [
+            "TrialOfSwordmancyAbandProbeWaitBackFreeze"
+        ]
+    },
+    "TrialOfSwordmancyAbandProbeWaitBackFreeze": {
+        "desc": "探测放弃次数②：等回抽牌页并 freeze",
+        "recognition": "And",
+        "all_of": [
+            "TrialOfSwordmancyEnemyCard1"
+        ],
+        "pre_delay": 0,
+        "post_delay": 400,
+        "post_wait_freezes": 200,
+        "next": [
+            "TrialOfSwordmancyDecide"
         ]
     },
     "TrialOfSwordmancyDecide": {

--- a/tools/schema/custom.recognition.schema.json
+++ b/tools/schema/custom.recognition.schema.json
@@ -33,6 +33,7 @@
                 "SellProductPriorityItem",
                 "SellProductSelectBestOperator",
                 "TrialOfSwordmancy.Recognize",
+                "TrialOfSwordmancy.RecognizeAband",
                 "VisitFriendsSelectFriendRecognition",
                 "WeaponInventoryScanRecognition",
                 "SeizeDeliveryJobsFindTargetRecognition",


### PR DESCRIPTION
主要优化点是把整行整列的 roi 合并，做一次完整识别后按 roi 分割，而不是每个 roi 都做一次识别

实测一轮识别用时 810ms -> 220ms

## Summary by Sourcery

优化《Trial of Swordmancy》的识别性能，并简化放弃次数（abandon-count）的处理逻辑。

新特性：
- 引入专用的 `AbandRecognition` 自定义识别运行器，用于读取放弃确认弹窗，并通过管线缓存剩余放弃次数。
- 为新的放弃弹窗识别和“次数耗尽状态”的颜色匹配增加节点和注册线路，同时提供共享的 ROI 工具函数。

Bug 修复：
- 确保在主游戏状态识别过程中，放弃次数识别不再执行会产生副作用的 UI 交互，防止重复的“放弃/取消”循环。

增强与优化：
- 重构手牌识别逻辑，改为使用基于行的模板匹配，并在一次识别中根据每张牌的 ROI 进行槽位级别识别。
- 重构牌库数量识别逻辑，改为一次性对整列进行 OCR，然后按配置的 ROI 分割各个计数。
- 简化游戏状态：从识别与日志中移除 `on-card-screen` 标记。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize Trial of Swordmancy recognition performance and streamline abandon-count handling.

New Features:
- Introduce a dedicated AbandRecognition custom recognition runner to read abandon confirmation popups and cache remaining abandon count via pipeline.
- Add node and registration wiring for the new abandon popup recognition and exhausted-state color match, along with shared ROI utilities.

Bug Fixes:
- Ensure abandon-count recognition no longer performs side-effectful UI interactions during main game-state recognition, preventing repeated give-up/cancel cycles.

Enhancements:
- Refactor hand card recognition to use row-based template matching with per-slot ROIs from a single pass.
- Refactor deck count recognition to OCR the full column once and split counts by configured ROIs.
- Simplify game state by removing the on-card-screen flag from recognition and logging.

</details>