### PR TITLE
feat(MapNavigator): 立面纳入跨越约束

### DIFF
--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -517,6 +517,122 @@ std::unordered_set<int64_t> BannedSteps(
     return out;
 }
 
+StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, const Mask& lay, double ox, double oy)
+{
+    StepBarrier out;
+    const int64_t nx = lay.nx, ny = lay.ny, NC = nx * ny, K = st.K;
+    if (K <= 0) {
+        return out;
+    }
+    constexpr float kInf = std::numeric_limits<float>::infinity();
+    std::vector<float> T(static_cast<size_t>(NC * K), kInf);
+    for (size_t j = 0; j < st.occ.size(); ++j) {
+        float* row = &T[static_cast<size_t>(st.occ[j] * K)];
+        int64_t n = 0;
+        for (int64_t k = 0; k < K; ++k) {
+            const int64_t sid = st.IK[j * static_cast<size_t>(K) + static_cast<size_t>(k)];
+            if (sid >= 0 && vis[static_cast<size_t>(sid)] != 0) {
+                row[n++] = st.sp_h[static_cast<size_t>(sid)];
+            }
+        }
+    }
+
+    std::vector<uint8_t> ghost(static_cast<size_t>(NC), 0);
+    bool any_ghost = false;
+    for (int64_t c = 0; c < NC; ++c) {
+        if (lay.v[static_cast<size_t>(c)] != 0 && !std::isfinite(T[static_cast<size_t>(c * K)])) {
+            ghost[static_cast<size_t>(c)] = 1;
+            any_ghost = true;
+        }
+    }
+    if (any_ghost) {
+        std::vector<float> g(static_cast<size_t>(NC));
+        for (int64_t c = 0; c < NC; ++c) {
+            g[static_cast<size_t>(c)] = T[static_cast<size_t>(c * K)];
+        }
+        const int64_t rounds = static_cast<int64_t>(std::ceil(std::sqrt(static_cast<double>(kHoleMaxCells)))) + 1;
+        for (int64_t it = 0; it < rounds; ++it) {
+            std::vector<float> nv = g;
+            for (int64_t y = 0; y < ny; ++y) {
+                for (int64_t x = 0; x < nx; ++x) {
+                    const size_t c = static_cast<size_t>(y * nx + x);
+                    if (ghost[c] == 0) {
+                        continue;
+                    }
+                    float m = g[c];
+                    if (x + 1 < nx) {
+                        m = std::min(m, g[c + 1]);
+                    }
+                    if (x > 0) {
+                        m = std::min(m, g[c - 1]);
+                    }
+                    if (y + 1 < ny) {
+                        m = std::min(m, g[c + static_cast<size_t>(nx)]);
+                    }
+                    if (y > 0) {
+                        m = std::min(m, g[c - static_cast<size_t>(nx)]);
+                    }
+                    nv[c] = m;
+                }
+            }
+            const bool same = nv == g;
+            g.swap(nv);
+            if (same) {
+                break;
+            }
+        }
+        for (int64_t c = 0; c < NC; ++c) {
+            if (ghost[static_cast<size_t>(c)] != 0) {
+                T[static_cast<size_t>(c * K)] = g[static_cast<size_t>(c)];
+            }
+        }
+    }
+
+    static constexpr std::array<std::array<int64_t, 2>, 4> kDirs { { { 1, 0 }, { 0, 1 }, { 1, 1 }, { 1, -1 } } };
+    for (const auto& d : kDirs) {
+        const int64_t dx = d[0], dy = d[1];
+        for (int64_t c = 0; c < NC; ++c) {
+            if (lay.v[static_cast<size_t>(c)] == 0 || !std::isfinite(T[static_cast<size_t>(c * K)])) {
+                continue;
+            }
+            const int64_t ax = c % nx + dx, ay = c / nx + dy;
+            if (ax < 0 || ax >= nx || ay < 0 || ay >= ny) {
+                continue;
+            }
+            const int64_t b = ay * nx + ax;
+            if (!std::isfinite(T[static_cast<size_t>(b * K)])) {
+                continue;
+            }
+            float best = kInf;
+            int64_t bka = 0, bkb = 0;
+            for (int64_t ka = 0; ka < K; ++ka) {
+                for (int64_t kb = 0; kb < K; ++kb) {
+                    const float raw = std::fabs(T[static_cast<size_t>(c * K + ka)] - T[static_cast<size_t>(b * K + kb)]);
+                    const float dd = std::isfinite(raw) ? raw : kInf;
+                    if (dd < best) {
+                        best = dd;
+                        bka = ka;
+                        bkb = kb;
+                    }
+                }
+            }
+            if (!(static_cast<double>(best) > kStep)) {
+                continue;
+            }
+            const bool up = T[static_cast<size_t>(b * K + bkb)] > T[static_cast<size_t>(c * K + bka)];
+            out.steps.insert(up ? c * NC + b : b * NC + c);
+            if (dx != 0 && dy != 0) {
+                continue;
+            }
+            const double px = ox + static_cast<double>(c % nx + dx) * kCS;
+            const double py = oy + static_cast<double>(c / nx + dy) * kCS;
+            out.p0.push_back({ px, py });
+            out.p1.push_back({ px + static_cast<double>(dy) * kCS, py + static_cast<double>(dx) * kCS });
+        }
+    }
+    return out;
+}
+
 std::vector<int64_t> Comps4(const Mask& mask)
 {
     const int64_t ny = mask.ny, nx = mask.nx, NC = nx * ny;

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -13,6 +13,7 @@ namespace navmesh::recast
 
 inline constexpr double kCS = 0.25;                // 体素边长 px
 inline constexpr double kClimb = 3.0;              // 相邻格可连通最大高差 px
+inline constexpr double kStep = 0.5;               // 相邻格可直接迈上的最大高差 px, 超出即立面
 inline constexpr double kMergeH = 1.0;             // 同列 span 合并容差 px
 inline constexpr double kEdtCap = 12.0;            // 距离场截断 px
 inline constexpr double kR = 1.75;                 // 期望余量上限 px
@@ -135,6 +136,15 @@ std::unordered_set<int64_t> BannedSteps(
     const std::vector<WorldPoint>& p1,
     double ox,
     double oy);
+
+struct StepBarrier
+{
+    std::unordered_set<int64_t> steps;
+    std::vector<WorldPoint> p0;
+    std::vector<WorldPoint> p1;
+};
+
+StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, const Mask& lay, double ox, double oy);
 
 std::vector<int64_t> Comps4(const Mask& mask);
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -31,6 +31,9 @@ struct WindowInfo
     std::vector<WorldPoint> wP0;
     std::vector<WorldPoint> wP1;
     WallCsr wcsr;
