### PR TITLE
feat(AutoEssence): 添加应龙关和北部禁区的万能跳转和基质刷取

### DIFF
--- a/assets/data/MapTracker/map_external_data.json
+++ b/assets/data/MapTracker/map_external_data.json
@@ -25,5 +25,23 @@
     },
     "map02_lv002": {
         "scene_manager_node": "SceneEnterMapWulingWulingCity"
+    },
+    "map02_lv003": {
+        "scene_manager_node": "SceneEnterMapWulingQingboStockade"
+    },
+    "map02_lv004": {
+        "scene_manager_node": "SceneEnterMapWulingMarkerStone"
+    },
+    "map02_lv005": {
+        "scene_manager_node": "SceneEnterMapWulingTestArea"
+    },
+    "map02_lv006": {
+        "scene_manager_node": "SceneEnterMapWulingSwordVaultDale"
+    },
+    "map02_lv007": {
+        "scene_manager_node": "SceneEnterMapWulingYinglungPass"
+    },
+    "map02_lv008": {
+        "scene_manager_node": "SceneEnterMapWulingNorthWulingExclusionZone"
     }
 }

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -10,6 +10,8 @@
     "global.region.QingboStockade": "Qingbo Stockade",
     "global.region.MarkerStone": "Marker Stone",
     "global.region.SwordVaultDale": "Sword Vault Dale",
+    "global.region.YinglungPass": "Yinglung Pass",
+    "global.region.NorthWulingExclusionZone": "North Wuling Exclusion Zone",
     "item.XiraniteGourd": "Xiranite Gourd",
     "item.XiraniteJadeGourd": "Xiranite Jade Gourd",
     "task.DeliveryJobs.AcceptJobOnly": "Accept-jobs-only mode is enabled. The subsequent transfer flow has been stopped. Please complete the delivery and run the task again.",

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -211,7 +211,7 @@
     "option.AutoEssenceDoOverride.label": "Use Inscription Vouchers",
     "option.AutoEssenceDoOverride.description": "If inscription is needed, please select the attribute to be inscribed on the accumulation point start interface in advance, and ensure sufficient inscription vouchers (if not enough, non-inscription collection will be performed).",
     "option.AutoEssenceChooseLocation.label": "Region",
-    "option.AutoEssenceChooseLocation.description": "Randomly picks one region from those selected to challenge (the task stops if none is selected).",
+    "option.AutoEssenceChooseLocation.description": "- Randomly picks one region from those selected to challenge (the task stops if none is selected).\n- Due to terrain, the regions with the highest success rate are currently Sword Vault Dale and Qingbo Stockade, while the lowest success rate is in Test Area.",
     "option.AutoEssenceChooseLocationMode.label": "Loop Execution Mode",
     "option.AutoEssenceChooseLocationMode.description": "Controls whether to randomly switch regions between each loop run",
     "option.AutoEssenceChooseLocationMode.cases.ChooseOnlyOnce.label": "Keep a single region throughout",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -207,7 +207,7 @@
     "option.AutoEssenceDoOverride.label": "刻印券を使用する",
     "option.AutoEssenceDoOverride.description": "刻印が必要な場合は、あらかじめ蓄積ポイント開始画面で刻印したい属性を選択し、刻印券が十分にあることを確認してください（不足している場合は非刻印で受け取ります）",
     "option.AutoEssenceChooseLocation.label": "地域",
-    "option.AutoEssenceChooseLocation.description": "選択した地域の中からランダムに1つを選んで挑戦します（何も選択しない場合はタスクを終了します）",
+    "option.AutoEssenceChooseLocation.description": "- 選択した地域の中からランダムに1つを選んで挑戦します（何も選択しない場合はタスクを終了します）。\n- 地形の影響により、現在成功率が最も高い地域は蔵剣谷と清波寨、最も低い地域は実験区域です。",
     "option.AutoEssenceChooseLocationMode.label": "ループ実行方式",
     "option.AutoEssenceChooseLocationMode.description": "ループ実行ごとにランダムで地域を切り替えるかどうかを制御します",
     "option.AutoEssenceChooseLocationMode.cases.ChooseOnlyOnce.label": "最後まで1つの地域に固定",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -10,6 +10,8 @@
     "global.region.QingboStockade": "清波寨",
     "global.region.MarkerStone": "首墩",
     "global.region.SwordVaultDale": "蔵剣谷",
