### PR TITLE
feat(EnvironmentMonitoring): 优化拍照流程与武陵路线（子模块）

### DIFF
--- a/.agents/skills/environment-monitoring-add-route/SKILL.md
+++ b/.agents/skills/environment-monitoring-add-route/SKILL.md
@@ -50,14 +50,14 @@ argument-hint: "可选：观察点名称，以及录制好的 EnterMap、MapAsse
 | 传送入口               | 默认填写真实 `EnterMap`（任意可作为 SubTask 正常返回的 Pipeline 节点）；或启用 `QuickTeleport: true` 从任务地图快捷传送 |
 | 路线方式               | 传送点可直接拍照时不填地图与寻路字段；否则 `MapPath` / `MapTarget` / `MapGoal` 必须且只能填写一个                         |
 | `MapName`              | 仅寻路路线必填。`MapPath`：MapTracker `map_name`；`MapGoal`：精确 MapTracker `map_name`；`MapTarget`：MapLocate `zone_id` |
-| `MapAssert`            | 直拍路线不填；普通传送和 `QuickTeleport + MapPath` 必填，`QuickTeleport + MapTarget/MapGoal` 可省略                       |
+| `MapAssert`            | 直拍路线不填；普通传送的寻路路线必填，`QuickTeleport + MapPath/MapTarget/MapGoal` 可省略                                |
 | `CameraSwipeDirection` | `EnvironmentMonitoringSwipeScreenUp/Down/Left/Right`，用于进入拍照后的摄像头调整                                          |
 
 ### 四种路线模式
 
 | 模式        | 数据格式          | 生成动作            | 适用场景                                                                    |
 | ----------- | ----------------- | ------------------- | --------------------------------------------------------------------------- |
-| `MapPath`   | `[[x1, y1], ...]` | `MapTrackerMove`    | 需要按实录路径逐点行走；传送后会再次用 `MapAssert` 复核固定起点             |
+| `MapPath`   | `[[x1, y1], ...]` | `MapTrackerMove`    | 需要按实录路径逐点行走；快捷传送后可从固定传送落点直接开始                 |
 | `MapTarget` | `[x, y]`          | `MapNavigateAction` | 使用 MapLocate / MapNavigator 的 NAVMESH 目标；快捷传送时可省略 `MapAssert` |
 | `MapGoal`   | `[x, y]`          | `MapTrackerGoal`    | 使用 MapTracker NavMesh 自动寻路；快捷传送时可省略 `MapAssert`              |
 | 传送后直拍  | 不配置地图字段    | 可选转向后拍照      | 传送落点已经满足拍照条件；可配置 `Heading`，但不配置地图断言或寻路字段      |
@@ -104,7 +104,7 @@ node .agents/skills/environment-monitoring-add-route/check_missing.mjs
 1. 传送入口：真实 `EnterMap`，或已实测任务地图支持的 `QuickTeleport: true`
 2. 路线方式：已实测可传送后直拍，或 `MapPath` / `MapTarget` / `MapGoal`
 3. 直拍时直接跳到第 7 项；寻路时收集 `MapName`
-4. `MapAssert`（普通传送或 `QuickTeleport + MapPath` 必填；`QuickTeleport + MapTarget/MapGoal` 跳过）
+4. `MapAssert`（普通传送的寻路路线必填；`QuickTeleport + MapPath/MapTarget/MapGoal` 跳过）
 5. 所选寻路字段的坐标
 6. `MapTargetTier`（仅 `MapTarget` 且确有跨 tier 目标时）
 7. `CameraSwipeDirection`

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToFloraObservationPoint"
+            "FloraObservationPointInQuickTeleportMap"
         ]
     },
     "AlreadyTrackedFloraObservationPoint": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToFloraObservationPoint"
+            "FloraObservationPointOpenTrackedMissionMap"
         ]
     },
     "FloraObservationPointOpenTrackedMissionMap": {
@@ -336,14 +336,18 @@
     "GoToFloraObservationPointStartPos": {
         "desc": "在植物观察点任务开始位置附近",
         "recognition": "Custom",
-        "custom_recognition": "MapLocateAssertLocation",
+        "custom_recognition": "MapTrackerAssertLocation",
         "custom_recognition_param": {
-            "zone_id": "Wuling_Base",
-            "target": [
-                477.62,
-                2108.95,
-                27.2,
-                27.33
+            "expected": [
+                {
+                    "map_name": "map02_lv004",
+                    "target": [
+                        0,
+                        0,
+                        1,
+                        1
+                    ]
+                }
             ]
         },
         "pre_delay": 0,
@@ -360,7 +364,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneEnterWorldWulingMarkerStone1"
+                "SceneAnyEnterWorld"
             ]
         },
         "post_delay": 0,
@@ -373,22 +377,20 @@
         "desc": "自动寻路前往植物观察点",
         "pre_delay": 0,
         "action": "Custom",
-        "custom_action": "MapNavigateAction",
+        "custom_action": "MapTrackerGoal",
         "custom_action_param": {
-            "path": [
-                {
-                    "action": "NAVMESH",
-                    "target": [
-                        125.73,
-                        112.6
-                    ],
-                    "target_tier": "Wuling_L4_330"
-                },
-                {
-                    "action": "HEADING",
-                    "angle": 180
+            "map_name": "map02_lv004",
+            "target": [
+                550.3,
+                252.6
+            ],
+            "on_finish": {
+                "action": "Custom",
+                "custom_action": "MapTrackerToward",
+                "custom_action_param": {
+                    "angle": 0
                 }
-            ]
+            }
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToHangingVines"
+            "HangingVinesInQuickTeleportMap"
         ]
     },
     "AlreadyTrackedHangingVines": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToHangingVines"
+            "HangingVinesOpenTrackedMissionMap"
         ]
     },
     "HangingVinesOpenTrackedMissionMap": {
@@ -342,10 +342,10 @@
                 {
                     "map_name": "map02_lv004",
                     "target": [
-                        602.8,
-                        325,
-                        9.7,
-                        8.1
+                        0,
+                        0,
+                        1,
+                        1
                     ]
                 }
             ]
@@ -364,7 +364,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneEnterWorldWulingMarkerStone3"
+                "SceneAnyEnterWorld"
             ]
         },
         "post_delay": 0,
@@ -381,14 +381,14 @@
         "custom_action_param": {
             "map_name": "map02_lv004",
             "target": [
-                520,
-                288
+                579.2,
+                253.7
             ],
             "on_finish": {
                 "action": "Custom",
                 "custom_action": "MapTrackerToward",
                 "custom_action_param": {
-                    "angle": 0
+                    "angle": 90
                 }
             }
         },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToPeachTreeAtBabblesSHome"
+            "PeachTreeAtBabblesSHomeInQuickTeleportMap"
         ]
     },
     "AlreadyTrackedPeachTreeAtBabblesSHome": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToPeachTreeAtBabblesSHome"
