### PR TITLE
fix: GiftOperatorSkipDialog 增加 post_wait_freezes

### DIFF
--- a/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
@@ -435,6 +435,16 @@
                 215
             ]
         },
+        "post_wait_freezes": {
+            "time": 200,
+            "timeout": 2000,
+            "target": [
+                977,
+                145,
+                192,
+                215
+            ]
+        },
         "action": {
             "type": "Click"
         },


### PR DESCRIPTION
点击跳过对话后等待对话框区域稳定，避免过早进入分支判断。

## Summary by Sourcery

错误修复：
- 在跳过 GiftOperator 对话框后，增加一个等待完成后的冻结步骤，以避免过早进行分支评估。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a post-wait freeze step after skipping the GiftOperator dialog to avoid premature branch evaluation.

</details>