### PR TITLE
feat(mapnavigator): 优化地图交互与配置导出

### DIFF
--- a/docs/zh_cn/developers/components/map-navigator.md
+++ b/docs/zh_cn/developers/components/map-navigator.md
@@ -69,8 +69,8 @@ python main.py
 
 | 模式 | 操作 | 导出内容 |
 | ---------- | ------------------------------------------ | ------------------------------------------------ |
-| `A* 寻路` | 选择底图与层级，在图上标记目标点并预览路线 | `复制 JSON 配置` → `NAVMESH` 节点 |
-| `断言模式` | 框选矩形区域 | `复制断言 JSON` → `MapLocateAssertLocation` 节点 |
+| `A* 寻路` | 选择底图与层级，在图上标记目标点并预览路线 | 复制 `NAVMESH` 节点，或仅复制环境监测 `MapTarget` 坐标 |
+| `断言模式` | 框选矩形区域 | 复制 `MapLocateAssertLocation` 节点，或仅复制环境监测 `MapAssert` 坐标 |
 | `路径编辑` | 连接游戏录制路线，编辑路径点动作 | `复制路径` → 完整 `path` |
 
 `A* 寻路` 与 `路径编辑` 对应 MapNavigator 的两种用法：给定终点由运行时规划路线，或给定完整路线按序执行。两者可混排在同一个 `path` 数组中——长距离移动用 `NAVMESH`，需要精确语义的局部段用坐标点。
@@ -206,6 +206,18 @@ python main.py
 ]
 ```
 
+`NAVMESH` 是例外：它是语义寻路节点，必须使用带 `target` 的对象，不能写成 `[x, y, "NAVMESH"]`：
+
+```json
+{
+    "action": "NAVMESH",
+    "target": [
+        1242.04,
+        773.41
+    ]
+}
+```
+
 可用动作：
 
 | 动作 | 到达后行为 |
@@ -217,6 +229,7 @@ python main.py
 | `INTERACT` | 交互一次 |
 | `COLLECT` | 采集：停止移动，触发 OCR 识别并点击采集，见[采集与挖掘](#采集与挖掘-collect--dig) |
 | `DIG` | 挖掘：停止移动，触发挖掘子任务，见[采集与挖掘](#采集与挖掘-collect--dig) |
+| `NAVMESH` | 从当前定位自动规划路线并移动到 `target`；必须使用上方对象格式 |
 | `TRANSFER` | 原地等待外力（剧情、传送等）将角色送至下一段，再从后续点继续 |
 | `PORTAL` | 过图点，触发后盲走一小段并等待区域切换 |
 | `HEADING` | 将镜头转到指定朝向，再按一次 `W` 使朝向生效 |
@@ -268,7 +281,7 @@ python main.py
 
 > [!NOTE]
 >
-> 页面的点编辑面向带坐标的路径点（`RUN / SPRINT / JUMP / FIGHT / INTERACT / PORTAL / TRANSFER / COLLECT / DIG`）以及由区域信息派生的 `ZONE` 声明。`HEADING` 是无坐标控制节点，不属于该编辑模型，建议在导出 `path` 后手动补充维护；`NAVMESH` 在 `A* 寻路` 模式中直接复制。
+> 页面的点编辑面向带坐标的路径点（`RUN / SPRINT / JUMP / FIGHT / INTERACT / PORTAL / TRANSFER / COLLECT / DIG / NAVMESH`）以及由区域信息派生的 `ZONE` 声明。`HEADING` 是无坐标控制节点，不属于该编辑模型，建议在导出 `path` 后手动补充维护；`NAVMESH` 也可以在 `A* 寻路` 模式中直接复制。
 
 ---
 

--- a/tools/MapNavigator/README.md
+++ b/tools/MapNavigator/README.md
@@ -71,14 +71,22 @@ MapNavigator 是用于 C++ MapNavigator 模块使用的地图路径录制与编�
         940,
         655,
         "DIG"
-    ]
+    ],
+    {
+        "action": "NAVMESH",
+        "target": [
+            1242.04,
+            773.41
+        ]
+    }
 ]
 ```
 
 - `ZONE` 是可选的无坐标声明节点，用于给后续点提供区域校验信息。
 - 普通坐标点继续使用 `[x, y]` / `[x, y, "ACTION"]`。
 - 严格点会导出为 `[x, y, true]` 或 `[x, y, "ACTION", true]`。
