### PR TITLE
refactor: 武陵城及首墩淤积点寻路改为MapTrackerGoal

### DIFF
--- a/assets/resource/pipeline/AutoEssence/RegionNodes/WLMarkerStone.json
+++ b/assets/resource/pipeline/AutoEssence/RegionNodes/WLMarkerStone.json
@@ -3,7 +3,7 @@
         "enabled": false,
         "pre_delay": 0,
         "anchor": {
-            "AutoEssenceMoveToTriggerPoint": "GotoTriggerPointMove_WLMarkerStone",
+            "AutoEssenceMoveToTriggerPoint": "GotoTriggerPointGoal_WLMarkerStone",
             "AutoEssenceMoveToTriggerPointMaybeTeleport": "GotoTriggerPointMaybeTeleport_WLMarkerStone"
         },
         "post_delay": 0,
@@ -32,10 +32,10 @@
                             // 淤积点附近
                             "map_name": "map02_lv004",
                             "target": [
-                                272.8,
-                                355.6,
-                                106.9,
-                                102.5
+                                288.6,
+                                367.0,
+                                72.6,
+                                73.9
                             ]
                         }
                     ]
@@ -45,7 +45,7 @@
         "inverse": true,
         "next": [
             "[JumpBack]__GotoTriggerPointTeleportOnce_WLMarkerStone",
-            "GotoTriggerPointMove_WLMarkerStone"
+            "GotoTriggerPointGoal_WLMarkerStone"
         ],
         "focus": {
             "Node.Action.Starting": "✈️准备传送到最近锚点"
@@ -59,103 +59,18 @@
             "SceneEnterWorldWulingMarkerStone2"
         ]
     },
