### PR TITLE
fix(SellProduct): 交易后优先检查调度券不足

### DIFF
--- a/assets/resource/pipeline/SellProduct/SellCore.json
+++ b/assets/resource/pipeline/SellProduct/SellCore.json
@@ -392,6 +392,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "[Anchor]SellProductZeroMoneyHandler",
             "SellProductReserveTargetReached",
             "[Anchor]SellProductBetterSliding"
         ],

--- a/docs/en_us/developers/tasks/sell-product-maintain.md
+++ b/docs/en_us/developers/tasks/sell-product-maintain.md
@@ -189,16 +189,17 @@ SellProductSellLoop                                  (unbounded selling loop)
                                  ├─ SellProductSell → SellProductSellCheck
                                  │      (no reserve rule; sell all)
                                  ├─ SellProductSellThenLoop → SellProductSellCheckThenLoop
-                                 │      (sell with a reserve; below the target, return to BetterSliding
-                                 │        and keep selling the current item; on reaching it, mark the
-                                 │        item satisfied via SellProductReserveTargetReached)
+                                 │      (sell with a reserve; after the trade, check vouchers first and
+                                 │        end if exhausted; otherwise mark the item satisfied via
+                                 │        SellProductReserveTargetReached when the reserve is reached,
+                                 │        or return to BetterSliding and continue selling)
                                  └─ SellProductSkipToNextSellLoop
                                       (stock not above the reserve; mark satisfied and skip)
                                      └─ SellProductSellLoop
                                           (continue until an exit condition is met)
 ```
 
-Each round checks the voucher balance before selecting goods. After a goods change, the insufficient-voucher check still takes precedence over an out-of-stock item, preventing traversal of later priority items once vouchers are exhausted. Insufficient vouchers on initial entry produce a notice; after a completed trade, the outpost selling loop ends silently.
+Each round checks the voucher balance before selecting goods. After a goods change, the insufficient-voucher check still takes precedence over an out-of-stock item, preventing traversal of later priority items once vouchers are exhausted. After a reserve-based trade completes, the flow also checks vouchers before deciding whether the reserve has been reached or running BetterSliding again. Insufficient vouchers on initial entry produce a notice; after a completed trade, the outpost selling loop ends silently.
 
 `SellProductPriorityItem` Custom Recognition only records the selected item as pending during recognition. After Pipeline clicks and confirms it and recognizes the outpost sell screen again, `SellProductPrioritySession` marks it attempted. A failed click or one-frame OCR fluctuation cannot skip a higher-priority item.
 

--- a/docs/zh_cn/developers/tasks/sell-product-maintain.md
+++ b/docs/zh_cn/developers/tasks/sell-product-maintain.md
@@ -189,16 +189,16 @@ SellProductSellLoop                                  （不限次数的售卖循
                                  ├─ SellProductSell → SellProductSellCheck
                                  │      （无保留规则，全部售出）
                                  ├─ SellProductSellThenLoop → SellProductSellCheckThenLoop
-                                 │      （按保留数量交易；未达保留目标时回到 BetterSliding
-                                 │        继续售卖当前货品，达到后经 SellProductReserveTargetReached
-                                 │        标记本次任务已满足）
+                                 │      （按保留数量交易；交易后先检查调度券，不足则结束；
+                                 │        充足时，达到保留目标则经 SellProductReserveTargetReached
+                                 │        标记本次任务已满足，否则回到 BetterSliding 继续售卖）
                                  └─ SellProductSkipToNextSellLoop
                                       （库存不高于保留量，标记已满足并跳过）
                                      └─ SellProductSellLoop
                                           （继续下一候选，直到满足结束条件）
 ```
 
-每轮选择货品前都会先检查调度券。换货后再次检查时，调度券不足的判断仍优先于当前货品缺货，避免调度券耗尽后继续遍历后续优先物品。首次进入据点即发现不足时显示提示；已有交易完成后则静默结束该据点售卖循环。
+每轮选择货品前都会先检查调度券。换货后再次检查时，调度券不足的判断仍优先于当前货品缺货，避免调度券耗尽后继续遍历后续优先物品。按保留数量完成一笔交易后，也会先检查调度券，再判断保留目标是否达到或重新进入 BetterSliding。首次进入据点即发现不足时显示提示；已有交易完成后则静默结束该据点售卖循环。
 
 `SellProductPriorityItem` 自定义识别器只在识别阶段把选中的货品记录为待提交。Pipeline 点击并确认货品、重新识别到据点售卖界面后，`SellProductPrioritySession` 才把该货品标记为已尝试。点击失败或单帧 OCR 波动不会跳过高优先级货品。
 

--- a/tools/pipeline-generate/SellProduct/data.test.mjs
+++ b/tools/pipeline-generate/SellProduct/data.test.mjs
@@ -494,7 +494,7 @@ test("SellProduct pipeline templates use one dynamic priority loop instead of fi
     assert.match(adbTemplate, /SellProduct\$\{LocationId\}BetterSliding/);
 });
 
