### PR TITLE
feat(BetterSliding): 目标超过滑条最大值的 80% 时先复位再精确点击

### DIFF
--- a/agent/go-service/bettersliding/handlers.go
+++ b/agent/go-service/bettersliding/handlers.go
@@ -465,6 +465,38 @@ func (a *BetterSlidingAction) handleFindEnd(ctx *maa.Context, arg *maa.CustomAct
 		}
 	}
 
+	if shouldResetBeforePreciseClick(a.TargetQuantity, a.sliderMaxQuantity) {
+		if err := ctx.OverridePipeline(map[string]any{
+			nodeBetterSlidingFindSwipeForReset: map[string]any{
+				"enabled": true,
+			},
+		}); err != nil {
+			a.logger.Error().
+				Err(err).
+				Msg("failed to enable reset gate before precise click")
+			return false
+		}
+
+		if err := ctx.OverrideNext(nodeBetterSlidingReset, []maa.NextItem{{Name: nodeBetterSlidingPreciseClick}}); err != nil {
+			a.logger.Error().
+				Err(err).
+				Msg("failed to route reset swipe to precise click")
+			return false
+		}
+
+		if err := ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: nodeBetterSlidingFindSwipeForReset}}); err != nil {
+			a.logger.Error().
+				Err(err).
+				Msg("failed to route find end to reset swipe")
+			return false
+		}
+
+		a.logger.Info().
+			Int("target_quantity", a.TargetQuantity).
+			Int("slider_max_quantity", a.sliderMaxQuantity).
+			Msg("target above 80% of slider max, reset to minimum before precise click")
+	}
+
 	return true
 }
 
@@ -770,4 +802,16 @@ func resolveSliderMaxQuantityNext(sliderMaxQuantity int, targetQuantity int) (st
 	}
 
 	return "", nil
+}
+
+// shouldResetBeforePreciseClick 判断目标数量是否严格大于滑条最大数量的 80%，
+// 决定精确点击前是否需要先向最小方向滑动复位。
+// 使用整数运算避免浮点误差：targetQuantity*5 > sliderMaxQuantity*4
+// 等价于 targetQuantity/sliderMaxQuantity > 0.8。
+func shouldResetBeforePreciseClick(targetQuantity int, sliderMaxQuantity int) bool {
+	if targetQuantity <= 0 || sliderMaxQuantity <= 1 || targetQuantity >= sliderMaxQuantity {
+		return false
+	}
+
+	return targetQuantity*5 > sliderMaxQuantity*4
 }

--- a/docs/en_us/developers/components/better-sliding.md
+++ b/docs/en_us/developers/components/better-sliding.md
@@ -15,11 +15,11 @@ Suitable for scenarios where you want to slide to the maximum/minimum. Parameter
 
 ### Parameter Description
 
-| Field | Type | Required | Description |
-| ------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Direction` | `string` | Yes | Swipe direction. Supports `left` / `right` / `up` / `down`. |
-| `SwipeButton` | `string` | No | Custom slider template path. Overrides the default template of the `BetterSlidingSwipeButton` node when provided. Default `""` (uses the shared default template `BetterSliding/SwipeButton.png`). |
-| `ResetBeforeFindStart` | `bool` | No | When `true`, first swipes toward the minimum before matching the slider start position, then performs the swipe. Default `false`. |
+| Field                  | Type     | Required | Description                                                                                                                                                                                        |
+| ---------------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Direction`            | `string` | Yes      | Swipe direction. Supports `left` / `right` / `up` / `down`.                                                                                                                                        |
+| `SwipeButton`          | `string` | No       | Custom slider template path. Overrides the default template of the `BetterSlidingSwipeButton` node when provided. Default `""` (uses the shared default template `BetterSliding/SwipeButton.png`). |
+| `ResetBeforeFindStart` | `bool`   | No       | When `true`, first swipes toward the minimum before matching the slider start position, then performs the swipe. Default `false`.                                                                  |
 
 > [!note]
 > When matching the `SwipeButton` internally, the CustomAction sets `GreenMask` to `true`. For the green masking method, please refer to the default template.
