### PR TITLE
fix(SellProduct): 优先处理新地区售卖与派驻

### DIFF
--- a/agent/go-service/sellproduct/operator_selection.go
+++ b/agent/go-service/sellproduct/operator_selection.go
@@ -159,13 +159,7 @@ func selectTargetCandidateForRestorePlan(
 	bestPlan := restorePlanForTargetCandidate(p, owned, bestCandidate)
 	for _, candidate := range candidates[1:] {
 		plan := restorePlanForTargetCandidate(p, owned, candidate)
-		if isBetterRestorePlan(
-			plan.Assigned,
-			plan.KeptTargets,
-			plan.ReusableTargets,
-			plan.TotalCost,
-			bestPlan,
-		) {
+		if isBetterRestorePlan(plan, bestPlan) {
 			bestCandidate = candidate
 			bestPlan = plan
 		}
@@ -342,20 +336,22 @@ func buildRestoreAssignmentPlanWithPreferencesAndTargets(
 	var walk func(index int, assigned int, keptTargets int, reusableCount int, totalCost int)
 	walk = func(index int, assigned int, keptTargets int, reusableCount int, totalCost int) {
 		if index >= len(groups) {
-			if isBetterRestorePlan(assigned, keptTargets, reusableCount, totalCost, best) {
-				best.Assigned = assigned
-				best.KeptTargets = keptTargets
-				best.ReusableTargets = reusableCount
-				best.TotalCost = totalCost
-				best.Assignments = cloneRestoreAssignments(current)
+			candidate := restoreAssignmentPlan{
+				Assignments:     current,
+				Assigned:        assigned,
+				KeptTargets:     keptTargets,
+				ReusableTargets: reusableCount,
+				TotalCost:       totalCost,
+			}
+			if isBetterRestorePlan(candidate, best) {
+				candidate.Assignments = cloneRestoreAssignments(current)
+				best = candidate
 			}
 			return
 		}
 
 		group := groups[index]
-		// 先探索跳过该据点的分支，保证资源不足时仍能覆盖部分据点。
-		walk(index+1, assigned, keptTargets, reusableCount, totalCost)
-
+		// 先探索当前据点的候选，使完全等价的方案保留生成数据中的新地区优先顺序。
 		for _, candidate := range filterOwnedCandidates(group.Candidates, owned) {
 			if _, ok := used[candidate.Name]; ok {
 				continue
@@ -379,30 +375,43 @@ func buildRestoreAssignmentPlanWithPreferencesAndTargets(
 			delete(current, group.Location)
 			delete(used, candidate.Name)
 		}
+
+		// 没有候选或把干员留给后续据点时，继续探索跳过当前据点的分支。
+		walk(index+1, assigned, keptTargets, reusableCount, totalCost)
 	}
 	walk(0, 0, 0, 0, 0)
 	return best
 }
 
 // 按“覆盖数、本次保持人数、下次可沿用人数、候选成本”的字典序比较方案。
-// 全部相等时返回 false，保留先找到的稳定方案。
-func isBetterRestorePlan(
-	assigned int,
-	keptTargets int,
-	reusableTargets int,
-	totalCost int,
-	best restoreAssignmentPlan,
-) bool {
-	if assigned != best.Assigned {
-		return assigned > best.Assigned
+// 候选成本只在分配据点集合相同时可比；据点集合不同时保留 DFS 先找到的新地区优先方案。
+func isBetterRestorePlan(candidate restoreAssignmentPlan, best restoreAssignmentPlan) bool {
+	if candidate.Assigned != best.Assigned {
+		return candidate.Assigned > best.Assigned
 	}
-	if keptTargets != best.KeptTargets {
-		return keptTargets > best.KeptTargets
+	if candidate.KeptTargets != best.KeptTargets {
+		return candidate.KeptTargets > best.KeptTargets
 	}
-	if reusableTargets != best.ReusableTargets {
-		return reusableTargets > best.ReusableTargets
+	if candidate.ReusableTargets != best.ReusableTargets {
+		return candidate.ReusableTargets > best.ReusableTargets
 	}
-	return totalCost < best.TotalCost
+	if !sameAssignedLocations(candidate.Assignments, best.Assignments) {
+		return false
+	}
+	return candidate.TotalCost < best.TotalCost
+}
+
+// 判断两个方案是否覆盖完全相同的据点；不同据点候选列表的 Priority 不可横向比较。
+func sameAssignedLocations(a map[string]operatorCandidate, b map[string]operatorCandidate) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for location := range a {
+		if _, ok := b[location]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // 复制分配表，避免回溯改写已保存的最优解。

--- a/agent/go-service/sellproduct/operator_selection_test.go
+++ b/agent/go-service/sellproduct/operator_selection_test.go
@@ -734,7 +734,7 @@ func orderedEnabledLocations(t *testing.T, gameOrder []string, enabled ...string
 }
 
 // TestPlanningMatches20260719LogSnapshot 使用 MaaEnd-logs-v0.1.0-20260719-094957
-// 中的完整拥有干员快照，验证六据点固定顺序下的售卖与恢复规划。
+// 中的完整拥有干员快照，验证六据点按新地区优先顺序的售卖与恢复规划。
 func TestPlanningMatches20260719LogSnapshot(t *testing.T) {
 	resetOperatorSessionForTest(t, operatorCacheModeCache)
 	data, err := loadOperatorSelectionData()
@@ -743,12 +743,12 @@ func TestPlanningMatches20260719LogSnapshot(t *testing.T) {
 	}
 
 	expectedLocationOrder := []string{
-		"RefugeeCamp",
-		"InfraStation",
-		"ReconstructionHQ",
 		"SkyKingFlatsConstructionSite",
 		"CardiacRemediationStation",
 		"XiranflowCloudseederStation",
+		"RefugeeCamp",
+		"InfraStation",
+		"ReconstructionHQ",
 	}
 	locationOrder := orderedEnabledLocations(t, data.LocationOrder, expectedLocationOrder...)
 	if !slices.Equal(locationOrder, expectedLocationOrder) {
@@ -832,6 +832,120 @@ func TestPlanningMatches20260719LogSnapshot(t *testing.T) {
 	active := operatorSessionSnapshot().ActiveLocations
 	if !operatorConflictSourceManaged("ReconstructionHQ", true, active) {
 		t.Fatal("日志中的重建指挥部已启用，莱万汀冲突应允许调至难民暂居处")
+	}
+}
+
+// TestPlanningPrioritizesWulingWith20260725Issue4514Snapshot 使用 Issue #4514
+// 的完整拥有干员快照，验证共享的陈千语优先派驻武陵盈天台；谷地基建前站
+// 没有其他恢复候选时保留售卖干员赛希。
+func TestPlanningPrioritizesWulingWith20260725Issue4514Snapshot(t *testing.T) {
+	resetOperatorSessionForTest(t, operatorCacheModeCache)
+	data, err := loadOperatorSelectionData()
+	if err != nil {
+		t.Fatalf("加载 SellProduct 干员数据失败：%v", err)
+	}
+	locationOrder := orderedEnabledLocations(t, data.LocationOrder,
+		"RefugeeCamp",
+		"InfraStation",
+		"ReconstructionHQ",
+		"SkyKingFlatsConstructionSite",
+		"CardiacRemediationStation",
+		"XiranflowCloudseederStation",
+	)
+	expectedLocationOrder := []string{
+		"SkyKingFlatsConstructionSite",
+		"CardiacRemediationStation",
+		"XiranflowCloudseederStation",
+		"RefugeeCamp",
+		"InfraStation",
+		"ReconstructionHQ",
+	}
+	if !slices.Equal(locationOrder, expectedLocationOrder) {
+		t.Fatalf("据点售卖顺序 = %#v，期望新地区优先顺序 %#v", locationOrder, expectedLocationOrder)
+	}
+	for _, location := range locationOrder {
+		operatorSessionRegisterLocation(location)
+		operatorSessionSetOutpostProsperityMax(location, true)
+	}
+
+	// 来源：MaaEnd-logs-v2.21.0-20260725-225531/record/SellProductCache.json。
+	owned := operatorIDSet([]string{
+		"Akekuri",
+		"Alesh",
+		"Antal",
+		"Arclight",
+		"Ardelia",
+		"Avywenna",
+		"Catcher",
+		"ChenQianyu",
+		"DaPan",
+		"Estella",
+		"Fluorite",
+		"Gilberta",
+		"Lifeng",
+		"Perlica",
+		"Pogranichnik",
+		"Rossi",
+		"Snowshine",
+		"Tangtang",
+		"Wulfgard",
+		"Xaihi",
+		"ZhuangFangyi",
+	})
+	expectedTarget := map[string]string{
+		"SkyKingFlatsConstructionSite": "Tangtang",
+		"CardiacRemediationStation":    "ZhuangFangyi",
+		"XiranflowCloudseederStation":  "Lifeng",
+		"RefugeeCamp":                  "Antal",
+		"InfraStation":                 "Xaihi",
+		"ReconstructionHQ":             "Gilberta",
+	}
+	expectedRestore := map[string]string{
+		"SkyKingFlatsConstructionSite": "Tangtang",
+		"CardiacRemediationStation":    "ZhuangFangyi",
+		"XiranflowCloudseederStation":  "ChenQianyu",
+		"RefugeeCamp":                  "Antal",
+		"InfraStation":                 "",
+		"ReconstructionHQ":             "Gilberta",
+	}
+
+	for _, location := range locationOrder {
+		targetSelection, resolveErr := resolveOperatorSelectionParam(&operatorActionParam{
+			Usage:    operatorActionUsageTarget,
+			Location: location,
+		})
+		if resolveErr != nil {
+			t.Fatalf("解析 %s 售卖参数失败：%v", location, resolveErr)
+		}
+		target := candidatesForCurrentSelection(targetSelection, owned)
+		if len(target) != 1 || target[0].Name != expectedTarget[location] {
+			t.Fatalf("%s 售卖干员 = %#v，期望 %s", location, target, expectedTarget[location])
+		}
+		operatorSessionSetTargetAssignment(location, target[0])
+
+		restoreSelection, resolveErr := resolveOperatorSelectionParam(&operatorActionParam{
+			Usage:    operatorActionUsageRestore,
+			Location: location,
+		})
+		if resolveErr != nil {
+			t.Fatalf("解析 %s 售后生产派驻参数失败：%v", location, resolveErr)
+		}
+		restore := candidatesForCurrentSelection(restoreSelection, owned)
+		wantRestore := expectedRestore[location]
+		if wantRestore == "" {
+			if len(restore) != 0 {
+				t.Fatalf("%s 售后生产派驻干员 = %#v，期望无候选并保留售卖干员", location, restore)
+			}
+			operatorSessionSkipRestore(location)
+			continue
+		}
+		if len(restore) != 1 || restore[0].Name != wantRestore {
+			t.Fatalf("%s 售后生产派驻干员 = %#v，期望 %s", location, restore, wantRestore)
+		}
+		operatorSessionSetPlannedRestore(location, restore[0], true)
+		if _, ok := operatorSessionCompleteRestore(location); !ok {
+			t.Fatalf("%s 售后生产派驻结果无法锁定", location)
+		}
 	}
 }
 

--- a/assets/data/SellProduct/selection_data.json
+++ b/assets/data/SellProduct/selection_data.json
@@ -508,12 +508,12 @@
         }
     },
     "location_order": [
-        "RefugeeCamp",
-        "InfraStation",
-        "ReconstructionHQ",
         "SkyKingFlatsConstructionSite",
         "CardiacRemediationStation",
-        "XiranflowCloudseederStation"
+        "XiranflowCloudseederStation",
+        "RefugeeCamp",
+        "InfraStation",
+        "ReconstructionHQ"
     ],
     "locations": {
         "RefugeeCamp": {

--- a/assets/resource/pipeline/SellProduct/Loop.json
+++ b/assets/resource/pipeline/SellProduct/Loop.json
@@ -9,8 +9,8 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "SellProductValleyIV",
             "SellProductWuling",
+            "SellProductValleyIV",
             "SellProductTaskEnd"
         ]
     }

--- a/docs/en_us/developers/tasks/sell-product-maintain.md
+++ b/docs/en_us/developers/tasks/sell-product-maintain.md
@@ -28,23 +28,23 @@ SellProductSchedule                                  (Task entry, weekday gate)
 
 The six reserve-rule registration nodes are always enabled and form a fixed slot-order chain. Task options override the stable `itemId` only for configured slots. Unconfigured slots keep an empty `item_id`, which the Custom Action treats as a successful no-op. The next node records the independent priority-selling master switch and whether only preferred products may be sold. Outpost registration nodes use the same fixed-chain approach: task options set `active` to `true` only for enabled outposts, while inactive outposts are successful no-ops. Neither initialization stage needs progressively shortened `next` candidate lists for every possible enabled-slot combination.
 
-`SellProductLoop` always executes regions in the fixed order Valley IV → Wuling. Outposts within each region follow the stable order in the generated model. Disabled regions and outposts are skipped by their entries, so the same enabled set always produces the same selling order. A region entry uses SceneManager to open outpost management, prepares the operator cache, then executes each outpost through `[JumpBack]`:
+`SellProductLoop` always executes regions in reverse order so that newer regions are processed first. Outposts within each region still follow the stable order in the generated model. Disabled regions and outposts are skipped by their entries, so the same enabled set always produces the same selling order. A region entry uses SceneManager to open outpost management, prepares the operator cache, then executes each outpost through `[JumpBack]`:
 
 ```text
 SellProductLoop                                      (Regional Development main loop)
-  ├─ SellProductValleyIVSell                         (enter Valley IV outpost management)
-  │    ├─ SellProductValleyIVInitializePrioritySession
-  │    │    └─ SellProductValleyIVRegisterPriorityItem{1..6} (activate regional priority table)
-  │    ├─ SellProductValleyIVPrepareOperatorCache    (prepare operator cache)
-  │    └─ [JumpBack]SellProductRefugeeCamp → SellProductInfraStation
-  │       → SellProductReconstructionHQ
-  │         (execute three outposts through JumpBack)
   ├─ SellProductWulingSell                           (enter Wuling outpost management)
   │    ├─ SellProductWulingInitializePrioritySession
   │    │    └─ SellProductWulingRegisterPriorityItem{1..6} (activate regional priority table)
   │    ├─ SellProductWulingPrepareOperatorCache      (prepare/reuse operator cache)
   │    └─ [JumpBack]SellProductSkyKingFlatsConstructionSite
   │       → SellProductCardiacRemediationStation → SellProductXiranflowCloudseederStation
+  │         (execute three outposts through JumpBack)
+  ├─ SellProductValleyIVSell                         (enter Valley IV outpost management)
+  │    ├─ SellProductValleyIVInitializePrioritySession
+  │    │    └─ SellProductValleyIVRegisterPriorityItem{1..6} (activate regional priority table)
+  │    ├─ SellProductValleyIVPrepareOperatorCache    (prepare operator cache)
+  │    └─ [JumpBack]SellProductRefugeeCamp → SellProductInfraStation
+  │       → SellProductReconstructionHQ
   │         (execute three outposts through JumpBack)
   └─ SellProductTaskEnd                              (all enabled regions are complete)
 ```
@@ -156,8 +156,10 @@ Post-sale production assignment must prevent one operator from occupying multipl
 1. Maximize the number of outposts that can be restored;
 2. With equal coverage, keep the selling operator already assigned before selling whenever possible to avoid unnecessary switches;
 3. With the same number of kept operators, maximize final assignments in each outpost's highest bonus tier (perfect for both selling and restoration) so later runs need no switch;
-4. With the same number of reusable assignments, choose the plan with the smaller total candidate `Priority`;
+4. With the same number of reusable assignments, choose the plan with the smaller total candidate `Priority` when both plans cover the same outpost set; when they cover different outposts, preserve the newer-region-first order;
 5. Lock each confirmed `location -> operator` assignment so later outposts cannot reuse it.
+
+Regional selling uses the same newer-region-first order, while outposts within each region remain in game order. This lets completed assignments in newer regions be locked first, preventing older regions from taking those operators later.
 
 A missing selling target or failed scan stops the task to avoid selling with the wrong operator. An unavailable restoration target is recorded as skipped so the current outpost can finish and the task continues.
 

--- a/docs/zh_cn/developers/tasks/sell-product-maintain.md
+++ b/docs/zh_cn/developers/tasks/sell-product-maintain.md
@@ -28,23 +28,23 @@ SellProductSchedule                                  （Task 入口，按星期�
 
 6 个保留规则注册节点始终启用，并按槽位顺序固定串联。任务选项只覆盖已配置槽位的稳定 `itemId`；未配置槽位保留空 `item_id`，Custom Action 将其作为 no-op 成功跳过。随后独立记录优先售卖总开关与是否只售卖优先产品。据点注册节点同样固定串联，任务选项只把启用据点的 `active` 参数设为 `true`，非活跃据点直接 no-op。两段初始化流程均无需为任意启用组合维护逐层缩短的 `next` 候选列表。
 
-`SellProductLoop` 始终按“四号谷地 → 武陵”的固定地区顺序执行；地区内据点也按生成模型中的固定顺序执行。未启用地区或据点由对应入口直接跳过，因此相同的启用组合总会得到相同的售卖顺序。地区入口通过 SceneManager 进入据点管理页，准备干员缓存，再用 `[JumpBack]` 依次执行该地区的据点：
+`SellProductLoop` 始终按新地区优先的倒序执行；地区内据点仍按生成模型中的固定顺序执行。未启用地区或据点由对应入口直接跳过，因此相同的启用组合总会得到相同的售卖顺序。地区入口通过 SceneManager 进入据点管理页，准备干员缓存，再用 `[JumpBack]` 依次执行该地区的据点：
 
 ```text
 SellProductLoop                                      （地区建设主循环）
-  ├─ SellProductValleyIVSell                         （进入四号谷地据点管理）
-  │    ├─ SellProductValleyIVInitializePrioritySession
-  │    │    └─ SellProductValleyIVRegisterPriorityItem{1..6} （切换地区优先表）
-  │    ├─ SellProductValleyIVPrepareOperatorCache    （准备干员缓存）
-  │    └─ [JumpBack]SellProductRefugeeCamp → SellProductInfraStation
-  │       → SellProductReconstructionHQ
-  │         （通过 JumpBack 依次执行三个据点）
   ├─ SellProductWulingSell                           （进入武陵据点管理）
   │    ├─ SellProductWulingInitializePrioritySession
   │    │    └─ SellProductWulingRegisterPriorityItem{1..6} （切换地区优先表）
   │    ├─ SellProductWulingPrepareOperatorCache      （准备/复用干员缓存）
   │    └─ [JumpBack]SellProductSkyKingFlatsConstructionSite
   │       → SellProductCardiacRemediationStation → SellProductXiranflowCloudseederStation
+  │         （通过 JumpBack 依次执行三个据点）
+  ├─ SellProductValleyIVSell                         （进入四号谷地据点管理）
+  │    ├─ SellProductValleyIVInitializePrioritySession
+  │    │    └─ SellProductValleyIVRegisterPriorityItem{1..6} （切换地区优先表）
+  │    ├─ SellProductValleyIVPrepareOperatorCache    （准备干员缓存）
+  │    └─ [JumpBack]SellProductRefugeeCamp → SellProductInfraStation
+  │       → SellProductReconstructionHQ
   │         （通过 JumpBack 依次执行三个据点）
   └─ SellProductTaskEnd                              （所有启用地区处理完成）
 ```
@@ -156,8 +156,10 @@ SellProduct 缓存统一保存在 `debug/record/SellProductCache.json`，按哈�
 1. 最大化能够恢复的据点数量；
 2. 覆盖数相同时，尽量保留各据点售前已经派驻的售卖干员，减少无意义切换；
 3. 沿用数量也相同时，尽量让最终派驻仍属于对应据点的最高加成档（同时满足售卖与恢复），使后续任务无需再次切换；
-4. 后续可沿用数量也相同时，选择候选 `Priority` 总和更小的方案；
+4. 后续可沿用数量也相同时，若方案覆盖相同的据点集合，选择候选 `Priority` 总和更小的方案；若覆盖不同据点，则保留新地区优先顺序；
 5. 已确认的 `location -> operator` 立即锁定，后续据点不能重复分配该干员。
+
+地区售卖同样按新地区优先执行；地区内据点仍保持游戏顺序。这样新地区完成的恢复结果会先锁定，后续旧地区不能再次调走对应干员。
 
 售卖目标找不到或扫描失败会停止任务，避免带着错误的干员继续交易；恢复目标不可用时记录跳过，完成当前据点后继续任务。
 

--- a/tools/pipeline-generate/SellProduct/data.test.mjs
+++ b/tools/pipeline-generate/SellProduct/data.test.mjs
@@ -2,7 +2,14 @@ import assert from "node:assert/strict";
 import {readFileSync} from "node:fs";
 import test from "node:test";
 
-import {sellProductLocations, sellProductRegions, settlementData, toPascalCase} from "./model.mjs";
+import {
+    sellProductLocations,
+    sellProductLocationsNewestFirst,
+    sellProductRegions,
+    sellProductRegionsNewestFirst,
+    settlementData,
+    toPascalCase,
+} from "./model.mjs";
 import sellProductAdbRows from "./pipeline-adb-data.mjs";
 import sellProductPipelineRows from "./pipeline-data.mjs";
 import sellProductSellRows from "./sell-data.mjs";
@@ -53,7 +60,7 @@ test("SellProduct 按固定地区顺序售卖且不再使用自动起始地区",
     const entry = readPipeline(new URL("../../../assets/resource/pipeline/SellProduct.json", import.meta.url));
 
     assert.deepEqual(loop.SellProductLoop.next, [
-        ...sellProductRegions.map((region) => `SellProduct${region.RegionPrefix}`),
+        ...sellProductRegionsNewestFirst.map((region) => `SellProduct${region.RegionPrefix}`),
         "SellProductTaskEnd",
     ]);
     assert.equal(entry.SellProductLoop, undefined);
@@ -61,6 +68,21 @@ test("SellProduct 按固定地区顺序售卖且不再使用自动起始地区",
         Object.keys(entry).filter((nodeName) => nodeName.startsWith("SellProductAuto")),
         [],
     );
+});
+
+test("SellProduct 优先售卖新地区且地区内保持游戏顺序", () => {
+    assert.deepEqual(sellProductRegionsNewestFirst, [...sellProductRegions].reverse());
+    for (const region of sellProductRegionsNewestFirst) {
+        assert.deepEqual(
+            sellProductLocationsNewestFirst
+                .filter((location) => location.RegionPrefix === region.RegionPrefix)
+                .map((location) => location.LocationId),
+            region.LocationIds,
+        );
+    }
+
+    const regionOrder = sellProductRegionsNewestFirst.map((region) => region.RegionPrefix);
+    assert.ok(regionOrder.indexOf("Wuling") < regionOrder.indexOf("ValleyIV"));
 });
 
 test("SellProduct templates consume separate minimal projections of the shared location model", () => {

--- a/tools/pipeline-generate/SellProduct/loop-data.mjs
+++ b/tools/pipeline-generate/SellProduct/loop-data.mjs
@@ -1,12 +1,12 @@
 // SellProduct 主循环模板数据
 
-import {sellProductRegions} from "./model.mjs";
+import {sellProductRegionsNewestFirst} from "./model.mjs";
 
 // 主循环是全局唯一节点，单行数据只把地区遍历列表注入模板的 next。
 export const sellProductLoopRows = [
     {
         LoopNext: [
-            ...sellProductRegions.map((region) => `SellProduct${region.RegionPrefix}`),
+            ...sellProductRegionsNewestFirst.map((region) => `SellProduct${region.RegionPrefix}`),
             "SellProductTaskEnd",
         ],
     },

--- a/tools/pipeline-generate/SellProduct/model.mjs
+++ b/tools/pipeline-generate/SellProduct/model.mjs
@@ -138,6 +138,13 @@ export const sellProductRegions = Object.values(
     }, {}),
 );
 
+// 实际售卖与恢复规划优先处理较新的地区，地区内仍保持游戏据点顺序。
+export const sellProductRegionsNewestFirst = [...sellProductRegions].reverse();
+const sellProductLocationById = new Map(sellProductLocations.map((location) => [location.LocationId, location]));
+export const sellProductLocationsNewestFirst = sellProductRegionsNewestFirst.flatMap((region) =>
+    region.LocationIds.map((locationId) => sellProductLocationById.get(locationId)),
+);
+
 // 国际化同步器消费的最小数据视图。命名规则与所有模板共享同一模型。
 export const sellProductLocaleEntries = {
     operators: Object.values(settlementData.operators || {})

--- a/tools/pipeline-generate/SellProduct/selection-data.mjs
+++ b/tools/pipeline-generate/SellProduct/selection-data.mjs
@@ -2,7 +2,14 @@ import {mkdirSync, writeFileSync} from "node:fs";
 import {dirname, resolve} from "node:path";
 import {fileURLToPath, pathToFileURL} from "node:url";
 
-import {getOperatorCaseName, isAdminOperator, sellProductLocations, settlementData, toPascalCase} from "./model.mjs";
+import {
+    getOperatorCaseName,
+    isAdminOperator,
+    sellProductLocations,
+    sellProductLocationsNewestFirst,
+    settlementData,
+    toPascalCase,
+} from "./model.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUTPUT_PATH = resolve(__dirname, "../../../assets/data/SellProduct/selection_data.json");
@@ -252,7 +259,7 @@ export function buildSellProductSelectionData() {
     return {
         items: itemData.items,
         operators,
-        location_order: sellProductLocations.map((location) => location.LocationId),
+        location_order: sellProductLocationsNewestFirst.map((location) => location.LocationId),
         locations,
     };
 }

--- a/tools/pipeline-generate/SellProduct/selection-data.test.mjs
+++ b/tools/pipeline-generate/SellProduct/selection-data.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import {readFileSync} from "node:fs";
 import test from "node:test";
 
-import {sellProductLocations} from "./model.mjs";
+import {sellProductLocationsNewestFirst} from "./model.mjs";
 import {
     buildLocationOperatorOrder,
     buildSelectionItems,
@@ -23,7 +23,7 @@ test("SellProduct selection data contains only valid stable references", () => {
     const data = sellProductSelectionData;
     assert.deepEqual(
         data.location_order,
-        sellProductLocations.map((location) => location.LocationId),
+        sellProductLocationsNewestFirst.map((location) => location.LocationId),
     );
     for (const item of Object.values(data.items)) {
         assert.deepEqual(Object.keys(item.names), [


### PR DESCRIPTION
## 用户可见变化

新地区据点获得的调度券通常更有用，因此「🛒售卖产品」现在会默认优先处理较新的地区，更早完成新地区的交易。

当前地区顺序由「四号谷地 → 武陵」调整为「武陵 → 四号谷地」，地区内各据点仍保持原有顺序。干员自动切换也遵循相同顺序：当多个据点需要同一名售后生产干员时，新地区会优先获得该干员；已经完成的派驻会被锁定，后续旧地区不会再将其调走。

以 Issue #4514 的账号为例，调整后结果为：

- 武陵「盈天台建设站」：黎风完成售卖后，派驻陈千语
- 四号谷地「基建前站」：赛希完成售卖后没有其他可用生产干员，因此继续保留赛希

无需新增选项，默认行为即为新地区优先；以后增加地区时也会自动按倒序优先处理新地区。

## 问题原因

原流程先处理四号谷地，且全局恢复规划会横向比较不同据点候选列表中的本地 `Priority`。这使陈千语先被分配到基建前站，盈天台建设站随后无可用恢复干员。

## 实现

- `SellProductLoop` 使用新地区优先顺序，地区内据点顺序不变
- 将同一顺序写入 `selection_data.location_order`，供 Go 售后恢复规划使用
- 不再横向比较不同据点候选列表中的本地 `Priority`；价值相同但覆盖据点不同时，保留新地区优先顺序
- `OperatorSession`、任务选项与多语言文案顺序保持不变
- 生成器测试动态反转地区列表，未来新增地区时无需修改现有地区数量断言
- 同步更新中英文 SellProduct 维护文档

## 回归测试

使用 Issue #4514 日志包中的完整干员持有快照覆盖六个据点的连续售卖与恢复规划，并验证上述盈天台、基建前站结果。

## 验证

- `pnpm format`
- `pnpm format:go`
- `pnpm check`
- `pnpm test`（638/638）
- `node --test tools/pipeline-generate/SellProduct/data.test.mjs tools/pipeline-generate/SellProduct/selection-data.test.mjs tools/pipeline-generate/SellProduct/sync-locales.test.mjs`（36/36）
- `go test ./sellproduct`
- `pnpm exec prettier --check docs/en_us/developers/tasks/sell-product-maintain.md`

补充：额外执行 `go test ./...` 时，当前分支在未修改的 `common/expendable` 包仍存在 `TestWithBlacklist` 的 `#` 转义期望失败。

fixed #4514