### PR TITLE
perf: 抽数计算支持从任意界面开始

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -232,7 +232,7 @@
     "option.SwitchTeamTeamChoose.label": "Select Team",
     "task.PuzzleSolver.description": "Automatically solve puzzle mini-games for you. No need to think anymore!",
     "task.PullCountCalculator.label": "🧮 Pull Count Calculator",
-    "task.PullCountCalculator.description": "Read the top resource bar on the Operator Recruitment screen, then scan recruitment vouchers in Valuables to estimate current and next-version pulls. Switch to the target recruitment page first.",
+    "task.PullCountCalculator.description": "Read the top resource bar on the Operator Headhunt screen, then scan headhunt vouchers in Valuables to estimate current and next-version pulls.",
     "task.PullCountCalculator.focus.start": "Reading resources and scanning warehouse vouchers",
     "task.PullCountCalculator.focus.succeeded": "Pull count calculated",
     "task.PullCountCalculator.focus.failed": "Pull count calculation failed. Make sure the Operator Recruitment screen is open, the top resource bar is visible, and Valuables can be entered.",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -228,7 +228,7 @@
     "option.SwitchTeamTeamChoose.label": "チーム選択",
     "task.PuzzleSolver.description": "パズルミニゲームを自動で解決します。もう考える必要はありません！",
     "task.PullCountCalculator.label": "🧮 スカウト回数計算",
-    "task.PullCountCalculator.description": "オペレーター募集画面の上部リソース欄を読み取り、貴重品庫のスカウト券もスキャンして、現在と次バージョンのスカウト回数を見積もります。先に対象の募集ページへ移動してください。",
+    "task.PullCountCalculator.description": "オペレーター募集画面の上部リソース欄を読み取り、貴重品庫のスカウト券もスキャンして、現在と次バージョンのスカウト回数を見積もります。",
     "task.PullCountCalculator.focus.start": "募集リソースと倉庫券を読み取り中",
     "task.PullCountCalculator.focus.succeeded": "スカウト回数の計算が完了しました",
     "task.PullCountCalculator.focus.failed": "スカウト回数の計算に失敗しました。募集画面を開き、上部リソース欄が隠れておらず、貴重品庫へ入れることを確認してください。",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -228,7 +228,7 @@
     "option.SwitchTeamTeamChoose.label": "팀 선택",
     "task.PuzzleSolver.description": "퍼즐 미니게임을 자동으로 해결해 줍니다. 더 이상 생각할 필요가 없습니다!",
     "task.PullCountCalculator.label": "🧮 모집 횟수 계산",
-    "task.PullCountCalculator.description": "오퍼레이터 모집 화면의 상단 자원 바를 읽고 귀중품 보관함의 모집권도 스캔해 현재 풀과 다음 버전 풀 모집 횟수를 계산합니다. 먼저 대상 모집 화면으로 이동해 주세요.",
+    "task.PullCountCalculator.description": "오퍼레이터 모집 화면의 상단 자원 바를 읽고 귀중품 보관함의 모집권도 스캔해 현재 풀과 다음 버전 풀 모집 횟수를 계산합니다.",
     "task.PullCountCalculator.focus.start": "모집 자원과 창고권을 읽는 중",
     "task.PullCountCalculator.focus.succeeded": "모집 횟수 계산 완료",
     "task.PullCountCalculator.focus.failed": "모집 횟수 계산 실패. 모집 화면이 열려 있고 상단 자원 바가 가려지지 않았으며 귀중품 보관함에 들어갈 수 있는지 확인해 주세요.",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -232,7 +232,7 @@
     "option.SwitchTeamTeamChoose.label": "选择队伍",
     "task.PuzzleSolver.description": "自动帮你通关拼图小游戏，太好了不用自己动脑子了.jpg",
     "task.PullCountCalculator.label": "🧮抽数计算",
-    "task.PullCountCalculator.description": "从干员寻访界面读取顶部资源栏，再进入贵重品库扫描寻访券，估算当前池和下版本池子抽数。请先手动切到目标寻访页面。",
+    "task.PullCountCalculator.description": "从干员寻访界面读取顶部资源栏，再进入贵重品库扫描寻访券，估算当前池和下版本池子抽数。",
     "task.PullCountCalculator.focus.start": "正在读取寻访资源并扫描仓库券",
     "task.PullCountCalculator.focus.succeeded": "抽数计算完成",
     "task.PullCountCalculator.focus.failed": "抽数计算失败，请确认当前处于干员寻访界面、顶部资源栏无遮挡，且可进入贵重品库",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -232,7 +232,7 @@
     "option.SwitchTeamTeamChoose.label": "選擇隊伍",
     "task.PuzzleSolver.description": "自動幫你通關拼圖小遊戲，太好了不用自己動腦子了.jpg",
     "task.PullCountCalculator.label": "🧮抽數計算",