+            "PeachTreeAtBabblesSHomeOpenTrackedMissionMap"
         ]
     },
     "PeachTreeAtBabblesSHomeOpenTrackedMissionMap": {
@@ -304,7 +304,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToPeachTreeAtBabblesSHomeStartPos"
+            "GoToPeachTreeAtBabblesSHomeMove"
         ]
     },
     "PeachTreeAtBabblesSHomeNotAdapted": {
@@ -342,10 +342,10 @@
                 {
                     "map_name": "map02_lv004_tier_328",
                     "target": [
-                        514,
-                        666,
-                        15,
-                        15
+                        0,
+                        0,
+                        1,
+                        1
                     ]
                 }
             ]
@@ -358,19 +358,19 @@
         ]
     },
     "GoToPeachTreeAtBabblesSHomeNotAtStartPos": {
-        "desc": "不在念念家的桃树任务开始位置附近，先传送再检查落点",
+        "desc": "不在念念家的桃树任务开始位置附近，先传送再继续寻路",
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneEnterWorldWulingMarkerStone4"
+                "SceneAnyEnterWorld"
             ]
         },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToPeachTreeAtBabblesSHomeStartPos"
+            "GoToPeachTreeAtBabblesSHomeMove"
         ]
     },
     "GoToPeachTreeAtBabblesSHomeMove": {

--- a/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
@@ -126,6 +126,165 @@
         "next": [
             "EnvironmentMonitoringShutterButtonHighlighted",
             "EnvironmentMonitoringShutterButtonPhotographyTarget",
+            "EnvironmentMonitoringOpenPhotoSettings"
+        ]
+    },
+    "EnvironmentMonitoringPhotoSettingsTab": {
+        "desc": "拍照设置中的画面标签",
+        "recognition": "OCR",
+        "roi": [
+            20,
+            20,
+            110,
+            70
+        ],
+        "expected": [
+            "画面",
+            "畫面",
+            "(?i)Scene",
+            "화면"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "EnvironmentMonitoringPhotoSettingsPanelClosed": {
+        "desc": "拍照画面设置已关闭，inverse 必须由该节点独立执行",
+        "recognition": "OCR",
+        "roi": [
+            20,
+            60,
+            220,
+            90
+        ],
+        "expected": [
+            "显示干员",
+            "顯示幹員",
+            "(?i)Show\\s*Operator",
+            "オペレーターを表示",
+            "오퍼레이터 표시"
+        ],
+        "inverse": true,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "EnvironmentMonitoringWaitShutterButtonAfterHidingOperators"
+        ]
+    },
+    "EnvironmentMonitoringOpenPhotoSettings": {
+        "desc": "拍照目标未达成，打开画面设置",
+        "recognition": "And",
+        "all_of": [
+            "EnvironmentMonitoringPhotoSettingsTab"
+        ],
+        "box_index": 0,
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "EnvironmentMonitoringPhotoSettingsShowAllOperators",
+            "EnvironmentMonitoringClosePhotoSettingsWithOperatorsHidden"
+        ]
+    },
+    "EnvironmentMonitoringPhotoSettingsShowAllOperators": {
+        "desc": "拍照画面设置当前显示全部干员",
+        "recognition": "OCR",
+        "roi": [
+            180,
+            60,
+            240,
+            75
+        ],
+        "expected": [
+            "显示全部",
+            "顯示全部",
+            "(?i)Show\\s*All",
+            "全て表示",
+            "전체 표시"
+        ],
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "EnvironmentMonitoringPhotoSettingsHideAllOperators"
+        ]
+    },
+    "EnvironmentMonitoringPhotoSettingsHideAllOperators": {
+        "desc": "在显示干员下拉框中选择隐藏全部",
+        "recognition": "OCR",
+        "roi": [
+            180,
+            165,
+            240,
+            130
+        ],
+        "expected": [
+            "隐藏全部",
+            "隱藏全部",
+            "(?i)Hide\\s*All",
+            "全て非表示",
+            "전체 숨기기"
+        ],
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "EnvironmentMonitoringClosePhotoSettingsWithOperatorsHidden"
+        ]
+    },
+    "EnvironmentMonitoringPhotoSettingsOperatorsHidden": {
+        "desc": "拍照画面设置当前隐藏全部干员",
+        "recognition": "OCR",
+        "roi": [
+            180,
+            60,
+            240,
+            75
+        ],
+        "expected": [
+            "隐藏全部",
+            "隱藏全部",
+            "(?i)Hide\\s*All",
+            "全て非表示",
+            "전체 숨기기"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "EnvironmentMonitoringClosePhotoSettingsWithOperatorsHidden": {
+        "desc": "确认干员已全部隐藏后关闭画面设置",
+        "recognition": "And",
+        "all_of": [
+            "EnvironmentMonitoringPhotoSettingsOperatorsHidden",
+            "EnvironmentMonitoringPhotoSettingsTab"
+        ],
+        "box_index": 1,
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "EnvironmentMonitoringPhotoSettingsPanelClosed"
+        ]
+    },
+    "EnvironmentMonitoringWaitShutterButtonAfterHidingOperators": {
+        "desc": "隐藏全部干员后重新检查拍照目标",
+        "recognition": "And",
+        "all_of": [
+            "ShutterButton"
+        ],
+        "pre_wait_freezes": 200,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "EnvironmentMonitoringShutterButtonHighlighted",
+            "EnvironmentMonitoringShutterButtonPhotographyTarget",
             "[JumpBack][Anchor]EnvironmentMonitoringAdjustCamera"
         ]
     },

--- a/docs/en_us/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/en_us/developers/tasks/environment-monitoring-maintain.md
@@ -160,14 +160,14 @@ The default export of `data.mjs` is an array, where each element = the rendering
 | `Name` | Comes from the Chinese name in `kite_station_i18n.json`; `MissionId` is only used by `model.mjs` to match `routes.json` and is not passed to the template |
 | `GoToMonitoringTerminal` | Determined by `Station` |
 | `EnterMap` | `routes.json[*].EnterMap`; any defined Pipeline node name is allowed, without a required prefix, as long as the node can complete and return normally when run as a SubTask |
