### PR TITLE
fix(daily-rewards): 活动列表入口点击右移 15px

### DIFF
--- a/assets/resource/pipeline/DailyRewards/Event.json
+++ b/assets/resource/pipeline/DailyRewards/Event.json
@@ -34,6 +34,13 @@
         },
         "pre_delay": 0,
         "action": "Click",
+        // OCR 框易贴 ROI 左缘，点击整体右移以免点到列表左边装饰
+        "target_offset": [
+            15,
+            0,
+            -15,
+            0
+        ],
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
@@ -53,6 +60,14 @@
         },
         "pre_delay": 0,
         "action": "Click",
+        // 与红点入口一致：点击区右移 15px
+        "target": true,
+        "target_offset": [
+            15,
+            0,
+            -15,
+            0
+        ],
         "post_delay": 0,
         "rate_limit": 0,
         "next": [


### PR DESCRIPTION
## Summary
- `DailyEventGoToByRedDot` / `DailyEventGoToByNew` 增加 `target_offset: [15, 0, -15, 0]`，点击区右移 15px，避免 OCR 框贴 ROI 左缘时点到列表左边装饰导致切换失败、日常奖励报红

Closes #4656

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- 将 DailyEventGoToByRedDot 和 DailyEventGoToByNew 的点击目标向右移动 15px，以防止误点装饰导致列表切换失败以及每日奖励状态错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Shift the DailyEventGoToByRedDot and DailyEventGoToByNew click targets 15px to the right to prevent erroneous decoration clicks leading to list switching failures and incorrect daily reward status.

</details>