### PR TITLE
refactor(BetterSliding)!: 统一数量相关命名与结果判定

### DIFF
--- a/agent/go-service/autostockpile/overrides.go
+++ b/agent/go-service/autostockpile/overrides.go
@@ -39,7 +39,7 @@ func buildSwipeSpecificQuantityOverride(target int) map[string]any {
 	return map[string]any{
 		"enabled": true,
 		"attach": map[string]any{
-			"Target": target,
+			"TargetQuantity": target,
 		},
 	}
 }

--- a/agent/go-service/autostockstaple/action.go
+++ b/agent/go-service/autostockstaple/action.go
@@ -41,7 +41,7 @@ type quantityValidatorNode struct {
 }
 
 // QuantityControlAction calculates the purchase quantity for an AutoStockStaple item
-// from its validator expression and overrides BetterSliding attach.Target via pipeline.
+// from its validator expression and overrides BetterSliding attach.TargetQuantity via pipeline.
 // Sliding itself is executed by the sibling CheckSliding / BetterSliding branch after Buy.
 type QuantityControlAction struct{}
 
@@ -151,7 +151,7 @@ func buildQuantityControlOverride(slidingNode string, target int) map[string]any
 		slidingNode: map[string]any{
 			"enabled": target > 0,
 			"attach": map[string]any{
-				"Target": target,
+				"TargetQuantity": target,
 			},
 		},
 	}

--- a/agent/go-service/bettersliding/handlers.go
+++ b/agent/go-service/bettersliding/handlers.go
@@ -204,75 +204,73 @@ func (a *BetterSlidingAction) handleGetSliderMaxQuantity(ctx *maa.Context, arg *
 		a.runtimeTargetResolved = true
 	}
 
-	upperOverflow := a.TargetQuantity > a.sliderMaxQuantity
-	lowerOverflow := a.TargetQuantityType == TargetQuantityTypeValue &&
-		a.ReverseTarget &&
-		a.TargetQuantity < 1
-	// Record reachability before clamping: selecting a clamped maximum does not mean the original target is reachable.
-	a.targetReachable = a.TargetQuantity >= 1 && a.TargetQuantity <= a.sliderMaxQuantity
+	originalResolvedTargetQuantity := a.TargetQuantity
+	resolvedTargetQuantity, outcome := resolveSliderQuantityOutcome(
+		a.TargetQuantity,
+		a.sliderMaxQuantity,
+		a.ClampTargetToSliderMax,
+	)
+	a.TargetQuantity = resolvedTargetQuantity
+	a.outOfRange = outcome == sliderQuantityOutcomeOutOfRange
+	a.targetReachable = outcome == sliderQuantityOutcomeTargetReachable
 
-	// Clamp upper overflow before out-of-range handling so clamping takes priority.
-	if a.ClampTargetToSliderMax && upperOverflow {
-		originalTargetQuantity := a.TargetQuantity
-		a.TargetQuantity = a.sliderMaxQuantity
+	if outcome == sliderQuantityOutcomeClamped {
 		a.logger.Warn().
-			Int("original_target_quantity", originalTargetQuantity).
+			Int("original_target_quantity", originalResolvedTargetQuantity).
 			Int("clamped_target_quantity", a.TargetQuantity).
 			Int("slider_max_quantity", a.sliderMaxQuantity).
 			Msg("target quantity clamped to slider max quantity")
-		upperOverflow = false
 	}
 
-	a.outOfRange = false
-	if a.OutOfRangeOverrideEnable != "" {
-		if upperOverflow || lowerOverflow || a.sliderMaxQuantity == 0 {
-			a.outOfRange = true
-			if err := overrideCheckQuantityBranch(
-				ctx,
-				arg.CurrentTaskName,
-				nodeBetterSlidingDone,
-				buttonTarget{},
-				0,
-				a.GreenMask,
-			); err != nil {
-				logEvent := a.logger.Error().
-					Err(err).
-					Int("slider_max_quantity", a.sliderMaxQuantity).
-					Int("target_quantity", a.TargetQuantity).
-					Str("next", nodeBetterSlidingDone)
-				if errors.Is(err, errCheckQuantityBranchNextOverride) {
-					logEvent.Msg("failed to override next for out-of-range branch")
-				} else {
-					logEvent.Msg("failed to override pipeline for out-of-range branch")
-				}
-				return false
-			}
-
-			logEvent := a.logger.Warn().
-				Int("original_target_quantity", a.OriginalTargetQuantity).
+	if a.outOfRange {
+		if a.OutOfRangeOverrideEnable == "" {
+			a.logger.Error().
+				Str("outcome", "out-of-range").
 				Int("resolved_target_quantity", a.TargetQuantity).
 				Int("slider_max_quantity", a.sliderMaxQuantity).
-				Str("override_node", a.OutOfRangeOverrideEnable)
-			if a.sliderMaxQuantity == 0 {
-				logEvent.Msg("slider max quantity is zero, skipping via out-of-range override")
-			} else {
-				logEvent.Msg("target quantity out of range; caller outcome scheduled")
-			}
-			return true
+				Msg("quantity outcome has no override configured")
+			return false
 		}
 
+		if err := overrideCheckQuantityBranch(
+			ctx,
+			arg.CurrentTaskName,
+			nodeBetterSlidingDone,
+			buttonTarget{},
+			0,
+			a.GreenMask,
+		); err != nil {
+			logEvent := a.logger.Error().
+				Err(err).
+				Str("outcome", "out-of-range").
+				Int("slider_max_quantity", a.sliderMaxQuantity).
+				Int("target_quantity", a.TargetQuantity).
+				Str("next", nodeBetterSlidingDone)
+			if errors.Is(err, errCheckQuantityBranchNextOverride) {
+				logEvent.Msg("failed to override next for quantity outcome branch")
+			} else {
+				logEvent.Msg("failed to override pipeline for quantity outcome branch")
+			}
+			return false
+		}
+
+		a.logger.Warn().
+			Str("outcome", "out-of-range").
+			Int("original_target_quantity", a.OriginalTargetQuantity).
+			Int("resolved_target_quantity", a.TargetQuantity).
+			Int("slider_max_quantity", a.sliderMaxQuantity).
+			Str("override_node", a.OutOfRangeOverrideEnable).
+			Msg("quantity adjustment skipped; caller outcome scheduled")
+		return true
+	}
+
+	if a.OutOfRangeOverrideEnable != "" {
 		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.OutOfRangeOverrideEnable, false)); err != nil {
 			a.logger.Error().Err(err).
 				Str("override_node", a.OutOfRangeOverrideEnable).
-				Msg("failed to disable out-of-range override")
+				Msg("failed to disable quantity outcome override")
 			return false
 		}
-	} else if lowerOverflow || upperOverflow {
-		a.logger.Error().
-			Int("resolved_target_quantity", a.TargetQuantity).
-			Int("slider_max_quantity", a.sliderMaxQuantity).
-			Msg("target quantity out of range and no override configured")
-		return false
 	}
 
 	nextNode, err := resolveSliderMaxQuantityNext(a.sliderMaxQuantity, a.TargetQuantity)
@@ -618,32 +616,8 @@ func (a *BetterSlidingAction) runInternalPipeline(ctx *maa.Context, arg *maa.Cus
 		return false
 	}
 
-	if a.outOfRange && a.OutOfRangeOverrideEnable != "" {
-		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.OutOfRangeOverrideEnable, true)); err != nil {
-			a.logger.Error().
-				Err(err).
-				Str("caller", arg.CurrentTaskName).
-				Str("override_node", a.OutOfRangeOverrideEnable).
-				Msg("failed to apply out-of-range override after internal pipeline")
-			return false
-		}
-
-		a.logger.Info().
-			Str("caller", arg.CurrentTaskName).
-			Str("override_node", a.OutOfRangeOverrideEnable).
-			Msg("applied out-of-range override after internal pipeline")
-	}
-
-	if a.TargetReachableOverrideEnable != "" {
-		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.TargetReachableOverrideEnable, a.targetReachable)); err != nil {
-			a.logger.Error().
-				Err(err).
-				Str("caller", arg.CurrentTaskName).
-				Str("override_node", a.TargetReachableOverrideEnable).
-				Bool("target_quantity_reachable", a.targetReachable).
-				Msg("failed to apply target-reachable override after internal pipeline")
-			return false
-		}
+	if !a.applyOutcomeOverrides(ctx, arg.CurrentTaskName) {
+		return false
 	}
 
 	if a.SwipeOnlyMode {
@@ -653,22 +627,7 @@ func (a *BetterSlidingAction) runInternalPipeline(ctx *maa.Context, arg *maa.Cus
 			Str("subtask_status", detail.Status.String()).
 			Bool("swipe_only_mode", true).
 			Msg("internal BetterSliding pipeline finished (swipe-only)")
-
-		if !a.outOfRange && a.OutOfRangeOverrideEnable != "" {
-			if err := ctx.OverridePipeline(buildNodeEnableOverride(a.OutOfRangeOverrideEnable, false)); err != nil {
-				a.logger.Error().Err(err).Msg("failed to apply out-of-range override after swipe-only")
-				return false
-			}
-		}
-
 		return true
-	}
-
-	if !a.outOfRange && a.OutOfRangeOverrideEnable != "" {
-		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.OutOfRangeOverrideEnable, false)); err != nil {
-			a.logger.Error().Err(err).Msg("failed to apply out-of-range override after internal pipeline")
-			return false
-		}
 	}
 
 	a.logger.Info().
@@ -676,6 +635,44 @@ func (a *BetterSlidingAction) runInternalPipeline(ctx *maa.Context, arg *maa.Cus
 		Int64("subtask_id", detail.ID).
 		Str("subtask_status", detail.Status.String()).
 		Msg("internal BetterSliding pipeline completed")
+	return true
+}
+
+// applyOutcomeOverrides 在内部流水线结束后，将调用方结果节点的开关统一同步为本次判定结果，
+// 保证命中的结果节点被启用、未命中的被禁用。新增结果时只需在此追加一项。
+func (a *BetterSlidingAction) applyOutcomeOverrides(ctx *maa.Context, caller string) bool {
+	outcomes := []struct {
+		name    string
+		node    string
+		enabled bool
+	}{
+		{"out-of-range", a.OutOfRangeOverrideEnable, a.outOfRange},
+		{"target-reachable", a.TargetReachableOverrideEnable, a.targetReachable},
+	}
+
+	for _, outcome := range outcomes {
+		if outcome.node == "" {
+			continue
+		}
+		if err := ctx.OverridePipeline(buildNodeEnableOverride(outcome.node, outcome.enabled)); err != nil {
+			a.logger.Error().
+				Err(err).
+				Str("caller", caller).
+				Str("outcome", outcome.name).
+				Str("override_node", outcome.node).
+				Bool("enabled", outcome.enabled).
+				Msg("failed to apply outcome override after internal pipeline")
+			return false
+		}
+		if outcome.enabled {
+			a.logger.Info().
+				Str("caller", caller).
+				Str("outcome", outcome.name).
+				Str("override_node", outcome.node).
+				Msg("applied outcome override after internal pipeline")
+		}
+	}
+
 	return true
 }
 
