### PR TITLE
perf: 增加截图卡死检测

### DIFF
--- a/agent/go-service/scenemanager/register.go
+++ b/agent/go-service/scenemanager/register.go
@@ -6,4 +6,5 @@ func Register() {
 	maa.AgentServerRegisterCustomAction("SceneManagerMenuListClickItemAction", &SceneManagerMenuListClickItemAction{})
 	maa.AgentServerRegisterCustomRecognition("ImageCheckNotPassedRecognition", &ImageCheckNotPassedRecognition{})
 	maa.AgentServerRegisterCustomAction("ImageCheckSetResultAction", &ImageCheckSetResultAction{})
+	maa.AgentServerRegisterCustomRecognition("ScreenshotStableRecognition", &ScreenshotStableRecognition{})
 }

--- a/agent/go-service/scenemanager/screenshotstable.go
+++ b/agent/go-service/scenemanager/screenshotstable.go
@@ -4,6 +4,8 @@ import (
 	"image"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pretask/gamesetting"
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -14,9 +16,9 @@ var screenshotStableBaseline *image.RGBA
 
 var _ maa.CustomRecognitionRunner = (*ScreenshotStableRecognition)(nil)
 
-// ScreenshotStableRecognition 在 Agent 进程生命周期内只判定一次画面是否连续三帧稳定。
-// 每次调用只用 arg.Img（固定全屏）：第 1 次存 baseline；第 2 帧与 baseline 比较，
-// 不匹配则直接结束周期（不再采第 3 帧）；匹配后再采第 3 帧确认。仅第 3 帧仍相似时命中。
+// ScreenshotStableRecognition 仅在 Win32-Front + 游戏全屏时，于 Agent 进程生命周期内判定一次
+// 画面是否连续三帧稳定。每次调用只用 arg.Img：第 1 次存 baseline；第 2 帧不匹配则结束周期；
+// 匹配后再采第 3 帧确认。仅第 3 帧仍相似时命中。
 type ScreenshotStableRecognition struct{}
 
 func (r *ScreenshotStableRecognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa.CustomRecognitionResult, bool) {
@@ -26,6 +28,9 @@ func (r *ScreenshotStableRecognition) Run(ctx *maa.Context, arg *maa.CustomRecog
 		return nil, false
 	}
 	if screenshotStableDone {
+		return nil, false
+	}
+	if !shouldRunScreenshotStable() {
 		return nil, false
 	}
 
@@ -64,6 +69,21 @@ func (r *ScreenshotStableRecognition) Run(ctx *maa.Context, arg *maa.CustomRecog
 		Box:    maa.Rect{b.Min.X, b.Min.Y, b.Dx(), b.Dy()},
 		Detail: `{"stable":true}`,
 	}, true
+}
+
+func shouldRunScreenshotStable() bool {
+	if pienv.ControllerName() != "Win32-Front" {
+		return false
+	}
+	fullScreen, err := gamesetting.GetVideoFullScreen()
+	if err != nil {
+		log.Debug().
+			Err(err).
+			Str("component", "ScreenshotStableRecognition").
+			Msg("failed to read fullscreen setting, skip")
+		return false
+	}
+	return fullScreen == 1
 }
 
 func finishScreenshotStable() {

--- a/agent/go-service/scenemanager/screenshotstable.go
+++ b/agent/go-service/scenemanager/screenshotstable.go
@@ -9,14 +9,14 @@ import (
 )
 
 var screenshotStableDone bool
-var screenshotStableCount int // 已采样帧数：0→存 baseline；1/2→与 baseline 比较
+var screenshotStableCount int // 0=未采；1=已有 baseline；2=第 2 帧已匹配，等待第 3 帧
 var screenshotStableBaseline *image.RGBA
 
 var _ maa.CustomRecognitionRunner = (*ScreenshotStableRecognition)(nil)
 
 // ScreenshotStableRecognition 在 Agent 进程生命周期内只判定一次画面是否连续三帧稳定。
-// 每次调用只用 arg.Img（固定全屏）：第 1 次把 baseline 留在内存；第 2/3 次与 baseline 做 NCC
-//（阈值 0.99）；仅第 3 次仍相似时命中；周期结束后恒未命中。不落盘、不 OverrideImage。
+// 每次调用只用 arg.Img（固定全屏）：第 1 次存 baseline；第 2 帧与 baseline 比较，
+// 不匹配则直接结束周期（不再采第 3 帧）；匹配后再采第 3 帧确认。仅第 3 帧仍相似时命中。
 type ScreenshotStableRecognition struct{}
 
 func (r *ScreenshotStableRecognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa.CustomRecognitionResult, bool) {
@@ -35,20 +35,27 @@ func (r *ScreenshotStableRecognition) Run(ctx *maa.Context, arg *maa.CustomRecog
 		return nil, false
 	}
 
+	// 第 1 帧：只存 baseline
 	if screenshotStableCount == 0 {
 		screenshotStableBaseline = minicv.ImageCopy(cur)
 		screenshotStableCount = 1
 		return nil, false
 	}
 
-	matched := imagesSimilar(cur, screenshotStableBaseline, 0.99)
-	screenshotStableCount++
-
-	if !matched || screenshotStableCount >= 3 {
-		screenshotStableDone = true
-		screenshotStableBaseline = nil
+	// 第 2 帧：与 baseline 比；不匹配则结束，不再需要第 3 帧
+	if screenshotStableCount == 1 {
+		if !imagesSimilar(cur, screenshotStableBaseline, 0.99) {
+			finishScreenshotStable()
+			return nil, false
+		}
+		screenshotStableCount = 2
+		return nil, false
 	}
-	if !matched || screenshotStableCount < 3 {
+
+	// 第 3 帧：仅在第 2 帧已匹配时才会走到这里
+	matched := imagesSimilar(cur, screenshotStableBaseline, 0.99)
+	finishScreenshotStable()
+	if !matched {
 		return nil, false
 	}
 
@@ -57,6 +64,12 @@ func (r *ScreenshotStableRecognition) Run(ctx *maa.Context, arg *maa.CustomRecog
 		Box:    maa.Rect{b.Min.X, b.Min.Y, b.Dx(), b.Dy()},
 		Detail: `{"stable":true}`,
 	}, true
+}
+
+func finishScreenshotStable() {
+	screenshotStableDone = true
+	screenshotStableBaseline = nil
+	screenshotStableCount = 0
 }
 
 func imagesSimilar(cur, baseline *image.RGBA, threshold float64) bool {

--- a/agent/go-service/scenemanager/screenshotstable.go
+++ b/agent/go-service/scenemanager/screenshotstable.go
@@ -1,0 +1,75 @@
+package scenemanager
+
+import (
+	"image"
+
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv"
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+var screenshotStableDone bool
+var screenshotStableCount int // 已采样帧数：0→存 baseline；1/2→与 baseline 比较
+var screenshotStableBaseline *image.RGBA
+
+var _ maa.CustomRecognitionRunner = (*ScreenshotStableRecognition)(nil)
+
+// ScreenshotStableRecognition 在 Agent 进程生命周期内只判定一次画面是否连续三帧稳定。
+// 每次调用只用 arg.Img（固定全屏）：第 1 次把 baseline 留在内存；第 2/3 次与 baseline 做 NCC
+//（阈值 0.99）；仅第 3 次仍相似时命中；周期结束后恒未命中。不落盘、不 OverrideImage。
+type ScreenshotStableRecognition struct{}
+
+func (r *ScreenshotStableRecognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa.CustomRecognitionResult, bool) {
+	_ = ctx
+	if arg == nil || arg.Img == nil {
+		log.Error().Str("component", "ScreenshotStableRecognition").Msg("nil arg or image")
+		return nil, false
+	}
+	if screenshotStableDone {
+		return nil, false
+	}
+
+	cur := minicv.ImageConvertRGBA(arg.Img)
+	if cur == nil || cur.Bounds().Empty() {
+		log.Error().Str("component", "ScreenshotStableRecognition").Msg("empty image")
+		return nil, false
+	}
+
+	if screenshotStableCount == 0 {
+		screenshotStableBaseline = minicv.ImageCopy(cur)
+		screenshotStableCount = 1
+		return nil, false
+	}
+
+	matched := imagesSimilar(cur, screenshotStableBaseline, 0.99)
+	screenshotStableCount++
+
+	if !matched || screenshotStableCount >= 3 {
+		screenshotStableDone = true
+		screenshotStableBaseline = nil
+	}
+	if !matched || screenshotStableCount < 3 {
+		return nil, false
+	}
+
+	b := cur.Bounds()
+	return &maa.CustomRecognitionResult{
+		Box:    maa.Rect{b.Min.X, b.Min.Y, b.Dx(), b.Dy()},
+		Detail: `{"stable":true}`,
+	}, true
+}
+
+func imagesSimilar(cur, baseline *image.RGBA, threshold float64) bool {
+	if cur == nil || baseline == nil {
+		return false
+	}
+	if cur.Bounds().Dx() != baseline.Bounds().Dx() || cur.Bounds().Dy() != baseline.Bounds().Dy() {
+		return false
+	}
+	stats := minicv.GetImageStats(baseline)
+	if stats.Std < 1e-6 {
+		return false
+	}
+	score := minicv.ComputeNCC(cur, minicv.GetIntegralArray(cur), baseline, stats, 0, 0)
+	return score >= threshold
+}

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -1016,6 +1016,7 @@
     "task.SceneManager.focus.mod_check_failed_prefix": "<span style=\"color: red; font-weight: bold;\">UID display is incomplete. Enabling UID-hiding mods removes text in the upper-left corner of the screen, which affects recognition.</span>",
     "task.SceneManager.focus.osd_check_failed": "<span style=\"color: red; font-weight: bold;\">Screen overlay detected. Close FPS/hardware monitoring overlays (e.g. FPS, CPU, GPU, Afterburner) and try again</span>",
     "task.SceneManager.focus.language_not_zh_cn": "<span style=\"color: red; font-weight: bold;\">The game language is not Simplified Chinese. Compatibility is limited, and tasks may fail.</span>",
+    "task.SceneManager.focus.screenshot_stable_abnormal": "<span style=\"color: red; font-weight: bold;\">Environment recognition is abnormal. Please launch the game with D3D11, or switch to windowed mode and retry.</span>",
     "description.file": "locales/interface/DESCRIPTION/DESCRIPTION.en_us.md",
     "contact.file": "https://end.maafw.com/CONTACT/CONTACT.en_us.md",
     "operator.Perlica": "Perlica",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -1016,6 +1016,7 @@
     "task.SceneManager.focus.mod_check_failed_prefix": "<span style=\"color: red; font-weight: bold;\">UIDの表示が不完全です。UID非表示MODを有効にすると、画面左上の文字が欠落し、認識に影響します。</span>",
     "task.SceneManager.focus.osd_check_failed": "<span style=\"color: red; font-weight: bold;\">画面にオーバーレイが検出されました。フレームレート／ハードウェア監視オーバーレイ（FPS、CPU、GPU、Afterburner など）を閉じてから再試行してください</span>",
     "task.SceneManager.focus.language_not_zh_cn": "<span style=\"color: red; font-weight: bold;\">ゲーム言語が簡体字中国語ではありません。互換性が低く、タスクが失敗する可能性があります。</span>",
+    "task.SceneManager.focus.screenshot_stable_abnormal": "<span style=\"color: red; font-weight: bold;\">現在の環境認識に異常があります。D3D11 でゲームを起動するか、ウィンドウモードに切り替えて再試行してください。</span>",
     "description.file": "locales/interface/DESCRIPTION/DESCRIPTION.ja_jp.md",
     "contact.file": "https://end.maafw.com/CONTACT/CONTACT.ja_jp.md",
     "operator.Perlica": "ペリカ",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -1016,6 +1016,7 @@
     "task.SceneManager.focus.mod_check_failed_prefix": "<span style=\"color: red; font-weight: bold;\">UID 표시가 불완전합니다. UID 숨김 MOD를 켜면 화면 왼쪽 상단의 문자가 누락되어 인식에 영향을 줍니다.</span>",
     "task.SceneManager.focus.osd_check_failed": "<span style=\"color: red; font-weight: bold;\">화면에 오버레이가 감지되었습니다. 프레임레이트/하드웨어 모니터링 오버레이(FPS, CPU, GPU, Afterburner 등)를 끈 후 다시 시도하세요</span>",
     "task.SceneManager.focus.language_not_zh_cn": "<span style=\"color: red; font-weight: bold;\">게임 언어가 간체 중국어가 아닙니다. 호환성이 낮아 작업이 실패할 수 있습니다.</span>",
+    "task.SceneManager.focus.screenshot_stable_abnormal": "<span style=\"color: red; font-weight: bold;\">현재 환경 인식이 비정상입니다. D3D11로 게임을 실행하거나 창 모드로 전환한 후 다시 시도하세요.</span>",
     "description.file": "locales/interface/DESCRIPTION/DESCRIPTION.ko_kr.md",
     "contact.file": "https://end.maafw.com/CONTACT/CONTACT.ko_kr.md",
     "operator.Perlica": "펠리카",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -1016,6 +1016,7 @@
     "task.SceneManager.focus.mod_check_failed_prefix": "<span style=\"color: red; font-weight: bold;\">UID显示不完整，开启UID隐藏MOD会导致画面左上方文字缺失，影响识别</span>",
     "task.SceneManager.focus.osd_check_failed": "<span style=\"color: red; font-weight: bold;\">屏幕存在遮挡，请关闭帧率/硬件监控悬浮窗（如 FPS、CPU、GPU、Afterburner 等）后重试</span>",
     "task.SceneManager.focus.language_not_zh_cn": "<span style=\"color: red; font-weight: bold;\">当前游戏语言不是简体中文，兼容性较差，任务可能会失败</span>",
+    "task.SceneManager.focus.screenshot_stable_abnormal": "<span style=\"color: red; font-weight: bold;\">当前环境识别异常，请使用 D3D11 启动游戏，或切换到窗口化重试</span>",
     "description.file": "locales/interface/DESCRIPTION/DESCRIPTION.zh_cn.md",
     "contact.file": "https://end.maafw.com/CONTACT/CONTACT.zh_cn.md",
     "operator.Perlica": "佩丽卡",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -1016,6 +1016,7 @@
     "task.SceneManager.focus.mod_check_failed_prefix": "<span style=\"color: red; font-weight: bold;\">UID顯示不完整，開啟UID隱藏MOD會導致畫面左上方文字缺失，影響識別</span>",
     "task.SceneManager.focus.osd_check_failed": "<span style=\"color: red; font-weight: bold;\">螢幕存在遮擋，請關閉幀率/硬體監控懸浮窗（如 FPS、CPU、GPU、Afterburner 等）後重試</span>",
     "task.SceneManager.focus.language_not_zh_cn": "<span style=\"color: red; font-weight: bold;\">當前遊戲語言不是簡體中文，相容性較差，任務可能會失敗</span>",
+    "task.SceneManager.focus.screenshot_stable_abnormal": "<span style=\"color: red; font-weight: bold;\">當前環境識別異常，請使用 D3D11 啟動遊戲，或切換到視窗化重試</span>",
     "description.file": "locales/interface/DESCRIPTION/DESCRIPTION.zh_tw.md",
     "contact.file": "https://end.maafw.com/CONTACT/CONTACT.zh_tw.md",
     "operator.Perlica": "佩麗卡",

--- a/assets/resource/pipeline/Interface/Scene.json
+++ b/assets/resource/pipeline/Interface/Scene.json
@@ -17,6 +17,7 @@
             "[JumpBack]__ScenePrivateWorldStorySkip",
             "[JumpBack]__ScenePrivateLoggedOutConfirm",
             "[JumpBack]SceneWaitLoadingExit",
+            "[JumpBack]__ScenePrivateScreenshotStableAbnormal",
             "[JumpBack]__ScenePrivateAnyExit"
         ]
     },

--- a/assets/resource/pipeline/SceneManager/SceneCommon.json
+++ b/assets/resource/pipeline/SceneManager/SceneCommon.json
@@ -13,6 +13,23 @@
         },
         "post_delay": 3000
     },
+    "__ScenePrivateScreenshotStableAbnormal": {
+        "desc": "连续画面不变时判定环境识别异常强制失败",
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "ScreenshotStableRecognition"
+            }
+        },
+        "action": "Custom",
+        "custom_action": "FalseAction",
+        "focus": {
+            "Node.Recognition.Succeeded": {
+                "content": "$task.SceneManager.focus.screenshot_stable_abnormal",
+                "display": "modal"
+            }
+        }
+    },
     "__ScenePrivateLoggedOutConfirm": {
         "desc": "确认自动登出弹窗",
         "recognition": "And",

--- a/assets/resource/pipeline/SceneManager/SceneCommon.json
+++ b/assets/resource/pipeline/SceneManager/SceneCommon.json
@@ -14,7 +14,7 @@
         "post_delay": 3000
     },
     "__ScenePrivateScreenshotStableAbnormal": {
-        "desc": "连续画面不变时判定环境识别异常强制失败",
+        "desc": "连续画面不变时判定环境识别异常强制失败,部分用户vulcan全屏游戏时，所有截图api截取到的画面都是不动的",
         "recognition": {
             "type": "Custom",
             "param": {

--- a/tools/schema/custom.recognition.schema.json
+++ b/tools/schema/custom.recognition.schema.json
@@ -30,6 +30,7 @@
                 "ReceptionRoomExchangeCountdownWithinThresholdRecognition",
                 "ReceptionRoomWaitExchangeKeepAliveDueRecognition",
                 "ScheduleRecognition",
+                "ScreenshotStableRecognition",
                 "SellProductCurrentBestOperator",
                 "SellProductCurrentOperatorUncached",
                 "SellProductOperatorCacheReady",


### PR DESCRIPTION
close #4706

## Summary by Sourcery

为场景管理器添加截图稳定识别功能，用于检测截图在多个帧中保持稳定，以识别潜在卡顿。

Enhancements:
- 引入 `ScreenshotStableRecognition`，用于判断界面在连续三个帧中是否在视觉上保持不变，并上报稳定状态。
- 在场景管理器中注册新的截图稳定识别功能，并将其集成到现有的场景/管线配置以及本地化界面资源中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a scene manager recognition to detect when screenshots remain stable over multiple frames to identify potential freezes.

Enhancements:
- Introduce ScreenshotStableRecognition to determine if the interface remains visually unchanged across three consecutive frames and report a stable state.
- Register the new screenshot stability recognition in the scene manager and integrate it into existing scene/pipeline configurations and localized interface resources.

</details>