### PR TITLE
fix(DeliveryJobs): 增加最大滑动次数至 10 以改善物品填充体验

### DIFF
--- a/assets/resource/pipeline/DeliveryJobs/PackCargo.json
+++ b/assets/resource/pipeline/DeliveryJobs/PackCargo.json
@@ -93,7 +93,7 @@
         ]
     },
     "DeliveryJobsSelectItemLoop": {
-        "desc": "选择要填充的物品，如果不在第一屏，向上滑动，再次寻找，直到找到或者滑动 5 次",
+        "desc": "选择要填充的物品，如果不在第一屏，向上滑动，再次寻找，直到找到或者滑动 10 次",
         "recognition": "OCR",
         "roi": [
             53,
@@ -169,7 +169,7 @@
     },
     "DeliveryJobsSelectItemScrollUp": {
         "desc": "如果要填充的物品不在第一屏，向上滑动屏幕",
-        "max_hit": 5,
+        "max_hit": 10,
         "pre_delay": 0,
         "action": "Swipe",
         "begin": [


### PR DESCRIPTION
fixed #4601

## Summary by Sourcery

Bug Fixes:
- 调整 PackCargo 的滑动次数限制，以解决问题 #4601 中用户无法进行足够次数的滑动来按预期装满货物的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust PackCargo swipe limit to address issue #4601 where users could not swipe enough times to fill cargo as intended.

</details>