@@ -46,61 +46,64 @@ Suitable for scenarios where you want to slide to the maximum/minimum. Parameter
 > [!important]
 > Before the CustomAction executes, ensure the slider is at its initial value, and that the initial value is 1. Otherwise, the position deviation of the slider between its minimum and maximum cannot be calculated, causing the quantity adjustment to fail. If the caller cannot guarantee that the slider starts at its initial value, set `ResetBeforeFindStart: true` so BetterSliding first swipes toward the minimum before matching the start position.
 
+> [!note]
+> When the resolved target quantity is strictly greater than 80% of the slider's max quantity, BetterSliding swipes toward the minimum once after recording the end position, before performing the proportional precise click, so values near the maximum end are set reliably from the minimum. When the target equals the max quantity, BetterSliding finishes directly without resetting. This behavior is enabled by default and requires no extra parameter.
+
 ### Parameter Description
 
 #### Parameters that can be passed in `attach`
 
 The following 5 fields are recommended to be passed via the calling node's `attach`. The `attach` priority is higher than the same-named fields in `custom_action_param`.
 
-| Field | Type | Required | Description |
+| Field                     | Type                     | Required | Description                                                                                                                                                                         |
 | ------------------------- | ------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TargetQuantity` | `int` (positive integer) | Yes | Target quantity. The desired final slider value, which must be greater than 0. |
-| `TargetQuantityType` | `string` | No | How to interpret `TargetQuantity`. `"Value"` (default): absolute count; `"Percentage"`: percentage of `availableQuantity` (1–100), rounded and clamped. |
-| `ReverseTarget` | `bool` | No | When `true`, resolves the target from the available quantity: Value mode uses `availableQuantity - TargetQuantity`; Percentage mode uses the remaining percentage. Default `false`. |
-| `FinishAfterPreciseClick` | `bool` | No | When `true`, returns success immediately after a precise click, without entering the quantity validation and fine-tuning process. Default `false`. |
-| `ResetBeforeFindStart` | `bool` | No | When `true`, first swipes toward the minimum before matching the slider start position, so the recorded start position is the minimum value. Default `false`. |
+| `TargetQuantity`          | `int` (positive integer) | Yes      | Target quantity. The desired final slider value, which must be greater than 0.                                                                                                      |
+| `TargetQuantityType`      | `string`                 | No       | How to interpret `TargetQuantity`. `"Value"` (default): absolute count; `"Percentage"`: percentage of `availableQuantity` (1–100), rounded and clamped.                             |
+| `ReverseTarget`           | `bool`                   | No       | When `true`, resolves the target from the available quantity: Value mode uses `availableQuantity - TargetQuantity`; Percentage mode uses the remaining percentage. Default `false`. |
+| `FinishAfterPreciseClick` | `bool`                   | No       | When `true`, returns success immediately after a precise click, without entering the quantity validation and fine-tuning process. Default `false`.                                  |
+| `ResetBeforeFindStart`    | `bool`                   | No       | When `true`, first swipes toward the minimum before matching the slider start position, so the recorded start position is the minimum value. Default `false`.                       |
 
 > [!note]
 > Combination calculation logic for `TargetQuantityType` and `ReverseTarget`:
 >
-> | TargetQuantityType | ReverseTarget | Effective target |
+> | TargetQuantityType | ReverseTarget | Effective target                                                                               |
 > | ------------------ | ------------- | ---------------------------------------------------------------------------------------------- |
-> | `"Value"` | `false` | `TargetQuantity` |
-> | `"Value"` | `true` | `availableQuantity - TargetQuantity` (not clamped, may be < 1) |
-> | `"Percentage"` | `false` | `round(availableQuantity × TargetQuantity / 100)`, clamped to `[1, availableQuantity]` |
-> | `"Percentage"` | `true` | `round(availableQuantity × (100 - TargetQuantity) / 100)`, clamped to `[1, availableQuantity]` |
+> | `"Value"`          | `false`       | `TargetQuantity`                                                                               |
+> | `"Value"`          | `true`        | `availableQuantity - TargetQuantity` (not clamped, may be < 1)                                 |
+> | `"Percentage"`     | `false`       | `round(availableQuantity × TargetQuantity / 100)`, clamped to `[1, availableQuantity]`         |
+> | `"Percentage"`     | `true`        | `round(availableQuantity × (100 - TargetQuantity) / 100)`, clamped to `[1, availableQuantity]` |
 
 #### Parameters that can only be passed via `custom_action_param`
 
 In addition to the 5 fields above, all other parameters can only be read from `custom_action_param`:
 
-| Field | Type | Required | Description |
+| Field                           | Type                    | Required | Description                                                                                                                                                                   |
 | ------------------------------- | ----------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Direction` | `string` | Yes | Swipe direction. Specifies "the direction of the maximum value", supports `left` / `right` / `up` / `down`. |
