### PR TITLE
feat(MapNavigator): 补齐 tick 时延与转向残差埋点

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/motion_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/motion_controller.cpp
@@ -209,13 +209,18 @@ TurnCommandResult MotionController::SendViewDelta(double delta_degrees)
     if (units == 0) {
         units = delta_degrees > 0.0 ? 1 : -1;
     }
-    if (!action_wrapper_->SendViewDeltaSync(units, 0)) {
+    const auto send_started_at = std::chrono::steady_clock::now();
+    const bool sent = action_wrapper_->SendViewDeltaSync(units, 0);
+    const int64_t send_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - send_started_at).count();
+    if (!sent) {
+        LogWarn << "Steering command rejected by the input backend." << VAR(delta_degrees) << VAR(units) << VAR(send_ms);
         return result;
     }
 
     result.issued = true;
     result.issued_delta_degrees = delta_degrees;
-    LogDebug << "Steering command issued." << VAR(delta_degrees) << VAR(units);
+    LogDebug << "Steering command issued." << VAR(delta_degrees) << VAR(units) << VAR(send_ms);
     return result;
 }
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -43,6 +43,10 @@ struct FlowState
 {
     std::chrono::steady_clock::time_point navigate_started_at {};
     std::chrono::steady_clock::time_point last_auto_sprint_time {};
+    // Entry stamp of the previous navigate tick, so the tick log can report the real loop period. Stamped on
+    // every entry including the ones that bail out early, and only ever reported from the steering tick, so a
+    // large gap means the ticks in between returned early rather than that this one ran long.
+    std::chrono::steady_clock::time_point last_tick_started_at {};
 };
 
 struct SemanticState
@@ -144,17 +148,27 @@ struct LateralBypassState
 // Previous-tick heading, used to estimate the agent's own turn rate for the steering damping term. Only the
 // physical heading is tracked here; the rate is gated at the call site on the elapsed gap and on plausibility,
 // so a stale entry after a recovery / relocation pause simply yields a zero rate that tick rather than a spike.
+// The cmd_* fields are diagnostic only: they hold the last turn actually sent to the controller so a later tick
+// can report how much heading the turn really produced. Nothing steers off them.
 struct SteeringRateState
 {
     double prev_heading_deg = 0.0;
     bool has_prev = false;
     std::chrono::steady_clock::time_point at {};
+    double cmd_heading_deg = 0.0;
+    double cmd_delta_deg = 0.0;
+    bool has_cmd = false;
+    std::chrono::steady_clock::time_point cmd_at {};
 
     void Reset()
     {
         prev_heading_deg = 0.0;
         has_prev = false;
         at = {};
+        cmd_heading_deg = 0.0;
+        cmd_delta_deg = 0.0;
+        has_cmd = false;
+        cmd_at = {};
     }
 };
 
@@ -247,6 +261,7 @@ struct NavigationRuntimeState
         nav_run_dirty = true;
         flow.navigate_started_at = now;
         flow.last_auto_sprint_time = {};
+        flow.last_tick_started_at = {};
     }
 
     void OnWaypointAdvance()

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -676,7 +676,9 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
         runtime_state_.route.startup_motion_confirmed = true;
     }
     runtime_state_.dynamic_replan_requested = false;
-    LogInfo << "Dynamic navmesh overlay selected." << VAR(reason) << VAR(use_detour) << VAR(continue_index) << VAR(generated_count);
+    const size_t planned_points = route->path.points.size();
+    LogInfo << "Dynamic navmesh overlay selected." << VAR(reason) << VAR(use_detour) << VAR(continue_index) << VAR(generated_count)
+            << VAR(planned_points) << VAR(detour_vertex.x) << VAR(detour_vertex.y) << VAR(anchor.x) << VAR(anchor.y);
     return true;
 }
 
