### PR TITLE
fix(SellProduct): 修复售卖后奖励界面偶发无法关闭

### DIFF
--- a/agent/go-service/common/repeataction/action.go
+++ b/agent/go-service/common/repeataction/action.go
@@ -137,7 +137,12 @@ func runRepeatUntil(
 
 		if _, err := ctx.RunAction(innerActionEntry, arg.Box, "", map[string]any{
 			innerActionEntry: map[string]any{
-				"action": actionNode,
+				// 临时节点只执行一次动作，显式清零 Framework 的节点级默认等待，
+				// 使 intervalMs 成为动作完成后、重新识别前唯一的主动等待。
+				"pre_delay":  0,
+				"post_delay": 0,
+				"rate_limit": 0,
+				"action":     actionNode,
 			},
 		}); err != nil {
 			log.Warn().Err(err).Str("component", component).Int("attempt", i+1).Msg("inner action failed")

--- a/assets/resource/pipeline/SellProduct/SellCore.json
+++ b/assets/resource/pipeline/SellProduct/SellCore.json
@@ -290,23 +290,29 @@
             "Node.Recognition.Succeeded": "$task.SellProduct.aid_quota_exceeded"
         }
     },
+    "SellProductCheckHeader": {
+        "desc": "交易完成后的获得物品界面页头",
+        "recognition": "TemplateMatch",
+        "roi": [
+            577,
+            10,
+            138,
+            118
+        ],
+        "template": [
+            "SellProduct/SellProductCheckHeader.png"
+        ],
+        "pre_delay": 0,
+        "action": "DoNothing",
+        "post_delay": 0,
+        "rate_limit": 0
+    },
     "SellProductSellCheck": {
         "desc": "交易后确认",
         "recognition": "And",
         "all_of": [
             "CloseRewardsButton",
-            {
-                "recognition": "TemplateMatch",
-                "roi": [
-                    577,
-                    10,
-                    138,
-                    118
-                ],
-                "template": [
-                    "SellProduct/SellProductCheckHeader.png"
-                ]
-            }
+            "SellProductCheckHeader"
         ],
         "pre_wait_freezes": {
             "time": 200,
@@ -318,7 +324,12 @@
             ]
         },
         "pre_delay": 0,
-        "action": "Click",
+        "action": "Custom",
+        "custom_action": "RepeatUntilNotFoundAction",
+        "custom_action_param": {
+            "action": "Click",
+            "wait_node": "SellProductCheckHeader"
+        },
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoney"
         },
@@ -361,22 +372,16 @@
         "recognition": "And",
         "all_of": [
             "CloseRewardsButton",
-            {
-                "recognition": "TemplateMatch",
-                "roi": [
-                    577,
-                    10,
-                    138,
-                    118
-                ],
-                "template": [
-                    "SellProduct/SellProductCheckHeader.png"
-                ]
-            }
+            "SellProductCheckHeader"
         ],
         "pre_wait_freezes": 80,
         "pre_delay": 0,
-        "action": "Click",
+        "action": "Custom",
+        "custom_action": "RepeatUntilNotFoundAction",
+        "custom_action_param": {
+            "action": "Click",
+            "wait_node": "SellProductCheckHeader"
+        },
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoney"
         },

--- a/assets/resource/pipeline/SellProduct/SellCore.json
+++ b/assets/resource/pipeline/SellProduct/SellCore.json
@@ -319,8 +319,8 @@
         "custom_action_param": {
             "action": "Click",
             "wait_node": "SellProductCheckHeader",
-            "repeat_count": 6,
-            "interval_ms": 500
+            "repeat_count": 10,
+            "interval_ms": 200
         },
         "target": [
             35,
@@ -377,8 +377,8 @@
         "custom_action_param": {
             "action": "Click",
             "wait_node": "SellProductCheckHeader",
-            "repeat_count": 6,
-            "interval_ms": 500
+            "repeat_count": 10,
+            "interval_ms": 200
         },
         "target": [
             35,

--- a/assets/resource/pipeline/SellProduct/SellCore.json
+++ b/assets/resource/pipeline/SellProduct/SellCore.json
@@ -297,7 +297,7 @@
             577,
             10,
             138,
-            118
+            479
         ],
         "template": [
             "SellProduct/SellProductCheckHeader.png"
@@ -311,25 +311,23 @@
         "desc": "交易后确认",
         "recognition": "And",
         "all_of": [
-            "CloseRewardsButton",
             "SellProductCheckHeader"
         ],
-        "pre_wait_freezes": {
-            "time": 200,
-            "target": [
-                357,
-                283,
-                577,
-                163
-            ]
-        },
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "RepeatUntilNotFoundAction",
         "custom_action_param": {
             "action": "Click",
-            "wait_node": "SellProductCheckHeader"
+            "wait_node": "SellProductCheckHeader",
+            "repeat_count": 6,
+            "interval_ms": 500
         },
+        "target": [
+            35,
+            611,
+            58,
+            57
+        ],
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoney"
         },
@@ -371,17 +369,23 @@
         "desc": "交易后确认，继续应用当前物品的保留规则",
         "recognition": "And",
         "all_of": [
-            "CloseRewardsButton",
             "SellProductCheckHeader"
         ],
-        "pre_wait_freezes": 80,
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "RepeatUntilNotFoundAction",
         "custom_action_param": {
             "action": "Click",
-            "wait_node": "SellProductCheckHeader"
+            "wait_node": "SellProductCheckHeader",
+            "repeat_count": 6,
+            "interval_ms": 500
         },
+        "target": [
+            35,
+            611,
+            58,
+            57
+        ],
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoney"
         },

