### PR TITLE
fix(MapNavigator): 净空场墙距与 StringPull 代价判据

### DIFF
--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -775,6 +775,16 @@ Grid<float> PrefField(const Grid<float>& dist, bool ridge)
     return out;
 }
 
+Grid<float> TargetField(const Grid<float>& dist)
+{
+    const Grid<float> locw = LocalMax(dist, static_cast<int64_t>(std::ceil(kR / kCS)));
+    Grid<float> tgt(dist.nx, dist.ny, 0.0f);
+    for (size_t i = 0; i < tgt.v.size(); ++i) {
+        tgt.v[i] = std::max(std::min(static_cast<float>(kGeoR), locw.v[i]), 0.25f);
+    }
+    return tgt;
+}
+
 namespace
 {
 
@@ -1018,22 +1028,94 @@ bool Blockers::offMask(const WorldPoint& p, const WorldPoint& q) const
     return false;
 }
 
-std::vector<WorldPoint> StringPull(const std::vector<WorldPoint>& pts, const Blockers& blk)
+float ClearanceFloor::seg(const WorldPoint& p, const WorldPoint& q) const
+{
+    const double L = std::hypot(q.x - p.x, q.y - p.y);
+    const int64_t n = static_cast<int64_t>(L / (cs_ * 0.5)) + 2;
+    const double step = 1.0 / static_cast<double>(n - 1);
+    float m = std::numeric_limits<float>::infinity();
+    for (int64_t i = 0; i < n; ++i) {
+        const double t = i == n - 1 ? 1.0 : static_cast<double>(i) * step;
+        int64_t gx = static_cast<int64_t>((p.x + (q.x - p.x) * t - x0_) / cs_);
+        int64_t gy = static_cast<int64_t>((p.y + (q.y - p.y) * t - y0_) / cs_);
+        gx = std::max<int64_t>(0, std::min<int64_t>(cf_->nx - 1, gx));
+        gy = std::max<int64_t>(0, std::min<int64_t>(cf_->ny - 1, gy));
+        m = std::min(m, cf_->at(gy, gx));
+    }
+    return m;
+}
+
+double ClearanceFloor::cost(const WorldPoint& p, const WorldPoint& q) const
+{
+    const double L = std::hypot(q.x - p.x, q.y - p.y);
+    const int64_t n = std::max<int64_t>(static_cast<int64_t>(std::ceil(L / (cs_ * 0.5))), 1);
+    double acc = 0.0;
+    for (int64_t i = 0; i < n; ++i) {
+        const double t = (static_cast<double>(i) + 0.5) / static_cast<double>(n);
+        int64_t gx = static_cast<int64_t>((p.x + (q.x - p.x) * t - x0_) / cs_);
+        int64_t gy = static_cast<int64_t>((p.y + (q.y - p.y) * t - y0_) / cs_);
+        gx = std::max<int64_t>(0, std::min<int64_t>(mg_->nx - 1, gx));
+        gy = std::max<int64_t>(0, std::min<int64_t>(mg_->ny - 1, gy));
+        acc += static_cast<double>(mg_->at(gy, gx));
+    }
+    return L * (acc / static_cast<double>(n));
+}
+
+std::vector<WorldPoint> StringPull(const std::vector<WorldPoint>& pts, const Blockers& blk, const ClearanceFloor* cfl)
 {
     std::vector<WorldPoint> P = pts;
+    // 跨点连线须同时不低于被跳过子路径的净空地板、不高于其代价泛函(与几何重寻同口径),
+    // 相邻点连线无条件保留
+    std::vector<float> seg;
+    std::vector<double> cst;
+    if (cfl != nullptr && P.size() > 1) {
+        seg.reserve(P.size() - 1);
+        cst.reserve(P.size() - 1);
+        for (size_t k = 0; k + 1 < P.size(); ++k) {
+            seg.push_back(cfl->seg(P[k], P[k + 1]));
+            cst.push_back(cfl->cost(P[k], P[k + 1]));
+        }
+    }
+    const bool guard = !seg.empty();
+    std::vector<size_t> idx(P.size());
+    for (size_t k = 0; k < idx.size(); ++k) {
+        idx[k] = k;
+    }
+    std::vector<float> acc;
+    std::vector<double> ac2;
     for (int round = 0; round < 6; ++round) {
         std::vector<WorldPoint> out { P[0] };
+        std::vector<size_t> oid { idx[0] };
         size_t i = 0;
         while (i < P.size() - 1) {
+            if (guard) {
+                acc.assign(seg.begin() + static_cast<int64_t>(idx[i]), seg.end());
+                for (size_t k = 1; k < acc.size(); ++k) {
+                    acc[k] = std::min(acc[k], acc[k - 1]);
+                }
+                ac2.assign(cst.begin() + static_cast<int64_t>(idx[i]), cst.end());
+                for (size_t k = 1; k < ac2.size(); ++k) {
+                    ac2[k] += ac2[k - 1];
+                }
+            }
             size_t j = P.size() - 1;
-            while (j > i + 1 && blk.blocked(P[i], P[j])) {
+            while (j > i + 1) {
+                const size_t k = idx[j] - idx[i] - 1;
+                if (!blk.blocked(P[i], P[j])
+                    && (!guard
+                        || (static_cast<double>(cfl->seg(P[i], P[j])) >= static_cast<double>(acc[k]) - kClrTol
+                            && cfl->cost(P[i], P[j]) <= ac2[k] * (1.0 + kCostTol)))) {
+                    break;
+                }
                 --j;
             }
             out.push_back(P[j]);
+            oid.push_back(idx[j]);
             i = j;
         }
         const bool changed = out.size() != P.size();
         P = std::move(out);
+        idx = std::move(oid);
         if (!changed) {
             break;
         }
@@ -1041,7 +1123,7 @@ std::vector<WorldPoint> StringPull(const std::vector<WorldPoint>& pts, const Blo
     return P;
 }
 
-std::vector<WorldPoint> Slim(const std::vector<WorldPoint>& pts, const Blockers& blk, double eps)
+std::vector<WorldPoint> Slim(const std::vector<WorldPoint>& pts, const Blockers& blk, double eps, const ClearanceFloor* cfl)
 {
     std::vector<WorldPoint> P = pts;
     bool ch = true;
@@ -1054,7 +1136,10 @@ std::vector<WorldPoint> Slim(const std::vector<WorldPoint>& pts, const Blockers&
             const double L2 = ux * ux + uy * uy;
             const double t = L2 == 0.0 ? 0.0 : std::max(0.0, std::min(1.0, ((b.x - a.x) * ux + (b.y - a.y) * uy) / L2));
             const double d = std::hypot(b.x - a.x - t * ux, b.y - a.y - t * uy);
-            if (d <= eps && !blk.blocked(a, c)) {
+            if (d <= eps && !blk.blocked(a, c)
+                && (cfl == nullptr
+                    || static_cast<double>(cfl->seg(a, c))
+                        >= std::min(static_cast<double>(cfl->seg(a, b)), static_cast<double>(cfl->seg(b, c))))) {
                 P.erase(P.begin() + static_cast<int64_t>(i));
                 ch = true;
             }

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -16,11 +16,14 @@ inline constexpr double kClimb = 3.0;              // 相邻格可连通最大�
 inline constexpr double kMergeH = 1.0;             // 同列 span 合并容差 px
 inline constexpr double kEdtCap = 12.0;            // 距离场截断 px
 inline constexpr double kR = 1.75;                 // 期望余量上限 px
+inline constexpr double kGeoR = 3.5;               // 几何口径舒适余量上限 px
 inline constexpr double kRel = 0.6;                // 期望余量 = min(R, REL×局部净空)
 inline constexpr double kLam = 1.5;                // 满亏欠一步加价倍数
 inline constexpr double kRidgeFloor = 0.5;         // 脊线保底余量地板 px
 inline constexpr double kMaxErr = 0.5;             // 轮廓 DP 容差 px
 inline constexpr double kSlimEps = 0.5;            // 终线共线剔除容差 px
+inline constexpr double kClrTol = 0.125;           // 拉直允许的净空退让 px, 取半格即采样步长
+inline constexpr double kCostTol = 1e-9;           // 代价判据相对容差, 容纳共线子路径的浮点求和差
 inline constexpr double kMcHBand = 8.0;            // 层高度带(墙筛/盖章)px
 inline constexpr double kHBand = 6.0;              // 真墙探针高度带 px
 inline constexpr double kEpsProbe = 0.75;          // 真墙探针距离 px
@@ -144,6 +147,8 @@ std::optional<std::vector<CellPt>>
 
 Grid<float> PrefField(const Grid<float>& dist, bool ridge);
 
+Grid<float> TargetField(const Grid<float>& dist);
+
 std::vector<std::vector<WorldPoint>> TraceContours(const Mask& mask);
 
 std::vector<WorldPoint> SimplifyLoop(const std::vector<WorldPoint>& P, double max_err);
@@ -178,9 +183,34 @@ private:
     std::optional<OnMask> on_;
 };
 
-std::vector<WorldPoint> StringPull(const std::vector<WorldPoint>& pts, const Blockers& blk);
+// 沿弦按半格步长采样: seg 取 min(净空, 目标余量) 的下确界, cost 取代价泛函积分
+class ClearanceFloor
+{
+public:
+    ClearanceFloor(const Grid<float>* cf, const Grid<float>* mg, double x0, double y0, double cs)
+        : cf_(cf)
+        , mg_(mg)
+        , x0_(x0)
+        , y0_(y0)
+        , cs_(cs)
+    {
+    }
 
-std::vector<WorldPoint> Slim(const std::vector<WorldPoint>& pts, const Blockers& blk, double eps);
+    float seg(const WorldPoint& p, const WorldPoint& q) const;
+
+    double cost(const WorldPoint& p, const WorldPoint& q) const;
+
+private:
+    const Grid<float>* cf_ = nullptr;
+    const Grid<float>* mg_ = nullptr;
+    double x0_ = 0.0;
+    double y0_ = 0.0;
+    double cs_ = kCS;
+};
+
+std::vector<WorldPoint> StringPull(const std::vector<WorldPoint>& pts, const Blockers& blk, const ClearanceFloor* cfl);
+
+std::vector<WorldPoint> Slim(const std::vector<WorldPoint>& pts, const Blockers& blk, double eps, const ClearanceFloor* cfl);
 
 std::vector<WorldPoint> DropLoops(const std::vector<WorldPoint>& pts);
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -202,6 +202,26 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
         const float c = std::min(std::max((pref.v[i] - info.dist.v[i]) / pref.v[i], 0.0F), 1.0F);
         mult.v[i] = 1.0F + static_cast<float>(kLam) * c;
     }
+    // 几何口径的净空: 掩膜距离场对跨越约束的墙无感, 取真墙距离的下确界补上
+    Mask wfree(nx, ny, 0);
+    for (size_t i = 0; i < wfree.v.size(); ++i) {
+        wfree.v[i] = info.wcsr.start[i + 1] > info.wcsr.start[i] ? 0 : 1;
+    }
+    const Grid<float> wdist = Clearance(wfree);
+    Grid<float> dgeo(nx, ny, 0.0F);
+    for (size_t i = 0; i < dgeo.v.size(); ++i) {
+        dgeo.v[i] = std::min(info.dist.v[i], wdist.v[i]);
+    }
+    // 几何口径的余量目标: 通道半宽封顶 kGeoR, 供绿段重寻与拉直判定
+    const Grid<float> tgt = TargetField(dgeo);
+    Grid<float> multg(nx, ny, 0.0F);
+    Grid<float> cf(nx, ny, 0.0F);
+    for (size_t i = 0; i < multg.v.size(); ++i) {
+        const float c = std::min(std::max((tgt.v[i] - dgeo.v[i]) / tgt.v[i], 0.0F), 1.0F);
+        multg.v[i] = 1.0F + static_cast<float>(kLam) * c;
+        cf.v[i] = std::min(dgeo.v[i], tgt.v[i]);
+    }
+    const ClearanceFloor cfl(&cf, &multg, x0, y0, kCS);
 
     const CellPt sc { static_cast<int64_t>((s.x - x0) / kCS), static_cast<int64_t>((s.y - y0) / kCS) };
     const CellPt gc { static_cast<int64_t>((g.x - x0) / kCS), static_cast<int64_t>((g.y - y0) / kCS) };
@@ -258,10 +278,12 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
         return std::nullopt;
     }
     const int64_t NC = nx * ny;
+    std::vector<size_t> bad;
     for (size_t k = 1; k < q->size(); ++k) {
         const int64_t ca = (*q)[k - 1].y * nx + (*q)[k - 1].x;
         const int64_t cb = (*q)[k].y * nx + (*q)[k].x;
         if (bn.contains(ca * NC + cb)) {
+            bad.push_back(k);
             dg.xwall.push_back({ x0 + (static_cast<double>((*q)[k].x) + 0.5) * kCS, y0 + (static_cast<double>((*q)[k].y) + 0.5) * kCS });
         }
     }
@@ -341,7 +363,6 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
     }
     const std::vector<Run> mg = merge(runs);
 
-    const Grid<float> ones(nx, ny, 1.0F);
     std::vector<WorldPoint> taut;
     for (const auto& run : mg) {
         const int64_t iend = std::min(run.i1 + 1, static_cast<int64_t>(q->size()) - 1);
@@ -383,7 +404,31 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                             || pm.at(y, x) != 0);
                     }
                 }
