### PR TITLE
perf: 选剑演武更快识别战斗结束

### DIFF
--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -53,15 +53,19 @@ func getCharactorLevelShow(ctx *maa.Context, img image.Image) bool {
 
 // hitExitNode 在 img 上依次运行 nodes 中各节点的识别，返回首个命中的节点名，未命中返回空字符串。
 func hitExitNode(ctx *maa.Context, img image.Image, nodes []string) string {
+	if len(nodes) == 0 {
+		return ""
+	}
 	for _, node := range nodes {
 		detail, err := ctx.RunRecognition(node, img)
-		if err != nil || detail == nil {
+		if err != nil {
 			log.Error().Err(err).Str("component", "AutoFight").Str("recognition", node).Msg("failed to run exit node recognition")
 			continue
 		}
-		if detail.Hit {
-			return node
+		if detail == nil || !detail.Hit {
+			continue
 		}
+		return node
 	}
 	return ""
 }

--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -20,18 +20,19 @@ import (
 // autoFightAttach 是 AutoFight 节点 attach 字段的反序列化目标，
 // 字段含义参考 assets/resource/pipeline/Interface/AutoFight.json。
 type autoFightAttach struct {
-	EnableAttack                 bool   `json:"enable_attack"`
-	EnableCombo                  bool   `json:"enable_combo"`
-	EnableDodge                  bool   `json:"enable_dodge"`
-	EnableDodgeCompat            bool   `json:"enable_dodge_compat"`
-	EnableHealthDangerousSwitch  bool   `json:"enable_health_dangerous_switch"`
-	EnableBreakAccumulatingPower bool   `json:"enable_break_accumulating_power"`
-	EnableSkill                  bool   `json:"enable_skill"`
-	EnableEndSkill               bool   `json:"enable_end_skill"`
-	EnableLockTarget             bool   `json:"enable_lock_target"`
-	ReserveSkillLevel            int    `json:"reserve_skill_level"`
-	EndAxisTimelineCode          string `json:"end_axis_timeline_code"`
-	SkipComboCooldown            bool   `json:"skip_combo_cooldown"`
+	EnableAttack                 bool     `json:"enable_attack"`
+	EnableCombo                  bool     `json:"enable_combo"`
+	EnableDodge                  bool     `json:"enable_dodge"`
+	EnableDodgeCompat            bool     `json:"enable_dodge_compat"`
+	EnableHealthDangerousSwitch  bool     `json:"enable_health_dangerous_switch"`
+	EnableBreakAccumulatingPower bool     `json:"enable_break_accumulating_power"`
+	EnableSkill                  bool     `json:"enable_skill"`
+	EnableEndSkill               bool     `json:"enable_end_skill"`
+	EnableLockTarget             bool     `json:"enable_lock_target"`
+	ReserveSkillLevel            int      `json:"reserve_skill_level"`
+	EndAxisTimelineCode          string   `json:"end_axis_timeline_code"`
+	SkipComboCooldown            bool     `json:"skip_combo_cooldown"`
+	ExitNodes                    []string `json:"exit_nodes"`
 }
 
 var screenAnalyzer = NewScreenAnalyzer()
@@ -48,6 +49,21 @@ func getCharactorLevelShow(ctx *maa.Context, img image.Image) bool {
 		return false
 	}
 	return detail.Hit
+}
+
+// hitExitNode 在 img 上依次运行 nodes 中各节点的识别，返回首个命中的节点名，未命中返回空字符串。
+func hitExitNode(ctx *maa.Context, img image.Image, nodes []string) string {
+	for _, node := range nodes {
+		detail, err := ctx.RunRecognition(node, img)
+		if err != nil || detail == nil {
+			log.Error().Err(err).Str("component", "AutoFight").Str("recognition", node).Msg("failed to run exit node recognition")
+			continue
+		}
+		if detail.Hit {
+			return node
+		}
+	}
+	return ""
 }
 
 func screencapImage(ctx *maa.Context) (image.Image, bool) {
@@ -375,6 +391,14 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 		img, ok := captureAndUpdateScreenDetail(ctx)
 		if !ok {
 			result = false
+			break
+		}
+
+		// 退出判定：attach 配置的 exit_nodes 任一命中（如选剑演武战斗胜利界面）立即退出
+		if exitNode := hitExitNode(ctx, img, params.ExitNodes); exitNode != "" {
+			log.Info().Str("component", "AutoFight").Str("exitNode", exitNode).Msg("exit node recognized, exiting fight")
+			maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
+			result = true
 			break
 		}
 

--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -398,14 +398,6 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 			break
 		}
 
-		// 退出判定：attach 配置的 exit_nodes 任一命中（如选剑演武战斗胜利界面）立即退出
-		if exitNode := hitExitNode(ctx, img, params.ExitNodes); exitNode != "" {
-			log.Info().Str("component", "AutoFight").Str("exitNode", exitNode).Msg("exit node recognized, exiting fight")
-			maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
-			result = true
-			break
-		}
-
 		// 暂停判定：检查是否在战斗空间内
 		charSelect := screenAnalyzer.GetCharacterSelect()
 		inFightSpace := charSelect > 0
@@ -418,6 +410,13 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 			}
 			if time.Since(pauseStart) >= 10*time.Second {
 				log.Info().Str("component", "AutoFight").Dur("elapsed", time.Since(pauseStart)).Msg("pause timeout, exiting fight")
+				maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
+				result = true
+				break
+			}
+			// 退出判定：attach 配置的 exit_nodes 任一命中（如选剑演武战斗胜利界面）立即退出
+			if exitNode := hitExitNode(ctx, img, params.ExitNodes); exitNode != "" {
+				log.Info().Str("component", "AutoFight").Str("exitNode", exitNode).Msg("exit node recognized, exiting fight")
 				maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
 				result = true
 				break

--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -32,7 +32,7 @@ type autoFightAttach struct {
 	ReserveSkillLevel            int      `json:"reserve_skill_level"`
 	EndAxisTimelineCode          string   `json:"end_axis_timeline_code"`
 	SkipComboCooldown            bool     `json:"skip_combo_cooldown"`
-	ExitNodes                    []string `json:"exit_nodes"`
+	PauseExitNodes               []string `json:"pause_exit_nodes"`
 }
 
 var screenAnalyzer = NewScreenAnalyzer()
@@ -414,8 +414,8 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 				result = true
 				break
 			}
-			// 退出判定：attach 配置的 exit_nodes 任一命中（如选剑演武战斗胜利界面）立即退出
-			if exitNode := hitExitNode(ctx, img, params.ExitNodes); exitNode != "" {
+			// 退出判定：暂停态下 attach 配置的 pause_exit_nodes 任一命中（如选剑演武战斗胜利界面）立即退出
+			if exitNode := hitExitNode(ctx, img, params.PauseExitNodes); exitNode != "" {
 				log.Info().Str("component", "AutoFight").Str("exitNode", exitNode).Msg("exit node recognized, exiting fight")
 				maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
 				result = true

--- a/agent/go-service/autofight/screenanalyzer.go
+++ b/agent/go-service/autofight/screenanalyzer.go
@@ -373,7 +373,7 @@ func (sa *ScreenAnalyzer) GetEndSkillFull(unused bool) []int {
 
 func (sa *ScreenAnalyzer) GetCharacterSelect() int {
 	for idx := 1; idx <= 4; idx++ {
-		if sa.hasLabelInFrames(LabelCharacterSelect, 3, false, characterRegions[idx-1]) {
+		if sa.hasLabelInFrames(LabelCharacterSelect, 5, false, characterRegions[idx-1]) {
 			return idx
 		}
 	}

--- a/assets/tasks/TrialOfSwordmancy.json
+++ b/assets/tasks/TrialOfSwordmancy.json
@@ -136,6 +136,15 @@
                 },
                 {
                     "name": "Yes",
+                    "pipeline_override": {
+                        "AutoFight": {
+                            "attach": {
+                                "exit_nodes": [
+                                    "TrialOfSwordmancyFightSuccess"
+                                ]
+                            }
+                        }
+                    },
                     "option": [
                         "AutoFightSetting",
                         "TrialOfSwordmancyRecoverBeforeBattle"

--- a/assets/tasks/TrialOfSwordmancy.json
+++ b/assets/tasks/TrialOfSwordmancy.json
@@ -139,7 +139,7 @@
                     "pipeline_override": {
                         "AutoFight": {
                             "attach": {
-                                "exit_nodes": [
+                                "pause_exit_nodes": [
                                     "TrialOfSwordmancyFightSuccess"
                                 ]
                             }


### PR DESCRIPTION
给自动战斗加了一个 `pause_exit_nodes` 设置，在识别不到干员时，识别命中其中的节点提前退出自动战斗。

在选剑表现一般的情况下可以节约 20~30s，相对平均约 5 分钟的用时可以说是显著

## Summary by Sourcery

为 AutoFight 添加可配置的退出节点识别功能，当检测到指定的 UI 状态时可提前结束战斗。

New Features:
- 为 AutoFight 的 attach 引入 `exit_nodes` 配置，当命中指定的识别节点时允许提前终止。

Enhancements:
- 记录已识别的退出节点，并在自动战斗通过退出节点结束时显示一条本地化消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable exit node recognition to AutoFight to end battles earlier when specified UI states are detected.

New Features:
- Introduce an exit_nodes configuration for AutoFight attach to allow early termination when designated recognition nodes are hit.

Enhancements:
- Log recognized exit nodes and display a localized message when auto fight exits via an exit node.

</details>

## Summary by Sourcery

为自动战斗添加可配置的退出节点识别功能，当检测到特定的暂停状态界面时，可更早结束战斗。

新功能：
- 为自动战斗节点引入 `pause_exit_nodes` 配置，用于指定识别目标，一旦匹配到这些目标即可立即结束当前战斗。

增强：
- 添加通用的退出节点识别辅助工具，复用基于节点的检测逻辑以实现战斗的提前终止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable exit node recognition to auto-fight to terminate battles earlier when specific pause-state screens are detected.

New Features:
- Introduce pause_exit_nodes configuration for auto-fight nodes to specify recognition targets that should immediately end an ongoing fight.

Enhancements:
- Add shared exit node recognition helper to reuse node-based detection for early fight termination.

</details>