-test("SellProduct 每轮换货前优先检查调度券不足", () => {
+test("SellProduct 每轮选货及保留交易后优先检查调度券不足", () => {
     const pipeline = readPipeline(
         new URL("../../../assets/resource/pipeline/SellProduct/SellCore.json", import.meta.url),
     );
@@ -508,6 +508,11 @@ test("SellProduct 每轮换货前优先检查调度券不足", () => {
         "SellProductZeroProductAfterChangeStillEmpty",
     ]);
     assert.equal(pipeline.SellProductSellCheckThenLoop.anchor.SellProductZeroMoneyHandler, "SellProductZeroMoney");
+    assert.deepEqual(pipeline.SellProductSellCheckThenLoop.next, [
+        "[Anchor]SellProductZeroMoneyHandler",
+        "SellProductReserveTargetReached",
+        "[Anchor]SellProductBetterSliding",
+    ]);
     assert.deepEqual(pipeline.SellProductZeroProductAfterChangeStillEmpty.next, [
         "[Anchor]SellProductMarkOutOfStock",
     ]);
@@ -581,10 +586,6 @@ test("SellProduct 持续售卖到保留量后再进入下一轮选货", () => {
         new URL("../../../assets/resource/pipeline/SellProduct/SellCore.json", import.meta.url),
     );
 
-    assert.deepEqual(pipeline.SellProductSellCheckThenLoop.next, [
-        "SellProductReserveTargetReached",
-        "[Anchor]SellProductBetterSliding",
-    ]);
     assert.equal(pipeline.SellProductReserveTargetReached.enabled, false);
     assert.equal(pipeline.SellProductReserveTargetReached.custom_action, "SellProductReserveSession");
     assert.deepEqual(pipeline.SellProductReserveTargetReached.custom_action_param, {


### PR DESCRIPTION
## 用户侧变化

修复按保留数量售卖时，一笔交易完成后调度券已经耗尽，却继续进入保留量判断并把当前产品误标记为“已达到保留数量”的问题。

现在每笔按保留数量的交易完成后，会优先识别 `SellProductZeroMoney`：

- 调度券不足：结束当前据点售卖循环，不会记录保留目标已满足；
- 调度券充足：再判断保留目标是否达到，或重新运行 BetterSliding 继续售卖。

首次进入售卖界面、每轮选货前和换货后的调度券检查保持不变。

## 实现

- 将 `[Anchor]SellProductZeroMoneyHandler` 放在 `SellProductSellCheckThenLoop.next` 首位；
- 使用现有 `SellProductZeroMoney` 界面识别处理业务状态，不修改 BetterSliding 通用组件；
- 补充交易后节点优先级回归测试；
- 更新 SellProduct 中英文维护文档。

## 验证

- `pnpm exec prettier --write -- <changed files>`
- `node --test tools/pipeline-generate/SellProduct/*.test.mjs`（37/37）
- `pnpm check`
- `pnpm test`（638/638）
- `git diff --check`

Fixed #4518

## Summary by Sourcery

在 SellProduct 流水线中，将基于储备（reserve-based）交易之后的“代金券不足（insufficient-voucher）”处理优先化，以避免在代金券已耗尽时错误地将储备目标标记为已满足。

Bug 修复：
- 防止基于储备的 SellProduct 工作流在交易后代金券已经耗尽的情况下，仍将商品标记为已达到其储备目标。

增强：
- 调整 SellProduct 流水线步骤顺序，使代金券耗尽检查在储备目标检查或后续在交易后循环中的进一步售卖之前运行。

文档：
- 更新 SellProduct 的英文与中文维护文档，明确描述新的交易后代金券检查行为与控制流程。

测试：
- 扩展 SellProduct 流水线测试，用于断言更新后的 `SellProductSellCheckThenLoop` 顺序以及在基于储备交易之后代金券检查的优先级。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prioritize insufficient-voucher handling after reserve-based trades in the SellProduct pipeline to avoid incorrectly marking reserve goals as satisfied when vouchers are exhausted.

Bug Fixes:
- Prevent reserve-based SellProduct workflows from marking items as having reached their reserve target when vouchers have already been exhausted after a trade.

Enhancements:
- Adjust the SellProduct pipeline step order so voucher exhaustion checks run before reserve-target checks or further selling in the post-trade loop.

Documentation:
- Clarify the SellProduct English and Chinese maintenance docs to describe the new post-trade voucher check behavior and control flow.

Tests:
- Extend SellProduct pipeline tests to assert the updated SellProductSellCheckThenLoop ordering and voucher-check priority after reserve-based trades.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 SellProduct 流水线中，将基于储备（reserve-based）交易之后的“代金券不足（insufficient-voucher）”处理优先化，以避免在代金券已耗尽时错误地将储备目标标记为已满足。

Bug 修复：
- 防止基于储备的 SellProduct 工作流在交易后代金券已经耗尽的情况下，仍将商品标记为已达到其储备目标。

增强：
- 调整 SellProduct 流水线步骤顺序，使代金券耗尽检查在储备目标检查或后续在交易后循环中的进一步售卖之前运行。

文档：
- 更新 SellProduct 的英文与中文维护文档，明确描述新的交易后代金券检查行为与控制流程。

测试：
- 扩展 SellProduct 流水线测试，用于断言更新后的 `SellProductSellCheckThenLoop` 顺序以及在基于储备交易之后代金券检查的优先级。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prioritize insufficient-voucher handling after reserve-based trades in the SellProduct pipeline to avoid incorrectly marking reserve goals as satisfied when vouchers are exhausted.

Bug Fixes:
- Prevent reserve-based SellProduct workflows from marking items as having reached their reserve target when vouchers have already been exhausted after a trade.

Enhancements:
- Adjust the SellProduct pipeline step order so voucher exhaustion checks run before reserve-target checks or further selling in the post-trade loop.

Documentation:
- Clarify the SellProduct English and Chinese maintenance docs to describe the new post-trade voucher check behavior and control flow.

Tests:
- Extend SellProduct pipeline tests to assert the updated SellProductSellCheckThenLoop ordering and voucher-check priority after reserve-based trades.

</details>

</details>