-                const auto q2 = CostAstar(er, cells.front(), cells.back(), ones, &bn, nullptr);
+                // 重寻硬禁穿墙步,不可避穿墙处切开逐子段重寻,原步原样保留
+                std::vector<size_t> cuts;
+                for (const size_t k : bad) {
+                    if (k > static_cast<size_t>(run.i0) && k <= static_cast<size_t>(run.i0) + cells.size() - 1) {
+                        cuts.push_back(k - static_cast<size_t>(run.i0));
+                    }
+                }
+                cuts.push_back(cells.size());
+                std::optional<std::vector<CellPt>> q2 = std::vector<CellPt> {};
+                size_t a2 = 0;
+                for (const size_t c2 : cuts) {
+                    const size_t b2 = c2 - 1;
+                    if (a2 == b2) {
+                        q2->push_back(cells[a2]);
+                    }
+                    else {
+                        const auto r2 = CostAstar(er, cells[a2], cells[b2], multg, &bn, nullptr);
+                        if (!r2.has_value()) {
+                            q2.reset();
+                            break;
+                        }
+                        q2->insert(q2->end(), r2->begin(), r2->end());
+                    }
+                    a2 = c2;
+                }
                 if (q2.has_value()) {
                     double l1 = 0.0;
                     double l2 = 0.0;
@@ -409,7 +454,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                 lw.insert(lw.end(), loops_core.begin(), loops_core.end());
                 blk_green.emplace(lw, &info.wP0, &info.wP1, onm);
             }
