### PR TITLE
fix: 修复路线12卡竹子的问题

### DIFF
--- a/assets/resource/pipeline/AutoCollect/AutoCollectRoute12.json
+++ b/assets/resource/pipeline/AutoCollect/AutoCollectRoute12.json
@@ -79,26 +79,12 @@
     "AutoCollectRoute12GotoFindLine1": {
         "desc": "前往中红柱状菌采集点",
         "action": "Custom",
-        "custom_action": "MapTrackerMove",
+        "custom_action": "MapTrackerGoal",
         "custom_action_param": {
             "map_name": "map02_lv004",
-            "path": [
-                [
-                    607.5,
-                    326.3
-                ],
-                [
-                    635.0,
-                    323.8
-                ],
-                [
-                    641.0,
-                    342.1
-                ],
-                [
-                    633.8,
-                    348.8
-                ]
+            "target": [
+                633.8,
+                348.8
             ]
         }
     },


### PR DESCRIPTION
close #4201 
close #4365
close #4466

## Summary by Sourcery

Bug Fixes:
- 修正自动收集路线 12 的路径规划，防止在竹子障碍物处卡住。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct auto-collect route 12 pathing to prevent getting stuck on bamboo obstacles.

</details>