### PR TITLE
fix(EnvironmentMonitoring): 临时删掉通过进入拍照按钮拍照的功能

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -514,8 +514,8 @@ void LogGeneratedNavmeshPath(
     const auto navmesh_path_points = PathPointsForLog(route_result.path);
     const auto navmesh_segment_breaks = route_result.path.segment_breaks;
     LogInfo << "NAVMESH generated path." << VAR(state.navmesh_zone) << VAR(state.current_zone) << VAR(route_result.cost)
-            << VAR(path_point_count) << VAR(navmesh_start_point) << VAR(navmesh_goal_point)
-            << VAR(navmesh_segment_breaks) << VAR(navmesh_path_points);
+            << VAR(path_point_count) << VAR(navmesh_start_point) << VAR(navmesh_goal_point) << VAR(navmesh_segment_breaks)
+            << VAR(navmesh_path_points);
 }
 
 // Probe from the target back toward the agent; the first reachable probe is the closest connected mesh
@@ -539,9 +539,8 @@ bool AppendBlindTargetFallback(
         return false;
     }
     const double snap_radius = std::max(param.navmesh_snap_radius, kBlindTargetFallbackSnapRadius);
-    const float snap_floor = goal_floor_y > navmesh::kBaseNavFloorYValidMin
-        ? goal_floor_y
-        : navmesh.pack.floorYForZoneName(state.current_zone);
+    const float snap_floor =
+        goal_floor_y > navmesh::kBaseNavFloorYValidMin ? goal_floor_y : navmesh.pack.floorYForZoneName(state.current_zone);
 
     // A probe at distance `offset` from the target snaps to within snap_radius, so its residual gap is at
     // least (offset - snap_radius). Past (kBlindTargetMaxExtension + snap_radius) every probe would fail the