-- 当前 GUI 导出的 canonical `path` 只覆盖坐标点与 `ZONE` 声明，不会直接生成 `HEADING` 这类无坐标控制节点。
+- `NAVMESH` 点会导出为 `{ "action": "NAVMESH", "target": [x, y] }`，由运行时从当前位置自动寻路到目标。
+- 当前 GUI 导出的 canonical `path` 覆盖坐标点（`NAVMESH` 按对象格式导出）与 `ZONE` 声明，不会直接生成 `HEADING` 这类无坐标控制节点。
 - 复制出来的内容可以直接粘贴到 pipeline 的 `custom_action_param.path`。
 
 ## Assert 模式
@@ -96,7 +104,7 @@ MapNavigator 是用于 C++ MapNavigator 模块使用的地图路径录制与编�
 1. 打开工具，切换到 `断言模式` 页签。
 2. 点击 `选择断言底图与层级`，选择目标 `zone`。
 3. 在底图上按住左键拖拽，框出一个矩形区域。
-4. 点击 `复制断言 JSON`。
+4. 选择复制完整断言节点或仅复制环境监测 `routes.json` 使用的 `MapAssert` 坐标，再点击复制按钮。
 
 ### 导出格式
 
@@ -171,6 +179,8 @@ dung01
 ```
 
 `NAVMESH` 的 `.nav` 区域由运行时根据当前定位自动推断；复制结果不需要填写 `zone_id` / `navmesh_zone`。
+
+复制内容可切换为 `仅坐标（MapTarget）`，此时只复制最后一个目标点的 `[x, y]`，可直接粘贴到环境监测 `routes.json` 的 `MapTarget`。分层底图的状态栏会同时提示应填写的 `MapTargetTier`。
 
 `.nav` 只连接 GLB 自身共享/重叠边，以及同高度的小距离 component bridge；不会为了跨 level 自动补 portal 或 drop link。游戏本身分离的 level 暂保持不可达。
 

--- a/tools/MapNavigator/json_import.py
+++ b/tools/MapNavigator/json_import.py
@@ -98,7 +98,13 @@ def export_path_nodes(points: list[PathPoint]) -> list[dict[str, Any] | list[int
 
         strict_arrival = coerce_strict_arrival(point.get("strict"), default=False)
         for action in get_point_actions(point):
-            node: list[int | float | str | bool] = [_compact_number(point["x"]), _compact_number(point["y"])]
+            target = [_compact_number(point["x"]), _compact_number(point["y"])]
+            if action == int(ActionType.NAVMESH):
+                # The runtime parses NAVMESH from an object target and makes its arrival strict itself.
+                exported_nodes.append({"action": "NAVMESH", "target": target})
+                continue
+
+            node: list[int | float | str | bool] = [*target]
             if action != int(ActionType.RUN):
                 node.append(export_action_token(action))
             if strict_arrival:

--- a/tools/MapNavigator/test_json_import.py
+++ b/tools/MapNavigator/test_json_import.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import unittest
+
+from json_import import export_path_nodes
+from model import ActionType, PathPoint
+
+
+def make_point(action: ActionType, *, strict: bool = False) -> PathPoint:
+    return {
+        "x": 1242.04,
+        "y": 773.41,
+        "action": int(action),
+        "actions": [int(action)],
+        "zone": "",
+        "strict": strict,
+    }
+
+
+class ExportPathNodesTest(unittest.TestCase):
+    def test_exports_navmesh_as_target_object(self) -> None:
+        nodes = export_path_nodes([make_point(ActionType.NAVMESH, strict=True)])
+
+        self.assertEqual(
+            nodes,
+            [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1242.04,
+                        773.41,
+                    ],
+                }
+            ],
+        )
+
+    def test_keeps_regular_action_array_format(self) -> None:
+        nodes = export_path_nodes([make_point(ActionType.INTERACT, strict=True)])
+
+        self.assertEqual(nodes, [[1242.04, 773.41, "INTERACT", True]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/MapNavigator/web/static/css/style.css
+++ b/tools/MapNavigator/web/static/css/style.css
@@ -326,6 +326,11 @@ canvas {
   white-space: nowrap;
 }
 
+.copy-format-combo {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .zone-label {
   flex: 1 1 auto;
   text-align: center;

--- a/tools/MapNavigator/web/static/index.html
+++ b/tools/MapNavigator/web/static/index.html
@@ -175,6 +175,13 @@
           <div class="sidebar-row border-top" style="margin-top: 4px; padding-top: 12px">
             <button id="btn-assert-locate" class="btn btn-primary" style="width: 100%; margin-bottom: 8px;" type="button" title="定位后在该参考点周围拖拽画出断言矩形">标出游戏内当前位置（参考点）</button>
           </div>
+          <div class="sidebar-row copy-format-row">
+            <label class="sidebar-label" for="assert-copy-format">复制内容</label>
+            <select id="assert-copy-format" class="combo copy-format-combo">
+              <option value="json">断言节点 JSON</option>
+              <option value="coordinates">仅坐标（MapAssert）</option>
+            </select>
+          </div>
           <div class="sidebar-row grid-btns-2">
             <button id="btn-assert-import" class="btn btn-secondary" type="button" title="导入路线（画出真实点）或 AssertLocation（画出断言矩形）">导入 JSON</button>
             <button id="btn-copy-assert" class="btn btn-secondary" type="button" title="复制当前断言矩形，需先在地图上拖拽画框">复制断言 JSON</button>
@@ -216,6 +223,13 @@
           </div>
           <div class="sidebar-hint">按坐标标预览点</div>
 
+          <div class="sidebar-row copy-format-row">
+            <label class="sidebar-label" for="navmesh-copy-format">复制内容</label>
+            <select id="navmesh-copy-format" class="combo copy-format-combo">
+              <option value="json">NAVMESH JSON 配置</option>
+              <option value="coordinates">仅坐标（MapTarget）</option>
+            </select>
+          </div>
           <div class="sidebar-row grid-btns-2">
             <button id="btn-astar-import" class="btn btn-secondary" type="button" title="把 JSON 里的点标成预览点（不写入路线）">导入 JSON</button>
             <button id="btn-copy-navmesh" class="btn btn-secondary" type="button" title="复制最后一个预览点为 NAVMESH 目标（有预览路线时复制整条）">复制 JSON 配置</button>

--- a/tools/MapNavigator/web/static/js/main.js
+++ b/tools/MapNavigator/web/static/js/main.js
@@ -50,6 +50,7 @@ const LOAD_POLL_MS = 400;
 const LEFT_PANEL_FIT_OFFSET = 350;
 // World px kept around the A* preview markers when framing them.
 const ASTAR_HINT_FIT_PADDING = 200;
+const COPY_FORMAT_COORDINATES = 'coordinates';
 
 /** round(value, 2) with CPython banker's rounding — parity for assert-target export. */
 function bankerRound2(value) {
@@ -180,6 +181,7 @@ class MapNavigatorApp {
       btnStop: $('btn-stop'),
       btnCopyPath: $('btn-copy-path'),
       btnCopyAssert: $('btn-copy-assert'),
+      assertCopyFormat: $('assert-copy-format'),
       btnImport: $('btn-import'),
       fileInput: $('file-input'),
       btnPrev: $('btn-prev'),
@@ -215,6 +217,7 @@ class MapNavigatorApp {
       astarZoneCombo: $('astar-zone-combo'),
       btnClearAstar: $('btn-clear-astar'),
       btnCopyNavmesh: $('btn-copy-navmesh'),
+      navmeshCopyFormat: $('navmesh-copy-format'),
       loadProgress: $('load-progress'),
       loadProgressBar: $('load-progress-bar'),
       loadProgressLabel: $('load-progress-label'),
@@ -264,6 +267,7 @@ class MapNavigatorApp {
       this._populateActionMenu();
       this._resetPropertyControls();
       this._wireEvents();
+      this._syncCopyButtonLabels();
 
       this.connection = new ConnectionPanel({
         kindCombo: this.els.kindCombo,
@@ -583,6 +587,7 @@ class MapNavigatorApp {
     const e = this.els;
     e.btnCopyPath.addEventListener('click', () => this._copyPath());
     e.btnCopyAssert.addEventListener('click', () => this._copyAssert());
+    e.assertCopyFormat.addEventListener('change', () => this._syncCopyButtonLabels());
     e.btnPrev.addEventListener('click', () => this._prevZone());
     e.btnNext.addEventListener('click', () => this._nextZone());
     e.btnZoomOut.addEventListener('click', () => this._zoomOut());
@@ -593,6 +598,7 @@ class MapNavigatorApp {
     e.astarZoneCombo.addEventListener('change', () => this._onAstarZoneChanged());
     e.btnClearAstar.addEventListener('click', () => this._onClearAstar());
     e.btnCopyNavmesh.addEventListener('click', () => this._copyNavmesh());
+    e.navmeshCopyFormat.addEventListener('change', () => this._syncCopyButtonLabels());
     e.btnAssertLocate.addEventListener('click', () => this._onLocateCurrentPosition('assert'));
     e.btnAstarLocate.addEventListener('click', () => this._onLocateCurrentPosition('astar'));
     e.btnAstarMarkCoord.addEventListener('click', () => this._onAstarMarkCoord());
@@ -1506,20 +1512,14 @@ class MapNavigatorApp {
     this.isDragging = false;
   }
 
-  /**
-   * Wheel input: plain wheel pans (trackpad-style), Ctrl/Cmd+wheel zooms at the cursor.
-   * @param {WheelEvent} e
-   * @returns {void}
-   */
+  /** Wheel input: zoom the map at the cursor. @param {WheelEvent} e @returns {void} */
   _onWheel(e) {
     e.preventDefault();
-    if (e.ctrlKey || e.metaKey) {
-      const [x, y] = this._evtXY(e);
-      const factor = Math.max(0.5, Math.min(2.0, Math.exp(-e.deltaY * 0.012)));
-      this.camera.zoomAt(x, y, factor);
-    } else {
-      this.camera.panBy(-e.deltaX * 1.3, -e.deltaY * 1.3);
-    }
+    const [x, y] = this._evtXY(e);
+    const deltaScale =
+      e.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : e.deltaMode === WheelEvent.DOM_DELTA_PAGE ? this._cssH : 1;
+    const factor = Math.max(0.5, Math.min(2.0, Math.exp(-e.deltaY * deltaScale * 0.0015)));
+    this.camera.zoomAt(x, y, factor);
     this._paint();
   }
 
@@ -2130,6 +2130,14 @@ class MapNavigatorApp {
   //  Copy actions
   // ==================================================================================
 
+  /** Keep each copy button's label aligned with its selected output format. @returns {void} */
+  _syncCopyButtonLabels() {
+    this.els.btnCopyNavmesh.textContent =
+      this.els.navmeshCopyFormat.value === COPY_FORMAT_COORDINATES ? '复制坐标' : '复制 JSON 配置';
+    this.els.btnCopyAssert.textContent =
+      this.els.assertCopyFormat.value === COPY_FORMAT_COORDINATES ? '复制坐标' : '复制断言 JSON';
+  }
+
   /** Export the route as a MapNavigator path node (backend, tk-byte-identical) and copy it. @returns {Promise<void>} */
   async _copyPath() {
     if (!this.state.points.length) {
@@ -2146,7 +2154,7 @@ class MapNavigatorApp {
     }
   }
 
-  /** Export the assert rect as a MapLocateAssertLocation node and copy it. @returns {Promise<void>} */
+  /** Export the assert rect as a full node or a routes.json MapAssert coordinate array. @returns {Promise<void>} */
   async _copyAssert() {
     const zoneId = this._displayZoneId();
     if (!zoneId) {
@@ -2159,6 +2167,11 @@ class MapNavigatorApp {
       return;
     }
     try {
+      if (this.els.assertCopyFormat.value === COPY_FORMAT_COORDINATES) {
+        await this._copyText(JSON.stringify(target, null, 4));
+        setStatus(`环境监测 MapAssert 坐标已复制: [${target.join(', ')}]`, '#10b981');
+        return;
+      }
       const result = await exportAssert(zoneId, target);
       await this._copyText(result.text);
       setStatus('MapLocateAssertLocation 节点已复制到剪贴板', '#10b981');
@@ -2171,7 +2184,9 @@ class MapNavigatorApp {
   /**
    * Copy the A* waypoints (all clicked points after the start, in base px) as
    * NAVMESH action payloads — a single object for one target, an array for a
-   * multi-leg route. With no route planned, falls back to the locate hint.
+   * multi-leg route. Coordinate-only output copies the final target for an
+   * EnvironmentMonitoring routes.json `MapTarget`. With no route planned, falls
+   * back to the locate hint.
    * @returns {Promise<void>}
    */
   async _copyNavmesh() {
@@ -2200,10 +2215,12 @@ class MapNavigatorApp {
         if (tierName) {
           payload.target_tier = tierName;
         }
-        await this._copyText(JSON.stringify(payload, null, 4));
-        const tierNote = tierName ? ` target_tier=${tierName}` : '';
+        const coordinatesOnly = this.els.navmeshCopyFormat.value === COPY_FORMAT_COORDINATES;
+        await this._copyText(JSON.stringify(coordinatesOnly ? payload.target : payload, null, 4));
+        const tierField = coordinatesOnly ? 'MapTargetTier' : 'target_tier';
+        const tierNote = tierName ? ` ${tierField}=${tierName}` : '';
         setStatus(
-          `NAVMESH 目标已复制: zone=${zoneId} target=[${payload.target[0]}, ${payload.target[1]}]${tierNote}`,
+          `${coordinatesOnly ? '环境监测 MapTarget 坐标' : 'NAVMESH 目标'}已复制: zone=${zoneId} target=[${payload.target[0]}, ${payload.target[1]}]${tierNote}`,
           '#10b981',
         );
         return;
@@ -2235,7 +2252,12 @@ class MapNavigatorApp {
       targets.push(payload);
     }
 
-    if (targets.length === 1) {
+    if (this.els.navmeshCopyFormat.value === COPY_FORMAT_COORDINATES) {
+      const target = targets[targets.length - 1];
+      await this._copyText(JSON.stringify(target.target, null, 4));
+      const tierNote = tierName ? ` MapTargetTier=${tierName}` : '';
+      setStatus(`环境监测 MapTarget 坐标已复制: [${target.target[0]}, ${target.target[1]}]${tierNote}`, '#10b981');
+    } else if (targets.length === 1) {
       await this._copyText(JSON.stringify(targets[0], null, 4));
       const tierNote = tierName ? ` target_tier=${tierName}` : '';
       setStatus(
@@ -2777,7 +2799,7 @@ class MapNavigatorApp {
     this._syncActionControls();
     this._refreshZoneLabel();
     setStatus(
-      '录制结束。Ctrl+滚轮缩放，滚轮或右键平移；添加工具左键点击插点，拖拽路点微调，Ctrl+拖拽框选批量操作，C 键复制选中点坐标。',
+      '录制结束。滚轮缩放，右键或 Alt+拖拽平移；添加工具左键点击插点，拖拽路点微调，Ctrl+拖拽框选批量操作，C 键复制选中点坐标。',
       '#10b981',
     );
     this._fitView();


### PR DESCRIPTION
## 改动

- 将地图普通滚轮改为围绕指针缩放，保留右键或 Alt 拖拽平移。
- 为 A* 与断言模式增加复制格式选择，可直接复制环境监测 routes.json 使用的 MapTarget / MapAssert 坐标。
- 修复路径编辑器将 NAVMESH 导出为 [x, y, "NAVMESH"] 的问题，统一输出 {"action":"NAVMESH","target":[x,y]}。
- 补充 NAVMESH 导出回归测试与 MapNavigator 使用文档。

## 验证

- `pnpm format:all`
- `python -m unittest discover -s tools/MapNavigator -p 'test_*.py'`（2/2）
- `pnpm check`
- `pnpm test`（768/768）
- 通过 `/api/export/path` 实测 1242.04 / 773.41 导出为 NAVMESH target 对象。
- 本地浏览器验证滚轮缩放、复制格式切换及剪贴板内容，控制台无错误。

## 验证边界

- 全库 `pnpm format:md:check` 仍报告 12 个既有 Markdown 规则问题；本次修改的两份文档已单独通过 markdownlint。

## Summary by Sourcery

改进 MapNavigator 地图交互和导出格式，以便更好地集成 NAVMESH 和环境监控功能。

New Features:
- 为 A* 和 assert 模式添加复制格式选择器，以便可以复制完整 JSON 节点或环境监控用的坐标数组。
- 支持将 NAVMESH 路点复制为 EnvironmentMonitoring 的 MapTarget 坐标，同时保留现有的 NAVMESH JSON 负载导出。

Bug Fixes:
- 修正 NAVMESH 路径导出格式，将之前的数组格式改为包含 `action` 和 `target` 字段的对象格式。

Enhancements:
- 修改鼠标滚轮行为，使其围绕光标位置进行缩放，并依赖右键或按住 Alt 拖动进行平移。
- 保持复制按钮标签与所选输出格式同步，以提供更清晰的 UI 行为。

Documentation:
- 更新 MapNavigator 开发者文档和 README，描述 NAVMESH 对象导出、仅坐标复制选项，以及输入行为。

Tests:
- 为 NAVMESH 路径导出格式添加回归测试，确保基于对象的目标格式以及其他操作仍使用数组格式并保持一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve MapNavigator map interaction and export formats for NAVMESH and environment monitoring integrations.

New Features:
- Add copy-format selectors for A* and assert modes to allow copying either full JSON nodes or environment monitoring coordinate arrays.
- Support copying NAVMESH waypoints as EnvironmentMonitoring MapTarget coordinates alongside existing NAVMESH JSON payloads.

Bug Fixes:
- Correct NAVMESH path export to use an object with action and target fields instead of the previous array format.

Enhancements:
- Change mouse wheel behavior to zoom around the cursor and rely on right-click or Alt-drag for panning.
- Keep copy button labels in sync with the selected output format for clearer UI behavior.

Documentation:
- Update MapNavigator developer and README documentation to describe NAVMESH object export, coordinate-only copy options, and input behavior.

Tests:
- Add regression tests for NAVMESH path export format to ensure object-based targets and array formats for other actions remain consistent.

</details>