+    "global.region.YinglungPass": "応龍関",
+    "global.region.NorthWulingExclusionZone": "北部封鎖区域",
     "item.XiraniteGourd": "息壌ひょうたん",
     "item.XiraniteJadeGourd": "息壌玉ひょうたん",
     "task.DeliveryJobs.AcceptJobOnly": "依頼受注のみモードが有効です。以降の転送フローを停止しました。配達を完了してから、もう一度タスクを実行してください。",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -207,7 +207,7 @@
     "option.AutoEssenceDoOverride.label": "각인권 사용",
     "option.AutoEssenceDoOverride.description": "각인이 필요한 경우 미리 축적 지점 시작 인터페이스에서 각인할 속성을 선택하고 각인권이 충분한지 확인하십시오. (부족 시 비각인 수령 진행)",
     "option.AutoEssenceChooseLocation.label": "지역",
-    "option.AutoEssenceChooseLocation.description": "선택한 지역 중에서 무작위로 하나를 골라 도전합니다 (아무것도 선택하지 않으면 작업이 종료됩니다)",
+    "option.AutoEssenceChooseLocation.description": "- 선택한 지역 중에서 무작위로 하나를 골라 도전합니다 (아무것도 선택하지 않으면 작업이 종료됩니다).\n- 지형의 영향으로 현재 성공률이 가장 높은 지역은 검고리 골짜기와 청파채이며, 성공률이 가장 낮은 지역은 실험 구역입니다.",
     "option.AutoEssenceChooseLocationMode.label": "반복 실행 방식",
     "option.AutoEssenceChooseLocationMode.description": "반복 실행마다 지역을 무작위로 전환할지 여부를 제어합니다",
     "option.AutoEssenceChooseLocationMode.cases.ChooseOnlyOnce.label": "처음부터 끝까지 단일 지역 고정",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -10,6 +10,8 @@
     "global.region.QingboStockade": "청파채",
     "global.region.MarkerStone": "마커 스톤",
     "global.region.SwordVaultDale": "검고리 골짜기",
+    "global.region.YinglungPass": "응룡 관문",
+    "global.region.NorthWulingExclusionZone": "북쪽 금지 구역",
     "item.XiraniteGourd": "식양 호리병",
     "item.XiraniteJadeGourd": "식양 옥 호리병",
     "task.DeliveryJobs.AcceptJobOnly": "임무 수락 전용 모드가 활성화되었습니다. 이후 전달 절차를 중지합니다. 배송을 완료한 뒤 작업을 다시 실행해 주세요.",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -211,7 +211,7 @@
     "option.AutoEssenceDoOverride.label": "使用刻写券",
     "option.AutoEssenceDoOverride.description": "如需刻写，请事先在淤积点开始界面选择要刻写的属性，并确保刻写券充足（数量不足则会进行非刻写领取）",
     "option.AutoEssenceChooseLocation.label": "地区选择",
-    "option.AutoEssenceChooseLocation.description": "将从所选的地区中，随机选取一个地区进行挑战（若全不选则任务终止）",
+    "option.AutoEssenceChooseLocation.description": "- 将从所选的地区中，随机选取一个地区进行挑战（若全不选则任务终止）。\n- 受地形影响，目前成功率最高的地区是藏剑谷和清波寨，成功率最低的地区是试验园区。",
     "option.AutoEssenceChooseLocationMode.label": "循环执行方式",
     "option.AutoEssenceChooseLocationMode.description": "可以控制每次循环执行间是否需要随机改换地区",
     "option.AutoEssenceChooseLocationMode.cases.ChooseOnlyOnce.label": "全程固定单个地区",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -10,6 +10,8 @@
     "global.region.QingboStockade": "清波寨",
     "global.region.MarkerStone": "首墩",
     "global.region.SwordVaultDale": "藏剑谷",