--- a/tools/pipeline-generate/SellProduct/data.test.mjs
+++ b/tools/pipeline-generate/SellProduct/data.test.mjs
@@ -491,6 +491,33 @@ test("SellProduct 每轮换货前优先检查调度券不足", () => {
     ]);
 });
 
+test("SellProduct 交易完成后重复点击直到获得物品界面消失", () => {
+    const pipeline = readPipeline(
+        new URL("../../../assets/resource/pipeline/SellProduct/SellCore.json", import.meta.url),
+    );
+
+    assert.equal(pipeline.SellProductCheckHeader.recognition, "TemplateMatch");
+    assert.deepEqual(pipeline.SellProductCheckHeader.template, [
+        "SellProduct/SellProductCheckHeader.png",
+    ]);
+
+    for (const nodeName of [
+        "SellProductSellCheck",
+        "SellProductSellCheckThenLoop",
+    ]) {
+        const node = pipeline[nodeName];
+        assert.deepEqual(node.all_of, [
+            "CloseRewardsButton",
+            "SellProductCheckHeader",
+        ]);
+        assert.equal(node.custom_action, "RepeatUntilNotFoundAction");
+        assert.deepEqual(node.custom_action_param, {
+            action: "Click",
+            wait_node: "SellProductCheckHeader",
+        });
+    }
+});
+
 test("SellProduct 缺货物品通过据点锚点标记并在本次任务内共享", () => {
     for (const location of sellProductLocations) {
         const pipeline = readPipeline(

--- a/tools/pipeline-generate/SellProduct/data.test.mjs
+++ b/tools/pipeline-generate/SellProduct/data.test.mjs
@@ -521,8 +521,8 @@ test("SellProduct 交易完成后重复点击直到获得物品界面消失", ()
         assert.deepEqual(node.custom_action_param, {
             action: "Click",
             wait_node: "SellProductCheckHeader",
-            repeat_count: 6,
-            interval_ms: 500,
+            repeat_count: 10,
+            interval_ms: 200,
         });
         assert.deepEqual(
             node.target,

--- a/tools/pipeline-generate/SellProduct/data.test.mjs
+++ b/tools/pipeline-generate/SellProduct/data.test.mjs
@@ -500,21 +500,39 @@ test("SellProduct 交易完成后重复点击直到获得物品界面消失", ()
     assert.deepEqual(pipeline.SellProductCheckHeader.template, [
         "SellProduct/SellProductCheckHeader.png",
     ]);
+    assert.deepEqual(
+        pipeline.SellProductCheckHeader.roi,
+        [
+            577,
+            10,
+            138,
+            479,
+        ],
+    );
 
     for (const nodeName of [
         "SellProductSellCheck",
         "SellProductSellCheckThenLoop",
     ]) {
         const node = pipeline[nodeName];
-        assert.deepEqual(node.all_of, [
-            "CloseRewardsButton",
-            "SellProductCheckHeader",
-        ]);
+        assert.deepEqual(node.all_of, ["SellProductCheckHeader"]);
+        assert.equal(node.pre_wait_freezes, undefined);
         assert.equal(node.custom_action, "RepeatUntilNotFoundAction");
         assert.deepEqual(node.custom_action_param, {
             action: "Click",
             wait_node: "SellProductCheckHeader",
+            repeat_count: 6,
+            interval_ms: 500,
         });
+        assert.deepEqual(
+            node.target,
+            [
+                35,
+                611,
+                58,
+                57,
+            ],
+        );
     }
 });
 


### PR DESCRIPTION
## 修复内容

售卖产品完成后，获得发展值、谷地券或武陵券的奖励界面偶发无法一次关闭，残留界面会使当前售卖流程失败，并阻断后续任务。

现在交易完成后会持续点击奖励界面的关闭区域，并在每次点击后检查交易完成页头；只有确认页头消失后才继续售卖流程。普通售卖与保留数量售卖两条路径均使用同一套处理。

同时扩大了交易完成页头的识别范围，并移除了关闭前不再需要的画面静止等待，以更快处理奖励界面的位置变化和点击未生效情况。

## 验证

- SellProduct 专项测试：23/23
- `pnpm check`
- `pnpm test`：638/638
- `git diff --check`

## ADB 实机验证

使用 ADB / MuMu 完整运行 `SellProductSchedule`：

- 10 次奖励界面关闭流程全部成功，共执行 19 次点击；9 次需要点击两次，1 次点击一次即关闭，均未达到 10 次重试上限。
- `interval_ms=200` 的实际等待稳定在约 200–202 ms。
- 点击到下一次识别启动为 221–239 ms，平均 227.6 ms；修复前样本约为 446 ms。
- 相邻两次点击平均约 393.4 ms，修复前样本约为 806 ms。
- 需要两次点击时，完整关闭动作平均约 775 ms，修复前样本约为 1593 ms。
- 任务最终成功完成，没有残留奖励界面阻断后续流程。

由于修复前样本使用 Win32、本次使用 ADB / MuMu，不将整个任务总耗时直接横向比较；组件自身的点击与识别循环耗时约减半。

Closes #4368

## Summary by Sourcery

确保 SellProduct 流程在交易完成后能可靠地关闭奖励界面，然后再继续后续的销售流程。

Bug 修复：
- 防止售出后奖励界面间歇性地保持打开状态，从而导致后续 SellProduct 步骤出现异常。

测试：
- 添加回归测试，验证在 SellProduct 的两种销售路径中，反复点击奖励关闭区域，直到完成标题在界面上消失。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure SellProduct flow reliably closes post-transaction reward UI before continuing the selling process.

Bug Fixes:
- Prevent post-sale reward screens from intermittently remaining open and breaking subsequent SellProduct steps.

Tests:
- Add regression test validating repeated clicking of the reward close area until the completion header disappears in both SellProduct selling paths.

</details>
