### PR TITLE
chore: 同步上游 linux 控制器重构

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/Backend/backend.cpp
+++ b/agent/cpp-algo/source/MapNavigator/Backend/backend.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<IInputBackend> CreateInputBackend(MaaController* ctrl)
     // WlRoots 与 Win32 共享同一套 Win32 VK 键码语义（前者在 interface.json 中开启
     // use_win32_vk_code，由 MaaFramework 翻译为 Linux evdev 码），但 WlRoots 仍需
     // 自己的 SendViewDeltaSync 实现来处理 Xwayland 鼠标捕获下的视角旋转。
-    if (IsWlrootsControllerType(controller_type)) {
+    if (IsWlrootsLikeControllerType(controller_type)) {
         return backend::wlroots::CreateWlrootsInputBackend(ctrl, std::move(controller_type));
     }
 

--- a/agent/cpp-algo/source/MapNavigator/controller_type_utils.h
+++ b/agent/cpp-algo/source/MapNavigator/controller_type_utils.h
@@ -29,9 +29,9 @@ inline bool IsPlayCoverControllerType(std::string_view controller_type)
     return EqualsIgnoreCase(controller_type, "playcover") || EqualsIgnoreCase(controller_type, "play_cover");
 }
 
-inline bool IsWlrootsControllerType(std::string_view controller_type)
+inline bool IsWlrootsLikeControllerType(std::string_view controller_type)
 {
-    return EqualsIgnoreCase(controller_type, "wlroots") || EqualsIgnoreCase(controller_type, "wl_roots");
+    return EqualsIgnoreCase(controller_type, "linux") || EqualsIgnoreCase(controller_type, "wlroots");
 }
 
 } // namespace mapnavigator

--- a/agent/go-service/pkg/control/utils.go
+++ b/agent/go-service/pkg/control/utils.go
@@ -16,6 +16,7 @@ const (
 	CONTROL_TYPE_WIN32   = "win32"
 	CONTROL_TYPE_MACOS   = "macos"
 	CONTROL_TYPE_WLROOTS = "wlroots"
+	CONTROL_TYPE_LINUX   = "linux"
 	CONTROL_TYPE_ADB     = "adb"
 )
 
@@ -47,7 +48,7 @@ func GetControlType(ctrl *maa.Controller) (string, error) {
 		if strings.Contains(infoStr, CONTROL_TYPE_MACOS) {
 			return CONTROL_TYPE_MACOS, nil
 		}
-		if strings.Contains(infoStr, CONTROL_TYPE_WLROOTS) {
+		if strings.Contains(infoStr, CONTROL_TYPE_LINUX) || strings.Contains(infoStr, CONTROL_TYPE_WLROOTS) {
 			return CONTROL_TYPE_WLROOTS, nil
 		}
 		if strings.Contains(infoStr, CONTROL_TYPE_ADB) {
@@ -65,7 +66,7 @@ func GetControlType(ctrl *maa.Controller) (string, error) {
 	if info.Type == CONTROL_TYPE_MACOS {
 		return CONTROL_TYPE_MACOS, nil
 	}
-	if info.Type == CONTROL_TYPE_WLROOTS {
+	if info.Type == CONTROL_TYPE_LINUX || info.Type == CONTROL_TYPE_WLROOTS {
 		return CONTROL_TYPE_WLROOTS, nil
 	}
 	if info.Type == CONTROL_TYPE_ADB {


### PR DESCRIPTION
## Summary by Sourcery

使控制器类型处理与上游的 Linux 控制器重构保持一致，并将通用的 Linux 控制器视为类似 wlroots 的后端。

改进内容：
- 添加专用的 Linux 控制类型，并在 Go 和 C++ 中将其映射到现有的 wlroots 处理路径。
- 通过共享的“类似 wlroots”的判定条件，将 wlroots 后端检测范围扩展到包含 Linux 控制器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align controller type handling with upstream Linux controller refactor and treat generic Linux controllers as wlroots-like backends.

Enhancements:
- Add a dedicated Linux control type and map it to the existing wlroots handling path in Go and C++.
- Broaden wlroots backend detection to include Linux controllers via a shared wlroots-like predicate.

</details>