+    "global.region.YinglungPass": "应龙关",
+    "global.region.NorthWulingExclusionZone": "北部禁区",
     "item.XiraniteGourd": "息壤葫芦",
     "item.XiraniteJadeGourd": "息壤玉葫芦",
     "task.DeliveryJobs.AcceptJobOnly": "已开启仅接取任务模式，停止后续转交流程，请完成送货后再次运行任务",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -10,6 +10,8 @@
     "global.region.QingboStockade": "清波寨",
     "global.region.MarkerStone": "首墩",
     "global.region.SwordVaultDale": "藏劍谷",
+    "global.region.YinglungPass": "應龍關",
+    "global.region.NorthWulingExclusionZone": "北部禁區",
     "item.XiraniteGourd": "息壤葫蘆",
     "item.XiraniteJadeGourd": "息壤玉葫蘆",
     "task.DeliveryJobs.AcceptJobOnly": "已開啟僅接取任務模式，停止後續轉交流程，請完成送貨後再次執行任務",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -211,7 +211,7 @@
     "option.AutoEssenceDoOverride.label": "使用刻寫券",
     "option.AutoEssenceDoOverride.description": "如需刻寫，請事先在淤積點開始界面選擇要刻寫的屬性，並確保刻寫券充足（數量不足則會進行非刻寫領取）",
     "option.AutoEssenceChooseLocation.label": "地區選擇",
-    "option.AutoEssenceChooseLocation.description": "將從所選的地區中，隨機選取一個地區進行挑戰（若全不選則任務終止）",
+    "option.AutoEssenceChooseLocation.description": "- 將從所選的地區中，隨機選取一個地區進行挑戰（若全不選則任務終止）。\n- 受地形影響，目前成功率最高的地區是藏劍谷和清波寨，成功率最低的地區是試驗園區。",
     "option.AutoEssenceChooseLocationMode.label": "循環執行方式",
     "option.AutoEssenceChooseLocationMode.description": "可以控制每次循環執行間是否需要隨機改換地區",
     "option.AutoEssenceChooseLocationMode.cases.ChooseOnlyOnce.label": "全程固定單個地區",

--- a/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
+++ b/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
@@ -32,7 +32,9 @@
                         "GotoTriggerPointSetAnchor_WLQingboStockade",
                         "GotoTriggerPointSetAnchor_WLMarkerStone",
                         "GotoTriggerPointSetAnchor_WLTestArea",
-                        "GotoTriggerPointSetAnchor_WLSwordVaultDale"
+                        "GotoTriggerPointSetAnchor_WLSwordVaultDale",
+                        "GotoTriggerPointSetAnchor_WLYinglungPass",
+                        "GotoTriggerPointSetAnchor_WLNorthWulingExclusionZone"
                     ],
                     "continue": false,
                     "strict": true,

