### PR TITLE
fix(EnvironmentMonitoring): 修复植物观察点任务

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "FloraObservationPointInQuickTeleportMap"
+            "GoToFloraObservationPoint"
         ]
     },
     "AlreadyTrackedFloraObservationPoint": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "FloraObservationPointOpenTrackedMissionMap"
+            "GoToFloraObservationPoint"
         ]
     },
     "FloraObservationPointOpenTrackedMissionMap": {
@@ -340,10 +340,10 @@
         "custom_recognition_param": {
             "zone_id": "Wuling_Base",
             "target": [
-                0,
-                0,
-                1,
-                1
+                477.62,
+                2108.95,
+                27.2,
+                27.33
             ]
         },
         "pre_delay": 0,
@@ -360,7 +360,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneAnyEnterWorld"
+                "SceneEnterWorldWulingMarkerStone1"
             ]
         },
         "post_delay": 0,
@@ -379,14 +379,14 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        93.84,
-                        185.41
+                        125.73,
+                        112.6
                     ],
                     "target_tier": "Wuling_L4_330"
                 },
                 {
                     "action": "HEADING",
-                    "angle": 0
+                    "angle": 180
                 }
             ]
         },
@@ -416,7 +416,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "EnvironmentMonitoringSwipeScreenLeft"
+            "EnvironmentMonitoringSwipeScreenDown"
         ]
     }
 }

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -619,15 +619,21 @@
         "MissionId": "m1m63",
         "Name": "植物观察点",
         "Id": "FloraObservationPoint",
-        "QuickTeleport": true,
+        "EnterMap": "SceneEnterWorldWulingMarkerStone1",
         "MapName": "Wuling_Base",
+        "MapAssert": [
+            477.62,
+            2108.95,
+            27.2,
+            27.33
+        ],
         "MapTarget": [
-            93.84,
-            185.41
+            125.73,
+            112.6
         ],
         "MapTargetTier": "Wuling_L4_330",
-        "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenLeft",
-        "Heading": 0
+        "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenDown",
+        "Heading": 180
     },
     {
         "MissionId": "m1m64",


### PR DESCRIPTION
之前的路径失败次数是第一，现在调整拍照路径尝试一下。

## Summary by Sourcery

错误修复：
- 修正环境监测配置中植物观测点照片的捕获路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct flora observation point photo capture path in environment monitoring configuration.

</details>