### PR TITLE
fix: 过滤不支持的16:9分辨率

### DIFF
--- a/agent/go-service/taskersink/aspectratio/checker.go
+++ b/agent/go-service/taskersink/aspectratio/checker.go
@@ -145,7 +145,7 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		return
 	}
 
-	aspectRatioOK, minResolutionOK, resolutionOK := isNonADBResolutionOK(width, height)
+	aspectRatioOK, minResolutionOK, resolutionOK, scaledW, scaledH := isNonADBResolutionOK(width, height)
 
 	log.Debug().
 		Uint64("task_id", detail.TaskID).
@@ -156,6 +156,8 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		Str("mode", "aspect_ratio_min_resolution").
 		Int32("width", width).
 		Int32("height", height).
+		Int("scaled_width", scaledW).
+		Int("scaled_height", scaledH).
 		Int("target_width", targetWidth).
 		Int("target_height", targetHeight).
 		Bool("aspect_ratio_ok", aspectRatioOK).
@@ -170,7 +172,7 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		}
 		width = recheckedWidth
 		height = recheckedHeight
-		aspectRatioOK, minResolutionOK, _ = isNonADBResolutionOK(width, height)
+		aspectRatioOK, minResolutionOK, _, scaledW, scaledH = isNonADBResolutionOK(width, height)
 		actualRatio := calculateAspectRatio(int(width), int(height))
 		log.Error().
 			Uint64("task_id", detail.TaskID).
@@ -181,6 +183,8 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 			Bool("stop_task", true).
 			Int32("width", width).
 			Int32("height", height).
+			Int("scaled_width", scaledW).
+			Int("scaled_height", scaledH).
 			Int("target_width", targetWidth).
 			Int("target_height", targetHeight).
 			Bool("aspect_ratio_ok", aspectRatioOK).