+    StepBarrier sev;
+    std::vector<WorldPoint> segA;
+    std::vector<WorldPoint> segB;
 };
 
 struct RouteDiag
@@ -179,6 +182,8 @@ std::optional<WindowInfo> buildWindow(
         }
     }
 
+    info.sev = StepBreaks(st, vis, info.lay, x0, y0);
+
     const std::vector<uint8_t> keep = WallsAtLayer(p0, p1, hh, info.lh, x0, y0);
     for (size_t i = 0; i < keep.size(); ++i) {
         if (keep[i] != 0) {
@@ -187,6 +192,10 @@ std::optional<WindowInfo> buildWindow(
         }
     }
     info.wcsr = BuildWallIndex(info.wP0, info.wP1, x0, y0, nx, ny);
+    info.segA = info.wP0;
+    info.segA.insert(info.segA.end(), info.sev.p0.begin(), info.sev.p0.end());
+    info.segB = info.wP1;
+    info.segB.insert(info.segB.end(), info.sev.p1.begin(), info.sev.p1.end());
     info.dist = Clearance(info.core);
     return info;
 }
@@ -202,6 +211,8 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
         walk.v[i] = static_cast<uint8_t>(info.core.v[i] != 0 && info.lay.v[i] != 0);
     }
     const auto bn = BannedSteps(info.lay, info.wcsr, info.wP0, info.wP1, x0, y0);
+    std::unordered_set<int64_t> blocked_steps = bn;
+    blocked_steps.insert(info.sev.steps.begin(), info.sev.steps.end());
     // 亏欠越多单价越高;脊线保底只进几何口径 prefg,禁入 mult
     const Grid<float> pref = PrefField(info.dist, false);
     const Grid<float> prefg = PrefField(info.dist, true);
