### PR TITLE
perf: 选剑演武缓存放弃次数；不再放弃跨日残局

### DIFF
--- a/agent/go-service/trialofswordmancy/abandstate.go
+++ b/agent/go-service/trialofswordmancy/abandstate.go
@@ -2,7 +2,6 @@ package trialofswordmancy
 
 import (
 	"strconv"
-	"sync"
 
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
@@ -62,32 +61,22 @@ func recognizeAbandExhausted(ctx *maa.Context, arg *maa.CustomRecognitionArg) (b
 //
 // 为何这一项要持久化、不能像其它字段那样每步从截图读：界面上不直接显示剩余放弃次数，
 // 只有点击「放弃」后弹出的确认框里才写（「本日剩余放弃次数x次」/「已用完」）。
-// 所以由 Pipeline 负责打开和关闭放弃弹窗，RecognizeAband 只识别当前弹窗文本并缓存次数；
-// 之后总成识别直接读缓存。
+// 所以由 Pipeline 在每轮任务开始时探测一次放弃弹窗（AbandProbe max_hit=1），
+// RecognizeAband 识别当前弹窗文本并缓存次数；之后总成识别直接读缓存，
+// 每次真实放弃（Decide 路由到 Abandon）时缓存减一，直到下次任务运行探测覆盖。
 //
 // 生命周期：
 //   - 进程内初始化为 -1（未知）。
-//   - 路由到 放弃(Abandon) 或 开始演算(Calculate) 时重置为 -1，回合结束后重新识别。
-var (
-	abandMu    sync.Mutex
-	abandCount = -1 // -1 = 未知，需从放弃弹窗识别
-)
+//   - 每轮任务运行的探测写入真实值。
+//   - 每次真实放弃减一（跨日残局那局不减，见 action.go DecideAction）。
+//
+// MaaFramework 保证任务回调单线程同步执行，无需加锁。
+var abandCount = -1 // -1 = 未知，需从放弃弹窗识别
 
 func getAband() int {
-	abandMu.Lock()
-	defer abandMu.Unlock()
 	return abandCount
 }
 
 func setAband(n int) {
-	abandMu.Lock()
-	defer abandMu.Unlock()
 	abandCount = n
-}
-
-// resetAband 把缓存的剩余放弃次数置为 -1（未知），等待 RecognizeAband 重新识别。
-func resetAband() {
-	abandMu.Lock()
-	defer abandMu.Unlock()
-	abandCount = -1
 }

--- a/agent/go-service/trialofswordmancy/abandstate.go
+++ b/agent/go-service/trialofswordmancy/abandstate.go
@@ -67,8 +67,7 @@ func recognizeAbandExhausted(ctx *maa.Context, arg *maa.CustomRecognitionArg) (b
 //
 // 生命周期：
 //   - 进程内初始化为 -1（未知）。
-//   - 路由到 放弃(Abandon) 或 开始演算(Calculate) 时重置为 -1——前者因为放弃会扣 1 次（缓存失效），
-//     后者作为回合结束的统一兜底，下回合重新识别。
+//   - 路由到 放弃(Abandon) 或 开始演算(Calculate) 时重置为 -1，回合结束后重新识别。
 var (
 	abandMu    sync.Mutex
 	abandCount = -1 // -1 = 未知，需从放弃弹窗识别

--- a/agent/go-service/trialofswordmancy/action.go
+++ b/agent/go-service/trialofswordmancy/action.go
@@ -22,7 +22,7 @@ var _ maa.CustomActionRunner = &DecideAction{}
 // 按决策用 OverrideNext 路由到执行节点。
 //
 // 几乎无状态：每步的完整 State 都由 recognition 读出后传入；本动作只做「求解 → 路由」。
-// 唯一副作用：路由到 放弃/开始演算（回合结束）时 resetAband()，使下回合重新识别放弃次数。
+// 唯一副作用：路由到 放弃（真实放弃）时把剩余放弃次数缓存减一；开始演算不影响放弃次数。
 // 单步循环靠 pipeline 的 next 回到 TrialOfSwordmancyDecide（recognition 重新读图），
 // 直到奖励耗尽（pipeline 检测 → Finish）。solver 只返回单步最优决策。
 type DecideAction struct{}
@@ -72,9 +72,14 @@ func (a *DecideAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		return false
 	}
 
-	// 放弃/开始演算会结束当前回合。重置为 -1，下回合首步重新探测放弃次数。
-	if best == solver.Abandon || best == solver.Calculate {
-		resetAband()
+	// 放弃会结束当前回合并消耗 1 次放弃次数。pipeline 只在每轮任务开始时探测一次
+	// （AbandProbe max_hit=1），不重探测，故这里按真实放弃把缓存减一，而非重置为 -1 等重读。
+	// 跨日残局那局（RemainCalc==4）放弃按求解器模型扣演算次数、不扣放弃，不减；
+	// 剩余 0（已用完）时也不减——0 减成 -1 会把缓存毒化成「未知」。
+	if best == solver.Abandon {
+		if gs.State.RemainCalc != 4 && gs.State.RemainAband > 0 {
+			setAband(gs.State.RemainAband - 1)
+		}
 	}
 
 	// 按决策路由到执行节点（节点自行点击 + 等动画），完成后回到 Decide 形成单步循环。

--- a/agent/go-service/trialofswordmancy/action.go
+++ b/agent/go-service/trialofswordmancy/action.go
@@ -18,16 +18,11 @@ import (
 
 var _ maa.CustomActionRunner = &DecideAction{}
 
-// remainCalcEndgame 标志跨天残局：求解器态空间 RemainCalc 上界 3（每日演算上限），
-// recognition 用 OCR+1 还原后，残局那局 OCR 读到 3 → RemainCalc=4，超出态空间。残局不求解，
-// Decide 直接放弃这局（见 DecideAction.Run）。
-const remainCalcEndgame = 4
-
 // DecideAction 反序列化 recognition 产出的 GameState，调 solver.Decide 取最优单步决策，
 // 按决策用 OverrideNext 路由到执行节点。
 //
 // 几乎无状态：每步的完整 State 都由 recognition 读出后传入；本动作只做「求解 → 路由」。
-// 唯一副作用：路由到 放弃/开始演算（回合结束）时 resetAband()（放弃会扣1次致缓存失效）。
+// 唯一副作用：路由到 放弃/开始演算（回合结束）时 resetAband()，使下回合重新识别放弃次数。
 // 单步循环靠 pipeline 的 next 回到 TrialOfSwordmancyDecide（recognition 重新读图），
 // 直到奖励耗尽（pipeline 检测 → Finish）。solver 只返回单步最优决策。
 type DecideAction struct{}
@@ -55,44 +50,6 @@ func (a *DecideAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		return false
 	}
 
-	// 跨天残局：recognition 读出 RemainCalc=4（OCR=3，超出求解器态空间上界 3=每日演算上限）。
-	// 残局那局白送、且放弃只扣放弃次数不扣演算次数——跳过求解，直接放弃这局，回到主入口开正常的 3 局。
-	// （求解器态空间不支持 4 层；故残局直接放弃，不在 recognition 钳制近似。）
-	if gs.State.RemainCalc == remainCalcEndgame {
-		resetAband() // 放弃扣 1 次放弃次数，缓存失效，下回合首步重新探测
-		if err := routeDecision(ctx, arg.CurrentTaskName, solver.Abandon); err != nil {
-			log.Error().Err(err).Str("component", component).Msg("failed to route endgame give-up")
-			return false
-		}
-		log.Info().
-			Str("component", component).
-			Int("remainCalc", gs.State.RemainCalc).
-			Msg("cross-day endgame (RemainCalc=4): skip solver, give up the free run")
-		maafocus.Print(ctx, i18n.T("trialofswordmancy.endgame"))
-		return true
-	}
-
-	// 手动残局：玩家手动打了跨天残局并消耗了翻倍 → 翻倍消耗超前于演算消耗，落进求解器 stateFilter
-	// 判不可达的状态（第3条 RemainDouble >= RemainCalc-3+MaxDouble）。典型如开局 331（Calc=3,Double=1）。
-	// 放弃只扣放弃次数、不扣演算，放完仍非法；演算才扣演算次数。故跳过求解直接演算：未翻倍 331→231 即合法；
-	// 已翻倍演算再扣 1 次翻倍（331→230→130），每步 RemainCalc 至少 -1，到 Calc=1 时 Double>=0 恒成立，
-	// 必然落回合法态空间，不死循环。
-	if gs.State.RemainDouble < gs.State.RemainCalc-3+solver.MaxDouble {
-		resetAband() // 开始演算结束本回合，下回合新局首步重新探测放弃次数
-		if err := routeDecision(ctx, arg.CurrentTaskName, solver.Calculate); err != nil {
-			log.Error().Err(err).Str("component", component).Msg("failed to route manual-endgame calculate")
-			return false
-		}
-		log.Info().
-			Str("component", component).
-			Int("remainCalc", gs.State.RemainCalc).
-			Int("remainDouble", gs.State.RemainDouble).
-			Bool("isDoubled", gs.State.IsDoubled).
-			Msg("manual endgame (Double<Calc-3+MaxDouble): skip solver, calculate to restore valid state")
-		maafocus.Print(ctx, i18n.T("trialofswordmancy.legacy_double"))
-		return true
-	}
-
 	// 配置：牌库/手牌/剩余次数/翻倍态来自 recognition 截图识别；溢出模式是玩家策略选项，
 	// 由本节点 custom_action_param.overflowMode 提供（任务 select 决定），覆盖 recognition 的默认值。
 	cfg := gs.Config
@@ -115,7 +72,7 @@ func (a *DecideAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		return false
 	}
 
-	// 放弃/开始演算会结束当前回合：放弃还会扣 1 次放弃次数（缓存失效）。重置为 -1，下回合首步重新探测。
+	// 放弃/开始演算会结束当前回合。重置为 -1，下回合首步重新探测放弃次数。
 	if best == solver.Abandon || best == solver.Calculate {
 		resetAband()
 	}

--- a/agent/go-service/trialofswordmancy/config.go
+++ b/agent/go-service/trialofswordmancy/config.go
@@ -1,8 +1,6 @@
 package trialofswordmancy
 
 import (
-	"sync"
-
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/trialofswordmancy/solver"
 )
 
@@ -13,19 +11,15 @@ import (
 
 // —— 求解器缓存：按 Config 哈希键，Config 变化才重新 Solve ——
 // 正常一副牌 + 三种溢出模式只产生极少量键；上限兜底，防止牌库 OCR 抖动产生大量误识别键导致常驻内存增长。
+// MaaFramework 保证任务回调单线程同步执行，无需加锁。
 const solverCacheLimit = 16
 
-var (
-	solverCacheMu sync.Mutex
-	solverCache   = map[string]*solver.Solver{}
-)
+var solverCache = map[string]*solver.Solver{}
 
 // solverFor 返回（必要时构造并预求解）给定配置的 *solver.Solver。
 // 每步查询复用同一实例，仅 Config 变化（牌库刷新 / 溢出模式变化）时才重 Solve。
 func solverFor(cfg solver.Config) *solver.Solver {
 	key := solver.ConfigKey(cfg)
-	solverCacheMu.Lock()
-	defer solverCacheMu.Unlock()
 	if s, ok := solverCache[key]; ok {
 		return s
 	}

--- a/agent/go-service/trialofswordmancy/nodes.go
+++ b/agent/go-service/trialofswordmancy/nodes.go
@@ -11,18 +11,9 @@ const (
 
 // pipeline 节点名常量。
 const (
-	// 决策循环入口：recognition=Recognize、action=Decide；next 由 Decide 运行时 override 到下方执行节点。
-	decideNode = "TrialOfSwordmancyDecide"
-
-	// 抽牌界面通用识别节点（定义在 TrialOfSwordmancyCommon.json）。
-	nodeDoubleReward        = "TrialOfSwordmancyDoubleReward"        // 翻倍按钮
-	nodeOverflowExclamation = "TrialOfSwordmancyOverflowExclamation" // 溢出（爆表）叹号
-
 	// 决策执行节点（节点自行点击按钮 + 等动画，完成后 next 回 Decide）。
-	nodeDoDrawCard            = "TrialOfSwordmancyDoDrawCard"            // 抽一张牌
-	nodeDoDrawCardConfirm     = "TrialOfSwordmancyDoDrawCardConfirm"     // 第三抽「抽取后无法更改翻倍」弹窗
-	nodeDoWaitDrawCardFreezes = "TrialOfSwordmancyDoWaitDrawCardFreezes" // 等抽牌动画结束
-	nodeDoDoubleReward        = "TrialOfSwordmancyDoDoubleReward"        // 选择本局翻倍
+	nodeDoDrawCard     = "TrialOfSwordmancyDoDrawCard"     // 抽一张牌
+	nodeDoDoubleReward = "TrialOfSwordmancyDoDoubleReward" // 选择本局翻倍
 
 	// 既有执行链入口。
 	nodeGiveUp     = "TrialOfSwordmancyDailyGiveUp" // 放弃本局 → 确认 → 重置寻路 → 回主入口

--- a/agent/go-service/trialofswordmancy/recognition.go
+++ b/agent/go-service/trialofswordmancy/recognition.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/trialofswordmancy/solver"
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
@@ -111,7 +112,7 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 // （放弃次数缓存未知不在此中止，见 Run 内注释。）
 func (r *Recognition) recognitionFailed(ctx *maa.Context, reason string) bool {
 	log.Warn().Str("component", component).Str("reason", reason).Msg("recognition failed, aborting task")
-	maafocus.Print(ctx, "选剑演武：识别失败")
+	maafocus.Print(ctx, i18n.T("trialofswordmancy.recognition_failed"))
 	return false
 }
 

--- a/agent/go-service/trialofswordmancy/recognition.go
+++ b/agent/go-service/trialofswordmancy/recognition.go
@@ -68,9 +68,9 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 	remainAband := getAband()
 
 	// 屏幕的「本日剩余奖励演算次数」显示的是「当前进行中这局之外的剩余」——进入抽牌界面即扣 1，
-	// 而求解器把进行中这局也算作可用 → solver = OCR + 1（solver 态空间 RemainCalc 1..3，对应 OCR 0..2）。
+	// 而求解器把进行中这局也算作可用 → solver = OCR + 1（常规状态 RemainCalc 1..3，对应 OCR 0..2）。
 	// 仅演算次数有此偏移：放弃/翻倍次数界面显示的就是真实值，直接用。走到这里 calcOK 必为真。
-	// 跨天残局那局白送：OCR 读到 3 → RemainCalc=4，超出态空间上界——本处不钳制，原样交给 Decide 直接放弃。
+	// 跨天残局那局白送：OCR 读到 3 → RemainCalc=4，由求解器按特殊规则处理。
 	state := solver.State{
 		RemainCalc:   remainCalc + 1,
 		RemainAband:  remainAband,

--- a/agent/go-service/trialofswordmancy/recognition.go
+++ b/agent/go-service/trialofswordmancy/recognition.go
@@ -27,7 +27,6 @@ var _ maa.CustomRecognitionRunner = &Recognition{}
 //   - RemainCalc / RemainDouble：OCR（RemainCalc / RemainDouble 节点）。
 //   - RemainAband：RecognizeAband 从放弃弹窗识别后写入的持久化缓存。
 //   - IsDoubled：模板匹配（IsDoubled 节点）。
-//   - Overflow：OverflowExclamation 在场（观测字段，不参与求解）。
 type Recognition struct{}
 
 // Run 执行总成识别。
@@ -44,7 +43,6 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 		return nil, r.recognitionFailed(ctx, "牌库 OCR 失败")
 	}
 
-	overflow := r.detectOverflow(ctx, arg.Img)
 	handCounts, handRaw := r.recognizeHand(ctx, arg.Img)
 
 	// 牌库面板显示的是「剩余库存」（抽一张即递减）；求解器的 Deck 是「总牌量」——它自己按 Deck-Hand 推剩余
@@ -80,10 +78,9 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 		Hand:         handCounts,
 	}
 	gs := GameState{
-		State:    state,
-		Config:   cfg,
-		HandRaw:  handRaw,
-		Overflow: overflow,
+		State:   state,
+		Config:  cfg,
+		HandRaw: handRaw,
 	}
 
 	detailBytes, err := json.Marshal(gs)
@@ -100,7 +97,6 @@ func (r *Recognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa
 		Bool("isDoubled", state.IsDoubled).
 		Ints("hand", state.Hand[:]).
 		Ints("handRaw", handRaw[:]).
-		Bool("overflow", overflow).
 		Str("overflowMode", cfg.OverflowMode.String()).
 		Msg("game state recognized")
 
@@ -114,11 +110,6 @@ func (r *Recognition) recognitionFailed(ctx *maa.Context, reason string) bool {
 	log.Warn().Str("component", component).Str("reason", reason).Msg("recognition failed, aborting task")
 	maafocus.Print(ctx, i18n.T("trialofswordmancy.recognition_failed"))
 	return false
-}
-
-// detectOverflow 判定是否识别到溢出叹号（爆表）。
-func (r *Recognition) detectOverflow(ctx *maa.Context, img image.Image) bool {
-	return runTemplateHit(ctx, img, nodeOverflowExclamation)
 }
 
 // recognizeHand 跑 HandPoint1-5 五个整行模板节点，再按 HandPosition1-5 ROI 筛选各槽点数。

--- a/agent/go-service/trialofswordmancy/solver/constants.go
+++ b/agent/go-service/trialofswordmancy/solver/constants.go
@@ -15,6 +15,9 @@ var DefaultReward = [11]int{0, 1000, 2000, 4000, 7500, 12000, 20000, 36000, 6000
 // MaxDouble 是等级 4 的翻倍次数上限，恒为 2。
 const MaxDouble = 2
 
+// maxRemainCalc 是包含跨日残局时的最大剩余演算次数。
+const maxRemainCalc = 4
+
 // DefaultConfig 是等级 4 的默认基础设定：默认牌库 + 等级 4 奖励 + 翻倍上限 2 +
 // 默认溢出模式「接受1至2次」（§5.5）。
 var DefaultConfig = Config{

--- a/agent/go-service/trialofswordmancy/solver/constants.go
+++ b/agent/go-service/trialofswordmancy/solver/constants.go
@@ -1,7 +1,5 @@
 package solver
 
-import "time"
-
 // 等级固定为 4 的两组常量（§5.2 / §5.3）。
 
 // DefaultDeck 是等级 4 的默认牌库：点数 1,2,3,4,5 的库存分别为 4,5,6,6,7。
@@ -25,31 +23,4 @@ var DefaultConfig = Config{
 	Reward:       DefaultReward,
 	MaxDouble:    MaxDouble,
 	OverflowMode: OverflowTwice,
-}
-
-// DefaultState 是默认查询状态：剩余演算 3 / 放弃 3 / 翻倍 2 / 未翻倍 / 空手（§5.5）。
-var DefaultState = State{
-	RemainCalc:   3,
-	RemainAband:  3,
-	RemainDouble: 2,
-	IsDoubled:    false,
-	Hand:         [5]int{0, 0, 0, 0, 0},
-}
-
-// 牌库刷新周期（§5.4，来自 trialOfSwordmancyDeck.ts）。
-//
-// 月份陷阱：TypeScript 源码 Date.UTC(2026, 5, 8, 20, 0, 0) 的月份是 0-indexed，
-// 即 6 月；Go 的 time.Date 月份是 1-indexed，必须写 6。差一个月会让刷新周期算错。
-var (
-	DeckRefreshOrigin = time.Date(2026, 6, 8, 20, 0, 0, 0, time.UTC)
-	DeckRefreshCycle  = 72 * time.Hour
-)
-
-// RefreshCycleNumber 返回 now 所处的牌库刷新周期编号；
-// now 早于刷新起点时返回 -1（周期尚未开始）。
-func RefreshCycleNumber(now time.Time) int {
-	if now.Before(DeckRefreshOrigin) {
-		return -1
-	}
-	return int(now.Sub(DeckRefreshOrigin) / DeckRefreshCycle)
 }

--- a/agent/go-service/trialofswordmancy/solver/solver.go
+++ b/agent/go-service/trialofswordmancy/solver/solver.go
@@ -1,7 +1,6 @@
 package solver
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -85,16 +84,13 @@ func (s *Solver) Solve() *Solution {
 
 	// 4. DP：距吸收态近的先算 → 处理某状态时其所有后继价值已就绪
 	value := make([]float64, N)
-	policy := make([]Action, N)
 	for _, idx := range order {
 		st := s.states[idx]
 		if st.isEnd {
 			value[idx] = 0
-			policy[idx] = ActionNone
 			continue
 		}
 		bestVal := math.Inf(-1)
-		bestAct := ActionNone
 		for _, action := range allowed[idx] {
 			imm := float64(s.immediateReward(st, action))
 			fut := 0.0
@@ -105,24 +101,13 @@ func (s *Solver) Solve() *Solution {
 			// 1e-10 阈值：只有严格更优（超出浮点噪声）才更新最优决策
 			if total > bestVal+1e-10 {
 				bestVal = total
-				bestAct = action
 			}
 		}
 		value[idx] = bestVal
-		policy[idx] = bestAct
-	}
-
-	// 组装对外 Solution（States：吸收态为零值 State，恒在 [0]）
-	statesOut := make([]State, N)
-	for i, ms := range s.states {
-		statesOut[i] = ms.State
 	}
 
 	s.solution = &Solution{
-		Value:  value,
-		Policy: policy,
-		States: statesOut,
-		Index:  s.index,
+		Value: value,
 	}
 	s.solved = true
 	return s.solution
@@ -144,7 +129,7 @@ func (s *Solver) queryIndex(st State) int {
 	return idx
 }
 
-// Decide 返回当前查询状态所有合法决策的评估结果，并标记与最优策略一致的那一项 IsBest。
+// Decide 返回当前查询状态所有合法决策的评估结果。
 //
 // 不可达状态（手牌张数超牌库、违反 §6.8 过滤、或 RemainCalc==0）返回空切片。
 func (s *Solver) Decide(st State) []Outcome {
@@ -157,7 +142,6 @@ func (s *Solver) Decide(st State) []Outcome {
 		return nil // 吸收态（RemainCalc==0）无决策
 	}
 	sol := s.solution
-	best := sol.Policy[idx]
 
 	allowed := s.allowedActions(from)
 	outcomes := make([]Outcome, 0, len(allowed))
@@ -172,34 +156,9 @@ func (s *Solver) Decide(st State) []Outcome {
 			Immediate: imm,
 			Expected:  fut,
 			Total:     float64(imm) + fut,
-			IsBest:    action == best,
 		})
 	}
 	return outcomes
-}
-
-// Best 返回当前查询状态的最优决策（与最优策略一致）。
-// 不可达状态返回 ActionNone 与非 nil error，调用方据此报错/重识别。
-func (s *Solver) Best(st State) (Action, error) {
-	idx := s.queryIndex(st)
-	if idx < 0 {
-		return ActionNone, fmt.Errorf("state is unreachable: %+v", st)
-	}
-	best := s.solution.Policy[idx]
-	if best == ActionNone {
-		return ActionNone, errors.New("no best action for absorbing state")
-	}
-	return best, nil
-}
-
-// Value 返回当前查询状态的期望总奖励（价值函数值）。
-// 不可达状态返回 0, false。
-func (s *Solver) Value(st State) (float64, bool) {
-	idx := s.queryIndex(st)
-	if idx < 0 {
-		return 0, false
-	}
-	return s.solution.Value[idx], true
 }
 
 // ConfigKey 返回 Config 的稳定哈希键，用于 L1 层按配置缓存求解器实例

--- a/agent/go-service/trialofswordmancy/solver/state.go
+++ b/agent/go-service/trialofswordmancy/solver/state.go
@@ -93,11 +93,7 @@ func (s *Solver) calcSettleReward(hand [5]int, isDoubled bool) int {
 	case OverflowTwice:
 		// 无上限
 	}
-	power := PowerOf(hand) // 恒为 0..10
-	r := 0
-	if power >= 0 && power < len(s.cfg.Reward) {
-		r = s.cfg.Reward[power]
-	}
+	r := s.cfg.Reward[PowerOf(hand)]
 	if isDoubled {
 		r *= 2
 	}
@@ -124,7 +120,7 @@ type transition struct {
 	prob  float64
 }
 
-// transitions 返回 from 在 action 下的 [(目标状态, 概率)]，并过滤概率为 0 的项（§6.5）。
+// transitions 返回 from 在 action 下的 [(目标状态, 概率)]（§6.5）。
 //
 // 吸收态自循环：返回 [(吸收态, 1.0)]。
 func (s *Solver) transitions(from mdpState, action Action) []transition {
@@ -133,7 +129,7 @@ func (s *Solver) transitions(from mdpState, action Action) []transition {
 	}
 
 	st := from.State
-	var raw []transition
+	var transitions []transition
 
 	switch action {
 	case DrawCard:
@@ -153,7 +149,7 @@ func (s *Solver) transitions(from mdpState, action Action) []transition {
 				targetHand := st.Hand
 				targetHand[i]++
 				target := s.getState(st.RemainCalc, st.RemainAband, st.RemainDouble, st.IsDoubled, targetHand)
-				raw = append(raw, transition{state: target, prob: p})
+				transitions = append(transitions, transition{state: target, prob: p})
 			}
 		}
 
@@ -168,7 +164,7 @@ func (s *Solver) transitions(from mdpState, action Action) []transition {
 		} else {
 			target = s.getState(st.RemainCalc-1, st.RemainAband, st.RemainDouble, false, [5]int{})
 		}
-		raw = append(raw, transition{state: target, prob: 1.0})
+		transitions = append(transitions, transition{state: target, prob: 1.0})
 
 	case Calculate:
 		// 结算：消耗演算次数；若已翻倍则消耗一次翻倍次数。
@@ -177,21 +173,15 @@ func (s *Solver) transitions(from mdpState, action Action) []transition {
 			nextDouble--
 		}
 		target := s.getState(st.RemainCalc-1, st.RemainAband, nextDouble, false, [5]int{})
-		raw = append(raw, transition{state: target, prob: 1.0})
+		transitions = append(transitions, transition{state: target, prob: 1.0})
 
 	case Double:
 		// 仅置位翻倍标志，不消耗任何次数（消耗发生在演算时）
 		target := s.getState(st.RemainCalc, st.RemainAband, st.RemainDouble, true, st.Hand)
-		raw = append(raw, transition{state: target, prob: 1.0})
+		transitions = append(transitions, transition{state: target, prob: 1.0})
 	}
 
-	out := make([]transition, 0, len(raw))
-	for _, t := range raw {
-		if t.prob > 0 {
-			out = append(out, t)
-		}
-	}
-	return out
+	return transitions
 }
 
 // allowedActions 返回状态下的合法决策集合（§6.6）。

--- a/agent/go-service/trialofswordmancy/solver/state.go
+++ b/agent/go-service/trialofswordmancy/solver/state.go
@@ -159,9 +159,11 @@ func (s *Solver) transitions(from mdpState, action Action) []transition {
 
 	case Abandon:
 		// 清空手牌；翻倍状态清除但翻倍次数不消耗。
-		// 剩余放弃次数 > 0 时扣放弃次数，否则扣演算次数。
+		// 跨日残局的额外一局扣演算次数；常规状态有放弃次数时扣放弃次数，否则扣演算次数。
 		var target mdpState
-		if st.RemainAband > 0 {
+		if st.RemainCalc == maxRemainCalc {
+			target = s.getState(st.RemainCalc-1, st.RemainAband, st.RemainDouble, false, [5]int{})
+		} else if st.RemainAband > 0 {
 			target = s.getState(st.RemainCalc, st.RemainAband-1, st.RemainDouble, false, [5]int{})
 		} else {
 			target = s.getState(st.RemainCalc-1, st.RemainAband, st.RemainDouble, false, [5]int{})
@@ -226,15 +228,16 @@ func (s *Solver) immediateReward(st mdpState, action Action) int {
 
 // stateFilter 判定过渡态是否需要纳入状态空间（§6.8，最易抄错，逐条对齐）。
 func (s *Solver) stateFilter(st State) bool {
-	if !(st.RemainCalc >= 1 && st.RemainCalc <= 3) {
+	if !(st.RemainCalc >= 1 && st.RemainCalc <= maxRemainCalc) {
 		return false
 	}
 	if !(st.RemainAband >= 0 && st.RemainAband <= 3) {
 		return false
 	}
-	// 第 3 条：剩余翻倍次数 - 3 + maxDouble <= 剩余翻倍次数 <= maxDouble
+	// 第 3 条：max(0, 剩余演算次数 - 4 + maxDouble) <= 剩余翻倍次数 <= maxDouble
 	// 语义等价于「已消耗翻倍次数 ≤ 已消耗演算次数」，排除翻倍用得比演算还多的非法态。
-	if !(st.RemainCalc-3+s.cfg.MaxDouble <= st.RemainDouble && st.RemainDouble <= s.cfg.MaxDouble) {
+	minRemainDouble := max(0, st.RemainCalc-maxRemainCalc+s.cfg.MaxDouble)
+	if !(minRemainDouble <= st.RemainDouble && st.RemainDouble <= s.cfg.MaxDouble) {
 		return false
 	}
 	total := handTotal(st.Hand)
@@ -253,7 +256,7 @@ func (s *Solver) buildStateList() {
 	s.index = map[string]int{mdpStateKey(endState()): 0}
 
 	combos := s.handCombinations()
-	for remainCalc := 1; remainCalc <= 3; remainCalc++ {
+	for remainCalc := 1; remainCalc <= maxRemainCalc; remainCalc++ {
 		for remainAband := 0; remainAband <= 3; remainAband++ {
 			for remainDouble := 0; remainDouble <= s.cfg.MaxDouble; remainDouble++ {
 				for _, isDoubled := range []bool{false, true} {

--- a/agent/go-service/trialofswordmancy/solver/types.go
+++ b/agent/go-service/trialofswordmancy/solver/types.go
@@ -132,7 +132,7 @@ type Config struct {
 // State 是对外查询的当前游戏状态（每步循环都变）。
 // 全部为扁平字段，Hand 用 [5]int 值类型避免底层数组串值。
 type State struct {
-	RemainCalc   int    `json:"remainCalc"`   // 剩余演算次数 1..3（0 = 已结束/吸收态）
+	RemainCalc   int    `json:"remainCalc"`   // 剩余演算次数 1..4（4 = 跨日残局，0 = 已结束/吸收态）
 	RemainAband  int    `json:"remainAband"`  // 剩余放弃次数 0..3
 	RemainDouble int    `json:"remainDouble"` // 剩余翻倍次数 0..MaxDouble
 	IsDoubled    bool   `json:"isDoubled"`    // 本局是否已选择翻倍

--- a/agent/go-service/trialofswordmancy/solver/types.go
+++ b/agent/go-service/trialofswordmancy/solver/types.go
@@ -43,34 +43,6 @@ func (a Action) String() string {
 	}
 }
 
-// MarshalJSON 把 Action 序列化为可读字符串（detail JSON 硬契约 §7.3 / 日志友好）。
-func (a Action) MarshalJSON() ([]byte, error) {
-	return json.Marshal(a.String())
-}
-
-// UnmarshalJSON 从字符串还原 Action。
-func (a *Action) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	switch s {
-	case "DrawCard":
-		*a = DrawCard
-	case "Abandon":
-		*a = Abandon
-	case "Calculate":
-		*a = Calculate
-	case "Double":
-		*a = Double
-	case "None":
-		*a = ActionNone
-	default:
-		return fmt.Errorf("invalid Action string: %q", s)
-	}
-	return nil
-}
-
 // OverflowMode 是「数据溢出」处理模式，决定总点数爆表时奖励是否归零。
 type OverflowMode int
 
@@ -145,14 +117,10 @@ type Outcome struct {
 	Immediate int     `json:"immediate"` // 即时奖励
 	Expected  float64 `json:"expected"`  // 期望未来价值
 	Total     float64 `json:"total"`     // 总价值 = Immediate + Expected
-	IsBest    bool    `json:"isBest"`    // 是否最优（与最优策略一致）
 }
 
-// Solution 是全量求解产物：每个状态的期望总奖励（价值函数）与最优决策（策略），
-// 外加状态列表与状态键索引。对外查询走 Decide / Best，通常不必直接读 Solution。
+// Solution 是全量求解产物：每个状态的期望总奖励（价值函数）。
+// 对外查询走 Decide，通常不必直接读 Solution。
 type Solution struct {
-	Value  []float64      // 价值函数，下标对应 States
-	Policy []Action       // 最优策略，下标对应 States；吸收态为 ActionNone
-	States []State        // 状态列表，吸收态恒为 States[0]（零值 State）
-	Index  map[string]int // 状态键 → 下标；"END" → 0
+	Value []float64 // 价值函数
 }

--- a/agent/go-service/trialofswordmancy/types.go
+++ b/agent/go-service/trialofswordmancy/types.go
@@ -14,6 +14,5 @@ type GameState struct {
 	Config solver.Config `json:"config"`
 
 	// 以下为识别原始字段，供日志/调试观测（写进 detail JSON），action 不读、不参与 MDP 求解。
-	HandRaw  [5]int `json:"handRaw"`  // 各槽位识别到的点数（下标=槽位，0=空槽）
-	Overflow bool   `json:"overflow"` // 是否识别到溢出叹号（爆表）
+	HandRaw [5]int `json:"handRaw"` // 各槽位识别到的点数（下标=槽位，0=空槽）
 }

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -223,8 +223,6 @@
     "trialofswordmancy.hand_empty": "empty",
     "trialofswordmancy.doubled": "Doubled",
     "trialofswordmancy.undoubled": "Not doubled",
-    "trialofswordmancy.endgame": "Trial of Swordmancy\nCross-day endgame\n→ Abandon round",
-    "trialofswordmancy.legacy_double": "Trial of Swordmancy\nLegacy trial runs consumed today's double uses\n→ Calculate now to restore a valid state",
     "trialofswordmancy.recognition_failed": "Trial of Swordmancy: recognition failed",
     "ims.sync_item_found": "Found %s: %d",
     "ims.add_item_found": "Gained %s ×%d",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -223,8 +223,6 @@
     "trialofswordmancy.hand_empty": "空",
     "trialofswordmancy.doubled": "ダブル中",
     "trialofswordmancy.undoubled": "ダブルなし",
-    "trialofswordmancy.endgame": "剣術演武\n持ち越しの残局\n→ 放棄",
-    "trialofswordmancy.legacy_double": "剣術演武\n持ち越し分が当日の倍化回数を消費している\n→ 演算を開始して正常状態に戻す",
     "trialofswordmancy.recognition_failed": "剣術演武：認識失敗",
     "ims.sync_item_found": "%s を認識：%d",
     "ims.add_item_found": "%s を獲得 ×%d",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -223,8 +223,6 @@
     "trialofswordmancy.hand_empty": "없음",
     "trialofswordmancy.doubled": "더블됨",
     "trialofswordmancy.undoubled": "더블 아님",
-    "trialofswordmancy.endgame": "검술 연무\n이월된 판\n→ 포기",
-    "trialofswordmancy.legacy_double": "검술 연무\n이월 횟수가 당일 더블 횟수를 소모함\n→ 연산을 시작해 정상 상태로 복귀",
     "trialofswordmancy.recognition_failed": "검술 연무: 인식 실패",
     "ims.sync_item_found": "%s 인식: %d",
     "ims.add_item_found": "%s 획득 ×%d",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -223,8 +223,6 @@
     "trialofswordmancy.hand_empty": "空",
     "trialofswordmancy.doubled": "已翻倍",
     "trialofswordmancy.undoubled": "未翻倍",
-    "trialofswordmancy.endgame": "选剑演武\n跨天残局\n→ 放弃本局",
-    "trialofswordmancy.legacy_double": "选剑演武\n识别到有之前遗留的演算奖励次数消耗了当日的双倍次数\n→ 直接开始演算以回归正确状态",
     "trialofswordmancy.recognition_failed": "选剑演武：识别失败",
     "ims.sync_item_found": "识别到 %s：%d",
     "ims.add_item_found": "获得 %s ×%d",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -223,8 +223,6 @@
     "trialofswordmancy.hand_empty": "空",
     "trialofswordmancy.doubled": "已翻倍",
     "trialofswordmancy.undoubled": "未翻倍",
-    "trialofswordmancy.endgame": "選劍演武\n跨天殘局\n→ 放棄本局",
-    "trialofswordmancy.legacy_double": "選劍演武\n識別到有之前遺留的演算獎勵次數消耗了當日的雙倍次數\n→ 直接開始演算以回歸正確狀態",
     "trialofswordmancy.recognition_failed": "選劍演武：識別失敗",
     "ims.sync_item_found": "識別到 %s：%d",
     "ims.add_item_found": "獲得 %s ×%d",

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -19,7 +19,17 @@
         "post_delay": 0,
         "next": [
             "TrialOfSwordmancyDailyRewardMode",
+            "TrialOfSwordmancyRetryRewardMode",
             "TrialOfSwordmancyDailyFinish"
+        ]
+    },
+    "TrialOfSwordmancyRetryRewardMode": {
+        "desc": "仅一次，放弃当前自由演算（跨日残局）",
+        "max_hit": 1,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "TrialOfSwordmancyCoatingGiveUp"
         ]
     },
     // 奖励耗尽 → 结束（CheckRewardMode 见非奖励模式 / Fight.json 战后 RewardExhausted 汇入）

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -55,7 +55,8 @@
         "post_delay": 0,
         "next": [
             "TrialOfSwordmancyEnsureFirstCard",
-            "TrialOfSwordmancyAbandProbeClickGiveUp"
+            "TrialOfSwordmancyAbandProbeClickGiveUp",
+            "TrialOfSwordmancyDecide"
         ]
     },
     // 若尚未抽牌（第1张 Lv 不在）则先抽一张，保证探测放弃次数时有牌；已有牌则 fall through 到 AbandProbe
@@ -92,12 +93,14 @@
         },
         "post_delay": 400,
         "next": [
-            "TrialOfSwordmancyAbandProbeClickGiveUp"
+            "TrialOfSwordmancyAbandProbeClickGiveUp",
+            "TrialOfSwordmancyDecide"
         ]
     },
-    // 探测放弃次数 → 回 Decide（同局继续）
+    // （仅一次）探测放弃次数 → 回 Decide
     "TrialOfSwordmancyAbandProbeClickGiveUp": {
         "desc": "探测放弃次数①：点放弃按钮",
+        "max_hit": 1,
         "recognition": "And",
         "all_of": [
             "TrialOfSwordmancyGiveUp"


### PR DESCRIPTION
之前好像是有顾虑性能问题，没有把扩展求解范围。实测下来，将演算次数提升到 4，完整求解时间约 200ms，内存峰值约 15MB，应当不存在性能问题。

顺手清理了一些死代码

放弃次数的检测现在整个流程只识别一次，它的变化是确定的，没有必要每次都花时间识别

## 由 Sourcery 提供的摘要

扩展 Trial of Swordmancy 求解器，以支持跨天终局运行，同时简化求解器输出并弃用未使用的特性；同时调整放弃次数缓存，使放弃操作通过递减缓存进行追踪，而不是依赖重复识别。

新功能：
- 允许求解器状态空间包含第四个剩余计算，以建模跨天终局运行，并通过 MDP 处理它们的放弃行为。

错误修复：
- 防止放弃次数缓存被不必要地重置，并确保仅真实的放弃操作会递减缓存计数且不会变为负值。
- 修复状态空间过滤与状态转移逻辑，使在扩展剩余计算上限时，手动终局和跨天场景仍保持在有效、可达的状态图中。

增强改进：
- 通过移除已存储的策略、状态和最佳动作辅助工具，简化求解器解的表示形式，改为仅基于价值与允许动作来计算决策。
- 从识别和游戏状态日志中移除溢出感叹号识别及相关字段，并删除未使用的牌组刷新计时工具以及动作上的 JSON 序列化/反序列化。
- 依托 MaaFramework 的单线程回调保证并收紧相关注释与文档，消除围绕求解器和放弃次数缓存的不必要互斥锁使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the Trial of Swordmancy solver to support cross-day endgame runs while simplifying solver outputs and abandoning unused features, and adjust abandon-count caching so that give-ups are tracked via a decrementing cache instead of repeated recognition.

New Features:
- Allow solver state space to include a fourth remaining calculation to model cross-day endgame runs and treat their abandon behavior via the MDP.

Bug Fixes:
- Prevent abandon-count cache from being reset unnecessarily and ensure only real give-ups decrement the cached count without going negative.
- Fix state-space filtering and transitions so manual endgame and cross-day scenarios remain in a valid, reachable state graph when extending remaining calculation limits.

Enhancements:
- Simplify solver solution representation by removing stored policies, states, and best-action helpers in favor of computing decisions from value and allowed actions only.
- Remove overflow-exclamation recognition and related fields from recognition and game state logging, and drop unused deck-refresh timing utilities and JSON (un)marshalling on actions.
- Eliminate unnecessary mutex locking around solver and abandon-count caches by relying on MaaFramework's single-threaded callback guarantees and tightening related comments and docs.

</details>