### PR TITLE
fix: 修复选剑演武识别失败

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCommon.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCommon.json
@@ -314,52 +314,52 @@
             1220,
             116,
             27,
-            227
+            228
         ]
     },
     "TrialOfSwordmancyDeckCount1": {
         "desc": "[go] 牌库点数1库存数",
         "roi": [
-            1220,
-            116,
-            27,
-            33
+            1218,
+            113,
+            31,
+            38
         ]
     },
     "TrialOfSwordmancyDeckCount2": {
         "desc": "[go] 牌库点数2库存数",
         "roi": [
-            1219,
-            168,
-            30,
-            27
+            1218,
+            162,
+            31,
+            38
         ]
     },
     "TrialOfSwordmancyDeckCount3": {
         "desc": "[go] 牌库点数3库存数",
         "roi": [
             1218,
-            215,
-            30,
-            30
+            211,
+            31,
+            38
         ]
     },
     "TrialOfSwordmancyDeckCount4": {
         "desc": "[go] 牌库点数4库存数",
         "roi": [
-            1219,
-            265,
-            30,
-            29
+            1218,
+            260,
+            31,
+            38
         ]
     },
     "TrialOfSwordmancyDeckCount5": {
         "desc": "[go] 牌库点数5库存数",
         "roi": [
-            1219,
-            312,
-            28,
-            31
+            1218,
+            309,
+            31,
+            38
         ]
     },
     "TrialOfSwordmancyAbandPopup": {

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -151,7 +151,15 @@
             "TrialOfSwordmancyEnemyCard1"
         ],
         "pre_delay": 0,
-        "post_wait_freezes": 200,
+        "post_wait_freezes": {
+            "time": 200,
+            "target": [
+                62,
+                146,
+                173,
+                289
+            ]
+        },
         "post_delay": 400,
         "next": [
             "TrialOfSwordmancyDecide"


### PR DESCRIPTION
不检查 roi 导致的（

close #4432 

## Summary by Sourcery

Bug Fixes:
- 解决由于管线配置中缺少 ROI 检查而导致的 Trial of Swordmancy 选择识别失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve Trial of Swordmancy selection recognition failures caused by missing ROI checks in pipeline configuration.

</details>