### PR TITLE
fix(puzzle): 调整拼图投影识别常数

### DIFF
--- a/agent/go-service/puzzle-solver/utils.go
+++ b/agent/go-service/puzzle-solver/utils.go
@@ -30,7 +30,7 @@ func matchTemplateAll(ctx *maa.Context, img image.Image, template string, roi []
 		nodeName: map[string]any{
 			"recognition": "TemplateMatch",
 			"template":    template,
-			"threshold":   0.7,
+			"threshold":   0.667,
 			"roi":         roi,
 			"order_by":    "score",
 			"method":      5, // TM_CCOEFF_NORMED


### PR DESCRIPTION
## 概要

此 PR 将拼图任务的通用识别函数的阈值从 0.7 降到 0.667。

## 关联

解决一个旧的 Issue：

Fix #1236

## Summary by Sourcery

改进：
- 将拼图识别的阈值常量从 0.7 调整为 0.667，以提高匹配的鲁棒性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust puzzle recognition threshold constant from 0.7 to 0.667 to improve matching robustness.

</details>