-| `SliderQuantity.Box` | `int[4]` | Yes | OCR region for the current slider quantity, format `[x, y, w, h]`. |
-| `IncreaseButton` | `string` or `int[2\|4]` | Yes | "Increase quantity" button. Template path is recommended (threshold fixed at `0.8`), or coordinates `[x, y]` or `[x, y, w, h]`. |
-| `DecreaseButton` | `string` or `int[2\|4]` | Yes | "Decrease quantity" button. Format same as `IncreaseButton`. |
-| `AvailableQuantity.Box` | `int[4]` | No | OCR region for reading the total available quantity. When missing, the slider endpoint value is used as the calculation reference. |
-| `SliderQuantity.Filter` | `object` | No | Color filter parameters for the current slider quantity OCR. |
-| `AvailableQuantity.Filter` | `object` | No | Color filter parameters for available-quantity OCR. Used only when `AvailableQuantity` is explicitly provided. |
-| `SliderQuantity.OnlyRec` | `bool` | No | Whether to enable `only_rec` for slider-quantity OCR. Default `false`. |
-| `AvailableQuantity.OnlyRec` | `bool` | No | Whether to enable `only_rec` for `BetterSlidingGetAvailableQuantity`. |
-| `GreenMask` | `bool` | No | When locating buttons using a template path, whether to enable green mask filtering for template matching. Default `false`. Applies to `IncreaseButton` and `DecreaseButton`. |
-| `CenterPointOffset` | `int[2]` | No | Click offset relative to the center point of the slider's recognition box `[x, y]`, negative values left/up, positive right/down. Default `[-10, 0]`. |
-| `ClampTargetToSliderMax` | `bool` | No | When `true`, a target above `sliderMaxQuantity` is clamped to the maximum selectable slider quantity. Default `false`. |
-| `SwipeButton` | `string` | No | Custom slider template path, overrides the default template of the `BetterSlidingSwipeButton` node. Default `""` (uses the shared default template). |
-| `OutOfRangeOverrideEnable` | `string` | No | When the resolved target is outside the slidable range, enables the specified Pipeline node and returns success. Default `""`. |
-| `TargetReachableOverrideEnable` | `string` | No | When the resolved target needs no clamping and falls within `[1, sliderMaxQuantity]`, enables the specified Pipeline node. Default `""`. |
+| `Direction`                     | `string`                | Yes      | Swipe direction. Specifies "the direction of the maximum value", supports `left` / `right` / `up` / `down`.                                                                   |
+| `SliderQuantity.Box`            | `int[4]`                | Yes      | OCR region for the current slider quantity, format `[x, y, w, h]`.                                                                                                            |
+| `IncreaseButton`                | `string` or `int[2\|4]` | Yes      | "Increase quantity" button. Template path is recommended (threshold fixed at `0.8`), or coordinates `[x, y]` or `[x, y, w, h]`.                                               |
+| `DecreaseButton`                | `string` or `int[2\|4]` | Yes      | "Decrease quantity" button. Format same as `IncreaseButton`.                                                                                                                  |
+| `AvailableQuantity.Box`         | `int[4]`                | No       | OCR region for reading the total available quantity. When missing, the slider endpoint value is used as the calculation reference.                                            |
+| `SliderQuantity.Filter`         | `object`                | No       | Color filter parameters for the current slider quantity OCR.                                                                                                                  |
+| `AvailableQuantity.Filter`      | `object`                | No       | Color filter parameters for available-quantity OCR. Used only when `AvailableQuantity` is explicitly provided.                                                                |
+| `SliderQuantity.OnlyRec`        | `bool`                  | No       | Whether to enable `only_rec` for slider-quantity OCR. Default `false`.                                                                                                        |
+| `AvailableQuantity.OnlyRec`     | `bool`                  | No       | Whether to enable `only_rec` for `BetterSlidingGetAvailableQuantity`.                                                                                                         |
+| `GreenMask`                     | `bool`                  | No       | When locating buttons using a template path, whether to enable green mask filtering for template matching. Default `false`. Applies to `IncreaseButton` and `DecreaseButton`. |
+| `CenterPointOffset`             | `int[2]`                | No       | Click offset relative to the center point of the slider's recognition box `[x, y]`, negative values left/up, positive right/down. Default `[-10, 0]`.                         |
+| `ClampTargetToSliderMax`        | `bool`                  | No       | When `true`, a target above `sliderMaxQuantity` is clamped to the maximum selectable slider quantity. Default `false`.                                                        |
+| `SwipeButton`                   | `string`                | No       | Custom slider template path, overrides the default template of the `BetterSlidingSwipeButton` node. Default `""` (uses the shared default template).                          |
+| `OutOfRangeOverrideEnable`      | `string`                | No       | When the resolved target is outside the slidable range, enables the specified Pipeline node and returns success. Default `""`.                                                |
+| `TargetReachableOverrideEnable` | `string`                | No       | When the resolved target needs no clamping and falls within `[1, sliderMaxQuantity]`, enables the specified Pipeline node. Default `""`.                                      |
 
 ### Outcome Node Contract
 
 `OutOfRangeOverrideEnable` and `TargetReachableOverrideEnable` report the current BetterSliding outcome to the caller. They must reference different nodes, and each outcome node should default to `enabled: false`.
 