-    "GotoTriggerPointMove_WLMarkerStone": {
-        "desc": "导航入口：已在淤积点附近则只走末段，否则走含圈完整路径",
-        "next": [
-            "GotoTriggerPointMoveNearTrigger_WLMarkerStone",
-            "GotoTriggerPointMoveMain_WLMarkerStone"
-        ],
-        "focus": {
-            "Node.Action.Starting": "🚶正在前往激发点附近"
-        }
-    },
-    "GotoTriggerPointMoveNearTrigger_WLMarkerStone": {
-        "desc": "已在淤积点/激发点区域，跳过圈路径",
-        "recognition": {
-            "type": "Custom",
-            "param": {
-                "custom_recognition": "MapTrackerAssertLocation",
-                "custom_recognition_param": {
-                    "expected": [
-                        {
-                            "map_name": "map02_lv004",
-                            "target": [
-                                287.2,
-                                365.1,
-                                79.8,
-                                85.8
-                            ]
-                        }
-                    ]
-                }
-            }
-        },
-        "next": [
-            "GotoTriggerPointMoveExact_WLMarkerStone"
-        ],
-        "focus": {
-            "Node.Action.Starting": "🚶正在前往激发点"
-        }
-    },
-    "GotoTriggerPointMoveMain_WLMarkerStone": {
-        "desc": "从锚点侧经圈路径接近激发点",
+    "GotoTriggerPointGoal_WLMarkerStone": {
         "action": {
             "type": "Custom",
             "param": {
-                "custom_action": "MapTrackerMove",
+                "custom_action": "MapTrackerGoal",
                 "custom_action_param": {
                     "map_name": "map02_lv004",
-                    "path": [
-                        [
-                            418.8,
-                            321.4
-                        ],
-                        [
-                            418.8,
-                            327.6
-                        ],
-                        [
-                            415.0,
-                            327.6
-                        ],
-                        [
-                            415.0,
-                            321.3
-                        ],
-                        [
-                            323.8,
-                            321.3
-                        ]
+                    "target": [
+                        324.5,
+                        405.5
                     ],
-                    "no_ensure_initial_movement_state": true
-                }
-            }
-        },
-        "next": [
-            "GotoTriggerPointMoveExact_WLMarkerStone"
-        ],
-        "focus": {
-            "Node.Action.Starting": "🚶正在前往激发点附近"
-        }
-    },
-    "GotoTriggerPointMoveExact_WLMarkerStone": {
-        "action": {
-            "type": "Custom",
-            "param": {
-                "custom_action": "MapTrackerMove",
-                "custom_action_param": {
-                    "map_name": "map02_lv004",
-                    "path": [
-                        [
-                            323.2,
-                            394.0
-                        ],
-                        [
-                            324.6,
-                            403.5
-                        ]
-                    ],
-                    "no_ensure_initial_movement_state": true
+                    "no_ensure_initial_movement_state": true // 由于该区域传送点附近是水域，禁用此设置以免掉落
                 }
             }
         },

--- a/assets/resource/pipeline/AutoEssence/RegionNodes/WLWulingCity.json
+++ b/assets/resource/pipeline/AutoEssence/RegionNodes/WLWulingCity.json
@@ -3,7 +3,7 @@
         "enabled": false,
         "pre_delay": 0,
         "anchor": {
-            "AutoEssenceMoveToTriggerPoint": "GotoTriggerPointMove_WLWulingCity",
+            "AutoEssenceMoveToTriggerPoint": "GotoTriggerPointGoal_WLWulingCity",
             "AutoEssenceMoveToTriggerPointMaybeTeleport": "GotoTriggerPointMaybeTeleport_WLWulingCity"
         },
         "post_delay": 0,
@@ -45,7 +45,7 @@
         "inverse": true,
         "next": [
             "[JumpBack]__GotoTriggerPointTeleportOnce_WLWulingCity",
-            "GotoTriggerPointMove_WLWulingCity"
+            "GotoTriggerPointGoal_WLWulingCity"
         ],
         "focus": {
             "Node.Action.Starting": "✈️准备传送到最近锚点"
@@ -59,120 +59,17 @@
             "SceneEnterWorldWulingWulingCity0"
         ]
     },
-    "GotoTriggerPointMove_WLWulingCity": {
+    "GotoTriggerPointGoal_WLWulingCity": {
         "action": {
             "type": "Custom",
             "param": {
-                "custom_action": "MapTrackerMove",
+                "custom_action": "MapTrackerGoal",
                 "custom_action_param": {
                     "map_name": "map02_lv002",
-                    "path": [
-                        [
-                            638.3,
-                            265.7
-                        ],
-                        [
-                            639.4,
-                            280.7
-                        ],
-                        [
-                            639.6,
-                            298.6
-                        ],
-                        [
-                            636.1,
-                            301.2
-                        ],
-                        [
-                            627.6,
-                            301.4
-                        ],
-                        [
-                            624.8,
-                            303.7
-                        ],
-                        [
-                            624.8,
-                            306.3
-                        ],
-                        [
-                            627.3,
-                            310.0
-                        ],
-                        [
-                            631.1,
-                            311.3
-                        ],
-                        [
-                            633.6,
-                            313.6
-                        ],
-                        [
-                            638.3,
-                            313.9
-                        ],
-                        [
-                            643.4,
-                            315.2
-                        ],
-                        [
-                            654.6,
-                            317.7
-                        ],
-                        [
-                            683.8,
-                            318.5
-                        ],
-                        [
-                            685.9,
-                            318.9
-                        ],
-                        [
-                            686.2,
-                            322.5
-                        ],
-                        [
-                            687.0,
-                            326.3
-                        ],
-                        [
-                            684.9,
-                            329.9
-                        ],
-                        [
-                            681.3,
-                            336.0
-                        ],
-                        [
-                            690.0,
-                            340.9
-                        ]
-                    ],
-                    "path_trim": true
-                }
-            }
-        },
-        "next": [
-            "GotoTriggerPointMoveExact_WLWulingCity"
-        ],
-        "focus": {
-            "Node.Action.Starting": "🚶正在前往激发点附近"
-        }
-    },
-    "GotoTriggerPointMoveExact_WLWulingCity": {
-        "action": {
-            "type": "Custom",
-            "param": {
-                "custom_action": "MapTrackerMove",
-                "custom_action_param": {
-                    "map_name": "map02_lv002",
-                    "path": [
-                        [
-                            680.9,
-                            350.9
-                        ]
-                    ],
-                    "no_ensure_initial_movement_state": true
+                    "target": [
+                        680.9,
+                        350.9
+                    ]
                 }
             }
         },


### PR DESCRIPTION
## 概要

此 PR 将武陵城及首墩区域的能量淤积点的寻路方式从 MapTrackerMove 改为了 MapTrackerGoal。此外，修复了先前引入的首墩淤积点终点坐标错误的问题。

## 关联

首墩淤积点终点的坐标错误是从 PR #3752 引入的。

## 跟踪

此 PR 提交前，遥测显示 3 日内武陵城基质刷取失败率为 17.5%，处于较低水平，属于运作正常的节点。后续可以观测失败率的变化，来判断 MapTrackerGoal 是否有提升性能。

## Summary by Sourcery

将五陵城和寿墩能量积累节点的路由切换为 `MapTrackerGoal`，并纠正寿墩终点坐标。

Bug Fixes:
- 修复之前修改中引入的寿墩能量积累节点终点坐标错误问题。

Enhancements:
- 重构五陵城和寿墩能量积累节点的导航逻辑，使其使用 `MapTrackerGoal` 而非 `MapTrackerMove`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch Wuling City and Shoudun energy accumulation node routing to MapTrackerGoal and correct the Shoudun endpoint coordinates.

Bug Fixes:
- Fix incorrect endpoint coordinates for the Shoudun energy accumulation node introduced in a previous change.

Enhancements:
- Refactor Wuling City and Shoudun energy accumulation node navigation to use MapTrackerGoal instead of MapTrackerMove.

</details>