-            pp = StringPull(pp, blk_green.has_value() ? *blk_green : blk_gray);
+            pp = StringPull(pp, blk_green.has_value() ? *blk_green : blk_gray, &cfl);
         }
         if (!taut.empty() && !pp.empty() && std::hypot(pp.front().x - taut.back().x, pp.front().y - taut.back().y) < 1e-9) {
             pp.erase(pp.begin());
@@ -436,7 +481,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
     }
     std::vector<WorldPoint> out = DropLoops(ded);
     if (kSlimEps > 0 && out.size() > 2) {
-        out = Slim(out, blk_gray, kSlimEps);
+        out = Slim(out, blk_gray, kSlimEps, &cfl);
     }
     return out;
 }

--- a/tools/MapNavigator/recastnav.py
+++ b/tools/MapNavigator/recastnav.py
@@ -10,11 +10,14 @@ CLIMB = 3.0        # 相邻格可连通最大高差 px
 MERGE_H = 1.0      # 同列 span 合并容差 px
 EDT_CAP = 12.0     # 距离场截断 px
 R = 1.75           # 期望余量上限 px
+GEO_R = 3.5        # 几何口径舒适余量上限 px
 REL = 0.6          # 期望余量 = min(R, REL×局部净空)
 LAM = 1.5          # 满亏欠一步加价倍数
 RIDGEF = 0.5       # 脊线保底余量地板 px
 MAXERR = 0.5       # 轮廓 DP 容差 px
 SLIMEPS = 0.5      # 终线共线剔除容差 px
