### PR TITLE
feat(AutoStockpile): 新增「至少购买一个」选项

### DIFF
--- a/agent/go-service/autostockpile/options.go
+++ b/agent/go-service/autostockpile/options.go
@@ -11,6 +11,7 @@ import (
 type serverTimeAttach struct {
 	ServerTime      *int `json:"server_time"`
 	AllowDataUpload bool `json:"allow_data_upload"`
+	MinBuyCount     int  `json:"min_buy_count"`
 }
 
 const (

--- a/agent/go-service/autostockpile/selector.go
+++ b/agent/go-service/autostockpile/selector.go
@@ -75,6 +75,17 @@ func (a *SelectItemAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 		return routeSkipWithAbortReason(ctx, arg.CurrentTaskName, result.AbortReason, nil, i18n.T("autostockpile.recognition_early_end"))
 	}
 
+	// 降级购买后标记跳过下一轮
+	if prev := getDecisionState(); prev != nil && prev.SkipNextRound {
+		log.Info().
+			Str("component", "autostockpile").
+			Msg("skip next round after fallback purchase")
+		if err := overrideSkipBranch(ctx); err != nil {
+			return false
+		}
+		return true
+	}
+
 	data := result.Data
 	region, err := resolveGoodsRegionFromActionArg(arg)
 	if err != nil {
@@ -125,10 +136,37 @@ func (a *SelectItemAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			Msg("allow all goods mode enabled")
 	}
 
+	// 第一轮：正常选品
+	minBuyFallback := false
 	selection, quantityDecision, err := computeDecision(*data, cfg, bypassThresholdFilter)
 	if err != nil {
 		return stopTaskWithFocus(ctx, mapComputeDecisionErrorToAbortReason(err), err)
 	}
+
+	// 「至少购买一个」：正常选品失败 + 非爆仓 + 四号谷地 → 降级重选
+	if !selection.Selected && attach.MinBuyCount > 0 && region == "ValleyIV" && !bypassThresholdFilter {
+		selection2, _, err2 := computeDecision(*data, cfg, true) // 爆仓模式重跑
+		if err2 != nil {
+			return stopTaskWithFocus(ctx, mapComputeDecisionErrorToAbortReason(err2), err2)
+		}
+		if selection2.Selected {
+			selection = selection2
+			quantityDecision = makeQuantityDecision(
+				quantityModeSwipeSpecificQuantity,
+				attach.MinBuyCount,
+				i18n.T("autostockpile.qty_min_buy_fallback"),
+			)
+			minBuyFallback = true
+			log.Info().
+				Str("component", "autostockpile").
+				Str("fallback_product", selection.ProductName).
+				Int("fallback_price", selection.CurrentPrice).
+				Int("quantity", quantityDecision.Target).
+				Msg("fallback purchase triggered")
+			maafocus.Print(ctx, i18n.T("autostockpile.fallback_purchase", selection.ProductName, selection.CurrentPrice))
+		}
+	}
+
 	if !selection.Selected {
 		log.Info().
 			Str("component", "autostockpile").
@@ -210,6 +248,7 @@ func (a *SelectItemAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 			Selection:        selection,
 			QuantityDecision: quantityDecision,
 		},
+		SkipNextRound: minBuyFallback && selection.Selected,
 	})
 
 	selectionMode := formatSelectionMode(selection, *data)
@@ -384,4 +423,9 @@ func formatSelectionMode(selection SelectionResult, data RecognitionData) string
 		return i18n.T("autostockpile.mode_overflow")
 	}
 	return i18n.T("autostockpile.mode_low_price")
+}
+
+// makeQuantityDecision creates a quantityDecision. Extracted to avoid variable shadowing in Run().
+func makeQuantityDecision(mode quantityMode, target int, reason string) quantityDecision {
+	return quantityDecision{Mode: mode, Target: target, Reason: reason}
 }

