### PR TITLE
fix(MapNavigator): 移除不知道谁丢的二向箔

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
@@ -200,57 +200,6 @@ navmesh::WorldPoint LookaheadOnCorridor(const navmesh::WorldPath& path, const Co
     return path.points.back();
 }
 
-double PointToSegmentDistance(const navmesh::WorldPoint& point, const navmesh::WorldPoint& a, const navmesh::WorldPoint& b)
-{
-    const double dx = b.x - a.x;
-    const double dy = b.y - a.y;
-    const double len_sq = dx * dx + dy * dy;
-    if (len_sq <= std::numeric_limits<double>::epsilon()) {
-        return std::hypot(point.x - a.x, point.y - a.y);
-    }
-    const double t = std::clamp(((point.x - a.x) * dx + (point.y - a.y) * dy) / len_sq, 0.0, 1.0);
-    return std::hypot(point.x - (a.x + t * dx), point.y - (a.y + t * dy));
-}
-
-// Longest arc the lookahead may be pushed forward before the straight chord from the projection to
-// that point leaves the corridor polyline by more than `slack`. Evaluated per tick at vertex
-// granularity: the chord to a candidate vertex is admissible only while every corridor vertex it
-// spans stays within slack of it, so the lookahead comes to rest on the corner instead of past it.
-double ClampLookaheadToPathSlack(const navmesh::WorldPath& path, const CorridorProjection& projection, double distance, double slack)
-{
-    if (path.points.size() < 2 || projection.edge_idx + 1 >= path.points.size() || slack <= 0.0) {
-        return distance;
-    }
-
-    const navmesh::WorldPoint& origin = projection.point;
-    navmesh::WorldPoint previous = origin;
-    double arc = 0.0;
-    double admissible = 0.0;
-
-    for (size_t vertex_idx = projection.edge_idx + 1; vertex_idx < path.points.size(); ++vertex_idx) {
-        const navmesh::WorldPoint& vertex = path.points[vertex_idx];
-        const double arc_to_vertex = arc + std::hypot(vertex.x - previous.x, vertex.y - previous.y);
-        double deviation = 0.0;
-        for (size_t spanned = projection.edge_idx + 1; spanned < vertex_idx && deviation <= slack; ++spanned) {
-            deviation = std::max(deviation, PointToSegmentDistance(path.points[spanned], origin, vertex));
-        }
-        if (deviation > slack) {
-            break;
-        }
-        admissible = arc_to_vertex;
-        if (arc_to_vertex >= distance) {
-            return distance;
-        }
-        arc = arc_to_vertex;
-        previous = vertex;
-    }
-
-    if (admissible <= 0.0) {
-        return distance;
-    }
-    return std::max(kNavRunLookaheadMinM, std::min(distance, admissible));
-}
-
 double UpcomingCorridorTurnDeg(const navmesh::WorldPath& path, const CorridorProjection& projection, double lookahead_distance)
 {
     if (path.points.size() < 2 || projection.edge_idx + 1 >= path.points.size() || lookahead_distance <= 0.0) {
@@ -350,6 +299,10 @@ bool NavRunController::buildPlan(
     if (authored.size() >= 2) {
         navmesh::WorldPath literal_path;
         literal_path.points = std::move(authored);
+        const navmesh::WorldPoint& span_start = literal_path.points.front();
+        if (std::hypot(position.x - span_start.x, position.y - span_start.y) > kMeasurementDefaultPositionQuantum) {
+            literal_path.points.insert(literal_path.points.begin(), { .x = position.x, .y = position.y });
+        }
         commit(std::move(literal_path), true);
         return true;
     }
@@ -365,16 +318,10 @@ bool NavRunController::buildPlan(
     return true;
 }
 
-double NavRunController::chooseLookaheadDistance(const RouteTrackingState& route, bool sprint_active, double upcoming_turn_deg) const
+double NavRunController::chooseLookaheadDistance(const RouteTrackingState& route) const
 {
-    if (upcoming_turn_deg >= kNavRunSharpTurnDeg) {
-        return kNavRunLookaheadSharpTurnM;
-    }
     if (!route.startup_motion_confirmed) {
         return kNavRunLookaheadLowSpeedM;
-    }
-    if (sprint_active) {
-        return kNavRunLookaheadSprintM;
     }
     return kNavRunLookaheadWalkM;
 }
@@ -395,7 +342,6 @@ NavRunTickResult NavRunController::tick(
     const NaviParam& param,
     size_t anchor_index,
     const Waypoint& anchor,
-    bool sprint_active,
     std::chrono::steady_clock::time_point now)
 {
     NavRunTickResult result;
@@ -471,6 +417,10 @@ NavRunTickResult NavRunController::tick(
         }
     }
 
+    if ((projection->before_window || projection->after_window) && projection->cross_track > kNavRunCrossTrackFailM) {
+        return result;
+    }
+
     const double remaining = RemainingAlongCorridor(plan_.path, *projection);
     if (last_remaining_to_anchor_ - remaining >= kRouteProgressEpsilon) {
         last_progress_seen_ = now;
@@ -481,11 +431,7 @@ NavRunTickResult NavRunController::tick(
     }
 
     const double upcoming_turn = UpcomingCorridorTurnDeg(plan_.path, *projection, kNavRunUpcomingTurnLookaheadM);
-    const double lookahead_distance = ClampLookaheadToPathSlack(
-        plan_.path,
-        *projection,
-        chooseLookaheadDistance(route, sprint_active, upcoming_turn),
-        kNavRunLookaheadPathSlackM);
+    const double lookahead_distance = chooseLookaheadDistance(route);
     const navmesh::WorldPoint lookahead = LookaheadOnCorridor(plan_.path, *projection, lookahead_distance);
     const double corridor_heading = NaviMath::CalcTargetRotation(position.x, position.y, lookahead.x, lookahead.y);
 

--- a/agent/cpp-algo/source/MapNavigator/nav_run_controller.h
+++ b/agent/cpp-algo/source/MapNavigator/nav_run_controller.h
@@ -70,7 +70,6 @@ public:
         const NaviParam& param,
         size_t anchor_index,
         const Waypoint& anchor,
-        bool sprint_active,
         std::chrono::steady_clock::time_point now);
 
     void invalidate();
@@ -89,7 +88,7 @@ private:
 
     NavRunReplanReason detectReplanTrigger(const RouteTrackingState& route, std::chrono::steady_clock::time_point now) const;
 
-    double chooseLookaheadDistance(const RouteTrackingState& route, bool sprint_active, double upcoming_turn_deg) const;
+    double chooseLookaheadDistance(const RouteTrackingState& route) const;
 
     NavRunPlan plan_;
     std::chrono::steady_clock::time_point last_progress_seen_ {};

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -86,6 +86,8 @@ constexpr double kSerialRouteDeviationThreshold = 1.5;
 constexpr double kSerialRouteDeviationFailThreshold = 3.0;
 constexpr double kSerialRouteCompensationMinDistance = 1.0;
 constexpr double kWaypointArrivalSlack = 0.5;
+// 判定圈按通道半宽收紧后的下限, 低于此值定位量化误差会让路点吃不掉
+constexpr double kMinArrivalBand = 1.0;
 constexpr int32_t kObstacleRecoveryMinTriggerMs = 3500;
 constexpr int32_t kDynamicRecoveryRetryIntervalMs = kObstacleRecoveryMinTriggerMs;
 constexpr int32_t kDynamicRecoveryTotalTimeoutMs = 30000;
@@ -142,20 +144,11 @@ constexpr int32_t kLocalizationThrashFailCount = 5;
 
 // --- NavRunController (RUN corridor follower) ---
 constexpr double kNavRunLookaheadLowSpeedM = 2.5;
-constexpr double kNavRunLookaheadWalkM = 4.0;
-constexpr double kNavRunLookaheadSprintM = 5.5;
-constexpr double kNavRunLookaheadSharpTurnM = 2.5;
-constexpr double kNavRunSharpTurnDeg = 55.0;
+// The lookahead point is measured forward along the corridor and the agent drives straight at it, so
+// this distance is the whole turn anticipation budget: the steering target only starts rotating once
+// the corner is inside it. It must cover the time a turn takes at the observed 5-8 px/s travel speed.
+constexpr double kNavRunLookaheadWalkM = 6.0;
 constexpr double kNavRunUpcomingTurnLookaheadM = 8.0;
-// The lookahead point is measured forward along the corridor, but the agent then drives straight at it.
-// Once that chord spans a corridor vertex it cuts the corner, by an amount set only by the lookahead
-// distance and the turn angle. Cap the distance so the chord stays within this much of the corridor
-// polyline. Measured tracking error runs about 1.7x this value; the rest is follower lag.
-constexpr double kNavRunLookaheadPathSlackM = 0.5;
-// Floor for the capped distance. Authored waypoint lines are recorded at whole-pixel granularity, so
-// their vertices zigzag within the slack and the cap would otherwise collapse to nothing; a steering
-// target that close sits level with the agent and the follower oscillates in place instead of advancing.
-constexpr double kNavRunLookaheadMinM = 2.0;
 constexpr double kNavRunCrossTrackWarnM = 2.2;
 constexpr double kNavRunCrossTrackFailM = 4.0;
 constexpr double kNavRunProgressReplanMinCrossTrackM = 1.25;

--- a/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <chrono>
 #include <string>
 
@@ -55,6 +56,8 @@ struct Waypoint
     ActionType action;
     bool has_position;
     bool strict_arrival;
+    // 该点处的通道半宽 px, 0 = 未知(非 navmesh 规划的点)
+    double corridor_clearance;
     bool heading_uses_target;
     double heading_angle;
     std::string zone_id;
@@ -73,6 +76,19 @@ struct Waypoint
             return kStrictArrivalLookaheadRadius;
         }
         return kLookaheadRadius;
+    }
+
+    // 到点判定圈半径, 通道比判定圈还窄时按通道收紧, 否则角色会提前弃点直奔下一点, 抄出撞墙的弦
+    double ArrivalBand(double position_quantum) const
+    {
+        if (RequiresStrictArrival()) {
+            return GetLookahead() + position_quantum;
+        }
+        const double band = GetLookahead() + kWaypointArrivalSlack + position_quantum;
+        if (corridor_clearance <= 0.0) {
+            return band;
+        }
+        return std::min(band, std::max(corridor_clearance, kMinArrivalBand));
     }
 
     bool RequiresStrictArrival() const
@@ -99,6 +115,7 @@ struct Waypoint
         , action(ActionType::RUN)
         , has_position(true)
         , strict_arrival(false)
+        , corridor_clearance(0.0)
         , heading_uses_target(false)
         , heading_angle(0.0)
         , zone_id()
@@ -111,6 +128,7 @@ struct Waypoint
         , action(waypoint_action)
         , has_position(true)
         , strict_arrival(false)
+        , corridor_clearance(0.0)
         , heading_uses_target(false)
         , heading_angle(0.0)
         , zone_id()

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -234,6 +234,8 @@ struct NavigationRuntimeState
     int global_reacquire_streak = 0;
     bool dynamic_replan_requested = false;
     bool nav_run_dirty = true;
+    bool progress_from_corridor = false;
+    size_t progress_source_reset_idx = std::numeric_limits<size_t>::max();
 
     void ResetNavigationAssistState()
     {

--- a/agent/cpp-algo/source/MapNavigator/navigation_session.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_session.cpp
@@ -290,11 +290,11 @@ double NavigationSession::best_distance_to_target() const
     return best_distance_to_target_;
 }
 
-void NavigationSession::ObserveHardProgress(size_t waypoint_idx, double actual_distance, const std::chrono::steady_clock::time_point& now)
+void NavigationSession::ObserveHardProgress(size_t target_key, double actual_distance, const std::chrono::steady_clock::time_point& now)
 {
     const double progress_epsilon = std::max(kNoProgressDistanceEpsilon, kMeasurementDefaultPositionQuantum);
-    if (!hard_progress_initialized_ || hard_progress_waypoint_idx_ != waypoint_idx) {
-        hard_progress_waypoint_idx_ = waypoint_idx;
+    if (!hard_progress_initialized_ || hard_progress_target_key_ != target_key) {
+        hard_progress_target_key_ = target_key;
         hard_best_distance_ = actual_distance;
         hard_last_progress_time_ = now;
         hard_progress_initialized_ = true;
@@ -317,19 +317,16 @@ int64_t NavigationSession::HardStalledMs(const std::chrono::steady_clock::time_p
 
 void NavigationSession::ResetHardProgress()
 {
-    hard_progress_waypoint_idx_ = std::numeric_limits<size_t>::max();
+    hard_progress_target_key_ = std::numeric_limits<size_t>::max();
     hard_best_distance_ = std::numeric_limits<double>::max();
     hard_last_progress_time_ = {};
     hard_progress_initialized_ = false;
 }
 
-void NavigationSession::ApplyDynamicOverlay(
-    std::vector<Waypoint> generated_prefix,
-    size_t continue_index,
-    const NaviPosition& pos,
-    bool reset_hard_progress)
+void NavigationSession::ApplyDynamicOverlay(std::vector<Waypoint> generated_prefix, size_t continue_index, const NaviPosition& pos)
 {
     assert(continue_index <= original_path_.size() && "Dynamic overlay continue index is out of range.");
+    const bool retargeted = continue_index != path_origin_index_;
     current_path_ = std::move(generated_prefix);
     const size_t generated_count = current_path_.size();
     current_path_.insert(current_path_.end(), original_path_.begin() + static_cast<std::ptrdiff_t>(continue_index), original_path_.end());
@@ -339,10 +336,7 @@ void NavigationSession::ApplyDynamicOverlay(
     current_node_idx_ = 0;
     current_zone_id_ = pos.zone_id;
     ResetProgress();
-    // Skipped by the unstick replan: it re-applies to the SAME waypoint every recovery retry, so clearing the
-    // hard clock here would keep re-arming it and defeat the recovery timeout. A genuine waypoint change is
-    // re-baselined by ObserveHardProgress on its own, so the clock still tracks real progress either way.
-    if (reset_hard_progress) {
+    if (retargeted) {
         ResetHardProgress();
     }
     LogInfo << "Dynamic route overlay applied." << VAR(generated_count) << VAR(continue_index) << VAR(current_path_.size()) << VAR(pos.x)

--- a/agent/cpp-algo/source/MapNavigator/navigation_session.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_session.h
@@ -61,15 +61,11 @@ struct NavigationSession
     // change (waypoint advance / skip / dynamic overlay) — never by ResetProgress. Dynamic-recovery escapes
     // call ResetProgress on every small jump, so the ordinary stall clock can be reset indefinitely while the
     // agent thrashes in place; this clock survives those resets and lets the recovery timeout actually fire.
-    void ObserveHardProgress(size_t waypoint_idx, double actual_distance, const std::chrono::steady_clock::time_point& now);
+    void ObserveHardProgress(size_t target_key, double actual_distance, const std::chrono::steady_clock::time_point& now);
     int64_t HardStalledMs(const std::chrono::steady_clock::time_point& now) const;
     void ResetHardProgress();
 
-    void ApplyDynamicOverlay(
-        std::vector<Waypoint> generated_prefix,
-        size_t continue_index,
-        const NaviPosition& pos,
-        bool reset_hard_progress = true);
+    void ApplyDynamicOverlay(std::vector<Waypoint> generated_prefix, size_t continue_index, const NaviPosition& pos);
 
     NaviPhase phase() const;
     void UpdatePhase(NaviPhase next_phase, const char* reason);
@@ -92,7 +88,7 @@ private:
     std::chrono::steady_clock::time_point last_progress_time_ {};
     bool progress_initialized_ = false;
 
-    size_t hard_progress_waypoint_idx_ = std::numeric_limits<size_t>::max();
+    size_t hard_progress_target_key_ = std::numeric_limits<size_t>::max();
     double hard_best_distance_ = std::numeric_limits<double>::max();
     std::chrono::steady_clock::time_point hard_last_progress_time_ {};
     bool hard_progress_initialized_ = false;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -622,6 +622,7 @@ bool NavigationStateMachine::ArmRiverFallRecoveryIfBlackScreenLoss(const char* v
     // River-fall owns the recovery: the pre-fall dynamic-recovery anchor is stale after the teleport, and a live
     // recovery's escaped-obstacle check (runs before the river-fall block) would otherwise pre-empt the about-face.
     runtime_state_.recovery.Reset();
+    session_->ResetHardProgress();
     LogInfo << "River-fall recovery armed (black-screen loss recovered)." << VAR(via) << VAR(position_->x) << VAR(position_->y)
             << VAR(runtime_state_.river_fall.water_heading);
     return true;
@@ -633,8 +634,7 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
     const Waypoint& anchor,
     bool use_detour,
     double route_heading,
-    bool emit_interior_corners,
-    bool reset_hard_progress)
+    bool emit_interior_corners)
 {
     if (!anchor.HasPosition()) {
         LogWarn << "Dynamic navmesh overlay skipped: anchor has no position." << VAR(reason) << VAR(continue_index);
@@ -673,7 +673,7 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
                 << VAR(position_->x) << VAR(position_->y);
     }
     const size_t generated_count = generated_prefix.size();
-    session_->ApplyDynamicOverlay(std::move(generated_prefix), continue_index, *position_, reset_hard_progress);
+    session_->ApplyDynamicOverlay(std::move(generated_prefix), continue_index, *position_);
     runtime_state_.route.Reset();
     runtime_state_.nav_run_dirty = true;
     if (generated_count == 0 && std::hypot(anchor.x - position_->x, anchor.y - position_->y) <= ArrivalBandForStartupBypass(anchor)) {
@@ -688,11 +688,7 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
     return true;
 }
 
-bool NavigationStateMachine::TryApplyDynamicOverlayToNextAnchor(
-    const char* reason,
-    bool use_detour,
-    double route_heading,
-    bool reset_hard_progress)
+bool NavigationStateMachine::TryApplyDynamicOverlayToNextAnchor(const char* reason, bool use_detour, double route_heading)
 {
     const std::optional<DynamicAnchor> anchor = ResolveCurrentAnchor(session_, *position_);
     if (!anchor) {
@@ -707,8 +703,7 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToNextAnchor(
         anchor->second,
         use_detour,
         route_heading,
-        /*emit_interior_corners=*/false,
-        reset_hard_progress);
+        /*emit_interior_corners=*/false);
 }
 
 bool NavigationStateMachine::HandleDynamicReplanRequest(const char* reason)
@@ -779,6 +774,7 @@ bool NavigationStateMachine::TryEnterCrossTierEscape()
     }
     runtime_state_.cross_tier_escape.active = true;
     runtime_state_.cross_tier_escape.anchor_zone = position_->zone_id;
+    session_->ResetHardProgress();
     LogInfo << "Cross-tier escape engaged: routing out of a wrong tier via navmesh." << VAR(position_->zone_id) << VAR(position_->x)
             << VAR(position_->y) << VAR(runtime_state_.cross_tier_escape.goal_x) << VAR(runtime_state_.cross_tier_escape.goal_y);
     return true;
@@ -836,9 +832,7 @@ bool NavigationStateMachine::ExecutePhysicalUnstick(double stuck_heading)
     LogInfo << "Physical unstick step executed." << VAR(distance) << VAR(moved) << VAR(dislodged) << VAR(unstick.count)
             << VAR(target_heading) << VAR(target->x) << VAR(target->y);
 
-    // Refresh the route from the new spot but keep the hard-progress clock: this replan re-fires every recovery
-    // retry while stuck, and resetting the clock each time would defeat the 30s recovery timeout (livelock).
-    if (TryApplyDynamicOverlayToNextAnchor("recovery_unstick_replan", false, 0.0, /*reset_hard_progress=*/false)) {
+    if (TryApplyDynamicOverlayToNextAnchor("recovery_unstick_replan", false)) {
         session_->ResetProgress();
         SelectPhaseForCurrentWaypoint("recovery_unstick_replan");
         return true;
@@ -969,6 +963,7 @@ bool NavigationStateMachine::TickNavigate()
     }
 
     NavRunTickResult nav_run_result;
+    std::optional<size_t> nav_run_anchor_index;
     if (route.valid && session_->HasCurrentWaypoint()) {
         const Waypoint& current_waypoint = session_->CurrentWaypoint();
         if (current_waypoint.HasPosition() && current_waypoint.action == ActionType::RUN) {
@@ -983,8 +978,7 @@ bool NavigationStateMachine::TickNavigate()
                 nav_run_anchor = ResolveCurrentAnchor(session_, *position_);
             }
             if (nav_run_anchor) {
-                const bool sprint_proxy = route.startup_motion_confirmed && param_.sprint_threshold > 0.0
-                                          && route.along_track_remaining > param_.sprint_threshold;
+                nav_run_anchor_index = nav_run_anchor->first;
                 nav_run_result = nav_run_controller_.tick(
                     session_,
                     &runtime_state_,
@@ -993,7 +987,6 @@ bool NavigationStateMachine::TickNavigate()
                     param_,
                     nav_run_anchor->first,
                     nav_run_anchor->second,
-                    sprint_proxy,
                     now);
             }
         }
@@ -1038,10 +1031,22 @@ bool NavigationStateMachine::TickNavigate()
     if (route.valid) {
         const double effective_progress =
             nav_run_result.has_corridor_heading ? nav_run_result.remaining_to_anchor : route.progress_distance;
+        if (runtime_state_.progress_from_corridor != nav_run_result.has_corridor_heading) {
+            runtime_state_.progress_from_corridor = nav_run_result.has_corridor_heading;
+            if (runtime_state_.progress_source_reset_idx != session_->current_node_idx()) {
+                runtime_state_.progress_source_reset_idx = session_->current_node_idx();
+                session_->ResetProgress();
+                session_->ResetHardProgress();
+            }
+        }
         session_->ObserveProgress(session_->current_node_idx(), effective_progress, now);
         // Feed the same signal to the hard watchdog, which recovery escapes can never reset (they only clear
         // the ordinary ObserveProgress clock). This is what lets the recovery timeout below actually fire.
-        session_->ObserveHardProgress(session_->current_node_idx(), effective_progress, now);
+        constexpr size_t kSerialProgressKeyBias = std::numeric_limits<size_t>::max() / 2;
+        const size_t hard_progress_key = nav_run_result.has_corridor_heading && nav_run_anchor_index
+                                             ? *nav_run_anchor_index
+                                             : kSerialProgressKeyBias + session_->current_node_idx();
+        session_->ObserveHardProgress(hard_progress_key, effective_progress, now);
     }
     // Cross-tier escape: follow the ONE planned corridor (arrival above is the success exit). Fast-fail when the
     // corridor makes no genuine progress for too long. Keys on the hard-progress clock, which the escape's own

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -50,13 +50,8 @@ private:
         const Waypoint& anchor,
         bool use_detour,
         double route_heading = 0.0,
-        bool emit_interior_corners = false,
-        bool reset_hard_progress = true);
-    bool TryApplyDynamicOverlayToNextAnchor(
-        const char* reason,
-        bool use_detour,
-        double route_heading = 0.0,
-        bool reset_hard_progress = true);
+        bool emit_interior_corners = false);
+    bool TryApplyDynamicOverlayToNextAnchor(const char* reason, bool use_detour, double route_heading = 0.0);
     bool HandleDynamicReplanRequest(const char* reason);
     bool TryEnterCrossTierEscape();
     bool PlanCrossTierEscapeCorridorFromHere(const char* reason);

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -462,6 +462,7 @@ navmesh::BaseNavRouteResult PlanCorridorRoute(const CachedNavmesh& navmesh, cons
     result.path.zone_id = zone->zone_id;
     result.path.zone_name = request.zone_name;
     result.path.points = std::move(plan.points);
+    result.path.clearance = std::move(plan.clearance);
     result.cost = plan.length;
     return result;
 }
@@ -1013,8 +1014,11 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshDetourRoute(
                 continue;
             }
             const auto route_to_detour = PlanNavmeshRouteImpl(param, position.zone_id, start, snapped->point, blocked, blocked_points);
+            if (!route_to_detour) {
+                continue;
+            }
             const auto route_to_goal = PlanNavmeshRouteImpl(param, position.zone_id, snapped->point, goal, blocked, blocked_points);
-            if (!route_to_detour || !route_to_goal) {
+            if (!route_to_goal) {
                 continue;
             }
 
@@ -1113,12 +1117,16 @@ bool AppendGeneratedNavmeshWaypoints(
     const std::unordered_set<size_t> segment_breaks(world_path.segment_breaks.begin(), world_path.segment_breaks.end());
     const size_t total = world_path.points.size();
     const size_t loop_end = include_goal ? total : (total > 0 ? total - 1 : 0);
+    const auto clearance_at = [&](size_t index) {
+        return index < world_path.clearance.size() ? world_path.clearance[index] : 0.0;
+    };
 
     if (emit_interior_corners) {
         for (size_t index = 1; index < loop_end; ++index) {
             const navmesh::WorldPoint& point = world_path.points[index];
             out_path.emplace_back(point.x, point.y, ActionType::RUN);
             out_path.back().strict_arrival = false;
+            out_path.back().corridor_clearance = clearance_at(index);
         }
         if (include_goal && total >= 2) {
             const navmesh::WorldPoint& goal = world_path.points[total - 1];
@@ -1137,12 +1145,14 @@ bool AppendGeneratedNavmeshWaypoints(
         for (size_t corner = prev + 1; corner < anchor; ++corner) {
             out_path.emplace_back(world_path.points[corner].x, world_path.points[corner].y, ActionType::RUN);
             out_path.back().strict_arrival = false;
+            out_path.back().corridor_clearance = clearance_at(corner);
         }
     };
     const auto flush_leg_to = [&](size_t anchor, bool strict_arrival) {
         restore_corners_to(anchor);
         out_path.emplace_back(world_path.points[anchor].x, world_path.points[anchor].y, ActionType::RUN);
         out_path.back().strict_arrival = strict_arrival;
+        out_path.back().corridor_clearance = clearance_at(anchor);
         prev = anchor;
     };
 

--- a/agent/cpp-algo/source/MapNavigator/route_tracker.cpp
+++ b/agent/cpp-algo/source/MapNavigator/route_tracker.cpp
@@ -129,12 +129,13 @@ bool TryAdvancePassedRunWaypoints(
         }
 
         const Waypoint& next_waypoint = session->CurrentPathAt(segment->to_idx);
-        const double next_arrival_band = next_waypoint.GetLookahead() + kWaypointArrivalSlack + position_quantum;
+        const double next_arrival_band = next_waypoint.ArrivalBand(position_quantum);
+        const bool near_next_waypoint = segment->next_distance <= next_arrival_band;
         const bool projection_growing =
             state->best_projection_on_segment >= 0.55 && segment->clamped_projection + 0.05 >= state->best_projection_on_segment;
         const bool route_fact_passed =
             segment->next_distance + position_quantum < segment->current_distance || segment->turn_back_yaw >= 110.0;
-        const bool hard_pass_evidence = route_fact_passed || segment->raw_projection >= 1.05 || segment->next_distance <= next_arrival_band;
+        const bool hard_pass_evidence = route_fact_passed || segment->raw_projection >= 1.05 || near_next_waypoint;
         const bool should_latch =
             !state->passed_waypoint_latched && segment->raw_projection >= 0.40
             && (((segment->cross_track_distance <= kSerialRouteDeviationThreshold) && hard_pass_evidence)
@@ -153,7 +154,7 @@ bool TryAdvancePassedRunWaypoints(
         }
 
         const bool entered_next_segment = segment->raw_projection >= 1.05;
-        if (segment->clamped_projection < 0.90 && segment->next_distance > next_arrival_band && !entered_next_segment) {
+        if (segment->clamped_projection < 0.90 && !near_next_waypoint && !entered_next_segment) {
             break;
         }
 
@@ -204,8 +205,7 @@ RouteTrackingState RouteTracker::Update(NavigationSession* session, RouteTracker
     }
 
     tracking.valid = true;
-    tracking.arrival_band = waypoint.RequiresStrictArrival() ? waypoint.GetLookahead() + PositionQuantum()
-                                                             : waypoint.GetLookahead() + kWaypointArrivalSlack + PositionQuantum();
+    tracking.arrival_band = waypoint.ArrivalBand(PositionQuantum());
     tracking.waypoint_distance = std::hypot(waypoint.x - position.x, waypoint.y - position.y);
     tracking.progress_distance = tracking.waypoint_distance;
     tracking.waypoint_heading = NaviMath::CalcTargetRotation(position.x, position.y, waypoint.x, waypoint.y);

--- a/agent/cpp-algo/source/MapNavigator/steering_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/steering_controller.cpp
@@ -11,10 +11,10 @@ namespace mapnavigator
 namespace
 {
 
-constexpr double kHeadingDeadband = 2.6;
+constexpr double kHeadingDeadband = 6.6;
 constexpr double kMovingMaxCmd = 90.0;
 constexpr double kTurningMaxCmd = 70.0;
-constexpr double kKp = 0.3;
+constexpr double kKp = 0.6;
 constexpr double kHeadingRateDampingGain = 0.5;
 constexpr double kHeadingRateDeadbandDeg = 3.0;
 constexpr double kHeadingRatePlausibleMaxDeg = 60.0;

--- a/agent/cpp-algo/source/Navmesh/NavmeshTypes.h
+++ b/agent/cpp-algo/source/Navmesh/NavmeshTypes.h
@@ -19,6 +19,8 @@ struct WorldPath
     uint16_t zone_id = 0;
     std::string zone_name;
     std::vector<WorldPoint> points;
+    // 与 points 等长的逐点通道半宽 px; 为空表示该路径不是 navmesh 规划出来的
+    std::vector<double> clearance;
     std::vector<size_t> segment_breaks;
 };
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -160,10 +160,12 @@ SpanTable BuildSpans(const std::vector<int64_t>& cell, const std::vector<float>&
     });
     double acc = 0.0;
     int64_t cnt = 0;
+    float anchor = 0.0F;
     for (int64_t i = 0; i < n; ++i) {
         const int64_t c = cell[ord[i]];
         const float hv = h[ord[i]];
-        const bool fresh = i == 0 || c != cell[ord[i - 1]] || (hv - h[ord[i - 1]]) > 1.0f;
+        const bool fresh =
+            i == 0 || c != cell[ord[i - 1]] || (static_cast<double>(hv) - static_cast<double>(anchor)) > kMergeH;
         if (fresh) {
             if (cnt) {
                 st.sp_h.push_back(static_cast<float>(acc / static_cast<double>(cnt)));
@@ -171,13 +173,40 @@ SpanTable BuildSpans(const std::vector<int64_t>& cell, const std::vector<float>&
             st.sp_cell.push_back(c);
             acc = 0.0;
             cnt = 0;
+            anchor = hv;
         }
         acc += static_cast<double>(hv);
         ++cnt;
     }
     st.sp_h.push_back(static_cast<float>(acc / static_cast<double>(cnt)));
+    return PackSpans(std::move(st.sp_cell), std::move(st.sp_h));
+}
 
-    const int64_t n_span = static_cast<int64_t>(st.sp_cell.size());
+SpanTable PackSpans(std::vector<int64_t> cell, std::vector<float> h, std::vector<uint8_t>* flags)
+{
+    SpanTable st;
+    const int64_t n_span = static_cast<int64_t>(cell.size());
+    if (n_span == 0) {
+        return st;
+    }
+    std::vector<int64_t> ord(static_cast<size_t>(n_span));
+    std::iota(ord.begin(), ord.end(), 0);
+    std::stable_sort(ord.begin(), ord.end(), [&](int64_t a, int64_t b) {
+        return cell[a] < cell[b] || (cell[a] == cell[b] && h[a] < h[b]);
+    });
+    st.sp_cell.resize(static_cast<size_t>(n_span));
+    st.sp_h.resize(static_cast<size_t>(n_span));
+    for (int64_t i = 0; i < n_span; ++i) {
+        st.sp_cell[i] = cell[ord[i]];
+        st.sp_h[i] = h[ord[i]];
+    }
+    if (flags != nullptr) {
+        std::vector<uint8_t> fo(static_cast<size_t>(n_span));
+        for (int64_t i = 0; i < n_span; ++i) {
+            fo[i] = (*flags)[ord[i]];
+        }
+        flags->swap(fo);
+    }
     for (int64_t i = 0; i < n_span; ++i) {
         if (i == 0 || st.sp_cell[i] != st.sp_cell[i - 1]) {
             st.occ.push_back(st.sp_cell[i]);
@@ -190,7 +219,7 @@ SpanTable BuildSpans(const std::vector<int64_t>& cell, const std::vector<float>&
     const int64_t n_occ = static_cast<int64_t>(st.occ.size());
     st.HK.assign(static_cast<size_t>(n_occ * st.K), std::numeric_limits<float>::infinity());
     st.IK.assign(static_cast<size_t>(n_occ * st.K), -1);
-    st.sp_ci.resize(n_span);
+    st.sp_ci.resize(static_cast<size_t>(n_span));
     for (int64_t ci = 0, si = 0; ci < n_occ; ++ci) {
         for (int64_t r = 0; r < st.ccnt[ci]; ++r, ++si) {
             st.HK[ci * st.K + r] = st.sp_h[si];
@@ -296,6 +325,46 @@ std::vector<uint8_t> Flood(int64_t seed, const SpanTable& st, int64_t nx)
                     }
                     const int64_t cand = st.IK[j * st.K + slot];
                     if (cand >= 0 && !vis[static_cast<size_t>(cand)]) {
+                        vis[static_cast<size_t>(cand)] = 1;
+                        next.push_back(cand);
+                    }
+                }
+            }
+        }
+        frontier = std::move(next);
+    }
+    return vis;
+}
+
+std::vector<uint8_t> SpanReach(int64_t seed, const SpanTable& st, const std::vector<uint8_t>& ok, int64_t nx, int64_t ny)
+{
+    std::vector<uint8_t> vis(st.sp_h.size(), 0);
+    if (seed < 0 || ok[static_cast<size_t>(seed)] == 0) {
+        return vis;
+    }
+    vis[static_cast<size_t>(seed)] = 1;
+    std::vector<int64_t> frontier { seed };
+    while (!frontier.empty()) {
+        std::vector<int64_t> next;
+        for (const int64_t f : frontier) {
+            const int64_t cid = st.occ[st.sp_ci[f]];
+            const int64_t gx = cid % nx, gy = cid / nx;
+            for (const auto& d : kNb8) {
+                const int64_t ax = gx + d.dx, ay = gy + d.dy;
+                if (ax < 0 || ax >= nx || ay < 0 || ay >= ny) {
+                    continue;
+                }
+                const int64_t j = occFind(st.occ, ay * nx + ax);
+                if (j < 0) {
+                    continue;
+                }
+                for (int64_t slot = 0; slot < st.K; ++slot) {
+                    const float dh = st.HK[j * st.K + slot] - st.sp_h[f];
+                    if (!(static_cast<double>(dh) <= kUp * d.w) || !(dh >= -static_cast<float>(kClimb))) {
+                        continue;
+                    }
+                    const int64_t cand = st.IK[j * st.K + slot];
+                    if (cand >= 0 && ok[static_cast<size_t>(cand)] != 0 && !vis[static_cast<size_t>(cand)]) {
                         vis[static_cast<size_t>(cand)] = 1;
                         next.push_back(cand);
                     }
@@ -587,6 +656,10 @@ StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, con
             }
         }
     }
+    out.t0.resize(static_cast<size_t>(NC));
+    for (int64_t c = 0; c < NC; ++c) {
+        out.t0[static_cast<size_t>(c)] = T[static_cast<size_t>(c * K)];
+    }
 
     static constexpr std::array<std::array<int64_t, 2>, 4> kDirs { { { 1, 0 }, { 0, 1 }, { 1, 1 }, { 1, -1 } } };
     for (const auto& d : kDirs) {
@@ -616,7 +689,7 @@ StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, con
                     }
                 }
             }
-            if (!(static_cast<double>(best) > kStep)) {
+            if (!(static_cast<double>(best) > kSlope * std::hypot(static_cast<double>(dx), static_cast<double>(dy)) * kCS)) {
                 continue;
             }
             const bool up = T[static_cast<size_t>(b * K + bkb)] > T[static_cast<size_t>(c * K + bka)];
@@ -759,8 +832,14 @@ Mask CloseCracks(const Mask& core, const Mask& lay, const Mask* protect)
     return out;
 }
 
-std::optional<std::vector<CellPt>>
-    CostAstar(const Mask& mask, CellPt s, CellPt g, const Grid<float>& mult, const std::unordered_set<int64_t>* banned, const double* bnp)
+std::optional<std::vector<CellPt>> CostAstar(
+    const Mask& mask,
+    CellPt s,
+    CellPt g,
+    const Grid<float>& mult,
+    const std::unordered_set<int64_t>* banned,
+    const double* bnp,
+    const std::unordered_set<int64_t>* forbidden)
 {
     const int64_t ny = mask.ny, nx = mask.nx;
     if (!mask.at(s.y, s.x) || !mask.at(g.y, g.x)) {
@@ -792,8 +871,12 @@ std::optional<std::vector<CellPt>>
             if (d.dx != 0 && d.dy != 0 && !(mask.at(y, a) && mask.at(b, x))) {
                 continue;
             }
+            const int64_t eid = (y * nx + x) * NC + (b * nx + a);
+            if (forbidden != nullptr && forbidden->contains(eid)) {
+                continue;
+            }
             double pen = 0.0;
-            if (banned != nullptr && banned->contains((y * nx + x) * NC + (b * nx + a))) {
+            if (banned != nullptr && banned->contains(eid)) {
                 if (bnp == nullptr) {
                     continue;
                 }
@@ -819,6 +902,103 @@ std::optional<std::vector<CellPt>>
         x = p % nx;
         y = p / nx;
         out.push_back({ x, y });
+    }
+    std::reverse(out.begin(), out.end());
+    return out;
+}
+
+std::optional<std::vector<int64_t>> SpanAstar(
+    const SpanTable& st,
+    const std::vector<uint8_t>& ok,
+    const std::vector<int64_t>& cidx,
+    const Mask& ok2,
+    int64_t s,
+    const std::vector<int64_t>& gset,
+    const Grid<float>& mult,
+    const std::unordered_set<int64_t>* banned,
+    const double* bnp,
+    const std::unordered_set<int64_t>* forbidden)
+{
+    if (s < 0 || ok[static_cast<size_t>(s)] == 0 || gset.empty()) {
+        return std::nullopt;
+    }
+    const int64_t nx = ok2.nx, ny = ok2.ny, NC = nx * ny, K = st.K;
+    const int64_t gc = st.occ[st.sp_ci[static_cast<size_t>(gset.front())]];
+    const int64_t gxx = gc % nx, gyy = gc / nx;
+    std::vector<double> dist(st.sp_h.size(), std::numeric_limits<double>::infinity());
+    std::vector<int64_t> prev(st.sp_h.size(), -1);
+    dist[static_cast<size_t>(s)] = 0.0;
+    using Node = std::tuple<double, int64_t>;
+    std::priority_queue<Node, std::vector<Node>, std::greater<Node>> pq;
+    pq.emplace(0.0, s);
+    int64_t hit = -1;
+    while (!pq.empty()) {
+        const auto [f, u] = pq.top();
+        pq.pop();
+        const double d0 = dist[static_cast<size_t>(u)];
+        const int64_t cu = st.occ[st.sp_ci[static_cast<size_t>(u)]];
+        const int64_t x = cu % nx, y = cu / nx;
+        if (f > d0 + std::hypot(static_cast<double>(gxx - x), static_cast<double>(gyy - y)) + 1e-9) {
+            continue;
+        }
+        if (std::find(gset.begin(), gset.end(), u) != gset.end()) {
+            hit = u;
+            break;
+        }
+        const float hu = st.sp_h[static_cast<size_t>(u)];
+        const float m0 = mult.v[static_cast<size_t>(cu)];
+        for (const auto& d : kNb8) {
+            const int64_t a = x + d.dx, b = y + d.dy;
+            if (a < 0 || a >= nx || b < 0 || b >= ny) {
+                continue;
+            }
+            const int64_t cv = b * nx + a;
+            if (ok2.v[static_cast<size_t>(cv)] == 0) {
+                continue;
+            }
+            if (d.dx != 0 && d.dy != 0 && !(ok2.at(y, a) && ok2.at(b, x))) {
+                continue;
+            }
+            const int64_t j = cidx[static_cast<size_t>(cv)];
+            if (j < 0) {
+                continue;
+            }
+            const int64_t eid = cu * NC + cv;
+            if (forbidden != nullptr && forbidden->contains(eid)) {
+                continue;
+            }
+            double pen = 0.0;
+            if (banned != nullptr && banned->contains(eid)) {
+                if (bnp == nullptr) {
+                    continue;
+                }
+                pen = *bnp;
+            }
+            const float step = static_cast<float>(d.w * 0.5) * (m0 + mult.v[static_cast<size_t>(cv)]);
+            const double nd = d0 + static_cast<double>(step) + pen;
+            for (int64_t k = 0; k < K; ++k) {
+                const int64_t v = st.IK[j * K + k];
+                if (v < 0 || ok[static_cast<size_t>(v)] == 0) {
+                    continue;
+                }
+                const float dh = st.HK[j * K + k] - hu;
+                if (static_cast<double>(dh) > kUp * d.w || dh < -static_cast<float>(kClimb)) {
+                    continue;
+                }
+                if (nd < dist[static_cast<size_t>(v)] - 1e-12) {
+                    dist[static_cast<size_t>(v)] = nd;
+                    prev[static_cast<size_t>(v)] = u;
+                    pq.emplace(nd + std::hypot(static_cast<double>(gxx - a), static_cast<double>(gyy - b)), v);
+                }
+            }
+        }
+    }
+    if (hit < 0) {
+        return std::nullopt;
+    }
+    std::vector<int64_t> out { hit };
+    while (out.back() != s) {
+        out.push_back(prev[static_cast<size_t>(out.back())]);
     }
     std::reverse(out.begin(), out.end());
     return out;
@@ -1177,11 +1357,82 @@ double ClearanceFloor::cost(const WorldPoint& p, const WorldPoint& q) const
     return L * (acc / static_cast<double>(n));
 }
 
-std::vector<WorldPoint> StringPull(const std::vector<WorldPoint>& pts, const Blockers& blk, const ClearanceFloor* cfl)
+std::optional<std::vector<float>> LayerOracle::walk(const std::vector<WorldPoint>& pts, float h) const
+{
+    std::vector<CellPt> cells;
+    for (size_t i = 1; i < pts.size(); ++i) {
+        const int64_t ax = static_cast<int64_t>((pts[i - 1].x - x0_) / kCS);
+        const int64_t ay = static_cast<int64_t>((pts[i - 1].y - y0_) / kCS);
+        const int64_t bx = static_cast<int64_t>((pts[i].x - x0_) / kCS);
+        const int64_t by = static_cast<int64_t>((pts[i].y - y0_) / kCS);
+        const int64_t n = std::max<int64_t>(std::max(std::abs(bx - ax), std::abs(by - ay)), 1);
+        for (int64_t k = 0; k <= n; ++k) {
+            const CellPt c { ax + static_cast<int64_t>(std::nearbyint(static_cast<double>(bx - ax) * static_cast<double>(k)
+                                                                     / static_cast<double>(n))),
+                             ay + static_cast<int64_t>(std::nearbyint(static_cast<double>(by - ay) * static_cast<double>(k)
+                                                                     / static_cast<double>(n))) };
+            if (cells.empty() || !(cells.back() == c)) {
+                cells.push_back(c);
+            }
+        }
+    }
+    std::erase_if(cells, [&](const CellPt& c) { return c.x < 0 || c.x >= nx_ || c.y < 0 || c.y >= ny_; });
+    std::vector<float> cur { h };
+    std::vector<float> nb;
+    std::vector<float> nxt;
+    CellPt pc = cells.empty() ? CellPt {} : cells[0];
+    for (size_t i = 1; i < cells.size(); ++i) {
+        const int64_t j = (*cidx_)[static_cast<size_t>(cells[i].y * nx_ + cells[i].x)];
+        if (j < 0) {
+            continue;
+        }
+        nb.clear();
+        for (int64_t k = 0; k < st_->K; ++k) {
+            if (st_->IK[j * st_->K + k] >= 0) {
+                nb.push_back(st_->HK[j * st_->K + k]);
+            }
+        }
+        if (nb.empty()) {
+            continue;
+        }
+        nxt.clear();
+        const double up = kSlope
+            * std::hypot(static_cast<double>(cells[i].x - pc.x), static_cast<double>(cells[i].y - pc.y)) * kCS;
+        for (const float t : nb) {
+            for (const float c : cur) {
+                const float dh = t - c;
+                if (static_cast<double>(dh) <= up && dh >= -static_cast<float>(kClimb)) {
+                    nxt.push_back(t);
+                    break;
+                }
+            }
+        }
+        if (nxt.empty()) {
+            return std::nullopt;
+        }
+        cur = nxt;
+        pc = cells[i];
+    }
+    return cur;
+}
+
+bool LayerOracle::ok(const WorldPoint& p, const WorldPoint& q, float h, float hq) const
+{
+    const auto cur = walk({ p, q }, h);
+    if (!cur.has_value()) {
+        return false;
+    }
+    return std::any_of(cur->begin(), cur->end(), [&](float v) { return std::fabs(v - hq) <= 1e-3F; });
+}
+
+std::vector<WorldPoint> StringPull(
+    const std::vector<WorldPoint>& pts,
+    const Blockers& blk,
+    const ClearanceFloor* cfl,
+    const LayerOracle* lyo,
+    const std::vector<float>* hs)
 {
     std::vector<WorldPoint> P = pts;
-    // 跨点连线须同时不低于被跳过子路径的净空地板、不高于其代价泛函(与几何重寻同口径),
-    // 相邻点连线无条件保留
     std::vector<float> seg;
     std::vector<double> cst;
     if (cfl != nullptr && P.size() > 1) {
@@ -1220,7 +1471,8 @@ std::vector<WorldPoint> StringPull(const std::vector<WorldPoint>& pts, const Blo
                 if (!blk.blocked(P[i], P[j])
                     && (!guard
                         || (static_cast<double>(cfl->seg(P[i], P[j])) >= static_cast<double>(acc[k]) - kClrTol
-                            && cfl->cost(P[i], P[j]) <= ac2[k] * (1.0 + kCostTol)))) {
+                            && cfl->cost(P[i], P[j]) <= ac2[k] * (1.0 + kCostTol)))
+                    && (lyo == nullptr || lyo->ok(P[i], P[j], (*hs)[idx[i]], (*hs)[idx[j]]))) {
                     break;
                 }
                 --j;

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -13,13 +13,14 @@ namespace navmesh::recast
 
 inline constexpr double kCS = 0.25;                // 体素边长 px
 inline constexpr double kClimb = 3.0;              // 相邻格可连通最大高差 px
-inline constexpr double kStep = 0.5;               // 相邻格可直接迈上的最大高差 px, 超出即立面
-inline constexpr double kMergeH = 1.0;             // 同列 span 合并容差 px
+inline constexpr double kSlope = 1.0;              // 可攀爬坡度上限 tanθ, 抬升超过水平位移的这个倍数即立面
+inline constexpr double kUp = kSlope * kCS;        // 正交相邻格允许的抬升 px, 斜向按实际水平位移等比放大
+inline constexpr double kMergeH = kUp;             // 同列 span 合并容差 px, 取 kUp 使同层内处处可一步跨到
 inline constexpr double kEdtCap = 12.0;            // 距离场截断 px
 inline constexpr double kR = 1.75;                 // 期望余量上限 px
 inline constexpr double kGeoR = 3.5;               // 几何口径舒适余量上限 px
 inline constexpr double kRel = 0.6;                // 期望余量 = min(R, REL×局部净空)
-inline constexpr double kLam = 1.5;                // 满亏欠一步加价倍数
+inline constexpr double kLam = 4.0;                // 满亏欠一步加价倍数
 inline constexpr double kRidgeFloor = 0.5;         // 脊线保底余量地板 px
 inline constexpr double kMaxErr = 0.5;             // 轮廓 DP 容差 px
 inline constexpr double kSlimEps = 0.5;            // 终线共线剔除容差 px
@@ -105,7 +106,11 @@ void AppendSeamBridge(RasterCells& rc, int64_t nx, int64_t ny);
 
 SpanTable BuildSpans(const std::vector<int64_t>& cell, const std::vector<float>& h);
 
+SpanTable PackSpans(std::vector<int64_t> cell, std::vector<float> h, std::vector<uint8_t>* flags = nullptr);
+
 std::vector<uint8_t> Flood(int64_t seed, const SpanTable& st, int64_t nx);
+
+std::vector<uint8_t> SpanReach(int64_t seed, const SpanTable& st, const std::vector<uint8_t>& ok, int64_t nx, int64_t ny);
 
 Grid<float> Clearance(const Mask& mask);
 
@@ -142,6 +147,7 @@ struct StepBarrier
     std::unordered_set<int64_t> steps;
     std::vector<WorldPoint> p0;
     std::vector<WorldPoint> p1;
+    std::vector<float> t0;
 };
 
 StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, const Mask& lay, double ox, double oy);
@@ -152,8 +158,26 @@ Mask FillHoles(const Mask& mask, int64_t max_cells, const Mask* protect);
 
 Mask CloseCracks(const Mask& core, const Mask& lay, const Mask* protect);
 
-std::optional<std::vector<CellPt>>
-    CostAstar(const Mask& mask, CellPt s, CellPt g, const Grid<float>& mult, const std::unordered_set<int64_t>* banned, const double* bnp);
+std::optional<std::vector<CellPt>> CostAstar(
+    const Mask& mask,
+    CellPt s,
+    CellPt g,
+    const Grid<float>& mult,
+    const std::unordered_set<int64_t>* banned,
+    const double* bnp,
+    const std::unordered_set<int64_t>* forbidden = nullptr);
+
+std::optional<std::vector<int64_t>> SpanAstar(
+    const SpanTable& st,
+    const std::vector<uint8_t>& ok,
+    const std::vector<int64_t>& cidx,
+    const Mask& ok2,
+    int64_t s,
+    const std::vector<int64_t>& gset,
+    const Grid<float>& mult,
+    const std::unordered_set<int64_t>* banned,
+    const double* bnp,
+    const std::unordered_set<int64_t>* forbidden = nullptr);
 
 Grid<float> PrefField(const Grid<float>& dist, bool ridge);
 
@@ -218,7 +242,38 @@ private:
     double cs_ = kCS;
 };
 
-std::vector<WorldPoint> StringPull(const std::vector<WorldPoint>& pts, const Blockers& blk, const ClearanceFloor* cfl);
+class LayerOracle
+{
+public:
+    LayerOracle(const SpanTable* st, const std::vector<int64_t>* cidx, int64_t nx, int64_t ny, double x0, double y0)
+        : st_(st)
+        , cidx_(cidx)
+        , nx_(nx)
+        , ny_(ny)
+        , x0_(x0)
+        , y0_(y0)
+    {
+    }
+
+    std::optional<std::vector<float>> walk(const std::vector<WorldPoint>& pts, float h) const;
+
+    bool ok(const WorldPoint& p, const WorldPoint& q, float h, float hq) const;
+
+private:
+    const SpanTable* st_ = nullptr;
+    const std::vector<int64_t>* cidx_ = nullptr;
+    int64_t nx_ = 0;
+    int64_t ny_ = 0;
+    double x0_ = 0.0;
+    double y0_ = 0.0;
+};
+
+std::vector<WorldPoint> StringPull(
+    const std::vector<WorldPoint>& pts,
+    const Blockers& blk,
+    const ClearanceFloor* cfl,
+    const LayerOracle* lyo = nullptr,
+    const std::vector<float>* hs = nullptr);
 
 std::vector<WorldPoint> Slim(const std::vector<WorldPoint>& pts, const Blockers& blk, double eps, const ClearanceFloor* cfl);
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -34,6 +34,11 @@ struct WindowInfo
     StepBarrier sev;
     std::vector<WorldPoint> segA;
     std::vector<WorldPoint> segB;
+    double h0 = 0.0;
+    SpanTable st3;
+    std::vector<uint8_t> vis3;
+    std::vector<int64_t> cidx;
+    std::vector<uint8_t> reach3;
 };
 
 struct RouteDiag
@@ -41,6 +46,7 @@ struct RouteDiag
     std::string err;
     std::vector<std::string> warn;
     std::vector<WorldPoint> xwall;
+    std::vector<double> clearance;
     double snap_start = 0.0;
     double snap_goal = 0.0;
 };
@@ -184,6 +190,54 @@ std::optional<WindowInfo> buildWindow(
 
     info.sev = StepBreaks(st, vis, info.lay, x0, y0);
 
+    info.h0 = h0;
+    std::vector<uint8_t> have(static_cast<size_t>(nx * ny), 0);
+    for (size_t si = 0; si < vis.size(); ++si) {
+        if (vis[si] != 0) {
+            have[static_cast<size_t>(st.sp_cell[si])] = 1;
+        }
+    }
+    std::vector<int64_t> ghost;
+    for (int64_t c = 0; c < nx * ny && !info.sev.t0.empty(); ++c) {
+        if (info.lay.v[static_cast<size_t>(c)] != 0 && have[static_cast<size_t>(c)] == 0
+            && std::isfinite(info.sev.t0[static_cast<size_t>(c)])) {
+            ghost.push_back(c);
+        }
+    }
+    info.vis3 = vis;
+    if (ghost.empty()) {
+        info.st3 = st;
+    }
+    else {
+        std::vector<int64_t> gc3 = st.sp_cell;
+        std::vector<float> gh3 = st.sp_h;
+        for (const int64_t c : ghost) {
+            gc3.push_back(c);
+            gh3.push_back(info.sev.t0[static_cast<size_t>(c)]);
+            info.vis3.push_back(1);
+        }
+        info.st3 = PackSpans(std::move(gc3), std::move(gh3), &info.vis3);
+    }
+    info.cidx.assign(static_cast<size_t>(nx * ny), -1);
+    for (size_t ci = 0; ci < info.st3.occ.size(); ++ci) {
+        info.cidx[static_cast<size_t>(info.st3.occ[ci])] = static_cast<int64_t>(ci);
+    }
+    const int64_t sj = info.cidx[static_cast<size_t>(cell0)];
+    int64_t seed3 = -1;
+    float best3 = 0.0F;
+    for (int64_t k = 0; k < info.st3.K; ++k) {
+        const int64_t sid = info.st3.IK[static_cast<size_t>(sj * info.st3.K + k)];
+        if (sid < 0) {
+            continue;
+        }
+        const float d = std::fabs(info.st3.sp_h[static_cast<size_t>(sid)] - static_cast<float>(h0));
+        if (seed3 < 0 || d < best3) {
+            seed3 = sid;
+            best3 = d;
+        }
+    }
+    info.reach3 = SpanReach(seed3, info.st3, info.vis3, nx, ny);
+
     const std::vector<uint8_t> keep = WallsAtLayer(p0, p1, hh, info.lh, x0, y0);
     for (size_t i = 0; i < keep.size(); ++i) {
         if (keep[i] != 0) {
@@ -200,7 +254,8 @@ std::optional<WindowInfo> buildWindow(
     return info;
 }
 
-std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const WorldPoint& s, const WorldPoint& g, RouteDiag& dg)
+std::optional<std::vector<WorldPoint>>
+    routeWindow(const WindowInfo& info, const WorldPoint& s, const WorldPoint& g, bool climb_faces, RouteDiag& dg)
 {
     const int64_t nx = info.nx;
     const int64_t ny = info.ny;
@@ -213,32 +268,32 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
     const auto bn = BannedSteps(info.lay, info.wcsr, info.wP0, info.wP1, x0, y0);
     std::unordered_set<int64_t> blocked_steps = bn;
     blocked_steps.insert(info.sev.steps.begin(), info.sev.steps.end());
-    // 亏欠越多单价越高;脊线保底只进几何口径 prefg,禁入 mult
-    const Grid<float> pref = PrefField(info.dist, false);
-    const Grid<float> prefg = PrefField(info.dist, true);
-    Grid<float> mult(nx, ny, 0.0F);
-    for (size_t i = 0; i < mult.v.size(); ++i) {
-        const float c = std::min(std::max((pref.v[i] - info.dist.v[i]) / pref.v[i], 0.0F), 1.0F);
-        mult.v[i] = 1.0F + static_cast<float>(kLam) * c;
-    }
-    // 几何口径的净空: 掩膜距离场对跨越约束的墙无感, 取真墙距离的下确界补上
+    // 掩膜距离场对跨越约束的墙无感, 取真墙距离的下确界补上
     Mask wfree(nx, ny, 0);
     for (size_t i = 0; i < wfree.v.size(); ++i) {
         wfree.v[i] = info.wcsr.start[i + 1] > info.wcsr.start[i] ? 0 : 1;
     }
     const Grid<float> wdist = Clearance(wfree);
-    Grid<float> dgeo(nx, ny, 0.0F);
-    for (size_t i = 0; i < dgeo.v.size(); ++i) {
-        dgeo.v[i] = std::min(info.dist.v[i], wdist.v[i]);
+    Grid<float> dist(nx, ny, 0.0F);
+    for (size_t i = 0; i < dist.v.size(); ++i) {
+        dist.v[i] = std::min(info.dist.v[i], wdist.v[i]);
+    }
+    // 亏欠越多单价越高;脊线保底只进几何口径 prefg,禁入 mult
+    const Grid<float> pref = PrefField(dist, false);
+    const Grid<float> prefg = PrefField(dist, true);
+    Grid<float> mult(nx, ny, 0.0F);
+    for (size_t i = 0; i < mult.v.size(); ++i) {
+        const float c = std::min(std::max((pref.v[i] - dist.v[i]) / pref.v[i], 0.0F), 1.0F);
+        mult.v[i] = 1.0F + static_cast<float>(kLam) * c;
     }
     // 几何口径的余量目标: 通道半宽封顶 kGeoR, 供绿段重寻与拉直判定
-    const Grid<float> tgt = TargetField(dgeo);
+    const Grid<float> tgt = TargetField(dist);
     Grid<float> multg(nx, ny, 0.0F);
     Grid<float> cf(nx, ny, 0.0F);
     for (size_t i = 0; i < multg.v.size(); ++i) {
-        const float c = std::min(std::max((tgt.v[i] - dgeo.v[i]) / tgt.v[i], 0.0F), 1.0F);
+        const float c = std::min(std::max((tgt.v[i] - dist.v[i]) / tgt.v[i], 0.0F), 1.0F);
         multg.v[i] = 1.0F + static_cast<float>(kLam) * c;
-        cf.v[i] = std::min(dgeo.v[i], tgt.v[i]);
+        cf.v[i] = std::min(dist.v[i], tgt.v[i]);
     }
     const ClearanceFloor cfl(&cf, &multg, x0, y0, kCS);
 
@@ -267,35 +322,126 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
         }
         return { bc, std::sqrt(static_cast<double>(bd)) * kCS };
     };
-    const auto [as_, dsa] = near(walk, sc);
-    const auto [ag_, dga] = near(walk, gc);
+    const SpanTable& st3 = info.st3;
+    const LayerOracle lyo(&st3, &info.cidx, nx, ny, x0, y0);
+    const auto mk = [&](const Mask& m2, std::vector<uint8_t>& use, Mask& c3) {
+        use.assign(st3.sp_h.size(), 0);
+        c3 = Mask(nx, ny, 0);
+        for (size_t i = 0; i < use.size(); ++i) {
+            const auto cell = static_cast<size_t>(st3.sp_cell[i]);
+            if (info.reach3[i] != 0 && m2.v[cell] != 0) {
+                use[i] = 1;
+                c3.v[cell] = 1;
+            }
+        }
+    };
+    std::vector<uint8_t> useW;
+    std::vector<uint8_t> useC;
+    Mask cw3;
+    Mask cc3;
+    mk(walk, useW, cw3);
+    mk(info.core, useC, cc3);
+    const auto pick = [&](const CellPt& c, const std::vector<uint8_t>& use) {
+        std::vector<int64_t> out;
+        const int64_t j = info.cidx[static_cast<size_t>(c.y * nx + c.x)];
+        if (j < 0) {
+            return out;
+        }
+        for (int64_t k = 0; k < st3.K; ++k) {
+            const int64_t v = st3.IK[static_cast<size_t>(j * st3.K + k)];
+            if (v >= 0 && use[static_cast<size_t>(v)] != 0) {
+                out.push_back(v);
+            }
+        }
+        return out;
+    };
+    const auto atSeedLayer = [&](const std::vector<int64_t>& vs) {
+        int64_t best = -1;
+        float bd = 0.0F;
+        for (const int64_t v : vs) {
+            const float d = std::fabs(st3.sp_h[static_cast<size_t>(v)] - static_cast<float>(info.h0));
+            if (best < 0 || d < bd) {
+                best = v;
+                bd = d;
+            }
+        }
+        return best;
+    };
+
+    auto [as_, dsa] = near(cw3, sc);
+    auto [ag_, dga] = near(cw3, gc);
     if (!as_.has_value()) {
         dg.err = "walk 掩膜为空";
         return std::nullopt;
     }
-    dg.snap_start = dsa;
-    dg.snap_goal = dga;
 
     const double BIGP = static_cast<double>(nx * ny) * kCS * (1.0 + kLam);
-    const Mask* used = &walk;
-    std::optional<std::vector<CellPt>> q;
+    const std::unordered_set<int64_t>* faces = climb_faces ? nullptr : &info.sev.steps;
+    const std::unordered_set<int64_t>& soft = climb_faces ? blocked_steps : bn;
+    Mask on3 = cw3;
+    std::optional<std::vector<int64_t>> qs;
     if (as_->x == ag_->x && as_->y == ag_->y) {
-        q = std::vector<CellPt> { *as_ };
+        qs = std::vector<int64_t> { atSeedLayer(pick(*as_, useW)) };
     }
     else {
-        q = CostAstar(walk, *as_, *ag_, mult, &blocked_steps, &BIGP);
+        qs = SpanAstar(st3, useW, info.cidx, cw3, atSeedLayer(pick(*as_, useW)), pick(*ag_, useW), mult, &soft, &BIGP, faces);
     }
-    if (!q.has_value()) {
-        used = &info.core;
-        q = CostAstar(info.core, *as_, *ag_, mult, &blocked_steps, &BIGP);
-        if (q.has_value()) {
-            dg.warn.push_back("walk 断开→退回 core");
+    if (!qs.has_value()) {
+        const auto [ac_, dc_] = near(cc3, sc);
+        const auto [ag2, dg2] = near(cc3, gc);
+        if (ac_.has_value() && ag2.has_value()) {
+            if (ac_->x == ag2->x && ac_->y == ag2->y) {
+                qs = std::vector<int64_t> { atSeedLayer(pick(*ac_, useC)) };
+            }
+            else {
+                qs = SpanAstar(
+                    st3, useC, info.cidx, cc3, atSeedLayer(pick(*ac_, useC)), pick(*ag2, useC), mult, &soft, &BIGP, faces);
+            }
+            if (qs.has_value()) {
+                on3 = cc3;
+                as_ = ac_;
+                dsa = dc_;
+                ag_ = ag2;
+                dga = dg2;
+                dg.warn.push_back("walk 断开→退回 core");
+            }
         }
     }
-    if (!q.has_value()) {
-        dg.err = "不连通";
-        return std::nullopt;
+    std::optional<std::vector<CellPt>> q;
+    if (qs.has_value()) {
+        std::vector<CellPt> cellq;
+        cellq.reserve(qs->size());
+        for (const int64_t v : *qs) {
+            const int64_t c = st3.sp_cell[static_cast<size_t>(v)];
+            cellq.push_back({ c % nx, c / nx });
+        }
+        q = std::move(cellq);
     }
+    else {
+        std::tie(as_, dsa) = near(walk, sc);
+        std::tie(ag_, dga) = near(walk, gc);
+        on3 = walk;
+        if (as_->x == ag_->x && as_->y == ag_->y) {
+            q = std::vector<CellPt> { *as_ };
+        }
+        else {
+            q = CostAstar(walk, *as_, *ag_, mult, &soft, &BIGP, faces);
+        }
+        if (!q.has_value()) {
+            on3 = info.core;
+            q = CostAstar(info.core, *as_, *ag_, mult, &soft, &BIGP, faces);
+            if (q.has_value()) {
+                dg.warn.push_back("walk 断开→退回 core");
+            }
+        }
+        if (!q.has_value()) {
+            dg.err = "不连通";
+            return std::nullopt;
+        }
+        dg.warn.push_back("层不连通→退回格级");
+    }
+    dg.snap_start = dsa;
+    dg.snap_goal = dga;
     const int64_t NC = nx * ny;
     std::vector<size_t> bad;
     for (size_t k = 1; k < q->size(); ++k) {
@@ -339,12 +485,12 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
     };
 
     const auto loops_core = toWorld(TraceContours(info.core));
-    const Blockers::OnMask onm { used, x0, y0, kCS };
+    const Blockers::OnMask onm { &on3, x0, y0, kCS };
     const Blockers blk_gray(loops_core, &info.segA, &info.segB, onm);
 
     std::vector<uint8_t> grn(q->size());
     for (size_t i = 0; i < q->size(); ++i) {
-        grn[i] = static_cast<uint8_t>(info.dist.at((*q)[i].y, (*q)[i].x) >= prefg.at((*q)[i].y, (*q)[i].x) - 1e-9F);
+        grn[i] = static_cast<uint8_t>(dist.at((*q)[i].y, (*q)[i].x) >= prefg.at((*q)[i].y, (*q)[i].x) - 1e-9F);
     }
 
     struct Run
@@ -392,6 +538,15 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
     for (const auto& run : mg) {
         const int64_t iend = std::min(run.i1 + 1, static_cast<int64_t>(q->size()) - 1);
         const std::vector<CellPt> cells(q->begin() + run.i0, q->begin() + iend + 1);
+        std::vector<int64_t> sub;
+        std::vector<float> hs;
+        if (qs.has_value()) {
+            sub.assign(qs->begin() + run.i0, qs->begin() + iend + 1);
+            hs.reserve(sub.size());
+            for (const int64_t v : sub) {
+                hs.push_back(st3.sp_h[static_cast<size_t>(v)]);
+            }
+        }
         std::vector<WorldPoint> pp = cen(cells);
         if (cells.size() >= 2) {
             std::optional<Blockers> blk_green;
@@ -425,7 +580,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                 for (int64_t y = 0; y < ny; ++y) {
                     for (int64_t x = 0; x < nx; ++x) {
                         er.at(y, x) = static_cast<uint8_t>(
-                            info.dist.at(y, x) >= pref.at(y, x) || (info.dist.at(y, x) >= prefg.at(y, x) && pmd.at(y, x) != 0)
+                            dist.at(y, x) >= pref.at(y, x) || (dist.at(y, x) >= prefg.at(y, x) && pmd.at(y, x) != 0)
                             || pm.at(y, x) != 0);
                     }
                 }
@@ -437,20 +592,42 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                     }
                 }
                 cuts.push_back(cells.size());
+                std::vector<uint8_t> ue;
+                Mask ce;
+                if (qs.has_value()) {
+                    mk(er, ue, ce);
+                }
                 std::optional<std::vector<CellPt>> q2 = std::vector<CellPt> {};
+                std::vector<float> h2;
                 size_t a2 = 0;
                 for (const size_t c2 : cuts) {
                     const size_t b2 = c2 - 1;
                     if (a2 == b2) {
                         q2->push_back(cells[a2]);
+                        if (qs.has_value()) {
+                            h2.push_back(hs[a2]);
+                        }
                     }
-                    else {
+                    else if (!qs.has_value()) {
                         const auto r2 = CostAstar(er, cells[a2], cells[b2], multg, &blocked_steps, nullptr);
                         if (!r2.has_value()) {
                             q2.reset();
                             break;
                         }
                         q2->insert(q2->end(), r2->begin(), r2->end());
+                    }
+                    else {
+                        const auto r2 = SpanAstar(
+                            st3, ue, info.cidx, ce, sub[a2], { sub[b2] }, multg, &blocked_steps, nullptr);
+                        if (!r2.has_value()) {
+                            q2.reset();
+                            break;
+                        }
+                        for (const int64_t v : *r2) {
+                            const int64_t c = st3.sp_cell[static_cast<size_t>(v)];
+                            q2->push_back({ c % nx, c / nx });
+                            h2.push_back(st3.sp_h[static_cast<size_t>(v)]);
+                        }
                     }
                     a2 = c2;
                 }
@@ -467,6 +644,9 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                     }
                     if (l2 <= l1 * 1.2 + 2.0 / kCS) {
                         pp = cen(*q2);
+                        if (qs.has_value()) {
+                            hs = h2;
+                        }
                     }
                 }
                 auto loops_er = TraceContours(er);
@@ -479,7 +659,8 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
                 lw.insert(lw.end(), loops_core.begin(), loops_core.end());
                 blk_green.emplace(lw, &info.segA, &info.segB, onm);
             }
-            pp = StringPull(pp, blk_green.has_value() ? *blk_green : blk_gray, &cfl);
+            pp = StringPull(
+                pp, blk_green.has_value() ? *blk_green : blk_gray, &cfl, hs.empty() ? nullptr : &lyo, hs.empty() ? nullptr : &hs);
         }
         if (!taut.empty() && !pp.empty() && std::hypot(pp.front().x - taut.back().x, pp.front().y - taut.back().y) < 1e-9) {
             pp.erase(pp.begin());
@@ -506,7 +687,16 @@ std::optional<std::vector<WorldPoint>> routeWindow(const WindowInfo& info, const
     }
     std::vector<WorldPoint> out = DropLoops(ded);
     if (kSlimEps > 0 && out.size() > 2) {
-        out = Slim(out, blk_gray, kSlimEps, &cfl);
+        const auto sl = Slim(out, blk_gray, kSlimEps, &cfl);
+        if (!qs.has_value() || lyo.walk(sl, st3.sp_h[static_cast<size_t>(qs->front())]).has_value()) {
+            out = sl;
+        }
+    }
+    dg.clearance.reserve(out.size());
+    for (const auto& p : out) {
+        const int64_t cx = std::min(std::max(static_cast<int64_t>(std::floor((p.x - info.x0) / kCS)), int64_t { 0 }), nx - 1);
+        const int64_t cy = std::min(std::max(static_cast<int64_t>(std::floor((p.y - info.y0) / kCS)), int64_t { 0 }), ny - 1);
+        dg.clearance.push_back(static_cast<double>(dist.at(cy, cx)));
     }
     return out;
 }
@@ -586,8 +776,11 @@ RecastPlanResult RecastNavEngine::planLocked(
     const double h0 = triHeightOf(zc.mesh, ss->tri);
 
     const double margins[4] = { kMargin, kMargin * 2, kMargin * 4, kMargin * 8 };
+    const int pass_count = (blocked.empty() && blocked_points.empty()) ? 8 : 1;
     std::string last_err;
-    for (int mi = 0; mi < 4; ++mi) {
+    for (int pass = 0; pass < pass_count; ++pass) {
+        const int mi = pass % 4;
+        const bool climb_faces = pass >= 4;
         const double x0 = std::min(start.x, goal.x) - margins[mi];
         const double y0 = std::min(start.y, goal.y) - margins[mi];
         const double x1 = std::max(start.x, goal.x) + margins[mi];
@@ -602,7 +795,7 @@ RecastPlanResult RecastNavEngine::planLocked(
         const auto info = buildWindow(zc, wo, start, ss->point, h0, x0, y0, x1, y1, blocked_local, blocked_points, err);
         if (info.has_value()) {
             RouteDiag dg;
-            const auto line = routeWindow(*info, start, goal, dg);
+            const auto line = routeWindow(*info, start, goal, climb_faces, dg);
             if (line.has_value()) {
                 // 锚点远 = 走廊出窗,同触界扩窗,否则末段盲跳穿墙
                 if (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius) {
@@ -638,6 +831,7 @@ RecastPlanResult RecastNavEngine::planLocked(
                             res.length += std::hypot((*line)[i].x - (*line)[i - 1].x, (*line)[i].y - (*line)[i - 1].y);
                         }
                         res.warnings = dg.warn;
+                        res.clearance = dg.clearance;
                         res.wall_cross = dg.xwall;
                         res.snap_start = dg.snap_start;
                         res.snap_goal = dg.snap_goal;

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -18,6 +18,7 @@ struct RecastPlanResult
     bool ok = false;
     std::string error;
     std::vector<WorldPoint> points;
+    std::vector<double> clearance; // 逐点通道半宽 px
     double length = 0.0;
     std::vector<std::string> warnings;
     std::vector<WorldPoint> wall_cross; // 不可避穿墙步的格心

--- a/tools/MapNavigator/recastnav.py
+++ b/tools/MapNavigator/recastnav.py
@@ -7,13 +7,14 @@ import numpy as np
 
 CS = 0.25          # 体素边长 px
 CLIMB = 3.0        # 相邻格可连通最大高差 px
-STEP = 0.5         # 相邻格可直接迈上的最大高差 px, 超出即立面, 只能绕行
-MERGE_H = 1.0      # 同列 span 合并容差 px
+SLOPE = 1.0        # 可攀爬坡度上限 tanθ, 抬升超过水平位移的这个倍数即立面, 只能绕行
+UP = SLOPE * CS    # 正交相邻格允许的抬升 px, 斜向按实际水平位移等比放大
+MERGE_H = UP       # 同列 span 合并容差 px, 取 UP 使同层内处处可一步跨到
 EDT_CAP = 12.0     # 距离场截断 px
 R = 1.75           # 期望余量上限 px
 GEO_R = 3.5        # 几何口径舒适余量上限 px
 REL = 0.6          # 期望余量 = min(R, REL×局部净空)
-LAM = 1.5          # 满亏欠一步加价倍数
+LAM = 4.0          # 满亏欠一步加价倍数
 RIDGEF = 0.5       # 脊线保底余量地板 px
 MAXERR = 0.5       # 轮廓 DP 容差 px
 SLIMEPS = 0.5      # 终线共线剔除容差 px
@@ -120,7 +121,20 @@ def spans(cell, hz, merge_h=MERGE_H):
     o = np.lexsort((hz, cell))
     cell = cell[o]; hz = hz[o]
     new = np.empty(len(cell), bool); new[0] = True
-    new[1:] = (cell[1:] != cell[:-1]) | (hz[1:] - hz[:-1] > merge_h)
+    new[1:] = cell[1:] != cell[:-1]
+    head = np.flatnonzero(new)
+    cnt = np.diff(np.append(head, len(cell)))
+    anc = hz[head].astype(np.float64)
+    for r in range(1, int(cnt.max()) if len(cnt) else 1):
+        sel = np.flatnonzero(cnt > r)
+        if not len(sel):
+            break
+        idx = head[sel] + r
+        over = hz[idx] - anc[sel] > merge_h
+        if not over.any():
+            continue
+        new[idx[over]] = True
+        anc[sel[over]] = hz[idx[over]]
     sid = np.cumsum(new) - 1
     n = int(sid[-1]) + 1
     cntv = np.bincount(sid, minlength=n)
@@ -223,6 +237,164 @@ def flood(seed, sp_h, occ, HK, IK, sp_ci, nx, climb=CLIMB):
     return vis
 
 
+def span_reach(seed, sp_h, occ, HK, IK, sp_ci, ok, nx, ny,
+               up=UP, climb=CLIMB):
+    vis = np.zeros(len(sp_h), bool)
+    if not ok[seed]:
+        return vis
+    vis[seed] = True
+    F = np.array([seed], np.int64)
+    while len(F):
+        nxt = []
+        cid = occ[sp_ci[F]]
+        gx, gy = cid % nx, cid // nx
+        for dx, dy, w in _NB8:
+            ax, ay = gx + dx, gy + dy
+            good = (ax >= 0) & (ax < nx) & (ay >= 0) & (ay < ny)
+            tgt = np.where(good, ay * nx + ax, 0)
+            j = np.searchsorted(occ, tgt)
+            good &= j < len(occ)
+            jj = np.where(good, np.minimum(j, len(occ) - 1), 0)
+            good &= occ[jj] == tgt
+            if not good.any():
+                continue
+            src = F[good]
+            jj = jj[good]
+            with np.errstate(invalid="ignore"):
+                dh = HK[jj] - sp_h[src][:, None]
+                m = (dh <= up * w) & (dh >= -climb)
+            cand = IK[jj][m]
+            cand = cand[cand >= 0]
+            cand = cand[ok[cand] & ~vis[cand]]
+            if len(cand):
+                cand = np.unique(cand)
+                vis[cand] = True
+                nxt.append(cand)
+        F = np.concatenate(nxt) if nxt else np.zeros(0, np.int64)
+    return vis
+
+
+def span_astar(ok, sp_h, occ, HK, IK, sp_ci, cidx, ok2, s, gset, mult, nx, ny,
+               banned=None, bnp=None, forbidden=None, up=UP, climb=CLIMB):
+    if not ok[s] or not gset:
+        return None
+    K = HK.shape[1]
+    bn = banned or ()
+    fb = forbidden or ()
+    mf = mult.ravel()
+    gc = int(occ[sp_ci[next(iter(gset))]])
+    gxx, gyy = gc % nx, gc // nx
+    dist = np.full(len(sp_h), np.inf)
+    prev = np.full(len(sp_h), -1, np.int64)
+    dist[s] = 0.0
+    pq = [(0.0, s)]
+    hit = -1
+    while pq:
+        f, u = heapq.heappop(pq)
+        d0 = dist[u]
+        cu = int(occ[sp_ci[u]])
+        x, y = cu % nx, cu // nx
+        if f > d0 + math.hypot(gxx - x, gyy - y) + 1e-9:
+            continue
+        if u in gset:
+            hit = u
+            break
+        hu = sp_h[u]
+        m0 = mf[cu]
+        for dx, dy, w in _NB8:
+            a, b = x + dx, y + dy
+            if not (0 <= a < nx and 0 <= b < ny):
+                continue
+            cv = b * nx + a
+            if not ok2[cv]:
+                continue
+            if dx and dy and not (ok2[y * nx + a] and ok2[b * nx + x]):
+                continue
+            j = cidx[cv]
+            if j < 0:
+                continue
+            e = (cu, cv)
+            if e in fb:
+                continue
+            pen = 0.0
+            if e in bn:
+                if bnp is None:
+                    continue
+                pen = bnp
+            nd = d0 + w * 0.5 * (m0 + mf[cv]) + pen
+            for k in range(K):
+                v = int(IK[j, k])
+                if v < 0 or not ok[v]:
+                    continue
+                dh = HK[j, k] - hu
+                if dh > up * w or dh < -climb:
+                    continue
+                if nd < dist[v] - 1e-12:
+                    dist[v] = nd
+                    prev[v] = u
+                    heapq.heappush(pq, (nd + math.hypot(gxx - a, gyy - b), v))
+    if hit < 0:
+        return None
+    out = [hit]
+    while out[-1] != s:
+        out.append(int(prev[out[-1]]))
+    return out[::-1]
+
+
+class LayerOracle:
+    def __init__(self, HK, IK, cidx, nx, ny, x0, y0, cs=CS,
+                 slope=SLOPE, climb=CLIMB):
+        self.HK = HK
+        self.IK = IK
+        self.cidx = cidx
+        self.nx = nx
+        self.ny = ny
+        self.x0 = x0
+        self.y0 = y0
+        self.cs = cs
+        self.slope = slope
+        self.climb = climb
+
+    def walk(self, pts, h):
+        cs, nx, ny = self.cs, self.nx, self.ny
+        cells = []
+        for i in range(1, len(pts)):
+            ax = int((pts[i - 1][0] - self.x0) / cs)
+            ay = int((pts[i - 1][1] - self.y0) / cs)
+            bx = int((pts[i][0] - self.x0) / cs)
+            by = int((pts[i][1] - self.y0) / cs)
+            n = max(abs(bx - ax), abs(by - ay)) or 1
+            for k in range(n + 1):
+                c = (ax + round((bx - ax) * k / n),
+                     ay + round((by - ay) * k / n))
+                if not cells or cells[-1] != c:
+                    cells.append(c)
+        cells = [c for c in cells if 0 <= c[0] < nx and 0 <= c[1] < ny]
+        cur = np.array([h], np.float32)
+        pc = cells[0] if cells else None
+        for c in cells[1:]:
+            j = int(self.cidx[c[1] * nx + c[0]])
+            if j < 0:
+                continue
+            nb = self.HK[j][self.IK[j] >= 0]
+            if not len(nb):
+                continue
+            up = self.slope * math.hypot(c[0] - pc[0], c[1] - pc[1]) * cs
+            d = nb[None, :] - cur[:, None]
+            m = (d <= up) & (d >= -self.climb)
+            if not m.any():
+                return None
+            cur = nb[m.any(0)]
+            pc = c
+        return cur
+
+    def ok(self, p, q, h, hq=None):
+        cur = self.walk((p, q), h)
+        if cur is None:
+            return False
+        return hq is None or bool((np.abs(cur - hq) <= 1e-3).any())
+
+
 def _step_heights(occ, HK, IK, vis, lay, nx, ny):
     HV = np.where((IK >= 0) & vis[np.maximum(IK, 0)], HK, np.inf)
     T = np.full((nx * ny, HV.shape[1]), np.inf, np.float32)
@@ -247,10 +419,10 @@ def _step_heights(occ, HK, IK, vis, lay, nx, ny):
     return T
 
 
-def step_breaks(occ, HK, IK, vis, lay, nx, ny, ox, oy, cs=CS, step=STEP):
+def step_breaks(occ, HK, IK, vis, lay, nx, ny, ox, oy, cs=CS, slope=SLOPE):
     out = set()
     src = np.nonzero(lay.ravel())[0]
-    if not len(src) or not np.isfinite(step):
+    if not len(src) or not np.isfinite(slope):
         return out, (np.zeros((0, 2)), np.zeros((0, 2)))
     T = _step_heights(occ, HK, IK, vis, lay, nx, ny)
     K = T.shape[1]
@@ -271,7 +443,7 @@ def step_breaks(occ, HK, IK, vis, lay, nx, ny, ox, oy, cs=CS, step=STEP):
         d = np.where(np.isfinite(d), d, np.inf).reshape(len(a), -1)
         k = d.argmin(1)
         r = np.arange(len(a))
-        bad = d[r, k] > step
+        bad = d[r, k] > slope * math.hypot(dx, dy) * cs
         if not bad.any():
             continue
         a, b = a[bad], b[bad]
@@ -499,11 +671,12 @@ def close_cracks(core, lay, protect=None):
     return out
 
 
-def cost_astar(mask, s, g, mult, banned=None, bnp=None):
+def cost_astar(mask, s, g, mult, banned=None, bnp=None, forbidden=None):
     ny, nx = mask.shape
     if not mask[s[1], s[0]] or not mask[g[1], g[0]]:
         return None
     bn = banned or ()
+    fb = forbidden or ()
     dist = np.full(mask.shape, np.inf)
     prev = np.full(mask.shape, -1, np.int64)
     dist[s[1], s[0]] = 0.0
@@ -522,8 +695,11 @@ def cost_astar(mask, s, g, mult, banned=None, bnp=None):
                 continue
             if dx and dy and not (mask[y, a] and mask[b, x]):
                 continue
+            e = (y * nx + x, b * nx + a)
+            if e in fb:
+                continue
             pen = 0.0
-            if (y * nx + x, b * nx + a) in bn:
+            if e in bn:
                 if bnp is None:
                     continue
                 pen = bnp
@@ -789,10 +965,8 @@ class ClearanceFloor:
         return L * float(self.mg[gy, gx].mean(dtype=np.float64))
 
 
-def string_pull(pts, blk, rounds=6, cfl=None):
+def string_pull(pts, blk, rounds=6, cfl=None, lyo=None, hs=None):
     P = [tuple(map(float, p)) for p in pts]
-    # 跨点连线须同时不低于被跳过子路径的净空地板、不高于其代价泛函(与几何重寻同口径),
-    # 相邻点连线无条件保留
     seg = cst = None
     if cfl is not None and len(P) > 1:
         seg = np.array([cfl.seg(P[k], P[k + 1]) for k in range(len(P) - 1)],
@@ -810,11 +984,13 @@ def string_pull(pts, blk, rounds=6, cfl=None):
             j = len(P) - 1
             while j > i + 1:
                 k = idx[j] - idx[i] - 1
-                if not blk.blocked(P[i], P[j]) and (
-                        acc is None
-                        or (cfl.seg(P[i], P[j]) >= float(acc[k]) - CLRTOL
-                            and cfl.cost(P[i], P[j])
-                            <= float(ac2[k]) * (1.0 + COSTTOL))):
+                if (not blk.blocked(P[i], P[j])
+                        and (acc is None
+                             or (cfl.seg(P[i], P[j]) >= float(acc[k]) - CLRTOL
+                                 and cfl.cost(P[i], P[j])
+                                 <= float(ac2[k]) * (1.0 + COSTTOL)))
+                        and (lyo is None
+                             or lyo.ok(P[i], P[j], hs[idx[i]], hs[idx[j]]))):
                     break
                 j -= 1
             out.append(P[j])

--- a/tools/MapNavigator/recastnav_route.py
+++ b/tools/MapNavigator/recastnav_route.py
@@ -68,6 +68,29 @@ def build(zc, wo, s, s_snap, h0, x0, y0, x1, y1):
 
     sev, sseg = rc.step_breaks(occ, HK, IK, vis, lay, nx, ny, x0, y0)
 
+    spC, spH, spV = sp_cell, sp_h, vis
+    spOcc, spHK, spIK, spCi = occ, HK, IK, sp_ci
+    have = np.zeros(ny * nx, bool)
+    have[sp_cell[vis]] = True
+    gh = np.nonzero(lay.ravel() & ~have)[0]
+    if len(gh):
+        T0 = rc._step_heights(occ, HK, IK, vis, lay, nx, ny)[:, 0]
+        gh = gh[np.isfinite(T0[gh])]
+    if len(gh):
+        spC = np.concatenate([sp_cell, gh])
+        spH = np.concatenate([sp_h, T0[gh].astype(np.float32)])
+        spV = np.concatenate([vis, np.ones(len(gh), bool)])
+        o = np.lexsort((spH, spC))
+        spC, spH, spV = spC[o], spH[o], spV[o]
+        spOcc, cst, cct = np.unique(spC, return_index=True, return_counts=True)
+        spHK, spIK, spCi = rc.dense_k(spH, spOcc, cst, cct)
+    cidx = np.full(ny * nx, -1, np.int32)
+    cidx[spOcc] = np.arange(len(spOcc), dtype=np.int32)
+    sj = int(cidx[gy * nx + gx])
+    cd = spIK[sj][spIK[sj] >= 0]
+    seedN = int(cd[int(np.argmin(np.abs(spH[cd] - h0)))])
+    reachN = rc.span_reach(seedN, spH, spOcc, spHK, spIK, spCi, spV, nx, ny)
+
     keep = rc.walls_at_layer(wo.P0[widx], wo.P1[widx], wo.HH[widx], lh,
                              x0, y0, nx, ny, hband=MC_HBAND)
     wP0, wP1 = wo.P0[widx][keep], wo.P1[widx][keep]
@@ -80,7 +103,9 @@ def build(zc, wo, s, s_snap, h0, x0, y0, x1, y1):
     info = dict(x0=x0, y0=y0, nx=nx, ny=ny, lay=lay, lh=lh, dist=dist,
                 core=core, t_vox=t_vox, t_fl=t_fl, t_edt=t_edt,
                 wP0=wP0, wP1=wP1, wid=wid, wstart=wstart,
-                sev=sev, sseg=sseg)
+                sev=sev, sseg=sseg, h0=h0,
+                spC=spC, spH=spH, spOcc=spOcc, spHK=spHK, spIK=spIK,
+                spCi=spCi, cidx=cidx, reachN=reachN)
     return info, None
 
 
@@ -134,25 +159,43 @@ def metrics(wo, P, h0, info, step=0.25):
             hug / tot * 100 if tot else 0.0)
 
 
-def route(info, s, g):
+def route(info, s, g, climb_faces=False):
     lay, dist, core = info["lay"], info["dist"], info["core"]
     x0, y0, nx, ny = info["x0"], info["y0"], info["nx"], info["ny"]
     walk = core & lay
     bn = rc.banned_steps(lay, info["wid"], info["wstart"],
                          info["wP0"], info["wP1"], x0, y0, nx)
     blocked = bn | info["sev"]
+    # 掩膜距离场对跨越约束的墙无感, 取真墙距离的下确界补上
+    ws = info["wstart"]
+    wcell = (ws[1:] > ws[:-1]).reshape(ny, nx)
+    dist = np.minimum(dist, rc.clearance(~wcell))
     # 亏欠越多单价越高;脊线保底只进几何口径 prefg,禁入 mult
     pref = rc.pref_field(dist)
     mult = 1.0 + LAM * np.clip((pref - dist) / pref, 0.0, 1.0)
     prefg = rc.pref_field(dist, ridge=True)
-    # 几何口径的净空: 掩膜距离场对跨越约束的墙无感, 取真墙距离的下确界补上
-    ws = info["wstart"]
-    wcell = (ws[1:] > ws[:-1]).reshape(ny, nx)
-    dg = np.minimum(dist, rc.clearance(~wcell))
     # 几何口径的余量目标: 通道半宽封顶 GEO_R, 供绿段重寻与拉直判定
-    tgt = rc.target_field(dg)
-    multg = 1.0 + LAM * np.clip((tgt - dg) / tgt, 0.0, 1.0)
-    cfl = rc.ClearanceFloor(np.minimum(dg, tgt), multg, x0, y0, CS)
+    tgt = rc.target_field(dist)
+    multg = 1.0 + LAM * np.clip((tgt - dist) / tgt, 0.0, 1.0)
+    cfl = rc.ClearanceFloor(np.minimum(dist, tgt), multg, x0, y0, CS)
+
+    spC, spH, spOcc = info["spC"], info["spH"], info["spOcc"]
+    spHK, spIK, spCi = info["spHK"], info["spIK"], info["spCi"]
+    cidx, reachN = info["cidx"], info["reachN"]
+    lyo = rc.LayerOracle(spHK, spIK, cidx, nx, ny, x0, y0)
+
+    def mk(m2):
+        u = reachN & m2.ravel()[spC]
+        c3 = np.zeros(ny * nx, bool)
+        c3[spC[u]] = True
+        return u, c3
+
+    useW, cw3 = mk(walk)
+    useC, cc3 = mk(core)
+
+    def pick(c, use):
+        j = int(cidx[c[1] * nx + c[0]])
+        return [int(v) for v in spIK[j] if v >= 0 and use[v]] if j >= 0 else []
 
     sc = (int((s[0] - x0) / CS), int((s[1] - y0) / CS))
     gc = (int((g[0] - x0) / CS), int((g[1] - y0) / CS))
@@ -166,21 +209,51 @@ def route(info, s, g):
         return (int(xs[i]), int(ys[i])), float(np.sqrt(d[i])) * CS
 
     warn = []
-    as_, dsa = near(walk, sc)
-    ag_, dga = near(walk, gc)
+    as_, dsa = near(cw3.reshape(ny, nx), sc)
+    ag_, dga = near(cw3.reshape(ny, nx), gc)
     if as_ is None:
         return None, {"err": "walk 掩膜为空"}
     BIGP = nx * ny * CS * (1.0 + LAM)
+    faces = None if climb_faces else info["sev"]
+    soft = blocked if climb_faces else bn
     t0 = time.time()
-    used = walk
-    q = rc.cost_astar(walk, as_, ag_, mult, blocked, BIGP) if as_ != ag_ else [as_]
-    if q is None:
-        used = core
-        q = rc.cost_astar(core, as_, ag_, mult, blocked, BIGP)
-        if q is not None:
+    on3 = cw3
+    ss = pick(as_, useW)
+    s0 = int(min(ss, key=lambda v: abs(spH[v] - info["h0"])))
+    qs = (rc.span_astar(useW, spH, spOcc, spHK, spIK, spCi, cidx, cw3,
+                        s0, set(pick(ag_, useW)), mult, nx, ny,
+                        soft, BIGP, faces)
+          if as_ != ag_ else [s0])
+    if qs is None:
+        ac_, dc_ = near(cc3.reshape(ny, nx), sc)
+        ag2, dg2 = near(cc3.reshape(ny, nx), gc)
+        if ac_ is not None and ag2 is not None:
+            s0 = int(min(pick(ac_, useC),
+                         key=lambda v: abs(spH[v] - info["h0"])))
+            qs = (rc.span_astar(useC, spH, spOcc, spHK, spIK, spCi, cidx, cc3,
+                                s0, set(pick(ag2, useC)), mult, nx, ny,
+                                soft, BIGP, faces)
+                  if ac_ != ag2 else [s0])
+        if qs is not None:
+            on3 = cc3
+            as_, dsa, ag_, dga = ac_, dc_, ag2, dg2
             warn.append("walk 断开→退回 core")
-    if q is None:
-        return None, {"err": "不连通", "warn": warn}
+    if qs is not None:
+        q = [(int(c % nx), int(c // nx)) for c in spC[qs]]
+    else:
+        as_, dsa = near(walk, sc)
+        ag_, dga = near(walk, gc)
+        on3 = walk.ravel()
+        q = (rc.cost_astar(walk, as_, ag_, mult, soft, BIGP, faces)
+             if as_ != ag_ else [as_])
+        if q is None:
+            on3 = core.ravel()
+            q = rc.cost_astar(core, as_, ag_, mult, soft, BIGP, faces)
+            if q is not None:
+                warn.append("walk 断开→退回 core")
+        if q is None:
+            return None, {"err": "不连通", "warn": warn}
+        warn.append("层不连通→退回格级")
     t_as = time.time() - t0
     xw = []
     bad = []
@@ -208,7 +281,7 @@ def route(info, s, g):
 
     wseg = (np.vstack([info["wP0"], info["sseg"][0]]),
             np.vstack([info["wP1"], info["sseg"][1]]))
-    onm = (used, x0, y0, CS)
+    onm = (on3.reshape(ny, nx), x0, y0, CS)
     blk_gray = rc.Blockers([w(P) for P in loops_c], extra=wseg, on=onm)
     grn = [bool(dist[b, a] >= prefg[b, a] - 1e-9) for a, b in q]
     runs, i = [], 0
@@ -239,8 +312,11 @@ def route(info, s, g):
     mg = merge(runs)
     taut = []
     for isg, i0, i1 in mg:
-        cells = q[i0:min(i1 + 1, len(q) - 1) + 1]
+        j1 = min(i1 + 1, len(q) - 1) + 1
+        cells = q[i0:j1]
+        sub = qs[i0:j1] if qs is not None else None
         pp = cen(cells)
+        hs = None if sub is None else [float(spH[v]) for v in sub]
         if len(cells) >= 2:
             blk = blk_gray
             if isg:
@@ -257,18 +333,33 @@ def route(info, s, g):
                         acc |= rc._sh(pmd, -i_ * dy, -i_ * dx)
                     pmd = acc
                 er = (dist >= pref) | ((dist >= prefg) & pmd) | pm
+                ue, ce = mk(er)
                 # 重寻硬禁穿墙步,不可避穿墙处切开逐子段重寻,原步原样保留
                 cuts = [k - i0 for k in bad if i0 < k <= i0 + len(cells) - 1]
-                q2, a2 = [], 0
+                q2, h2, a2 = [], [], 0
                 for c2 in cuts + [len(cells)]:
                     b2 = c2 - 1
-                    r2 = ([cells[a2]] if a2 == b2 else
-                          rc.cost_astar(er, cells[a2], cells[b2], multg,
-                                        blocked, None))
+                    if a2 == b2:
+                        r2 = [cells[a2]]
+                        r2h = [hs[a2]] if hs is not None else None
+                    elif sub is None:
+                        r2 = rc.cost_astar(er, cells[a2], cells[b2], multg,
+                                           blocked, None)
+                        r2h = None
+                    else:
+                        r2s = rc.span_astar(ue, spH, spOcc, spHK, spIK, spCi,
+                                            cidx, ce, sub[a2], {sub[b2]},
+                                            multg, nx, ny, blocked, None)
+                        r2 = (None if r2s is None else
+                              [(int(c % nx), int(c // nx)) for c in spC[r2s]])
+                        r2h = None if r2s is None else [float(spH[v])
+                                                       for v in r2s]
                     if r2 is None:
                         q2 = None
                         break
                     q2.extend(r2)
+                    if r2h is not None:
+                        h2.extend(r2h)
                     a2 = c2
                 if q2 is not None:
                     l2 = sum(math.dist(q2[k - 1], q2[k])
@@ -277,12 +368,15 @@ def route(info, s, g):
                              for k in range(1, len(cells)))
                     if l2 <= l1 * 1.2 + 2.0 / CS:
                         pp = cen(q2)
+                        hs = h2 if sub is not None else None
                 lp = [rc.simplify_loop(P, MAXERR / CS) for P in
                       rc.trace_contours(er)]
                 blk = rc.Blockers(
                     [w(P) for P in lp] + [w(P) for P in loops_c],
                     extra=wseg, on=onm)
-            pp = [tuple(p) for p in rc.string_pull(pp, blk, cfl=cfl)]
+            pp = [tuple(p) for p in
+                  rc.string_pull(pp, blk, cfl=cfl,
+                                 lyo=lyo if hs is not None else None, hs=hs)]
         if taut and pp and math.dist(pp[0], taut[-1]) < 1e-9:
             pp = pp[1:]
         taut.extend(pp)
@@ -297,8 +391,15 @@ def route(info, s, g):
             ded.append(p)
     line = rc.drop_loops(ded)
     if SLIMEPS > 0 and len(line) > 2:
-        line = rc.slim(line, blk_gray, SLIMEPS, cfl)
-    return line, {"warn": warn, "snapd": (dsa, dga),
+        sl = rc.slim(line, blk_gray, SLIMEPS, cfl)
+        if qs is None or lyo.walk(sl, float(spH[qs[0]])) is not None:
+            line = sl
+    clr = []
+    for px, py in line:
+        a = min(max(int(math.floor((px - x0) / CS)), 0), nx - 1)
+        b = min(max(int(math.floor((py - y0) / CS)), 0), ny - 1)
+        clr.append(float(dist[b, a]))
+    return line, {"warn": warn, "snapd": (dsa, dga), "clr": clr,
                   "t_as": t_as, "t_sp": t_sp, "xwall": xw}
 
 
@@ -361,7 +462,8 @@ class RecastEngine:
         margins = [MARGIN, MARGIN * 2, MARGIN * 4, MARGIN * 8]
         info = line = dg = None
         last_err = None
-        for i, margin in enumerate(margins):
+        for p in range(len(margins) * 2):
+            i, margin = p % len(margins), margins[p % len(margins)]
             x0 = min(s[0], g[0]) - margin; y0 = min(s[1], g[1]) - margin
             x1 = max(s[0], g[0]) + margin; y1 = max(s[1], g[1]) + margin
             nx = int(np.ceil((x1 - x0) / CS))
@@ -370,7 +472,7 @@ class RecastEngine:
                 raise ValueError(f"窗口过大 ({nx}×{ny} 格)")
             info, err = build(zc, wo, s, ss[1], h0, x0, y0, x1, y1)
             if err is None:
-                line, dg = route(info, s, g)
+                line, dg = route(info, s, g, p >= len(margins))
                 if line is not None:
                     P = np.asarray(line, float)
                     pad = 2.0
@@ -400,6 +502,7 @@ class RecastEngine:
         ow, ol = offmesh(line, info)
         return {
             "points": [(float(x), float(y)) for x, y in line],
+            "clearance": list(dg["clr"]),
             "length": L,
             "warn": list(dg["warn"]),
             "wall_cross": [(float(x), float(y)) for x, y in dg["xwall"]],


### PR DESCRIPTION
- fix #4678 
- fix #4671 
- fix #4642 
- fix #4619 
- fix #4611 
- fix #4311

## Summary by Sourcery

改进 MapNavigator 的导航网格（navmesh）路径规划、走廊跟随以及导航进度跟踪，引入垂直层级感知和净空传播，并收紧恢复行为。

新特性：
- 在导航网格路径中跟踪逐点走廊净空，并通过航路点暴露，用于到达带宽（arrival band）尺寸计算。
- 引入跨度级（span-level）可达性以及在高度层上的 A* 搜索，在回退到栅格级路径规划之前，优先在同一垂直层内进行路由。
- 添加 LayerOracle 工具，用于验证路径拉直和瘦化是否遵守高度层连续性。

缺陷修复：
- 防止当只有目标腿可路由时，动态导航网格绕行规划失败。
- 在 RUN 走廊跟随期间，避免使用超出窗口或越过横向偏离（cross-track）限制的走廊段。
- 确保诸如“river-fall”和“cross-tier escape”等恢复流程能正确重置硬进度看门狗，避免进入活锁。
- 修复停滞检测，以区分基于走廊的进度和串行路径进度，避免错误更新硬进度时钟。

改进优化：
- 重新调整导航网格遍历参数（坡度、合并高度、距离惩罚），以更好地符合可攀爬坡度，并加大对低净空栅格单元的惩罚。
- 改进净空与偏好场的计算，将真实墙体净空纳入计算，并在路径规划与“绿色段”（green-segment）重新规划中一致使用。
- 收紧 RUN 转向增益和前视距离，以提高转弯预判能力并减少振荡。
- 调整路径跟踪的到达逻辑，在判断航路点是否已通过时使用走廊宽度，从而减少航路点被过早跳过的情况。
- 简化 NavRun 的前视逻辑，移除基于弦长的裕度钳制以及冲刺/急转弯的特殊分支。
- 使动态叠加层仅在重新锁定底层航路点时才重置硬进度，以保持恢复超时具有实际意义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve navmesh routing, corridor following, and navigation progress tracking for MapNavigator, adding vertical layer awareness and clearance propagation while tightening recovery behavior.

New Features:
- Track per-point corridor clearance in navmesh routes and expose it through waypoints for arrival band sizing.
- Introduce span-level reachability and A* search over height layers to route within the same vertical layer before falling back to grid-level pathing.
- Add LayerOracle utilities to validate that path straightening and slimming respect height-layer continuity.

Bug Fixes:
- Prevent dynamic navmesh detour planning from failing when only the goal leg is routable.
- Avoid using corridor segments that fall outside the window or overshoot cross-track limits during RUN corridor following.
- Ensure recovery flows like river-fall and cross-tier escape correctly reset the hard-progress watchdog to avoid livelock.
- Fix stall detection to distinguish corridor-based progress from serial path progress and avoid mis-keying the hard-progress clock.

Enhancements:
- Retune navmesh traversal parameters (slope, merge height, distance penalties) to better respect climbable slopes and penalize low-clearance cells.
- Refine clearance and preference field computation to include true wall clearance and use it consistently for routing and green-segment re-planning.
- Tighten RUN steering gains and lookahead distance to improve turn anticipation and reduce oscillation.
- Adjust route tracking arrival logic to use corridor width when deciding when a waypoint is passed, reducing early waypoint skipping.
- Simplify NavRun lookahead logic by removing chord-based slack clamping and sprint/sharp-turn special cases.
- Make dynamic overlays reset hard progress only when retargeting the underlying waypoint to keep recovery timeouts meaningful.

</details>