@@ -845,6 +847,13 @@ bool NavigationStateMachine::ExecutePhysicalUnstick(double stuck_heading)
 
 bool NavigationStateMachine::TickNavigate()
 {
+    const auto tick_started_at = std::chrono::steady_clock::now();
+    const int64_t tick_gap_ms =
+        runtime_state_.flow.last_tick_started_at.time_since_epoch().count() > 0
+            ? std::chrono::duration_cast<std::chrono::milliseconds>(tick_started_at - runtime_state_.flow.last_tick_started_at).count()
+            : 0;
+    runtime_state_.flow.last_tick_started_at = tick_started_at;
+
     if (!session_->HasCurrentWaypoint()) {
         session_->NoteRouteTailConsumed(*position_, "route_tail_consumed");
         return true;
@@ -870,7 +879,11 @@ bool NavigationStateMachine::TickNavigate()
         return true;
     }
 
-    if (!CaptureCurrentPosition(false)) {
+    const auto capture_started_at = std::chrono::steady_clock::now();
+    const bool position_captured = CaptureCurrentPosition(false);
+    const int64_t capture_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - capture_started_at).count();
+    if (!position_captured) {
         return HandleLocalizationLoss();
     }
     {
@@ -935,6 +948,13 @@ bool NavigationStateMachine::TickNavigate()
     const double current_heading = NaviMath::NormalizeAngle(position_->angle);
     const bool degraded_fix =
         position_provider_->LastCaptureWasHeld() || position_provider_->LastCaptureWasBlackScreen() || !position_->valid;
+    // Gap between the screencap this tick's fix came from and the decision below: the locate itself plus the work
+    // in between. Every successful capture restamps, held ones included, so how stale the coordinates themselves
+    // are is held_fix_streak, not this.
+    const int64_t fix_age_ms = position_->timestamp.time_since_epoch().count() > 0
+                                   ? std::chrono::duration_cast<std::chrono::milliseconds>(now - position_->timestamp).count()
+                                   : 0;
+    const int held_fix_streak = position_provider_->HeldFixStreak();
 
     const size_t node_idx_before_tracking = session_->current_node_idx();
     RouteTrackingState route = RouteTracker::Update(session_, &runtime_state_.route, *position_);
@@ -1312,6 +1332,19 @@ bool NavigationStateMachine::TickNavigate()
 
     const double effective_route_heading = nav_run_result.has_corridor_heading ? nav_run_result.corridor_heading : route.route_heading;
 
+    // Heading observed to have moved since the last turn was sent, and how far that lands from the commanded
+    // delta. It is the whole observed change, not the turn in isolation: forward motion and camera follow are in
+    // there too. Only ticks that really send a turn stamp the reference below, so on a tick that sends nothing
+    // these keep reporting the previous command as it settles — the elapsed field tells the two apart.
+    double turn_achieved_deg = 0.0;
+    double turn_residual_deg = 0.0;
+    int64_t turn_elapsed_ms = 0;
+    if (runtime_state_.steering_rate.has_cmd) {
+        turn_achieved_deg = NaviMath::NormalizeAngle(current_heading - runtime_state_.steering_rate.cmd_heading_deg);
+        turn_residual_deg = NaviMath::NormalizeAngle(turn_achieved_deg - runtime_state_.steering_rate.cmd_delta_deg);
+        turn_elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - runtime_state_.steering_rate.cmd_at).count();
+    }
+
     double heading_rate_deg = 0.0;
     double heading_rate_raw_delta_deg = 0.0;
     int64_t heading_rate_gap_ms = 0;
@@ -1346,11 +1379,30 @@ bool NavigationStateMachine::TickNavigate()
             issued_delta_deg = steering_result.issued_delta_degrees;
         }
     }
+    if (issued_delta_deg != 0.0) {
+        runtime_state_.steering_rate.cmd_heading_deg = current_heading;
+        runtime_state_.steering_rate.cmd_delta_deg = issued_delta_deg;
+        runtime_state_.steering_rate.cmd_at = now;
+        runtime_state_.steering_rate.has_cmd = true;
+    }
 
+    const double lookahead_x = nav_run_result.lookahead_point.x;
+    const double lookahead_y = nav_run_result.lookahead_point.y;
+    const int nav_run_replan_reason = static_cast<int>(nav_run_result.replanned_with);
+    LogDebug << "TickNavigate corridor target." << VAR(session_->current_node_idx()) << VAR(waypoint.x) << VAR(waypoint.y)
+             << VAR(waypoint.RequiresStrictArrival()) << VAR(lookahead_x) << VAR(lookahead_y) << VAR(nav_run_result.remaining_to_anchor)
+             << VAR(nav_run_result.passed_run_waypoints) << VAR(nav_run_replan_reason) << VAR(route.along_track_remaining)
+             << VAR(route.cross_track) << VAR(route.projection_anchor) << VAR(arrival_distance) << VAR(position_->zone_id)
+             << VAR(stalled_ms);
+
+    const int64_t tick_compute_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - tick_started_at).count();
     LogDebug << "TickNavigate steering decision." << VAR(current_heading) << VAR(route.route_heading) << VAR(effective_route_heading)
              << VAR(nav_run_result.has_corridor_heading) << VAR(nav_run_result.cross_track) << VAR(nav_run_result.upcoming_turn_deg)
              << VAR(heading_rate_deg) << VAR(heading_rate_raw_delta_deg) << VAR(heading_rate_gap_ms) << VAR(heading_error)
