### PR TITLE
fix: 更新多个 JSON 文件中的 upper 值以优化识别逻辑

### DIFF
--- a/assets/resource/pipeline/AutoStockStaple/General/Item.json
+++ b/assets/resource/pipeline/AutoStockStaple/General/Item.json
@@ -62,7 +62,7 @@
                     0
                 ],
                 "upper": [
-                    180
+                    160
                 ],
                 "connected": true,
                 "count": 1500,

--- a/assets/resource/pipeline/CreditShopping/Item/Blacklist.json
+++ b/assets/resource/pipeline/CreditShopping/Item/Blacklist.json
@@ -16,7 +16,7 @@
                     0
                 ],
                 "upper": [
-                    180
+                    160
                 ],
                 "connected": true,
                 "count": 1500,

--- a/assets/resource/pipeline/CreditShopping/Item/Priority1.json
+++ b/assets/resource/pipeline/CreditShopping/Item/Priority1.json
@@ -16,7 +16,7 @@
                     0
                 ],
                 "upper": [
-                    180
+                    160
                 ],
                 "connected": true,
                 "count": 1500,
@@ -80,7 +80,7 @@
                     0
                 ],
                 "upper": [
-                    180
+                    160
                 ],
                 "connected": true,
                 "count": 1500,

--- a/assets/resource/pipeline/CreditShopping/Item/Priority2.json
+++ b/assets/resource/pipeline/CreditShopping/Item/Priority2.json
@@ -16,7 +16,7 @@
                     0
                 ],
                 "upper": [
-                    180
+                    160
                 ],
                 "connected": true,
                 "count": 1500,
@@ -80,7 +80,7 @@
                     0
                 ],
                 "upper": [
-                    180
+                    160
                 ],
                 "connected": true,
                 "count": 1500,

--- a/assets/resource/pipeline/CreditShopping/Item/Priority3.json
+++ b/assets/resource/pipeline/CreditShopping/Item/Priority3.json
@@ -16,7 +16,7 @@
                     0
                 ],
                 "upper": [
-                    180
+                    160
                 ],
                 "connected": true,
                 "count": 1500,
@@ -80,7 +80,7 @@
                     0
                 ],
                 "upper": [
-                    180
+                    160
                 ],
                 "connected": true,
                 "count": 1500,

--- a/assets/resource/pipeline/CreditShopping/record.json
+++ b/assets/resource/pipeline/CreditShopping/record.json
@@ -16,7 +16,7 @@
                     0
                 ],
                 "upper": [
-                    180
+                    160
                 ],
                 "connected": true,
                 "count": 1500,


### PR DESCRIPTION
- 将多个文件中的 "upper" 值从 180 调整为 160，以改善物品识别的准确性和处理逻辑。

相关文件：
- AutoStockStaple/General/Item.json
- CreditShopping/record.json
- CreditShopping/Item/Blacklist.json
- CreditShopping/Item/Priority1.json
- CreditShopping/Item/Priority2.json
- CreditShopping/Item/Priority3.json

## Summary by Sourcery

错误修复：
- 通过在多个管线 JSON 文件中将配置的上限阈值从 180 降低到 160，提升物品识别的准确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Improve item recognition accuracy by lowering the configured upper threshold from 180 to 160 in multiple pipeline JSON files.

</details>