### PR TITLE
fix: 大世界进入地图失败

### DIFF
--- a/agent/go-service/common/repeataction/action.go
+++ b/agent/go-service/common/repeataction/action.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	defaultRepeatCount = 3
-	defaultIntervalMs  = 1000
+	defaultIntervalMs  = 3000
 	innerActionEntry   = "__RepeatUntilActionInner"
 )
 

--- a/assets/resource/pipeline/Interface/Example/RepeatUntilFoundAction.json
+++ b/assets/resource/pipeline/Interface/Example/RepeatUntilFoundAction.json
@@ -13,8 +13,8 @@
             ],
             // 可选，最大尝试次数；省略或 <= 0 时默认 3
             "repeat_count": 3,
-            // 可选，每次尝试后、识别前的等待（毫秒）；省略或 0 时默认 1000
-            "interval_ms": 1000
+            // 可选，每次尝试后、识别前的等待（毫秒）；省略或 0 时默认 3000
+            "interval_ms": 3000
         },
         "next": []
     },
@@ -45,7 +45,7 @@
                 "RepeatUntilFoundActionExampleReady"
             ],
             "repeat_count": 3,
-            "interval_ms": 1000
+            "interval_ms": 3000
         },
         "next": []
     }

--- a/docs/en_us/developers/custom.md
+++ b/docs/en_us/developers/custom.md
@@ -94,7 +94,7 @@ Both are implemented in `agent/go-service/common/repeataction`. They repeatedly 
     - `custom_action?: string`: Registered custom action name (e.g. `AutoAltClickAction`). Mutually exclusive with `action`.
     - `custom_action_param?: object`: Forwarded to the nested custom action.
     - `repeat_count?: int`: Maximum attempts. Defaults to `3` when omitted or `<= 0`.
-    - `interval_ms?: int`: Wait after each attempt before recognition, in milliseconds. Defaults to `1000` when omitted or `0`. Negative values are invalid.
+    - `interval_ms?: int`: Wait after each attempt before recognition, in milliseconds. Defaults to `3000` when omitted or `0`. Negative values are invalid.
 - `RepeatUntilFoundAction` extra:
     - `wait_nodes: string[]`: Pipeline node names to wait for. Required.
 - `RepeatUntilNotFoundAction` extra:

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -96,7 +96,7 @@ Action 节点用于执行自定义动作。常见写法如下：
     - `custom_action?: string`：已注册的自定义动作名（如 `AutoAltClickAction`），与 `action` 二选一。
     - `custom_action_param?: object`：透传给内层自定义动作的参数。
     - `repeat_count?: int`：最大尝试次数；省略或 `<= 0` 时默认 `3`。
-    - `interval_ms?: int`：每次尝试后、识别前的等待（毫秒）；省略或 `0` 时默认 `1000`；负值非法。
+    - `interval_ms?: int`：每次尝试后、识别前的等待（毫秒）；省略或 `0` 时默认 `3000`；负值非法。
 - `RepeatUntilFoundAction` 额外参数：
     - `wait_nodes: string[]`：等待出现的 Pipeline 节点名列表，必填。
 - `RepeatUntilNotFoundAction` 额外参数：

--- a/tools/schema/components/repeat_action.schema.json
+++ b/tools/schema/components/repeat_action.schema.json
@@ -30,7 +30,7 @@
                 },
                 "interval_ms": {
                     "title": "Interval Ms",
-                    "description": "Wait after each attempt before recognition (ms). Omit or 0 defaults to 1000.",
+                    "description": "Wait after each attempt before recognition (ms). Omit or 0 defaults to 3000.",
                     "type": "integer",
                     "minimum": 0
                 }


### PR DESCRIPTION
close #4500

## Summary by Sourcery

增加默认重复操作间隔，以减少快速重试并统一相关文档。

Bug Fixes:
- 将默认重复间隔调整为 3000 ms，以缓解进入开放世界地图时发生的失败问题。

Enhancements:
- 更新英文和中文的开发者文档，以反映新的 3000 ms 默认重复间隔。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Increase the default repeat action interval to reduce rapid retries and align related documentation.

Bug Fixes:
- Adjust default repeat interval to 3000 ms to mitigate failures when entering the open world map.

Enhancements:
- Update English and Chinese developer documentation to reflect the new 3000 ms default repeat interval.

</details>