+CLRTOL = 0.125     # 拉直允许的净空退让 px, 取半格即采样步长
+COSTTOL = 1e-9     # 代价判据相对容差, 容纳共线子路径的浮点求和差
 TAU = 1.0          # 贴墙诊断阈 px
 CAP = 12.0         # wall_dist 截断 px
 MC_HBAND = 8.0     # 层高度带(墙筛/盖章)px
@@ -517,7 +520,12 @@ def pref_field(dist, ridge=False):
     return np.where(rg, np.minimum(pref, dist), pref)
 
 
-def slim(pts, blk, eps=SLIMEPS):
+def target_field(dist):
+    locw = local_max(dist, int(math.ceil(R / CS)))
+    return np.maximum(np.minimum(GEO_R, locw), 0.25)
+
+
+def slim(pts, blk, eps=SLIMEPS, cfl=None):
     P = [tuple(p) for p in pts]
     ch = True
     while ch:
@@ -530,7 +538,9 @@ def slim(pts, blk, eps=SLIMEPS):
             t = 0.0 if L2 == 0 else max(0.0, min(1.0, (
                 (b[0] - a[0]) * ux + (b[1] - a[1]) * uy) / L2))
             d = math.hypot(b[0] - a[0] - t * ux, b[1] - a[1] - t * uy)
