### PR TITLE
fix: 售卖弹性物资好友价格判断失败

### DIFF
--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -368,10 +368,6 @@
                 "template": [
                     "AutoSell/SellTicketFriendValleyIV.png",
                     "AutoSell/SellTicketFriendWuling.png"
-                ],
-                "threshold": [
-                    0.9,
-                    0.9
                 ]
             }
         ],


### PR DESCRIPTION
close #4423

## Summary by Sourcery

Bug Fixes:
- 修复 AutoSell ItemTask 配置中好友价格条件不正确的问题，该问题会导致弹性物品售卖被错误评估。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect friend price condition in AutoSell ItemTask configuration that caused elastic item sales to be mis-evaluated.

</details>