-    "task.PullCountCalculator.description": "從幹員尋訪介面讀取頂部資源欄，再進入貴重品庫掃描尋訪券，估算目前池與下版本池子抽數。請先手動切到目標尋訪頁面。",
+    "task.PullCountCalculator.description": "從幹員尋訪介面讀取頂部資源欄，再進入貴重品庫掃描尋訪券，估算目前池與下版本池子抽數。",
     "task.PullCountCalculator.focus.start": "正在讀取尋訪資源並掃描倉庫券",
     "task.PullCountCalculator.focus.succeeded": "抽數計算完成",
     "task.PullCountCalculator.focus.failed": "抽數計算失敗，請確認目前處於幹員尋訪介面、頂部資源欄未被遮擋，且可進入貴重品庫",

--- a/assets/resource/pipeline/Interface/InScene/Headhunt.json
+++ b/assets/resource/pipeline/Interface/InScene/Headhunt.json
@@ -1,0 +1,21 @@
+{
+    "InHeadhunt": {
+        "desc": "在干员寻访界面内",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    0,
+                    0,
+                    240,
+                    100
+                ],
+                "expected": [
+                    "干员寻访"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0
+    }
+}

--- a/assets/resource/pipeline/Interface/SceneMenu.json
+++ b/assets/resource/pipeline/Interface/SceneMenu.json
@@ -190,6 +190,16 @@
             "[JumpBack]SceneAnyEnterWorld"
         ]
     },
+    "SceneEnterMenuHeadhunt": {
+        "desc": "从任意界面进入干员寻访界面",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateWorldEnterMenuHeadhunt",
+            "[JumpBack]SceneAnyEnterWorld"
+        ]
+    },
     "SceneEnterMenuLogin": {
         "desc": "从任意界面进入登录界面",
         "pre_delay": 0,

--- a/assets/resource/pipeline/PullCountCalculator.json
+++ b/assets/resource/pipeline/PullCountCalculator.json
@@ -1,6 +1,6 @@
 {
     "PullCountCalculatorMain": {
-        "desc": "抽数计算入口：读取当前干员寻访界面顶部资源栏，再进入贵重品库扫描可留到下版本的寻访券并输出当前池/下版本池抽数估算",
+        "desc": "抽数计算入口：先进入干员寻访界面读取顶部资源栏，再进入贵重品库扫描可留到下版本的寻访券并输出当前池/下版本池抽数估算",
         "recognition": "DirectHit",
         "action": "Custom",
         "custom_action": "PullCountCalculatorAction",
@@ -8,12 +8,33 @@
             "stage": "init"
         },
         "next": [
-            "PullCountCalculatorOriginiumOCR"
+            "PullCountCalculatorEnterHeadhunt"
         ],
         "focus": {
             "Node.Action.Starting": "$task.PullCountCalculator.focus.start",
             "Node.Action.Failed": "$task.PullCountCalculator.focus.failed"
         }
+    },
+    "PullCountCalculatorEnterHeadhunt": {
+        "desc": "进入干员寻访界面，界面跳转交由 SceneManager Pipeline 处理",
+        "next": [
+            "PullCountCalculatorInHeadhunt",
+            "[JumpBack]SceneEnterMenuHeadhunt"
+        ]
+    },
+    "PullCountCalculatorInHeadhunt": {
+        "desc": "确认当前已经在干员寻访界面",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "InHeadhunt"
+                ]
+            }
+        },
+        "next": [
+            "PullCountCalculatorOriginiumOCR"
+        ]
     },
     "PullCountCalculatorOriginiumOCR": {
         "desc": "识别顶部衍质源石换算嵌晶玉数量",

--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -316,6 +316,76 @@
         "pre_delay": 0,
         "post_delay": 0
     },