-             << VAR(steering.yaw_delta_deg) << VAR(issued_delta_deg) << VAR(route.waypoint_distance) << VAR(route.on_route);
+             << VAR(steering.yaw_delta_deg) << VAR(issued_delta_deg) << VAR(turn_achieved_deg) << VAR(turn_residual_deg)
+             << VAR(turn_elapsed_ms) << VAR(route.waypoint_distance) << VAR(route.on_route) << VAR(degraded_fix) << VAR(held_fix_streak)
+             << VAR(capture_ms) << VAR(fix_age_ms) << VAR(tick_gap_ms) << VAR(tick_compute_ms);
 
     // Collect routes: keep sprint for travel but drop to walking speed once near a COLLECT point (cancels any
     // active sprint), so the detection-stop can land before we overrun the collectible. No-op off collect

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <condition_variable>
 #include <cstddef>
@@ -480,25 +481,31 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRouteImpl(
     }
 
     const std::filesystem::path navmesh_path = ResolveNavmeshFile(param.navmesh_file);
+    const auto load_started_at = std::chrono::steady_clock::now();
     const auto navmesh = LoadCachedNavmesh(navmesh_path, navmesh_zone);
+    const int64_t navmesh_load_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - load_started_at).count();
     if (!navmesh) {
         return std::nullopt;
     }
 
     const bool detour_probe = !blocked_triangles.empty() || !blocked_points.empty();
     const auto request = BuildRouteRequest(navmesh->pack, locator_zone, navmesh_zone, start, goal, blocked_triangles, blocked_points);
+    const auto plan_started_at = std::chrono::steady_clock::now();
     const auto route_result = PlanCorridorRoute(*navmesh, request);
+    const int64_t plan_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - plan_started_at).count();
     if (!route_result.ok()) {
         if (!detour_probe) {
             LogWarn << "Failed to plan NAVMESH route." << VAR(navmesh_zone) << VAR(locator_zone) << VAR(start.x) << VAR(start.y)
-                    << VAR(goal.x) << VAR(goal.y) << VAR(navmesh::ToString(route_result.status));
+                    << VAR(goal.x) << VAR(goal.y) << VAR(navmesh::ToString(route_result.status)) << VAR(plan_ms);
         }
         return std::nullopt;
     }
 
     if (!detour_probe) {
         LogInfo << "NAVMESH route planned." << VAR(navmesh_zone) << VAR(locator_zone) << VAR(route_result.cost)
-                << VAR(route_result.path.points.size());
+                << VAR(route_result.path.points.size()) << VAR(plan_ms) << VAR(navmesh_load_ms);
     }
     return route_result;
 }