--- a/assets/resource/pipeline/AutoEssence/RegionNodes/WLNorthWulingExclusionZone.json
+++ b/assets/resource/pipeline/AutoEssence/RegionNodes/WLNorthWulingExclusionZone.json
@@ -1,0 +1,128 @@
+{
+    "GotoTriggerPointSetAnchor_WLNorthWulingExclusionZone": {
+        "enabled": false,
+        "pre_delay": 0,
+        "anchor": {
+            "AutoEssenceMoveToTriggerPoint": "GotoTriggerPointMove_WLNorthWulingExclusionZone",
+            "AutoEssenceMoveToTriggerPointMaybeTeleport": "GotoTriggerPointMaybeTeleport_WLNorthWulingExclusionZone"
+        },
+        "post_delay": 0,
+        "focus": {
+            "Node.Action.Starting": "📌目标地点：北部禁区"
+        }
+    },
+    "GotoTriggerPointMaybeTeleport_WLNorthWulingExclusionZone": {
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "MapTrackerAssertLocation",
+                "custom_recognition_param": {
+                    "expected": [
+                        {
+                            // 距离淤积点最近的锚点附近
+                            "map_name": "map02_lv008",
+                            "target": [
+                                526.1,
+                                505.3,
+                                15.9,
+                                16.7
+                            ]
+                        },
+                        {
+                            // 淤积点附近
+                            "map_name": "map02_lv008",
+                            "target": [
+                                509.3,
+                                531.8,
+                                30.7,
+                                25.4
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "inverse": true,
+        "next": [
+            "[JumpBack]__GotoTriggerPointTeleportOnce_WLNorthWulingExclusionZone",
+            "GotoTriggerPointMove_WLNorthWulingExclusionZone"
+        ],
+        "focus": {
+            "Node.Action.Starting": "✈️准备传送到最近锚点"
+        }
+    },
+    "__GotoTriggerPointTeleportOnce_WLNorthWulingExclusionZone": {
+        "max_hit": 1,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            // 距离淤积点最近的锚点：平波堤（锚点编号按 X 从左到右递增）
+            "SceneEnterWorldWulingNorthWulingExclusionZone5"
+        ]
+    },
+    "GotoTriggerPointMove_WLNorthWulingExclusionZone": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv008",
+                    "path": [
+                        [
+                            532.9,
+                            512.3
+                        ],
+                        [
+                            535.9,
+                            511.7
+                        ],
+                        [
+                            540.8,
+                            520.0
+                        ],
+                        [
+                            535.6,
+                            538.9
+                        ],
+                        [
+                            530.6,
+                            547.1
+                        ]
+                    ],
+                    "path_trim": true
+                }
+            }
+        },
+        "next": [
+            "GotoTriggerPointMoveExact_WLNorthWulingExclusionZone"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在前往预备位置"
+        }
+    },
+    "GotoTriggerPointMoveExact_WLNorthWulingExclusionZone": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "map02_lv008",
+                    "path": [
+                        [
+                            522.7,
+                            546.0
+                        ]
+                    ],
+                    "no_ensure_initial_movement_state": true
+                }
+            }
+        },
+        "post_delay": 1500, // 确保彻底停下，规避移动惯性
+        "next": [
+            "AutoEssenceDispatcher"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在前往激发点"
+        }
+    }
+}

--- a/assets/resource/pipeline/AutoEssence/RegionNodes/WLYinglungPass.json
+++ b/assets/resource/pipeline/AutoEssence/RegionNodes/WLYinglungPass.json
@@ -1,0 +1,85 @@
+{
+    "GotoTriggerPointSetAnchor_WLYinglungPass": {
+        "enabled": false,
+        "pre_delay": 0,
+        "anchor": {
+            "AutoEssenceMoveToTriggerPoint": "GotoTriggerPointGoal_WLYinglungPass",
+            "AutoEssenceMoveToTriggerPointMaybeTeleport": "GotoTriggerPointMaybeTeleport_WLYinglungPass"
+        },
+        "post_delay": 0,
+        "focus": {
+            "Node.Action.Starting": "📌目标地点：应龙关"
+        }
+    },
+    "GotoTriggerPointMaybeTeleport_WLYinglungPass": {
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "MapTrackerAssertLocation",
+                "custom_recognition_param": {
+                    "expected": [
+                        {
+                            // 距离淤积点最近的锚点附近
+                            "map_name": "map02_lv007",
+                            "target": [
+                                557.8,
+                                220.1,
+                                16.3,
+                                13.8
+                            ]
+                        },
+                        {
+                            // 淤积点附近
+                            "map_name": "map02_lv007",
+                            "target": [
+                                480.8,
+                                293.8,
+                                38.3,
+                                38.3
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "inverse": true,
+        "next": [
+            "[JumpBack]__GotoTriggerPointTeleportOnce_WLYinglungPass",
+            "GotoTriggerPointGoal_WLYinglungPass"
+        ],
+        "focus": {
+            "Node.Action.Starting": "✈️准备传送到最近锚点"
+        }
+    },
+    "__GotoTriggerPointTeleportOnce_WLYinglungPass": {
+        "max_hit": 1,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            // 距离淤积点最近的锚点：应龙主营（锚点编号按 X 从左到右递增）
+            "SceneEnterWorldWulingYinglungPass2"
+        ]
+    },
+    "GotoTriggerPointGoal_WLYinglungPass": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapTrackerGoal",
+                "custom_action_param": {
+                    "map_name": "map02_lv007",
+                    "target": [
+                        501.0,
+                        313.2
+                    ]
+                }
+            }
+        },
+        "post_delay": 1500, // 确保彻底停下，规避移动惯性
+        "next": [
+            "AutoEssenceDispatcher"
+        ],
+        "focus": {
+            "Node.Action.Starting": "🚶正在前往激发点"
+        }
+    }
+}