@@ -272,11 +283,11 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
         q = std::vector<CellPt> { *as_ };
     }
     else {
-        q = CostAstar(walk, *as_, *ag_, mult, &bn, &BIGP);
+        q = CostAstar(walk, *as_, *ag_, mult, &blocked_steps, &BIGP);
     }
     if (!q.has_value()) {
         used = &info.core;
-        q = CostAstar(info.core, *as_, *ag_, mult, &bn, &BIGP);
+        q = CostAstar(info.core, *as_, *ag_, mult, &blocked_steps, &BIGP);
         if (q.has_value()) {
             dg.warn.push_back("walk 断开→退回 core");
         }
@@ -290,13 +301,19 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
     for (size_t k = 1; k < q->size(); ++k) {
         const int64_t ca = (*q)[k - 1].y * nx + (*q)[k - 1].x;
         const int64_t cb = (*q)[k].y * nx + (*q)[k].x;
+        if (!blocked_steps.contains(ca * NC + cb)) {
+            continue;
+        }
+        bad.push_back(k);
         if (bn.contains(ca * NC + cb)) {
-            bad.push_back(k);
             dg.xwall.push_back({ x0 + (static_cast<double>((*q)[k].x) + 0.5) * kCS, y0 + (static_cast<double>((*q)[k].y) + 0.5) * kCS });
         }
     }
     if (!dg.xwall.empty()) {
         dg.warn.push_back("不可避穿墙 " + std::to_string(dg.xwall.size()) + " 步");
+    }
+    if (bad.size() > dg.xwall.size()) {
+        dg.warn.push_back("不可避立面 " + std::to_string(bad.size() - dg.xwall.size()) + " 步");
     }
 
     const auto cen = [&](const std::vector<CellPt>& P) {
@@ -323,7 +340,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
 
     const auto loops_core = toWorld(TraceContours(info.core));
     const Blockers::OnMask onm { used, x0, y0, kCS };
-    const Blockers blk_gray(loops_core, &info.wP0, &info.wP1, onm);
+    const Blockers blk_gray(loops_core, &info.segA, &info.segB, onm);
 
     std::vector<uint8_t> grn(q->size());
     for (size_t i = 0; i < q->size(); ++i) {
@@ -428,7 +445,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                         q2->push_back(cells[a2]);
                     }
                     else {
-                        const auto r2 = CostAstar(er, cells[a2], cells[b2], multg, &bn, nullptr);
+                        const auto r2 = CostAstar(er, cells[a2], cells[b2], multg, &blocked_steps, nullptr);
                         if (!r2.has_value()) {
                             q2.reset();
                             break;
@@ -460,7 +477,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                 }
                 auto lw = toWorld(lp);
                 lw.insert(lw.end(), loops_core.begin(), loops_core.end());
-                blk_green.emplace(lw, &info.wP0, &info.wP1, onm);
+                blk_green.emplace(lw, &info.segA, &info.segB, onm);
             }
             pp = StringPull(pp, blk_green.has_value() ? *blk_green : blk_gray, &cfl);
         }

--- a/tools/MapNavigator/recastnav.py
+++ b/tools/MapNavigator/recastnav.py
@@ -7,6 +7,7 @@ import numpy as np
 
 CS = 0.25          # 体素边长 px
 CLIMB = 3.0        # 相邻格可连通最大高差 px
+STEP = 0.5         # 相邻格可直接迈上的最大高差 px, 超出即立面, 只能绕行
 MERGE_H = 1.0      # 同列 span 合并容差 px
 EDT_CAP = 12.0     # 距离场截断 px
 R = 1.75           # 期望余量上限 px
@@ -220,6 +221,71 @@ def flood(seed, sp_h, occ, HK, IK, sp_ci, nx, climb=CLIMB):
                 nxt.append(cand)
         F = np.concatenate(nxt) if nxt else np.zeros(0, np.int64)
     return vis
+
+
+def _step_heights(occ, HK, IK, vis, lay, nx, ny):
+    HV = np.where((IK >= 0) & vis[np.maximum(IK, 0)], HK, np.inf)
+    T = np.full((nx * ny, HV.shape[1]), np.inf, np.float32)
+    T[occ] = np.sort(HV, axis=1)
+    ghost = lay.ravel() & ~np.isfinite(T[:, 0])
+    if ghost.any():
+        gm = ghost.reshape(ny, nx)
+        g = T[:, 0].reshape(ny, nx).copy()
+        for _ in range(int(np.ceil(np.sqrt(HOLE_MAX))) + 1):
+            p = g
+            n = g
+            for dy, dx in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+                s = np.full_like(g, np.inf)
+                s[max(dy, 0):ny + min(dy, 0), max(dx, 0):nx + min(dx, 0)] = \
+                    g[-min(dy, 0):ny - max(dy, 0) or None,
+                      -min(dx, 0):nx - max(dx, 0) or None]
+                n = np.minimum(n, s)
+            g = np.where(gm, n, p)
+            if np.array_equal(g, p):
+                break
+        T[ghost, 0] = g.ravel()[ghost]
+    return T
+
+
+def step_breaks(occ, HK, IK, vis, lay, nx, ny, ox, oy, cs=CS, step=STEP):
+    out = set()
+    src = np.nonzero(lay.ravel())[0]
+    if not len(src) or not np.isfinite(step):
+        return out, (np.zeros((0, 2)), np.zeros((0, 2)))
+    T = _step_heights(occ, HK, IK, vis, lay, nx, ny)
+    K = T.shape[1]
+    src = src[np.isfinite(T[src, 0])]
+    ea, eb = [], []
+    gx, gy = src % nx, src // nx
+    for dx, dy in ((1, 0), (0, 1), (1, 1), (1, -1)):
+        ax, ay = gx + dx, gy + dy
+        m = (ax >= 0) & (ax < nx) & (ay >= 0) & (ay < ny)
+        nb = np.where(m, ay * nx + ax, 0)
+        m &= np.isfinite(T[nb, 0])
+        if not m.any():
+            continue
+        a, b = src[m], nb[m]
+        A, B = T[a], T[b]
+        with np.errstate(invalid="ignore"):
+            d = np.abs(A[:, :, None] - B[:, None, :])
+        d = np.where(np.isfinite(d), d, np.inf).reshape(len(a), -1)
+        k = d.argmin(1)
+        r = np.arange(len(a))
+        bad = d[r, k] > step
+        if not bad.any():
+            continue
+        a, b = a[bad], b[bad]
+        up = B[r[bad], k[bad] % K] > A[r[bad], k[bad] // K]
+        out.update(zip(np.where(up, a, b).tolist(), np.where(up, b, a).tolist()))
+        if dx and dy:
+            continue
+        px = ox + (a % nx + dx) * cs
+        py = oy + (a // nx + dy) * cs
+        ea.append(np.column_stack([px, py]))
+        eb.append(np.column_stack([px + dy * cs, py + dx * cs]))
+    if not ea:
+        return out, (np.zeros((0, 2)), np.zeros((0, 2)))
+    return out, (np.vstack(ea), np.vstack(eb))
 
 
 def clearance(mask, cs=CS, cap=EDT_CAP):

--- a/tools/MapNavigator/recastnav_route.py
+++ b/tools/MapNavigator/recastnav_route.py
@@ -66,6 +66,8 @@ def build(zc, wo, s, s_snap, h0, x0, y0, x1, y1):
                          protect=wallcell.reshape(ny, nx))
     core = rc.close_cracks(core, lay, protect=wallcell.reshape(ny, nx))
 
+    sev, sseg = rc.step_breaks(occ, HK, IK, vis, lay, nx, ny, x0, y0)
+
     keep = rc.walls_at_layer(wo.P0[widx], wo.P1[widx], wo.HH[widx], lh,
                              x0, y0, nx, ny, hband=MC_HBAND)
     wP0, wP1 = wo.P0[widx][keep], wo.P1[widx][keep]
@@ -77,7 +79,8 @@ def build(zc, wo, s, s_snap, h0, x0, y0, x1, y1):
 
     info = dict(x0=x0, y0=y0, nx=nx, ny=ny, lay=lay, lh=lh, dist=dist,
                 core=core, t_vox=t_vox, t_fl=t_fl, t_edt=t_edt,
-                wP0=wP0, wP1=wP1, wid=wid, wstart=wstart)
+                wP0=wP0, wP1=wP1, wid=wid, wstart=wstart,
+                sev=sev, sseg=sseg)
     return info, None
 
 
@@ -137,6 +140,7 @@ def route(info, s, g):
     walk = core & lay
     bn = rc.banned_steps(lay, info["wid"], info["wstart"],
                          info["wP0"], info["wP1"], x0, y0, nx)
+    blocked = bn | info["sev"]
     # 亏欠越多单价越高;脊线保底只进几何口径 prefg,禁入 mult
     pref = rc.pref_field(dist)
     mult = 1.0 + LAM * np.clip((pref - dist) / pref, 0.0, 1.0)
@@ -169,10 +173,10 @@ def route(info, s, g):
     BIGP = nx * ny * CS * (1.0 + LAM)
     t0 = time.time()
     used = walk
-    q = rc.cost_astar(walk, as_, ag_, mult, bn, BIGP) if as_ != ag_ else [as_]
+    q = rc.cost_astar(walk, as_, ag_, mult, blocked, BIGP) if as_ != ag_ else [as_]
     if q is None:
         used = core
-        q = rc.cost_astar(core, as_, ag_, mult, bn, BIGP)
+        q = rc.cost_astar(core, as_, ag_, mult, blocked, BIGP)
         if q is not None:
             warn.append("walk 断开→退回 core")
     if q is None:
@@ -181,13 +185,17 @@ def route(info, s, g):
     xw = []
     bad = []
     for k in range(1, len(q)):
-        if (q[k - 1][1] * nx + q[k - 1][0],
-                q[k][1] * nx + q[k][0]) in bn:
-            bad.append(k)
+        e = (q[k - 1][1] * nx + q[k - 1][0], q[k][1] * nx + q[k][0])
+        if e not in blocked:
+            continue
+        bad.append(k)
+        if e in bn:
             xw.append((x0 + (q[k][0] + 0.5) * CS,
                        y0 + (q[k][1] + 0.5) * CS))
     if xw:
         warn.append(f"不可避穿墙 {len(xw)} 步")
+    if len(bad) > len(xw):
+        warn.append(f"不可避立面 {len(bad) - len(xw)} 步")
 
     def cen(P):
         return [(x0 + (a + 0.5) * CS, y0 + (b + 0.5) * CS) for a, b in P]
@@ -198,7 +206,8 @@ def route(info, s, g):
     def w(P):
         return np.column_stack([x0 + P[:, 0] * CS, y0 + P[:, 1] * CS])
 
-    wseg = (info["wP0"], info["wP1"])
+    wseg = (np.vstack([info["wP0"], info["sseg"][0]]),
+            np.vstack([info["wP1"], info["sseg"][1]]))
     onm = (used, x0, y0, CS)
     blk_gray = rc.Blockers([w(P) for P in loops_c], extra=wseg, on=onm)
     grn = [bool(dist[b, a] >= prefg[b, a] - 1e-9) for a, b in q]
@@ -254,7 +263,8 @@ def route(info, s, g):
                 for c2 in cuts + [len(cells)]:
                     b2 = c2 - 1
                     r2 = ([cells[a2]] if a2 == b2 else
-                          rc.cost_astar(er, cells[a2], cells[b2], multg, bn, None))
+                          rc.cost_astar(er, cells[a2], cells[b2], multg,
+                                        blocked, None))
                     if r2 is None:
                         q2 = None
                         break