-            if d <= eps and not blk.blocked(a, c):
+            if d <= eps and not blk.blocked(a, c) and (
+                    cfl is None
+                    or cfl.seg(a, c) >= min(cfl.seg(a, b), cfl.seg(b, c))):
                 P.pop(i)
                 ch = True
             else:
@@ -685,19 +695,68 @@ class Blockers:
         return not bool(msk[gy, gx].all())
 
 
-def string_pull(pts, blk, rounds=6):
+# 沿弦按半格步长采样: seg 取 min(净空, 目标余量) 的下确界, cost 取代价泛函积分
+class ClearanceFloor:
+    def __init__(self, cf, mg, x0, y0, cs=CS):
+        self.cf = cf
+        self.mg = mg
+        self.x0 = x0
+        self.y0 = y0
+        self.cs = cs
+
+    def _cells(self, p, q, t):
+        gx = ((p[0] + (q[0] - p[0]) * t - self.x0) / self.cs).astype(np.int64)
+        gy = ((p[1] + (q[1] - p[1]) * t - self.y0) / self.cs).astype(np.int64)
+        return (np.clip(gy, 0, self.cf.shape[0] - 1),
+                np.clip(gx, 0, self.cf.shape[1] - 1))
+
+    def seg(self, p, q):
+        L = float(np.hypot(q[0] - p[0], q[1] - p[1]))
+        gy, gx = self._cells(p, q, np.linspace(0.0, 1.0,
+                                               int(L / (self.cs * 0.5)) + 2))
+        return float(self.cf[gy, gx].min())
+
+    def cost(self, p, q):
+        L = float(np.hypot(q[0] - p[0], q[1] - p[1]))
+        n = max(int(math.ceil(L / (self.cs * 0.5))), 1)
+        gy, gx = self._cells(p, q, (np.arange(n) + 0.5) / n)
+        return L * float(self.mg[gy, gx].mean(dtype=np.float64))
+
+
+def string_pull(pts, blk, rounds=6, cfl=None):
     P = [tuple(map(float, p)) for p in pts]