@@ -215,6 +219,8 @@ func (c *AspectRatioChecker) OnTaskerTask(tasker *maa.Tasker, event maa.EventSta
 		Str("requirement", "aspect_ratio_min_resolution").
 		Int32("width", width).
 		Int32("height", height).
+		Int("scaled_width", scaledW).
+		Int("scaled_height", scaledH).
 		Int("target_width", targetWidth).
 		Int("target_height", targetHeight).
 		Bool("aspect_ratio_ok", aspectRatioOK).
@@ -247,10 +253,26 @@ func readResolutionWithRetry(controller *maa.Controller) (int32, int32, bool) {
 	return width, height, false
 }
 
-func isNonADBResolutionOK(width, height int32) (bool, bool, bool) {
-	aspectRatioOK := isAspectRatio16x9(int(width), int(height))
-	minResolutionOK := isAtLeastTargetResolution(int(width), int(height))
-	return aspectRatioOK, minResolutionOK, aspectRatioOK && minResolutionOK
+func isNonADBResolutionOK(width, height int32) (bool, bool, bool, int, int) {
+	w, h := int(width), int(height)
+	aspectRatioOK := isAspectRatio16x9(w, h)
+	minResolutionOK := isAtLeastTargetResolution(w, h)
+
+	// 需要严格支持缩放后1280x720，例如1360×768缩放后是1275×720会识别异常
+	var scaledW, scaledH int
+	if w > 0 && h > 0 {
+		if w > h {
+			scaledW = int(math.Round(float64(targetHeight) * float64(w) / float64(h)))
+			scaledH = targetHeight
+		} else {
+			scaledW = targetHeight
+			scaledH = int(math.Round(float64(targetHeight) * float64(h) / float64(w)))
+		}
+	}
+	scaledOK := (scaledW == targetWidth && scaledH == targetHeight) ||
+		(scaledW == targetHeight && scaledH == targetWidth)
+
+	return aspectRatioOK, minResolutionOK, aspectRatioOK && minResolutionOK && scaledOK, scaledW, scaledH
 }
 
 func trySwitchFullscreenToWindowedAndRecheck(controller *maa.Controller, detail maa.TaskerTaskDetail, width, height int32) (int32, int32, bool) {
@@ -330,12 +352,14 @@ func recheckResolutionAfterFullscreenToggle(readResolution resolutionReader, det
 
 	width = recheckedWidth
 	height = recheckedHeight
-	aspectRatioOK, minResolutionOK, resolutionOK := isNonADBResolutionOK(width, height)
+	aspectRatioOK, minResolutionOK, resolutionOK, scaledW, scaledH := isNonADBResolutionOK(width, height)
 	log.Debug().
 		Uint64("task_id", detail.TaskID).
 		Str("entry", detail.Entry).
 		Int32("width", width).
 		Int32("height", height).
+		Int("scaled_width", scaledW).
+		Int("scaled_height", scaledH).
 		Bool("aspect_ratio_ok", aspectRatioOK).
 		Bool("min_resolution_ok", minResolutionOK).
 		Msg("Rechecked resolution after Alt+Enter")

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -184,7 +184,7 @@
     "tasker.aspect_ratio_warning.current_resolution": "Current resolution:",
     "tasker.aspect_ratio_warning.requirement_label": "Required:",
     "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
-    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 aspect ratio and at least 1280x720; for example 3840x2160, 2560x1440, 1920x1080, 1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio": "Current resolution is not supported; use a 16:9 resolution that scales to 1280x720, for example 3840x2160, 2560x1440, 1920x1080, 1600x900, 1280x720",
     "tasker.aspect_ratio_warning.requirement_ratio_window_mismatch": "16:9 aspect ratio with the window not exceeding monitor edges; try switching the game to a smaller 16:9 resolution",
     "tasker.aspect_ratio_warning.full_screen_illegal": "Windowed mode; fullscreen requires a physical 16:9 monitor, which your current display does not meet.",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -184,7 +184,7 @@
     "tasker.aspect_ratio_warning.current_resolution": "現在の解像度：",
     "tasker.aspect_ratio_warning.requirement_label": "必要条件：",
     "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
-    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比率かつ 1280x720 以上。例: 3840x2160、2560x1440、1920x1080、1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio": "現在の解像度は非対応です。1280x720 にスケールできる 16:9 解像度を使用してください。例: 3840x2160、2560x1440、1920x1080、1600x900、1280x720",
     "tasker.aspect_ratio_warning.requirement_ratio_window_mismatch": "16:9 比率で、ウィンドウがモニター端を超えないこと。より小さい 16:9 解像度への切り替えをお試しください",
     "tasker.aspect_ratio_warning.full_screen_illegal": "ウィンドウモード；全画面モードでは物理的に 16:9 のディスプレイが必要ですが、現在のディスプレイは条件を満たしません。",
     "maptracker.emergency_stop.title": "🚨 緊急停止",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -184,7 +184,7 @@
     "tasker.aspect_ratio_warning.current_resolution": "현재 해상도:",
     "tasker.aspect_ratio_warning.requirement_label": "요구 사항:",
     "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
-    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 비율이고 최소 1280x720 이상이어야 합니다; 예: 3840x2160, 2560x1440, 1920x1080, 1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio": "현재 해상도는 지원되지 않습니다. 1280x720으로 스케일되는 16:9 해상도를 사용하세요. 예: 3840x2160, 2560x1440, 1920x1080, 1600x900, 1280x720",
     "tasker.aspect_ratio_warning.requirement_ratio_window_mismatch": "16:9 비율이며 창이 모니터 가장자리를 넘지 않아야 합니다. 더 작은 16:9 해상도로 전환해 보세요",
     "tasker.aspect_ratio_warning.full_screen_illegal": "창 모드; 전체 화면 모드는 물리적으로 16:9 해상도 모니터가 필요하며 현재 디스플레이는 조건에 맞지 않습니다.",
     "maptracker.emergency_stop.title": "🚨 긴급 정지",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -184,7 +184,7 @@
     "tasker.aspect_ratio_warning.current_resolution": "当前分辨率：",
     "tasker.aspect_ratio_warning.requirement_label": "目标要求：",
     "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
-    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例且不低于 1280x720；例如 3840x2160、2560x1440、1920x1080、1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio": "当前分辨率不支持；请使用可缩放为 1280x720 的 16:9 分辨率，例如 3840x2160、2560x1440、1920x1080、1600x900、1280x720",
     "tasker.aspect_ratio_warning.requirement_ratio_window_mismatch": "16:9 比例且窗口不超过显示器边缘，可尝试将游戏切换至更小的 16:9 比例",
     "tasker.aspect_ratio_warning.full_screen_illegal": "窗口模式；全屏模式需使用物理分辨率16:9的显示器，当前显示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -184,7 +184,7 @@
     "tasker.aspect_ratio_warning.current_resolution": "目前解析度：",
     "tasker.aspect_ratio_warning.requirement_label": "目標要求：",
     "tasker.aspect_ratio_warning.requirement_exact": "%dx%d",
-    "tasker.aspect_ratio_warning.requirement_ratio": "16:9 比例且不低於 1280x720；例如 3840x2160、2560x1440、1920x1080、1280x720",
+    "tasker.aspect_ratio_warning.requirement_ratio": "目前解析度不支援；請使用可縮放為 1280x720 的 16:9 解析度，例如 3840x2160、2560x1440、1920x1080、1600x900、1280x720",
     "tasker.aspect_ratio_warning.requirement_ratio_window_mismatch": "16:9 比例且視窗不超過顯示器邊緣，可嘗試將遊戲切換至更小的 16:9 比例",
     "tasker.aspect_ratio_warning.full_screen_illegal": "視窗模式；全螢幕模式需使用物理解析度 16:9 的顯示器，目前顯示器不符合",
     "maptracker.emergency_stop.title": "🚨 EMERGENCY STOP",


### PR DESCRIPTION
close #1981

## Summary by Sourcery

对非 ADB 任务实施更严格的 16:9 分辨率校验，通过引入缩放分辨率检查以及增强对推导所得分辨率的日志记录来实现。

Bug Fixes:
- 拒绝那些经缩放后无法精确得到目标分辨率（例如 1280x720）的伪 16:9 分辨率，从而防止误判为支持的显示模式。

Enhancements:
- 在纵横比和分辨率校验过程中记录计算得到的缩放宽度和高度，以便诊断与分辨率相关的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce stricter 16:9 resolution validation for non-ADB tasks by incorporating scaled resolution checks and enhanced logging of derived dimensions.

Bug Fixes:
- Reject 16:9-like resolutions whose scaling does not produce the exact target resolution (e.g., 1280x720), preventing mis-detection of unsupported display modes.

Enhancements:
- Log computed scaled width and height during aspect ratio and resolution checks to aid diagnosis of resolution-related issues.

</details>