### PR TITLE
fix: 生态农场拍照模式跟随「使用当前便捷工具」键位

### DIFF
--- a/assets/tasks/setting/Keymap.json
+++ b/assets/tasks/setting/Keymap.json
@@ -31,6 +31,15 @@
                 },
                 "EnterCameraModeKeyUp": {
                     "key": "{KeymapUseCurrentQuickTool.primary}"
+                },
+                "_AutoEcoFarmEnterCameraModeKeyDownR": {
+                    "key": "{KeymapUseCurrentQuickTool.primary}"
+                },
+                "_AutoEcoFarmEnterCameraModeFailKeyUp": {
+                    "key": "{KeymapUseCurrentQuickTool.primary}"
+                },
+                "_AutoEcoFarmEnterCameraModeKeyUpR": {
+                    "key": "{KeymapUseCurrentQuickTool.primary}"
                 }
             }
         },


### PR DESCRIPTION
## Summary
- 将生态农场进入拍照模式的三个硬编码按键节点纳入 `KeymapGeneral.pipeline_override`，使其跟随「使用当前便捷工具」设置
- 修复用户将快捷键改为非默认 R（如 T）后，生态农场仍按 R 长按导致无法打开选相机界面的问题

Closes https://github.com/MaaEnd/MaaEnd/issues/4788

## Summary by Sourcery

使生态农场照片模式的按键绑定与通用的“使用当前快捷工具”按键配置保持一致。

Bug Fixes:
- 确保生态农场照片模式和相机选择遵循自定义按键绑定，而不是假定默认的 R 键。
- 修复当“使用当前快捷工具”被重新绑定到非默认按键时，无法在生态农场打开相机选择界面的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align eco farm photo mode keybindings with the generic "use current quick tool" keymap configuration.

Bug Fixes:
- Ensure eco farm photo mode and camera selection respect custom keybindings instead of assuming the default R key.
- Fix inability to open the camera selection UI in eco farm when "use current quick tool" is rebound to a non-default key.

</details>