### PR TITLE
fix: 修复IMS A3偶发的识别丢失

### DIFF
--- a/assets/resource/pipeline/DijiangRewards/GrowthChamber.json
+++ b/assets/resource/pipeline/DijiangRewards/GrowthChamber.json
@@ -110,13 +110,14 @@
         },
         "pre_wait_freezes": {
             "time": 300,
+            "threshold": 0.97,
+            "timeout": 1500,
             "target": [
-                300,
-                250,
-                750,
-                200
-            ],
-            "timeout": 1000
+                528,
+                299,
+                222,
+                131
+            ]
         },
         "pre_delay": 0,
         "action": {

--- a/assets/resource/pipeline/DijiangRewards/Manufacturing.json
+++ b/assets/resource/pipeline/DijiangRewards/Manufacturing.json
@@ -169,13 +169,14 @@
         },
         "pre_wait_freezes": {
             "time": 300,
+            "threshold": 0.97,
+            "timeout": 1500,
             "target": [
-                300,
-                250,
-                750,
-                200
-            ],
-            "timeout": 1000
+                528,
+                299,
+                222,
+                131
+            ]
         },
         "pre_delay": 0,
         "action": {

--- a/assets/resource/pipeline/IMS/AddItemData.json
+++ b/assets/resource/pipeline/IMS/AddItemData.json
@@ -11,12 +11,14 @@
         },
         "pre_wait_freezes": {
             "target": [
-                300,
-                250,
-                750,
-                200
+                528,
+                299,
+                222,
+                131
             ],
-            "time": 300
+            "time": 300,
+            "threshold": 0.97,
+            "timeout": 1500
         },
         "pre_delay": 0,
         "action": {

--- a/assets/resource/pipeline/IMS/common.json
+++ b/assets/resource/pipeline/IMS/common.json
@@ -1,14 +1,14 @@
 {
     "IMSItemColorYellow": {
-        "desc": "IMS 通用：培养素材页列表区黄色品质槽 ColorMatch（供物品节点作 roi 锚点）",
+        "desc": "IMS 通用：全屏黄色品质槽 ColorMatch（供物品节点作 roi 锚点）",
         "recognition": {
             "type": "ColorMatch",
             "param": {
                 "roi": [
-                    4,
-                    46,
-                    965,
-                    589
+                    0,
+                    0,
+                    1280,
+                    720
                 ],
                 "method": 40,
                 "lower": [
@@ -22,7 +22,7 @@
                     255
                 ],
                 "connected": true,
-                "count": 100
+                "count": 75
             }
         },
         "pre_delay": 0,
@@ -30,15 +30,15 @@
         "rate_limit": 0
     },
     "IMSItemColorPurple": {
-        "desc": "IMS 通用：培养素材页列表区紫色品质槽 ColorMatch（供物品节点作 roi 锚点）",
+        "desc": "IMS 通用：全屏紫色品质槽 ColorMatch（供物品节点作 roi 锚点）",
         "recognition": {
             "type": "ColorMatch",
             "param": {
                 "roi": [
-                    4,
-                    46,
-                    965,
-                    589
+                    0,
+                    0,
+                    1280,
+                    720
                 ],
                 "method": 40,
                 "lower": [
@@ -52,7 +52,7 @@
                     248
                 ],
                 "connected": true,
-                "count": 100
+                "count": 75
             }
         },
         "pre_delay": 0,
@@ -60,15 +60,15 @@
         "rate_limit": 0
     },
     "IMSItemColorBlue": {
-        "desc": "IMS 通用：培养素材页列表区蓝色品质槽 ColorMatch（供物品节点作 roi 锚点）",
+        "desc": "IMS 通用：全屏蓝色品质槽 ColorMatch（供物品节点作 roi 锚点）",
         "recognition": {
             "type": "ColorMatch",
             "param": {
                 "roi": [
-                    4,
-                    46,
-                    965,
-                    589
+                    0,
+                    0,
+                    1280,
+                    720
                 ],
                 "method": 40,
                 "lower": [
@@ -82,7 +82,7 @@
                     251
                 ],
                 "connected": true,
-                "count": 100
+                "count": 75
             }
         },
         "pre_delay": 0,
@@ -90,15 +90,15 @@
         "rate_limit": 0
     },
     "IMSItemColorGreen": {
-        "desc": "IMS 通用：培养素材页列表区绿色品质槽 ColorMatch（供物品节点作 roi 锚点）",
+        "desc": "IMS 通用：全屏绿色品质槽 ColorMatch（供物品节点作 roi 锚点）",
         "recognition": {
             "type": "ColorMatch",
             "param": {
                 "roi": [
-                    4,
-                    46,
-                    965,
-                    589
+                    0,
+                    0,
+                    1280,
+                    720
                 ],
                 "method": 40,
                 "lower": [
@@ -112,7 +112,7 @@
                     205
                 ],
                 "connected": true,
-                "count": 100
+                "count": 75
             }
         },
         "pre_delay": 0,
@@ -120,15 +120,15 @@
         "rate_limit": 0
     },
     "IMSItemColorWhite": {
-        "desc": "IMS 通用：培养素材页列表区白色品质槽 ColorMatch（供物品节点作 roi 锚点）",
+        "desc": "IMS 通用：全屏白色品质槽 ColorMatch（供物品节点作 roi 锚点）",
         "recognition": {
             "type": "ColorMatch",
             "param": {
                 "roi": [
-                    4,
-                    46,
-                    965,
-                    589
+                    0,
+                    0,
+                    1280,
+                    720
                 ],
                 "method": 40,
                 "lower": [
@@ -142,7 +142,7 @@
                     156
                 ],
                 "connected": true,
-                "count": 100
+                "count": 75
             }
         },
         "pre_delay": 0,
@@ -150,15 +150,15 @@
         "rate_limit": 0
     },
     "IMSItemColorRed": {
-        "desc": "IMS 通用：奖励/列表区红色品质槽 ColorMatch（嵌晶玉等；供物品节点作 roi 锚点）",
+        "desc": "IMS 通用：全屏红色品质槽 ColorMatch（嵌晶玉等；供物品节点作 roi 锚点）",
         "recognition": {
             "type": "ColorMatch",
             "param": {
                 "roi": [
-                    4,
-                    46,
-                    965,
-                    589
+                    0,
+                    0,
+                    1280,
+                    720
                 ],
                 "method": 40,
                 "lower": [
@@ -172,7 +172,7 @@
                     255
                 ],
                 "connected": true,
-                "count": 100
+                "count": 75
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/Interface/Scene.json
+++ b/assets/resource/pipeline/Interface/Scene.json
@@ -87,13 +87,14 @@
             }
         },
         "pre_wait_freezes": {
-            "time": 400,
-            "timeout": 5000,
+            "time": 300,
+            "threshold": 0.97,
+            "timeout": 1500,
             "target": [
-                230,
-                250,
-                800,
-                200
+                528,
+                299,
+                222,
+                131
             ]
         },
         "pre_delay": 0,
@@ -183,13 +184,14 @@
             }
         },
         "pre_wait_freezes": {
-            "time": 400,
-            "timeout": 5000,
+            "time": 300,
+            "threshold": 0.97,
+            "timeout": 1500,
             "target": [
-                230,
-                250,
-                800,
-                200
+                528,
+                299,
+                222,
+                131
             ]
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -767,12 +767,14 @@
         "recognition": "DirectHit",
         "pre_wait_freezes": {
             "target": [
-                300,
-                250,
-                750,
-                200
+                528,
+                299,
+                222,
+                131
             ],
-            "time": 300
+            "time": 300,
+            "threshold": 0.97,
+            "timeout": 1500
         },
         "pre_delay": 0,
         "action": "Custom",


### PR DESCRIPTION
放宽了识别物品的第一步(颜色匹配物品下方的颜色条)
<img width="637" height="441" alt="image" src="https://github.com/user-attachments/assets/73a7a306-17d4-4dfb-94e2-76fedf52f7aa" />
颜色阈值(100->75)
将识别区域从原本的忽略右侧改为全屏

将所有使用A3动作来播报结果的动作添加了统一的等待画面禁止
<img width="735" height="418" alt="image" src="https://github.com/user-attachments/assets/d6617c89-3e94-437f-9bb7-54e10be911fd" />
等待300ms 阈值0.97
超时时间1.5秒



## Summary by Sourcery

更新多个与 GrowthChamber、Manufacturing、物品添加、通用 IMS 行为、界面场景以及太空中协议处理相关的 IMS 和 Dijiang 奖励流水线 JSON 配置，以解决 IMS A3 中偶发的识别丢失问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update multiple IMS and Dijiang rewards pipeline JSON configurations related to GrowthChamber, Manufacturing, item addition, common IMS behavior, interface scenes, and in-space protocol handling to address occasional recognition loss in IMS A3.

</details>