### PR TITLE
fix: 更改进入运送委托列表的节点为线性流程以防 max_hit 超限

### DIFF
--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsCommon.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsCommon.json
@@ -68,15 +68,14 @@
         "rate_limit": 500, // 加速等待运送委托列表加载完成
         "next": [
             "__SeizeDeliveryJobsInJobList",
-            "[JumpBack]__SeizeDeliveryJobsEnterJobList"
+            "__SeizeDeliveryJobsEnterJobList"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "已位于武陵仓储管理"
         }
     },
     "__SeizeDeliveryJobsEnterJobList": {
-        "desc": "在任意地区仓储管理页面，进入运送委托列表（需 jumpback 调用）",
-        "max_hit": 10,
+        "desc": "在任意地区仓储管理页面，进入运送委托列表",
         "recognition": "And",
         "all_of": [
             "__SeizeDeliveryJobsRecoJobList"
@@ -84,7 +83,10 @@
         "action": "Click",
         "focus": {
             "Node.Action.Starting": "点击运送委托列表"
-        }
+        },
+        "next": [
+            "__SeizeDeliveryJobsInJobList"
+        ]
     },
     "__SeizeDeliveryJobsInJobList": {
         "desc": "已经在运送委托列表，且列表已加载完成",


### PR DESCRIPTION
Fix #4609

## Summary by Sourcery

调整 `SeizeDeliveryJobsCommon` 管道配置，在进入配送委派列表时使用线性流程，防止 `maxhit` 阻止进入该节点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust the SeizeDeliveryJobsCommon pipeline configuration to use a linear flow when entering the delivery delegation list, preventing maxhit from blocking entry into the node.

</details>