@@ -945,8 +944,7 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshDetourRoute(
                 if (!triangle || triangle == start_triangle || triangle == goal_triangle) {
                     continue;
                 }
-                if (blocked.size() < kDetourBlockedTriangleCount
-                    && std::find(blocked.begin(), blocked.end(), *triangle) == blocked.end()) {
+                if (blocked.size() < kDetourBlockedTriangleCount && std::find(blocked.begin(), blocked.end(), *triangle) == blocked.end()) {
                     blocked.push_back(*triangle);
                 }
             }
@@ -992,8 +990,7 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshDetourRoute(
             }
 
             const double backtrack_penalty = std::max(0.0, std::abs(heading_offset) - 120.0) / 60.0 * kDetourBacktrackPenalty;
-            const double score =
-                route_to_detour->cost + route_to_goal->cost + backtrack_penalty + snapped->distance * kDetourSnapPenalty;
+            const double score = route_to_detour->cost + route_to_goal->cost + backtrack_penalty + snapped->distance * kDetourSnapPenalty;
             if (score < best_score) {
                 best = *route_to_detour;
                 best->cost += route_to_goal->cost;

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -80,7 +80,9 @@ public:
 
     // RecastNav 复用
     const std::vector<uint32_t>& adjacencyOffsets() const { return adjacency_offsets_; }
+
     const std::vector<uint32_t>& adjacencyLinks() const { return adjacency_links_; }
+
     bool isSmallIslandTriangle(uint32_t triangle_index) const;
     std::optional<std::array<WorldPoint, 2>> closestEdgeBridgePoints(uint32_t lhs, uint32_t rhs) const;
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -26,9 +26,14 @@ struct Nb8
 };
 
 const Nb8 kNb8[8] = {
-    { 1, 0, 1.0 },  { -1, 0, 1.0 }, { 0, 1, 1.0 },  { 0, -1, 1.0 },
-    { 1, 1, std::sqrt(2.0) },  { 1, -1, std::sqrt(2.0) },
-    { -1, 1, std::sqrt(2.0) }, { -1, -1, std::sqrt(2.0) },
+    { 1, 0, 1.0 },
+    { -1, 0, 1.0 },
+    { 0, 1, 1.0 },
+    { 0, -1, 1.0 },
+    { 1, 1, std::sqrt(2.0) },
+    { 1, -1, std::sqrt(2.0) },
+    { -1, 1, std::sqrt(2.0) },
+    { -1, -1, std::sqrt(2.0) },
 };
 
 // t[k] = k/(steps-1),末点强制 1.0(np.linspace 语义)
@@ -211,7 +216,7 @@ void AppendSeamBridge(RasterCells& rc, int64_t nx, int64_t ny)
     const auto occAt = [&](int64_t y, int64_t x) {
         return y >= 0 && y < ny && x >= 0 && x < nx && O2[static_cast<size_t>(y * nx + x)] != 0;
     };
-    const int64_t dirs[2][2] = { { 0, 1 }, { 1, 0 } };  // (dy,dx)
+    const int64_t dirs[2][2] = { { 0, 1 }, { 1, 0 } }; // (dy,dx)
     for (const auto& d : dirs) {
         const int64_t dy = d[0], dx = d[1];
         for (int64_t dl = 1; dl <= kb; ++dl) {
@@ -270,7 +275,7 @@ std::vector<uint8_t> Flood(int64_t seed, const SpanTable& st, int64_t nx)
     std::vector<uint8_t> vis(st.sp_h.size(), 0);
     vis[static_cast<size_t>(seed)] = 1;
     std::vector<int64_t> frontier { seed };
-    const int64_t dirs[4][2] = { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } };  // (dx,dy)
+    const int64_t dirs[4][2] = { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } }; // (dx,dy)
     while (!frontier.empty()) {
         std::vector<int64_t> next;
         for (const int64_t f : frontier) {
@@ -346,8 +351,7 @@ Grid<float> Clearance(const Mask& mask)
     Grid<float> out(nx, ny, 0.0f);
     for (int64_t i = 0; i < nx * ny; ++i) {
         if (mask.v[static_cast<size_t>(i)]) {
-            out.v[static_cast<size_t>(i)] =
-                std::min(std::sqrt(best.v[static_cast<size_t>(i)]) * 0.25f, 12.0f);
+            out.v[static_cast<size_t>(i)] = std::min(std::sqrt(best.v[static_cast<size_t>(i)]) * 0.25f, 12.0f);
         }
     }
     return out;
@@ -423,13 +427,7 @@ std::vector<uint8_t> WallsAtLayer(
     return keep;
 }
 
-WallCsr BuildWallIndex(
-    const std::vector<WorldPoint>& p0,
-    const std::vector<WorldPoint>& p1,
-    double ox,
-    double oy,
-    int64_t nx,
-    int64_t ny)
+WallCsr BuildWallIndex(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny)
 {
     WallCsr csr;
     csr.start.assign(static_cast<size_t>(nx * ny + 1), 0);
@@ -645,13 +643,8 @@ Mask CloseCracks(const Mask& core, const Mask& lay, const Mask* protect)
     return out;
 }
 
-std::optional<std::vector<CellPt>> CostAstar(
-    const Mask& mask,
-    CellPt s,
-    CellPt g,
-    const Grid<float>& mult,
-    const std::unordered_set<int64_t>* banned,
-    const double* bnp)
+std::optional<std::vector<CellPt>>
+    CostAstar(const Mask& mask, CellPt s, CellPt g, const Grid<float>& mult, const std::unordered_set<int64_t>* banned, const double* bnp)
 {
     const int64_t ny = mask.ny, nx = mask.nx;
     if (!mask.at(s.y, s.x) || !mask.at(g.y, g.x)) {
@@ -760,7 +753,7 @@ Grid<float> PrefField(const Grid<float>& dist, bool ridge)
     const auto at = [&](int64_t y, int64_t x) {
         return y >= 0 && y < ny && x >= 0 && x < nx ? dist.at(y, x) : ninf;
     };
-    const int64_t dirs[4][2] = { { 0, 1 }, { 1, 0 }, { 1, 1 }, { 1, -1 } };  // (dy,dx)
+    const int64_t dirs[4][2] = { { 0, 1 }, { 1, 0 }, { 1, 1 }, { 1, -1 } }; // (dy,dx)
     Grid<float> out = pref;
     for (int64_t y = 0; y < ny; ++y) {
         for (int64_t x = 0; x < nx; ++x) {

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -11,23 +11,23 @@
 namespace navmesh::recast
 {
 
-inline constexpr double kCS = 0.25;         // 体素边长 px
-inline constexpr double kClimb = 3.0;       // 相邻格可连通最大高差 px
-inline constexpr double kMergeH = 1.0;      // 同列 span 合并容差 px
-inline constexpr double kEdtCap = 12.0;     // 距离场截断 px
-inline constexpr double kR = 1.75;          // 期望余量上限 px
-inline constexpr double kRel = 0.6;         // 期望余量 = min(R, REL×局部净空)
-inline constexpr double kLam = 1.5;         // 满亏欠一步加价倍数
-inline constexpr double kRidgeFloor = 0.5;  // 脊线保底余量地板 px
-inline constexpr double kMaxErr = 0.5;      // 轮廓 DP 容差 px
-inline constexpr double kSlimEps = 0.5;     // 终线共线剔除容差 px
-inline constexpr double kMcHBand = 8.0;     // 层高度带(墙筛/盖章)px
-inline constexpr double kHBand = 6.0;       // 真墙探针高度带 px
-inline constexpr double kEpsProbe = 0.75;   // 真墙探针距离 px
-inline constexpr double kSnapRadius = 8.0;  // 起终点吸附半径 px
-inline constexpr double kMargin = 25.0;     // 窗口外扩 px
-inline constexpr double kBlockedPointRadius = 1.0;  // 封堵点盖章半径 px
-inline constexpr int64_t kHoleMaxCells = 32;        // 封闭小洞填充上限(格 = 2px²)
+inline constexpr double kCS = 0.25;                // 体素边长 px
+inline constexpr double kClimb = 3.0;              // 相邻格可连通最大高差 px
+inline constexpr double kMergeH = 1.0;             // 同列 span 合并容差 px
+inline constexpr double kEdtCap = 12.0;            // 距离场截断 px
+inline constexpr double kR = 1.75;                 // 期望余量上限 px
+inline constexpr double kRel = 0.6;                // 期望余量 = min(R, REL×局部净空)
+inline constexpr double kLam = 1.5;                // 满亏欠一步加价倍数
+inline constexpr double kRidgeFloor = 0.5;         // 脊线保底余量地板 px
+inline constexpr double kMaxErr = 0.5;             // 轮廓 DP 容差 px
+inline constexpr double kSlimEps = 0.5;            // 终线共线剔除容差 px
+inline constexpr double kMcHBand = 8.0;            // 层高度带(墙筛/盖章)px
+inline constexpr double kHBand = 6.0;              // 真墙探针高度带 px
+inline constexpr double kEpsProbe = 0.75;          // 真墙探针距离 px
+inline constexpr double kSnapRadius = 8.0;         // 起终点吸附半径 px
+inline constexpr double kMargin = 25.0;            // 窗口外扩 px
+inline constexpr double kBlockedPointRadius = 1.0; // 封堵点盖章半径 px
+inline constexpr int64_t kHoleMaxCells = 32;       // 封闭小洞填充上限(格 = 2px²)
 inline constexpr int64_t kMaxCells = 30'000'000;
 
 template <typename T>
@@ -123,13 +123,7 @@ std::vector<uint8_t> WallsAtLayer(
     double ox,
     double oy);
 
-WallCsr BuildWallIndex(
-    const std::vector<WorldPoint>& p0,
-    const std::vector<WorldPoint>& p1,
-    double ox,
-    double oy,
-    int64_t nx,
-    int64_t ny);
+WallCsr BuildWallIndex(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny);
 
 std::unordered_set<int64_t> BannedSteps(
     const Mask& free,
@@ -145,13 +139,8 @@ Mask FillHoles(const Mask& mask, int64_t max_cells, const Mask* protect);
 
 Mask CloseCracks(const Mask& core, const Mask& lay, const Mask* protect);
 
-std::optional<std::vector<CellPt>> CostAstar(
-    const Mask& mask,
-    CellPt s,
-    CellPt g,
-    const Grid<float>& mult,
-    const std::unordered_set<int64_t>* banned,
-    const double* bnp);
+std::optional<std::vector<CellPt>>
+    CostAstar(const Mask& mask, CellPt s, CellPt g, const Grid<float>& mult, const std::unordered_set<int64_t>* banned, const double* bnp);
 
 Grid<float> PrefField(const Grid<float>& dist, bool ridge);
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -61,8 +61,7 @@ std::optional<WindowInfo> buildWindow(
     AppendSeamBridge(rcs, nx, ny);
     const SpanTable st = BuildSpans(rcs.cell, rcs.h);
 
-    const auto widx = wo.wallsInBbox(x0 - 4, y0 - 4, x0 + static_cast<double>(nx) * kCS + 4,
-                                     y0 + static_cast<double>(ny) * kCS + 4);
+    const auto widx = wo.wallsInBbox(x0 - 4, y0 - 4, x0 + static_cast<double>(nx) * kCS + 4, y0 + static_cast<double>(ny) * kCS + 4);
     std::vector<WorldPoint> p0;
     std::vector<WorldPoint> p1;
     std::vector<double> hh;
@@ -263,8 +262,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
         const int64_t ca = (*q)[k - 1].y * nx + (*q)[k - 1].x;
         const int64_t cb = (*q)[k].y * nx + (*q)[k].x;
         if (bn.contains(ca * NC + cb)) {
-            dg.xwall.push_back({ x0 + (static_cast<double>((*q)[k].x) + 0.5) * kCS,
-                                 y0 + (static_cast<double>((*q)[k].y) + 0.5) * kCS });
+            dg.xwall.push_back({ x0 + (static_cast<double>((*q)[k].x) + 0.5) * kCS, y0 + (static_cast<double>((*q)[k].y) + 0.5) * kCS });
         }
     }
     if (!dg.xwall.empty()) {
@@ -299,15 +297,16 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
 
     std::vector<uint8_t> grn(q->size());
     for (size_t i = 0; i < q->size(); ++i) {
-        grn[i] = static_cast<uint8_t>(
-            info.dist.at((*q)[i].y, (*q)[i].x) >= prefg.at((*q)[i].y, (*q)[i].x) - 1e-9F);
+        grn[i] = static_cast<uint8_t>(info.dist.at((*q)[i].y, (*q)[i].x) >= prefg.at((*q)[i].y, (*q)[i].x) - 1e-9F);
     }
+
     struct Run
     {
         bool green;
         int64_t i0;
         int64_t i1;
     };
+
     std::vector<Run> runs;
     for (size_t i = 0; i < q->size();) {
         size_t j2 = i;
@@ -330,8 +329,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
         return out;
     };
     for (size_t k = 0; k < runs.size(); ++k) {
-        if (!runs[k].green && static_cast<double>(runs[k].i1 - runs[k].i0) * kCS < 2.0 && k > 0
-            && k < runs.size() - 1) {
+        if (!runs[k].green && static_cast<double>(runs[k].i1 - runs[k].i0) * kCS < 2.0 && k > 0 && k < runs.size() - 1) {
             runs[k].green = true;
         }
     }
@@ -367,8 +365,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                             const int64_t dy = sgn * sh * ddy;
                             const int64_t dx = sgn * sh * ddx;
                             for (int64_t y = std::max<int64_t>(0, dy); y < ny + std::min<int64_t>(0, dy); ++y) {
-                                for (int64_t x = std::max<int64_t>(0, dx); x < nx + std::min<int64_t>(0, dx);
-                                     ++x) {
+                                for (int64_t x = std::max<int64_t>(0, dx); x < nx + std::min<int64_t>(0, dx); ++x) {
                                     if (pmd.at(y - dy, x - dx) != 0) {
                                         acc.at(y, x) = 1;
                                     }
@@ -382,8 +379,8 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                 for (int64_t y = 0; y < ny; ++y) {
                     for (int64_t x = 0; x < nx; ++x) {
                         er.at(y, x) = static_cast<uint8_t>(
-                            info.dist.at(y, x) >= pref.at(y, x)
-                            || (info.dist.at(y, x) >= prefg.at(y, x) && pmd.at(y, x) != 0) || pm.at(y, x) != 0);
+                            info.dist.at(y, x) >= pref.at(y, x) || (info.dist.at(y, x) >= prefg.at(y, x) && pmd.at(y, x) != 0)
+                            || pm.at(y, x) != 0);
                     }
                 }
                 const auto q2 = CostAstar(er, cells.front(), cells.back(), ones, &bn, nullptr);
@@ -391,12 +388,12 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                     double l1 = 0.0;
                     double l2 = 0.0;
                     for (size_t k = 1; k < cells.size(); ++k) {
-                        l1 += std::hypot(static_cast<double>(cells[k].x - cells[k - 1].x),
-                                         static_cast<double>(cells[k].y - cells[k - 1].y));
+                        l1 +=
+                            std::hypot(static_cast<double>(cells[k].x - cells[k - 1].x), static_cast<double>(cells[k].y - cells[k - 1].y));
                     }
                     for (size_t k = 1; k < q2->size(); ++k) {
-                        l2 += std::hypot(static_cast<double>((*q2)[k].x - (*q2)[k - 1].x),
-                                         static_cast<double>((*q2)[k].y - (*q2)[k - 1].y));
+                        l2 +=
+                            std::hypot(static_cast<double>((*q2)[k].x - (*q2)[k - 1].x), static_cast<double>((*q2)[k].y - (*q2)[k - 1].y));
                     }
                     if (l2 <= l1 * 1.2 + 2.0 / kCS) {
                         pp = cen(*q2);
@@ -414,8 +411,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
             }
             pp = StringPull(pp, blk_green.has_value() ? *blk_green : blk_gray);
         }
-        if (!taut.empty() && !pp.empty()
-            && std::hypot(pp.front().x - taut.back().x, pp.front().y - taut.back().y) < 1e-9) {
+        if (!taut.empty() && !pp.empty() && std::hypot(pp.front().x - taut.back().x, pp.front().y - taut.back().y) < 1e-9) {
             pp.erase(pp.begin());
         }
         taut.insert(taut.end(), pp.begin(), pp.end());
@@ -428,8 +424,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
     std::vector<WorldPoint> stripped;
     for (size_t i = 0; i < line.size(); ++i) {
         if (i == 0 || i == line.size() - 1
-            || (std::hypot(line[i].x - s.x, line[i].y - s.y) > 0.4
-                && std::hypot(line[i].x - g.x, line[i].y - g.y) > 0.4)) {
+            || (std::hypot(line[i].x - s.x, line[i].y - s.y) > 0.4 && std::hypot(line[i].x - g.x, line[i].y - g.y) > 0.4)) {
             stripped.push_back(line[i]);
         }
     }
@@ -505,9 +500,8 @@ RecastPlanResult RecastNavEngine::planLocked(
             blocked_local.push_back(static_cast<int32_t>(local));
         }
     }
-    const std::optional<double> sfl = start_floor_y > kBaseNavFloorYValidMin
-        ? std::optional<double>(static_cast<double>(start_floor_y))
-        : std::nullopt;
+    const std::optional<double> sfl =
+        start_floor_y > kBaseNavFloorYValidMin ? std::optional<double>(static_cast<double>(start_floor_y)) : std::nullopt;
     const std::optional<double> gfl =
         goal_floor_y > kBaseNavFloorYValidMin ? std::optional<double>(static_cast<double>(goal_floor_y)) : std::nullopt;
     const auto ss = zc.snap(start, kSnapRadius, sfl);
@@ -544,8 +538,12 @@ RecastPlanResult RecastNavEngine::planLocked(
                 if (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius) {
                     if (mi == 3) {
                         char buf[128];
-                        std::snprintf(buf, sizeof(buf), "端点接不上可走层 (起 %.1fpx / 终 %.1fpx, 疑似不连通)",
-                                      dg.snap_start, dg.snap_goal);
+                        std::snprintf(
+                            buf,
+                            sizeof(buf),
+                            "端点接不上可走层 (起 %.1fpx / 终 %.1fpx, 疑似不连通)",
+                            dg.snap_start,
+                            dg.snap_goal);
                         res.error = buf;
                         return res;
                     }

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -20,8 +20,8 @@ struct RecastPlanResult
     std::vector<WorldPoint> points;
     double length = 0.0;
     std::vector<std::string> warnings;
-    std::vector<WorldPoint> wall_cross;   // 不可避穿墙步的格心
-    double snap_start = 0.0;              // 起/终点到可走格锚点距离 px
+    std::vector<WorldPoint> wall_cross; // 不可避穿墙步的格心
+    double snap_start = 0.0;            // 起/终点到可走格锚点距离 px
     double snap_goal = 0.0;
 };
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -14,7 +14,7 @@ namespace navmesh::recast
 namespace
 {
 
-constexpr double kPortalSamples[5] = { 0.5, 0.25, 0.75, 0.1, 0.9 };  // 共边 hop 的门户采样位
+constexpr double kPortalSamples[5] = { 0.5, 0.25, 0.75, 0.1, 0.9 }; // 共边 hop 的门户采样位
 
 double triHeight(const PolyMesh& mesh, int32_t t)
 {
@@ -79,9 +79,8 @@ void PolyMesh::buildNb()
             const int64_t a = T[static_cast<size_t>(i)][k];
             const int64_t b = T[static_cast<size_t>(i)][(k + 1) % 3];
             const int64_t kr = b * n + a;
-            const size_t pos = std::min(
-                static_cast<size_t>(std::lower_bound(skeys.begin(), skeys.end(), kr) - skeys.begin()),
-                skeys.size() - 1);
+            const size_t pos =
+                std::min(static_cast<size_t>(std::lower_bound(skeys.begin(), skeys.end(), kr) - skeys.begin()), skeys.size() - 1);
             if (skeys[pos] == kr) {
                 NB[static_cast<size_t>(i)][k] = se[pos].second / 3;
             }
@@ -345,10 +344,8 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
     }
     comp_island.resize(static_cast<size_t>(m));
     for (int64_t c = 0; c < m; ++c) {
-        comp_island[static_cast<size_t>(c)] = (n_tot[static_cast<size_t>(c)] == 0
-                                               || n_isl[static_cast<size_t>(c)] * 2 > n_tot[static_cast<size_t>(c)])
-            ? 1
-            : 0;
+        comp_island[static_cast<size_t>(c)] =
+            (n_tot[static_cast<size_t>(c)] == 0 || n_isl[static_cast<size_t>(c)] * 2 > n_tot[static_cast<size_t>(c)]) ? 1 : 0;
     }
 
     // link 层 hop:NB 已邻接跳过;跨分量共焊边 → 门户采样,否则 touch/bridge;
@@ -379,8 +376,7 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
         int ns = 0;
         for (int ka = 0; ka < 3 && ns < 2; ++ka) {
             const int32_t v = T[static_cast<size_t>(ti)][ka];
-            if (v == T[static_cast<size_t>(tj)][0] || v == T[static_cast<size_t>(tj)][1]
-                || v == T[static_cast<size_t>(tj)][2]) {
+            if (v == T[static_cast<size_t>(tj)][0] || v == T[static_cast<size_t>(tj)][1] || v == T[static_cast<size_t>(tj)][2]) {
                 sh[ns++] = v;
             }
         }
@@ -407,8 +403,7 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
             ++n_edge;
         }
         else {
-            const auto br =
-                planner.closestEdgeBridgePoints(static_cast<uint32_t>(lo + i), static_cast<uint32_t>(lo + j));
+            const auto br = planner.closestEdgeBridgePoints(static_cast<uint32_t>(lo + i), static_cast<uint32_t>(lo + j));
             if (!br) {
                 continue;
             }
@@ -457,7 +452,7 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
                 if (nb2 < 0 || seen.contains(nb2)) {
                     continue;
                 }
-                if (nb2 == tb) {  // 目标判定先于出框判定
+                if (nb2 == tb) { // 目标判定先于出框判定
                     hit = true;
                     break;
                 }
@@ -476,8 +471,7 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
             pushPortals(ta, tb);
         }
         else {
-            const auto br =
-                planner.closestEdgeBridgePoints(static_cast<uint32_t>(lo + ta), static_cast<uint32_t>(lo + tb));
+            const auto br = planner.closestEdgeBridgePoints(static_cast<uint32_t>(lo + ta), static_cast<uint32_t>(lo + tb));
             if (!br) {
                 continue;
             }
@@ -498,10 +492,9 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
             ++ncomps;
         }
     }
-    stats = "weld " + std::to_string(n_weld) + "v dup-sever " + std::to_string(n_dup) + ", link-mask cut "
-        + std::to_string(n_cut) + ", comps " + std::to_string(ncomps) + ", hops edge " + std::to_string(n_edge)
-        + " touch " + std::to_string(n_touch) + " bridge " + std::to_string(n_bridge) + " srcadj "
-        + std::to_string(n_srcadj);
+    stats = "weld " + std::to_string(n_weld) + "v dup-sever " + std::to_string(n_dup) + ", link-mask cut " + std::to_string(n_cut)
+            + ", comps " + std::to_string(ncomps) + ", hops edge " + std::to_string(n_edge) + " touch " + std::to_string(n_touch)
+            + " bridge " + std::to_string(n_bridge) + " srcadj " + std::to_string(n_srcadj);
 }
 
 std::vector<int32_t> ZoneClean::batchLocate(const std::vector<WorldPoint>& pts, const std::vector<double>& hints) const
@@ -510,8 +503,7 @@ std::vector<int32_t> ZoneClean::batchLocate(const std::vector<WorldPoint>& pts, 
     for (size_t p = 0; p < pts.size(); ++p) {
         const int64_t gx = static_cast<int64_t>(std::floor(pts[p].x / PolyMesh::kGridCell));
         const int64_t gy = static_cast<int64_t>(std::floor(pts[p].y / PolyMesh::kGridCell));
-        const auto [glo, ghi] =
-            std::equal_range(mesh.gkeys.begin(), mesh.gkeys.end(), gx * PolyMesh::kGridStride + gy);
+        const auto [glo, ghi] = std::equal_range(mesh.gkeys.begin(), mesh.gkeys.end(), gx * PolyMesh::kGridStride + gy);
         double best = 0.0;
         int32_t bt = -1;
         for (auto it = glo; it != ghi; ++it) {
@@ -633,8 +625,7 @@ bool WallOracle::hopNear(int64_t ei, double tol) const
     const int64_t cy1 = static_cast<int64_t>(std::floor((std::max(p0.y, p1.y) + tol) / kHopCell));
     for (int64_t cx = cx0; cx <= cx1; ++cx) {
         for (int64_t cy = cy0; cy <= cy1; ++cy) {
-            const auto it =
-                hop_grid_.find((cx + (int64_t(1) << 30)) * (int64_t(1) << 31) + (cy + (int64_t(1) << 30)));
+            const auto it = hop_grid_.find((cx + (int64_t(1) << 30)) * (int64_t(1) << 31) + (cy + (int64_t(1) << 30)));
             if (it == hop_grid_.end()) {
                 continue;
             }
@@ -672,8 +663,7 @@ void WallOracle::classify(const std::vector<int64_t>& idx)
     }
     const auto tri = zc_.batchLocate(P, hh);
     for (size_t j = 0; j < todo.size(); ++j) {
-        const bool free =
-            tri[j] >= 0 && std::fabs(triHeight(zc_.mesh, tri[j]) - hh[j]) <= kHBand;
+        const bool free = tri[j] >= 0 && std::fabs(triHeight(zc_.mesh, tri[j]) - hh[j]) <= kHBand;
         bool wall = !free;
         if (wall && hopNear(todo[j])) {
             wall = false;
@@ -686,8 +676,8 @@ std::vector<int64_t> WallOracle::wallsInBbox(double x0, double y0, double x1, do
 {
     std::vector<int64_t> idx;
     for (int64_t i = 0; i < static_cast<int64_t>(P0.size()); ++i) {
-        if (hi_[static_cast<size_t>(i)].x >= x0 && lo_[static_cast<size_t>(i)].x <= x1
-            && hi_[static_cast<size_t>(i)].y >= y0 && lo_[static_cast<size_t>(i)].y <= y1) {
+        if (hi_[static_cast<size_t>(i)].x >= x0 && lo_[static_cast<size_t>(i)].x <= x1 && hi_[static_cast<size_t>(i)].y >= y0
+            && lo_[static_cast<size_t>(i)].y <= y1) {
             idx.push_back(i);
         }
     }

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.h
@@ -14,8 +14,8 @@
 namespace navmesh::recast
 {
 
-inline constexpr double kWeldDh = 3.0;                 // 顶点焊接同柱高差容差 px
-inline constexpr double kSnapFallbackRadius = 16.0;    // 吸附兜底半径 px
+inline constexpr double kWeldDh = 3.0;              // 顶点焊接同柱高差容差 px
+inline constexpr double kSnapFallbackRadius = 16.0; // 吸附兜底半径 px
 inline constexpr double kSrcadjMaxGap = 8.0;
 inline constexpr double kSrcadjLocalR = 12.0;
 
@@ -30,7 +30,7 @@ struct PolyMesh
     PolyMesh(std::vector<WorldPoint> v, std::vector<std::array<int32_t, 3>> t, std::vector<double> h);
 
     void buildNb();
-    std::vector<int32_t> trisNear(const WorldPoint& p, double r) const;  // 升序去重
+    std::vector<int32_t> trisNear(const WorldPoint& p, double r) const; // 升序去重
 
     static constexpr double kGridCell = 24.0;
     static constexpr int64_t kGridStride = int64_t(1) << 24;
@@ -73,8 +73,8 @@ public:
     int64_t lo = 0;
     int64_t hi = 0;
     PolyMesh mesh;
-    std::vector<int32_t> comp;          // 三角 → 分量代表(区内最小三角号)
-    std::vector<uint8_t> comp_island;   // 按分量代表值索引
+    std::vector<int32_t> comp;        // 三角 → 分量代表(区内最小三角号)
+    std::vector<uint8_t> comp_island; // 按分量代表值索引
     std::vector<HopPt> hops;
     std::string stats;
 

--- a/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
@@ -5,7 +5,9 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "EnvironmentMonitoringEnterCameraMode",
+            // 暂时取消掉这个方法
+            // 因为当前寻路存在惯性，可能会出现识别到之后往前走一步无法单击的情况。
+            // "EnvironmentMonitoringEnterCameraMode",
             "EnvironmentMonitoringTakePhotoDirectly"
         ]
     },

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
@@ -435,6 +435,9 @@
                 215
             ]
         },
+        "action": {
+            "type": "Click"
+        },
         "post_wait_freezes": {
             "time": 200,
             "timeout": 2000,
@@ -444,9 +447,6 @@
                 192,
                 215
             ]
-        },
-        "action": {
-            "type": "Click"
         },
         "next": [
             "GiftOperatorBranchGift",


### PR DESCRIPTION
Fixes #4287

## Summary by Sourcery

改进：
- 调整 EnvironmentMonitoring TakePhoto 管线配置，以防止通过专用按钮进入时触发应用内拍照功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust EnvironmentMonitoring TakePhoto pipeline configuration to prevent launching the in-app photo capture when entering via the dedicated button.

</details>