### PR TITLE
fix: 协议空间重新挑战后等待加载

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -770,7 +770,7 @@
         ],
         "action": "Click",
         "next": [
-            "[JumpBack]SceneWaitLoadingExit",
+            "[JumpBack]SceneWaitBlackScreenLoadingExit",
             "ProtocolSpaceEnterSpaceSuccess",
             "ProtocolSpaceRewardClaimSuccessSanityLowDialog"
         ],


### PR DESCRIPTION
与选剑演武战斗前的加载一样，都是黑屏加载

## Summary by Sourcery

Bug Fixes:
- 确保在场景重新加载期间，ProtocolSpace 重新挑战流程能正确显示黑屏加载状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure ProtocolSpace re-challenge flow correctly shows a black screen loading state while the scene reloads.

</details>