### PR TITLE
perf: 售卖弹性物资识别失败时避免死循环

### DIFF
--- a/assets/resource/pipeline/AutoSell/ItemTask.json
+++ b/assets/resource/pipeline/AutoSell/ItemTask.json
@@ -4,6 +4,10 @@
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,
+        "anchor": {
+            "AutoSellStockRedistributionItemFailedToValleyIVAnchor": "AutoSellStockRedistributionItemOpenPrepareFriendsFailedToValleyIV",
+            "AutoSellStockRedistributionItemFailedToWulingAnchor": "AutoSellStockRedistributionItemOpenPrepareFriendsFailedToWuling"
+        },
         "next": [
             "AutoSellStockRedistributionItemOpenPrepareRegionalDevelopmentValleyIV",
             "AutoSellStockRedistributionItemOpenPrepareRegionalDevelopmentWuling",
@@ -152,7 +156,7 @@
         "next": [
             "AutoSellTicketValleyIVOverflow",
             "AutoSellStockRedistributionItemOpenInFriends",
-            "AutoSellStockRedistributionItemOpenPrepareFriendsFailedToValleyIV"
+            "[Anchor]AutoSellStockRedistributionItemFailedToValleyIVAnchor"
         ]
     },
     "AutoSellStockRedistributionItemOpenPrepareFriendsSwitchWuling": {
@@ -177,7 +181,7 @@
         "next": [
             "AutoSellTicketWulingOverflow",
             "AutoSellStockRedistributionItemOpenInFriends",
-            "AutoSellStockRedistributionItemOpenPrepareFriendsFailedToWuling"
+            "[Anchor]AutoSellStockRedistributionItemFailedToWulingAnchor"
         ]
     },
     "AutoSellStockRedistributionItemOpenPrepareFriendsFailedToValleyIV": {
@@ -608,6 +612,10 @@
             "フレン",
             "친구"
         ],
+        "anchor": {
+            "AutoSellStockRedistributionItemFailedToValleyIVAnchor": "",
+            "AutoSellStockRedistributionItemFailedToWulingAnchor": ""
+        }, // 下一个好友一定能找到，找不到是识别问题，任务失败查看截图内容
         "pre_wait_freezes": 100,
         "pre_delay": 0,
         "action": "Click",


### PR DESCRIPTION
#4474

## Summary by Sourcery

错误修复：
- 当对弹性商品的物品识别失败时，避免 AutoSell 流水线中的死循环行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid dead-loop behavior in the AutoSell pipeline when item recognition for elastic goods fails.

</details>