### PR DESCRIPTION
- fix #4611
- fix #4619

## Summary by Sourcery

在 MapNavigator 的路径规划中引入台阶高度约束，把陡峭的垂直变化视为障碍，并将其纳入寻路与诊断过程。

New Features:
- 添加每个网格单元的台阶高度阈值配置与计算，用于识别导航网格中不可跨越的垂直变化。
- 将识别出的台阶障碍整合到路径规划中，使路径同时避开墙体和过大的台阶高度。
- 将台阶障碍线段暴露给阻塞构造逻辑，以便折线后处理能够遵守垂直约束。

Bug Fixes:
- 通过标记并阻塞超过最大台阶高度的边缘，防止路径无意间穿越陡峭的垂直面，修复不正确的跨越行为。
- 改进诊断警告信息，区分不可避免的墙体穿越与不可避免的垂直面穿越。

Enhancements:
- 使 C++ 和 Python 的 MapNavigator 实现在共享的台阶高度参数与障碍逻辑上保持一致，以在各工具间实现一致行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce step height constraints into MapNavigator routing to treat steep vertical transitions as barriers and incorporate them into pathfinding and diagnostics.

New Features:
- Add configuration and computation of per-cell step height thresholds to identify non-steppable vertical transitions in the navigation grid.
- Integrate detected step barriers into route planning so that paths avoid both walls and excessive step heights.
- Expose step barrier segments to blocker construction so polyline post-processing respects vertical constraints.

Bug Fixes:
- Prevent routes from unintentionally traversing steep vertical faces by marking and blocking edges that exceed the maximum step height, addressing incorrect crossing behavior.
- Improve diagnostic warnings by distinguishing unavoidable wall crossings from unavoidable vertical-face crossings.

Enhancements:
- Align C++ and Python MapNavigator implementations with shared step height parameters and barrier logic for consistent behavior across tools.

</details>