-| Resolved target | `OutOfRangeOverrideEnable` | `TargetReachableOverrideEnable` | BetterSliding behavior |
+| Resolved target                                                                  | `OutOfRangeOverrideEnable` | `TargetReachableOverrideEnable` | BetterSliding behavior                                               |
 | -------------------------------------------------------------------------------- | -------------------------- | ------------------------------- | -------------------------------------------------------------------- |
-| Below 1, zero `sliderMaxQuantity`, or above `sliderMaxQuantity` without clamping | `true` | `false` | Returns success without adjustment; the caller handles the outcome |
-| Within `[1, sliderMaxQuantity]` | `false` | `true` | Adjusts to the target quantity |
-| Above `sliderMaxQuantity` with clamping enabled | `false` | `false` | Adjusts to `sliderMaxQuantity`; original target is not yet reachable |
+| Below 1, zero `sliderMaxQuantity`, or above `sliderMaxQuantity` without clamping | `true`                     | `false`                         | Returns success without adjustment; the caller handles the outcome   |
+| Within `[1, sliderMaxQuantity]`                                                  | `false`                    | `true`                          | Adjusts to the target quantity                                       |
+| Above `sliderMaxQuantity` with clamping enabled                                  | `false`                    | `false`                         | Adjusts to `sliderMaxQuantity`; original target is not yet reachable |
 
 `sliderMaxQuantity == 0` only means that no positive target is currently selectable. BetterSliding does not infer business causes such as insufficient balance, insufficient stock, or a disabled control. Callers that need to distinguish those states should recognize the corresponding UI in Pipeline.
 

