### PR TITLE
chore: 非PC平台不提示反馈链接

### DIFF
--- a/agent/go-service/taskersink/taskfail/sink.go
+++ b/agent/go-service/taskersink/taskfail/sink.go
@@ -3,6 +3,7 @@ package taskfail
 import (
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -51,6 +52,15 @@ func (s *Sink) OnTaskerTask(_ *maa.Tasker, event maa.EventStatus, detail maa.Tas
 			Uint64("task_id", detail.TaskID).
 			Str("entry", detail.Entry).
 			Msg("Task failed but entry is not in feedback hint list, skip feedback hint")
+		return
+	}
+
+	if pienv.ControllerName() != "Win32-Front" {
+		log.Debug().
+			Uint64("task_id", detail.TaskID).
+			Str("entry", detail.Entry).
+			Str("controller", pienv.ControllerName()).
+			Msg("Task failed but controller is not Win32-Front, skip feedback hint")
 		return
 	}
 


### PR DESCRIPTION
非主要用户优先级降低

## Summary by Sourcery

增强：
- 当活动控制器不是 Win32-Front 实现时，记录并忽略任务失败反馈提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Log and ignore task failure feedback hints when the active controller is not the Win32-Front implementation.

</details>