### PR TITLE
fix: 修复赠送礼物中寻找干员的导航多次转向

### DIFF
--- a/assets/resource/pipeline/GiftOperator/GiftOperatorMain.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorMain.json
@@ -106,6 +106,7 @@
         "custom_action": "ClearHitCount",
         "custom_action_param": {
             "nodes": [
+                "GiftOperatorMoveResetBackward",
                 "GiftOperatorMoveLocation3",
                 "GiftOperatorMoveLocation3Move",
                 "GiftOperatorMoveLocation2",

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorNavigation.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorNavigation.json
@@ -24,14 +24,43 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "GiftOperatorMoveResetBackward",
             "GiftOperatorMoveLocation3",
-            //"GiftOperatorMoveLocation3Move",
+            "GiftOperatorMoveLocation3Move",
             "GiftOperatorMoveLocation2",
-            //"GiftOperatorMoveLocation2Move",
+            "GiftOperatorMoveLocation2Move",
             "GiftOperatorMoveLocation1",
-            //"GiftOperatorMoveLocation1Move",
+            "GiftOperatorMoveLocation1Move",
             "GiftOperatorMoveFail"
         ]
+    },
+    "GiftOperatorMoveResetBackward": {
+        "desc": "向后(S)一步，再向前(W)重置视角",
+        "max_hit": 1,
+        "pre_delay": 0,
+        "action": {
+            "type": "ClickKey",
+            "param": {
+                "key": 83
+            }
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "GiftOperatorMoveResetForward"
+        ]
+    },
+    "GiftOperatorMoveResetForward": {
+        "desc": "向前(W)一步，完成视角重置",
+        "pre_delay": 0,
+        "action": {
+            "type": "ClickKey",
+            "param": {
+                "key": 87
+            }
+        },
+        "post_delay": 0,
+        "rate_limit": 0
     },
     "GiftOperatorMoveFail": {
         "desc": "移动未能接触到干员，炸掉程序",
@@ -46,7 +75,7 @@
     },
     "GiftOperatorMoveLocation1": {
         "desc": "转向270度(正西)尝试接触到干员(预设位置1)",
-        "max_hit": 2,
+        "max_hit": 1,
         "pre_delay": 0,
         "action": {
             "type": "Custom",
@@ -67,38 +96,22 @@
         "rate_limit": 0
     },
     "GiftOperatorMoveLocation1Move": {
-        "desc": "移动尝试接触到干员(预设位置1)",
+        "desc": "转向270度后向前(W)一段尝试接触干员(预设位置1)",
         "max_hit": 1,
+        "pre_delay": 0,
         "action": {
-            "type": "Custom",
+            "type": "LongPressKey",
             "param": {
-                "custom_action": "MapTrackerMove",
-                "custom_action_param": {
-                    "map_name": "base01_lv003",
-                    "no_ensure_initial_movement_state": true,
-                    "path": [
-                        [
-                            186.6,
-                            175.0
-                        ]
-                    ]
-                }
+                "duration": 300,
+                "key": 87
             }
         },
-        "post_wait_freezes": {
-            "time": 150,
-            "target": [
-                807,
-                420,
-                70,
-                121
-            ],
-            "timeout": 2000
-        }
+        "post_delay": 0,
+        "rate_limit": 0
     },
     "GiftOperatorMoveLocation2": {
         "desc": "转向345度(北偏西15度)尝试接触到干员(预设位置2)",
-        "max_hit": 2,
+        "max_hit": 1,
         "pre_delay": 0,
         "action": {
             "type": "Custom",
@@ -119,38 +132,22 @@
         "rate_limit": 0
     },
     "GiftOperatorMoveLocation2Move": {
-        "desc": "移动尝试接触到干员(预设位置2)",
+        "desc": "转向345度后向前(W)一段尝试接触干员(预设位置2)",
         "max_hit": 1,
+        "pre_delay": 0,
         "action": {
-            "type": "Custom",
+            "type": "LongPressKey",
             "param": {
-                "custom_action": "MapTrackerMove",
-                "custom_action_param": {
-                    "map_name": "base01_lv003",
-                    "no_ensure_initial_movement_state": true,
-                    "path": [
-                        [
-                            188.0,
-                            175.3
-                        ]
-                    ]
-                }
+                "duration": 300,
+                "key": 87
             }
         },
-        "post_wait_freezes": {
-            "time": 150,
-            "target": [
-                807,
-                420,
-                70,
-                121
-            ],
-            "timeout": 2000
-        }
+        "post_delay": 0,
+        "rate_limit": 0
     },
     "GiftOperatorMoveLocation3": {
         "desc": "转向90度(正东)尝试接触到干员(预设位置3)",
-        "max_hit": 2,
+        "max_hit": 1,
         "pre_delay": 0,
         "action": {
             "type": "Custom",
@@ -171,34 +168,18 @@
         "rate_limit": 0
     },
     "GiftOperatorMoveLocation3Move": {
-        "desc": "移动尝试接触到干员(预设位置3)",
+        "desc": "转向90度后向前(W)一段尝试接触干员(预设位置3)",
         "max_hit": 1,
+        "pre_delay": 0,
         "action": {
-            "type": "Custom",
+            "type": "LongPressKey",
             "param": {
-                "custom_action": "MapTrackerMove",
-                "custom_action_param": {
-                    "map_name": "base01_lv003",
-                    "no_ensure_initial_movement_state": true,
-                    "path": [
-                        [
-                            188.6,
-                            176.2
-                        ]
-                    ]
-                }
+                "duration": 300,
+                "key": 87
             }
         },
-        "post_wait_freezes": {
-            "time": 150,
-            "target": [
-                807,
-                420,
-                70,
-                121
-            ],
-            "timeout": 2000
-        }
+        "post_delay": 0,
+        "rate_limit": 0
     },
     "GiftOperatorMoveMapTracker": {
         "desc": "使用 MapTracker 识别寻路走到干员联络台",

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorNavigation.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorNavigation.json
@@ -26,11 +26,11 @@
         "next": [
             "GiftOperatorMoveResetBackward",
             "GiftOperatorMoveLocation3",
-            "GiftOperatorMoveLocation3Move",
+            //"GiftOperatorMoveLocation3Move",
             "GiftOperatorMoveLocation2",
-            "GiftOperatorMoveLocation2Move",
+            //"GiftOperatorMoveLocation2Move",
             "GiftOperatorMoveLocation1",
-            "GiftOperatorMoveLocation1Move",
+            //"GiftOperatorMoveLocation1Move",
             "GiftOperatorMoveFail"
         ]
     },
@@ -75,7 +75,7 @@
     },
     "GiftOperatorMoveLocation1": {
         "desc": "转向270度(正西)尝试接触到干员(预设位置1)",
-        "max_hit": 1,
+        "max_hit": 2,
         "pre_delay": 0,
         "action": {
             "type": "Custom",
@@ -96,22 +96,38 @@
         "rate_limit": 0
     },
     "GiftOperatorMoveLocation1Move": {
-        "desc": "转向270度后向前(W)一段尝试接触干员(预设位置1)",
+        "desc": "移动尝试接触到干员(预设位置1)",
         "max_hit": 1,
-        "pre_delay": 0,
         "action": {
-            "type": "LongPressKey",
+            "type": "Custom",
             "param": {
-                "duration": 300,
-                "key": 87
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "base01_lv003",
+                    "no_ensure_initial_movement_state": true,
+                    "path": [
+                        [
+                            186.6,
+                            175.0
+                        ]
+                    ]
+                }
             }
         },
-        "post_delay": 0,
-        "rate_limit": 0
+        "post_wait_freezes": {
+            "time": 150,
+            "target": [
+                807,
+                420,
+                70,
+                121
+            ],
+            "timeout": 2000
+        }
     },
     "GiftOperatorMoveLocation2": {
         "desc": "转向345度(北偏西15度)尝试接触到干员(预设位置2)",
-        "max_hit": 1,
+        "max_hit": 2,
         "pre_delay": 0,
         "action": {
             "type": "Custom",
@@ -132,22 +148,38 @@
         "rate_limit": 0
     },
     "GiftOperatorMoveLocation2Move": {
-        "desc": "转向345度后向前(W)一段尝试接触干员(预设位置2)",
+        "desc": "移动尝试接触到干员(预设位置2)",
         "max_hit": 1,
-        "pre_delay": 0,
         "action": {
-            "type": "LongPressKey",
+            "type": "Custom",
             "param": {
-                "duration": 300,
-                "key": 87
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "base01_lv003",
+                    "no_ensure_initial_movement_state": true,
+                    "path": [
+                        [
+                            188.0,
+                            175.3
+                        ]
+                    ]
+                }
             }
         },
-        "post_delay": 0,
-        "rate_limit": 0
+        "post_wait_freezes": {
+            "time": 150,
+            "target": [
+                807,
+                420,
+                70,
+                121
+            ],
+            "timeout": 2000
+        }
     },
     "GiftOperatorMoveLocation3": {
         "desc": "转向90度(正东)尝试接触到干员(预设位置3)",
-        "max_hit": 1,
+        "max_hit": 2,
         "pre_delay": 0,
         "action": {
             "type": "Custom",
@@ -168,18 +200,34 @@
         "rate_limit": 0
     },
     "GiftOperatorMoveLocation3Move": {
-        "desc": "转向90度后向前(W)一段尝试接触干员(预设位置3)",
+        "desc": "移动尝试接触到干员(预设位置3)",
         "max_hit": 1,
-        "pre_delay": 0,
         "action": {
-            "type": "LongPressKey",
+            "type": "Custom",
             "param": {
-                "duration": 300,
-                "key": 87
+                "custom_action": "MapTrackerMove",
+                "custom_action_param": {
+                    "map_name": "base01_lv003",
+                    "no_ensure_initial_movement_state": true,
+                    "path": [
+                        [
+                            188.6,
+                            176.2
+                        ]
+                    ]
+                }
             }
         },
-        "post_delay": 0,
-        "rate_limit": 0
+        "post_wait_freezes": {
+            "time": 150,
+            "target": [
+                807,
+                420,
+                70,
+                121
+            ],
+            "timeout": 2000
+        }
     },
     "GiftOperatorMoveMapTracker": {
         "desc": "使用 MapTracker 识别寻路走到干员联络台",

--- a/assets/resource_adb/pipeline/GiftOperator/GiftOperatorNavigation.json
+++ b/assets/resource_adb/pipeline/GiftOperator/GiftOperatorNavigation.json
@@ -1,0 +1,94 @@
+{
+    // MapTracker ADB 摇杆：中心 (195, 551)，步行偏移 15
+    // 后退 (195, 566) / 前进 (195, 536)
+    "GiftOperatorMoveResetBackward": {
+        "desc": "向后走一步（ADB 虚拟摇杆下推），再向前重置视角",
+        "action": {
+            "type": "Swipe",
+            "param": {
+                "begin": [
+                    195,
+                    551
+                ],
+                "end": [
+                    195,
+                    566
+                ],
+                "end_hold": 100,
+                "duration": 50
+            }
+        }
+    },
+    "GiftOperatorMoveResetForward": {
+        "desc": "向前走一步（ADB 虚拟摇杆上推），完成视角重置",
+        "action": {
+            "type": "Swipe",
+            "param": {
+                "begin": [
+                    195,
+                    551
+                ],
+                "end": [
+                    195,
+                    536
+                ],
+                "end_hold": 100,
+                "duration": 50
+            }
+        }
+    },
+    "GiftOperatorMoveLocation1Move": {
+        "desc": "转向270度后向前一段（ADB 虚拟摇杆上推）",
+        "action": {
+            "type": "Swipe",
+            "param": {
+                "begin": [
+                    195,
+                    551
+                ],
+                "end": [
+                    195,
+                    536
+                ],
+                "end_hold": 300,
+                "duration": 50
+            }
+        }
+    },
+    "GiftOperatorMoveLocation2Move": {
+        "desc": "转向345度后向前一段（ADB 虚拟摇杆上推）",
+        "action": {
+            "type": "Swipe",
+            "param": {
+                "begin": [
+                    195,
+                    551
+                ],
+                "end": [
+                    195,
+                    536
+                ],
+                "end_hold": 300,
+                "duration": 50
+            }
+        }
+    },
+    "GiftOperatorMoveLocation3Move": {
+        "desc": "转向90度后向前一段（ADB 虚拟摇杆上推）",
+        "action": {
+            "type": "Swipe",
+            "param": {
+                "begin": [
+                    195,
+                    551
+                ],
+                "end": [
+                    195,
+                    536
+                ],
+                "end_hold": 300,
+                "duration": 50
+            }
+        }
+    }
+}

--- a/assets/resource_adb/pipeline/GiftOperator/GiftOperatorNavigation.json
+++ b/assets/resource_adb/pipeline/GiftOperator/GiftOperatorNavigation.json
@@ -36,59 +36,5 @@
                 "duration": 50
             }
         }
-    },
-    "GiftOperatorMoveLocation1Move": {
-        "desc": "转向270度后向前一段（ADB 虚拟摇杆上推）",
-        "action": {
-            "type": "Swipe",
-            "param": {
-                "begin": [
-                    195,
-                    551
-                ],
-                "end": [
-                    195,
-                    536
-                ],
-                "end_hold": 300,
-                "duration": 50
-            }
-        }
-    },
-    "GiftOperatorMoveLocation2Move": {
-        "desc": "转向345度后向前一段（ADB 虚拟摇杆上推）",
-        "action": {
-            "type": "Swipe",
-            "param": {
-                "begin": [
-                    195,
-                    551
-                ],
-                "end": [
-                    195,
-                    536
-                ],
-                "end_hold": 300,
-                "duration": 50
-            }
-        }
-    },
-    "GiftOperatorMoveLocation3Move": {
-        "desc": "转向90度后向前一段（ADB 虚拟摇杆上推）",
-        "action": {
-            "type": "Swipe",
-            "param": {
-                "begin": [
-                    195,
-                    551
-                ],
-                "end": [
-                    195,
-                    536
-                ],
-                "end_hold": 300,
-                "duration": 50
-            }
-        }
     }
 }


### PR DESCRIPTION
MapNag依赖小地图角色方向进行计算
默认当前视角处于正前方
但是MapTra的精确接近模式会使用A和D进行微调,导致视角不会处于正前方

本次PR加入了一个节点在Nag计算前,使用S和W来重置视角为正前方
ADB使用click指定位置

## Summary by Sourcery

重构礼物运营导航资源，将主流水线与导航流水线分离，并将导航配置迁移到 ADB 专用的资源路径。

增强点：
- 将礼物运营流水线配置拆分为独立的主 JSON 资源与导航 JSON 资源，以提高清晰度和结构化程度。
- 将礼物运营导航 JSON 从通用的资源流水线目录迁移到 ADB 专用的 `resource_adb` 目录，以更好地对齐平台特定资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the gift-operator navigation resources to separate main and navigation pipelines and relocate navigation configuration to the ADB-specific resource path.

Enhancements:
- Split gift operator pipeline configuration into distinct main and navigation JSON resources for clearer structure.
- Relocate gift operator navigation JSON from the generic resource pipeline directory to the ADB-specific resource_adb directory to align with platform-specific assets.

</details>