### PR TITLE
feat(MapNavigator): 前视点按贴线预算夹在走廊拐角前

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
@@ -196,6 +196,61 @@ navmesh::WorldPoint LookaheadOnCorridor(const navmesh::WorldPath& path, const Co
     return path.points.back();
 }
 
+double PointToSegmentDistance(const navmesh::WorldPoint& point, const navmesh::WorldPoint& a, const navmesh::WorldPoint& b)
+{
+    const double dx = b.x - a.x;
+    const double dy = b.y - a.y;
+    const double len_sq = dx * dx + dy * dy;
+    if (len_sq <= std::numeric_limits<double>::epsilon()) {
+        return std::hypot(point.x - a.x, point.y - a.y);
+    }
+    const double t = std::clamp(((point.x - a.x) * dx + (point.y - a.y) * dy) / len_sq, 0.0, 1.0);
+    return std::hypot(point.x - (a.x + t * dx), point.y - (a.y + t * dy));
+}
+
+// Longest arc the lookahead may be pushed forward before the straight chord from the projection to
+// that point leaves the corridor polyline by more than `slack`. Evaluated per tick at vertex
+// granularity: the chord to a candidate vertex is admissible only while every corridor vertex it
+// spans stays within slack of it, so the lookahead comes to rest on the corner instead of past it.
+double ClampLookaheadToPathSlack(
+    const navmesh::WorldPath& path,
+    const CorridorProjection& projection,
+    double distance,
+    double slack)
+{
+    if (path.points.size() < 2 || projection.edge_idx + 1 >= path.points.size() || slack <= 0.0) {
+        return distance;
+    }
+
+    const navmesh::WorldPoint& origin = projection.point;
+    navmesh::WorldPoint previous = origin;
+    double arc = 0.0;
+    double admissible = 0.0;
+
+    for (size_t vertex_idx = projection.edge_idx + 1; vertex_idx < path.points.size(); ++vertex_idx) {
+        const navmesh::WorldPoint& vertex = path.points[vertex_idx];
+        const double arc_to_vertex = arc + std::hypot(vertex.x - previous.x, vertex.y - previous.y);
+        double deviation = 0.0;
+        for (size_t spanned = projection.edge_idx + 1; spanned < vertex_idx && deviation <= slack; ++spanned) {
+            deviation = std::max(deviation, PointToSegmentDistance(path.points[spanned], origin, vertex));
+        }
+        if (deviation > slack) {
+            break;
+        }
+        admissible = arc_to_vertex;
+        if (arc_to_vertex >= distance) {
+            return distance;
+        }
+        arc = arc_to_vertex;
+        previous = vertex;
+    }
+
+    if (admissible <= 0.0) {
+        return distance;
+    }
+    return std::max(kNavRunLookaheadMinM, std::min(distance, admissible));
+}
+
 double UpcomingCorridorTurnDeg(const navmesh::WorldPath& path, const CorridorProjection& projection, double lookahead_distance)
 {
     if (path.points.size() < 2 || projection.edge_idx + 1 >= path.points.size() || lookahead_distance <= 0.0) {
@@ -426,7 +481,8 @@ NavRunTickResult NavRunController::tick(
     }
 
     const double upcoming_turn = UpcomingCorridorTurnDeg(plan_.path, *projection, kNavRunUpcomingTurnLookaheadM);
-    const double lookahead_distance = chooseLookaheadDistance(route, sprint_active, upcoming_turn);
+    const double lookahead_distance = ClampLookaheadToPathSlack(
+        plan_.path, *projection, chooseLookaheadDistance(route, sprint_active, upcoming_turn), kNavRunLookaheadPathSlackM);
     const navmesh::WorldPoint lookahead = LookaheadOnCorridor(plan_.path, *projection, lookahead_distance);
     const double corridor_heading = NaviMath::CalcTargetRotation(position.x, position.y, lookahead.x, lookahead.y);
 

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -147,6 +147,15 @@ constexpr double kNavRunLookaheadSprintM = 5.5;
 constexpr double kNavRunLookaheadSharpTurnM = 2.5;
 constexpr double kNavRunSharpTurnDeg = 55.0;
 constexpr double kNavRunUpcomingTurnLookaheadM = 8.0;
+// The lookahead point is measured forward along the corridor, but the agent then drives straight at it.
+// Once that chord spans a corridor vertex it cuts the corner, by an amount set only by the lookahead
+// distance and the turn angle. Cap the distance so the chord stays within this much of the corridor
+// polyline. Measured tracking error runs about 1.7x this value; the rest is follower lag.
+constexpr double kNavRunLookaheadPathSlackM = 0.5;
+// Floor for the capped distance. Authored waypoint lines are recorded at whole-pixel granularity, so
+// their vertices zigzag within the slack and the cap would otherwise collapse to nothing; a steering
+// target that close sits level with the agent and the follower oscillates in place instead of advancing.
+constexpr double kNavRunLookaheadMinM = 2.0;
 constexpr double kNavRunCrossTrackWarnM = 2.2;
 constexpr double kNavRunCrossTrackFailM = 4.0;
 constexpr double kNavRunProgressReplanMinCrossTrackM = 1.25;


### PR DESCRIPTION
- fix #4584
- fix #4591

## Summary by Sourcery

限制导航前视距离，使前方转向目标保持在走廊拐角内而不是切过拐角，从而改善车辆在转弯处的路径跟踪。

New Features:
- 引入基于走廊路径裕度的前视距离限制机制，用于控制转向目标在路径上可被设置的最大前视距离。

Bug Fixes:
- 通过根据走廊几何约束前视点位置，防止智能体在狭窄走廊拐角处出现过冲或切角现象。

Enhancements:
- 增加配置项，用于设置直线弦相对走廊折线的最大允许偏离，以及最小封顶前视距离，以稳定跟随者的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clamp navigation lookahead distance so the forward steering target stays within a corridor corner instead of cutting past it, improving path tracking around turns.

New Features:
- Introduce lookahead clamping based on corridor path slack to limit how far ahead the steering target can be placed.

Bug Fixes:
- Prevent the agent from over-shooting or cutting tight corridor corners by constraining the lookahead point relative to corridor geometry.

Enhancements:
- Add configuration for maximum allowed deviation of the straight-line chord from the corridor polyline and a minimum capped lookahead distance to stabilize follower behavior.

</details>