### PR TITLE
feat: 取货前取消任务追踪蓝点

### DIFF
--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsPost.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsPost.json
@@ -142,7 +142,8 @@
         "post_delay": 0,
         "next": [
             "SeizeDeliveryJobsIsCarryingGoods",
-            "[Anchor]SeizeDeliveryJobsWalkToDepotNode", // 没有携带货物，则正常去走到仓储节点
+            "SeizeDeliveryJobsPrepareFetchGoods", // 全自动送货模式下，先取消任务追踪再前往仓储节点
+            "[Anchor]SeizeDeliveryJobsWalkToDepotNode", // 其他模式下，直接前往仓储节点
             "SeizeDeliveryJobsFatalCannotDetermineDestination" // 兜底报错回显，以防 Anchor 未被赋值
         ]
     },
@@ -264,7 +265,44 @@
             "Node.Recognition.Succeeded": "正在重新走到试验园区仓储节点"
         }
     },
-    // ===== 接取货物的收尾流程 =====
+    // ===== 接取货物流程 =====
+    "SeizeDeliveryJobsPrepareFetchGoods": {
+        "desc": "自动接取货物前的准备入口，先进入当前任务地图取消任务追踪（此节点默认关闭）",
+        "enabled": false,
+        "pre_delay": 0,
+        "anchor": {
+            "SeizeDeliveryJobsAfterEnterDestinationMap": "SeizeDeliveryJobsCancelTrackingBeforeFetch"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SeizeDeliveryJobsEnterDestinationMap"
+        ],
+        "focus": {
+            "Node.Action.Starting": "准备取消任务追踪后接取货物"
+        }
+    },
+    "SeizeDeliveryJobsCancelTrackingBeforeFetch": {
+        "desc": "在当前任务地图取消任务追踪，返回大世界后再前往仓储节点接取货物",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SeizeDeliveryJobsCancelTracking",
+                "SceneAnyEnterWorld"
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[Anchor]SeizeDeliveryJobsWalkToDepotNode",
+            "SeizeDeliveryJobsFatalCannotDetermineDestination"
+        ],
+        "focus": {
+            "Node.Action.Starting": "取消任务追踪后返回大世界"
+        }
+    },
     "SeizeDeliveryJobsFetchGoods": {
         "desc": "在任意仓储节点面前，接取货物",
         "recognition": "TemplateMatch",

--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsPostDeparture.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsPostDeparture.json
@@ -57,7 +57,7 @@
         ]
     },
     "SeizeDeliveryJobsCancelTracking": {
-        "desc": "在目的地地图界面，取消任务追踪以防止追踪标志干扰后续识别",
+        "desc": "在当前任务地图界面，取消任务追踪以防止追踪标志干扰后续识别",
         "enabled": true,
         "recognition": "TemplateMatch",
         "roi": [
@@ -74,7 +74,7 @@
             // 后续由 Go 内部逻辑来进行后续流程控制
         ],
         "focus": {
-            "Node.Action.Starting": "成功识别目的地位置"
+            "Node.Action.Starting": "取消任务追踪"
         }
     },
     "SeizeDeliveryJobsSubmitEntry": {

--- a/assets/tasks/SeizeDeliveryJobs.json
+++ b/assets/tasks/SeizeDeliveryJobs.json
@@ -303,6 +303,9 @@
                         "SeizeDeliveryJobsPostProcessingEntry": {
                             "enabled": true
                         },
+                        "SeizeDeliveryJobsPrepareFetchGoods": {
+                            "enabled": true
+                        },
                         "SeizeDeliveryJobsPostDepartureEntry": {
                             "enabled": true
                         }


### PR DESCRIPTION
## Summary by Sourcery

更新 SeizeDeliveryJobs 流水线和任务配置，以在取件前停止追踪蓝色位置标记。

New Features:
- 调整 SeizeDeliveryJobs 的 post 和 departure 流水线资源，以禁用在取件前对蓝色位置指示器的追踪。

Enhancements:
- 将 SeizeDeliveryJobs 任务配置与新的行为对齐，即在取件前不再追踪蓝色标记。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update SeizeDeliveryJobs pipeline and task configuration to stop tracking the blue location marker before pickup.

New Features:
- Adjust SeizeDeliveryJobs post and departure pipeline resources to disable pre-pickup tracking of the blue position indicator.

Enhancements:
- Align SeizeDeliveryJobs task configuration with the new behavior of not tracking the blue marker prior to pickup.

</details>