### PR TITLE
perf(map): 降低 MapTracker 可视化日志的样式匹配开销

### DIFF
--- a/assets/locales/go-service/HTML/navigation-moving.html
+++ b/assets/locales/go-service/HTML/navigation-moving.html
@@ -1,9 +1,9 @@
 <div class="maptracker-internal-message-navigation-moving" style="background:#ffffff; color:#222222; padding:12px; border-radius:8px; border:1px solid #e6f9ff; max-width:560px;">
   <style>
-    div:has(.maptracker-internal-message-navigation-moving):has(~ div .maptracker-internal-message-navigation-moving) {
+    #logs-panel > .overflow-y-auto > div:has(.maptracker-internal-message-navigation-moving):has(+ div[aria-hidden="true"] + div .maptracker-internal-message-navigation-moving) {
       display: none !important;
     }
-    div:has(.maptracker-internal-message-navigation-moving):has(~ div .maptracker-internal-message-navigation-finished) {
+    #logs-panel > .overflow-y-auto > div:has(.maptracker-internal-message-navigation-moving):has(+ div[aria-hidden="true"] + div .maptracker-internal-message-navigation-finished) {
       display: none !important;
     }
   </style>


### PR DESCRIPTION
gpt-5.6-sol

解决运行多次 maptracker 导航任务后 mxu 滑不动日志的问题

## Summary by Sourcery

增强：
- 将“范围导航移动”和“导航完成”的抑制规则限定到日志面板容器中，以避免使用开销较大的全局选择器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Scope navigation-moving and navigation-finished suppression rules to the logs panel container to avoid expensive global selectors.

</details>