### PR TITLE
perf(MapNavigator): 削去启动期的冗余规划开销

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -298,6 +298,7 @@ std::optional<DynamicAnchor>
     std::optional<DynamicAnchor> best_anchor;
     double best_cost = std::numeric_limits<double>::infinity();
     int planned_count = 0;
+    int skipped_count = 0;
 
     for (size_t index = std::min(start_index, path_size); index < path_size; ++index) {
         const Waypoint& waypoint = session->CurrentPathAt(index);
@@ -323,13 +324,18 @@ std::optional<DynamicAnchor>
 
         const navmesh::WorldPoint start { .x = position.x, .y = position.y };
         const navmesh::WorldPoint goal { .x = waypoint.x, .y = waypoint.y };
-        const auto route = PlanNavmeshRoute(param, position.zone_id, start, goal);
-        if (route) {
-            ++planned_count;
-            if (route->cost < best_cost) {
-                best_cost = route->cost;
-                best_anchor = { *canonical_index, waypoint };
+        if (std::hypot(goal.x - start.x, goal.y - start.y) < best_cost) {
+            const auto route = PlanNavmeshRoute(param, position.zone_id, start, goal);
+            if (route) {
+                ++planned_count;
+                if (route->cost < best_cost) {
+                    best_cost = route->cost;
+                    best_anchor = { *canonical_index, waypoint };
+                }
             }
+        }
+        else {
+            ++skipped_count;
         }
         if (IsRequiredSemanticAnchor(waypoint)) {
             break;
@@ -338,7 +344,7 @@ std::optional<DynamicAnchor>
 
     if (best_anchor) {
         LogInfo << "Bootstrap navmesh anchor selected." << VAR(best_anchor->first) << VAR(best_cost) << VAR(planned_count)
-                << VAR(start_index);
+                << VAR(skipped_count) << VAR(start_index);
     }
     return best_anchor;
 }

--- a/tools/MapNavigator/recastnav_zone.py
+++ b/tools/MapNavigator/recastnav_zone.py
@@ -242,23 +242,25 @@ class ZoneClean:
                     & (ring1 >= 0)[:, :, None]).any((1, 2))
             LOCAL_R = 12.0
             Ccent = mesh.V[T].mean(1)
+            NBL = NB.tolist()
+            CcX = Ccent[:, 0].tolist()
+            CcY = Ccent[:, 1].tolist()
             for r in np.nonzero(~near)[0]:
                 ta_, tb_ = int(iaS[r]), int(ibS[r])
-                mx = (Ccent[ta_] + Ccent[tb_]) * 0.5
+                mxx = (CcX[ta_] + CcX[tb_]) * 0.5
+                mxy = (CcY[ta_] + CcY[tb_]) * 0.5
                 seen = {ta_}
                 dq2 = deque([ta_])
                 hit = False
                 while dq2 and not hit:
-                    t2 = dq2.popleft()
-                    for nb2 in NB[t2]:
-                        nb2 = int(nb2)
+                    for nb2 in NBL[dq2.popleft()]:
                         if nb2 < 0 or nb2 in seen:
                             continue
                         if nb2 == tb_:
                             hit = True
                             break
-                        if abs(Ccent[nb2, 0] - mx[0]) > LOCAL_R \
-                                or abs(Ccent[nb2, 1] - mx[1]) > LOCAL_R:
+                        if abs(CcX[nb2] - mxx) > LOCAL_R \
+                                or abs(CcY[nb2] - mxy) > LOCAL_R:
                             continue
                         seen.add(nb2)
                         dq2.append(nb2)


### PR DESCRIPTION
<img width="2372" height="688" alt="image" src="https://github.com/user-attachments/assets/1222b4d6-4e6a-4693-850b-355988283327" />
<img width="1116" height="694" alt="image" src="https://github.com/user-attachments/assets/9fb5f722-d6f2-4937-b2dc-1c7bd889d3f1" />
<img width="896" height="667" alt="image" src="https://github.com/user-attachments/assets/0dacffbb-765d-4d7b-b65d-aebfec15e100" />


## Summary by Sourcery

在引导锚点选择过程中减少冗余的导航网格路径规划，并优化导航网格区域图遍历性能。

Enhancements:
- 对于距离当前最佳锚点候选更远的路径点，跳过导航网格路径规划，以减少不必要的规划工作。
- 在选择引导导航网格锚点时记录被跳过的路径点数量，以便改进诊断能力。
- 通过预先计算坐标和邻接列表，并在 BFS 循环中使用标量值代替 NumPy 数组，优化 Python 导航网格区域连通性搜索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reduce redundant navmesh route planning during bootstrap anchor selection and optimize navmesh zone graph traversal for performance.

Enhancements:
- Skip navmesh route planning for waypoints that are farther than the current best anchor candidate to cut unnecessary planning work.
- Log the number of skipped waypoints when selecting the bootstrap navmesh anchor for better diagnostics.
- Optimize Python navmesh zone connectivity search by precomputing coordinate and neighbor lists and using scalar values instead of NumPy arrays in the BFS loop.

</details>