@@ -633,14 +640,20 @@ bool AppendNavmeshWaypoint(
     NavmeshExpansionState& state,
     std::vector<Waypoint>& out_path)
 {
+    const auto expand_started_at = std::chrono::steady_clock::now();
     const ProjectedTarget target = ResolveProjectedTarget(navmesh.pack, waypoint);
     navmesh::BaseNavRouteRequest request =
         BuildRouteRequest(navmesh.pack, state.current_zone, state.navmesh_zone, state.route_start, target.point, {}, {}, target.floor_y);
+    const auto plan_started_at = std::chrono::steady_clock::now();
     auto route_result = PlanCorridorRoute(navmesh, request);
+    bool start_recovered = false;
     if (!route_result.ok() && AppendStartRecovery(param, navmesh, request, state, out_path)) {
         request.start = state.route_start;
         route_result = PlanCorridorRoute(navmesh, request);
+        start_recovered = true;
     }
+    const int64_t plan_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - plan_started_at).count();
     if (!route_result.ok()) {
         LogWarn << "NAVMESH waypoint not directly reachable; attempting blind-target fallback." << VAR(state.navmesh_zone)
                 << VAR(state.current_zone) << VAR(target.point.x) << VAR(target.point.y) << VAR(navmesh::ToString(route_result.status));
@@ -653,6 +666,7 @@ bool AppendNavmeshWaypoint(
     }
 
     LogGeneratedNavmeshPath(state, request, route_result);
+    const size_t insert_index = out_path.size();
     if (!AppendGeneratedNavmeshWaypoints(route_result.path, out_path, true, false, &navmesh.planner, route_result.path.zone_id)) {
         LogError << "NAVMESH planning returned an empty path." << VAR(state.navmesh_zone);
         return false;
@@ -660,7 +674,13 @@ bool AppendNavmeshWaypoint(
 
     state.route_start = route_result.path.points.back();
     const size_t path_point_count = route_result.path.points.size();
-    LogInfo << "Expanded NAVMESH waypoint." << VAR(state.navmesh_zone) << VAR(state.current_zone) << VAR(path_point_count);
+    const size_t appended_waypoints = out_path.size() - insert_index;
+    const size_t route_waypoints = out_path.size();
+    const int64_t expand_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - expand_started_at).count();
+    LogInfo << "Expanded NAVMESH waypoint." << VAR(state.navmesh_zone) << VAR(state.current_zone) << VAR(path_point_count)
+            << VAR(insert_index) << VAR(appended_waypoints) << VAR(route_waypoints) << VAR(start_recovered) << VAR(plan_ms)
+            << VAR(expand_ms);
     return true;
 }
 
@@ -770,7 +790,10 @@ bool ExpandNavmeshWaypoints(const NaviParam& param, const NaviPosition& initial_
     }
 
     const std::filesystem::path navmesh_path = ResolveNavmeshFile(param.navmesh_file);
+    const auto expand_started_at = std::chrono::steady_clock::now();
     const auto navmesh = LoadCachedNavmesh(navmesh_path, state->navmesh_zone);
+    const int64_t navmesh_load_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - expand_started_at).count();
     if (!navmesh) {
         return false;
     }
@@ -791,6 +814,12 @@ bool ExpandNavmeshWaypoints(const NaviParam& param, const NaviPosition& initial_
             return false;
         }
     }
+    const int64_t expand_total_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - expand_started_at).count();
+    const size_t authored_waypoints = param.path.size();
+    const size_t expanded_waypoints = out_path.size();
+    LogInfo << "NAVMESH route expansion finished." << VAR(state->navmesh_zone) << VAR(authored_waypoints) << VAR(expanded_waypoints)
+            << VAR(navmesh_load_ms) << VAR(expand_total_ms);
     return true;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

为导航和导航网格（navmesh）路径规划加入额外的计时和诊断遥测，用于监控 tick 节奏、定位数据新鲜度、转向变化以及路径扩展/规划。

Enhancements:
- 为 TickNavigate 日志增加详细的计时和诊断字段，包括 tick 间隔、采集时长、定位解龄期（fix age）、转向残差以及计算时间。
- 在导航运行时状态中追踪上一次 tick 入口时间和最后一次下发的转向指令，以便下游遥测使用。
- 扩展动态 navmesh 覆盖层选择和通道（corridor）目标日志，加入计划点数量、绕行/锚点坐标以及前视/重规划上下文信息。
- 测量并记录 navmesh 加载、通道规划以及航点扩展的耗时，同时记录航点数量和恢复相关元数据。
- 为运动控制器的视角增量（view-delta）指令加入发送延迟统计，并显式记录被拒绝的指令日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Instrument navigation and navmesh routing with additional timing and diagnostic telemetry for tick cadence, localization freshness, steering turns, and path expansion/planning.

Enhancements:
- Add detailed timing and diagnostic fields to TickNavigate logs, including tick gap, capture duration, fix age, turn residuals, and compute time.
- Track last tick entry time and last issued steering command in navigation runtime state for downstream telemetry.
- Extend dynamic navmesh overlay selection and corridor target logs with planned point counts, detour/anchor coordinates, and lookahead/replan context.
- Measure and log navmesh load, corridor planning, and waypoint expansion timings, along with waypoint counts and recovery metadata.
- Instrument motion controller view-delta commands with send latency and explicit rejection logging.

</details>