-| `MapName` / `MapAssert` / `MapPath` / `MapTarget` / `MapTargetTier` / `MapGoal` | `routes.json[*]`, corresponding to the initial location check and subsequent pathfinding parameters; `MapPath` generates `MapTrackerAssertLocation` + `MapTrackerMove`, `MapTarget` generates `MapLocateAssertLocation` + `MapNavigateAction` with the `NAVMESH` target point, `MapTargetTier` optionally generates `target_tier`, and `MapGoal` generates `MapTrackerAssertLocation` + `MapTrackerGoal`. Omit all of these fields when the teleport landing point can be photographed directly; otherwise exactly one of `MapPath` / `MapTarget` / `MapGoal` is required. |
+| `MapName` / `MapAssert` / `MapPath` / `MapTarget` / `MapTargetTier` / `MapGoal` | `routes.json[*]`, corresponding to the initial location check and subsequent pathfinding parameters; `MapPath` generates `MapTrackerAssertLocation` + `MapTrackerMove`, `MapTarget` generates `MapLocateAssertLocation` + `MapNavigateAction` with the `NAVMESH` target point, `MapTargetTier` optionally generates `target_tier`, and `MapGoal` generates `MapTrackerAssertLocation` + `MapTrackerGoal`. Omit all of these fields when the teleport landing point can be photographed directly; otherwise exactly one of `MapPath` / `MapTarget` / `MapGoal` is required. All three navigation modes may omit `MapAssert` when combined with `QuickTeleport`. |
 | `CameraSwipeDirection` | `routes.json[*]`, must be one of `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` |
 | `CameraMaxHit` | `routes.json[*].CameraMaxHit`, defaults to `2`; corresponds to the maximum hit count for the `${Id}AdjustCamera` swipe action |
 | `OcrReplace` | Passed through from `routes.json[*].Replace` to `Check${Id}Text.replace` and `In${Id}Mission.replace`; used to configure task-specific OCR replacement pairs for the task list and mission detail page, without affecting route adaptation checks |
 | `ExpectedText` | Automatically expanded from the `mission.name` multilingual map in `kite_station_i18n.json` (5 languages, English converted to flexible regex) |
 | `InExpectedText` | Automatically expanded from the `mission.shotTargetName` in `kite_station_i18n.json` |
 | `TrackOrGoToNext` / `AfterTrackedNext` | Automatically determined by `data.mjs` based on whether the route is complete: `TrackOrGoToNext` converges to `Track${Id}` / `AlreadyTracked${Id}`, `AfterTrackedNext` is `GoTo${Id}` when adapted, `${Id}NotAdapted` when not adapted |
-| `GoToNext` / `AfterTeleportDescription` / `AfterTeleportNext` | Automatically determined by `data.mjs`: direct-photo routes always perform the configured teleport and enter `${Id}TakePhoto`; `MapPath` returns to `GoTo${Id}StartPos` to verify the landing point; `MapTarget` / `MapGoal` proceed directly to `GoTo${Id}Move`. |
+| `GoToNext` / `AfterTeleportDescription` / `AfterTeleportNext` | Automatically determined by `data.mjs`: direct-photo routes always perform the configured teleport and enter `${Id}TakePhoto`; `QuickTeleport` with any navigation mode proceeds directly to `GoTo${Id}Move`; regular `MapPath` routes return to `GoTo${Id}StartPos` to verify the landing point, while `MapTarget` / `MapGoal` proceed directly to `GoTo${Id}Move`. |
 
 ### Terminal Grouping: `terminals-config.json`
 
@@ -215,10 +215,10 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 The teleport and pathfinding flow for observation points combines MapTracker and MapNavigator according to the route type:
 
-- `MapTrackerAssertLocation` / `MapLocateAssertLocation` (Recognition): Judges whether the current position is within the `MapAssert` rectangle based on the minimap. Uses `MapTrackerAssertLocation` when using `MapPath` / `MapGoal`, and `MapLocateAssertLocation` when using `MapTarget`.
+- `MapTrackerAssertLocation` / `MapLocateAssertLocation` (Recognition): Judges whether the current position is within the `MapAssert` rectangle based on the minimap. Regular teleport routes use it to decide whether `EnterMap` is needed, and `MapPath` checks it again after teleporting; quick-teleport routes may skip this check.
 - `MapTrackerMove` / `MapTrackerGoal` / `MapNavigateAction` (Action): Walks along the `MapPath` route to the target point, plans with `MapTrackerGoal`, or generates a `NAVMESH` target from `MapTarget`; `MapTargetTier` is passed through as `target_tier`.
 - `${Id}TakePhoto` (wrapper): Sets the task-specific `EnvironmentMonitoringBackToTerminal` and `EnvironmentMonitoringAdjustCamera` anchors before entering the shared photo flow.
-- Direct-photo routes perform neither a location assertion nor pathfinding; optional `Heading` invokes standalone `MapTrackerToward`. `MapPath` verifies `MapAssert` again after teleporting; `MapTarget` / `MapGoal` start NavMesh pathfinding immediately.
+- Direct-photo routes perform neither a location assertion nor pathfinding; optional `Heading` invokes standalone `MapTrackerToward`. Quick-teleport routes start `MapPath` / `MapTarget` / `MapGoal` navigation directly from the fixed landing point. After a regular teleport, `MapPath` verifies `MapAssert` again, while `MapTarget` / `MapGoal` start NavMesh pathfinding immediately.
 
 For detailed parameters and coordinate recording methods, see [map-tracker.md](../components/map-tracker.md), [map-locator.md](../components/map-locator.md), and [map-navigator.md](../components/map-navigator.md).
 
