### PR TITLE
fix: 部分锚点传送失败

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneMap.json
+++ b/assets/resource/pipeline/SceneManager/SceneMap.json
@@ -316,6 +316,191 @@
             "time": 400
         }
     },
+    "__ScenePrivateMapZoomNonExtreme": {
+        "desc": "在地图界面，将缩放条调到非顶点区域，供bigmapick使用，防止内部处理出错",
+        "recognition": "And",
+        "all_of": [
+            {
+                "recognition": "ColorMatch",
+                "roi": [
+                    1225,
+                    423,
+                    26,
+                    26
+                ],
+                "lower": [
+                    200,
+                    200,
+                    200
+                ],
+                "upper": [
+                    255,
+                    255,
+                    255
+                ],
+                "connected": true,
+                "count": 150
+            },
+            {
+                "recognition": "ColorMatch",
+                "roi": [
+                    1225,
+                    240,
+                    26,
+                    26
+                ],
+                "lower": [
+                    200,
+                    200,
+                    200
+                ],
+                "upper": [
+                    255,
+                    255,
+                    255
+                ],
+                "connected": true,
+                "count": 150
+            }
+        ],
+        "inverse": true,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateMapZoomNonExtremeFromZoomIn",
+            "__ScenePrivateMapZoomNonExtremeFromZoomOut"
+        ]
+    },
+    "__ScenePrivateMapZoomNonExtremeFromZoomIn": {
+        "desc": "上面 + 号识别到白色，点击 + 与 - 中间",
+        "recognition": "ColorMatch",
+        "roi": [
+            1225,
+            240,
+            26,
+            26
+        ],
+        "lower": [
+            200,
+            200,
+            200
+        ],
+        "upper": [
+            255,
+            255,
+            255
+        ],
+        "connected": true,
+        "count": 150,
+        "action": "Click",
+        "target": [
+            1238,
+            345
+        ],
+        "post_wait_freezes": {
+            "target": [
+                -100,
+                0,
+                100,
+                100
+            ],
+            "time": 400
+        },
+        "next": [
+            "__ScenePrivateMapZoomNonExtremeSuccess"
+        ]
+    },
+    "__ScenePrivateMapZoomNonExtremeFromZoomOut": {
+        "desc": "下面 - 号识别到白色，点击 + 与 - 中间",
+        "recognition": "ColorMatch",
+        "roi": [
+            1225,
+            423,
+            26,
+            26
+        ],
+        "lower": [
+            200,
+            200,
+            200
+        ],
+        "upper": [
+            255,
+            255,
+            255
+        ],
+        "connected": true,
+        "count": 150,
+        "action": "Click",
+        "target": [
+            1238,
+            345
+        ],
+        "post_wait_freezes": {
+            "target": [
+                -100,
+                0,
+                100,
+                100
+            ],
+            "time": 400
+        },
+        "next": [
+            "__ScenePrivateMapZoomNonExtremeSuccess"
+        ]
+    },
+    "__ScenePrivateMapZoomNonExtremeSuccess": {
+        "desc": "确认 ZoomIn/ZoomOut 均识别到白色，已在非顶点",
+        "recognition": "And",
+        "all_of": [
+            {
+                "recognition": "ColorMatch",
+                "roi": [
+                    1225,
+                    423,
+                    26,
+                    26
+                ],
+                "lower": [
+                    200,
+                    200,
+                    200
+                ],
+                "upper": [
+                    255,
+                    255,
+                    255
+                ],
+                "connected": true,
+                "count": 150
+            },
+            {
+                "recognition": "ColorMatch",
+                "roi": [
+                    1225,
+                    240,
+                    26,
+                    26
+                ],
+                "lower": [
+                    200,
+                    200,
+                    200
+                ],
+                "upper": [
+                    255,
+                    255,
+                    255
+                ],
+                "connected": true,
+                "count": 150
+            }
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
     "__ScenePrivateMapFilterClear": {
         "desc": "在地图界面，清除筛选条件",
         "recognition": "TemplateMatch",

--- a/assets/resource/pipeline/SceneManager/SceneValleyIV.json
+++ b/assets/resource/pipeline/SceneManager/SceneValleyIV.json
@@ -652,6 +652,7 @@
         "next": [
             "__ScenePrivateMapTeleportSuccess",
             "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapZoomNonExtreme",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     },

--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -454,6 +454,7 @@
         "next": [
             "__ScenePrivateMapTeleportSuccess",
             "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapZoomNonExtreme",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     },
@@ -468,6 +469,7 @@
         "next": [
             "__ScenePrivateMapTeleportSuccess",
             "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapZoomNonExtreme",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     },
@@ -482,6 +484,7 @@
         "next": [
             "__ScenePrivateMapTeleportSuccess",
             "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapZoomNonExtreme",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     },
@@ -496,6 +499,7 @@
         "next": [
             "__ScenePrivateMapTeleportSuccess",
             "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapZoomNonExtreme",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     },
@@ -510,6 +514,7 @@
         "next": [
             "__ScenePrivateMapTeleportSuccess",
             "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapZoomNonExtreme",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     },
@@ -524,6 +529,7 @@
         "next": [
             "__ScenePrivateMapTeleportSuccess",
             "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapZoomNonExtreme",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     }


### PR DESCRIPTION
close #4646

## Summary by Sourcery

Bug Fixes:
- 修复 SceneMap、SceneValleyIV 和 SceneWuling 中不正确或缺失的锚点配置，以确保传送功能按预期工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect or missing anchor configurations in SceneMap, SceneValleyIV, and SceneWuling to ensure teleportation works as expected.

</details>