--- a/docs/zh_cn/developers/components/better-sliding.md
+++ b/docs/zh_cn/developers/components/better-sliding.md
@@ -15,11 +15,11 @@
 
 ### 参数说明
 
-| 字段 | 类型 | 必填 | 说明 |
-| ------------- | -------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `Direction` | `string` | 是 | 滑动方向。支持 `left` / `right` / `up` / `down`。 |
-| `SwipeButton` | `string` | 否 | 自定义滑块模板路径。提供时覆盖 `BetterSlidingSwipeButton` 节点的默认模板。默认 `""`（使用共享默认模板 `BetterSliding/SwipeButton.png`）。 |
-| `ResetBeforeFindStart` | `bool` | 否 | 为 `true` 时，先向最小方向滑动复位，再匹配滑块起始位置并执行滑动。默认 `false`。 |
+| 字段                   | 类型     | 必填 | 说明                                                                                                                                      |
+| ---------------------- | -------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `Direction`            | `string` | 是   | 滑动方向。支持 `left` / `right` / `up` / `down`。                                                                                         |
+| `SwipeButton`          | `string` | 否   | 自定义滑块模板路径。提供时覆盖 `BetterSlidingSwipeButton` 节点的默认模板。默认 `""`（使用共享默认模板 `BetterSliding/SwipeButton.png`）。 |
+| `ResetBeforeFindStart` | `bool`   | 否   | 为 `true` 时，先向最小方向滑动复位，再匹配滑块起始位置并执行滑动。默认 `false`。                                                          |
 
 > [!note]
 > Custom内部在对`SwipeButton`进行匹配时，`GreenMask`设置为`true`，涂绿方式可参考默认模板
@@ -46,61 +46,64 @@
 > [!important]
 > 在CustomAction执行前，请确保滑块位于初始值，且初始值为1。否则将无法计算滑块在最小与最大的位置偏差，导致数量调整失效。若调用方无法保证滑块位于初始值，可设置 `ResetBeforeFindStart: true`，BetterSliding 会在匹配起始位置前先向最小方向滑动复位。
 
+> [!note]
+> 当解析后的目标数量严格大于滑条最大数量的 80% 时，BetterSliding 会在记录终点位置后、执行精确点击前，先向最小方向滑动复位一次，再从最小值起按比例精确点击，保证靠近最大端的档位也能稳定命中。目标数量等于最大数量时仍直接完成，不执行复位。该行为默认开启，无需额外参数。
+
 ### 参数说明
 
 #### 可在 `attach` 中传入的参数
 
 以下 5 个字段推荐通过调用节点的 `attach` 传入，`attach` 优先级高于 `custom_action_param` 中的同名字段。
 