--- a/agent/go-service/autostockpile/state.go
+++ b/agent/go-service/autostockpile/state.go
@@ -14,6 +14,7 @@ type DecisionState struct {
 	EffectiveConfig    SelectionConfig
 	RawRecognitionData RecognitionData
 	CurrentDecision    currentDecision
+	SkipNextRound      bool
 }
 
 var (

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -217,5 +217,7 @@
     "trialofswordmancy.undoubled": "Not doubled",
     "trialofswordmancy.endgame": "Trial of Swordmancy\nCross-day endgame\n→ Abandon round",
     "trialofswordmancy.legacy_double": "Trial of Swordmancy\nLegacy trial runs consumed today's double uses\n→ Calculate now to restore a valid state",
-    "trialofswordmancy.recognition_failed": "Trial of Swordmancy: recognition failed"
+    "trialofswordmancy.recognition_failed": "Trial of Swordmancy: recognition failed",
+    "autostockpile.qty_min_buy_fallback": "Completed daily minimum purchase",
+    "autostockpile.fallback_purchase": "No goods below price threshold, fallback to cheapest %s (price %d) for daily quest"
 }

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -217,5 +217,7 @@
     "trialofswordmancy.undoubled": "未翻倍",
     "trialofswordmancy.endgame": "选剑演武\n跨天残局\n→ 放弃本局",
     "trialofswordmancy.legacy_double": "选剑演武\n识别到有之前遗留的演算奖励次数消耗了当日的双倍次数\n→ 直接开始演算以回归正确状态",
-    "trialofswordmancy.recognition_failed": "选剑演武：识别失败"
+    "trialofswordmancy.recognition_failed": "选剑演武：识别失败",
+    "autostockpile.qty_min_buy_fallback": "已完成每日最低购买数量",
+    "autostockpile.fallback_purchase": "未找到低于心理价位的商品，已降级购买最便宜的 %s（价格 %d）以完成每日任务"
 }

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -1198,5 +1198,7 @@
     "option.ClientVersion.cases.Bilibili.label": "CN (Bilibili)",
     "option.ClientVersion.cases.Global.label": "Global (Gryphline)",
     "option.ClientVersion.cases.VN.label": "Vietnam (Gryphline)",
-    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "Teleport to heal before each battle"
+    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "Teleport to heal before each battle",
+    "task.AutoStockpile.option.AutoStockpileMinBuyCount.label": "Buy At Least One",
+    "task.AutoStockpile.option.AutoStockpileMinBuyCount.description": "When all goods are above the price threshold, force-buy the cheapest item to complete the daily quest"
 }

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -1198,5 +1198,7 @@
     "option.ClientVersion.cases.Bilibili.label": "中国サーバー（ビリビリ）",
     "option.ClientVersion.cases.Global.label": "グローバルサーバー（グリフライン）",
     "option.ClientVersion.cases.VN.label": "ベトナムサーバー（グリフライン）",
-    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "各戦闘前にテレポートしてHP回復"
+    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "各戦闘前にテレポートしてHP回復",
+    "task.AutoStockpile.option.AutoStockpileMinBuyCount.label": "Buy At Least One",
+    "task.AutoStockpile.option.AutoStockpileMinBuyCount.description": "When all goods are above the price threshold, force-buy the cheapest item to complete the daily quest"
 }

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -1198,5 +1198,7 @@
     "option.ClientVersion.cases.Bilibili.label": "Bilibili",
     "option.ClientVersion.cases.Global.label": "글로벌 서버",
     "option.ClientVersion.cases.VN.label": "베트남 서버",
-    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "전투 전마다 순간이동해 체력 회복"
+    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "전투 전마다 순간이동해 체력 회복",
+    "task.AutoStockpile.option.AutoStockpileMinBuyCount.label": "Buy At Least One",
+    "task.AutoStockpile.option.AutoStockpileMinBuyCount.description": "When all goods are above the price threshold, force-buy the cheapest item to complete the daily quest"
 }

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -1198,5 +1198,7 @@
     "option.ClientVersion.cases.Bilibili.label": "B服",
     "option.ClientVersion.cases.Global.label": "国际服",
     "option.ClientVersion.cases.VN.label": "越南服",
-    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "每次战斗前传送回复血量"
+    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "每次战斗前传送回复血量",
+    "task.AutoStockpile.option.AutoStockpileMinBuyCount.label": "至少购买一个",
+    "task.AutoStockpile.option.AutoStockpileMinBuyCount.description": "当所有商品价格均高于心理价位时，强制购买一个最便宜的商品，以完成每日任务"
 }

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -1198,5 +1198,7 @@
     "option.ClientVersion.cases.Bilibili.label": "B服",
     "option.ClientVersion.cases.Global.label": "國際服",
     "option.ClientVersion.cases.VN.label": "越南服",
