### PR TITLE
fix: 抢委托送货未接取货物时标记失败

### DIFF
--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsPost.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsPost.json
@@ -375,6 +375,8 @@
     "SeizeDeliveryJobsFatalCannotFetchGoods": {
         "desc": "致命错误，始终未识别到接取货物按钮",
         "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "FalseAction",
         "post_delay": 0,
         "next": [
             // 无后续节点，即停止任务


### PR DESCRIPTION
fix #4654

## Summary by Sourcery

Bug 修复：
- 纠正对 seize-delivery 作业的处理方式，确保对于尚未接受取货货物的订单，将其标记为失败，而不是保持在错误的状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct handling of seize-delivery jobs so that orders with unaccepted pickup goods are marked as failed instead of remaining in an incorrect state.

</details>