+    # 跨点连线须同时不低于被跳过子路径的净空地板、不高于其代价泛函(与几何重寻同口径),
+    # 相邻点连线无条件保留
+    seg = cst = None
+    if cfl is not None and len(P) > 1:
+        seg = np.array([cfl.seg(P[k], P[k + 1]) for k in range(len(P) - 1)],
+                       dtype=np.float64)
+        cst = np.array([cfl.cost(P[k], P[k + 1]) for k in range(len(P) - 1)],
+                       dtype=np.float64)
+    idx = list(range(len(P)))
     for _ in range(rounds):
         out = [P[0]]
+        oid = [idx[0]]
         i = 0
         while i < len(P) - 1:
+            acc = None if seg is None else np.minimum.accumulate(seg[idx[i]:])
+            ac2 = None if cst is None else np.cumsum(cst[idx[i]:])
             j = len(P) - 1
-            while j > i + 1 and blk.blocked(P[i], P[j]):
+            while j > i + 1:
+                k = idx[j] - idx[i] - 1
+                if not blk.blocked(P[i], P[j]) and (
+                        acc is None
+                        or (cfl.seg(P[i], P[j]) >= float(acc[k]) - CLRTOL
+                            and cfl.cost(P[i], P[j])
+                            <= float(ac2[k]) * (1.0 + COSTTOL))):
+                    break
                 j -= 1
             out.append(P[j])
+            oid.append(idx[j])
             i = j
         changed = len(out) != len(P)
         P = out
+        idx = oid
         if not changed:
             break
     return P

--- a/tools/MapNavigator/recastnav_route.py
+++ b/tools/MapNavigator/recastnav_route.py
@@ -137,6 +137,14 @@ def route(info, s, g):
     pref = rc.pref_field(dist)
     mult = 1.0 + LAM * np.clip((pref - dist) / pref, 0.0, 1.0)
     prefg = rc.pref_field(dist, ridge=True)
+    # 几何口径的净空: 掩膜距离场对跨越约束的墙无感, 取真墙距离的下确界补上
+    ws = info["wstart"]
+    wcell = (ws[1:] > ws[:-1]).reshape(ny, nx)
+    dg = np.minimum(dist, rc.clearance(~wcell))
+    # 几何口径的余量目标: 通道半宽封顶 GEO_R, 供绿段重寻与拉直判定
+    tgt = rc.target_field(dg)
+    multg = 1.0 + LAM * np.clip((tgt - dg) / tgt, 0.0, 1.0)
+    cfl = rc.ClearanceFloor(np.minimum(dg, tgt), multg, x0, y0, CS)
 
     sc = (int((s[0] - x0) / CS), int((s[1] - y0) / CS))
     gc = (int((g[0] - x0) / CS), int((g[1] - y0) / CS))
@@ -167,9 +175,11 @@ def route(info, s, g):
         return None, {"err": "不连通", "warn": warn}
     t_as = time.time() - t0
     xw = []
+    bad = []
     for k in range(1, len(q)):
         if (q[k - 1][1] * nx + q[k - 1][0],
                 q[k][1] * nx + q[k][0]) in bn:
+            bad.append(k)
             xw.append((x0 + (q[k][0] + 0.5) * CS,
                        y0 + (q[k][1] + 0.5) * CS))
     if xw:
@@ -214,7 +224,6 @@ def route(info, s, g):
         if r_[0] and (r_[2] - r_[1]) * CS < 1.5:
             r_[0] = False
     mg = merge(runs)
-    ones = np.ones_like(mult)
     taut = []
     for isg, i0, i1 in mg:
         cells = q[i0:min(i1 + 1, len(q) - 1) + 1]