-    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "每次戰鬥前傳送回復血量"
+    "option.TrialOfSwordmancyRecoverBeforeBattle.label": "每次戰鬥前傳送回復血量",
+    "task.AutoStockpile.option.AutoStockpileMinBuyCount.label": "至少購買一個",
+    "task.AutoStockpile.option.AutoStockpileMinBuyCount.description": "當所有商品價格均高於心理價位時，強制購買一個最便宜的商品，以完成每日任務"
 }

--- a/assets/resource/pipeline/AutoStockpile/Purchase.json
+++ b/assets/resource/pipeline/AutoStockpile/Purchase.json
@@ -201,7 +201,7 @@
                 ]
             }
         },
-        "pre_wait_freezes": 80,
+        "pre_wait_freezes": 160,
         "pre_delay": 0,
         "action": {
             "type": "Click"

--- a/assets/resource/pipeline/Common/Button/CloseRewardsButton.json
+++ b/assets/resource/pipeline/Common/Button/CloseRewardsButton.json
@@ -15,8 +15,8 @@
             }
         },
         "pre_wait_freezes": {
-            "time": 50,
-            "timeout": 1000
+            "time": 100,
+            "timeout": 2000
         },
         "pre_delay": 0,
         "post_wait_freezes": {

--- a/assets/tasks/AutoStockpile.json
+++ b/assets/tasks/AutoStockpile.json
@@ -18,7 +18,8 @@
                 "AutoStockpileServerTime",
                 "AutoStockpileAllowDataUpload",
                 "AutoStockpileElasticValleyIV",
-                "AutoStockpileElasticWuling"
+                "AutoStockpileElasticWuling",
+                "AutoStockpileMinBuyCount"
             ]
         }
     ],
@@ -148,6 +149,27 @@
                             "enabled": false
                         }
                     }
+                }
+            ]
+        },
+        "AutoStockpileMinBuyCount": {
+            "type": "switch",
+            "label": "$task.AutoStockpile.option.AutoStockpileMinBuyCount.label",
+            "description": "$task.AutoStockpile.option.AutoStockpileMinBuyCount.description",
+            "default_case": "No",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "AutoStockpileAttach": {
+                            "attach": {
+                                "min_buy_count": 1
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "No"
                 }
             ]
         }


### PR DESCRIPTION
当所有商品价格高于心理价位时，复用爆仓逻辑选亏最少商品，买1个完成每日任务。优化购买弹窗关闭等待时间。

## Summary by Sourcery

为 AutoStockpile 添加一个备用购买路径，当在高于阈值价格下正常选择失败时，保证至少购买一个物品，并将其接入现有的日常任务流程。

新功能：
- 为 AutoStockpile 引入一个可配置的最低购买数量选项，在满足条件时确保至少购买一件物品。
- 添加逻辑，在所有商品都超过目标价格时，复用 Valley IV 中的溢出选择策略作为备用方案。

增强：
- 使用标志位跟踪决策状态，在备用购买之后跳过下一轮购买，以便后续任务路由保持一致。
- 调整 AutoStockpile 任务和购买流水线配置，包括奖励关闭处理，以优化购买后的等待时间和对话框关闭行为。

文档：
- 更新界面和服务的本地化字符串，以涵盖新的最低购买备用逻辑及相关 UI 文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a fallback purchase path for AutoStockpile that guarantees buying at least one item when normal selection fails above threshold prices, and wire it into the existing daily task flow.

New Features:
- Introduce a configurable minimum purchase count option for AutoStockpile to ensure at least one item is bought when conditions are met.
- Add logic to reuse the overflow selection strategy in Valley IV as a fallback when all goods exceed the target price.

Enhancements:
- Track decision state with a flag to skip the next purchase round after a fallback buy, aligning subsequent task routing.
- Adjust AutoStockpile task and purchase pipeline configuration, including reward-close handling, to optimize post-purchase wait and dialog closing behavior.

Documentation:
- Update interface and service localization strings to cover the new minimum-buy fallback behavior and related UI text.

</details>