### PR TITLE
fix: 更新 Item.json 中的 ROI 偏移值以优化识别精度

### DIFF
--- a/assets/resource/pipeline/AutoStockStaple/General/Item.json
+++ b/assets/resource/pipeline/AutoStockStaple/General/Item.json
@@ -125,10 +125,10 @@
             "param": {
                 "roi": "AutoStockInStapleItemName",
                 "roi_offset": [
-                    82,
-                    -182,
-                    -71,
-                    18
+                    39,
+                    -212,
+                    25,
+                    63
                 ],
                 "expected": [
                     "95",
@@ -150,10 +150,10 @@
             "param": {
                 "roi": "AutoStockInStapleItemName",
                 "roi_offset": [
-                    82,
-                    -182,
-                    -71,
-                    18
+                    39,
+                    -212,
+                    25,
+                    63
                 ],
                 "expected": [
                     "95",


### PR DESCRIPTION
- 调整 General/Item.json 文件中的 roi_offset 值，以改善物品识别的准确性和处理逻辑。
- 新的偏移值为 [39, -212, 25, 63]，旨在提升识别效果。

## Summary by Sourcery

Bug Fixes:
- 更正 General/Item.json 中的 ROI 偏移值，以解决 AutoStockStaple 流水线中物品识别不准确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct ROI offset values in General/Item.json to address inaccurate item recognition in the AutoStockStaple pipeline.

</details>