### PR TITLE
fix(EnvironmentMonitoring):更改小池荷拍照点位

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PoolLotus.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PoolLotus.json
@@ -381,14 +381,14 @@
         "custom_action_param": {
             "map_name": "map02_lv004",
             "target": [
-                594.4,
-                324.1
+                581.4,
+                305.1
             ],
             "on_finish": {
                 "action": "Custom",
                 "custom_action": "MapTrackerToward",
                 "custom_action_param": {
-                    "angle": 334
+                    "angle": 180
                 }
             }
         },
@@ -413,12 +413,12 @@
     },
     "PoolLotusAdjustCamera": {
         "desc": "小池荷任务中调整朝向",
-        "max_hit": 1,
+        "max_hit": 4,
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "EnvironmentMonitoringSwipeScreenRight"
+            "EnvironmentMonitoringSwipeScreenDown"
         ]
     }
 }

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -896,12 +896,12 @@
             8.1
         ],
         "MapGoal": [
-            594.4,
-            324.1
+            581.4,
+            305.1
         ],
-        "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenRight",
-        "CameraMaxHit": 1,
-        "Heading": 334
+        "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenDown",
+        "CameraMaxHit": 4,
+        "Heading": 180
     },
     {
         "MissionId": "m1m70",


### PR DESCRIPTION
更改小池荷拍照点位，增加转动视角后稳定性
close #4418

## Summary by Sourcery

调整 EnvironmentMonitoring 池塘莲花采集配置，以更新拍摄点位置，并在相机旋转后提高稳定性。

增强内容：
- 更新 PoolLotus 监控配置，在小池塘莲花场景中使用新的照片采集位置。
- 调整 EnvironmentMonitoring 的路线生成配置，以反映更新后的 PoolLotus 采集点和视角行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust EnvironmentMonitoring pool lotus capture configuration to update the photo point location and improve stability after camera rotation.

Enhancements:
- Update PoolLotus monitoring configuration to use a new photo capture position for the small pond lotus scene.
- Align route generation config for EnvironmentMonitoring to reflect the updated PoolLotus capture point and view behavior.

</details>