--- a/assets/resource/pipeline/Interface/InScene/Region.json
+++ b/assets/resource/pipeline/Interface/InScene/Region.json
@@ -156,6 +156,52 @@
             }
         ]
     },
+    "InMapWulingYinglungPass": {
+        "desc": "在武陵-应龙关地图界面",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny",
+            {
+                "recognition": "OCR",
+                "roi": [
+                    0,
+                    0,
+                    250,
+                    60
+                ],
+                "expected": [
+                    "应龙关",
+                    "Yinglung Pass",
+                    "應龍關",
+                    "応龍関",
+                    "응룡 관문"
+                ]
+            }
+        ]
+    },
+    "InMapWulingNorthWulingExclusionZone": {
+        "desc": "在武陵-北部禁区地图界面",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny",
+            {
+                "recognition": "OCR",
+                "roi": [
+                    0,
+                    0,
+                    250,
+                    60
+                ],
+                "expected": [
+                    "北部禁区",
+                    "North Wuling Exclusion Zone",
+                    "北部禁區",
+                    "北部封鎖区域",
+                    "북쪽 금지 구역"
+                ]
+            }
+        ]
+    },
     "InMapDijiang": {
         "desc": "在帝江号地图界面",
         "recognition": "And",

--- a/assets/resource/pipeline/Interface/SceneWuling.json
+++ b/assets/resource/pipeline/Interface/SceneWuling.json
@@ -512,5 +512,239 @@
             "__ScenePrivateMapWulingSwordVaultDaleEnterWorldAnchorWithPick",
             "[JumpBack]SceneEnterMapWulingSwordVaultDale"
         ]
+    },
+    "SceneEnterMapWulingYinglungPass": {
+        "desc": "从任意界面进入武陵-应龙关地图界面",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingYinglungPass",
+            "[JumpBack]SceneEnterMapAny"
+        ]
+    },
+    "SceneEnterWorldWulingYinglungPass0": {
+        "desc": "从任意界面进入武陵-应龙关-临关渠北侧大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass0"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingYinglungPassEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingYinglungPass"
+        ]
+    },
+    "SceneEnterWorldWulingYinglungPass1": {
+        "desc": "从任意界面进入武陵-应龙关-奇松岭东侧大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass1"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingYinglungPassEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingYinglungPass"
+        ]
+    },
+    "SceneEnterWorldWulingYinglungPass2": {
+        "desc": "从任意界面进入武陵-应龙关-应龙主营大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass2"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingYinglungPassEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingYinglungPass"
+        ]
+    },
+    "SceneEnterWorldWulingYinglungPass3": {
+        "desc": "从任意界面进入武陵-应龙关-石涧崖南侧大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass3"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingYinglungPassEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingYinglungPass"
+        ]
+    },
+    "SceneEnterWorldWulingYinglungPass4": {
+        "desc": "从任意界面进入武陵-应龙关-置器阁大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass4"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingYinglungPassEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingYinglungPass"
+        ]
+    },
+    "SceneEnterWorldWulingYinglungPass5": {
+        "desc": "从任意界面进入武陵-应龙关-应龙档案室大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass5"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingYinglungPassEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingYinglungPass"
+        ]
+    },
+    "SceneEnterMapWulingNorthWulingExclusionZone": {
+        "desc": "从任意界面进入武陵-北部禁区地图界面",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingNorthWulingExclusionZone",
+            "[JumpBack]SceneEnterMapAny"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone0": {
+        "desc": "从任意界面进入武陵-北部禁区-前哨基地大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone0"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone1": {
+        "desc": "从任意界面进入武陵-北部禁区-水利枢纽大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone1"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone2": {
+        "desc": "从任意界面进入武陵-北部禁区-城建区西北侧大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone2"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone3": {
+        "desc": "从任意界面进入武陵-北部禁区-谈剑堂大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone3"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone4": {
+        "desc": "从任意界面进入武陵-北部禁区-城建区东南侧大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone4"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone5": {
+        "desc": "从任意界面进入武陵-北部禁区-平波堤大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone5"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone6": {
+        "desc": "从任意界面进入武陵-北部禁区-息壤研究所大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone6"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone7": {
+        "desc": "从任意界面进入武陵-北部禁区-天师桩研发中心大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone7"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone8": {
+        "desc": "从任意界面进入武陵-北部禁区-幽台试验场大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone8"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone9": {
+        "desc": "从任意界面进入武陵-北部禁区-甚大裂隙地下层大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone9"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone10": {
+        "desc": "从任意界面进入武陵-北部禁区-天柱大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone10"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "SceneEnterWorldWulingNorthWulingExclusionZone11": {
+        "desc": "从任意界面进入武陵-北部禁区-甚大裂隙地表层大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone11"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
+        ]
     }
 }