@@ -698,6 +695,50 @@ func (a *BetterSlidingAction) resetState() {
 	a.outOfRange = false
 	a.targetReachable = false
 	a.runtimeTargetResolved = false
+}
+
+// sliderQuantityOutcome 描述目标数量相对滑条最大数量的判定结果。
+type sliderQuantityOutcome uint8
+
+const (
+	// sliderQuantityOutcomeOutOfRange 表示目标小于 1、滑条最大数量为 0，
+	// 或在未启用钳制时超过滑条最大数量。
+	sliderQuantityOutcomeOutOfRange sliderQuantityOutcome = iota
+	// sliderQuantityOutcomeTargetReachable 表示目标位于滑条可选范围内，无需钳制即可达到。
+	sliderQuantityOutcomeTargetReachable
+	// sliderQuantityOutcomeClamped 表示目标超过滑条最大数量，已钳制到该最大数量。
+	sliderQuantityOutcomeClamped
+)
+
+// resolveSliderQuantityOutcome 根据解析后的目标数量与滑条最大可选数量，
+// 返回本次实际使用的目标数量及其判定结果。
+//
+// 判定按以下优先级依次短路，三种结果互斥：
+//
+//  1. targetQuantity < 1 或 sliderMaxQuantity == 0 → OutOfRange：没有可选的有效目标。
+//  2. targetQuantity > sliderMaxQuantity：启用 clampTargetToSliderMax 时将目标下调到
+//     滑条上限并返回 Clamped（目标数量被替换为 sliderMaxQuantity，属部分达成，
+//     因此不算 TargetReachable）；未启用钳制时返回 OutOfRange，由调用方决定如何处理。
+//  3. 其余情况 → TargetReachable：目标在 [1, sliderMaxQuantity] 内，无需钳制即可达成。
+//
+// 除 Clamped 外，返回的目标数量均为入参原值。判定结果最终通过
+// applyOutcomeOverrides 映射到调用方的结果节点开关（Clamped 不启用任何结果节点）。
+func resolveSliderQuantityOutcome(
+	targetQuantity int,
+	sliderMaxQuantity int,
+	clampTargetToSliderMax bool,
+) (int, sliderQuantityOutcome) {
+	if targetQuantity < 1 || sliderMaxQuantity == 0 {
+		return targetQuantity, sliderQuantityOutcomeOutOfRange
+	}
+	if targetQuantity > sliderMaxQuantity {
+		if clampTargetToSliderMax {
+			return sliderMaxQuantity, sliderQuantityOutcomeClamped
+		}
+		return targetQuantity, sliderQuantityOutcomeOutOfRange
+	}
+
+	return targetQuantity, sliderQuantityOutcomeTargetReachable
 }
 
 func resolveSliderMaxQuantityNext(sliderMaxQuantity int, targetQuantity int) (string, error) {

--- a/agent/go-service/bettersliding/handlers.go
+++ b/agent/go-service/bettersliding/handlers.go
@@ -36,10 +36,10 @@ func (a *BetterSlidingAction) dispatchActionNode(ctx *maa.Context, arg *maa.Cust
 		return a.handleMain(ctx, arg)
 	case nodeBetterSlidingFindStart:
 		return a.handleFindStart(ctx, arg)
-	case nodeBetterSlidingGetMaxQuantity:
-		return a.handleGetMaxQuantity(ctx, arg)
-	case nodeBetterSlidingGetMaxTarget:
-		return a.handleGetMaxTarget(ctx, arg)
+	case nodeBetterSlidingGetSliderMaxQuantity:
+		return a.handleGetSliderMaxQuantity(ctx, arg)
+	case nodeBetterSlidingGetAvailableQuantity:
+		return a.handleGetAvailableQuantity(ctx, arg)
 	case nodeBetterSlidingFindEnd:
 		return a.handleFindEnd(ctx, arg)
 	case nodeBetterSlidingCheckQuantity:
@@ -60,16 +60,16 @@ func (a *BetterSlidingAction) handleMain(ctx *maa.Context, _ *maa.CustomActionAr
 		return false
 	}
 
-	if !a.SwipeOnlyMode && len(a.QuantityBox) != 4 {
+	if !a.SwipeOnlyMode && len(a.SliderQuantityBox) != 4 {
 		a.logger.Error().
-			Ints("quantity_box", a.QuantityBox).
-			Msg("invalid quantity box, expected [x,y,w,h]")
+			Ints("slider_quantity_box", a.SliderQuantityBox).
+			Msg("invalid slider quantity box, expected [x,y,w,h]")
 		return false
 	}
-	if a.MaxTargetExplicit && len(a.MaxTargetBox) != 4 {
+	if a.AvailableQuantityExplicit && len(a.AvailableQuantityBox) != 4 {
 		a.logger.Error().
-			Ints("max_target_box", a.MaxTargetBox).
-			Msg("invalid max target box, expected [x,y,w,h]")
+			Ints("available_quantity_box", a.AvailableQuantityBox).
+			Msg("invalid available quantity box, expected [x,y,w,h]")
 		return false
 	}
 
@@ -84,13 +84,13 @@ func (a *BetterSlidingAction) handleMain(ctx *maa.Context, _ *maa.CustomActionAr
 
 	override := buildMainInitializationOverride(
 		end,
-		a.QuantityBox,
-		a.MaxTargetBox,
-		a.MaxTargetExplicit,
-		a.QuantityFilter,
-		a.MaxTargetFilter,
-		a.QuantityOnlyRec,
-		a.MaxTargetOnlyRec,
+		a.SliderQuantityBox,
+		a.AvailableQuantityBox,
+		a.AvailableQuantityExplicit,
+		a.SliderQuantityFilter,
+		a.AvailableQuantityFilter,
+		a.SliderQuantityOnlyRec,
+		a.AvailableQuantityOnlyRec,
 		a.SwipeButton,
 		a.GreenMask,
 	)
@@ -111,28 +111,28 @@ func (a *BetterSlidingAction) handleMain(ctx *maa.Context, _ *maa.CustomActionAr
 	initializationLog := a.logger.Info().
 		Str("direction", a.Direction).
 		Ints("end", end).
-		Ints("quantity_roi", a.QuantityBox).
-		Ints("max_target_roi", a.MaxTargetBox).
-		Bool("max_target_explicit", a.MaxTargetExplicit).
+		Ints("slider_quantity_roi", a.SliderQuantityBox).
+		Ints("available_quantity_roi", a.AvailableQuantityBox).
+		Bool("available_quantity_explicit", a.AvailableQuantityExplicit).
 		Bool("green_mask", a.GreenMask).
-		Bool("quantity_filter_enabled", a.QuantityFilter != nil).
-		Bool("max_target_filter_enabled", a.MaxTargetFilter != nil).
-		Bool("quantity_only_rec", a.QuantityOnlyRec).
-		Bool("max_target_only_rec", a.MaxTargetOnlyRec).
+		Bool("slider_quantity_filter_enabled", a.SliderQuantityFilter != nil).
+		Bool("available_quantity_filter_enabled", a.AvailableQuantityFilter != nil).
+		Bool("slider_quantity_only_rec", a.SliderQuantityOnlyRec).
+		Bool("available_quantity_only_rec", a.AvailableQuantityOnlyRec).
 		Bool("swipe_only_mode", a.SwipeOnlyMode)
 
-	if a.QuantityFilter != nil {
+	if a.SliderQuantityFilter != nil {
 		initializationLog = initializationLog.
-			Int("quantity_filter_method", a.QuantityFilter.Method).
-			Ints("quantity_filter_lower", a.QuantityFilter.Lower).
-			Ints("quantity_filter_upper", a.QuantityFilter.Upper)
+			Int("slider_quantity_filter_method", a.SliderQuantityFilter.Method).
+			Ints("slider_quantity_filter_lower", a.SliderQuantityFilter.Lower).
+			Ints("slider_quantity_filter_upper", a.SliderQuantityFilter.Upper)
 	}
 
-	if a.MaxTargetFilter != nil {
+	if a.AvailableQuantityFilter != nil {
 		initializationLog = initializationLog.
-			Int("max_target_filter_method", a.MaxTargetFilter.Method).
-			Ints("max_target_filter_lower", a.MaxTargetFilter.Lower).
-			Ints("max_target_filter_upper", a.MaxTargetFilter.Upper)
+			Int("available_quantity_filter_method", a.AvailableQuantityFilter.Method).
+			Ints("available_quantity_filter_lower", a.AvailableQuantityFilter.Lower).
+			Ints("available_quantity_filter_upper", a.AvailableQuantityFilter.Upper)
 	}
 
 	initializationLog.Msg("main initialization completed with pipeline overrides")
@@ -156,7 +156,7 @@ func (a *BetterSlidingAction) handleFindStart(_ *maa.Context, arg *maa.CustomAct
 	return true
 }
 
-func (a *BetterSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+func (a *BetterSlidingAction) handleGetSliderMaxQuantity(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 	if ctx == nil {
 		a.logger.Error().Msg("context is nil")
 		return false
@@ -166,116 +166,129 @@ func (a *BetterSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa.Cu
 		return false
 	}
 
-	maxQuantity, err := readQuantityValue(arg.RecognitionDetail)
+	sliderMaxQuantity, err := readQuantityValue(arg.RecognitionDetail)
 	if err != nil {
-		a.logger.Error().Err(err).Msg("failed to parse max quantity from ocr")
+		a.logger.Error().Err(err).Msg("failed to parse slider max quantity from ocr")
 		return false
 	}
 
-	a.maxQuantity = maxQuantity
+	a.sliderMaxQuantity = sliderMaxQuantity
 
-	if !a.maxTargetResolved {
-		resolved, resolveErr := resolveTarget(a.OriginalTarget, a.TargetType, a.TargetReverse, a.maxQuantity)
+	if !a.availableQuantityResolved {
+		resolved, resolveErr := resolveTargetQuantity(
+			a.OriginalTargetQuantity,
+			a.TargetQuantityType,
+			a.ReverseTarget,
+			a.sliderMaxQuantity,
+		)
 		if resolveErr != nil {
 			a.logger.Error().
 				Err(resolveErr).
-				Int("target", a.OriginalTarget).
-				Str("target_type", a.TargetType).
-				Bool("target_reverse", a.TargetReverse).
-				Msg("failed to resolve target")
+				Int("target_quantity", a.OriginalTargetQuantity).
+				Str("target_quantity_type", a.TargetQuantityType).
+				Bool("reverse_target", a.ReverseTarget).
+				Msg("failed to resolve target quantity")
 			return false
 		}
 
-		if resolved != a.OriginalTarget {
+		if resolved != a.OriginalTargetQuantity {
 			a.logger.Info().
-				Int("original_target", a.OriginalTarget).
-				Int("resolved_target", resolved).
-				Str("target_type", a.TargetType).
-				Bool("target_reverse", a.TargetReverse).
-				Int("max_quantity", a.maxQuantity).
-				Msg("target resolved")
+				Int("original_target_quantity", a.OriginalTargetQuantity).
+				Int("resolved_target_quantity", resolved).
+				Str("target_quantity_type", a.TargetQuantityType).
+				Bool("reverse_target", a.ReverseTarget).
+				Int("slider_max_quantity", a.sliderMaxQuantity).
+				Msg("target quantity resolved")
 		}
-		a.Target = resolved
+		a.TargetQuantity = resolved
 		a.runtimeTargetResolved = true
 	}
 
-	upperOverflow := a.Target > a.maxQuantity
-	lowerOverflow := a.TargetType == TargetTypeValue && a.TargetReverse && a.Target < 1
+	upperOverflow := a.TargetQuantity > a.sliderMaxQuantity
+	lowerOverflow := a.TargetQuantityType == TargetQuantityTypeValue &&
+		a.ReverseTarget &&
+		a.TargetQuantity < 1
 	// Record reachability before clamping: selecting a clamped maximum does not mean the original target is reachable.
-	a.targetReachable = a.Target >= 1 && a.Target <= a.maxQuantity
+	a.targetReachable = a.TargetQuantity >= 1 && a.TargetQuantity <= a.sliderMaxQuantity
 
-	// Clamp upper overflow before any exceeding-override handling so clamp takes priority.
-	if a.ClampTargetToMax && upperOverflow {
-		originalTarget := a.Target
-		a.Target = a.maxQuantity
+	// Clamp upper overflow before out-of-range handling so clamping takes priority.
+	if a.ClampTargetToSliderMax && upperOverflow {
+		originalTargetQuantity := a.TargetQuantity
+		a.TargetQuantity = a.sliderMaxQuantity
 		a.logger.Warn().
-			Int("original_target", originalTarget).
-			Int("clamped_target", a.Target).
-			Int("max_quantity", a.maxQuantity).
-			Msg("target clamped to max quantity")
+			Int("original_target_quantity", originalTargetQuantity).
+			Int("clamped_target_quantity", a.TargetQuantity).
+			Int("slider_max_quantity", a.sliderMaxQuantity).
+			Msg("target quantity clamped to slider max quantity")
 		upperOverflow = false
 	}
 
-	a.exceeded = false
-	if a.ExceedingOverrideEnable != "" {
-		if upperOverflow || lowerOverflow || a.maxQuantity == 0 {
-			a.exceeded = true
-			if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingDone, buttonTarget{}, 0, a.GreenMask); err != nil {
+	a.outOfRange = false
+	if a.OutOfRangeOverrideEnable != "" {
+		if upperOverflow || lowerOverflow || a.sliderMaxQuantity == 0 {
+			a.outOfRange = true
+			if err := overrideCheckQuantityBranch(
+				ctx,
+				arg.CurrentTaskName,
+				nodeBetterSlidingDone,
+				buttonTarget{},
+				0,
+				a.GreenMask,
+			); err != nil {
 				logEvent := a.logger.Error().
 					Err(err).
-					Int("max_quantity", a.maxQuantity).
-					Int("target", a.Target).
+					Int("slider_max_quantity", a.sliderMaxQuantity).
+					Int("target_quantity", a.TargetQuantity).
 					Str("next", nodeBetterSlidingDone)
 				if errors.Is(err, errCheckQuantityBranchNextOverride) {
-					logEvent.Msg("failed to override next for exceeding branch")
+					logEvent.Msg("failed to override next for out-of-range branch")
 				} else {
-					logEvent.Msg("failed to override pipeline for exceeding branch")
+					logEvent.Msg("failed to override pipeline for out-of-range branch")
 				}
-
 				return false
 			}
 
 			logEvent := a.logger.Warn().
-				Int("original_target", a.OriginalTarget).
-				Int("resolved_target", a.Target).
-				Int("max_quantity", a.maxQuantity).
-				Str("override_node", a.ExceedingOverrideEnable)
-			if a.maxQuantity == 0 {
-				logEvent.Msg("max quantity is zero, skipping via exceeding override")
+				Int("original_target_quantity", a.OriginalTargetQuantity).
+				Int("resolved_target_quantity", a.TargetQuantity).
+				Int("slider_max_quantity", a.sliderMaxQuantity).
+				Str("override_node", a.OutOfRangeOverrideEnable)
+			if a.sliderMaxQuantity == 0 {
+				logEvent.Msg("slider max quantity is zero, skipping via out-of-range override")
 			} else {
-				logEvent.Msg("target out of range: exceeding override scheduled, branching to done")
+				logEvent.Msg("target quantity out of range; caller outcome scheduled")
 			}
 			return true
 		}
 
-		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.ExceedingOverrideEnable, false)); err != nil {
+		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.OutOfRangeOverrideEnable, false)); err != nil {
 			a.logger.Error().Err(err).
-				Str("override_node", a.ExceedingOverrideEnable).
-				Msg("failed to override exceeding disable state")
+				Str("override_node", a.OutOfRangeOverrideEnable).
+				Msg("failed to disable out-of-range override")
 			return false
 		}
 	} else if lowerOverflow || upperOverflow {
 		a.logger.Error().
-			Int("resolved_target", a.Target).
-			Int("max_quantity", a.maxQuantity).
-			Msg("target out of range and no exceeding override configured")
+			Int("resolved_target_quantity", a.TargetQuantity).
+			Int("slider_max_quantity", a.sliderMaxQuantity).
+			Msg("target quantity out of range and no override configured")
 		return false
 	}
 
-	nextNode, err := resolveMaxQuantityNext(a.maxQuantity, a.Target)
+	nextNode, err := resolveSliderMaxQuantityNext(a.sliderMaxQuantity, a.TargetQuantity)
 	if err != nil {
 		a.logger.Error().
-			Int("max_quantity", a.maxQuantity).
-			Int("target", a.Target).
-			Msg("max quantity lower than target")
+			Int("slider_max_quantity", a.sliderMaxQuantity).
+			Int("target_quantity", a.TargetQuantity).
+			Msg("slider max quantity lower than target quantity")
 		return false
 	}
 	if nextNode != "" {
 		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nextNode, buttonTarget{}, 0, a.GreenMask); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
-				Int("max_quantity", a.maxQuantity).
-				Int("target", a.Target).
+				Int("slider_max_quantity", a.sliderMaxQuantity).
+				Int("target_quantity", a.TargetQuantity).
 				Str("next", nextNode)
 			if errors.Is(err, errCheckQuantityBranchNextOverride) {
 				logEvent.Msg("failed to override next for direct-done branch")
@@ -286,21 +299,21 @@ func (a *BetterSlidingAction) handleGetMaxQuantity(ctx *maa.Context, arg *maa.Cu
 		}
 
 		a.logger.Info().
-			Int("max_quantity", a.maxQuantity).
-			Int("target", a.Target).
+			Int("slider_max_quantity", a.sliderMaxQuantity).
+			Int("target_quantity", a.TargetQuantity).
 			Str("next", nextNode).
-			Msg("max quantity already satisfies target, branch to done")
+			Msg("slider max quantity already matches target quantity, branch to done")
 		return true
 	}
 
 	a.logger.Info().
-		Int("max_quantity", a.maxQuantity).
-		Int("target", a.Target).
-		Msg("max quantity parsed")
+		Int("slider_max_quantity", a.sliderMaxQuantity).
+		Int("target_quantity", a.TargetQuantity).
+		Msg("slider max quantity parsed")
 	return true
 }
 
-func (a *BetterSlidingAction) handleGetMaxTarget(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+func (a *BetterSlidingAction) handleGetAvailableQuantity(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 	if ctx == nil {
 		a.logger.Error().Msg("context is nil")
 		return false
@@ -310,42 +323,47 @@ func (a *BetterSlidingAction) handleGetMaxTarget(ctx *maa.Context, arg *maa.Cust
 		return false
 	}
 
-	maxTarget, err := readQuantityValue(arg.RecognitionDetail)
+	availableQuantity, err := readQuantityValue(arg.RecognitionDetail)
 	if err != nil {
-		a.logger.Error().Err(err).Msg("failed to parse max target from ocr")
+		a.logger.Error().Err(err).Msg("failed to parse available quantity from ocr")
 		return false
 	}
 
-	a.maxTarget = maxTarget
+	a.availableQuantity = availableQuantity
 
-	resolved, resolveErr := resolveTarget(a.OriginalTarget, a.TargetType, a.TargetReverse, a.maxTarget)
+	resolved, resolveErr := resolveTargetQuantity(
+		a.OriginalTargetQuantity,
+		a.TargetQuantityType,
+		a.ReverseTarget,
+		a.availableQuantity,
+	)
 	if resolveErr != nil {
 		a.logger.Error().
 			Err(resolveErr).
-			Int("target", a.OriginalTarget).
-			Str("target_type", a.TargetType).
-			Bool("target_reverse", a.TargetReverse).
-			Msg("failed to resolve target from max target")
+			Int("target_quantity", a.OriginalTargetQuantity).
+			Str("target_quantity_type", a.TargetQuantityType).
+			Bool("reverse_target", a.ReverseTarget).
+			Msg("failed to resolve target quantity from available quantity")
 		return false
 	}
 
-	if resolved != a.OriginalTarget {
+	if resolved != a.OriginalTargetQuantity {
 		a.logger.Info().
-			Int("original_target", a.OriginalTarget).
-			Int("resolved_target", resolved).
-			Str("target_type", a.TargetType).
-			Bool("target_reverse", a.TargetReverse).
-			Int("max_target", a.maxTarget).
-			Msg("target resolved from max target")
+			Int("original_target_quantity", a.OriginalTargetQuantity).
+			Int("resolved_target_quantity", resolved).
+			Str("target_quantity_type", a.TargetQuantityType).
+			Bool("reverse_target", a.ReverseTarget).
+			Int("available_quantity", a.availableQuantity).
+			Msg("target quantity resolved from available quantity")
 	}
-	a.Target = resolved
+	a.TargetQuantity = resolved
 	a.runtimeTargetResolved = true
-	a.maxTargetResolved = true
+	a.availableQuantityResolved = true
 
 	a.logger.Info().
-		Int("max_target", a.maxTarget).
-		Int("resolved_target", a.Target).
-		Msg("max target parsed")
+		Int("available_quantity", a.availableQuantity).
+		Int("resolved_target_quantity", a.TargetQuantity).
+		Msg("available quantity parsed")
 	return true
 }
 
@@ -358,10 +376,10 @@ func (a *BetterSlidingAction) handleFindEnd(ctx *maa.Context, arg *maa.CustomAct
 		a.logger.Error().Msg("recognition detail is nil")
 		return false
 	}
-	if a.maxQuantity < 1 {
+	if a.sliderMaxQuantity < 1 {
 		a.logger.Error().
-			Int("max_quantity", a.maxQuantity).
-			Msg("invalid max quantity for precise click calculation")
+			Int("slider_max_quantity", a.sliderMaxQuantity).
+			Msg("invalid slider max quantity for precise click calculation")
 		return false
 	}
 
@@ -388,11 +406,11 @@ func (a *BetterSlidingAction) handleFindEnd(ctx *maa.Context, arg *maa.CustomAct
 	startX, startY := centerPoint(a.startBox, a.CenterPointOffset)
 	endX, endY := centerPoint(a.endBox, a.CenterPointOffset)
 
-	numerator := a.Target - 1
-	denominator := a.maxQuantity - 1
+	numerator := a.TargetQuantity - 1
+	denominator := a.sliderMaxQuantity - 1
 	if denominator == 0 {
 		a.logger.Error().
-			Int("max_quantity", a.maxQuantity).
+			Int("slider_max_quantity", a.sliderMaxQuantity).
 			Msg("denominator is zero in precise click calculation")
 		return false
 	}
@@ -416,8 +434,8 @@ func (a *BetterSlidingAction) handleFindEnd(ctx *maa.Context, arg *maa.CustomAct
 	a.logger.Info().
 		Ints("start_box", a.startBox).
 		Ints("end_box", a.endBox).
-		Int("target", a.Target).
-		Int("max_quantity", a.maxQuantity).
+		Int("target_quantity", a.TargetQuantity).
+		Int("slider_max_quantity", a.sliderMaxQuantity).
 		Int("click_x", clickX).
 		Int("click_y", clickY).
 		Msg("precise click calculated")
@@ -457,12 +475,12 @@ func (a *BetterSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.Cus
 	}
 
 	switch {
-	case currentQuantity == a.Target:
+	case currentQuantity == a.TargetQuantity:
 		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingDone, buttonTarget{}, 0, a.GreenMask); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
 				Int("current_quantity", currentQuantity).
-				Int("target", a.Target)
+				Int("target_quantity", a.TargetQuantity)
 			if errors.Is(err, errCheckQuantityBranchNextOverride) {
 				logEvent.Msg("failed to override next to done")
 			} else {
@@ -473,18 +491,18 @@ func (a *BetterSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.Cus
 
 		a.logger.Info().
 			Int("current_quantity", currentQuantity).
-			Int("target", a.Target).
+			Int("target_quantity", a.TargetQuantity).
 			Str("next", nodeBetterSlidingDone).
 			Msg("quantity matched target")
 		return true
-	case currentQuantity < a.Target:
-		diff := a.Target - currentQuantity
+	case currentQuantity < a.TargetQuantity:
+		diff := a.TargetQuantity - currentQuantity
 		repeat := clampClickRepeat(diff)
 		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingIncreaseQuantity, a.IncreaseButton, repeat, a.GreenMask); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
 				Int("current_quantity", currentQuantity).
-				Int("target", a.Target).
+				Int("target_quantity", a.TargetQuantity).
 				Int("diff", diff).
 				Int("repeat", repeat).
 				Interface("increase_button", a.IncreaseButton.logValue())
@@ -498,7 +516,7 @@ func (a *BetterSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.Cus
 
 		a.logger.Info().
 			Int("current_quantity", currentQuantity).
-			Int("target", a.Target).
+			Int("target_quantity", a.TargetQuantity).
 			Int("diff", diff).
 			Int("repeat", repeat).
 			Interface("button", a.IncreaseButton.logValue()).
@@ -506,13 +524,13 @@ func (a *BetterSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.Cus
 			Msg("quantity below target, branch to increase")
 		return true
 	default:
-		diff := currentQuantity - a.Target
+		diff := currentQuantity - a.TargetQuantity
 		repeat := clampClickRepeat(diff)
 		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingDecreaseQuantity, a.DecreaseButton, repeat, a.GreenMask); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
 				Int("current_quantity", currentQuantity).
-				Int("target", a.Target).
+				Int("target_quantity", a.TargetQuantity).
 				Int("diff", diff).
 				Int("repeat", repeat).
 				Interface("decrease_button", a.DecreaseButton.logValue())
@@ -526,7 +544,7 @@ func (a *BetterSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.Cus
 
 		a.logger.Info().
 			Int("current_quantity", currentQuantity).
-			Int("target", a.Target).
+			Int("target_quantity", a.TargetQuantity).
 			Int("diff", diff).
 			Int("repeat", repeat).
 			Interface("button", a.DecreaseButton.logValue()).
@@ -538,7 +556,7 @@ func (a *BetterSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.Cus
 
 func (a *BetterSlidingAction) handleDone(_ *maa.Context, _ *maa.CustomActionArg) bool {
 	a.logger.Info().
-		Int("target", a.Target).
+		Int("target_quantity", a.TargetQuantity).
 		Msg("quantity adjustment completed")
 	return true
 }
@@ -600,30 +618,30 @@ func (a *BetterSlidingAction) runInternalPipeline(ctx *maa.Context, arg *maa.Cus
 		return false
 	}
 
-	if a.exceeded && a.ExceedingOverrideEnable != "" {
-		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.ExceedingOverrideEnable, true)); err != nil {
+	if a.outOfRange && a.OutOfRangeOverrideEnable != "" {
+		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.OutOfRangeOverrideEnable, true)); err != nil {
 			a.logger.Error().
 				Err(err).
 				Str("caller", arg.CurrentTaskName).
-				Str("override_node", a.ExceedingOverrideEnable).
-				Msg("failed to apply exceeding override after internal pipeline")
+				Str("override_node", a.OutOfRangeOverrideEnable).
+				Msg("failed to apply out-of-range override after internal pipeline")
 			return false
 		}
 
 		a.logger.Info().
 			Str("caller", arg.CurrentTaskName).
-			Str("override_node", a.ExceedingOverrideEnable).
-			Msg("applied exceeding override after internal pipeline")
+			Str("override_node", a.OutOfRangeOverrideEnable).
+			Msg("applied out-of-range override after internal pipeline")
 	}
 
-	if a.TargetReachedOverrideEnable != "" {
-		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.TargetReachedOverrideEnable, a.targetReachable)); err != nil {
+	if a.TargetReachableOverrideEnable != "" {
+		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.TargetReachableOverrideEnable, a.targetReachable)); err != nil {
 			a.logger.Error().
 				Err(err).
 				Str("caller", arg.CurrentTaskName).
-				Str("override_node", a.TargetReachedOverrideEnable).
-				Bool("target_reachable", a.targetReachable).
-				Msg("failed to apply target-reached override after internal pipeline")
+				Str("override_node", a.TargetReachableOverrideEnable).
+				Bool("target_quantity_reachable", a.targetReachable).
+				Msg("failed to apply target-reachable override after internal pipeline")
 			return false
 		}
 	}
@@ -636,9 +654,9 @@ func (a *BetterSlidingAction) runInternalPipeline(ctx *maa.Context, arg *maa.Cus
 			Bool("swipe_only_mode", true).
 			Msg("internal BetterSliding pipeline finished (swipe-only)")
 
-		if !a.exceeded && a.ExceedingOverrideEnable != "" {
-			if err := ctx.OverridePipeline(buildNodeEnableOverride(a.ExceedingOverrideEnable, false)); err != nil {
-				a.logger.Error().Err(err).Msg("failed to apply exceeding override after swipe-only")
+		if !a.outOfRange && a.OutOfRangeOverrideEnable != "" {
+			if err := ctx.OverridePipeline(buildNodeEnableOverride(a.OutOfRangeOverrideEnable, false)); err != nil {
+				a.logger.Error().Err(err).Msg("failed to apply out-of-range override after swipe-only")
 				return false
 			}
 		}
@@ -646,9 +664,9 @@ func (a *BetterSlidingAction) runInternalPipeline(ctx *maa.Context, arg *maa.Cus
 		return true
 	}
 
-	if !a.exceeded && a.ExceedingOverrideEnable != "" {
-		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.ExceedingOverrideEnable, false)); err != nil {
-			a.logger.Error().Err(err).Msg("failed to apply exceeding override after internal pipeline")
+	if !a.outOfRange && a.OutOfRangeOverrideEnable != "" {
+		if err := ctx.OverridePipeline(buildNodeEnableOverride(a.OutOfRangeOverrideEnable, false)); err != nil {
+			a.logger.Error().Err(err).Msg("failed to apply out-of-range override after internal pipeline")
 			return false
 		}
 	}
@@ -674,22 +692,26 @@ func isBetterSlidingActionNode(taskName string) bool {
 func (a *BetterSlidingAction) resetState() {
 	a.startBox = nil
 	a.endBox = nil
-	a.maxQuantity = 0
-	a.maxTarget = 0
-	a.maxTargetResolved = false
-	a.exceeded = false
+	a.sliderMaxQuantity = 0
+	a.availableQuantity = 0
+	a.availableQuantityResolved = false
+	a.outOfRange = false
 	a.targetReachable = false
 	a.runtimeTargetResolved = false
 }
 
-func resolveMaxQuantityNext(maxQuantity int, target int) (string, error) {
-	if maxQuantity == target {
+func resolveSliderMaxQuantityNext(sliderMaxQuantity int, targetQuantity int) (string, error) {
+	if sliderMaxQuantity == targetQuantity {
 		return nodeBetterSlidingDone, nil
 	}
-	if maxQuantity < target {
-		return "", fmt.Errorf("max quantity %d lower than target %d", maxQuantity, target)
+	if sliderMaxQuantity < targetQuantity {
+		return "", fmt.Errorf(
+			"slider max quantity %d lower than target quantity %d",
+			sliderMaxQuantity,
+			targetQuantity,
+		)
 	}
-	if maxQuantity == 1 && target == 1 {
+	if sliderMaxQuantity == 1 && targetQuantity == 1 {
 		return nodeBetterSlidingDone, nil
 	}
 

--- a/agent/go-service/bettersliding/handlers_test.go
+++ b/agent/go-service/bettersliding/handlers_test.go
@@ -1,0 +1,77 @@
+package bettersliding
+
+import "testing"
+
+func TestResolveSliderQuantityOutcome(t *testing.T) {
+	tests := []struct {
+		name               string
+		targetQuantity     int
+		sliderMaxQuantity  int
+		clamp              bool
+		wantTargetQuantity int
+		wantOutcome        sliderQuantityOutcome
+	}{
+		{
+			name:               "positive target with zero slider max is out of range",
+			targetQuantity:     17720,
+			sliderMaxQuantity:  0,
+			clamp:              true,
+			wantTargetQuantity: 17720,
+			wantOutcome:        sliderQuantityOutcomeOutOfRange,
+		},
+		{
+			name:               "below-range outcome takes precedence when target and slider max are zero",
+			targetQuantity:     0,
+			sliderMaxQuantity:  0,
+			clamp:              true,
+			wantTargetQuantity: 0,
+			wantOutcome:        sliderQuantityOutcomeOutOfRange,
+		},
+		{
+			name:               "upper target clamps to positive slider max",
+			targetQuantity:     17947,
+			sliderMaxQuantity:  229,
+			clamp:              true,
+			wantTargetQuantity: 229,
+			wantOutcome:        sliderQuantityOutcomeClamped,
+		},
+		{
+			name:               "reachable target remains unchanged",
+			targetQuantity:     229,
+			sliderMaxQuantity:  229,
+			clamp:              true,
+			wantTargetQuantity: 229,
+			wantOutcome:        sliderQuantityOutcomeTargetReachable,
+		},
+		{
+			name:               "upper target without clamp is out of range",
+			targetQuantity:     230,
+			sliderMaxQuantity:  229,
+			clamp:              false,
+			wantTargetQuantity: 230,
+			wantOutcome:        sliderQuantityOutcomeOutOfRange,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotTargetQuantity, gotOutcome := resolveSliderQuantityOutcome(
+				test.targetQuantity,
+				test.sliderMaxQuantity,
+				test.clamp,
+			)
+			if gotTargetQuantity != test.wantTargetQuantity || gotOutcome != test.wantOutcome {
+				t.Fatalf(
+					"resolveSliderQuantityOutcome(%d, %d, %t) = (%d, %d), want (%d, %d)",
+					test.targetQuantity,
+					test.sliderMaxQuantity,
+					test.clamp,
+					gotTargetQuantity,
+					gotOutcome,
+					test.wantTargetQuantity,
+					test.wantOutcome,
+				)
+			}
+		})
+	}
+}

--- a/agent/go-service/bettersliding/nodes.go
+++ b/agent/go-service/bettersliding/nodes.go
@@ -3,35 +3,35 @@ package bettersliding
 const (
 	betterSlidingActionName = "BetterSliding"
 
-	nodeBetterSlidingMain           = "BetterSlidingMain"
-	nodeBetterSlidingFindStart      = "BetterSlidingFindStart"
-	nodeBetterSlidingGetMaxQuantity = "BetterSlidingGetMaxQuantity"
-	nodeBetterSlidingGetMaxTarget   = "BetterSlidingGetMaxTarget"
-	nodeBetterSlidingFindEnd        = "BetterSlidingFindEnd"
-	nodeBetterSlidingCheckQuantity  = "BetterSlidingCheckQuantity"
-	nodeBetterSlidingDone           = "BetterSlidingDone"
+	nodeBetterSlidingMain                 = "BetterSlidingMain"
+	nodeBetterSlidingFindStart            = "BetterSlidingFindStart"
+	nodeBetterSlidingGetSliderMaxQuantity = "BetterSlidingGetSliderMaxQuantity"
+	nodeBetterSlidingGetAvailableQuantity = "BetterSlidingGetAvailableQuantity"
+	nodeBetterSlidingFindEnd              = "BetterSlidingFindEnd"
+	nodeBetterSlidingCheckQuantity        = "BetterSlidingCheckQuantity"
+	nodeBetterSlidingDone                 = "BetterSlidingDone"
 
-	nodeBetterSlidingSwipeToMax        = "BetterSlidingSwipeToMax"
-	nodeBetterSlidingGetQuantity       = "BetterSlidingGetQuantity"
-	nodeBetterSlidingQuantityFilter    = "BetterSlidingQuantityFilter"
-	nodeBetterSlidingMaxTargetFilter   = "BetterSlidingMaxTargetFilter"
-	nodeBetterSlidingSwipeButton       = "BetterSlidingSwipeButton"
-	nodeBetterSlidingIncreaseButton    = "BetterSlidingIncreaseButton"
-	nodeBetterSlidingDecreaseButton    = "BetterSlidingDecreaseButton"
-	nodeBetterSlidingPreciseClick      = "BetterSlidingPreciseClick"
-	nodeBetterSlidingClearMaxHit       = "BetterSlidingClearMaxHit"
-	nodeBetterSlidingJumpBackNode      = "BetterSlidingJumpBackNode"
-	nodeBetterSlidingJumpBackMoveMouse = "[JumpBack]BetterSlidingMoveMouse"
-	nodeBetterSlidingFail              = "BetterSlidingFail"
-	nodeBetterSlidingIncreaseQuantity  = "BetterSlidingIncreaseQuantity"
-	nodeBetterSlidingDecreaseQuantity  = "BetterSlidingDecreaseQuantity"
+	nodeBetterSlidingSwipeToMax              = "BetterSlidingSwipeToMax"
+	nodeBetterSlidingGetSliderQuantity       = "BetterSlidingGetSliderQuantity"
+	nodeBetterSlidingSliderQuantityFilter    = "BetterSlidingSliderQuantityFilter"
+	nodeBetterSlidingAvailableQuantityFilter = "BetterSlidingAvailableQuantityFilter"
+	nodeBetterSlidingSwipeButton             = "BetterSlidingSwipeButton"
+	nodeBetterSlidingIncreaseButton          = "BetterSlidingIncreaseButton"
+	nodeBetterSlidingDecreaseButton          = "BetterSlidingDecreaseButton"
+	nodeBetterSlidingPreciseClick            = "BetterSlidingPreciseClick"
+	nodeBetterSlidingClearMaxHit             = "BetterSlidingClearMaxHit"
+	nodeBetterSlidingJumpBackNode            = "BetterSlidingJumpBackNode"
+	nodeBetterSlidingJumpBackMoveMouse       = "[JumpBack]BetterSlidingMoveMouse"
+	nodeBetterSlidingFail                    = "BetterSlidingFail"
+	nodeBetterSlidingIncreaseQuantity        = "BetterSlidingIncreaseQuantity"
+	nodeBetterSlidingDecreaseQuantity        = "BetterSlidingDecreaseQuantity"
 )
 
 var betterSlidingActionNodes = []string{
 	nodeBetterSlidingMain,
 	nodeBetterSlidingFindStart,
-	nodeBetterSlidingGetMaxQuantity,
-	nodeBetterSlidingGetMaxTarget,
+	nodeBetterSlidingGetSliderMaxQuantity,
+	nodeBetterSlidingGetAvailableQuantity,
 	nodeBetterSlidingFindEnd,
 	nodeBetterSlidingCheckQuantity,
 	nodeBetterSlidingDone,

--- a/agent/go-service/bettersliding/normalize.go
+++ b/agent/go-service/bettersliding/normalize.go
@@ -149,82 +149,93 @@ func centerPoint(rect []int, offset [2]int) (int, int) {
 	return rect[0] + rect[2]/2 + offset[0], rect[1] + rect[3]/2 + offset[1]
 }
 
-// normalizeTargetType normalizes a TargetType string, returning the canonical
-// form (TargetTypeValue or TargetTypePercentage). An empty string defaults to TargetTypeValue.
-func normalizeTargetType(raw string) (string, error) {
+// normalizeTargetQuantityType normalizes a TargetQuantityType string, returning the canonical
+// form. An empty string defaults to TargetQuantityTypeValue.
+func normalizeTargetQuantityType(raw string) (string, error) {
 	s := strings.TrimSpace(raw)
 	if s == "" {
-		return TargetTypeValue, nil
+		return TargetQuantityTypeValue, nil
 	}
 
 	switch strings.ToLower(s) {
 	case "value":
-		return TargetTypeValue, nil
+		return TargetQuantityTypeValue, nil
 	case "percentage":
-		return TargetTypePercentage, nil
+		return TargetQuantityTypePercentage, nil
 	default:
-		return "", fmt.Errorf("invalid TargetType %q, expected %q or %q", raw, TargetTypeValue, TargetTypePercentage)
+		return "", fmt.Errorf(
+			"invalid TargetQuantityType %q, expected %q or %q",
+			raw,
+			TargetQuantityTypeValue,
+			TargetQuantityTypePercentage,
+		)
 	}
 }
 
-// resolveTarget computes the effective discrete target from TargetType and TargetReverse.
+// resolveTargetQuantity computes the effective slider quantity using the available quantity as
+// the reference for percentage and reverse calculations.
 //
-//	TargetTypeValue + !Reverse → target unchanged.
-//	TargetTypeValue + Reverse  → maxQuantity - target (may be < 1 for upper-layer handling).
-//	TargetTypePercentage + !Reverse → round(maxQuantity * target / 100), clamped to [1, maxQuantity].
-//	TargetTypePercentage + Reverse  → round(maxQuantity * (100-target) / 100), clamped to [1, maxQuantity].
-func resolveTarget(target int, targetType string, targetReverse bool, maxQuantity int) (int, error) {
-	switch targetType {
-	case TargetTypeValue:
-		if !targetReverse {
-			return target, nil
+//	Value + !Reverse → targetQuantity unchanged.
+//	Value + Reverse  → availableQuantity - targetQuantity (may be < 1).
+//	Percentage + !Reverse → round(availableQuantity * targetQuantity / 100), clamped.
+//	Percentage + Reverse  → round(availableQuantity * (100-targetQuantity) / 100), clamped.
+func resolveTargetQuantity(
+	targetQuantity int,
+	targetQuantityType string,
+	reverseTarget bool,
+	availableQuantity int,
+) (int, error) {
+	switch targetQuantityType {
+	case TargetQuantityTypeValue:
+		if !reverseTarget {
+			return targetQuantity, nil
 		}
 
-		return maxQuantity - target, nil
+		return availableQuantity - targetQuantity, nil
 
-	case TargetTypePercentage:
-		if target == 0 {
+	case TargetQuantityTypePercentage:
+		if targetQuantity == 0 {
 			return 0, fmt.Errorf("percentage target must be greater than 0")
 		}
 
-		if target > 100 {
-			return 0, fmt.Errorf("percentage target must be at most 100, got %d", target)
+		if targetQuantity > 100 {
+			return 0, fmt.Errorf("percentage target must be at most 100, got %d", targetQuantity)
 		}
 
 		var factor float64
-		if !targetReverse {
-			factor = float64(target) / 100.0
+		if !reverseTarget {
+			factor = float64(targetQuantity) / 100.0
 		} else {
-			factor = float64(100-target) / 100.0
+			factor = float64(100-targetQuantity) / 100.0
 		}
 
-		resolved := int(math.Round(float64(maxQuantity) * factor))
+		resolved := int(math.Round(float64(availableQuantity) * factor))
 		if resolved < 1 {
 			resolved = 1
 		}
 
-		if resolved > maxQuantity {
-			resolved = maxQuantity
+		if resolved > availableQuantity {
+			resolved = availableQuantity
 		}
 
 		return resolved, nil
 
 	default:
-		return 0, fmt.Errorf("invalid target type %q", targetType)
+		return 0, fmt.Errorf("invalid target quantity type %q", targetQuantityType)
 	}
 }
 
 func isSwipeOnlyMode(params betterSlidingParam) bool {
-	return !params.presence.Target &&
-		!params.presence.Quantity &&
-		!params.presence.MaxTarget &&
+	return !params.presence.TargetQuantity &&
+		!params.presence.SliderQuantity &&
+		!params.presence.AvailableQuantity &&
 		!params.presence.GreenMask &&
 		!params.presence.IncreaseButton &&
 		!params.presence.DecreaseButton &&
-		!params.presence.ExceedingOverrideEnable &&
-		!params.presence.TargetReachedOverrideEnable &&
-		!params.presence.TargetType &&
-		!params.presence.TargetReverse &&
+		!params.presence.OutOfRangeOverrideEnable &&
+		!params.presence.TargetReachableOverrideEnable &&
+		!params.presence.TargetQuantityType &&
+		!params.presence.ReverseTarget &&
 		!params.presence.CenterPointOffset &&
-		!params.presence.ClampTargetToMax
+		!params.presence.ClampTargetToSliderMax
 }

--- a/agent/go-service/bettersliding/ocr.go
+++ b/agent/go-service/bettersliding/ocr.go
@@ -38,7 +38,7 @@ func readQuantityText(detail *maa.RecognitionDetail) string {
 		return ""
 	}
 
-	candidate := findRecognitionDetailByName(detail, nodeBetterSlidingGetQuantity)
+	candidate := findRecognitionDetailByName(detail, nodeBetterSlidingGetSliderQuantity)
 	if candidate == nil {
 		candidate = detail
 	}

--- a/agent/go-service/bettersliding/overrides.go
+++ b/agent/go-service/bettersliding/overrides.go
@@ -26,13 +26,13 @@ func buildSwipeEnd(direction string) ([]int, error) {
 
 func buildMainInitializationOverride(
 	end []int,
-	quantityBox []int,
-	maxTargetBox []int,
-	maxTargetExplicit bool,
-	quantityFilter *quantityFilterParam,
-	maxTargetFilter *quantityFilterParam,
-	quantityOnlyRec bool,
-	maxTargetOnlyRec bool,
+	sliderQuantityBox []int,
+	availableQuantityBox []int,
+	availableQuantityExplicit bool,
+	sliderQuantityFilter *quantityFilterParam,
+	availableQuantityFilter *quantityFilterParam,
+	sliderQuantityOnlyRec bool,
+	availableQuantityOnlyRec bool,
 	swipeButton string,
 	greenMask bool,
 ) map[string]any {
@@ -60,58 +60,58 @@ func buildMainInitializationOverride(
 		}
 	}
 
-	if len(quantityBox) == 0 {
+	if len(sliderQuantityBox) == 0 {
 		return override
 	}
 
-	quantityParam := map[string]any{
-		"roi":      append([]int(nil), quantityBox...),
-		"only_rec": quantityOnlyRec,
+	sliderQuantityParam := map[string]any{
+		"roi":      append([]int(nil), sliderQuantityBox...),
+		"only_rec": sliderQuantityOnlyRec,
 	}
-	if quantityFilter != nil {
-		quantityParam["color_filter"] = nodeBetterSlidingQuantityFilter
-		override[nodeBetterSlidingQuantityFilter] = map[string]any{
+	if sliderQuantityFilter != nil {
+		sliderQuantityParam["color_filter"] = nodeBetterSlidingSliderQuantityFilter
+		override[nodeBetterSlidingSliderQuantityFilter] = map[string]any{
 			"recognition": map[string]any{
 				"param": map[string]any{
-					"method": quantityFilter.Method,
-					"lower":  [][]int{append([]int(nil), quantityFilter.Lower...)},
-					"upper":  [][]int{append([]int(nil), quantityFilter.Upper...)},
+					"method": sliderQuantityFilter.Method,
+					"lower":  [][]int{append([]int(nil), sliderQuantityFilter.Lower...)},
+					"upper":  [][]int{append([]int(nil), sliderQuantityFilter.Upper...)},
 				},
 			},
 		}
 	}
 
-	override[nodeBetterSlidingGetQuantity] = map[string]any{
+	override[nodeBetterSlidingGetSliderQuantity] = map[string]any{
 		"recognition": map[string]any{
-			"param": quantityParam,
+			"param": sliderQuantityParam,
 		},
 	}
 
-	if maxTargetExplicit {
-		maxTargetParam := map[string]any{
-			"roi":      append([]int(nil), maxTargetBox...),
-			"only_rec": maxTargetOnlyRec,
+	if availableQuantityExplicit {
+		availableQuantityParam := map[string]any{
+			"roi":      append([]int(nil), availableQuantityBox...),
+			"only_rec": availableQuantityOnlyRec,
 		}
-		if maxTargetFilter != nil {
-			maxTargetParam["color_filter"] = nodeBetterSlidingMaxTargetFilter
-			override[nodeBetterSlidingMaxTargetFilter] = map[string]any{
+		if availableQuantityFilter != nil {
+			availableQuantityParam["color_filter"] = nodeBetterSlidingAvailableQuantityFilter
+			override[nodeBetterSlidingAvailableQuantityFilter] = map[string]any{
 				"recognition": map[string]any{
 					"param": map[string]any{
-						"method": maxTargetFilter.Method,
-						"lower":  [][]int{append([]int(nil), maxTargetFilter.Lower...)},
-						"upper":  [][]int{append([]int(nil), maxTargetFilter.Upper...)},
+						"method": availableQuantityFilter.Method,
+						"lower":  [][]int{append([]int(nil), availableQuantityFilter.Lower...)},
+						"upper":  [][]int{append([]int(nil), availableQuantityFilter.Upper...)},
 					},
 				},
 			}
 		}
-		override[nodeBetterSlidingGetMaxTarget] = map[string]any{
+		override[nodeBetterSlidingGetAvailableQuantity] = map[string]any{
 			"enabled": true,
 			"recognition": map[string]any{
-				"param": maxTargetParam,
+				"param": availableQuantityParam,
 			},
 		}
 	} else {
-		override[nodeBetterSlidingGetMaxTarget] = map[string]any{
+		override[nodeBetterSlidingGetAvailableQuantity] = map[string]any{
 			"enabled": false,
 		}
 	}

--- a/agent/go-service/bettersliding/params.go
+++ b/agent/go-service/bettersliding/params.go
@@ -9,27 +9,27 @@ import (
 )
 
 type parsedBetterSlidingParams struct {
-	target                      int
-	quantityBox                 []int
-	maxTargetBox                []int
-	maxTargetExplicit           bool
-	quantityFilter              *quantityFilterParam
-	maxTargetFilter             *quantityFilterParam
-	quantityOnlyRec             bool
-	maxTargetOnlyRec            bool
-	greenMask                   bool
-	direction                   string
-	increaseButton              buttonTarget
-	decreaseButton              buttonTarget
-	centerPointOffset           [2]int
-	clampTargetToMax            bool
-	swipeButton                 string
-	exceedingOverrideEnable     string
-	targetReachedOverrideEnable string
-	targetType                  string
-	targetReverse               bool
-	swipeOnlyMode               bool
-	finishAfterPreciseClick     bool
+	targetQuantity                int
+	sliderQuantityBox             []int
+	availableQuantityBox          []int
+	availableQuantityExplicit     bool
+	sliderQuantityFilter          *quantityFilterParam
+	availableQuantityFilter       *quantityFilterParam
+	sliderQuantityOnlyRec         bool
+	availableQuantityOnlyRec      bool
+	greenMask                     bool
+	direction                     string
+	increaseButton                buttonTarget
+	decreaseButton                buttonTarget
+	centerPointOffset             [2]int
+	clampTargetToSliderMax        bool
+	swipeButton                   string
+	outOfRangeOverrideEnable      string
+	targetReachableOverrideEnable string
+	targetQuantityType            string
+	reverseTarget                 bool
+	swipeOnlyMode                 bool
+	finishAfterPreciseClick       bool
 }
 
 func detectBetterSlidingParamPresence(rawParam string) (betterSlidingParamPresence, error) {
@@ -38,30 +38,47 @@ func detectBetterSlidingParamPresence(rawParam string) (betterSlidingParamPresen
 		return betterSlidingParamPresence{}, err
 	}
 
-	_, quantityPresent := rawKeys["Quantity"]
+	_, sliderQuantityPresent := rawKeys["SliderQuantity"]
 
 	return betterSlidingParamPresence{
-		Target:                      hasNonNullRawKey(rawKeys, "Target"),
-		Quantity:                    quantityPresent,
-		MaxTarget:                   hasNonNullRawKey(rawKeys, "MaxTarget"),
-		GreenMask:                   hasNonNullRawKey(rawKeys, "GreenMask"),
-		Direction:                   hasNonNullRawKey(rawKeys, "Direction"),
-		IncreaseButton:              hasNonNullRawKey(rawKeys, "IncreaseButton"),
-		DecreaseButton:              hasNonNullRawKey(rawKeys, "DecreaseButton"),
-		SwipeButton:                 hasNonNullRawKey(rawKeys, "SwipeButton"),
-		ExceedingOverrideEnable:     hasNonNullRawKey(rawKeys, "ExceedingOverrideEnable"),
-		TargetReachedOverrideEnable: hasNonNullRawKey(rawKeys, "TargetReachedOverrideEnable"),
-		TargetType:                  hasNonNullRawKey(rawKeys, "TargetType"),
-		TargetReverse:               hasNonNullRawKey(rawKeys, "TargetReverse"),
-		CenterPointOffset:           hasNonNullRawKey(rawKeys, "CenterPointOffset"),
-		ClampTargetToMax:            hasNonNullRawKey(rawKeys, "ClampTargetToMax"),
-		FinishAfterPreciseClick:     hasNonNullRawKey(rawKeys, "FinishAfterPreciseClick"),
+		TargetQuantity:                hasNonNullRawKey(rawKeys, "TargetQuantity"),
+		SliderQuantity:                sliderQuantityPresent,
+		AvailableQuantity:             hasNonNullRawKey(rawKeys, "AvailableQuantity"),
+		GreenMask:                     hasNonNullRawKey(rawKeys, "GreenMask"),
+		Direction:                     hasNonNullRawKey(rawKeys, "Direction"),
+		IncreaseButton:                hasNonNullRawKey(rawKeys, "IncreaseButton"),
+		DecreaseButton:                hasNonNullRawKey(rawKeys, "DecreaseButton"),
+		SwipeButton:                   hasNonNullRawKey(rawKeys, "SwipeButton"),
+		OutOfRangeOverrideEnable:      hasNonNullRawKey(rawKeys, "OutOfRangeOverrideEnable"),
+		TargetReachableOverrideEnable: hasNonNullRawKey(rawKeys, "TargetReachableOverrideEnable"),
+		TargetQuantityType:            hasNonNullRawKey(rawKeys, "TargetQuantityType"),
+		ReverseTarget:                 hasNonNullRawKey(rawKeys, "ReverseTarget"),
+		CenterPointOffset:             hasNonNullRawKey(rawKeys, "CenterPointOffset"),
+		ClampTargetToSliderMax:        hasNonNullRawKey(rawKeys, "ClampTargetToSliderMax"),
+		FinishAfterPreciseClick:       hasNonNullRawKey(rawKeys, "FinishAfterPreciseClick"),
 	}, nil
 }
 
 func hasNonNullRawKey(rawKeys map[string]json.RawMessage, key string) bool {
 	raw, ok := rawKeys[key]
 	return ok && len(raw) > 0 && string(raw) != "null"
+}
+
+func (a *BetterSlidingAction) validateOutcomeOverrideNodes(nodes ...string) bool {
+	seen := make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		if node == "" {
+			continue
+		}
+		if _, exists := seen[node]; exists {
+			a.logger.Error().
+				Str("node", node).
+				Msg("BetterSliding outcome overrides must use different nodes")
+			return false
+		}
+		seen[node] = struct{}{}
+	}
+	return true
 }
 
 func parseBetterSlidingParam(customActionParam string) (betterSlidingParam, error) {
@@ -101,21 +118,21 @@ func (a *BetterSlidingAction) loadActionParams(customActionParam string) bool {
 
 func (a *BetterSlidingAction) normalizeActionParams(params betterSlidingParam) (parsedBetterSlidingParams, bool) {
 	swipeButton := strings.TrimSpace(params.SwipeButton)
-	exceedingOverrideEnable := strings.TrimSpace(params.ExceedingOverrideEnable)
-	targetReachedOverrideEnable := strings.TrimSpace(params.TargetReachedOverrideEnable)
-	if exceedingOverrideEnable != "" && exceedingOverrideEnable == targetReachedOverrideEnable {
-		a.logger.Error().
-			Str("node", exceedingOverrideEnable).
-			Msg("exceeding and target-reached overrides must use different nodes")
+	outOfRangeOverrideEnable := strings.TrimSpace(params.OutOfRangeOverrideEnable)
+	targetReachableOverrideEnable := strings.TrimSpace(params.TargetReachableOverrideEnable)
+	if !a.validateOutcomeOverrideNodes(
+		outOfRangeOverrideEnable,
+		targetReachableOverrideEnable,
+	) {
 		return parsedBetterSlidingParams{}, false
 	}
 
-	targetType, err := normalizeTargetType(params.TargetType)
+	targetQuantityType, err := normalizeTargetQuantityType(params.TargetQuantityType)
 	if err != nil {
 		a.logger.Error().
 			Err(err).
-			Str("target_type", params.TargetType).
-			Msg("invalid TargetType")
+			Str("target_quantity_type", params.TargetQuantityType).
+			Msg("invalid TargetQuantityType")
 		return parsedBetterSlidingParams{}, false
 	}
 
@@ -131,33 +148,34 @@ func (a *BetterSlidingAction) normalizeActionParams(params betterSlidingParam) (
 		}
 
 		return parsedBetterSlidingParams{
-			target:                  0,
-			quantityBox:             nil,
-			maxTargetBox:            nil,
-			maxTargetExplicit:       false,
-			quantityFilter:          nil,
-			maxTargetFilter:         nil,
-			quantityOnlyRec:         false,
-			maxTargetOnlyRec:        false,
-			greenMask:               params.GreenMask,
-			direction:               direction,
-			increaseButton:          buttonTarget{},
-			decreaseButton:          buttonTarget{},
-			centerPointOffset:       defaultCenterPointOffset,
-			clampTargetToMax:        params.ClampTargetToMax,
-			swipeButton:             swipeButton,
-			exceedingOverrideEnable: exceedingOverrideEnable,
-			targetType:              targetType,
-			targetReverse:           params.TargetReverse,
-			swipeOnlyMode:           true,
-			finishAfterPreciseClick: false,
+			targetQuantity:                0,
+			sliderQuantityBox:             nil,
+			availableQuantityBox:          nil,
+			availableQuantityExplicit:     false,
+			sliderQuantityFilter:          nil,
+			availableQuantityFilter:       nil,
+			sliderQuantityOnlyRec:         false,
+			availableQuantityOnlyRec:      false,
+			greenMask:                     params.GreenMask,
+			direction:                     direction,
+			increaseButton:                buttonTarget{},
+			decreaseButton:                buttonTarget{},
+			centerPointOffset:             defaultCenterPointOffset,
+			clampTargetToSliderMax:        params.ClampTargetToSliderMax,
+			swipeButton:                   swipeButton,
+			outOfRangeOverrideEnable:      outOfRangeOverrideEnable,
+			targetReachableOverrideEnable: targetReachableOverrideEnable,
+			targetQuantityType:            targetQuantityType,
+			reverseTarget:                 params.ReverseTarget,
+			swipeOnlyMode:                 true,
+			finishAfterPreciseClick:       false,
 		}, true
 	}
 
-	if params.Target <= 0 {
+	if params.TargetQuantity <= 0 {
 		a.logger.Error().
-			Int("target", params.Target).
-			Msg("invalid target, must be greater than 0")
+			Int("target_quantity", params.TargetQuantity).
+			Msg("invalid target quantity, must be greater than 0")
 		return parsedBetterSlidingParams{}, false
 	}
 
@@ -185,122 +203,125 @@ func (a *BetterSlidingAction) normalizeActionParams(params betterSlidingParam) (
 		return parsedBetterSlidingParams{}, false
 	}
 
-	quantityFilter, err := normalizeQuantityFilter("Quantity.Filter", params.Quantity.Filter)
+	sliderQuantityFilter, err := normalizeQuantityFilter("SliderQuantity.Filter", params.SliderQuantity.Filter)
 	if err != nil {
 		a.logger.Error().
 			Err(err).
-			Msg("failed to normalize quantity filter")
+			Msg("failed to normalize slider quantity filter")
 		return parsedBetterSlidingParams{}, false
 	}
 
-	quantityBox, quantityOnlyRec := normalizeQuantityParam(params.Quantity)
+	sliderQuantityBox, sliderQuantityOnlyRec := normalizeQuantityParam(params.SliderQuantity)
 
-	var maxTargetFilter *quantityFilterParam
-	maxTargetBox := []int(nil)
-	maxTargetOnlyRec := false
-	if params.presence.MaxTarget {
-		maxTargetFilter, err = normalizeQuantityFilter("MaxTarget.Filter", params.MaxTarget.Filter)
+	var availableQuantityFilter *quantityFilterParam
+	availableQuantityBox := []int(nil)
+	availableQuantityOnlyRec := false
+	if params.presence.AvailableQuantity {
+		availableQuantityFilter, err = normalizeQuantityFilter(
+			"AvailableQuantity.Filter",
+			params.AvailableQuantity.Filter,
+		)
 		if err != nil {
 			a.logger.Error().
 				Err(err).
-				Msg("failed to normalize max target filter")
+				Msg("failed to normalize available quantity filter")
 			return parsedBetterSlidingParams{}, false
 		}
-		maxTargetBox, maxTargetOnlyRec = normalizeQuantityParam(params.MaxTarget)
+		availableQuantityBox, availableQuantityOnlyRec = normalizeQuantityParam(params.AvailableQuantity)
 	}
 
 	return parsedBetterSlidingParams{
-		target:                      params.Target,
-		quantityBox:                 quantityBox,
-		maxTargetBox:                maxTargetBox,
-		maxTargetExplicit:           params.presence.MaxTarget,
-		quantityFilter:              quantityFilter,
-		maxTargetFilter:             maxTargetFilter,
-		quantityOnlyRec:             quantityOnlyRec,
-		maxTargetOnlyRec:            maxTargetOnlyRec,
-		greenMask:                   params.GreenMask,
-		direction:                   strings.ToLower(strings.TrimSpace(params.Direction)),
-		increaseButton:              increaseButton,
-		decreaseButton:              decreaseButton,
-		centerPointOffset:           centerPointOffset,
-		clampTargetToMax:            params.ClampTargetToMax,
-		swipeButton:                 swipeButton,
-		exceedingOverrideEnable:     exceedingOverrideEnable,
-		targetReachedOverrideEnable: targetReachedOverrideEnable,
-		targetType:                  targetType,
-		targetReverse:               params.TargetReverse,
-		swipeOnlyMode:               false,
-		finishAfterPreciseClick:     params.FinishAfterPreciseClick,
+		targetQuantity:                params.TargetQuantity,
+		sliderQuantityBox:             sliderQuantityBox,
+		availableQuantityBox:          availableQuantityBox,
+		availableQuantityExplicit:     params.presence.AvailableQuantity,
+		sliderQuantityFilter:          sliderQuantityFilter,
+		availableQuantityFilter:       availableQuantityFilter,
+		sliderQuantityOnlyRec:         sliderQuantityOnlyRec,
+		availableQuantityOnlyRec:      availableQuantityOnlyRec,
+		greenMask:                     params.GreenMask,
+		direction:                     strings.ToLower(strings.TrimSpace(params.Direction)),
+		increaseButton:                increaseButton,
+		decreaseButton:                decreaseButton,
+		centerPointOffset:             centerPointOffset,
+		clampTargetToSliderMax:        params.ClampTargetToSliderMax,
+		swipeButton:                   swipeButton,
+		outOfRangeOverrideEnable:      outOfRangeOverrideEnable,
+		targetReachableOverrideEnable: targetReachableOverrideEnable,
+		targetQuantityType:            targetQuantityType,
+		reverseTarget:                 params.ReverseTarget,
+		swipeOnlyMode:                 false,
+		finishAfterPreciseClick:       params.FinishAfterPreciseClick,
 	}, true
 }
 
 func (a *BetterSlidingAction) applyActionParams(params parsedBetterSlidingParams) {
-	a.OriginalTarget = params.target
+	a.OriginalTargetQuantity = params.targetQuantity
 	if !a.runtimeTargetResolved {
-		a.Target = params.target
+		a.TargetQuantity = params.targetQuantity
 	}
-	a.QuantityBox = params.quantityBox
-	a.MaxTargetBox = params.maxTargetBox
-	a.MaxTargetExplicit = params.maxTargetExplicit
-	a.QuantityFilter = params.quantityFilter
-	a.MaxTargetFilter = params.maxTargetFilter
-	a.QuantityOnlyRec = params.quantityOnlyRec
-	a.MaxTargetOnlyRec = params.maxTargetOnlyRec
+	a.SliderQuantityBox = params.sliderQuantityBox
+	a.AvailableQuantityBox = params.availableQuantityBox
+	a.AvailableQuantityExplicit = params.availableQuantityExplicit
+	a.SliderQuantityFilter = params.sliderQuantityFilter
+	a.AvailableQuantityFilter = params.availableQuantityFilter
+	a.SliderQuantityOnlyRec = params.sliderQuantityOnlyRec
+	a.AvailableQuantityOnlyRec = params.availableQuantityOnlyRec
 	a.GreenMask = params.greenMask
 	a.Direction = params.direction
 	a.IncreaseButton = params.increaseButton
 	a.DecreaseButton = params.decreaseButton
 	a.CenterPointOffset = params.centerPointOffset
-	a.ClampTargetToMax = params.clampTargetToMax
+	a.ClampTargetToSliderMax = params.clampTargetToSliderMax
 	a.SwipeButton = params.swipeButton
-	a.ExceedingOverrideEnable = params.exceedingOverrideEnable
-	a.TargetReachedOverrideEnable = params.targetReachedOverrideEnable
-	a.TargetType = params.targetType
-	a.TargetReverse = params.targetReverse
+	a.OutOfRangeOverrideEnable = params.outOfRangeOverrideEnable
+	a.TargetReachableOverrideEnable = params.targetReachableOverrideEnable
+	a.TargetQuantityType = params.targetQuantityType
+	a.ReverseTarget = params.reverseTarget
 	a.SwipeOnlyMode = params.swipeOnlyMode
 	a.FinishAfterPreciseClick = params.finishAfterPreciseClick
 }
 
 func (a *BetterSlidingAction) logParsedActionParams() {
 	parseLog := a.logger.Info().
-		Int("target", a.OriginalTarget).
-		Ints("quantity_box", a.QuantityBox).
-		Ints("max_target_box", a.MaxTargetBox).
-		Bool("max_target_explicit", a.MaxTargetExplicit).
+		Int("target_quantity", a.OriginalTargetQuantity).
+		Ints("slider_quantity_box", a.SliderQuantityBox).
+		Ints("available_quantity_box", a.AvailableQuantityBox).
+		Bool("available_quantity_explicit", a.AvailableQuantityExplicit).
 		Str("direction", a.Direction).
 		Interface("increase_button", a.IncreaseButton.logValue()).
 		Interface("decrease_button", a.DecreaseButton.logValue()).
 		Bool("green_mask", a.GreenMask).
-		Bool("quantity_filter_enabled", a.QuantityFilter != nil).
-		Bool("max_target_filter_enabled", a.MaxTargetFilter != nil).
-		Bool("quantity_only_rec", a.QuantityOnlyRec).
-		Bool("max_target_only_rec", a.MaxTargetOnlyRec).
+		Bool("slider_quantity_filter_enabled", a.SliderQuantityFilter != nil).
+		Bool("available_quantity_filter_enabled", a.AvailableQuantityFilter != nil).
+		Bool("slider_quantity_only_rec", a.SliderQuantityOnlyRec).
+		Bool("available_quantity_only_rec", a.AvailableQuantityOnlyRec).
 		Ints("center_point_offset", []int{a.CenterPointOffset[0], a.CenterPointOffset[1]}).
-		Bool("clamp_target_to_max", a.ClampTargetToMax).
+		Bool("clamp_target_to_slider_max", a.ClampTargetToSliderMax).
 		Bool("finish_after_precise_click", a.FinishAfterPreciseClick).
 		Str("swipe_button", a.SwipeButton).
-		Str("exceeding_override_enable", a.ExceedingOverrideEnable).
-		Str("target_reached_override_enable", a.TargetReachedOverrideEnable).
-		Str("target_type", a.TargetType).
-		Bool("target_reverse", a.TargetReverse).
+		Str("out_of_range_override_enable", a.OutOfRangeOverrideEnable).
+		Str("target_reachable_override_enable", a.TargetReachableOverrideEnable).
+		Str("target_quantity_type", a.TargetQuantityType).
+		Bool("reverse_target", a.ReverseTarget).
 		Bool("swipe_only_mode", a.SwipeOnlyMode)
 
 	if a.runtimeTargetResolved {
-		parseLog = parseLog.Int("runtime_target", a.Target)
+		parseLog = parseLog.Int("runtime_target_quantity", a.TargetQuantity)
 	}
 
-	if a.QuantityFilter != nil {
+	if a.SliderQuantityFilter != nil {
 		parseLog = parseLog.
-			Int("quantity_filter_method", a.QuantityFilter.Method).
-			Ints("quantity_filter_lower", a.QuantityFilter.Lower).
-			Ints("quantity_filter_upper", a.QuantityFilter.Upper)
+			Int("slider_quantity_filter_method", a.SliderQuantityFilter.Method).
+			Ints("slider_quantity_filter_lower", a.SliderQuantityFilter.Lower).
+			Ints("slider_quantity_filter_upper", a.SliderQuantityFilter.Upper)
 	}
 
-	if a.MaxTargetFilter != nil {
+	if a.AvailableQuantityFilter != nil {
 		parseLog = parseLog.
-			Int("max_target_filter_method", a.MaxTargetFilter.Method).
-			Ints("max_target_filter_lower", a.MaxTargetFilter.Lower).
-			Ints("max_target_filter_upper", a.MaxTargetFilter.Upper)
+			Int("available_quantity_filter_method", a.AvailableQuantityFilter.Method).
+			Ints("available_quantity_filter_lower", a.AvailableQuantityFilter.Lower).
+			Ints("available_quantity_filter_upper", a.AvailableQuantityFilter.Upper)
 	}
 
 	parseLog.Msg("parsed custom action parameters")
@@ -314,7 +335,8 @@ func (a *BetterSlidingAction) initLogger(taskName string) {
 }
 
 // mergeAttachParams reads the attach block from the caller pipeline node and merges
-// Target, TargetType, TargetReverse, and FinishAfterPreciseClick into the customActionParam JSON.
+// TargetQuantity, TargetQuantityType, ReverseTarget, and FinishAfterPreciseClick into
+// the customActionParam JSON.
 // On any error, the original customActionParam string is returned unchanged.
 func mergeAttachParams(ctx *maa.Context, callerNodeName string, customActionParam string) string {
 	if ctx == nil || callerNodeName == "" {
@@ -368,43 +390,43 @@ func mergeAttachParams(ctx *maa.Context, callerNodeName string, customActionPara
 		return customActionParam
 	}
 
-	if targetRaw, has := attachKeys["Target"]; has {
+	if targetRaw, has := attachKeys["TargetQuantity"]; has {
 		var target int
 		if err := json.Unmarshal(targetRaw, &target); err == nil {
-			paramMap["Target"] = float64(target)
+			paramMap["TargetQuantity"] = float64(target)
 		} else {
 			logger.Warn().
 				Err(err).
 				Str("node", callerNodeName).
-				Str("field", "attach.Target").
+				Str("field", "attach.TargetQuantity").
 				Str("value", string(targetRaw)).
 				Msg("failed to parse attach field")
 		}
 	}
 
-	if ttRaw, has := attachKeys["TargetType"]; has {
+	if ttRaw, has := attachKeys["TargetQuantityType"]; has {
 		var tt string
 		if err := json.Unmarshal(ttRaw, &tt); err == nil {
-			paramMap["TargetType"] = tt
+			paramMap["TargetQuantityType"] = tt
 		} else {
 			logger.Warn().
 				Err(err).
 				Str("node", callerNodeName).
-				Str("field", "attach.TargetType").
+				Str("field", "attach.TargetQuantityType").
 				Str("value", string(ttRaw)).
 				Msg("failed to parse attach field")
 		}
 	}
 
-	if trRaw, has := attachKeys["TargetReverse"]; has {
+	if trRaw, has := attachKeys["ReverseTarget"]; has {
 		var tr bool
 		if err := json.Unmarshal(trRaw, &tr); err == nil {
-			paramMap["TargetReverse"] = tr
+			paramMap["ReverseTarget"] = tr
 		} else {
 			logger.Warn().
 				Err(err).
 				Str("node", callerNodeName).
-				Str("field", "attach.TargetReverse").
+				Str("field", "attach.ReverseTarget").
 				Str("value", string(trRaw)).
 				Msg("failed to parse attach field")
 		}

--- a/agent/go-service/bettersliding/params_test.go
+++ b/agent/go-service/bettersliding/params_test.go
@@ -1,0 +1,63 @@
+package bettersliding
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseBetterSlidingParamCanonicalQuantityFields(t *testing.T) {
+	raw := `{
+		"TargetQuantity": 88,
+		"SliderQuantity": {"Box": [1, 2, 3, 4]},
+		"AvailableQuantity": {"Box": [5, 6, 7, 8]},
+		"OutOfRangeOverrideEnable": "OutOfRange",
+		"TargetReachableOverrideEnable": "TargetReachable",
+		"TargetQuantityType": "Percentage",
+		"ReverseTarget": true,
+		"ClampTargetToSliderMax": true
+	}`
+
+	got, err := parseBetterSlidingParam(raw)
+	if err != nil {
+		t.Fatalf("parseBetterSlidingParam returned error: %v", err)
+	}
+
+	if got.TargetQuantity != 88 {
+		t.Fatalf("unexpected TargetQuantity: got %d, want 88", got.TargetQuantity)
+	}
+	if !reflect.DeepEqual(got.SliderQuantity.Box, []int{1, 2, 3, 4}) {
+		t.Fatalf("unexpected SliderQuantity.Box: %#v", got.SliderQuantity.Box)
+	}
+	if !reflect.DeepEqual(got.AvailableQuantity.Box, []int{5, 6, 7, 8}) {
+		t.Fatalf("unexpected AvailableQuantity.Box: %#v", got.AvailableQuantity.Box)
+	}
+	if got.OutOfRangeOverrideEnable != "OutOfRange" {
+		t.Fatalf("unexpected OutOfRangeOverrideEnable: %q", got.OutOfRangeOverrideEnable)
+	}
+	if got.TargetReachableOverrideEnable != "TargetReachable" {
+		t.Fatalf("unexpected TargetReachableOverrideEnable: %q", got.TargetReachableOverrideEnable)
+	}
+	if got.TargetQuantityType != TargetQuantityTypePercentage {
+		t.Fatalf("unexpected TargetQuantityType: %q", got.TargetQuantityType)
+	}
+	if !got.ReverseTarget {
+		t.Fatal("ReverseTarget was not parsed")
+	}
+	if !got.ClampTargetToSliderMax {
+		t.Fatal("ClampTargetToSliderMax was not parsed")
+	}
+
+	wantPresence := betterSlidingParamPresence{
+		TargetQuantity:                true,
+		SliderQuantity:                true,
+		AvailableQuantity:             true,
+		OutOfRangeOverrideEnable:      true,
+		TargetReachableOverrideEnable: true,
+		TargetQuantityType:            true,
+		ReverseTarget:                 true,
+		ClampTargetToSliderMax:        true,
+	}
+	if got.presence != wantPresence {
+		t.Fatalf("unexpected parameter presence: got %#v, want %#v", got.presence, wantPresence)
+	}
+}

--- a/agent/go-service/bettersliding/types.go
+++ b/agent/go-service/bettersliding/types.go
@@ -6,40 +6,40 @@ import (
 )
 
 type betterSlidingParam struct {
-	Target                      int                        `json:"Target"`
-	Quantity                    quantityParam              `json:"Quantity"`
-	MaxTarget                   quantityParam              `json:"MaxTarget"`
-	GreenMask                   bool                       `json:"GreenMask"`
-	Direction                   string                     `json:"Direction"`
-	IncreaseButton              any                        `json:"IncreaseButton"`
-	DecreaseButton              any                        `json:"DecreaseButton"`
-	SwipeButton                 string                     `json:"SwipeButton"`
-	ExceedingOverrideEnable     string                     `json:"ExceedingOverrideEnable"`
-	TargetReachedOverrideEnable string                     `json:"TargetReachedOverrideEnable"`
-	TargetType                  string                     `json:"TargetType"`
-	TargetReverse               bool                       `json:"TargetReverse"`
-	CenterPointOffset           any                        `json:"CenterPointOffset"`
-	ClampTargetToMax            bool                       `json:"ClampTargetToMax"`
-	FinishAfterPreciseClick     bool                       `json:"FinishAfterPreciseClick"`
-	presence                    betterSlidingParamPresence `json:"-"`
+	TargetQuantity                int                        `json:"TargetQuantity"`
+	SliderQuantity                quantityParam              `json:"SliderQuantity"`
+	AvailableQuantity             quantityParam              `json:"AvailableQuantity"`
+	GreenMask                     bool                       `json:"GreenMask"`
+	Direction                     string                     `json:"Direction"`
+	IncreaseButton                any                        `json:"IncreaseButton"`
+	DecreaseButton                any                        `json:"DecreaseButton"`
+	SwipeButton                   string                     `json:"SwipeButton"`
+	OutOfRangeOverrideEnable      string                     `json:"OutOfRangeOverrideEnable"`
+	TargetReachableOverrideEnable string                     `json:"TargetReachableOverrideEnable"`
+	TargetQuantityType            string                     `json:"TargetQuantityType"`
+	ReverseTarget                 bool                       `json:"ReverseTarget"`
+	CenterPointOffset             any                        `json:"CenterPointOffset"`
+	ClampTargetToSliderMax        bool                       `json:"ClampTargetToSliderMax"`
+	FinishAfterPreciseClick       bool                       `json:"FinishAfterPreciseClick"`
+	presence                      betterSlidingParamPresence `json:"-"`
 }
 
 type betterSlidingParamPresence struct {
-	Target                      bool
-	Quantity                    bool
-	MaxTarget                   bool
-	GreenMask                   bool
-	Direction                   bool
-	IncreaseButton              bool
-	DecreaseButton              bool
-	SwipeButton                 bool
-	ExceedingOverrideEnable     bool
-	TargetReachedOverrideEnable bool
-	TargetType                  bool
-	TargetReverse               bool
-	CenterPointOffset           bool
-	ClampTargetToMax            bool
-	FinishAfterPreciseClick     bool
+	TargetQuantity                bool
+	SliderQuantity                bool
+	AvailableQuantity             bool
+	GreenMask                     bool
+	Direction                     bool
+	IncreaseButton                bool
+	DecreaseButton                bool
+	SwipeButton                   bool
+	OutOfRangeOverrideEnable      bool
+	TargetReachableOverrideEnable bool
+	TargetQuantityType            bool
+	ReverseTarget                 bool
+	CenterPointOffset             bool
+	ClampTargetToSliderMax        bool
+	FinishAfterPreciseClick       bool
 }
 
 type quantityParam struct {
@@ -60,64 +60,63 @@ type quantityFilterParam struct {
 // the target quantity, and fine-tunes via increase/decrease buttons.
 //
 // Parameter fields:
-//   - Target: target quantity (overridden by attach.Target when present)
-//   - Quantity.Box: OCR ROI [x,y,w,h] for reading the current slider quantity.
-//   - MaxTarget.Box: OCR ROI [x,y,w,h] for reading the max available quantity of the item.
-//     When provided, BetterSlidingGetMaxTarget runs after SwipeToMax and its OCR result is used for
-//     resolveTarget (TargetReverse / TargetType calculation).
-//     When MaxTarget is not provided, BetterSlidingGetMaxTarget stays disabled and
-//     resolveTarget falls back to the BetterSlidingGetMaxQuantity runtime value (slider endpoint).
-//   - Quantity.Filter: optional color filter for quantity OCR
-//   - Quantity.OnlyRec: enable only_rec for the quantity OCR node
-//   - MaxTarget.Filter: optional color filter for max-target OCR when MaxTarget is provided
-//   - MaxTarget.OnlyRec: enable only_rec for the max-target OCR node when MaxTarget is provided
+//   - TargetQuantity: target quantity (overridden by attach.TargetQuantity when present)
+//   - SliderQuantity.Box: OCR ROI [x,y,w,h] for reading the current slider quantity.
+//   - AvailableQuantity.Box: OCR ROI [x,y,w,h] for reading the total available quantity.
+//     When provided, BetterSlidingGetAvailableQuantity runs after SwipeToMax and its OCR result is
+//     used for ReverseTarget / TargetQuantityType calculation.
+//     When AvailableQuantity is not provided, target resolution falls back to the
+//     BetterSlidingGetSliderMaxQuantity runtime value (slider endpoint).
+//   - SliderQuantity.Filter: optional color filter for slider quantity OCR
+//   - SliderQuantity.OnlyRec: enable only_rec for the slider quantity OCR node
+//   - AvailableQuantity.Filter: optional color filter for available quantity OCR
+//   - AvailableQuantity.OnlyRec: enable only_rec for available quantity OCR
 //   - GreenMask: map to green_mask in TemplateMatch for slider/button templates
 //   - Direction: swipe direction (left/right/up/down)
 //   - IncreaseButton: increase button template path or coordinates
 //   - DecreaseButton: decrease button template path or coordinates
 //   - CenterPointOffset: click offset from slider handle center, default [-10, 0]
-//   - ClampTargetToMax: clamp target to maxQuantity instead of failing (default false)
+//   - ClampTargetToSliderMax: clamp target to sliderMaxQuantity instead of failing (default false)
 //   - FinishAfterPreciseClick: skip fine-tuning and return success after precise click (default false)
 //   - SwipeButton: custom slider template path overriding BetterSlidingSwipeButton
-//   - ExceedingOverrideEnable: Pipeline node name to enable when target is out of range
-//   - TargetReachedOverrideEnable: Pipeline node name to enable when the resolved target can be
-//     reached without clamping to the maximum selectable quantity. The caller must still confirm
-//     that its outer operation succeeded before treating the target as completed.
-//   - TargetType: TargetTypeValue (default) or TargetTypePercentage
-//   - TargetReverse: reverse target calculation
+//   - OutOfRangeOverrideEnable: Pipeline node name to enable when target is out of range
+//   - TargetReachableOverrideEnable: Pipeline node name to enable when the resolved target can be
+//     reached without clamping. The caller must still confirm that its outer operation succeeded.
+//   - TargetQuantityType: TargetQuantityTypeValue (default) or TargetQuantityTypePercentage
+//   - ReverseTarget: reverse target calculation
 type BetterSlidingAction struct {
-	Target                      int
-	QuantityBox                 []int
-	MaxTargetBox                []int
-	MaxTargetExplicit           bool
-	QuantityFilter              *quantityFilterParam
-	MaxTargetFilter             *quantityFilterParam
-	QuantityOnlyRec             bool
-	MaxTargetOnlyRec            bool
-	GreenMask                   bool
-	Direction                   string
-	IncreaseButton              buttonTarget
-	DecreaseButton              buttonTarget
-	CenterPointOffset           [2]int
-	ClampTargetToMax            bool
-	FinishAfterPreciseClick     bool
-	SwipeButton                 string
-	ExceedingOverrideEnable     string
-	TargetReachedOverrideEnable string
-	TargetType                  string
-	TargetReverse               bool
-	SwipeOnlyMode               bool
-	OriginalTarget              int
+	TargetQuantity                int
+	SliderQuantityBox             []int
+	AvailableQuantityBox          []int
+	AvailableQuantityExplicit     bool
+	SliderQuantityFilter          *quantityFilterParam
+	AvailableQuantityFilter       *quantityFilterParam
+	SliderQuantityOnlyRec         bool
+	AvailableQuantityOnlyRec      bool
+	GreenMask                     bool
+	Direction                     string
+	IncreaseButton                buttonTarget
+	DecreaseButton                buttonTarget
+	CenterPointOffset             [2]int
+	ClampTargetToSliderMax        bool
+	FinishAfterPreciseClick       bool
+	SwipeButton                   string
+	OutOfRangeOverrideEnable      string
+	TargetReachableOverrideEnable string
+	TargetQuantityType            string
+	ReverseTarget                 bool
+	SwipeOnlyMode                 bool
+	OriginalTargetQuantity        int
 
-	startBox              []int
-	endBox                []int
-	maxQuantity           int
-	maxTarget             int
-	maxTargetResolved     bool
-	exceeded              bool
-	targetReachable       bool
-	runtimeTargetResolved bool
-	logger                zerolog.Logger
+	startBox                  []int
+	endBox                    []int
+	sliderMaxQuantity         int
+	availableQuantity         int
+	availableQuantityResolved bool
+	outOfRange                bool
+	targetReachable           bool
+	runtimeTargetResolved     bool
+	logger                    zerolog.Logger
 }
 
 type buttonTarget struct {
@@ -135,10 +134,10 @@ func (b buttonTarget) logValue() any {
 
 const maxClickRepeat = 30
 
-// TargetType constants for canonical target type values.
+// TargetQuantityType constants for canonical target quantity type values.
 const (
-	TargetTypeValue      = "Value"
-	TargetTypePercentage = "Percentage"
+	TargetQuantityTypeValue      = "Value"
+	TargetQuantityTypePercentage = "Percentage"
 )
 
 var defaultCenterPointOffset = [2]int{-10, 0}

--- a/agent/go-service/sellproduct/reserve_session.go
+++ b/agent/go-service/sellproduct/reserve_session.go
@@ -136,7 +136,7 @@ func (a *ReserveSessionAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) b
 			Str("item_id", itemID).
 			Int("quantity", quantity).
 			Bool("marked", marked).
-			Msg("reserve target satisfied for current task")
+			Msg("reserve quantity satisfied for current task")
 		if marked {
 			printRuntimeReserveSatisfied(ctx, itemID, quantity)
 		}
@@ -226,7 +226,7 @@ func markSelectedReserveSatisfied() (itemID string, quantity int, marked bool, o
 	return itemID, quantity, !exists, true
 }
 
-// reserveSatisfiedItemsSnapshot 返回本次任务已经达到保留目标的物品集合。
+// reserveSatisfiedItemsSnapshot 返回本次任务已经达到保留数量的物品集合。
 // 该状态与用户黑名单、运行期缺货分别维护，避免混淆排除原因。
 func reserveSatisfiedItemsSnapshot() map[string]struct{} {
 	reserveSessionMu.Lock()
@@ -292,12 +292,12 @@ func buildReserveSlidingOverride(slidingNode string, quantity int, configured bo
 		return map[string]any{
 			slidingNode: map[string]any{
 				"next": []string{
-					"SellProductSkipToNextSellLoop",
+					"SellProductReserveAlreadySatisfied",
 					"SellProductSellThenLoop",
 				},
 				"attach": map[string]any{
-					"Target":        quantity,
-					"TargetReverse": true,
+					"TargetQuantity": quantity,
+					"ReverseTarget":  true,
 				},
 			},
 		}
@@ -306,8 +306,8 @@ func buildReserveSlidingOverride(slidingNode string, quantity int, configured bo
 		slidingNode: map[string]any{
 			"next": []string{"SellProductSell"},
 			"attach": map[string]any{
-				"Target":        999999,
-				"TargetReverse": false,
+				"TargetQuantity": 999999,
+				"ReverseTarget":  false,
 			},
 		},
 	}

--- a/agent/go-service/sellproduct/reserve_session_test.go
+++ b/agent/go-service/sellproduct/reserve_session_test.go
@@ -98,10 +98,10 @@ func TestBuildReserveSlidingOverride(t *testing.T) {
 	withReserve := buildReserveSlidingOverride("Sliding", 88, true)
 	wantWithReserve := map[string]any{
 		"Sliding": map[string]any{
-			"next": []string{"SellProductSkipToNextSellLoop", "SellProductSellThenLoop"},
+			"next": []string{"SellProductReserveAlreadySatisfied", "SellProductSellThenLoop"},
 			"attach": map[string]any{
-				"Target":        88,
-				"TargetReverse": true,
+				"TargetQuantity": 88,
+				"ReverseTarget":  true,
 			},
 		},
 	}
@@ -114,8 +114,8 @@ func TestBuildReserveSlidingOverride(t *testing.T) {
 		"Sliding": map[string]any{
 			"next": []string{"SellProductSell"},
 			"attach": map[string]any{
-				"Target":        999999,
-				"TargetReverse": false,
+				"TargetQuantity": 999999,
+				"ReverseTarget":  false,
 			},
 		},
 	}

--- a/assets/resource/pipeline/AutoStockStaple/General/Item.json
+++ b/assets/resource/pipeline/AutoStockStaple/General/Item.json
@@ -243,12 +243,12 @@
             "param": {
                 "custom_action": "BetterSliding",
                 "custom_action_param": {
-                    "ClampTargetToMax": true,
+                    "ClampTargetToSliderMax": true,
                     "DecreaseButton": "AutoStockpile/DecreaseButton.png",
                     "Direction": "right",
                     "IncreaseButton": "AutoStockpile/IncreaseButton.png",
                     "GreenMask": true,
-                    "Quantity": {
+                    "SliderQuantity": {
                         "Box": [
                             375,
                             508,
@@ -257,7 +257,7 @@
                         ],
                         "OnlyRec": true
                     }
-                    //"Quantity": {
+                    //"SliderQuantity": {
                     //    "Box": [
                     //        375,
                     //        508,
@@ -291,7 +291,7 @@
             "Node.Action.Failed": "$task.AutoStockStaple.focus.quantity_control.better_sliding_failed"
         },
         "attach": {
-            "Target": 10 //这里会被custom程序覆盖后运行
+            "TargetQuantity": 10 //这里会被 custom 程序覆盖后运行
         }
     }
 }

--- a/assets/resource/pipeline/AutoStockpile/Purchase.json
+++ b/assets/resource/pipeline/AutoStockpile/Purchase.json
@@ -82,8 +82,8 @@
                     "Direction": "right",
                     "IncreaseButton": "AutoStockpile/IncreaseButton.png",
                     "GreenMask": true,
-                    "Target": 1,
-                    "Quantity": {
+                    "TargetQuantity": 1,
+                    "SliderQuantity": {
                         "Box": [
                             360,
                             480,
@@ -104,7 +104,7 @@
                             "method": 40
                         }
                     },
-                    "ClampTargetToMax": true
+                    "ClampTargetToSliderMax": true
                 }
             }
         },

--- a/assets/resource/pipeline/BetterSliding/Helper.json
+++ b/assets/resource/pipeline/BetterSliding/Helper.json
@@ -53,7 +53,7 @@
         "post_delay": 0,
         "rate_limit": 0
     },
-    "BetterSlidingGetQuantity": {
+    "BetterSlidingGetSliderQuantity": {
         "desc": "识别当前选择的数量",
         "recognition": {
             "type": "OCR",
@@ -75,8 +75,8 @@
         "post_delay": 0,
         "rate_limit": 0
     },
-    "BetterSlidingQuantityFilter": {
-        "desc": "辅助GetQuantity节点进行OCR",
+    "BetterSlidingSliderQuantityFilter": {
+        "desc": "辅助 GetSliderQuantity 节点进行 OCR",
         "recognition": {
             "type": "ColorMatch",
             "param": {
@@ -98,8 +98,8 @@
             }
         }
     },
-    "BetterSlidingMaxTargetFilter": {
-        "desc": "辅助GetMaxTarget节点进行OCR",
+    "BetterSlidingAvailableQuantityFilter": {
+        "desc": "辅助 GetAvailableQuantity 节点进行 OCR",
         "recognition": {
             "type": "ColorMatch",
             "param": {

--- a/assets/resource/pipeline/BetterSliding/Main.json
+++ b/assets/resource/pipeline/BetterSliding/Main.json
@@ -169,8 +169,8 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "BetterSlidingGetMaxTarget",
-            "BetterSlidingGetMaxQuantity"
+            "BetterSlidingGetAvailableQuantity",
+            "BetterSlidingGetSliderMaxQuantity"
         ]
     },
     "BetterSlidingCheckQuantity": {
@@ -180,7 +180,7 @@
             "type": "And",
             "param": {
                 "all_of": [
-                    "BetterSlidingGetQuantity"
+                    "BetterSlidingGetSliderQuantity"
                 ]
             }
         },
@@ -239,13 +239,13 @@
         "post_wait_freezes": 200,
         "post_delay": 0
     },
-    "BetterSlidingGetMaxQuantity": {
-        "desc": "识别最大可选数量，存入go，如果小于target，会在此处action返回false",
+    "BetterSlidingGetSliderMaxQuantity": {
+        "desc": "识别滑条最大可选数量并存入 Go",
         "recognition": {
             "type": "And",
             "param": {
                 "all_of": [
-                    "BetterSlidingGetQuantity"
+                    "BetterSlidingGetSliderQuantity"
                 ]
             }
         },
@@ -262,8 +262,8 @@
             "BetterSlidingFindEnd"
         ]
     },
-    "BetterSlidingGetMaxTarget": {
-        "desc": "在滑动到最大值后识别最大目标数量并存入go，仅在显式指定MaxTarget时启用",
+    "BetterSlidingGetAvailableQuantity": {
+        "desc": "在滑动到最大值后识别可用总量并存入 Go，仅在显式指定 AvailableQuantity 时启用",
         "enabled": false,
         "recognition": {
             "type": "OCR",
@@ -291,7 +291,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "BetterSlidingGetMaxQuantity"
+            "BetterSlidingGetSliderMaxQuantity"
         ]
     }
 }

--- a/assets/resource/pipeline/BetterSliding/Test.json
+++ b/assets/resource/pipeline/BetterSliding/Test.json
@@ -49,7 +49,7 @@
                         20,
                         10
                     ],
-                    "Quantity": {
+                    "SliderQuantity": {
                         "Box": [
                             1090,
                             535,
@@ -57,7 +57,7 @@
                             30
                         ]
                     },
-                    "Target": 325
+                    "TargetQuantity": 325
                 }
             }
         },
@@ -109,7 +109,7 @@
                         20,
                         10
                     ],
-                    "Quantity": {
+                    "SliderQuantity": {
                         "Box": [
                             1090,
                             535,
@@ -117,8 +117,8 @@
                             30
                         ]
                     },
-                    "Target": 325,
-                    "TargetReverse": true
+                    "TargetQuantity": 325,
+                    "ReverseTarget": true
                 }
             }
         },
@@ -151,7 +151,7 @@
                         20,
                         10
                     ],
-                    "Quantity": {
+                    "SliderQuantity": {
                         "Box": [
                             1090,
                             535,
@@ -159,8 +159,8 @@
                             30
                         ]
                     },
-                    "Target": 10,
-                    "TargetType": "Percentage"
+                    "TargetQuantity": 10,
+                    "TargetQuantityType": "Percentage"
                 }
             }
         },
@@ -193,7 +193,7 @@
                         20,
                         10
                     ],
-                    "Quantity": {
+                    "SliderQuantity": {
                         "Box": [
                             1090,
                             535,
@@ -201,9 +201,9 @@
                             30
                         ]
                     },
-                    "Target": 10,
-                    "TargetType": "Percentage",
-                    "TargetReverse": true
+                    "TargetQuantity": 10,
+                    "TargetQuantityType": "Percentage",
+                    "ReverseTarget": true
                 }
             }
         },
@@ -236,7 +236,7 @@
                         20,
                         10
                     ],
-                    "Quantity": {
+                    "SliderQuantity": {
                         "Box": [
                             1090,
                             535,
@@ -244,9 +244,9 @@
                             30
                         ]
                     },
-                    "Target": 10000,
-                    "ExceedingOverrideEnable": "__BS-T-4",
-                    "TargetReverse": true
+                    "TargetQuantity": 10000,
+                    "OutOfRangeOverrideEnable": "__BS-T-4",
+                    "ReverseTarget": true
                 }
             }
         },
@@ -287,7 +287,7 @@
                         20,
                         10
                     ],
-                    "Quantity": {
+                    "SliderQuantity": {
                         "Box": [
                             1090,
                             535,
@@ -295,7 +295,7 @@
                             30
                         ]
                     },
-                    "Target": 325
+                    "TargetQuantity": 325
                 }
             }
         },

--- a/assets/resource/pipeline/SellProduct/SellCore.json
+++ b/assets/resource/pipeline/SellProduct/SellCore.json
@@ -392,15 +392,15 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "SellProductReserveTargetReached",
+            "SellProductReserveQuantityReached",
             "[Anchor]SellProductBetterSliding"
         ],
         "focus": {
             "Node.Action.Succeeded": "$task.SellProduct.trade_completed"
         }
     },
-    "SellProductReserveTargetReached": {
-        "desc": "本次交易已达到保留目标，将当前物品标记为本次任务无需再次处理",
+    "SellProductReserveQuantityReached": {
+        "desc": "本次交易已达到保留数量，将当前物品标记为本次任务无需再次处理",
         "enabled": false,
         "recognition": "DirectHit",
         "pre_delay": 0,
@@ -415,7 +415,7 @@
             "SellProductSellLoop"
         ]
     },
-    "SellProductSkipToNextSellLoop": {
+    "SellProductReserveAlreadySatisfied": {
         "desc": "保留数量大于等于当前库存，继续选择下一个优先物品",
         "enabled": false,
         "recognition": "DirectHit",

--- a/assets/resource/pipeline/SellProduct/ValleyIV/InfraStation.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/InfraStation.json
@@ -1180,9 +1180,9 @@
         "custom_action": "BetterSliding",
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1073,
                     327,
@@ -1191,7 +1191,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1107,
                     535,
@@ -1203,8 +1203,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         },
         "post_wait_freezes": 80,
         "post_delay": 0,

--- a/assets/resource/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
@@ -1184,9 +1184,9 @@
         "custom_action": "BetterSliding",
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1073,
                     327,
@@ -1195,7 +1195,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1107,
                     535,
@@ -1207,8 +1207,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         },
         "post_wait_freezes": 80,
         "post_delay": 0,

--- a/assets/resource/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
@@ -1182,9 +1182,9 @@
         "custom_action": "BetterSliding",
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1073,
                     327,
@@ -1193,7 +1193,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1107,
                     535,
@@ -1205,8 +1205,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         },
         "post_wait_freezes": 80,
         "post_delay": 0,

--- a/assets/resource/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
@@ -1182,9 +1182,9 @@
         "custom_action": "BetterSliding",
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1073,
                     327,
@@ -1193,7 +1193,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1107,
                     535,
@@ -1205,8 +1205,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         },
         "post_wait_freezes": 80,
         "post_delay": 0,

--- a/assets/resource/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
@@ -1192,9 +1192,9 @@
         "custom_action": "BetterSliding",
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1073,
                     327,
@@ -1203,7 +1203,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1107,
                     535,
@@ -1215,8 +1215,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         },
         "post_wait_freezes": 80,
         "post_delay": 0,

--- a/assets/resource/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
@@ -1182,9 +1182,9 @@
         "custom_action": "BetterSliding",
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1073,
                     327,
@@ -1193,7 +1193,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1107,
                     535,
@@ -1205,8 +1205,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         },
         "post_wait_freezes": 80,
         "post_delay": 0,

--- a/assets/resource_adb/pipeline/AutoStockStaple/General/Item.json
+++ b/assets/resource_adb/pipeline/AutoStockStaple/General/Item.json
@@ -29,12 +29,12 @@
             "param": {
                 "custom_action": "BetterSliding",
                 "custom_action_param": {
-                    "ClampTargetToMax": true,
+                    "ClampTargetToSliderMax": true,
                     "DecreaseButton": "AutoStockpile/DecreaseButton.png",
                     "Direction": "right",
                     "IncreaseButton": "AutoStockpile/IncreaseButton.png",
                     "GreenMask": true,
-                    "Quantity": {
+                    "SliderQuantity": {
                         "Box": [
                             304,
                             540,

--- a/assets/resource_adb/pipeline/AutoStockpile/Purchase.json
+++ b/assets/resource_adb/pipeline/AutoStockpile/Purchase.json
@@ -17,12 +17,12 @@
             "param": {
                 "custom_action": "BetterSliding",
                 "custom_action_param": {
-                    "ClampTargetToMax": true,
+                    "ClampTargetToSliderMax": true,
                     "DecreaseButton": "AutoStockpile/DecreaseButton.png",
                     "Direction": "right",
                     "GreenMask": true,
                     "IncreaseButton": "AutoStockpile/IncreaseButton.png",
-                    "Quantity": {
+                    "SliderQuantity": {
                         "Box": [
                             303,
                             516,
@@ -43,7 +43,7 @@
                             "method": 40
                         }
                     },
-                    "Target": 1
+                    "TargetQuantity": 1
                 }
             }
         }

--- a/assets/resource_adb/pipeline/SellProduct/ValleyIV/InfraStation.json
+++ b/assets/resource_adb/pipeline/SellProduct/ValleyIV/InfraStation.json
@@ -2,9 +2,9 @@
     "SellProductInfraStationBetterSliding": {
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1041,
                     239,
@@ -13,7 +13,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1065,
                     499,
@@ -25,8 +25,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         }
     }
 }

--- a/assets/resource_adb/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
+++ b/assets/resource_adb/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
@@ -2,9 +2,9 @@
     "SellProductReconstructionHQBetterSliding": {
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1041,
                     239,
@@ -13,7 +13,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1065,
                     499,
@@ -25,8 +25,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         }
     }
 }

--- a/assets/resource_adb/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
+++ b/assets/resource_adb/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
@@ -2,9 +2,9 @@
     "SellProductRefugeeCampBetterSliding": {
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1041,
                     239,
@@ -13,7 +13,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1065,
                     499,
@@ -25,8 +25,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         }
     }
 }

--- a/assets/resource_adb/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
+++ b/assets/resource_adb/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
@@ -2,9 +2,9 @@
     "SellProductCardiacRemediationStationBetterSliding": {
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1041,
                     239,
@@ -13,7 +13,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1065,
                     499,
@@ -25,8 +25,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         }
     }
 }

--- a/assets/resource_adb/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
+++ b/assets/resource_adb/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
@@ -2,9 +2,9 @@
     "SellProductSkyKingFlatsConstructionSiteBetterSliding": {
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1041,
                     239,
@@ -13,7 +13,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1065,
                     499,
@@ -25,8 +25,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         }
     }
 }

--- a/assets/resource_adb/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
+++ b/assets/resource_adb/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
@@ -2,9 +2,9 @@
     "SellProductXiranflowCloudseederStationBetterSliding": {
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
                 "Box": [
                     1041,
                     239,
@@ -13,7 +13,7 @@
                 ],
                 "OnlyRec": true
             },
-            "Quantity": {
+            "SliderQuantity": {
                 "Box": [
                     1065,
                     499,
@@ -25,8 +25,8 @@
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         }
     }
 }

--- a/docs/en_us/developers/components/better-sliding.md
+++ b/docs/en_us/developers/components/better-sliding.md
@@ -94,11 +94,13 @@ In addition to the 4 fields above, all other parameters can only be read from `c
 
 `OutOfRangeOverrideEnable` and `TargetReachableOverrideEnable` report the current BetterSliding outcome to the caller. They must reference different nodes, and each outcome node should default to `enabled: false`.
 
-| Resolved target                                                             | `OutOfRangeOverrideEnable` | `TargetReachableOverrideEnable` | BetterSliding behavior                                               |
-| --------------------------------------------------------------------------- | -------------------------- | ------------------------------- | -------------------------------------------------------------------- |
-| Below 1, above `sliderMaxQuantity` without clamping, or slider maximum is 0 | `true`                     | `false`                         | Returns success without adjustment; the caller handles the outcome   |
-| Within `[1, sliderMaxQuantity]`                                             | `false`                    | `true`                          | Adjusts to the target quantity                                       |
-| Above `sliderMaxQuantity` with clamping enabled                             | `false`                    | `false`                         | Adjusts to `sliderMaxQuantity`; original target is not yet reachable |
+| Resolved target                                                                  | `OutOfRangeOverrideEnable` | `TargetReachableOverrideEnable` | BetterSliding behavior                                               |
+| -------------------------------------------------------------------------------- | -------------------------- | ------------------------------- | -------------------------------------------------------------------- |
+| Below 1, zero `sliderMaxQuantity`, or above `sliderMaxQuantity` without clamping | `true`                     | `false`                         | Returns success without adjustment; the caller handles the outcome   |
+| Within `[1, sliderMaxQuantity]`                                                  | `false`                    | `true`                          | Adjusts to the target quantity                                       |
+| Above `sliderMaxQuantity` with clamping enabled                                  | `false`                    | `false`                         | Adjusts to `sliderMaxQuantity`; original target is not yet reachable |
+
+`sliderMaxQuantity == 0` only means that no positive target is currently selectable. BetterSliding does not infer business causes such as insufficient balance, insufficient stock, or a disabled control. Callers that need to distinguish those states should recognize the corresponding UI in Pipeline.
 
 > [!important]
 > `TargetReachableOverrideEnable` only means that the caller's next operation can reach the target; it does not mean that operation has succeeded. Selling, purchasing, and similar flows must still confirm the outer transaction in Pipeline before recording the business target as completed.

--- a/docs/en_us/developers/components/better-sliding.md
+++ b/docs/en_us/developers/components/better-sliding.md
@@ -51,57 +51,57 @@ Suitable for scenarios where you want to slide to the maximum/minimum. Parameter
 
 The following 4 fields are recommended to be passed via the calling node's `attach`. The `attach` priority is higher than the same-named fields in `custom_action_param`.
 
-| Field                     | Type                     | Required | Description                                                                                                                                                                                                                       |
-| ------------------------- | ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Target`                  | `int` (positive integer) | Yes      | Target quantity. The desired final gear value to slide to, must be greater than 0.                                                                                                                                                |
-| `TargetType`              | `string`                 | No       | How to interpret `Target`. `"Value"` (default): absolute discrete count; `"Percentage"`: percentage of `maxQuantity` (1–100), rounded and clamped to `[1, maxQuantity]`.                                                          |
-| `TargetReverse`           | `bool`                   | No       | When `true`, calculates the target from the far end of the range: Value mode becomes `maxQuantity - Target`; Percentage mode becomes `round(maxQuantity * (100 - Target) / 100)`, clamped to `[1, maxQuantity]`. Default `false`. |
-| `FinishAfterPreciseClick` | `bool`                   | No       | When `true`, returns success immediately after a precise click, without entering the quantity validation and fine-tuning process. Default `false`.                                                                                |
+| Field                     | Type                     | Required | Description                                                                                                                                                                         |
+| ------------------------- | ------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TargetQuantity`          | `int` (positive integer) | Yes      | Target quantity. The desired final slider value, which must be greater than 0.                                                                                                      |
+| `TargetQuantityType`      | `string`                 | No       | How to interpret `TargetQuantity`. `"Value"` (default): absolute count; `"Percentage"`: percentage of `availableQuantity` (1–100), rounded and clamped.                             |
+| `ReverseTarget`           | `bool`                   | No       | When `true`, resolves the target from the available quantity: Value mode uses `availableQuantity - TargetQuantity`; Percentage mode uses the remaining percentage. Default `false`. |
+| `FinishAfterPreciseClick` | `bool`                   | No       | When `true`, returns success immediately after a precise click, without entering the quantity validation and fine-tuning process. Default `false`.                                  |
 
 > [!note]
-> Combination calculation logic for `TargetType` and `TargetReverse`:
+> Combination calculation logic for `TargetQuantityType` and `ReverseTarget`:
 >
-> | TargetType     | TargetReverse | Effective Target                                                           |
-> | -------------- | ------------- | -------------------------------------------------------------------------- |
-> | `"Value"`      | `false`       | `Target` (original value)                                                  |
-> | `"Value"`      | `true`        | `maxQuantity - Target` (not clamped, may be < 1)                           |
-> | `"Percentage"` | `false`       | `round(maxQuantity × Target / 100)`, clamped to `[1, maxQuantity]`         |
-> | `"Percentage"` | `true`        | `round(maxQuantity × (100 - Target) / 100)`, clamped to `[1, maxQuantity]` |
+> | TargetQuantityType | ReverseTarget | Effective target                                                                               |
+> | ------------------ | ------------- | ---------------------------------------------------------------------------------------------- |
+> | `"Value"`          | `false`       | `TargetQuantity`                                                                               |
+> | `"Value"`          | `true`        | `availableQuantity - TargetQuantity` (not clamped, may be < 1)                                 |
+> | `"Percentage"`     | `false`       | `round(availableQuantity × TargetQuantity / 100)`, clamped to `[1, availableQuantity]`         |
+> | `"Percentage"`     | `true`        | `round(availableQuantity × (100 - TargetQuantity) / 100)`, clamped to `[1, availableQuantity]` |
 
 #### Parameters that can only be passed via `custom_action_param`
 
 In addition to the 4 fields above, all other parameters can only be read from `custom_action_param`:
 
-| Field                         | Type                    | Required | Description                                                                                                                                                                                 |
-| ----------------------------- | ----------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Direction`                   | `string`                | Yes      | Swipe direction. Specifies "the direction of the maximum value", supports `left` / `right` / `up` / `down`.                                                                                 |
-| `Quantity.Box`                | `int[4]`                | Yes      | OCR region for the current quantity, format `[x, y, w, h]`.                                                                                                                                 |
-| `IncreaseButton`              | `string` or `int[2\|4]` | Yes      | "Increase quantity" button. Template path is recommended (threshold fixed at `0.8`), or coordinates `[x, y]` or `[x, y, w, h]`.                                                             |
-| `DecreaseButton`              | `string` or `int[2\|4]` | Yes      | "Decrease quantity" button. Format same as `IncreaseButton`.                                                                                                                                |
-| `MaxTarget.Box`               | `int[4]`                | No       | OCR region for reading the item's maximum available quantity (e.g., purchasable/sellable quantity), format `[x, y, w, h]`. When missing, the slider's endpoint value is used as a fallback. |
-| `Quantity.Filter`             | `object`                | No       | Color filter parameters for the current quantity OCR, suitable for scenarios where the digit color is stable but background interference is high.                                           |
-| `MaxTarget.Filter`            | `object`                | No       | Color filter parameters for the maximum target quantity OCR. Used only when `MaxTarget` is explicitly provided.                                                                             |
-| `Quantity.OnlyRec`            | `bool`                  | No       | Whether to enable `only_rec` for the quantity OCR node. Default `false`.                                                                                                                    |
-| `MaxTarget.OnlyRec`           | `bool`                  | No       | Whether to enable `only_rec` for the `BetterSlidingGetMaxTarget` OCR node. Used only when `MaxTarget` is explicitly provided.                                                               |
-| `GreenMask`                   | `bool`                  | No       | When locating buttons using a template path, whether to enable green mask filtering for template matching. Default `false`. Applies to `IncreaseButton` and `DecreaseButton`.               |
-| `CenterPointOffset`           | `int[2]`                | No       | Click offset relative to the center point of the slider's recognition box `[x, y]`, negative values left/up, positive right/down. Default `[-10, 0]`.                                       |
-| `ClampTargetToMax`            | `bool`                  | No       | When `true`, if the target exceeds `maxQuantity`, it is automatically clamped to `maxQuantity` and execution continues, instead of failing directly. Default `false`.                       |
-| `SwipeButton`                 | `string`                | No       | Custom slider template path, overrides the default template of the `BetterSlidingSwipeButton` node. Default `""` (uses the shared default template).                                        |
-| `ExceedingOverrideEnable`     | `string`                | No       | When the resolved target exceeds the slidable range, sets the specified Pipeline node's `enabled` to `true`, then returns success. Default `""` (disabled, the action fails directly).      |
-| `TargetReachedOverrideEnable` | `string`                | No       | When the resolved target needs no clamping and falls within `[1, maxQuantity]`, sets the specified Pipeline node's `enabled` to `true`. Default `""` (does not report this result).         |
+| Field                           | Type                    | Required | Description                                                                                                                                                                   |
+| ------------------------------- | ----------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Direction`                     | `string`                | Yes      | Swipe direction. Specifies "the direction of the maximum value", supports `left` / `right` / `up` / `down`.                                                                   |
+| `SliderQuantity.Box`            | `int[4]`                | Yes      | OCR region for the current slider quantity, format `[x, y, w, h]`.                                                                                                            |
+| `IncreaseButton`                | `string` or `int[2\|4]` | Yes      | "Increase quantity" button. Template path is recommended (threshold fixed at `0.8`), or coordinates `[x, y]` or `[x, y, w, h]`.                                               |
+| `DecreaseButton`                | `string` or `int[2\|4]` | Yes      | "Decrease quantity" button. Format same as `IncreaseButton`.                                                                                                                  |
+| `AvailableQuantity.Box`         | `int[4]`                | No       | OCR region for reading the total available quantity. When missing, the slider endpoint value is used as the calculation reference.                                            |
+| `SliderQuantity.Filter`         | `object`                | No       | Color filter parameters for the current slider quantity OCR.                                                                                                                  |
+| `AvailableQuantity.Filter`      | `object`                | No       | Color filter parameters for available-quantity OCR. Used only when `AvailableQuantity` is explicitly provided.                                                                |
+| `SliderQuantity.OnlyRec`        | `bool`                  | No       | Whether to enable `only_rec` for slider-quantity OCR. Default `false`.                                                                                                        |
+| `AvailableQuantity.OnlyRec`     | `bool`                  | No       | Whether to enable `only_rec` for `BetterSlidingGetAvailableQuantity`.                                                                                                         |
+| `GreenMask`                     | `bool`                  | No       | When locating buttons using a template path, whether to enable green mask filtering for template matching. Default `false`. Applies to `IncreaseButton` and `DecreaseButton`. |
+| `CenterPointOffset`             | `int[2]`                | No       | Click offset relative to the center point of the slider's recognition box `[x, y]`, negative values left/up, positive right/down. Default `[-10, 0]`.                         |
+| `ClampTargetToSliderMax`        | `bool`                  | No       | When `true`, a target above `sliderMaxQuantity` is clamped to the maximum selectable slider quantity. Default `false`.                                                        |
+| `SwipeButton`                   | `string`                | No       | Custom slider template path, overrides the default template of the `BetterSlidingSwipeButton` node. Default `""` (uses the shared default template).                          |
+| `OutOfRangeOverrideEnable`      | `string`                | No       | When the resolved target is outside the slidable range, enables the specified Pipeline node and returns success. Default `""`.                                                |
+| `TargetReachableOverrideEnable` | `string`                | No       | When the resolved target needs no clamping and falls within `[1, sliderMaxQuantity]`, enables the specified Pipeline node. Default `""`.                                      |
 
 ### Outcome Node Contract
 
-`ExceedingOverrideEnable` and `TargetReachedOverrideEnable` report the current BetterSliding outcome to the caller. They must reference different nodes, and each outcome node should default to `enabled: false`. When both parameters are configured, their state after each run is:
+`OutOfRangeOverrideEnable` and `TargetReachableOverrideEnable` report the current BetterSliding outcome to the caller. They must reference different nodes, and each outcome node should default to `enabled: false`.
 
-| Resolved target                                                         | `ExceedingOverrideEnable` | `TargetReachedOverrideEnable` | BetterSliding behavior                                         |
-| ----------------------------------------------------------------------- | ------------------------- | ----------------------------- | -------------------------------------------------------------- |
-| Below 1, above `maxQuantity` without clamping, or maximum quantity is 0 | `true`                    | `false`                       | Returns success without adjusting; caller handles overflow     |
-| Within `[1, maxQuantity]`                                               | `false`                   | `true`                        | Adjusts to the target quantity                                 |
-| Above `maxQuantity` with clamping enabled                               | `false`                   | `false`                       | Adjusts to `maxQuantity`; original target is not yet reachable |
+| Resolved target                                                             | `OutOfRangeOverrideEnable` | `TargetReachableOverrideEnable` | BetterSliding behavior                                               |
+| --------------------------------------------------------------------------- | -------------------------- | ------------------------------- | -------------------------------------------------------------------- |
+| Below 1, above `sliderMaxQuantity` without clamping, or slider maximum is 0 | `true`                     | `false`                         | Returns success without adjustment; the caller handles the outcome   |
+| Within `[1, sliderMaxQuantity]`                                             | `false`                    | `true`                          | Adjusts to the target quantity                                       |
+| Above `sliderMaxQuantity` with clamping enabled                             | `false`                    | `false`                         | Adjusts to `sliderMaxQuantity`; original target is not yet reachable |
 
 > [!important]
-> `TargetReachedOverrideEnable` only means that the caller's next operation can reach the target; it does not mean that operation has succeeded. Selling, purchasing, and similar flows must still confirm the outer transaction in Pipeline before recording the business target as completed.
+> `TargetReachableOverrideEnable` only means that the caller's next operation can reach the target; it does not mean that operation has succeeded. Selling, purchasing, and similar flows must still confirm the outer transaction in Pipeline before recording the business target as completed.
 
 ### Example
 
@@ -115,16 +115,16 @@ In addition to the 4 fields above, all other parameters can only be read from `c
                 "Direction": "right",
                 "IncreaseButton": "AutoStockpile/IncreaseButton.png",
                 "DecreaseButton": "AutoStockpile/DecreaseButton.png",
-                "Quantity": {
+                "SliderQuantity": {
                     "Box": [340, 430, 200, 140]
                 }
             }
         }
     },
     "attach": {
-        "Target": 50,
-        "TargetType": "Percentage",
-        "TargetReverse": false
+        "TargetQuantity": 50,
+        "TargetQuantityType": "Percentage",
+        "ReverseTarget": false
     }
 }
 ```

--- a/docs/en_us/developers/tasks/auto-stockstaple-maintain.md
+++ b/docs/en_us/developers/tasks/auto-stockstaple-maintain.md
@@ -98,7 +98,7 @@ When the bottom red "Insufficient Dispatch Tickets" prompt is identified in the 
 Read the OCR of the current held quantity in the top-right corner of the popup, and compare it using an expression with the user-configured limit (matched when `limit > current held quantity`):
 
 1.  The Go action calculates `quantity_to_buy = limit - current_held_quantity`.
-2.  Write the result into BetterSliding's `Target` to smoothly adjust the purchase quantity slider.
+2.  Write the result into BetterSliding's `TargetQuantity` to smoothly adjust the purchase quantity slider.
 3.  Click confirm purchase, close the reward popup, and return to the list to continue scanning.
 
 #### Branch 3: Held Quantity Reaches or Exceeds Limit, Exclude
@@ -250,7 +250,7 @@ Action logic:
 2.  Run quantity OCR on the current screenshot to get the **current held quantity**.
 3.  Calculate `target = target_limit - current_held_quantity`.
 4.  If `target <= 0`, skip sliding (disable `AutoStockStapleBetterSliding`).
-5.  Otherwise, enable `AutoStockStapleBetterSliding` via `OverridePipeline` and write `target` into its `attach.Target`.
+5.  Otherwise, enable `AutoStockStapleBetterSliding` via `OverridePipeline` and write `target` into its `attach.TargetQuantity`.
 
 Go **no longer** executes `RunTask` to perform sliding; quantity adjustment is completed by the low-code branch:
 
@@ -282,11 +282,11 @@ The Exclude branch **does not** purchase; it only removes "reached target" items
 
 This task has two types of runtime overrides; do not confuse them during maintenance:
 
-| Action                                 | Trigger Location                                  | Purpose                                                                |
-| -------------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------- |
-| `AttachToExpectedRegexAction`          | `AutoStockStapleMain` entry; Exclude → Reset node | Merge attach keywords → OCR whitelist regex                            |
-| `PipelineOverrideAction`               | Each item's `{Item}RemoveFilter`                  | Set specified attach key to `false`, excluding the item                |
-| `AutoStockStapleQuantityControlAction` | Each item's `{Item}Buy`                           | Calculate difference and override BetterSliding's `Target` / `enabled` |
+| Action                                 | Trigger Location                                  | Purpose                                                                        |
+| -------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `AttachToExpectedRegexAction`          | `AutoStockStapleMain` entry; Exclude → Reset node | Merge attach keywords → OCR whitelist regex                                    |
+| `PipelineOverrideAction`               | Each item's `{Item}RemoveFilter`                  | Set specified attach key to `false`, excluding the item                        |
+| `AutoStockStapleQuantityControlAction` | Each item's `{Item}Buy`                           | Calculate difference and override BetterSliding's `TargetQuantity` / `enabled` |
 
 `attach` semantics (see `attachregex/action.go`):
 

--- a/docs/en_us/developers/tasks/auto-stockstaple-maintain.md
+++ b/docs/en_us/developers/tasks/auto-stockstaple-maintain.md
@@ -262,7 +262,7 @@ Go **no longer** executes `RunTask` to perform sliding; quantity adjustment is c
   -> AutoStockStapleQuantityControlConfirmBuy
 ```
 
-`AutoStockStapleBetterSliding` is defined in `General/Item.json`, with `enabled: false` by default; it is only enabled after Go override; the default value of `attach.Target` is just a placeholder.
+`AutoStockStapleBetterSliding` is defined in `General/Item.json`, with `enabled: false` by default; it is only enabled after Go override; the default value of `attach.TargetQuantity` is just a placeholder.
 
 After the purchase quantity adjustment is complete, `next` enters `AutoStockStapleQuantityControlConfirmBuy` to click the yellow confirm button, then closes the reward popup and returns to the list.
 

--- a/docs/en_us/developers/tasks/sell-product-maintain.md
+++ b/docs/en_us/developers/tasks/sell-product-maintain.md
@@ -191,8 +191,8 @@ SellProductSellLoop                                  (unbounded selling loop)
                                  ├─ SellProductSellThenLoop → SellProductSellCheckThenLoop
                                  │      (sell with a reserve; below the target, return to BetterSliding
                                  │        and keep selling the current item; on reaching it, mark the
-                                 │        item satisfied via SellProductReserveTargetReached)
-                                 └─ SellProductSkipToNextSellLoop
+                                 │        item satisfied via SellProductReserveQuantityReached)
+                                 └─ SellProductReserveAlreadySatisfied
                                       (stock not above the reserve; mark satisfied and skip)
                                      └─ SellProductSellLoop
                                           (continue until an exit condition is met)
@@ -210,14 +210,14 @@ The loop ends only when:
 - Every known visible item is unavailable as a candidate (attempted, out of stock, reserve-satisfied, or never-sell), and the same set is recognized twice consecutively;
 - `SellProductAidQuotaExceededStop` stops the task because the exchange limit was exceeded.
 
-An empty OCR result does not mean “no remaining goods.” Out-of-stock items remain in the stable recognized set but are no longer candidates. Zero stock, a completed trade, reaching the reserve target, or a reserve-based skip continues to the next round.
+An empty OCR result does not mean “no remaining goods.” Out-of-stock items remain in the stable recognized set but are no longer candidates. Zero stock, a completed trade, reaching the reserve quantity, or a reserve-based skip continues to the next round.
 
 Independent reserve rules provide six slots. Each stable `itemId` can use either **Keep Specified Quantity** or **Never Sell**:
 
 - Without a matching rule, BetterSliding uses the default sell-all behavior.
-- **Keep Specified Quantity** uses `TargetReverse` to sell only stock above the reserve.
-- When a single trade reaches the reserve target, the trade confirmation marks the item as satisfied for this task via `SellProductReserveTargetReached`; below the target, the flow returns to the quantity slider and keeps selling the current item.
-- If stock is not above the reserve, `SellProductSkipToNextSellLoop` skips the trade and likewise marks the item as satisfied for this task.
+- **Keep Specified Quantity** uses `ReverseTarget` to sell only stock above the reserve.
+- When a single trade reaches the reserve quantity, the trade confirmation marks the item as satisfied for this task via `SellProductReserveQuantityReached`; below the reserve quantity, the flow returns to the quantity slider and keeps selling the current item.
+- If stock is not above the reserve, `SellProductReserveAlreadySatisfied` skips the trade and likewise marks the item as satisfied for this task.
 - Satisfied items are skipped during goods selection at later outposts, with a runtime notice on the first mark.
 - **Never Sell** excludes the item during selection, before switching goods, and does not report it as out of stock. Internally it uses quantity `-1`; users do not enter this sentinel value.
 - Later slots override earlier slots for the same item. Quantity `0` means no reserve.

--- a/docs/zh_cn/developers/components/better-sliding.md
+++ b/docs/zh_cn/developers/components/better-sliding.md
@@ -51,57 +51,57 @@
 
 以下 4 个字段推荐通过调用节点的 `attach` 传入，`attach` 优先级高于 `custom_action_param` 中的同名字段。
 
-| 字段                      | 类型            | 必填 | 说明                                                                                                                                                                          |
-| ------------------------- | --------------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Target`                  | `int`（正整数） | 是   | 目标数量。最终希望滑到的档位值，必须大于 0。                                                                                                                                  |
-| `TargetType`              | `string`        | 否   | 如何解释 `Target`。`"Value"`（默认）：绝对离散计数；`"Percentage"`：`maxQuantity` 的百分比（1–100），四舍五入后钳制到 `[1, maxQuantity]`。                                    |
-| `TargetReverse`           | `bool`          | 否   | 为 `true` 时从范围远端计算目标：Value 模式为 `maxQuantity - Target`；Percentage 模式为 `round(maxQuantity * (100 - Target) / 100)`，钳制到 `[1, maxQuantity]`。默认 `false`。 |
-| `FinishAfterPreciseClick` | `bool`          | 否   | 为 `true` 时精确点击后直接返回成功，不再进入数量校验与微调流程。默认 `false`。                                                                                                |
+| 字段                      | 类型            | 必填 | 说明                                                                                                                                                           |
+| ------------------------- | --------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TargetQuantity`          | `int`（正整数） | 是   | 目标数量。最终希望滑到的档位值，必须大于 0。                                                                                                                   |
+| `TargetQuantityType`      | `string`        | 否   | 如何解释 `TargetQuantity`。`"Value"`（默认）：绝对离散计数；`"Percentage"`：`availableQuantity` 的百分比（1–100），四舍五入后钳制到 `[1, availableQuantity]`。 |
+| `ReverseTarget`           | `bool`          | 否   | 为 `true` 时从可用总量反向计算目标：Value 模式为 `availableQuantity - TargetQuantity`；Percentage 模式按剩余百分比计算。默认 `false`。                         |
+| `FinishAfterPreciseClick` | `bool`          | 否   | 为 `true` 时精确点击后直接返回成功，不再进入数量校验与微调流程。默认 `false`。                                                                                 |
 
 > [!note]
-> `TargetType` 与 `TargetReverse` 的组合计算逻辑：
+> `TargetQuantityType` 与 `ReverseTarget` 的组合计算逻辑：
 >
-> | TargetType     | TargetReverse | 有效目标                                                               |
-> | -------------- | ------------- | ---------------------------------------------------------------------- |
-> | `"Value"`      | `false`       | `Target`（原值）                                                       |
-> | `"Value"`      | `true`        | `maxQuantity - Target`（不钳制，可能 < 1）                             |
-> | `"Percentage"` | `false`       | `round(maxQuantity × Target / 100)`，钳制到 `[1, maxQuantity]`         |
-> | `"Percentage"` | `true`        | `round(maxQuantity × (100 - Target) / 100)`，钳制到 `[1, maxQuantity]` |
+> | TargetQuantityType | ReverseTarget | 有效目标                                                                                   |
+> | ------------------ | ------------- | ------------------------------------------------------------------------------------------ |
+> | `"Value"`          | `false`       | `TargetQuantity`（原值）                                                                   |
+> | `"Value"`          | `true`        | `availableQuantity - TargetQuantity`（不钳制，可能 < 1）                                   |
+> | `"Percentage"`     | `false`       | `round(availableQuantity × TargetQuantity / 100)`，钳制到 `[1, availableQuantity]`         |
+> | `"Percentage"`     | `true`        | `round(availableQuantity × (100 - TargetQuantity) / 100)`，钳制到 `[1, availableQuantity]` |
 
 #### 仅能通过 `custom_action_param` 传入的参数
 
 除上述 4 个字段外，其余参数都只能从 `custom_action_param` 读取：
 
-| 字段                          | 类型                    | 必填 | 说明                                                                                                                          |
-| ----------------------------- | ----------------------- | ---- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `Direction`                   | `string`                | 是   | 滑动方向。指定"最大值所在方向"，支持 `left` / `right` / `up` / `down`。                                                       |
-| `Quantity.Box`                | `int[4]`                | 是   | 当前数量 OCR 区域，格式 `[x, y, w, h]`。                                                                                      |
-| `IncreaseButton`              | `string` 或 `int[2\|4]` | 是   | "增加数量"按钮。推荐传模板路径（阈值固定 `0.8`），也可传坐标 `[x, y]` 或 `[x, y, w, h]`。                                     |
-| `DecreaseButton`              | `string` 或 `int[2\|4]` | 是   | "减少数量"按钮。格式同 `IncreaseButton`。                                                                                     |
-| `MaxTarget.Box`               | `int[4]`                | 否   | OCR 区域，用于读取物品的最大可用数量（如可购买/可出售数量），格式 `[x, y, w, h]`。缺失时使用滑块终点值作为回退。              |
-| `Quantity.Filter`             | `object`                | 否   | 当前数量 OCR 的颜色过滤参数，适合数字颜色稳定但背景干扰较多的场景。                                                           |
-| `MaxTarget.Filter`            | `object`                | 否   | 最大目标数量 OCR 的颜色过滤参数。仅在显式提供 `MaxTarget` 时使用。                                                            |
-| `Quantity.OnlyRec`            | `bool`                  | 否   | 是否为数量 OCR 节点启用 `only_rec`。默认 `false`。                                                                            |
-| `MaxTarget.OnlyRec`           | `bool`                  | 否   | 是否为 `BetterSlidingGetMaxTarget` 的 OCR 节点启用 `only_rec`。仅在显式提供 `MaxTarget` 时使用。                              |
-| `GreenMask`                   | `bool`                  | 否   | 使用模板路径定位按钮时，是否对模板匹配启用绿色掩膜过滤。默认 `false`。对`IncreaseButton`与`DecreaseButton`生效                |
-| `CenterPointOffset`           | `int[2]`                | 否   | 相对滑块识别框中心点的点击偏移 `[x, y]`，负数向左/上，正数向右/下。默认 `[-10, 0]`。                                          |
-| `ClampTargetToMax`            | `bool`                  | 否   | 为 `true` 时，若目标超过 `maxQuantity` 则自动钳制为 `maxQuantity` 继续执行，而非直接失败。默认 `false`。                      |
-| `SwipeButton`                 | `string`                | 否   | 自定义滑块模板路径，覆盖 `BetterSlidingSwipeButton` 节点的默认模板。默认 `""`（使用共享默认模板）。                           |
-| `ExceedingOverrideEnable`     | `string`                | 否   | 当解析后的目标超出可滑动范围时，将指定 Pipeline 节点的 `enabled` 设为 `true`，然后返回成功。默认 `""`（禁用，动作直接失败）。 |
-| `TargetReachedOverrideEnable` | `string`                | 否   | 当解析后的目标无需钳制且位于 `[1, maxQuantity]` 时，将指定 Pipeline 节点的 `enabled` 设为 `true`。默认 `""`（不输出该结果）。 |
+| 字段                            | 类型                    | 必填 | 说明                                                                                                                |
+| ------------------------------- | ----------------------- | ---- | ------------------------------------------------------------------------------------------------------------------- |
+| `Direction`                     | `string`                | 是   | 滑动方向。指定"最大值所在方向"，支持 `left` / `right` / `up` / `down`。                                             |
+| `SliderQuantity.Box`            | `int[4]`                | 是   | 当前滑条数量 OCR 区域，格式 `[x, y, w, h]`。                                                                        |
+| `IncreaseButton`                | `string` 或 `int[2\|4]` | 是   | "增加数量"按钮。推荐传模板路径（阈值固定 `0.8`），也可传坐标 `[x, y]` 或 `[x, y, w, h]`。                           |
+| `DecreaseButton`                | `string` 或 `int[2\|4]` | 是   | "减少数量"按钮。格式同 `IncreaseButton`。                                                                           |
+| `AvailableQuantity.Box`         | `int[4]`                | 否   | OCR 区域，用于读取物品可购买/可出售的总量。缺失时使用滑条终点值作为计算基准。                                       |
+| `SliderQuantity.Filter`         | `object`                | 否   | 当前滑条数量 OCR 的颜色过滤参数。                                                                                   |
+| `AvailableQuantity.Filter`      | `object`                | 否   | 可用总量 OCR 的颜色过滤参数。仅在显式提供 `AvailableQuantity` 时使用。                                              |
+| `SliderQuantity.OnlyRec`        | `bool`                  | 否   | 是否为滑条数量 OCR 节点启用 `only_rec`。默认 `false`。                                                              |
+| `AvailableQuantity.OnlyRec`     | `bool`                  | 否   | 是否为 `BetterSlidingGetAvailableQuantity` 启用 `only_rec`。                                                        |
+| `GreenMask`                     | `bool`                  | 否   | 使用模板路径定位按钮时，是否对模板匹配启用绿色掩膜过滤。默认 `false`。对`IncreaseButton`与`DecreaseButton`生效      |
+| `CenterPointOffset`             | `int[2]`                | 否   | 相对滑块识别框中心点的点击偏移 `[x, y]`，负数向左/上，正数向右/下。默认 `[-10, 0]`。                                |
+| `ClampTargetToSliderMax`        | `bool`                  | 否   | 为 `true` 时，若目标超过 `sliderMaxQuantity`，则钳制为滑条最大可选数量继续执行。默认 `false`。                      |
+| `SwipeButton`                   | `string`                | 否   | 自定义滑块模板路径，覆盖 `BetterSlidingSwipeButton` 节点的默认模板。默认 `""`（使用共享默认模板）。                 |
+| `OutOfRangeOverrideEnable`      | `string`                | 否   | 当解析后的目标超出可滑动范围时，将指定 Pipeline 节点的 `enabled` 设为 `true`，然后返回成功。默认 `""`。             |
+| `TargetReachableOverrideEnable` | `string`                | 否   | 当解析后的目标无需钳制且位于 `[1, sliderMaxQuantity]` 时，将指定 Pipeline 节点的 `enabled` 设为 `true`。默认 `""`。 |
 
 ### 结果节点契约
 
-`ExceedingOverrideEnable` 与 `TargetReachedOverrideEnable` 用于把本次 BetterSliding 的判定传回调用方。两个参数必须引用不同节点，且结果节点建议默认设置 `enabled: false`。当两个参数均已配置时，每次执行结束后的状态如下：
+`OutOfRangeOverrideEnable` 与 `TargetReachableOverrideEnable` 用于把本次 BetterSliding 的判定传回调用方。两个参数必须引用不同节点，且结果节点建议默认设置 `enabled: false`。
 
-| 解析后的目标                                       | `ExceedingOverrideEnable` | `TargetReachedOverrideEnable` | BetterSliding 行为                           |
-| -------------------------------------------------- | ------------------------- | ----------------------------- | -------------------------------------------- |
-| 小于 1、未钳制时大于 `maxQuantity`，或最大数量为 0 | `true`                    | `false`                       | 不调整数量，返回成功，由调用方处理越界结果   |
-| 位于 `[1, maxQuantity]`                            | `false`                   | `true`                        | 调整到目标数量                               |
-| 大于 `maxQuantity` 且启用钳制                      | `false`                   | `false`                       | 调整到 `maxQuantity`，本次尚不能达到原始目标 |
+| 解析后的目标                                                 | `OutOfRangeOverrideEnable` | `TargetReachableOverrideEnable` | BetterSliding 行为                             |
+| ------------------------------------------------------------ | -------------------------- | ------------------------------- | ---------------------------------------------- |
+| 小于 1、未钳制时大于 `sliderMaxQuantity`，或滑条最大数量为 0 | `true`                     | `false`                         | 不调整数量，返回成功，由调用方处理越界结果     |
+| 位于 `[1, sliderMaxQuantity]`                                | `false`                    | `true`                          | 调整到目标数量                                 |
+| 大于 `sliderMaxQuantity` 且启用钳制                          | `false`                    | `false`                         | 调整到 `sliderMaxQuantity`，尚不能达到原始目标 |
 
 > [!important]
-> `TargetReachedOverrideEnable` 只表示调用方的下一步操作可以达到目标，不表示该操作已经成功。例如售卖、购买等流程仍须在外层 Pipeline 确认交易成功后，才能记录业务目标已完成。
+> `TargetReachableOverrideEnable` 只表示调用方的下一步操作可以达到目标，不表示该操作已经成功。例如售卖、购买等流程仍须在外层 Pipeline 确认交易成功后，才能记录业务目标已完成。
 
 ### 示例
 
@@ -115,16 +115,16 @@
                 "Direction": "right",
                 "IncreaseButton": "AutoStockpile/IncreaseButton.png",
                 "DecreaseButton": "AutoStockpile/DecreaseButton.png",
-                "Quantity": {
+                "SliderQuantity": {
                     "Box": [340, 430, 200, 140]
                 }
             }
         }
     },
     "attach": {
-        "Target": 50,
-        "TargetType": "Percentage",
-        "TargetReverse": false
+        "TargetQuantity": 50,
+        "TargetQuantityType": "Percentage",
+        "ReverseTarget": false
     }
 }
 ```

--- a/docs/zh_cn/developers/components/better-sliding.md
+++ b/docs/zh_cn/developers/components/better-sliding.md
@@ -96,9 +96,11 @@
 
 | 解析后的目标                                                 | `OutOfRangeOverrideEnable` | `TargetReachableOverrideEnable` | BetterSliding 行为                             |
 | ------------------------------------------------------------ | -------------------------- | ------------------------------- | ---------------------------------------------- |
-| 小于 1、未钳制时大于 `sliderMaxQuantity`，或滑条最大数量为 0 | `true`                     | `false`                         | 不调整数量，返回成功，由调用方处理越界结果     |
+| 小于 1、`sliderMaxQuantity` 为 0，或未钳制时大于滑条最大数量 | `true`                     | `false`                         | 不调整数量，返回成功，由调用方处理越界结果     |
 | 位于 `[1, sliderMaxQuantity]`                                | `false`                    | `true`                          | 调整到目标数量                                 |
 | 大于 `sliderMaxQuantity` 且启用钳制                          | `false`                    | `false`                         | 调整到 `sliderMaxQuantity`，尚不能达到原始目标 |
+
+`sliderMaxQuantity == 0` 只表示当前没有可选的正数目标，BetterSliding 不推断余额不足、库存不足或控件不可用等业务原因。调用方如需区分具体状态，应在 Pipeline 中识别对应界面。
 
 > [!important]
 > `TargetReachableOverrideEnable` 只表示调用方的下一步操作可以达到目标，不表示该操作已经成功。例如售卖、购买等流程仍须在外层 Pipeline 确认交易成功后，才能记录业务目标已完成。

--- a/docs/zh_cn/developers/tasks/auto-stockstaple-maintain.md
+++ b/docs/zh_cn/developers/tasks/auto-stockstaple-maintain.md
@@ -98,7 +98,7 @@ Exclude 分支（物品已达标或券不足被剔除）也会触发重新初始
 读取弹窗右上角当前持有数量 OCR，与用户配置的上限做表达式比较（`上限 > 当前持有量` 时命中）：
 
 1. Go 动作计算 `需购数量 = 上限 − 当前持有量`。
-2. 将结果写入 BetterSliding 的 `Target`，平滑调节购买数量滑条。
+2. 将结果写入 BetterSliding 的 `TargetQuantity`，平滑调节购买数量滑条。
 3. 点击确认购买，关闭奖励弹窗，回到列表继续扫描。
 
 #### 分支 3：持有量已达上限，排除
@@ -250,7 +250,7 @@ Exclude: {ValleyEngravingPermitLimit} <= {AutoStockStapleGoodsCountValidate}
 2. 对当前截图运行数量 OCR，得到 **当前持有数量**。
 3. 计算 `target = 目标上限 - 当前持有数量`。
 4. 若 `target <= 0`，跳过滑动（禁用 `AutoStockStapleBetterSliding`）。
-5. 否则通过 `OverridePipeline` 启用 `AutoStockStapleBetterSliding`，并将 `target` 写入其 `attach.Target`。
+5. 否则通过 `OverridePipeline` 启用 `AutoStockStapleBetterSliding`，并将 `target` 写入其 `attach.TargetQuantity`。
 
 Go **不再** `RunTask` 执行滑动；数量调节由低代码分支完成：
 
@@ -262,7 +262,7 @@ Go **不再** `RunTask` 执行滑动；数量调节由低代码分支完成：
   → AutoStockStapleQuantityControlConfirmBuy
 ```
 
-`AutoStockStapleBetterSliding` 定义在 `General/Item.json`，默认 `enabled: false`，仅在 Go override 后启用；`attach.Target` 的默认值只是占位。
+`AutoStockStapleBetterSliding` 定义在 `General/Item.json`，默认 `enabled: false`，仅在 Go override 后启用；`attach.TargetQuantity` 的默认值只是占位。
 
 购买数量调节完成后，`next` 进入 `AutoStockStapleQuantityControlConfirmBuy` 点击黄色确认按钮，再关闭奖励弹窗回到列表。
 
@@ -282,11 +282,11 @@ Exclude 分支 **不会** 购买，仅把“已达标”的物品从本轮扫描
 
 本任务有两类运行时 override，维护时不要混淆：
 
-| 动作                                   | 触发位置                                          | 作用                                                      |
-| -------------------------------------- | ------------------------------------------------- | --------------------------------------------------------- |
-| `AttachToExpectedRegexAction`          | `AutoStockStapleMain` 入口；Exclude 后 Reset 节点 | 合并 attach 关键词 → OCR 白名单正则                       |
-| `PipelineOverrideAction`               | 各物品 `{Item}RemoveFilter`                       | 将指定 attach 键设为 `false`，排除该物品                  |
-| `AutoStockStapleQuantityControlAction` | 各物品 `{Item}Buy`                                | 计算差值并 override BetterSliding 的 `Target` / `enabled` |
+| 动作                                   | 触发位置                                          | 作用                                                              |
+| -------------------------------------- | ------------------------------------------------- | ----------------------------------------------------------------- |
+| `AttachToExpectedRegexAction`          | `AutoStockStapleMain` 入口；Exclude 后 Reset 节点 | 合并 attach 关键词 → OCR 白名单正则                               |
+| `PipelineOverrideAction`               | 各物品 `{Item}RemoveFilter`                       | 将指定 attach 键设为 `false`，排除该物品                          |
+| `AutoStockStapleQuantityControlAction` | 各物品 `{Item}Buy`                                | 计算差值并 override BetterSliding 的 `TargetQuantity` / `enabled` |
 
 `attach` 语义（见 `attachregex/action.go`）：
 

--- a/docs/zh_cn/developers/tasks/sell-product-maintain.md
+++ b/docs/zh_cn/developers/tasks/sell-product-maintain.md
@@ -189,10 +189,10 @@ SellProductSellLoop                                  （不限次数的售卖循
                                  ├─ SellProductSell → SellProductSellCheck
                                  │      （无保留规则，全部售出）
                                  ├─ SellProductSellThenLoop → SellProductSellCheckThenLoop
-                                 │      （按保留数量交易；未达保留目标时回到 BetterSliding
-                                 │        继续售卖当前货品，达到后经 SellProductReserveTargetReached
+                                 │      （按保留数量交易；未达保留数量时回到 BetterSliding
+                                 │        继续售卖当前货品，达到后经 SellProductReserveQuantityReached
                                  │        标记本次任务已满足）
-                                 └─ SellProductSkipToNextSellLoop
+                                 └─ SellProductReserveAlreadySatisfied
                                       （库存不高于保留量，标记已满足并跳过）
                                      └─ SellProductSellLoop
                                           （继续下一候选，直到满足结束条件）
@@ -210,14 +210,14 @@ SellProductSellLoop                                  （不限次数的售卖循
 - 当前可见的已知货品全部不可成为候选（已尝试、已缺货、已达保留量或配置为永不售卖），且连续两次识别到相同集合；
 - 超出兑换上限时由 `SellProductAidQuotaExceededStop` 停止整个任务。
 
-空 OCR 结果不会被当作“无剩余货品”。缺货物品仍保留在稳定识别集合中，但不会再次成为候选；缺货、交易完成、达到保留目标或因保留量跳过都会继续下一轮。
+空 OCR 结果不会被当作“无剩余货品”。缺货物品仍保留在稳定识别集合中，但不会再次成为候选；缺货、交易完成、达到保留数量或因保留量跳过都会继续下一轮。
 
 独立保留规则提供六个槽位，每个槽位按稳定 `itemId` 选择“保留指定数量”或“永不售卖”：
 
 - 未命中规则时，BetterSliding 使用默认“全部售出”。
-- “保留指定数量”使用 `TargetReverse` 只售卖高于保留量的部分。
-- 单次交易达到保留目标时，交易确认成功后经 `SellProductReserveTargetReached` 把该物品标记为本次任务已满足；未达到目标时回到数量滑块继续售卖当前货品。
-- 当前库存不高于保留量时，通过 `SellProductSkipToNextSellLoop` 跳过交易，同样把该物品标记为本次任务已满足。
+- “保留指定数量”使用 `ReverseTarget` 只售卖高于保留量的部分。
+- 单次交易达到保留数量时，交易确认成功后经 `SellProductReserveQuantityReached` 把该物品标记为本次任务已满足；未达到保留数量时回到数量滑块继续售卖当前货品。
+- 当前库存不高于保留量时，通过 `SellProductReserveAlreadySatisfied` 跳过交易，同样把该物品标记为本次任务已满足。
 - 已满足的物品在后续据点的选品阶段直接跳过，并在首次标记时输出提示。
 - “永不售卖”在选货识别阶段直接排除物品，不切换货品，也不会记为缺货；内部以数量 `-1` 表示，用户界面不要求输入该哨兵值。
 - 同一物品重复配置时，后面的槽位覆盖前面的槽位；数量 `0` 等价于不保留。

--- a/tools/pipeline-generate/SellProduct/data.test.mjs
+++ b/tools/pipeline-generate/SellProduct/data.test.mjs
@@ -100,19 +100,19 @@ test("SellProduct templates consume separate minimal projections of the shared l
     }
 
     assert.deepEqual(sortedKeys(sellProductPipelineRows[0]), [
+        "AvailableQuantityBox",
         "CurrentOperatorROI",
         "LocationDesc",
         "LocationId",
-        "MaxTargetBox",
-        "QuantityBox",
         "RegionPrefix",
+        "SliderQuantityBox",
         "TextExpected",
     ]);
     assert.deepEqual(sortedKeys(sellProductAdbRows[0]), [
+        "AvailableQuantityBoxAdb",
         "LocationId",
-        "MaxTargetBoxAdb",
-        "QuantityBoxAdb",
         "RegionPrefix",
+        "SliderQuantityBoxAdb",
     ]);
     assert.deepEqual(sortedKeys(sellProductSessionRows[0]), [
         "LocationDesc",
@@ -582,21 +582,21 @@ test("SellProduct 持续售卖到保留量后再进入下一轮选货", () => {
     );
 
     assert.deepEqual(pipeline.SellProductSellCheckThenLoop.next, [
-        "SellProductReserveTargetReached",
+        "SellProductReserveQuantityReached",
         "[Anchor]SellProductBetterSliding",
     ]);
-    assert.equal(pipeline.SellProductReserveTargetReached.enabled, false);
-    assert.equal(pipeline.SellProductReserveTargetReached.custom_action, "SellProductReserveSession");
-    assert.deepEqual(pipeline.SellProductReserveTargetReached.custom_action_param, {
+    assert.equal(pipeline.SellProductReserveQuantityReached.enabled, false);
+    assert.equal(pipeline.SellProductReserveQuantityReached.custom_action, "SellProductReserveSession");
+    assert.deepEqual(pipeline.SellProductReserveQuantityReached.custom_action_param, {
         operation: "satisfy",
     });
-    assert.deepEqual(pipeline.SellProductReserveTargetReached.next, ["SellProductSellLoop"]);
-    assert.equal(pipeline.SellProductSkipToNextSellLoop.recognition, "DirectHit");
-    assert.equal(pipeline.SellProductSkipToNextSellLoop.custom_action, "SellProductReserveSession");
-    assert.deepEqual(pipeline.SellProductSkipToNextSellLoop.custom_action_param, {
+    assert.deepEqual(pipeline.SellProductReserveQuantityReached.next, ["SellProductSellLoop"]);
+    assert.equal(pipeline.SellProductReserveAlreadySatisfied.recognition, "DirectHit");
+    assert.equal(pipeline.SellProductReserveAlreadySatisfied.custom_action, "SellProductReserveSession");
+    assert.deepEqual(pipeline.SellProductReserveAlreadySatisfied.custom_action_param, {
         operation: "satisfy",
     });
-    assert.deepEqual(pipeline.SellProductSkipToNextSellLoop.next, ["SellProductSellLoop"]);
+    assert.deepEqual(pipeline.SellProductReserveAlreadySatisfied.next, ["SellProductSellLoop"]);
 
     for (const location of sellProductLocations) {
         const outpost = readPipeline(
@@ -606,8 +606,9 @@ test("SellProduct 持续售卖到保留量后再进入下一轮选货", () => {
             ),
         );
         assert.equal(
-            outpost[`SellProduct${location.LocationId}BetterSliding`].custom_action_param.TargetReachedOverrideEnable,
-            "SellProductReserveTargetReached",
+            outpost[`SellProduct${location.LocationId}BetterSliding`].custom_action_param
+                .TargetReachableOverrideEnable,
+            "SellProductReserveQuantityReached",
         );
     }
 });

--- a/tools/pipeline-generate/SellProduct/pipeline-adb-data.mjs
+++ b/tools/pipeline-generate/SellProduct/pipeline-adb-data.mjs
@@ -17,6 +17,6 @@ const MAX_QUANTITY_BOX_ADB = [
 export default sellProductLocations.map((location) => ({
     RegionPrefix: location.RegionPrefix,
     LocationId: location.LocationId,
-    QuantityBoxAdb: QUANTITY_BOX_ADB,
-    MaxTargetBoxAdb: MAX_QUANTITY_BOX_ADB,
+    SliderQuantityBoxAdb: QUANTITY_BOX_ADB,
+    AvailableQuantityBoxAdb: MAX_QUANTITY_BOX_ADB,
 }));

--- a/tools/pipeline-generate/SellProduct/pipeline-adb-template.jsonc
+++ b/tools/pipeline-generate/SellProduct/pipeline-adb-template.jsonc
@@ -2,21 +2,21 @@
     "SellProduct${LocationId}BetterSliding": {
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
-                "Box": "${MaxTargetBoxAdb}",
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
+                "Box": "${AvailableQuantityBoxAdb}",
                 "OnlyRec": true
             },
-            "Quantity": {
-                "Box": "${QuantityBoxAdb}",
+            "SliderQuantity": {
+                "Box": "${SliderQuantityBoxAdb}",
                 "OnlyRec": true
             },
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         }
     }
 }

--- a/tools/pipeline-generate/SellProduct/pipeline-data.mjs
+++ b/tools/pipeline-generate/SellProduct/pipeline-data.mjs
@@ -29,6 +29,6 @@ export default sellProductLocations.map((location) => ({
     LocationDesc: location.LocationDesc,
     TextExpected: location.TextExpected,
     CurrentOperatorROI: CURRENT_OPERATOR_ROI,
-    QuantityBox: QUANTITY_BOX,
-    MaxTargetBox: MAX_QUANTITY_BOX,
+    SliderQuantityBox: QUANTITY_BOX,
+    AvailableQuantityBox: MAX_QUANTITY_BOX,
 }));

--- a/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
+++ b/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
@@ -1155,21 +1155,21 @@
         "custom_action": "BetterSliding",
         "custom_action_param": {
             "GreenMask": true,
-            "Target": 999999,
-            "ClampTargetToMax": true,
-            "MaxTarget": {
-                "Box": "${MaxTargetBox}",
+            "TargetQuantity": 999999,
+            "ClampTargetToSliderMax": true,
+            "AvailableQuantity": {
+                "Box": "${AvailableQuantityBox}",
                 "OnlyRec": true
             },
-            "Quantity": {
-                "Box": "${QuantityBox}",
+            "SliderQuantity": {
+                "Box": "${SliderQuantityBox}",
                 "OnlyRec": true
             },
             "Direction": "right",
             "DecreaseButton": "SellProduct/DecreaseButton.png",
             "IncreaseButton": "SellProduct/IncreaseButton.png",
-            "ExceedingOverrideEnable": "SellProductSkipToNextSellLoop",
-            "TargetReachedOverrideEnable": "SellProductReserveTargetReached"
+            "OutOfRangeOverrideEnable": "SellProductReserveAlreadySatisfied",
+            "TargetReachableOverrideEnable": "SellProductReserveQuantityReached"
         },
         "post_wait_freezes": 80,
         "post_delay": 0,


### PR DESCRIPTION
## BetterSliding 接口整理

统一 BetterSliding 中目标数量、滑条数量与可用总量的命名，不保留旧名称兼容层：

- `Target` → `TargetQuantity`
- `Quantity` → `SliderQuantity`
- `MaxTarget` → `AvailableQuantity`
- `TargetType` → `TargetQuantityType`
- `TargetReverse` → `ReverseTarget`
- `ClampTargetToMax` → `ClampTargetToSliderMax`
- `ExceedingOverrideEnable` → `OutOfRangeOverrideEnable`
- `TargetReachedOverrideEnable` → `TargetReachableOverrideEnable`

SellProduct 的结果节点同时由 `SellProductReserveTargetReached` 统一为 `SellProductReserveQuantityReached`。

## 结果判定

- 将目标数量相对滑条上限的结果统一为 `OutOfRange`、`TargetReachable` 与 `Clamped`；
- `sliderMaxQuantity == 0` 作为通用 `OutOfRange` 处理；
- BetterSliding 不推断余额不足、库存不足或控件不可用等业务原因，调用方应在 Pipeline 中识别具体界面状态；
- 统一同步调用方结果节点开关，并为结果优先级与钳制行为补充单元测试及注释。

相关 Go 调用方、Pipeline、SellProduct 生成器、PC/ADB 资源以及中英文文档均已同步。

## 兼容性

这是破坏性接口改名。使用旧 BetterSliding 参数名的外部 Pipeline 需要同步迁移。

## 验证

- `go -C agent/go-service test ./bettersliding ./sellproduct ./autostockpile ./autostockstaple`
- `node --test tools/pipeline-generate/SellProduct/*.test.mjs`（37/37）
- `pnpm check`
- `pnpm test`（638/638）
- `git diff --check`

## Summary by Sourcery

在 Go 处理器、流水线和文档中重命名 BetterSliding 与数量相关的参数和结果，并统一滑杆范围结果的处理方式。

Bug 修复：
- 统一 BetterSliding 在超出范围和目标可达性方面的处理逻辑，以区分不可达目标、被夹紧（clamped）的目标和可达目标，包括 `sliderMaxQuantity == 0` 的情况。

增强：
- 在 Go、流水线生成器和文档中统一 BetterSliding 中目标、滑杆和可用数量的命名。
- 优化 BetterSliding 结果覆盖（outcome override）的接线方式，使调用方可以通过专门的节点一致地接收超出范围和目标可达性的信号。
- 将 SellProduct 的预留（reserve）处理与新的 BetterSliding 结果模型对齐，并重命名其预留结果节点以提升清晰度。
- 添加单元测试，覆盖 BetterSliding 滑杆数量结果解析以及 SellProduct 预留流水线生成。

文档：
- 更新 BetterSliding 的英文和中文开发者文档及任务文档，以反映新的 `TargetQuantity` / `SliderQuantity` / `AvailableQuantity` 模型和结果语义。

测试：
- 扩展 BetterSliding 测试，以覆盖滑杆数量结果解析，并验证 SellProduct 流水线和预留覆盖是否使用新的命名和节点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename BetterSliding quantity-related parameters and outcomes across Go handlers, pipelines, and docs, and standardize slider range result handling.

Bug Fixes:
- Unify BetterSliding out-of-range and target-reachability handling to distinguish unreachable, clamped, and reachable targets, including sliderMaxQuantity == 0.

Enhancements:
- Standardize BetterSliding naming for target, slider, and available quantities in Go, pipeline generators, and documentation.
- Refine BetterSliding outcome override wiring so callers receive consistent out-of-range and target-reachable signals via dedicated nodes.
- Align SellProduct reserve handling with the new BetterSliding outcome model and rename its reserve result nodes for clarity.
- Add unit tests covering BetterSliding slider quantity outcome resolution and SellProduct reserve pipeline generation.

Documentation:
- Update BetterSliding English and Chinese developer docs and task docs to reflect the new TargetQuantity / SliderQuantity / AvailableQuantity model and outcome semantics.

Tests:
- Extend BetterSliding tests to cover slider quantity outcome resolution and verify SellProduct pipelines and reserve overrides use the new naming and nodes.

</details>