### PR TITLE
fix(account-switch): 切换账号失败

### DIFF
--- a/assets/resource/pipeline/AccountSwitch.json
+++ b/assets/resource/pipeline/AccountSwitch.json
@@ -136,6 +136,7 @@
     },
     "__AccountSwitchClickDropdown": {
         "desc": "点击账号下拉按钮,maafw在前台截图时5秒内会置顶一次游戏窗口，导致下拉框消失，因此需要重试",
+        "max_hit": 3,
         "recognition": {
             "type": "OCR",
             "param": {
@@ -161,7 +162,8 @@
         },
         "post_wait_freezes": 500,
         "next": [
-            "__AccountSwitchClickDropdownSuccess"
+            "__AccountSwitchClickDropdownSuccess",
+            "__AccountSwitchClickDropdown"
         ]
     },
     "__AccountSwitchClickDropdownSuccess": {
@@ -180,6 +182,13 @@
             }
         },
         "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "ClearHitCount",
+        "custom_action_param": {
+            "nodes": [
+                "__AccountSwitchClickDropdown"
+            ]
+        },
         "post_delay": 0,
         "next": [
             "__AccountSwitchOCRSelectAccount"


### PR DESCRIPTION
## Summary
- `__AccountSwitchClickDropdown` 增加 `max_hit: 3`，失败时可回点自身重试（应对 Win32 前台截图置顶导致下拉收起）
- `__AccountSwitchClickDropdownSuccess` 成功后 `ClearHitCount` 清零 `__AccountSwitchClickDropdown`，避免后续再次展开被 max_hit 挡掉

Closes #4818

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

允许在失败时重试账户切换下拉菜单操作，同时防止后续尝试因过期的点击次数限制而被阻止。

Bug 修复：
- 当账户切换下拉菜单因意外收起导致点击失败时，支持重试该下拉菜单点击操作。
- 在成功点击账户切换下拉菜单后重置其点击计数器，以避免后续尝试被最大点击次数限制所阻止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow the account switch dropdown action to be retried on failure while preventing future attempts from being blocked by stale hit limits.

Bug Fixes:
- Enable retrying the account switch dropdown click when it fails due to the dropdown collapsing unexpectedly.
- Reset the hit counter for the account switch dropdown after a successful click to avoid later attempts being blocked by the max-hit limit.

</details>