### PR TITLE
refactor(选剑演武): 重新编排战斗前传送恢复血量的节点

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCoating.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCoating.json
@@ -313,7 +313,7 @@
         "custom_action": "ClearHitCount",
         "custom_action_param": {
             "nodes": [
-                "TrialOfSwordmancyGotoTrialArenaCpp"
+                "TrialOfSwordmancyGotoTrialArenaStart"
             ]
         },
         "post_wait_freezes": 200,

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -291,7 +291,7 @@
         "custom_action": "ClearHitCount",
         "custom_action_param": {
             "nodes": [
-                "TrialOfSwordmancyGotoTrialArenaCpp"
+                "TrialOfSwordmancyGotoTrialArenaStart"
             ]
         },
         "post_wait_freezes": 200,

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
@@ -184,39 +184,19 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "TrialOfSwordmancyDailyAutoFightRearmResetState",
+            "TrialOfSwordmancyAutoFightResetNavigator",
             "TrialOfSwordmancyMain"
         ]
     },
-    "TrialOfSwordmancyDailyAutoFightResetState": {
-        "desc": "自动作战模式下，一次性重置到选剑演武入口",
+    "TrialOfSwordmancyAutoFightResetNavigator": {
+        "desc": "重置寻路计数",
         "enabled": false,
-        "max_hit": 1,
-        "recognition": "DirectHit",
-        "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "SubTask",
-        "custom_action_param": {
-            "sub": [
-                "TrialOfSwordmancyGotoTrialArenaStart"
-            ]
-        },
-        "post_delay": 0,
-        "next": [
-            "TrialOfSwordmancyDailyMain"
-        ]
-    },
-    "TrialOfSwordmancyDailyAutoFightRearmResetState": {
-        "desc": "自动作战模式下，为下一轮重新启用入口重置",
-        "enabled": false,
-        "recognition": "DirectHit",
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "ClearHitCount",
         "custom_action_param": {
             "nodes": [
-                "TrialOfSwordmancyDailyAutoFightResetState",
-                "TrialOfSwordmancyGotoTrialArenaCpp"
+                "TrialOfSwordmancyGotoTrialArenaStart"
             ]
         },
         "post_delay": 0,

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyNav.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyNav.json
@@ -72,6 +72,7 @@
         "desc": "已到达演武入口，准备点击进入演算",
         "pre_delay": 0,
         "post_delay": 0,
+        "timeout": 5000,
         "next": [
             "TrialOfSwordmancyEnterTrialMenu"
         ]

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyNav.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyNav.json
@@ -54,6 +54,7 @@
     },
     "TrialOfSwordmancyGotoTrialArenaStart": {
         "desc": "前往演武入口（子任务入口）",
+        "max_hit": 1,
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "SubTask",
@@ -97,7 +98,6 @@
     },
     "TrialOfSwordmancyGotoTrialArenaCpp": {
         "desc": "使用MapNavigator导航前往目标地点",
-        "max_hit": 1,
         "recognition": "DirectHit",
         "pre_delay": 0,
         "action": "Custom",

--- a/assets/tasks/TrialOfSwordmancy.json
+++ b/assets/tasks/TrialOfSwordmancy.json
@@ -154,19 +154,15 @@
                 {
                     "name": "Yes",
                     "pipeline_override": {
-                        "TrialOfSwordmancyDailyAutoFightResetState": {
-                            "enabled": true
-                        },
-                        "TrialOfSwordmancyDailyAutoFightRearmResetState": {
-                            "enabled": true
-                        },
                         "TrialOfSwordmancyDailyMain": {
                             "next": [
-                                "TrialOfSwordmancyDailyAutoFightResetState",
+                                "[JumpBack]TrialOfSwordmancyGotoTrialArenaStart",
                                 "TrialOfSwordmancyDailyCheckRewardMode",
-                                "[JumpBack]TrialOfSwordmancyEnterTrialMenu",
-                                "[JumpBack]TrialOfSwordmancyGotoTrialArenaStart"
+                                "[JumpBack]TrialOfSwordmancyEnterTrialMenu"
                             ]
+                        },
+                        "TrialOfSwordmancyAutoFightResetNavigator": {
+                            "enabled": true
                         }
                     }
                 }


### PR DESCRIPTION
干掉一个 SubTask，这样在遥测里能更清楚点

## Summary by Sourcery

Enhancements:
- 从 TrialOfSwordmancy 任务流水线中移除一个多余的 SubTask，以精简场景配置和遥测数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove an extra SubTask from the TrialOfSwordmancy task pipeline to streamline the scenario configuration and telemetry data.

</details>