### PR TITLE
fix(VisitFriends): 识别点击离开按钮退出飞船

### DIFF
--- a/assets/resource/pipeline/VisitFriends/Exectue.json
+++ b/assets/resource/pipeline/VisitFriends/Exectue.json
@@ -676,8 +676,19 @@
         "template": "VisitFriends/ShipEscButton.png",
         "pre_wait_freezes": 400,
         "pre_delay": 0,
-        "action": "ClickKey",
-        "key": 27, // ESC
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "RepeatUntilFoundAction",
+                "custom_action_param": {
+                    "custom_action": "AutoAltClickAction",
+                    "wait_nodes": [
+                        "VisitFriendsEnterFriendsListSuccess"
+                    ],
+                    "interval_ms": 6000
+                }
+            }
+        },
         "post_delay": 0,
         "next": [
             "VisitFriendsEnterFriendsListSuccess"

--- a/assets/resource_adb/pipeline/VisitFriends/Exectue.json
+++ b/assets/resource_adb/pipeline/VisitFriends/Exectue.json
@@ -3,10 +3,5 @@
         "action": {
             "type": "Click"
         }
-    },
-    "VisitFriendsWorldShipExitToMenuFriends": {
-        "action": {
-            "type": "Click"
-        }
     }
 }

--- a/assets/resource_macos/pipeline/MacOSKeyMap.json
+++ b/assets/resource_macos/pipeline/MacOSKeyMap.json
@@ -258,14 +258,6 @@
             }
         }
     },
-    "VisitFriendsWorldShipExitToMenuFriends": {
-        "action": {
-            "type": "ClickKey",
-            "param": {
-                "key": 53
-            }
-        }
-    },
     "_AutoEcoFarmAltDown": {
         "action": {
             "type": "KeyDown",


### PR DESCRIPTION
fix https://github.com/MaaEnd/MaaEnd/issues/4665

## Summary by Sourcery

更新 VisitFriends 流程管线和 MacOS 按键映射，以正确检测并处理通过离开按钮退出飞船的行为。

Bug Fixes（错误修复）:
- 修复 VisitFriends 流程，使点击离开按钮被识别为退出飞船，而不是继续留在场景中。

Enhancements（功能增强）:
- 对齐默认、ADB 和 macOS 环境中的 VisitFriends 流程管线 JSON 资源，以支持一致的离开按钮处理逻辑。

Chores（杂项维护）:
- 调整 macOS 按键映射配置，使其与更新后的 VisitFriends 交互逻辑相匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update VisitFriends pipelines and MacOS key mappings to correctly detect and handle exiting the spaceship via the leave button.

Bug Fixes:
- Fix VisitFriends flow so clicking the leave button is recognized as exiting the spaceship rather than remaining in the scene.

Enhancements:
- Align VisitFriends pipeline JSON resources across default, ADB, and macOS environments to support consistent leave-button handling.

Chores:
- Adjust macOS key mapping configuration to match the updated VisitFriends interaction logic.

</details>