+    "__ScenePrivateWorldEnterMenuHeadhunt": {
+        "desc": "从大世界进入干员寻访界面",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "InWorld"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateMenuListEnterMenuHeadhunt",
+            "[JumpBack]__ScenePrivateWorldEnterMenuList"
+        ]
+    },
+    "__ScenePrivateMenuListEnterMenuHeadhunt": {
+        "desc": "从菜单列表进入干员寻访界面",
+        "recognition": "And",
+        "all_of": [
+            "InMenuList",
+            {
+                "recognition": {
+                    "type": "OCR",
+                    "param": {
+                        "roi": [
+                            0,
+                            0,
+                            400,
+                            720
+                        ],
+                        "expected": [
+                            "寻访"
+                        ]
+                    }
+                }
+            }
+        ],
+        "box_index": 1,
+        "action": {
+            "type": "Click"
+        },
+        "next": [
+            "__ScenePrivateAnyEnterMenuHeadhuntSuccess"
+        ]
+    },
+    "__ScenePrivateAnyEnterMenuHeadhuntSuccess": {
+        "desc": "成功进入干员寻访界面",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "InHeadhunt"
+                ]
+            }
+        },
+        "pre_wait_freezes": {
+            "time": 200,
+            "target": [
+                0,
+                0,
+                200,
+                100
+            ]
+        },
+        "pre_delay": 0,
+        "post_delay": 0
+    },
     "__ScenePrivateWorldEnterMenuAICPlan": {
         "desc": "从大世界进入工业计划菜单",
         "recognition": {

--- a/docs/en_us/developers/scene-manager.md
+++ b/docs/en_us/developers/scene-manager.md
@@ -69,6 +69,7 @@ These node names **do not start with `__ScenePrivate`**.
 | Menu | `SceneEnterMenuProtocolPass` | Enter Protocol Pass menu. |
 | Menu | `SceneEnterMenuBackpack` | Enter inventory screen. |
 | Menu | `SceneEnterMenuShop` | Enter shop screen. |
+| Menu | `SceneEnterMenuHeadhunt` | Enter Operator Headhunt screen. |
 | Helper | `SceneDialogConfirm` | Click confirm button in dialogs. |
 | Helper | `SceneDialogCancel` | Click cancel button in dialogs. |
 | Helper | `SceneNoticeRewardsConfirm` | Click confirm button on rewards screens. |

--- a/docs/zh_cn/developers/scene-manager.md
+++ b/docs/zh_cn/developers/scene-manager.md
@@ -66,6 +66,7 @@ SceneManager 使用 MaaFramework 的 `[JumpBack]` 机制，将场景接口组织
 | 菜单 | `SceneEnterMenuProtocolPass` | 进入通行证菜单 |
 | 菜单 | `SceneEnterMenuBackpack` | 进入背包界面 |
 | 菜单 | `SceneEnterMenuShop` | 进入商店界面 |
+| 菜单 | `SceneEnterMenuHeadhunt` | 进入干员寻访界面 |
 | 辅助 | `SceneDialogConfirm` | 点击对话框确认按钮 |
 | 辅助 | `SceneDialogCancel` | 点击对话框取消按钮 |
 | 辅助 | `SceneNoticeRewardsConfirm` | 点击奖励界面确认按钮 |


### PR DESCRIPTION
close #4666

## Summary by Sourcery

支持从 Headhunt 界面开始计算抽卡次数，并将新的 Headhunt 场景集成到场景/菜单管线中。

新功能：
- 引入一个可配置的 Headhunt 场景内界面，供抽卡次数计算器使用，以便从任意界面开始计算。

改进：
- 添加 Headhunt 界面场景资源，并将其接入场景管理器和菜单管线。
- 更新界面本地化文件，以覆盖新的与 Headhunt 相关的 UI 元素。

文档：
- 在英文和中文开发者文档中记录新的 `SceneEnterMenuHeadhunt` 场景入口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support pull count calculation starting from the Headhunt interface and integrate the new Headhunt scene into the scene/menu pipelines.

New Features:
- Introduce a configurable Headhunt in-scene interface used by the pull count calculator to start from arbitrary screens.

Enhancements:
- Add Headhunt interface scene resources and hook them into the scene manager and menu pipelines.
- Update interface localization files to cover the new Headhunt-related UI elements.

Documentation:
- Document the new `SceneEnterMenuHeadhunt` scene entry in both English and Chinese developer docs.

</details>