-| 字段 | 类型 | 必填 | 说明 |
+| 字段                      | 类型            | 必填 | 说明                                                                                                                                                           |
 | ------------------------- | --------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TargetQuantity` | `int`（正整数） | 是 | 目标数量。最终希望滑到的档位值，必须大于 0。 |
-| `TargetQuantityType` | `string` | 否 | 如何解释 `TargetQuantity`。`"Value"`（默认）：绝对离散计数；`"Percentage"`：`availableQuantity` 的百分比（1–100），四舍五入后钳制到 `[1, availableQuantity]`。 |
-| `ReverseTarget` | `bool` | 否 | 为 `true` 时从可用总量反向计算目标：Value 模式为 `availableQuantity - TargetQuantity`；Percentage 模式按剩余百分比计算。默认 `false`。 |
-| `FinishAfterPreciseClick` | `bool` | 否 | 为 `true` 时精确点击后直接返回成功，不再进入数量校验与微调流程。默认 `false`。 |
-| `ResetBeforeFindStart` | `bool` | 否 | 为 `true` 时，在匹配滑条起始位置前先向最小方向滑动复位，保证后续记录到的起始位置为最小值。默认 `false`。 |
+| `TargetQuantity`          | `int`（正整数） | 是   | 目标数量。最终希望滑到的档位值，必须大于 0。                                                                                                                   |
+| `TargetQuantityType`      | `string`        | 否   | 如何解释 `TargetQuantity`。`"Value"`（默认）：绝对离散计数；`"Percentage"`：`availableQuantity` 的百分比（1–100），四舍五入后钳制到 `[1, availableQuantity]`。 |
+| `ReverseTarget`           | `bool`          | 否   | 为 `true` 时从可用总量反向计算目标：Value 模式为 `availableQuantity - TargetQuantity`；Percentage 模式按剩余百分比计算。默认 `false`。                         |
+| `FinishAfterPreciseClick` | `bool`          | 否   | 为 `true` 时精确点击后直接返回成功，不再进入数量校验与微调流程。默认 `false`。                                                                                 |
+| `ResetBeforeFindStart`    | `bool`          | 否   | 为 `true` 时，在匹配滑条起始位置前先向最小方向滑动复位，保证后续记录到的起始位置为最小值。默认 `false`。                                                       |
 
 > [!note]
 > `TargetQuantityType` 与 `ReverseTarget` 的组合计算逻辑：
 >
-> | TargetQuantityType | ReverseTarget | 有效目标 |
+> | TargetQuantityType | ReverseTarget | 有效目标                                                                                   |
 > | ------------------ | ------------- | ------------------------------------------------------------------------------------------ |
-> | `"Value"` | `false` | `TargetQuantity`（原值） |
-> | `"Value"` | `true` | `availableQuantity - TargetQuantity`（不钳制，可能 < 1） |
-> | `"Percentage"` | `false` | `round(availableQuantity × TargetQuantity / 100)`，钳制到 `[1, availableQuantity]` |
-> | `"Percentage"` | `true` | `round(availableQuantity × (100 - TargetQuantity) / 100)`，钳制到 `[1, availableQuantity]` |
+> | `"Value"`          | `false`       | `TargetQuantity`（原值）                                                                   |
+> | `"Value"`          | `true`        | `availableQuantity - TargetQuantity`（不钳制，可能 < 1）                                   |
+> | `"Percentage"`     | `false`       | `round(availableQuantity × TargetQuantity / 100)`，钳制到 `[1, availableQuantity]`         |
+> | `"Percentage"`     | `true`        | `round(availableQuantity × (100 - TargetQuantity) / 100)`，钳制到 `[1, availableQuantity]` |
 
 #### 仅能通过 `custom_action_param` 传入的参数
 
 除上述 5 个字段外，其余参数都只能从 `custom_action_param` 读取：
 
-| 字段 | 类型 | 必填 | 说明 |
+| 字段                            | 类型                    | 必填 | 说明                                                                                                                |
 | ------------------------------- | ----------------------- | ---- | ------------------------------------------------------------------------------------------------------------------- |
-| `Direction` | `string` | 是 | 滑动方向。指定"最大值所在方向"，支持 `left` / `right` / `up` / `down`。 |
-| `SliderQuantity.Box` | `int[4]` | 是 | 当前滑条数量 OCR 区域，格式 `[x, y, w, h]`。 |
-| `IncreaseButton` | `string` 或 `int[2\|4]` | 是 | "增加数量"按钮。推荐传模板路径（阈值固定 `0.8`），也可传坐标 `[x, y]` 或 `[x, y, w, h]`。 |
-| `DecreaseButton` | `string` 或 `int[2\|4]` | 是 | "减少数量"按钮。格式同 `IncreaseButton`。 |
-| `AvailableQuantity.Box` | `int[4]` | 否 | OCR 区域，用于读取物品可购买/可出售的总量。缺失时使用滑条终点值作为计算基准。 |
-| `SliderQuantity.Filter` | `object` | 否 | 当前滑条数量 OCR 的颜色过滤参数。 |
-| `AvailableQuantity.Filter` | `object` | 否 | 可用总量 OCR 的颜色过滤参数。仅在显式提供 `AvailableQuantity` 时使用。 |
-| `SliderQuantity.OnlyRec` | `bool` | 否 | 是否为滑条数量 OCR 节点启用 `only_rec`。默认 `false`。 |
-| `AvailableQuantity.OnlyRec` | `bool` | 否 | 是否为 `BetterSlidingGetAvailableQuantity` 启用 `only_rec`。 |
-| `GreenMask` | `bool` | 否 | 使用模板路径定位按钮时，是否对模板匹配启用绿色掩膜过滤。默认 `false`。对`IncreaseButton`与`DecreaseButton`生效 |
-| `CenterPointOffset` | `int[2]` | 否 | 相对滑块识别框中心点的点击偏移 `[x, y]`，负数向左/上，正数向右/下。默认 `[-10, 0]`。 |
-| `ClampTargetToSliderMax` | `bool` | 否 | 为 `true` 时，若目标超过 `sliderMaxQuantity`，则钳制为滑条最大可选数量继续执行。默认 `false`。 |
-| `SwipeButton` | `string` | 否 | 自定义滑块模板路径，覆盖 `BetterSlidingSwipeButton` 节点的默认模板。默认 `""`（使用共享默认模板）。 |
-| `OutOfRangeOverrideEnable` | `string` | 否 | 当解析后的目标超出可滑动范围时，将指定 Pipeline 节点的 `enabled` 设为 `true`，然后返回成功。默认 `""`。 |
-| `TargetReachableOverrideEnable` | `string` | 否 | 当解析后的目标无需钳制且位于 `[1, sliderMaxQuantity]` 时，将指定 Pipeline 节点的 `enabled` 设为 `true`。默认 `""`。 |
+| `Direction`                     | `string`                | 是   | 滑动方向。指定"最大值所在方向"，支持 `left` / `right` / `up` / `down`。                                             |
+| `SliderQuantity.Box`            | `int[4]`                | 是   | 当前滑条数量 OCR 区域，格式 `[x, y, w, h]`。                                                                        |
+| `IncreaseButton`                | `string` 或 `int[2\|4]` | 是   | "增加数量"按钮。推荐传模板路径（阈值固定 `0.8`），也可传坐标 `[x, y]` 或 `[x, y, w, h]`。                           |
+| `DecreaseButton`                | `string` 或 `int[2\|4]` | 是   | "减少数量"按钮。格式同 `IncreaseButton`。                                                                           |
+| `AvailableQuantity.Box`         | `int[4]`                | 否   | OCR 区域，用于读取物品可购买/可出售的总量。缺失时使用滑条终点值作为计算基准。                                       |
+| `SliderQuantity.Filter`         | `object`                | 否   | 当前滑条数量 OCR 的颜色过滤参数。                                                                                   |
+| `AvailableQuantity.Filter`      | `object`                | 否   | 可用总量 OCR 的颜色过滤参数。仅在显式提供 `AvailableQuantity` 时使用。                                              |
+| `SliderQuantity.OnlyRec`        | `bool`                  | 否   | 是否为滑条数量 OCR 节点启用 `only_rec`。默认 `false`。                                                              |
+| `AvailableQuantity.OnlyRec`     | `bool`                  | 否   | 是否为 `BetterSlidingGetAvailableQuantity` 启用 `only_rec`。                                                        |
+| `GreenMask`                     | `bool`                  | 否   | 使用模板路径定位按钮时，是否对模板匹配启用绿色掩膜过滤。默认 `false`。对`IncreaseButton`与`DecreaseButton`生效      |
+| `CenterPointOffset`             | `int[2]`                | 否   | 相对滑块识别框中心点的点击偏移 `[x, y]`，负数向左/上，正数向右/下。默认 `[-10, 0]`。                                |
+| `ClampTargetToSliderMax`        | `bool`                  | 否   | 为 `true` 时，若目标超过 `sliderMaxQuantity`，则钳制为滑条最大可选数量继续执行。默认 `false`。                      |
+| `SwipeButton`                   | `string`                | 否   | 自定义滑块模板路径，覆盖 `BetterSlidingSwipeButton` 节点的默认模板。默认 `""`（使用共享默认模板）。                 |
+| `OutOfRangeOverrideEnable`      | `string`                | 否   | 当解析后的目标超出可滑动范围时，将指定 Pipeline 节点的 `enabled` 设为 `true`，然后返回成功。默认 `""`。             |
+| `TargetReachableOverrideEnable` | `string`                | 否   | 当解析后的目标无需钳制且位于 `[1, sliderMaxQuantity]` 时，将指定 Pipeline 节点的 `enabled` 设为 `true`。默认 `""`。 |
 
 ### 结果节点契约
 
 `OutOfRangeOverrideEnable` 与 `TargetReachableOverrideEnable` 用于把本次 BetterSliding 的判定传回调用方。两个参数必须引用不同节点，且结果节点建议默认设置 `enabled: false`。
 
-| 解析后的目标 | `OutOfRangeOverrideEnable` | `TargetReachableOverrideEnable` | BetterSliding 行为 |
+| 解析后的目标                                                 | `OutOfRangeOverrideEnable` | `TargetReachableOverrideEnable` | BetterSliding 行为                             |
 | ------------------------------------------------------------ | -------------------------- | ------------------------------- | ---------------------------------------------- |
-| 小于 1、`sliderMaxQuantity` 为 0，或未钳制时大于滑条最大数量 | `true` | `false` | 不调整数量，返回成功，由调用方处理越界结果 |
-| 位于 `[1, sliderMaxQuantity]` | `false` | `true` | 调整到目标数量 |
-| 大于 `sliderMaxQuantity` 且启用钳制 | `false` | `false` | 调整到 `sliderMaxQuantity`，尚不能达到原始目标 |
+| 小于 1、`sliderMaxQuantity` 为 0，或未钳制时大于滑条最大数量 | `true`                     | `false`                         | 不调整数量，返回成功，由调用方处理越界结果     |
+| 位于 `[1, sliderMaxQuantity]`                                | `false`                    | `true`                          | 调整到目标数量                                 |
+| 大于 `sliderMaxQuantity` 且启用钳制                          | `false`                    | `false`                         | 调整到 `sliderMaxQuantity`，尚不能达到原始目标 |
 
 `sliderMaxQuantity == 0` 只表示当前没有可选的正数目标，BetterSliding 不推断余额不足、库存不足或控件不可用等业务原因。调用方如需区分具体状态，应在 Pipeline 中识别对应界面。
 


### PR DESCRIPTION
## Summary by Sourcery

调整 BetterSliding 的行为，使当目标值超过滑块最大值的 80% 时，在进行精确点击前先触发一次重置滑动，并在英文和中文指南中记录这一行为。

New Features:
- 当解析得到的目标数量严格大于滑块最大值的 80% 时，引入在精确点击前自动重置到最小值的行为，同时保持最大目标值的既有行为不变。

Enhancements:
- 更新英文和中文的 BetterSliding 文档以包含新的高端目标处理规则，并改进参数说明表格的格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust BetterSliding behavior so targets above 80% of the slider max trigger a reset swipe before precise clicking, and document this behavior in both English and Chinese guides.

New Features:
- Introduce automatic reset-to-minimum before precise click when the resolved target quantity is strictly greater than 80% of the slider maximum, while leaving max-target behavior unchanged.

Enhancements:
- Update English and Chinese BetterSliding documentation with the new high-end target handling rule and improve table formatting for parameter descriptions.

</details>