@@ -226,7 +226,7 @@ For detailed parameters and coordinate recording methods, see [map-tracker.md](.
 
 The `EnterMap` field must name an existing node under `assets/resource/pipeline/`. The name does not need to start with `Scene` and has no additional character restriction. A regular SceneManager entry or a task entry that encapsulates teleportation and interactions can both be used, provided that it can complete and return normally when run as a SubTask. With `QuickTeleport: true`, `EnterMap` is not called and may be omitted.
 
-`model.mjs` determines whether to enter the pathfinding/photo-taking process based on whether the `routes.json` entry is complete. Every adapted entry needs a real `EnterMap` or `QuickTeleport: true`, plus `CameraSwipeDirection`. If the teleport landing point can be photographed directly, omit `MapName`, `MapAssert`, and every navigation-related field; otherwise configure `MapName`, exactly one of `MapPath` / `MapTarget` / `MapGoal`, and the required `MapAssert`. Unadapted points take the `${Id}NotAdapted` branch.
+`model.mjs` determines whether to enter the pathfinding/photo-taking process based on whether the `routes.json` entry is complete. Every adapted entry needs a real `EnterMap` or `QuickTeleport: true`, plus `CameraSwipeDirection`. If the teleport landing point can be photographed directly, omit `MapName`, `MapAssert`, and every navigation-related field. Otherwise configure `MapName` and exactly one of `MapPath` / `MapTarget` / `MapGoal`; regular teleport routes also require `MapAssert`, while quick-teleport routes may omit it. Unadapted points take the `${Id}NotAdapted` branch.
 
 ### `routes.json` Configuration Types
 
@@ -236,7 +236,7 @@ Every fully adapted entry needs metadata, `CameraSwipeDirection`, and one telepo
 | ----------------- | -------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------- |
 | Metadata only | `MissionId` / `Name` / `Id` only | Omit | Accept and track only; no teleport or photo |
 | Photo at teleport | No `MapName` or navigation field; optional `Heading` | Omit | Teleport → optional `MapTrackerToward` → photo |
-| `MapPath` | `MapName` + `MapPath`; optional `Heading` / `NoEnsureInitialMovementState` | Required for both teleport methods | Assert fixed start → `MapTrackerMove` → photo |
+| `MapPath` | `MapName` + `MapPath`; optional `Heading` / `NoEnsureInitialMovementState` | Required with `EnterMap`; optional with quick teleport | `MapTrackerMove` → photo |
 | `MapTarget` | `MapName` + `MapTarget`; optional `MapTargetTier` for cross-tier targets | Required with `EnterMap`; optional with quick teleport | `MapNavigateAction` NAVMESH → photo |
 | `MapGoal` | `MapName` + `MapGoal`; optional `Heading` / `NoEnsureInitialMovementState` | Required with `EnterMap`; optional with quick teleport | `MapTrackerGoal` → photo |
 
@@ -280,7 +280,7 @@ Compare the `entrustTasks` in `kite_station_i18n.json` with the entries in `rout
     "Id": "MyNewObservationPoint",           // Final template node ID, for human searching nodes/file names only
     "EnterMap": "SceneEnterWorldWulingXxx",  // Defined Pipeline node that can complete and return as a SubTask
     "MapName": "map02_lv001",                // Map identifier: MapPath uses MapTracker map_name; MapGoal uses exact MapTracker map_name that can load NavMesh; MapTarget uses MapLocate zone_id
-    "MapAssert": [x, y, w, h],               // Initial location rectangle; only MapPath verifies it again after teleporting
+    "MapAssert": [x, y, w, h],               // Required for regular teleport navigation; optional for QuickTeleport with any navigation mode
     "MapPath": [[x1, y1], [x2, y2]],         // Pathfinding path (minimap coordinates), select one from MapTarget / MapGoal
     // "MapTarget": [x, y],                  // NAVMESH target point for MapNavigateAction
     // "MapTargetTier": "ValleyIV_L1_171",   // Optional; target_tier where the MapTarget coordinates are located, fill when target and start point are not in the same tier
@@ -317,7 +317,7 @@ Do not include `MapName`, `MapAssert`, `MapPath`, `MapTarget`, `MapTargetTier`, 
 
 ### 4. Record Coordinates and Paths
 
-If the teleport landing point cannot be photographed directly, use the GUI tool in [map-navigator.md](../components/map-navigator.md) to record `MapAssert` / `MapPath`. Copy the `NAVMESH` target point from MapNavigateAction into `MapTarget`, or use a `MapGoal`, and confirm in the game:
+If the teleport landing point cannot be photographed directly, use the GUI tool in [map-navigator.md](../components/map-navigator.md) to record `MapAssert` / `MapPath`. Copy the `NAVMESH` target point from MapNavigateAction into `MapTarget`, or use a `MapGoal`. `QuickTeleport` with any of these three navigation modes may omit `MapAssert`. Confirm in the game:
 
 - `MapName` is consistent with the tool used: For `MapPath` routes, fill in the MapTracker `map_name` (e.g., `map02_lv001` / regex); for `MapGoal` routes, fill in the exact MapTracker `map_name` that can load NavMesh (e.g., `map02_lv001`); for `MapTarget` routes, fill in the MapLocate `zone_id` (e.g., `Wuling_Base`); optional `MapTargetTier` fills the MapNavigator `target_tier` region name. Do not mix the two sets of identifiers.
 
@@ -360,7 +360,7 @@ Before submission, at least check:
 
 1. Are the fields for new/modified entries in `tools/pipeline-generate/EnvironmentMonitoring/routes.json` complete?
 2. Does the `MissionId` for new entries in `routes.json` match the `missionId` in `kite_station_i18n.json`; `Id` is automatically refreshed by the generator.
-3. Does every adapted entry have a real teleport method and `CameraSwipeDirection`; do direct-photo routes omit all map/navigation fields, while navigation routes select exactly one of `MapPath` / `MapTarget` / `MapGoal` and provide the required `MapAssert`?
+3. Does every adapted entry have a real teleport method and `CameraSwipeDirection`; do direct-photo routes omit all map/navigation fields, while navigation routes select exactly one of `MapPath` / `MapTarget` / `MapGoal` and regular teleport routes provide `MapAssert`?
 4. In the regenerated `Terminals.json`, does each `{Station}MonitoringTerminalLoop.next` contain all new `[JumpBack]{Id}Job`, and end with `EnvironmentMonitoringTerminalFinish`?
 5. Does the node referenced by `EnterMap` exist under `assets/resource/pipeline/`, and can it complete and return normally as a SubTask?
 6. Is `CameraSwipeDirection` one of the four: `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}`?

--- a/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
@@ -172,14 +172,14 @@ MysteriousCryptidGraffiti         → 谜之生物的涂鸦
 | `GoToMonitoringTerminal` | 由 `Station` 决定 |
 | `EnterMap` | `routes.json[*].EnterMap`，默认传送入口；可填写任意已定义、能作为 SubTask 正常返回的 Pipeline 节点名，不限制名称前缀；启用 `QuickTeleport` 时不会使用，可省略 |
 | `QuickTeleport` | `routes.json[*].QuickTeleport`，可选布尔值，默认 `false`；启用后从追踪任务地图依次点击“前往传送”和“传送”，不调用 `EnterMap` |
-| `MapName` / `MapAssert` / `MapPath` / `MapTarget` / `MapTargetTier` / `MapGoal` | `routes.json[*]`，对应初始位置判断与后续寻路参数；`MapPath` 生成 `MapTrackerAssertLocation` + `MapTrackerMove`，`MapTarget` 生成 `MapLocateAssertLocation` + `MapNavigateAction` 的 `NAVMESH` 目标点，`MapTargetTier` 可选生成 `target_tier`，`MapGoal` 生成 `MapTrackerAssertLocation` + `MapTrackerGoal`。传送后直拍时这些字段全部省略；寻路时 `MapPath` / `MapTarget` / `MapGoal` 三者必须且只能选一个；`QuickTeleport + MapTarget/MapGoal` 可省略 `MapAssert` |
+| `MapName` / `MapAssert` / `MapPath` / `MapTarget` / `MapTargetTier` / `MapGoal` | `routes.json[*]`，对应初始位置判断与后续寻路参数；`MapPath` 生成 `MapTrackerAssertLocation` + `MapTrackerMove`，`MapTarget` 生成 `MapLocateAssertLocation` + `MapNavigateAction` 的 `NAVMESH` 目标点，`MapTargetTier` 可选生成 `target_tier`，`MapGoal` 生成 `MapTrackerAssertLocation` + `MapTrackerGoal`。传送后直拍时这些字段全部省略；寻路时 `MapPath` / `MapTarget` / `MapGoal` 三者必须且只能选一个；`QuickTeleport` 与三种寻路方式组合时均可省略 `MapAssert` |
 | `CameraSwipeDirection` | `routes.json[*]`，必须是 `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` 之一 |
 | `CameraMaxHit` | `routes.json[*].CameraMaxHit`，缺省为 `2`；对应 `${Id}AdjustCamera` 滑屏动作的最大命中次数 |
 | `OcrReplace` | 由 `routes.json[*].Replace` 透传到 `Check${Id}Text.replace` 与 `In${Id}Mission.replace`；用于按任务配置任务列表和任务详情页 OCR 的易混字符替换，不影响路线是否已适配的判断 |
 | `ExpectedText` | 由 `kite_station_i18n.json` 的 `mission.name` 多语言 map 自动展开（5 语言，英文转柔性正则） |
 | `InExpectedText` | 由 `kite_station_i18n.json` 的 `mission.shotTargetName` 自动展开 |
 | `TrackOrGoToNext` / `AfterTrackNext` / `AfterAlreadyTrackedNext` | 由 `data.mjs` 根据路线是否完整及 `QuickTeleport` 自动决定：默认进入 `GoTo${Id}`；快捷传送时，开始追踪后等待任务地图，已追踪则先点击定位图标打开任务地图；未适配时进入 `${Id}NotAdapted` |
-| `GoToNext` / `AfterTeleportDescription` / `AfterTeleportNext` | 由 `data.mjs` 根据路线类型自动决定：传送后直拍始终执行真实传送并进入 `${Id}TakePhoto`；`MapPath` 传送后返回 `GoTo${Id}StartPos` 复核落点；`MapTarget` / `MapGoal` 传送后直接进入 `GoTo${Id}Move` |
+| `GoToNext` / `AfterTeleportDescription` / `AfterTeleportNext` | 由 `data.mjs` 根据传送入口和路线类型自动决定：传送后直拍始终执行真实传送并进入 `${Id}TakePhoto`；`QuickTeleport` 与任一寻路方式组合时传送后直接进入 `GoTo${Id}Move`；普通传送的 `MapPath` 返回 `GoTo${Id}StartPos` 复核落点，`MapTarget` / `MapGoal` 直接进入 `GoTo${Id}Move` |
 
 ### 终端分组：`terminals-config.json`
 
@@ -227,10 +227,10 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 观察点的传送与寻路流程会按路线类型组合使用 MapTracker 与 MapNavigator：
 
-- `MapTrackerAssertLocation` / `MapLocateAssertLocation`（识别）：根据当前小地图判断是否在 `MapAssert` 矩形内。普通传送路线用于判断是否需要调用 `EnterMap`，`QuickTeleport + MapPath` 用于传送后复核固定起点；`QuickTeleport + MapTarget/MapGoal` 不进入该节点，可省略 `MapAssert`。
+- `MapTrackerAssertLocation` / `MapLocateAssertLocation`（识别）：根据当前小地图判断是否在 `MapAssert` 矩形内。普通传送路线用于判断是否需要调用 `EnterMap`，其中 `MapPath` 还会在传送后再次复核；`QuickTeleport + MapPath/MapTarget/MapGoal` 从固定传送落点直接开始寻路，不进入该节点，可省略 `MapAssert`。
 - `MapTrackerMove` / `MapTrackerGoal` / `MapNavigateAction`（动作）：沿 `MapPath` 路径走到目标点，按 `MapGoal` 调用 `MapTrackerGoal` 自动规划并前往目标，或按 `MapTarget` 生成 `NAVMESH` 目标点并前往目标；`MapTargetTier` 会透传为 `target_tier`，用于目标坐标与起点不在同一 tier 的情况。
 - `${Id}TakePhoto`（包装节点）：为寻路和直拍路线统一设置 `EnvironmentMonitoringBackToTerminal` / `EnvironmentMonitoringAdjustCamera` anchor，再进入公共拍照流程。
-- 传送后直拍不执行地图断言或寻路；配置 `Heading` 时会独立调用 `MapTrackerToward` 调整角色朝向。`MapPath` 路线传送后再次复核 `MapAssert`；`MapTarget` / `MapGoal` 路线依靠 NavMesh 从传送点附近自行前往目标。
+- 传送后直拍不执行地图断言或寻路；配置 `Heading` 时会独立调用 `MapTrackerToward` 调整角色朝向。快捷传送路线从固定传送落点直接开始 `MapPath` / `MapTarget` / `MapGoal` 寻路；普通传送的 `MapPath` 会再次复核 `MapAssert`，`MapTarget` / `MapGoal` 则直接开始 NavMesh 寻路。
 
 详细参数与坐标录制方式见 [map-tracker.md](../components/map-tracker.md)、[map-locator.md](../components/map-locator.md) 与 [map-navigator.md](../components/map-navigator.md)。
 
@@ -238,7 +238,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 默认传送路线的 `EnterMap` 字段必须填写 `assets/resource/pipeline/` 中已存在的 Pipeline 节点名。名称不要求以 `Scene` 开头，也不限制字符组合；普通 SceneManager 万能跳转与封装了传送、交互等流程的任务入口均可使用，但节点必须能作为 SubTask 完整执行后正常返回。启用 `QuickTeleport: true` 时不会调用 `EnterMap`，该字段可以省略。
 
-`model.mjs` 通过判断 `routes.json` 条目是否完整决定是否进入寻路/拍照流程，未适配点会直接走 `${Id}NotAdapted` 分支。所有已适配条目都必须在真实 `EnterMap` 与 `QuickTeleport: true` 中至少选择一种传送入口，并配置 `CameraSwipeDirection`。如果传送落点已经满足拍照条件，则省略 `MapName`、`MapAssert` 和全部寻路相关字段，生成器自动进入直拍分支；否则需要配置 `MapName`，在 `MapPath` / `MapTarget` / `MapGoal` 中三选一，并按路线类型补 `MapAssert`。
+`model.mjs` 通过判断 `routes.json` 条目是否完整决定是否进入寻路/拍照流程，未适配点会直接走 `${Id}NotAdapted` 分支。所有已适配条目都必须在真实 `EnterMap` 与 `QuickTeleport: true` 中至少选择一种传送入口，并配置 `CameraSwipeDirection`。如果传送落点已经满足拍照条件，则省略 `MapName`、`MapAssert` 和全部寻路相关字段，生成器自动进入直拍分支；否则需要配置 `MapName`，在 `MapPath` / `MapTarget` / `MapGoal` 中三选一。普通传送寻路路线还需配置 `MapAssert`，快捷传送寻路路线可省略。
 
 ### `routes.json` 配置类型
 
@@ -248,7 +248,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 | ------------- | ---------------------------------------------------------------------- | ---------------------------- | ------------------------------------------ |
 | metadata-only | 仅 `MissionId` / `Name` / `Id` | 不填 | 仅接取并追踪，不传送或拍照 |
 | 传送后直拍 | 不填 `MapName` 和寻路字段；可选 `Heading` | 不填 | 传送 → 可选 `MapTrackerToward` → 拍照 |
-| `MapPath` | `MapName` + `MapPath`；可选 `Heading` / `NoEnsureInitialMovementState` | 默认传送和快捷传送都必填 | 断言固定起点 → `MapTrackerMove` → 拍照 |
+| `MapPath` | `MapName` + `MapPath`；可选 `Heading` / `NoEnsureInitialMovementState` | 默认传送必填；快捷传送可省略 | `MapTrackerMove` → 拍照 |
 | `MapTarget` | `MapName` + `MapTarget`；跨层时可加 `MapTargetTier` | 默认传送必填；快捷传送可省略 | `MapNavigateAction` 的 NAVMESH 寻路 → 拍照 |
 | `MapGoal` | `MapName` + `MapGoal`；可选 `Heading` / `NoEnsureInitialMovementState` | 默认传送必填；快捷传送可省略 | `MapTrackerGoal` 自动寻路 → 拍照 |
 
@@ -289,7 +289,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
     "EnterMap": "SceneEnterWorldWulingXxx", // 已定义且能作为 SubTask 正常返回的 Pipeline 节点
     // "QuickTeleport": true,             // 可选；启用后从追踪任务地图快捷传送，EnterMap 可省略
     "MapName": "map02_lv001",               // 地图标识：MapPath 用 MapTracker map_name；MapGoal 用可加载 NavMesh 的精确 MapTracker map_name；MapTarget 用 MapLocate zone_id
-    "MapAssert": [x, y, w, h],              // 普通传送和 QuickTeleport + MapPath 必填；快捷传送的 MapTarget / MapGoal 可省略
+    "MapAssert": [x, y, w, h],              // 普通传送的寻路路线必填；快捷传送的 MapPath / MapTarget / MapGoal 可省略
     "MapPath": [[x1, y1], [x2, y2]],        // 寻路路径（小地图坐标），与 MapTarget / MapGoal 三选一
     // "MapTarget": [x, y],             // MapNavigateAction 的 NAVMESH 目标点
     // "MapTargetTier": "ValleyIV_L1_171", // 可选；MapTarget 坐标所在的 target_tier，目标与起点不在同一 tier 时填写
@@ -326,7 +326,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 ### 4. 录制坐标和路径
 
-如果传送点不能直接拍照，参考 [map-navigator.md](../components/map-navigator.md) 的 GUI 工具录制所需的 `MapAssert` / `MapPath`，复制 MapNavigateAction 的 `NAVMESH` 目标点填入 `MapTarget`，需要跨层目标时把 `target_tier` 填入 `MapTargetTier`，或复制 MapTrackerGoal 目标点填入 `MapGoal`。仅 `QuickTeleport + MapTarget/MapGoal` 不需要录制 `MapAssert`。随后在游戏中确认：
+如果传送点不能直接拍照，参考 [map-navigator.md](../components/map-navigator.md) 的 GUI 工具录制所需的 `MapAssert` / `MapPath`，复制 MapNavigateAction 的 `NAVMESH` 目标点填入 `MapTarget`，需要跨层目标时把 `target_tier` 填入 `MapTargetTier`，或复制 MapTrackerGoal 目标点填入 `MapGoal`。`QuickTeleport + MapPath/MapTarget/MapGoal` 不需要录制 `MapAssert`。随后在游戏中确认：
 
 - `MapName` 与使用的工具一致：`MapPath` 路线填写 MapTracker 的 `map_name`（如 `map02_lv001` / 正则），`MapGoal` 路线填写可加载 NavMesh 的精确 MapTracker `map_name`（如 `map02_lv001`），`MapTarget` 路线填写 MapLocate 的 `zone_id`（如 `Wuling_Base`），可选的 `MapTargetTier` 填 MapNavigator `target_tier` 的区域名。两套标识不要混用。
 
@@ -369,7 +369,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 1. `tools/pipeline-generate/EnvironmentMonitoring/routes.json` 中新增/修改条目是否字段齐全。
 2. `routes.json` 中新增条目的 `MissionId` 是否能匹配 `kite_station_i18n.json` 的 `missionId`；`Id` 由生成器自动刷新。
-3. 已适配条目的传送入口已在真实 `EnterMap` 与 `QuickTeleport: true` 中至少选择一种，`CameraSwipeDirection` 已填写真实值；直拍路线没有任何地图与寻路字段，寻路路线则在 `MapPath` / `MapTarget` / `MapGoal` 中三选一，并按类型补齐真实 `MapAssert`。
+3. 已适配条目的传送入口已在真实 `EnterMap` 与 `QuickTeleport: true` 中至少选择一种，`CameraSwipeDirection` 已填写真实值；直拍路线没有任何地图与寻路字段，寻路路线则在 `MapPath` / `MapTarget` / `MapGoal` 中三选一，且普通传送路线补齐真实 `MapAssert`。
 4. 重生成的 `Terminals.json` 中各 `{Station}MonitoringTerminalLoop.next` 包含全部新 `[JumpBack]{Id}Job`，并以 `EnvironmentMonitoringTerminalFinish` 收尾。
 5. 若填写了 `EnterMap`，其引用的节点确实存在于 `assets/resource/pipeline/`，并能作为 SubTask 完整执行后正常返回。
 6. `CameraSwipeDirection` 是 `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` 四者之一。

--- a/tests/EnvironmentMonitoring/test_job.json
+++ b/tests/EnvironmentMonitoring/test_job.json
@@ -25,13 +25,44 @@
         {
             "image": "武陵_拍照模式_拍摄目标.png",
             "hits": [
+                "EnvironmentMonitoringPhotoSettingsTab",
+                "EnvironmentMonitoringOpenPhotoSettings",
                 "EnvironmentMonitoringShutterButtonHighlighted",
                 "EnvironmentMonitoringShutterButtonPhotographyTarget"
             ]
         },
         {
             "image": "武陵_拍照模式_拍摄目标未达成.png",
-            "hits": []
+            "hits": [
+                "EnvironmentMonitoringPhotoSettingsTab",
+                "EnvironmentMonitoringOpenPhotoSettings"
+            ]
+        },
+        {
+            "image": "武陵_拍照模式_画面设置.png",
+            "hits": [
+                "EnvironmentMonitoringPhotoSettingsTab",
+                "EnvironmentMonitoringOpenPhotoSettings",
+                "EnvironmentMonitoringPhotoSettingsShowAllOperators"
+            ]
+        },
+        {
+            "image": "武陵_拍照模式_显示干员选项.png",
+            "hits": [
+                "EnvironmentMonitoringPhotoSettingsTab",
+                "EnvironmentMonitoringOpenPhotoSettings",
+                "EnvironmentMonitoringPhotoSettingsShowAllOperators",
+                "EnvironmentMonitoringPhotoSettingsHideAllOperators"
+            ]
+        },
+        {
+            "image": "武陵_拍照模式_隐藏全部.png",
+            "hits": [
+                "EnvironmentMonitoringPhotoSettingsTab",
+                "EnvironmentMonitoringOpenPhotoSettings",
+                "EnvironmentMonitoringPhotoSettingsOperatorsHidden",
+                "EnvironmentMonitoringClosePhotoSettingsWithOperatorsHidden"
+            ]
         }
     ]
 }

--- a/tools/pipeline-generate/EnvironmentMonitoring/README.md
+++ b/tools/pipeline-generate/EnvironmentMonitoring/README.md
@@ -54,8 +54,8 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
         // 使用 MapGoal 时填可加载 NavMesh 的精确 MapTracker map_name；
         // 使用 MapTarget 时填 MapLocate 的 zone_id。必须与录制工具保持一致。
     "MapAssert": [x, y, w, h],
-        // 初始位置判断矩形。普通传送和 QuickTeleport + MapPath 必填；
-        // QuickTeleport + MapTarget / MapGoal 传送后直接开始 NavMesh 寻路，可省略。
+        // 初始位置判断矩形。普通传送的寻路路线必填；
+        // QuickTeleport + MapPath / MapTarget / MapGoal 传送后直接开始寻路，可省略。
         // 如果传送点可以直接拍照，则连同 MapName 和三种寻路字段一起省略。
     "MapPath": [[x1, y1], [x2, y2]],
         // 寻路路径（小地图坐标序列），由 MapTrackerMove 逐点跟随。
@@ -96,7 +96,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 > `routes.json` 是严格 JSON：不允许行内注释、不允许尾随逗号。上面的注释只是文档示意，实际文件里要去掉。需要寻路时，`MapPath` / `MapTarget` / `MapGoal` 必须且只能填写其中一个；如果传送点可以直接拍照，则不要填写 `MapName`、`MapAssert`、三种寻路字段、`MapTargetTier` 或 `NoEnsureInitialMovementState`，但可以按实测结果保留可选的 `Heading`。生成器会根据“存在真实传送入口和 `CameraSwipeDirection`，同时没有 `MapAssert` 和寻路配置”自动进入直拍分支，不需要额外开关字段。
 
-> 传送后的处理取决于路线类型：传送后直拍不做位置断言或寻路；配置 `Heading` 时先独立调用 `MapTrackerToward`，随后进入任务专属拍照包装节点。`MapPath` 需要再次通过 `MapAssert` 复核固定起点；`MapTarget` / `MapGoal` 使用 NavMesh，可从传送点附近自行前往目标，因此快捷传送后会直接开始寻路并允许省略 `MapAssert`。普通传送的寻路路线仍会在决定是否调用 `EnterMap` 前使用 `MapAssert`，所以不能省略。
+> 传送后的处理取决于入口和路线类型：传送后直拍不做位置断言或寻路；配置 `Heading` 时先独立调用 `MapTrackerToward`，随后进入任务专属拍照包装节点。`QuickTeleport` 的固定传送落点可直接进入 `MapPath` / `MapTarget` / `MapGoal` 寻路，因此允许省略 `MapAssert`。普通传送的寻路路线仍会在决定是否调用 `EnterMap` 前使用 `MapAssert`，所以不能省略；传送完成后，仅 `MapPath` 会再次复核固定起点，`MapTarget` / `MapGoal` 直接开始 NavMesh 寻路。
 
 > 传送入口由 `QuickTeleport` 决定：默认通过 `EnterMap` 调用配置的 Pipeline 节点，不限制节点名称；该节点需能作为 SubTask 完整执行后正常返回。启用快捷传送后，“开始追踪”会直接等待任务地图，“已追踪”会先点击“停止追踪”旁的定位图标打开任务地图，随后依次点击“前往传送”和“传送”，此时 `EnterMap` 可省略。
 
@@ -112,7 +112,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 | ------------- | ---------------------------------------------------------------------- | ---------------------------- | ------------------------------------------ |
 | metadata-only | 仅 `MissionId` / `Name` / `Id` | 不填 | 仅接取并追踪，不传送或拍照 |
 | 传送后直拍 | 不填 `MapName` 和任何寻路字段；`Heading` 可选 | 不填 | 传送 → 可选 `MapTrackerToward` → 拍照 |
-| `MapPath` | `MapName` + `MapPath`；可选 `Heading` / `NoEnsureInitialMovementState` | 默认传送和快捷传送都必填 | 断言固定起点 → `MapTrackerMove` → 拍照 |
+| `MapPath` | `MapName` + `MapPath`；可选 `Heading` / `NoEnsureInitialMovementState` | 默认传送必填；快捷传送可省略 | `MapTrackerMove` → 拍照 |
 | `MapTarget` | `MapName` + `MapTarget`；跨层时可加 `MapTargetTier` | 默认传送必填；快捷传送可省略 | `MapNavigateAction` 的 NAVMESH 寻路 → 拍照 |
 | `MapGoal` | `MapName` + `MapGoal`；可选 `Heading` / `NoEnsureInitialMovementState` | 默认传送必填；快捷传送可省略 | `MapTrackerGoal` 自动寻路 → 拍照 |
 

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/data.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/data.mjs
@@ -59,7 +59,7 @@ export function buildRow(mission) {
                   `GoTo${Id}StartPos`,
                   `GoTo${Id}NotAtStartPos`,
               ];
-    // NavMesh 可自行处理传送点附近的落点；手录路径仍需确认固定起点。
+    // NavMesh 可处理传送点附近落点，快捷传送的手录路径也可从固定落点开始；普通 MapPath 仍需复核起点。
     const AfterTeleportDescription = route.IsDirectPhoto
         ? route.HasHeading
             ? "传送后调整朝向并拍照"

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.mjs
@@ -41,7 +41,7 @@ export function collectMissingRouteFields(route) {
         hasMapGoal,
     ].filter(Boolean).length;
     const isDirectPhoto = !hasMapAssert && navigationConfigCount === 0;
-    const canSkipMapAssert = quickTeleport && navigationConfigCount === 1 && (hasMapTarget || hasMapGoal);
+    const canSkipMapAssert = quickTeleport && navigationConfigCount === 1;
     const missingFields = [];
 
     if (!quickTeleport && isFieldMissing(route.EnterMap)) {
@@ -273,7 +273,7 @@ export function createRouteResolver(routeConfig, options = {}) {
                 hasMapGoal,
             ].filter(Boolean).length;
             const isDirectPhoto = isFieldMissing(override?.MapAssert) && navigationConfigCount === 0;
-            const canSkipMapAssert = QuickTeleport && navigationConfigCount === 1 && (hasMapTarget || hasMapGoal);
+            const canSkipMapAssert = QuickTeleport && navigationConfigCount === 1;
 
             const resolved = {};
             const missingFields = collectMissingRouteFields(override);
@@ -346,7 +346,8 @@ export function createRouteResolver(routeConfig, options = {}) {
                 NoEnsureInitialMovementState,
                 QuickTeleport,
                 IsDirectPhoto: isAdapted && isDirectPhoto,
-                ShouldAssertAfterTeleport: !isDirectPhoto && (navigationConfigCount !== 1 || hasMapPath),
+                ShouldAssertAfterTeleport:
+                    !isDirectPhoto && (navigationConfigCount !== 1 || (hasMapPath && !QuickTeleport)),
                 ...heading,
                 ...buildNavigationParams({
                     MapName,

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.test.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.test.mjs
@@ -130,3 +130,68 @@ test("existing navigation forms remain adapted", () => {
     assert.equal(result.IsDirectPhoto, false);
     assert.deepEqual(result.missingFields, []);
 });
+
+test("QuickTeleport MapPath routes can skip MapAssert", () => {
+    const result = resolve({
+        MissionId: mission.missionId,
+        Name: "测试观察点",
+        Id: "TestMission",
+        QuickTeleport: true,
+        MapName: "map02_lv001",
+        MapPath: [
+            [
+                5,
+                5,
+            ],
+        ],
+        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
+    });
+
+    assert.equal(result.isAdapted, true);
+    assert.equal(result.IsDirectPhoto, false);
+    assert.equal(result.ShouldAssertAfterTeleport, false);
+    assert.equal(result.RouteAction, "MapTrackerMove");
+    assert.deepEqual(result.missingFields, []);
+});
+
+test("non-QuickTeleport MapPath routes still require MapAssert", () => {
+    const missingFields = collectMissingRouteFields({
+        EnterMap: "SceneEnterWorldTest",
+        MapName: "map02_lv001",
+        MapPath: [
+            [
+                5,
+                5,
+            ],
+        ],
+        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
+    });
+
+    assert.deepEqual(missingFields, ["MapAssert"]);
+});
+
+test("non-QuickTeleport MapGoal routes still skip the post-teleport assertion", () => {
+    const result = resolve({
+        MissionId: mission.missionId,
+        Name: "测试观察点",
+        Id: "TestMission",
+        EnterMap: "SceneEnterWorldTest",
+        MapName: "map02_lv001",
+        MapAssert: [
+            0,
+            0,
+            10,
+            10,
+        ],
+        MapGoal: [
+            5,
+            5,
+        ],
+        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
+    });
+
+    assert.equal(result.isAdapted, true);
+    assert.equal(result.ShouldAssertAfterTeleport, false);
+    assert.equal(result.RouteAction, "MapTrackerGoal");
+    assert.deepEqual(result.missingFields, []);
+});

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -673,14 +673,8 @@
         "MissionId": "m1m66",
         "Name": "念念家的桃树",
         "Id": "PeachTreeAtBabblesSHome",
-        "EnterMap": "SceneEnterWorldWulingMarkerStone4",
+        "QuickTeleport": true,
         "MapName": "map02_lv004_tier_328",
-        "MapAssert": [
-            514,
-            666,
-            15,
-            15
-        ],
         "MapPath": [
             [
                 520.3,

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -599,41 +599,28 @@
         "MissionId": "m1m62",
         "Name": "垂藤",
         "Id": "HangingVines",
-        "EnterMap": "SceneEnterWorldWulingMarkerStone3",
+        "QuickTeleport": true,
         "MapName": "map02_lv004",
-        "MapAssert": [
-            602.8,
-            325,
-            9.7,
-            8.1
-        ],
         "MapGoal": [
-            520,
-            288
+            579.2,
+            253.7
         ],
         "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenUp",
         "CameraMaxHit": 3,
-        "Heading": 0
+        "Heading": 90
     },
     {
         "MissionId": "m1m63",
         "Name": "植物观察点",
         "Id": "FloraObservationPoint",
-        "EnterMap": "SceneEnterWorldWulingMarkerStone1",
-        "MapName": "Wuling_Base",
-        "MapAssert": [
-            477.62,
-            2108.95,
-            27.2,
-            27.33
+        "QuickTeleport": true,
+        "MapName": "map02_lv004",
+        "MapGoal": [
+            550.3,
+            252.6
         ],
-        "MapTarget": [
-            125.73,
-            112.6
-        ],
-        "MapTargetTier": "Wuling_L4_330",
         "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenDown",
-        "Heading": 180
+        "Heading": 0
     },
     {
         "MissionId": "m1m64",

--- a/tools/schema/environment_monitoring_routes.schema.json
+++ b/tools/schema/environment_monitoring_routes.schema.json
@@ -177,6 +177,11 @@
                                                     "anyOf": [
                                                         {
                                                             "required": [
+                                                                "MapPath"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "required": [
                                                                 "MapTarget"
                                                             ]
                                                         },
@@ -260,7 +265,7 @@
             },
             "MapAssert": {
                 "type": "array",
-                "description": "初始位置判断矩形 [x, y, w, h]。普通传送寻路路线和 MapPath 快捷传送路线必填；QuickTeleport 与 MapTarget / MapGoal 组合时可省略；传送后直拍时必须省略。",
+                "description": "初始位置判断矩形 [x, y, w, h]。普通传送寻路路线必填；QuickTeleport 与 MapPath / MapTarget / MapGoal 组合时可省略；传送后直拍时必须省略。",
                 "items": {
                     "type": "number"
                 },


### PR DESCRIPTION
fixed #4751
fixed #4745
fixed #4742
fixed #4729

## 概要

- 拍照目标与快门高亮均未达成时，先打开画面设置并隐藏全部干员；重新检查仍未达成后才调整摄像头视角
- 将垂藤、植物观察点改为任务地图快速传送，并更新实测的 MapGoal 与 Heading
- 修正快速传送 MapPath 路线的生成契约，同步念念家的桃树产物、schema、维护文档与 skill
- 为 Win32 / ADB 补充画面设置、显示干员选项和隐藏全部三类脱敏测试截图

## 验证

- `pnpm generate:EnvironmentMonitoring`：32 条路线、832 个节点、0 个诊断
- `node .agents/skills/environment-monitoring-add-route/check_missing.mjs`：全部观察点完整适配
- `pnpm format`
- `pnpm check`
- `pnpm test`：768 / 768
- 实机验证拍照隐藏干员流程通过

## 子模块

- `tests/MaaEndTestset` → `fe7beccd7cc7b35dca94059731e0d9a658165c9a`

## Summary by Sourcery

放宽针对快速传送（quick-teleport）导航路线的 MapAssert 要求，并统一生成器行为、测试和文档。

Enhancements:
- 更新路由解析器，使 QuickTeleport 的 MapPath/MapTarget/MapGoal 路线可以跳过 MapAssert，并且对 quick-teleport 的 MapPath 免除传送后的断言。
- 调整环境监控数据生成逻辑，在起始于固定落点（fixed landing points）时，将 quick-teleport 的 MapPath 与 NavMesh 路线同等对待。

Documentation:
- 在英文和中文的环境监控维护文档及 README 中，记录放宽的 MapAssert 要求以及 QuickTeleport 路线新的传送/导航行为。

Tests:
- 新增路由解析器测试，用于覆盖 QuickTeleport MapPath 的行为以及非 QuickTeleport 的 MapPath/MapGoal 断言要求。
- 更新环境监控的流水线、路由、schema，以及 MaaEndTestset fixtures，以反映新的路由约定和武陵（Wuling）观察路线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax MapAssert requirements for quick-teleport navigation routes and align generator behavior, tests, and documentation.

Enhancements:
- Update route resolver to allow QuickTeleport MapPath/MapTarget/MapGoal routes to skip MapAssert and avoid post-teleport assertions for quick-teleport MapPath.
- Adjust Environment Monitoring data generation to treat quick-teleport MapPath similarly to NavMesh routes when starting from fixed landing points.

Documentation:
- Document the relaxed MapAssert requirement and new teleport/navigation behavior for QuickTeleport routes in both English and Chinese environment monitoring maintenance docs and README.

Tests:
- Add route resolver tests to cover QuickTeleport MapPath behavior and non-QuickTeleport MapPath/MapGoal assertion requirements.
- Update Environment Monitoring pipelines, routes, schema, and MaaEndTestset fixtures to reflect the new routing contracts and Wuling observation routes.

</details>