### PR TITLE
fix: 切换账号描述补充关闭帧生成提示

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -1304,7 +1304,7 @@
     "task.ResourceRecycleStation.focus.Found": "Resource recycle station found",
     "task.ResourceRecycleStation.focus.Empty": "No collectible resources in this region",
     "task.AccountSwitch.label": "Auto Account Switch",
-    "task.AccountSwitch.description": "Automatically log out and switch to an account by matching the last 4 digits\n**Set the frame rate to 60 FPS and the image enhancement option to TAAU in Endfield settings**",
+    "task.AccountSwitch.description": "Automatically log out and switch to an account by matching the last 4 digits\n**Set the frame rate to 60 FPS, disable frame generation, and set the image enhancement option to TAAU in Endfield settings**",
     "option.AccountSwitchLastFourDigits.label": "Target account last 4 digits",
     "option.AccountSwitchLastFourDigits.LastFourDigits.label": "Enter last 4 digits",
     "task.TrialOfSwordmancy.label": "🗡️Trial of Swordmancy",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -1304,7 +1304,7 @@
     "task.ResourceRecycleStation.focus.Found": "資源回収ステーションを発見",
     "task.ResourceRecycleStation.focus.Empty": "この地域に収集可能な資源はありません",
     "task.AccountSwitch.label": "自動アカウント切替",
-    "task.AccountSwitch.description": "現在のアカウントからログアウトし、指定した下4桁のアカウントに切り替えます\n**終末地の設定でフレームレートを60FPS、画質向上オプションをTAAUに変更してください**",
+    "task.AccountSwitch.description": "現在のアカウントからログアウトし、指定した下4桁のアカウントに切り替えます\n**終末地の設定でフレームレートを60FPSに設定し、フレーム生成を無効にして、画質向上オプションをTAAUに変更してください**",
     "option.AccountSwitchLastFourDigits.label": "対象アカウント下4桁",
     "option.AccountSwitchLastFourDigits.LastFourDigits.label": "下4桁を入力",
     "task.TrialOfSwordmancy.label": "🗡️剣術演武",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -1304,7 +1304,7 @@
     "task.ResourceRecycleStation.focus.Found": "자원 재활용 스테이션 발견",
     "task.ResourceRecycleStation.focus.Empty": "이 지역에 수집 가능한 자원이 없습니다",
     "task.AccountSwitch.label": "자동 계정 전환",
-    "task.AccountSwitch.description": "현재 계정에서 로그아웃하고 지정한 마지막 4자리 계정으로 전환합니다\n**종말지 설정에서 프레임을 60FPS로, 화질 향상 옵션을 TAAU로 변경하세요**",
+    "task.AccountSwitch.description": "현재 계정에서 로그아웃하고 지정한 마지막 4자리 계정으로 전환합니다\n**종말지 설정에서 프레임을 60FPS로 설정하고, 프레임 생성을 끈 다음, 화질 향상 옵션을 TAAU로 변경하세요**",
     "option.AccountSwitchLastFourDigits.label": "대상 계정 마지막 4자리",
     "option.AccountSwitchLastFourDigits.LastFourDigits.label": "마지막 4자리 입력",
     "task.TrialOfSwordmancy.label": "🗡️검술 연무",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -1304,7 +1304,7 @@
     "task.ResourceRecycleStation.focus.Found": "发现资源回收站",
     "task.ResourceRecycleStation.focus.Empty": "该地区暂无可收取资源",
     "task.AccountSwitch.label": "自动切换账号",
-    "task.AccountSwitch.description": "自动登出当前账号并切换到指定账号的后四位\n**要将终末地设置中帧率改为60帧，且画质提升选项改为TAAU**",
+    "task.AccountSwitch.description": "自动登出当前账号并切换到指定账号的后四位\n**要将终末地设置中帧率改为60帧，且关闭帧生成，并将画质提升选项改为TAAU**",
     "option.AccountSwitchLastFourDigits.label": "目标账号后四位",
     "option.AccountSwitchLastFourDigits.LastFourDigits.label": "输入账号后四位",
     "task.TrialOfSwordmancy.label": "🗡️选剑演武",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -1304,7 +1304,7 @@
     "task.ResourceRecycleStation.focus.Found": "發現資源回收站",
     "task.ResourceRecycleStation.focus.Empty": "該地區暫無可收取資源",
     "task.AccountSwitch.label": "自動切換帳號",
-    "task.AccountSwitch.description": "自動登出當前帳號並切換到指定帳號的後四位\n**請將終末地設定中的幀率改為60幀，且畫質提升選項改為TAAU**",
+    "task.AccountSwitch.description": "自動登出當前帳號並切換到指定帳號的後四位\n**請將終末地設定中的幀率改為60幀、關閉幀生成，並將畫質提升選項改為TAAU**",
     "option.AccountSwitchLastFourDigits.label": "目標帳號後四位",
     "option.AccountSwitchLastFourDigits.LastFourDigits.label": "輸入帳號後四位",
     "task.TrialOfSwordmancy.label": "🗡️選劍演武",


### PR DESCRIPTION
## Summary by Sourcery

增强内容：
- 调整本地化文件中的 UI 文案，以在英文、日文、韩文、简体中文和繁体中文中更清楚地描述在切换账号以及关闭画面生成提示时的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust UI copy in localization files to clarify behavior when switching accounts and closing the frame generation prompt in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

</details>