### PR TITLE
fix(processcheck): 将 AltSnap.exe 加入进程检测黑名单

### DIFF
--- a/agent/go-service/taskersink/processcheck/checker.go
+++ b/agent/go-service/taskersink/processcheck/checker.go
@@ -19,7 +19,7 @@ type blacklistEntry struct {
 var blacklist = []blacklistEntry{
 	{"DNFAutoFire.exe", "DNFAutoFire.exe"}, // 会让alt按键事件失效
 	{"DAF连发工具.exe", "DAF连发工具.exe"},         // 会让alt按键事件失效
-	{"AltSnap.exe", "AltSnap.exe"},         // 会拦截鼠标点击导致点击失效
+	{"AltSnap.exe", "AltSnap.exe"},         // 会让alt按键事件失效
 }
 
 // ProcessChecker detects blacklisted processes before task execution

--- a/agent/go-service/taskersink/processcheck/checker.go
+++ b/agent/go-service/taskersink/processcheck/checker.go
@@ -19,6 +19,7 @@ type blacklistEntry struct {
 var blacklist = []blacklistEntry{
 	{"DNFAutoFire.exe", "DNFAutoFire.exe"}, // 会让alt按键事件失效
 	{"DAF连发工具.exe", "DAF连发工具.exe"},         // 会让alt按键事件失效
+	{"AltSnap.exe", "AltSnap.exe"},         // 会拦截鼠标点击导致点击失效
 }
 
 // ProcessChecker detects blacklisted processes before task execution


### PR DESCRIPTION
## Summary
- 在启动进程检测黑名单中加入 `AltSnap.exe`，避免其拦截鼠标点击导致任务点击失效

Closes #4805

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- 通过将 AltSnap.exe 视为黑名单进程，防止在其拦截鼠标点击时导致任务点击失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent task click failures when AltSnap.exe intercepts mouse clicks by treating it as a blacklisted process.

</details>