### PR TITLE
fix(EnvironmentMonitoring): 储备站周围的生态环境与植物观察点使用快速传送

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToFloraObservationPoint"
+            "FloraObservationPointInQuickTeleportMap"
         ]
     },
     "AlreadyTrackedFloraObservationPoint": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToFloraObservationPoint"
+            "FloraObservationPointOpenTrackedMissionMap"
         ]
     },
     "FloraObservationPointOpenTrackedMissionMap": {
@@ -340,10 +340,10 @@
         "custom_recognition_param": {
             "zone_id": "Wuling_Base",
             "target": [
-                567.66,
-                2210.92,
-                65.56,
-                55.32
+                0,
+                0,
+                1,
+                1
             ]
         },
         "pre_delay": 0,
@@ -360,7 +360,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneEnterWorldWulingMarkerStone3"
+                "SceneAnyEnterWorld"
             ]
         },
         "post_delay": 0,

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EcologyNearTheFieldLogisticsDepot.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToEcologyNearTheFieldLogisticsDepot"
+            "EcologyNearTheFieldLogisticsDepotInQuickTeleportMap"
         ]
     },
     "AlreadyTrackedEcologyNearTheFieldLogisticsDepot": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToEcologyNearTheFieldLogisticsDepot"
+            "EcologyNearTheFieldLogisticsDepotOpenTrackedMissionMap"
         ]
     },
     "EcologyNearTheFieldLogisticsDepotOpenTrackedMissionMap": {
@@ -342,10 +342,10 @@
                 {
                     "map_name": "map02_lv002",
                     "target": [
-                        684.3,
-                        910.9,
-                        20.5,
-                        20.5
+                        0,
+                        0,
+                        1,
+                        1
                     ]
                 }
             ]
@@ -364,7 +364,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneEnterWorldWulingWulingCity8"
+                "SceneAnyEnterWorld"
             ]
         },
         "post_delay": 0,

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -304,14 +304,8 @@
         "MissionId": "m1m37",
         "Name": "储备站周围的生态环境",
         "Id": "EcologyNearTheFieldLogisticsDepot",
-        "EnterMap": "SceneEnterWorldWulingWulingCity8",
+        "QuickTeleport": true,
         "MapName": "map02_lv002",
-        "MapAssert": [
-            684.3,
-            910.9,
-            20.5,
-            20.5
-        ],
         "MapGoal": [
             618.8,
             901.6
@@ -661,14 +655,8 @@
         "MissionId": "m1m63",
         "Name": "植物观察点",
         "Id": "FloraObservationPoint",
-        "EnterMap": "SceneEnterWorldWulingMarkerStone3",
+        "QuickTeleport": true,
         "MapName": "Wuling_Base",
-        "MapAssert": [
-            567.66,
-            2210.92,
-            65.56,
-            55.32
-        ],
         "MapTarget": [
             93.84,
             185.41


### PR DESCRIPTION
fixed #4664
fixed #4679

## Summary by Sourcery

为与植物观测点以及野外后勤仓库附近生态相关的特定 EnvironmentMonitoring 终端启用快速旅行交互。

Bug Fixes:
- 修复在植物观测点监测终端处无法访问或旅行行为错误的问题。
- 修复在野外后勤仓库附近生态监测终端处无法访问或旅行行为错误的问题。

Enhancements:
- 调整 EnvironmentMonitoring 路线配置，使受影响的终端始终使用快速旅行功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable fast travel interaction for specific EnvironmentMonitoring terminals related to flora observation points and ecology near the field logistics depot.

Bug Fixes:
- Fix inaccessible or incorrect travel behavior at the flora observation point monitoring terminal.
- Fix inaccessible or incorrect travel behavior at the ecology near the field logistics depot monitoring terminal.

Enhancements:
- Align EnvironmentMonitoring route configuration so the affected terminals consistently use fast travel.

</details>