--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -1611,5 +1611,491 @@
         "next": [
             "__ScenePrivateMapTeleportConfirmWithSwipeAnchorClear"
         ]
+    },
+    "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass0": {
+        "desc": "在地图界面找锚点 (应龙关-临关渠北侧)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingYinglungPass"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv007",
+            "target": [
+                310.61,
+                303.17
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass1": {
+        "desc": "在地图界面找锚点 (应龙关-奇松岭东侧)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingYinglungPass"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv007",
+            "target": [
+                544.93,
+                410.38
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass2": {
+        "desc": "在地图界面找锚点 (应龙关-应龙主营)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingYinglungPass"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv007",
+            "target": [
+                566.01,
+                226.31
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass3": {
+        "desc": "在地图界面找锚点 (应龙关-石涧崖南侧)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingYinglungPass"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv007",
+            "target": [
+                601.31,
+                468.04
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass4": {
+        "desc": "在地图界面找锚点 (应龙关-置器阁)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingYinglungPass"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv007",
+            "target": [
+                644.34,
+                200.91
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingYinglungPassEnterWorldWulingYinglungPass5": {
+        "desc": "在地图界面找锚点 (应龙关-应龙档案室)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingYinglungPass"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv007",
+            "target": [
+                646.08,
+                339.36
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone0": {
+        "desc": "在地图界面找锚点 (北部禁区-前哨基地)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                261.09,
+                607.3
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone1": {
+        "desc": "在地图界面找锚点 (北部禁区-水利枢纽)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                307.92,
+                321.18
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone2": {
+        "desc": "在地图界面找锚点 (北部禁区-城建区西北侧)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                343.33,
+                439.41
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone3": {
+        "desc": "在地图界面找锚点 (北部禁区-谈剑堂)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                422.72,
+                330.69
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone4": {
+        "desc": "在地图界面找锚点 (北部禁区-城建区东南侧)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                435.31,
+                620.83
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone5": {
+        "desc": "在地图界面找锚点 (北部禁区-平波堤)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                537.27,
+                510.37
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone6": {
+        "desc": "在地图界面找锚点 (北部禁区-息壤研究所)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                539.3,
+                325.89
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone7": {
+        "desc": "在地图界面找锚点 (北部禁区-天师桩研发中心)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                599.63,
+                538.04
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone8": {
+        "desc": "在地图界面找锚点 (北部禁区-幽台试验场)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                691.81,
+                328.34
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone9": {
+        "desc": "在地图界面找锚点 (北部禁区-甚大裂隙地下层)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                730.12,
+                449.93
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone10": {
+        "desc": "在地图界面找锚点 (北部禁区-天柱)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                734.21,
+                386.53
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldWulingNorthWulingExclusionZone11": {
+        "desc": "在地图界面找锚点 (北部禁区-甚大裂隙地表层)",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapTrackerBigMapPick",
+        "custom_action_param": {
+            "map_name": "map02_lv008",
+            "target": [
+                737.62,
+                472.57
+            ],
+            "on_find": "Click"
+        },
+        "anchor": {
+            "__ScenePrivateMapMapTrackerBigMapPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "__ScenePrivateMapTeleportConfirm"
+        ]
     }
 }

--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -600,6 +600,7 @@
         "next": [
             "__ScenePrivateMapTeleportSuccess",
             "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapZoomNonExtreme",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     },
@@ -670,6 +671,7 @@
         "next": [
             "__ScenePrivateMapTeleportSuccess",
             "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapZoomNonExtreme",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
     }

--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -532,5 +532,145 @@
             "[JumpBack]__ScenePrivateMapZoomNonExtreme",
             "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
         ]
+    },
+    "__ScenePrivateMapAnyEnterMapWulingYinglungPass": {
+        "desc": "在任意地图界面，进入武陵-应龙关地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny"
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingYinglungPassSuccess",
+            "__ScenePrivateMapOverviewEnterMapWulingYinglungPass",
+            "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
+        ]
+    },
+    "__ScenePrivateMapAnyEnterMapWulingYinglungPassSuccess": {
+        "desc": "在地图界面，成功进入武陵-应龙关地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingYinglungPass"
+        ],
+        "pre_wait_freezes": 100,
+        "pre_delay": 0,
+        "post_delay": 0
+    },
+    "__ScenePrivateMapOverviewEnterMapWulingYinglungPass": {
+        "desc": "在地图总览界面，进入武陵-应龙关地图",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    -450,
+                    -150,
+                    350,
+                    150
+                ],
+                "template": [
+                    "SceneManager/MapOverviewWulingChoose.png",
+                    "SceneManager/MapOverviewWulingNotChoose.png"
+                ],
+                "threshold": 0.9
+            }
+        },
+        "next": [
+            "[JumpBack]__ScenePrivateMapOverviewSwitchMapOverviewWuling",
+            "__ScenePrivateMapOverviewWulingEnterMapWulingYinglungPass"
+        ]
+    },
+    "__ScenePrivateMapOverviewWulingEnterMapWulingYinglungPass": {
+        "desc": "在武陵总览界面，进入武陵-应龙关地图",
+        "action": "Click",
+        "target": [
+            733,
+            202
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingYinglungPassSuccess"
+        ]
+    },
+    "__ScenePrivateMapWulingYinglungPassEnterWorldAnchorWithPick": {
+        "desc": "在武陵-应龙关地图界面，进入[锚点]大世界",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingYinglungPass"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapTeleportSuccess",
+            "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
+        ]
+    },
+    "__ScenePrivateMapAnyEnterMapWulingNorthWulingExclusionZone": {
+        "desc": "在任意地图界面，进入武陵-北部禁区地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapAny"
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingNorthWulingExclusionZoneSuccess",
+            "__ScenePrivateMapOverviewEnterMapWulingNorthWulingExclusionZone",
+            "[JumpBack]__ScenePrivateMapAnyEnterMapOverview"
+        ]
+    },
+    "__ScenePrivateMapAnyEnterMapWulingNorthWulingExclusionZoneSuccess": {
+        "desc": "在地图界面，成功进入武陵-北部禁区地图",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_wait_freezes": 100,
+        "pre_delay": 0,
+        "post_delay": 0
+    },
+    "__ScenePrivateMapOverviewEnterMapWulingNorthWulingExclusionZone": {
+        "desc": "在地图总览界面，进入武陵-北部禁区地图",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    -450,
+                    -150,
+                    350,
+                    150
+                ],
+                "template": [
+                    "SceneManager/MapOverviewWulingChoose.png",
+                    "SceneManager/MapOverviewWulingNotChoose.png"
+                ],
+                "threshold": 0.9
+            }
+        },
+        "next": [
+            "[JumpBack]__ScenePrivateMapOverviewSwitchMapOverviewWuling",
+            "__ScenePrivateMapOverviewWulingEnterMapWulingNorthWulingExclusionZone"
+        ]
+    },
+    "__ScenePrivateMapOverviewWulingEnterMapWulingNorthWulingExclusionZone": {
+        "desc": "在武陵总览界面，进入武陵-北部禁区地图",
+        "action": "Click",
+        "target": [
+            891,
+            116
+        ],
+        "next": [
+            "__ScenePrivateMapAnyEnterMapWulingNorthWulingExclusionZoneSuccess"
+        ]
+    },
+    "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick": {
+        "desc": "在武陵-北部禁区地图界面，进入[锚点]大世界",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingNorthWulingExclusionZone"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapTeleportSuccess",
+            "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack][Anchor]__ScenePrivateMapMapTrackerBigMapPickAnchor"
+        ]
     }
 }

