### PR TITLE
fix(MapNavigator): 起点离网时按吸附点取窗口种子

### DIFF
--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -46,6 +46,7 @@ std::optional<WindowInfo> buildWindow(
     const ZoneClean& zc,
     WallOracle& wo,
     const WorldPoint& s,
+    const WorldPoint& s_snap,
     double h0,
     double x0,
     double y0,
@@ -72,10 +73,17 @@ std::optional<WindowInfo> buildWindow(
     }
     const std::vector<uint8_t> dead = StampWalls(p0, p1, hh, x0, y0, nx, ny, st);
 
-    const int64_t gx = static_cast<int64_t>((s.x - x0) / kCS);
-    const int64_t gy = static_cast<int64_t>((s.y - y0) / kCS);
-    const int64_t cell0 = gy * nx + gx;
-    const auto occ_it = std::lower_bound(st.occ.begin(), st.occ.end(), cell0);
+    int64_t gx = static_cast<int64_t>((s.x - x0) / kCS);
+    int64_t gy = static_cast<int64_t>((s.y - y0) / kCS);
+    int64_t cell0 = gy * nx + gx;
+    auto occ_it = std::lower_bound(st.occ.begin(), st.occ.end(), cell0);
+    if (occ_it == st.occ.end() || *occ_it != cell0) {
+        // 起点离网时其所在格无体素,退用按楼层吸附过的起点定种子
+        gx = static_cast<int64_t>((s_snap.x - x0) / kCS);
+        gy = static_cast<int64_t>((s_snap.y - y0) / kCS);
+        cell0 = gy * nx + gx;
+        occ_it = std::lower_bound(st.occ.begin(), st.occ.end(), cell0);
+    }
     if (occ_it == st.occ.end() || *occ_it != cell0) {
         err = "起点格无体素 (gx=" + std::to_string(gx) + ",gy=" + std::to_string(gy) + ")";
         return std::nullopt;
@@ -574,7 +582,7 @@ RecastPlanResult RecastNavEngine::planLocked(
             return res;
         }
         std::string err;
-        const auto info = buildWindow(zc, wo, start, h0, x0, y0, x1, y1, blocked_local, blocked_points, err);
+        const auto info = buildWindow(zc, wo, start, ss->point, h0, x0, y0, x1, y1, blocked_local, blocked_points, err);
         if (info.has_value()) {
             RouteDiag dg;
             const auto line = routeWindow(*info, start, goal, dg);

--- a/tools/MapNavigator/recastnav_route.py
+++ b/tools/MapNavigator/recastnav_route.py
@@ -12,7 +12,7 @@ from recastnav import (CAP, CS, LAM, MARGIN, MAX_CELLS, MAXERR, MC_HBAND, R,
 from recastnav_zone import CleanNav, WallOracle
 
 
-def build(zc, wo, s, h0, x0, y0, x1, y1):
+def build(zc, wo, s, s_snap, h0, x0, y0, x1, y1):
     nx = int(np.ceil((x1 - x0) / CS))
     ny = int(np.ceil((y1 - y0) / CS))
     m = zc.mesh
@@ -35,6 +35,10 @@ def build(zc, wo, s, h0, x0, y0, x1, y1):
 
     gx = int((s[0] - x0) / CS); gy = int((s[1] - y0) / CS)
     j = int(np.searchsorted(occ, gy * nx + gx))
+    if j >= len(occ) or occ[j] != gy * nx + gx:
+        # 起点离网时其所在格无体素,退用按楼层吸附过的起点定种子
+        gx = int((s_snap[0] - x0) / CS); gy = int((s_snap[1] - y0) / CS)
+        j = int(np.searchsorted(occ, gy * nx + gx))
     if j >= len(occ) or occ[j] != gy * nx + gx:
         return None, f"起点格无体素 (gx={gx},gy={gy})"
     cand = IK[j][IK[j] >= 0]
@@ -354,7 +358,7 @@ class RecastEngine:
             ny = int(np.ceil((y1 - y0) / CS))
             if nx * ny > MAX_CELLS:
                 raise ValueError(f"窗口过大 ({nx}×{ny} 格)")
-            info, err = build(zc, wo, s, h0, x0, y0, x1, y1)
+            info, err = build(zc, wo, s, ss[1], h0, x0, y0, x1, y1)
             if err is None:
                 line, dg = route(info, s, g)
                 if line is not None:


### PR DESCRIPTION
- fix #4582
- fix #4554
- fix #4466

## Summary by Sourcery

Bug Fixes:
- 修复当起点位于导航网格之外时导致路径窗口构建失败的问题：通过在 C++ 引擎和 Python MapNavigator 工具中，使用吸附到地面的起点位置重新尝试构建路径窗口来解决。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix route window construction failing when the start point lies off the navmesh by retrying with the floor-snapped start position in both C++ engine and Python MapNavigator tooling.

</details>