### PR TITLE
fix: 循环打开大地图

### DIFF
--- a/agent/go-service/common/repeataction/action.go
+++ b/agent/go-service/common/repeataction/action.go
@@ -2,7 +2,6 @@ package repeataction
 
 import (
 	"encoding/json"
-	"image"
 	"time"
 
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
@@ -11,8 +10,10 @@ import (
 
 const (
 	defaultRepeatCount = 3
-	defaultIntervalMs  = 6000
-	innerActionEntry   = "__RepeatUntilActionInner"
+	defaultIntervalMs  = 3000
+	// pollIntervalMs is the recognition cadence inside each interval_ms wait window.
+	pollIntervalMs   = 500
+	innerActionEntry = "__RepeatUntilActionInner"
 )
 
 type repeatUntilFoundParam struct {
@@ -128,7 +129,7 @@ func runRepeatUntil(
 	}
 
 	ctrl := ctx.GetTasker().GetController()
-	interval := time.Duration(intervalMs) * time.Millisecond
+	poll := time.Duration(pollIntervalMs) * time.Millisecond
 
 	for i := 0; i < repeatCount; i++ {
 		if ctx.GetTasker().Stopping() {
@@ -138,7 +139,7 @@ func runRepeatUntil(
 		if _, err := ctx.RunAction(innerActionEntry, arg.Box, "", map[string]any{
 			innerActionEntry: map[string]any{
 				// 临时节点只执行一次动作，显式清零 Framework 的节点级默认等待，
-				// 使 intervalMs 成为动作完成后、重新识别前唯一的主动等待。
+				// 使 intervalMs 成为动作完成后、轮询识别前唯一的主动等待窗口。
 				"pre_delay":  0,
 				"post_delay": 0,
 				"rate_limit": 0,
@@ -148,29 +149,49 @@ func runRepeatUntil(
 			log.Warn().Err(err).Str("component", component).Int("attempt", i+1).Msg("inner action failed")
 		}
 
-		// Wait after the action so UI transitions can settle before recognition.
-		time.Sleep(interval)
+		// Within intervalMs, poll recognition every pollIntervalMs so a fast UI
+		// transition can succeed without waiting out the full window.
+		deadline := time.Now().Add(time.Duration(intervalMs) * time.Millisecond)
+		for {
+			if ctx.GetTasker().Stopping() {
+				return false
+			}
 
-		ctrl.PostScreencap().Wait()
-		img, err := ctrl.CacheImage()
-		if err != nil || img == nil {
-			log.Warn().Err(err).Str("component", component).Msg("cache image failed")
-		} else if waitConditionMet(ctx, img, waitNodes, untilFound) {
-			return true
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				break
+			}
+
+			sleep := poll
+			if sleep > remaining {
+				sleep = remaining
+			}
+			time.Sleep(sleep)
+
+			if ctx.GetTasker().Stopping() {
+				return false
+			}
+
+			ctrl.PostScreencap().Wait()
+			img, err := ctrl.CacheImage()
+			if err != nil || img == nil {
+				log.Warn().Err(err).Str("component", component).Msg("cache image failed")
+				continue
+			}
+
+			if untilFound {
+				for _, node := range waitNodes {
+					if detail, err := ctx.RunRecognition(node, img); err == nil && detail != nil && detail.Hit {
+						return true
+					}
+				}
+			} else {
+				detail, err := ctx.RunRecognition(waitNodes[0], img)
+				if err != nil || detail == nil || !detail.Hit {
+					return true
+				}
+			}
 		}
 	}
 	return false
-}
-
-func waitConditionMet(ctx *maa.Context, img image.Image, nodes []string, untilFound bool) bool {
-	if untilFound {
-		for _, node := range nodes {
-			if detail, err := ctx.RunRecognition(node, img); err == nil && detail != nil && detail.Hit {
-				return true
-			}
-		}
-		return false
-	}
-	detail, err := ctx.RunRecognition(nodes[0], img)
-	return err != nil || detail == nil || !detail.Hit
 }

--- a/agent/go-service/common/repeataction/action.go
+++ b/agent/go-service/common/repeataction/action.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	defaultRepeatCount = 3
-	defaultIntervalMs  = 3000
+	defaultIntervalMs  = 10000
 	innerActionEntry   = "__RepeatUntilActionInner"
 )
 

--- a/agent/go-service/common/repeataction/action.go
+++ b/agent/go-service/common/repeataction/action.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	defaultRepeatCount = 3
-	defaultIntervalMs  = 10000
+	defaultIntervalMs  = 6000
 	innerActionEntry   = "__RepeatUntilActionInner"
 )
 

--- a/assets/resource/pipeline/SceneManager/SceneMap.json
+++ b/assets/resource/pipeline/SceneManager/SceneMap.json
@@ -520,7 +520,8 @@
                     "custom_action": "AutoAltClickAction",
                     "wait_nodes": [
                         "__ScenePrivateAnyEnterMapSuccess"
-                    ]
+                    ],
+                    "interval_ms": 6000
                 },
                 "target": [
                     90,

--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -107,7 +107,8 @@
                     "custom_action": "AutoAltClickAction",
                     "wait_nodes": [
                         "__ScenePrivateAnyEnterMenuListSuccess"
-                    ]
+                    ],
+                    "interval_ms": 6000
                 },
                 "target_offset": [
                     5,

--- a/docs/en_us/developers/custom.md
+++ b/docs/en_us/developers/custom.md
@@ -94,7 +94,7 @@ Both are implemented in `agent/go-service/common/repeataction`. They repeatedly 
     - `custom_action?: string`: Registered custom action name (e.g. `AutoAltClickAction`). Mutually exclusive with `action`.
     - `custom_action_param?: object`: Forwarded to the nested custom action.
     - `repeat_count?: int`: Maximum attempts. Defaults to `3` when omitted or `<= 0`.
-    - `interval_ms?: int`: Wait after each attempt before recognition, in milliseconds. Defaults to `10000` when omitted or `0`. Negative values are invalid.
+    - `interval_ms?: int`: Wait after each attempt before recognition, in milliseconds. Defaults to `6000` when omitted or `0`. Negative values are invalid.
 - `RepeatUntilFoundAction` extra:
     - `wait_nodes: string[]`: Pipeline node names to wait for. Required.
 - `RepeatUntilNotFoundAction` extra:

--- a/docs/en_us/developers/custom.md
+++ b/docs/en_us/developers/custom.md
@@ -84,7 +84,7 @@ The `FalseAction` implementation is located in `agent/go-service/common/falseact
 
 ### RepeatUntilFoundAction / RepeatUntilNotFoundAction
 
-Both are implemented in `agent/go-service/common/repeataction`. They repeatedly run a built-in or custom action, wait, then check recognition. They succeed when the wait condition is met, and fail after `repeat_count` attempts without success.
+Both are implemented in `agent/go-service/common/repeataction`. They repeatedly run a built-in or custom action, then poll recognition inside a wait window. They succeed when the wait condition is met, and fail after `repeat_count` attempts without success.
 
 - `RepeatUntilFoundAction`: succeeds when **any** `wait_nodes` entry hits.
 - `RepeatUntilNotFoundAction`: succeeds when `wait_node` misses.
@@ -94,7 +94,7 @@ Both are implemented in `agent/go-service/common/repeataction`. They repeatedly 
     - `custom_action?: string`: Registered custom action name (e.g. `AutoAltClickAction`). Mutually exclusive with `action`.
     - `custom_action_param?: object`: Forwarded to the nested custom action.
     - `repeat_count?: int`: Maximum attempts. Defaults to `3` when omitted or `<= 0`.
-    - `interval_ms?: int`: Wait after each attempt before recognition, in milliseconds. Defaults to `6000` when omitted or `0`. Negative values are invalid.
+    - `interval_ms?: int`: Wait window after each action, in milliseconds. Within the window, screencap/recognize every `500ms` and succeed early on a hit. Defaults to `3000` when omitted or `0`. Negative values are invalid.
 - `RepeatUntilFoundAction` extra:
     - `wait_nodes: string[]`: Pipeline node names to wait for. Required.
 - `RepeatUntilNotFoundAction` extra:

--- a/docs/en_us/developers/custom.md
+++ b/docs/en_us/developers/custom.md
@@ -94,7 +94,7 @@ Both are implemented in `agent/go-service/common/repeataction`. They repeatedly 
     - `custom_action?: string`: Registered custom action name (e.g. `AutoAltClickAction`). Mutually exclusive with `action`.
     - `custom_action_param?: object`: Forwarded to the nested custom action.
     - `repeat_count?: int`: Maximum attempts. Defaults to `3` when omitted or `<= 0`.
-    - `interval_ms?: int`: Wait after each attempt before recognition, in milliseconds. Defaults to `3000` when omitted or `0`. Negative values are invalid.
+    - `interval_ms?: int`: Wait after each attempt before recognition, in milliseconds. Defaults to `10000` when omitted or `0`. Negative values are invalid.
 - `RepeatUntilFoundAction` extra:
     - `wait_nodes: string[]`: Pipeline node names to wait for. Required.
 - `RepeatUntilNotFoundAction` extra:

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -86,7 +86,7 @@ Action 节点用于执行自定义动作。常见写法如下：
 
 ### RepeatUntilFoundAction / RepeatUntilNotFoundAction
 
-二者实现均位于 `agent/go-service/common/repeataction`，用于反复执行一次内置或自定义动作，每次执行后等待再识别；条件满足即成功，耗尽次数仍不满足则失败。
+二者实现均位于 `agent/go-service/common/repeataction`，用于反复执行一次内置或自定义动作，每次执行后在等待窗口内轮询识别；条件满足即成功，耗尽次数仍不满足则失败。
 
 - `RepeatUntilFoundAction`：`wait_nodes` 中**任一命中**即成功。
 - `RepeatUntilNotFoundAction`：`wait_node` **未命中**即成功。
@@ -96,7 +96,7 @@ Action 节点用于执行自定义动作。常见写法如下：
     - `custom_action?: string`：已注册的自定义动作名（如 `AutoAltClickAction`），与 `action` 二选一。
     - `custom_action_param?: object`：透传给内层自定义动作的参数。
     - `repeat_count?: int`：最大尝试次数；省略或 `<= 0` 时默认 `3`。
-    - `interval_ms?: int`：每次尝试后、识别前的等待（毫秒）；省略或 `0` 时默认 `6000`；负值非法。
+    - `interval_ms?: int`：每次动作后的等待窗口（毫秒）；窗口内每 `500ms` 截图识别一次，命中则提前成功；省略或 `0` 时默认 `3000`；负值非法。
 - `RepeatUntilFoundAction` 额外参数：
     - `wait_nodes: string[]`：等待出现的 Pipeline 节点名列表，必填。
 - `RepeatUntilNotFoundAction` 额外参数：

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -96,7 +96,7 @@ Action 节点用于执行自定义动作。常见写法如下：
     - `custom_action?: string`：已注册的自定义动作名（如 `AutoAltClickAction`），与 `action` 二选一。
     - `custom_action_param?: object`：透传给内层自定义动作的参数。
     - `repeat_count?: int`：最大尝试次数；省略或 `<= 0` 时默认 `3`。
-    - `interval_ms?: int`：每次尝试后、识别前的等待（毫秒）；省略或 `0` 时默认 `10000`；负值非法。
+    - `interval_ms?: int`：每次尝试后、识别前的等待（毫秒）；省略或 `0` 时默认 `6000`；负值非法。
 - `RepeatUntilFoundAction` 额外参数：
     - `wait_nodes: string[]`：等待出现的 Pipeline 节点名列表，必填。
 - `RepeatUntilNotFoundAction` 额外参数：

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -96,7 +96,7 @@ Action 节点用于执行自定义动作。常见写法如下：
     - `custom_action?: string`：已注册的自定义动作名（如 `AutoAltClickAction`），与 `action` 二选一。
     - `custom_action_param?: object`：透传给内层自定义动作的参数。
     - `repeat_count?: int`：最大尝试次数；省略或 `<= 0` 时默认 `3`。
-    - `interval_ms?: int`：每次尝试后、识别前的等待（毫秒）；省略或 `0` 时默认 `3000`；负值非法。
+    - `interval_ms?: int`：每次尝试后、识别前的等待（毫秒）；省略或 `0` 时默认 `10000`；负值非法。
 - `RepeatUntilFoundAction` 额外参数：
     - `wait_nodes: string[]`：等待出现的 Pipeline 节点名列表，必填。
 - `RepeatUntilNotFoundAction` 额外参数：

--- a/tools/schema/components/repeat_action.schema.json
+++ b/tools/schema/components/repeat_action.schema.json
@@ -30,7 +30,7 @@
                 },
                 "interval_ms": {
                     "title": "Interval Ms",
-                    "description": "Wait after each attempt before recognition (ms). Omit or 0 defaults to 6000.",
+                    "description": "Wait window after each attempt (ms); within it, recognize every 500ms and succeed early on hit. Omit or 0 defaults to 3000.",
                     "type": "integer",
                     "minimum": 0
                 }

--- a/tools/schema/components/repeat_action.schema.json
+++ b/tools/schema/components/repeat_action.schema.json
@@ -30,7 +30,7 @@
                 },
                 "interval_ms": {
                     "title": "Interval Ms",
-                    "description": "Wait after each attempt before recognition (ms). Omit or 0 defaults to 3000.",
+                    "description": "Wait after each attempt before recognition (ms). Omit or 0 defaults to 10000.",
                     "type": "integer",
                     "minimum": 0
                 }

--- a/tools/schema/components/repeat_action.schema.json
+++ b/tools/schema/components/repeat_action.schema.json
@@ -30,7 +30,7 @@
                 },
                 "interval_ms": {
                     "title": "Interval Ms",
-                    "description": "Wait after each attempt before recognition (ms). Omit or 0 defaults to 10000.",
+                    "description": "Wait after each attempt before recognition (ms). Omit or 0 defaults to 6000.",
                     "type": "integer",
                     "minimum": 0
                 }


### PR DESCRIPTION
close #4493 
close #4617

## Summary by Sourcery

增加重复动作之间的默认间隔，以减少快速重试，并使开发者文档与新行为保持一致。

增强内容：
- 将 RepeatUntil* 动作的默认重复动作间隔从 3000ms 提高到 10000ms。

文档：
- 更新英文和中文的自定义动作开发者文档，以反映新的默认 `interval_ms` 为 10000ms。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Increase the default interval between repeat actions to reduce rapid retries and align developer documentation with the new behavior.

Enhancements:
- Raise the default repeat action interval from 3000ms to 10000ms for RepeatUntil* actions.

Documentation:
- Update English and Chinese custom action developer docs to reflect the new 10000ms default interval_ms value.

</details>