@@ -235,7 +244,18 @@ def route(info, s, g):
                         acc |= rc._sh(pmd, -i_ * dy, -i_ * dx)
                     pmd = acc
                 er = (dist >= pref) | ((dist >= prefg) & pmd) | pm
-                q2 = rc.cost_astar(er, cells[0], cells[-1], ones, bn, None)
+                # 重寻硬禁穿墙步,不可避穿墙处切开逐子段重寻,原步原样保留
+                cuts = [k - i0 for k in bad if i0 < k <= i0 + len(cells) - 1]
+                q2, a2 = [], 0
+                for c2 in cuts + [len(cells)]:
+                    b2 = c2 - 1
+                    r2 = ([cells[a2]] if a2 == b2 else
+                          rc.cost_astar(er, cells[a2], cells[b2], multg, bn, None))
+                    if r2 is None:
+                        q2 = None
+                        break
+                    q2.extend(r2)
+                    a2 = c2
                 if q2 is not None:
                     l2 = sum(math.dist(q2[k - 1], q2[k])
                              for k in range(1, len(q2)))
@@ -248,7 +268,7 @@ def route(info, s, g):
                 blk = rc.Blockers(
                     [w(P) for P in lp] + [w(P) for P in loops_c],
                     extra=wseg, on=onm)
-            pp = [tuple(p) for p in rc.string_pull(pp, blk)]
+            pp = [tuple(p) for p in rc.string_pull(pp, blk, cfl=cfl)]
         if taut and pp and math.dist(pp[0], taut[-1]) < 1e-9:
             pp = pp[1:]
         taut.extend(pp)
@@ -263,7 +283,7 @@ def route(info, s, g):
             ded.append(p)
     line = rc.drop_loops(ded)
     if SLIMEPS > 0 and len(line) > 2:
-        line = rc.slim(line, blk_gray, SLIMEPS)
+        line = rc.slim(line, blk_gray, SLIMEPS, cfl)
     return line, {"warn": warn, "snapd": (dsa, dga),
                   "t_as": t_as, "t_sp": t_sp, "xwall": xw}
 


### PR DESCRIPTION
- fix #4198 
- fix #4525 
- fix #4527 
- fix #4530 

<img width="2325" height="1230" alt="image" src="https://github.com/user-attachments/assets/61b86648-2746-47c9-9697-6b27fd004a05" />

## Summary by Sourcery

收紧 MapNavigator 的路径规划，使其在拉直路径和重新运行路径段时，能够遵守净空和成本约束，并在 C++ 和 Python 实现中使用统一的净空下限。

New Features:
- 引入净空下限模型和目标场计算，用于指导导航网格路径中的几何路径优化以及成本评估。

Bug Fixes:
- 防止路径拉直过程减少与墙体的净空，或将有效路径成本降到原始路径段之下，从而避免不安全的捷径和穿墙问题。
- 确保在绕过违反约束的步进时，仅拆分受影响的子路径段，同时保留不可避免的贴墙（穿墙）步进。

Enhancements:
- 对齐 C++ 和 Python 的 MapNavigator 实现，使其在净空容差和几何舒适半径方面共享一致的参数和逻辑。
- 优化 Slim 和 StringPull 操作，在简化最终路径时，同时考虑障碍阻挡以及净空/成本分布特性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten MapNavigator routing to respect clearance and cost when straightening paths and re-running segments, using a unified clearance floor in both C++ and Python implementations.

New Features:
- Introduce a clearance floor model and target-field computation to guide geometric path refinement and cost evaluation in navmesh routing.

Bug Fixes:
- Prevent path straightening from reducing wall clearance or lowering effective path cost below the original routed segments, avoiding unsafe shortcuts and wall clipping.
- Ensure re-routing around constraint-violating steps splits only the affected subsegments while preserving unavoidable wall-crossing steps.

Enhancements:
- Align C++ and Python MapNavigator implementations with shared parameters and logic for clearance tolerances and geometric comfort radii.
- Refine Slim and StringPull operations to consider both obstacle blockers and clearance/cost profiles when simplifying final routes.

</details>