### PR TITLE
fix(login): 登录界面优先关闭错误弹窗，避免万能跳转空转

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneLogin.json
+++ b/assets/resource/pipeline/SceneManager/SceneLogin.json
@@ -1,6 +1,7 @@
 {
     "__ScenePrivateLogin": {
         "desc": "处理登录界面",
+        "max_hit": 500,
         "recognition": {
             "type": "TemplateMatch",
             "param": {
@@ -16,6 +17,7 @@
             }
         },
         "next": [
+            "[JumpBack]__ScenePrivateCloseErrorDialog",
             "[JumpBack]__ScenePrivateCloseLoginAnnouncement",
             "__ScenePrivateLoginContinue",
             "__ScenePrivateLogin"


### PR DESCRIPTION
## Summary
- 在 `__ScenePrivateLogin.next` 前置 `__ScenePrivateCloseErrorDialog`，错误确认框遮住「点击任意位置继续」时也能点「确认」
- 为 `__ScenePrivateLogin` 增加 `max_hit: 500`，避免登录兜底长时间空转

Closes #4730

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

调整登录场景行为，以优先关闭错误对话框，并在备用登录期间减少空闲循环。

Bug 修复：
- 确保即使错误确认对话框与通用“点击继续”区域重叠，仍然可以将其关闭。
- 限制备用登录重试次数，防止登录场景无限循环等待。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust login scene behavior to prioritize closing error dialogs and reduce idle looping during fallback login.

Bug Fixes:
- Ensure error confirmation dialog can be closed even when it overlaps the universal tap-to-continue area.
- Limit fallback login retries to prevent the login scene from spinning indefinitely.

</details>