--- a/assets/tasks/AutoEssence.json
+++ b/assets/tasks/AutoEssence.json
@@ -115,6 +115,24 @@
                             "enabled": true
                         }
                     }
+                },
+                {
+                    "name": "WLYinglungPass",
+                    "label": "$global.region.YinglungPass",
+                    "pipeline_override": {
+                        "GotoTriggerPointSetAnchor_WLYinglungPass": {
+                            "enabled": true
+                        }
+                    }
+                },
+                {
+                    "name": "WLNorthWulingExclusionZone",
+                    "label": "$global.region.NorthWulingExclusionZone",
+                    "pipeline_override": {
+                        "GotoTriggerPointSetAnchor_WLNorthWulingExclusionZone": {
+                            "enabled": true
+                        }
+                    }
                 }
             ]
         },

--- a/assets/tasks/AutoEssence.json
+++ b/assets/tasks/AutoEssence.json
@@ -32,7 +32,17 @@
             "label": "$option.AutoEssenceChooseLocation.label",
             "description": "$option.AutoEssenceChooseLocation.description",
             "default_case": [
-                "VFTheHub"
+                "VFTheHub",
+                "VFOriginiumSciencePark",
+                "VFOriginLodespring",
+                "VFPowerPlateau",
+                "WLWulingCity",
+                "WLQingboStockade",
+                "WLMarkerStone",
+                "WLTestArea",
+                "WLSwordVaultDale",
+                "WLYinglungPass",
+                "WLNorthWulingExclusionZone"
             ],
             "cases": [
                 {


### PR DESCRIPTION
## 概要

此 PR 为武陵应龙关地区、武陵北部禁区地区添加了万能跳转支持和基质刷取支持。

此外调整了基质刷取的地区默认值。

## Summary by Sourcery

为新的五陵区域添加 AutoEssence 支持，用于通用传送和精华刷取。

New Features:
- 为五陵应龙关和五陵北部封锁区启用 AutoEssence 通用传送和精华刷取功能。
- 在场景内接口和场景管理器接口中暴露新的五陵区域，以支持地图追踪和传送。
- 更新地图追踪器的外部数据和本地化界面字符串，使其识别新的五陵 AutoEssence 区域。

Enhancements:
- 扩展 AutoEssence 的通用与区域节点配置以及相关任务定义，以覆盖新的五陵区域。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add AutoEssence support for universal teleport and essence farming in new Wuling regions.

New Features:
- Enable AutoEssence universal teleport and essence farming for Wuling Yinglong Pass and North Wuling Exclusion Zone regions.
- Expose the new Wuling regions in the in-scene and scene manager interfaces for map tracking and teleport.
- Update map tracker external data and localized interface strings to recognize the new Wuling AutoEssence regions.

Enhancements:
- Extend AutoEssence common and region node configurations and associated task definitions to cover the new Wuling areas.

</details>