### PR TITLE
fix(SellProduct): 使优先物品绕过选品策略

### DIFF
--- a/agent/go-service/sellproduct/goods/selection.go
+++ b/agent/go-service/sellproduct/goods/selection.go
@@ -60,7 +60,11 @@ func selectGoodsTarget(
 	}
 	if pending != "" {
 		if observation, visible := observations[pending]; visible && stockCandidateAvailable(observation) {
-			if _, selectable := selector.Select([]sellstrategy.Candidate{observation}); selectable {
+			if _, selectable := selectGoodsCandidate(
+				selector,
+				[]sellstrategy.Candidate{observation},
+				policy.Preferred,
+			); selectable {
 				return pending, recognized
 			}
 		}
@@ -99,7 +103,7 @@ func stockCandidateAvailable(candidate sellstrategy.Candidate) bool {
 	return !candidate.StockKnown || candidate.Stock > 0
 }
 
-// selectGoodsCandidate 先按用户配置顺序尝试策略允许的优先货品，
+// selectGoodsCandidate 先按用户配置顺序选择可用优先货品，不应用选品策略；
 // 没有可用优先货品时再由策略从全部公共候选中选择。
 func selectGoodsCandidate(
 	selector sellstrategy.Selector,
@@ -115,9 +119,7 @@ func selectGoodsCandidate(
 		if !ok {
 			continue
 		}
-		if selected, ok := selector.Select([]sellstrategy.Candidate{candidate}); ok {
-			return selected, true
-		}
+		return candidate, true
 	}
 	return selector.Select(candidates)
 }

--- a/agent/go-service/sellproduct/goods/selection_test.go
+++ b/agent/go-service/sellproduct/goods/selection_test.go
@@ -151,30 +151,65 @@ func TestSelectGoodsTargetKeepsNameOnlyItemForStaticStrategies(t *testing.T) {
 	}
 }
 
-func TestSelectGoodsTargetUsesEligibleManualPriorityBeforeStrategy(t *testing.T) {
+// TestSelectGoodsTargetPriorityBypassesStockMinimumPrice 使用 Issue #4824 的配置验证：
+// 优先物品不受库存策略最低单价过滤，并严格按用户配置顺序选择。
+func TestSelectGoodsTargetPriorityBypassesStockMinimumPrice(t *testing.T) {
 	resetReserveSession()
 	groups := []itemPriorityGroup{
-		{ItemID: "other", Rarity: 3, UnitPrice: 70},
-		{ItemID: "cheap", Rarity: 2, UnitPrice: 2},
-		{ItemID: "preferred", Rarity: 2, UnitPrice: 20},
+		{ItemID: "item_bottled_rec_hp_1", Rarity: 3, UnitPrice: 10},
+		{ItemID: "item_bottled_food_1", Rarity: 3, UnitPrice: 10},
+		{ItemID: "item_bottled_rec_hp_3", Rarity: 4, UnitPrice: 70},
+		{ItemID: "item_proc_battery_3", Rarity: 4, UnitPrice: 70},
 	}
 	observations := map[string]sellstrategy.Candidate{
-		"other":     {ItemID: "other", Stock: 99999, StockKnown: true, Rarity: 3, UnitPrice: 70},
-		"cheap":     {ItemID: "cheap", Stock: 1000, StockKnown: true, Rarity: 2, UnitPrice: 2},
-		"preferred": {ItemID: "preferred", Stock: 10, StockKnown: true, Rarity: 2, UnitPrice: 20},
+		"item_bottled_rec_hp_1": {ItemID: "item_bottled_rec_hp_1", Stock: 9952, StockKnown: true, Rarity: 3, UnitPrice: 10},
+		"item_bottled_food_1":   {ItemID: "item_bottled_food_1", Stock: 9952, StockKnown: true, Rarity: 3, UnitPrice: 10},
+		"item_bottled_rec_hp_3": {ItemID: "item_bottled_rec_hp_3", Stock: 254, StockKnown: true, Rarity: 4, UnitPrice: 70},
+		"item_proc_battery_3":   {ItemID: "item_proc_battery_3", Stock: 62400, StockKnown: true, Rarity: 4, UnitPrice: 70},
 	}
 	itemID, _ := selectGoodsTarget(
 		"Outpost",
 		groups,
 		prioritySelectionPolicy{
-			Preferred:      []string{"cheap", "preferred"},
+			Preferred: []string{
+				"item_bottled_rec_hp_1",
+				"item_bottled_food_1",
+				"item_bottled_rec_hp_3",
+				"item_proc_battery_3",
+			},
+			OnlyPreferred:  true,
 			Strategy:       sellstrategy.KindStock,
-			StrategyConfig: sellstrategy.Config{MinimumUnitPrice: 10},
+			StrategyConfig: sellstrategy.Config{MinimumUnitPrice: 22},
+		},
+		observations,
+	)
+	if itemID != "item_bottled_rec_hp_1" {
+		t.Fatalf("manual priority target = %q, want item_bottled_rec_hp_1", itemID)
+	}
+}
+
+func TestSelectGoodsTargetKeepsPendingPriorityBelowMinimumPrice(t *testing.T) {
+	resetReserveSession()
+	prioritySelectionMu.Lock()
+	prioritySelection.Pending["Outpost"] = "preferred"
+	prioritySelectionMu.Unlock()
+	groups := []itemPriorityGroup{{ItemID: "preferred", UnitPrice: 10}}
+	observations := map[string]sellstrategy.Candidate{
+		"preferred": {ItemID: "preferred", Stock: 100, StockKnown: true, UnitPrice: 10},
+	}
+
+	itemID, _ := selectGoodsTarget(
+		"Outpost",
+		groups,
+		prioritySelectionPolicy{
+			Preferred:      []string{"preferred"},
+			Strategy:       sellstrategy.KindStock,
+			StrategyConfig: sellstrategy.Config{MinimumUnitPrice: 22},
 		},
 		observations,
 	)
 	if itemID != "preferred" {
-		t.Fatalf("manual priority target = %q, want preferred", itemID)
+		t.Fatalf("pending priority target = %q, want preferred", itemID)
 	}
 }
 


### PR DESCRIPTION
## 变更说明

- 优先物品按用户配置的优先级顺序直接选择，不再受稀有度、单价或库存选品策略过滤
- pending 状态下重试同一优先物品时保持一致语义，避免被最低单价再次过滤
- 使用 Issue #4824 的真实配置补充回归测试

## 验证

- `go test ./sellproduct/... -count=1`
- `go vet ./sellproduct/...`
- `pnpm format:go`
- `pnpm check`
- `pnpm test`（768/768）
- `git diff --check`

Closes #4824

## Summary by Sourcery

确保手动优先的商品始终按照用户定义的顺序被选中，并且不会被基于库存的最低价格策略过滤掉，包括处于待选状态的条目。

Bug Fixes:
- 防止已标记为手动优先的优选商品在应用库存策略的最低单价过滤时被拒绝。
- 在其单价低于配置的最低价格阈值时，仍然保留处于待处理状态的手动优先选择。

Tests:
- 使用来自 Issue #4824 的真实配置替换合成的优先选择测试数据，以覆盖最低价格绕过以及待处理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure manual priority items are always selected by user-defined order and not filtered out by stock-based minimum price strategies, including pending selections.

Bug Fixes:
- Prevent preferred goods from being rejected by stock strategy minimum unit price filters when they are marked as manual priority.
- Preserve pending manual priority selections even when their unit price falls below the configured minimum price threshold.

Tests:
- Replace synthetic priority selection test data with the real configuration from Issue #4824 to cover the minimum price bypass and pending behavior.

</details>