### PR TITLE
fix: 明确优先访问备注好友的语义

### DIFF
--- a/assets/resource/pipeline/VisitFriends/MenuScan.json
+++ b/assets/resource/pipeline/VisitFriends/MenuScan.json
@@ -1,6 +1,6 @@
 {
     "VisitFriendsMenuScan": {
-        "desc": "识别当前好友列表",
+        "desc": "识别当前好友列表；备注优先开启时首轮仅 TargetFriendOpenRemark，到底后 RemarkFallback 重开列表再走任意好友",
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
@@ -65,7 +65,7 @@
         }
     },
     "VisitFriendsMenuScanTargetFriendOpenRemark": {
-        "desc": "备注选友链路：名字框 ∧ 进船图标；默认启用便于节点测试，VisitFriendsRemark=No 时关闭；进船点击走 EnterShipRemark",
+        "desc": "备注选友链路：名字框 ∧ 进船图标；VisitFriendsRemark=Yes 时仅走本链路；进船点击走 EnterShipRemark",
         "enabled": true,
         "recognition": "And",
         "all_of": [
@@ -83,7 +83,7 @@
         ]
     },
     "VisitFriendsMenuScanTargetFriendOpen": {
-        "desc": "普通选友链路：名字框 ∧ 进船图标；box_index=1 点击飞船按钮",
+        "desc": "普通选友链路：名字框 ∧ 进船图标；box_index=1 点击飞船按钮；VisitFriendsRemark=Yes 首轮关闭，Fallback 后开启",
         "recognition": "And",
         "all_of": [
             "VisitFriendsMenuScanSelectFriendConsumable",
@@ -114,12 +114,74 @@
         ]
     },
     "VisitFriendsMenuScanScrollFinish": {
-        "desc": "滚动完成,滑动后仍然无其他目标",
+        "desc": "列表已到底：备注优先时先走 RemarkFallback 重开并切任意好友；否则或已回退过则结束",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "VisitFriendsMenuScanRemarkFallback",
+            "VisitFriendsMenuScanScrollFinishDone"
+        ]
+    },
+    "VisitFriendsMenuScanScrollFinishDone": {
+        "desc": "好友列表已滚动到底部，拜访完成",
         "pre_delay": 0,
         "post_delay": 0,
         "focus": {
             "Node.Recognition.Succeeded": "好友列表已滚动到底部，拜访完成"
         }
+    },
+    "VisitFriendsMenuScanRemarkFallback": {
+        "desc": "备注优先回退：首轮仅备注扫到底后，关闭备注选友、开启任意选友，清空 visited/滚动指纹；max_hit=1 只回退一次；VisitFriendsRemark=Yes 时开启",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "PipelineOverrideAction",
+        "custom_action_param": {
+            "patch": {
+                "VisitFriendsMenuScanTargetFriendOpenRemark": {
+                    "enabled": false
+                },
+                "VisitFriendsMenuScanTargetFriendOpen": {
+                    "enabled": true
+                },
+                "VisitFriendsMenuScanVisited": {
+                    "attach": {
+                        "visited": []
+                    }
+                },
+                "VisitFriendsMenuScanScrollList": {
+                    "attach": {
+                        "last_text": "",
+                        "unchanged_count": 0
+                    }
+                }
+            }
+        },
+        "post_delay": 0,
+        "next": [
+            "VisitFriendsMenuScanRemarkFallbackReopen"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": "备注好友已扫完，重新打开列表并拜访任意好友"
+        }
+    },
+    "VisitFriendsMenuScanRemarkFallbackReopen": {
+        "desc": "退出至大世界后重新打开好友列表，使列表回到顶部后再进入扫描",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld",
+                "SceneEnterMenuFriendsList"
+            ]
+        },
+        "post_delay": 0,
+        "next": [
+            "VisitFriendsMenu"
+        ]
     },
     "VisitFriendsMenuScanFriendsFull": {
         "desc": "拜访好友已达到上限：助力次数与线索交换次数均归零",
@@ -135,7 +197,7 @@
         }
     },
     "VisitFriendsMenuScanScrollList": {
-        "desc": "好友列表未到底时向下滚动：ListComplete 对比 WithNameForScroll（不检查线索）首尾 OCR 指纹；retry=1 表示指纹不变时再滑一次确认，unchanged_count>retry 才视为到底。attach.last_text / unchanged_count 由 ListCompleteRecognition 运行时维护",
+        "desc": "好友列表未到底时向下滚动：ListComplete 对比 WithNameForScroll（不检查线索）首尾 OCR 指纹；retry=1 表示指纹不变时再滑一次确认，unchanged_count>retry 才视为到底。attach.last_text / unchanged_count 由 ListCompleteRecognition 运行时维护；备注回退重开前会清空",
         "recognition": "Custom",
         "custom_recognition": "ListCompleteRecognition",
         "custom_recognition_param": {
@@ -153,7 +215,11 @@
             150
         ],
         "end_hold": 600, // 太短了松开会晃动
-        "post_delay": 0
+        "post_delay": 0,
+        "attach": {
+            "last_text": "",
+            "unchanged_count": 0
+        }
     },
     "VisitFriendsCheckAssist": {
         "desc": "打开好友详情后检查可访问资源（识别②）：线索交换固定开启；助力子节点未勾选时为 OCR a^，勾选后覆盖为 TemplateMatch",

--- a/assets/resource/pipeline/VisitFriends/Recognition.json
+++ b/assets/resource/pipeline/VisitFriends/Recognition.json
@@ -101,7 +101,7 @@
         "box_index": 3
     },
     "VisitFriendsRecognitionItemWithRemark": {
-        "desc": "识别进船按钮与带备注好友名；box_index=3 返回名字框，供备注优先消费性选友",
+        "desc": "识别进船按钮与带备注好友名；box_index=3 返回名字框，供备注选友链路消费",
         "recognition": "And",
         "all_of": [
             "VisitFriendsRecognitionItemEnterButton",

--- a/assets/tasks/VisitFriends.json
+++ b/assets/tasks/VisitFriends.json
@@ -31,6 +31,12 @@
                     "pipeline_override": {
                         "VisitFriendsMenuScanTargetFriendOpenRemark": {
                             "enabled": true
+                        },
+                        "VisitFriendsMenuScanTargetFriendOpen": {
+                            "enabled": false
+                        },
+                        "VisitFriendsMenuScanRemarkFallback": {
+                            "enabled": true
                         }
                     }
                 },
@@ -38,6 +44,12 @@
                     "name": "No",
                     "pipeline_override": {
                         "VisitFriendsMenuScanTargetFriendOpenRemark": {
+                            "enabled": false
+                        },
+                        "VisitFriendsMenuScanTargetFriendOpen": {
+                            "enabled": true
+                        },
+                        "VisitFriendsMenuScanRemarkFallback": {
                             "enabled": false
                         }
                     }


### PR DESCRIPTION
## 简介
旧: 同时执行备注扫描和正常扫描,在同屏情况下,优先点击备注好友
新:只执行备注扫描,到达列表尽头后重新执行普通扫描


## Summary by Sourcery

澄清并调整 VisitFriends 流水线，使其在菜单扫描和识别流程中明确优先访问带有备注的好友。

增强内容：
- 优化 VisitFriends 菜单扫描和识别配置，以体现对已备注好友的优先访问。
- 更新 VisitFriends 任务配置，使其与访问已备注好友的澄清语义保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and adjust the VisitFriends pipeline so it explicitly prioritizes visiting friends with remarks in menu scanning and recognition flows.

Enhancements:
- Refine VisitFriends menu scan and recognition configurations to reflect prioritized access to remarked friends.
- Update VisitFriends task configuration to align with the clarified semantics for visiting remarked friends.

</details>