### PR TITLE
fix:识别物品数量使用颜色过滤来缓解识别异常

### DIFF
--- a/assets/resource/pipeline/IMS/item/ADVANCED_COGNITIVE_CARRIER.json
+++ b/assets/resource/pipeline/IMS/item/ADVANCED_COGNITIVE_CARRIER.json
@@ -99,7 +99,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ADVANCED_COGNITIVE_CARRIER.json
+++ b/assets/resource/pipeline/IMS/item/ADVANCED_COGNITIVE_CARRIER.json
@@ -99,7 +99,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__ADVANCED_COGNITIVE_CARRIER_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ADVANCED_COGNITIVE_CARRIER.json
+++ b/assets/resource/pipeline/IMS/item/ADVANCED_COGNITIVE_CARRIER.json
@@ -99,8 +99,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__ADVANCED_COGNITIVE_CARRIER_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ADVANCED_COMBAT_RECORD.json
+++ b/assets/resource/pipeline/IMS/item/ADVANCED_COMBAT_RECORD.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ADVANCED_COMBAT_RECORD.json
+++ b/assets/resource/pipeline/IMS/item/ADVANCED_COMBAT_RECORD.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__ADVANCED_COMBAT_RECORD_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ADVANCED_COMBAT_RECORD.json
+++ b/assets/resource/pipeline/IMS/item/ADVANCED_COMBAT_RECORD.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__ADVANCED_COMBAT_RECORD_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ARMS_INSPECTOR.json
+++ b/assets/resource/pipeline/IMS/item/ARMS_INSPECTOR.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ARMS_INSPECTOR.json
+++ b/assets/resource/pipeline/IMS/item/ARMS_INSPECTOR.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__ARMS_INSPECTOR_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ARMS_INSPECTOR.json
+++ b/assets/resource/pipeline/IMS/item/ARMS_INSPECTOR.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__ARMS_INSPECTOR_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ARMS_INSP_KIT.json
+++ b/assets/resource/pipeline/IMS/item/ARMS_INSP_KIT.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ARMS_INSP_KIT.json
+++ b/assets/resource/pipeline/IMS/item/ARMS_INSP_KIT.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__ARMS_INSP_KIT_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ARMS_INSP_KIT.json
+++ b/assets/resource/pipeline/IMS/item/ARMS_INSP_KIT.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__ARMS_INSP_KIT_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ARMS_INSP_SET.json
+++ b/assets/resource/pipeline/IMS/item/ARMS_INSP_SET.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ARMS_INSP_SET.json
+++ b/assets/resource/pipeline/IMS/item/ARMS_INSP_SET.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__ARMS_INSP_SET_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ARMS_INSP_SET.json
+++ b/assets/resource/pipeline/IMS/item/ARMS_INSP_SET.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__ARMS_INSP_SET_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/CAST_DIE.json
+++ b/assets/resource/pipeline/IMS/item/CAST_DIE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/CAST_DIE.json
+++ b/assets/resource/pipeline/IMS/item/CAST_DIE.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__CAST_DIE_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/CAST_DIE.json
+++ b/assets/resource/pipeline/IMS/item/CAST_DIE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__CAST_DIE_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/CHARTERED_HH_PERMIT.json
+++ b/assets/resource/pipeline/IMS/item/CHARTERED_HH_PERMIT.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/CHARTERED_HH_PERMIT.json
+++ b/assets/resource/pipeline/IMS/item/CHARTERED_HH_PERMIT.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__CHARTERED_HH_PERMIT_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/CHARTERED_HH_PERMIT.json
+++ b/assets/resource/pipeline/IMS/item/CHARTERED_HH_PERMIT.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__CHARTERED_HH_PERMIT_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/COOLANT_GEL.json
+++ b/assets/resource/pipeline/IMS/item/COOLANT_GEL.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/COOLANT_GEL.json
+++ b/assets/resource/pipeline/IMS/item/COOLANT_GEL.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__COOLANT_GEL_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/COOLANT_GEL.json
+++ b/assets/resource/pipeline/IMS/item/COOLANT_GEL.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__COOLANT_GEL_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/D96_STEEL_SAMPLE_4.json
+++ b/assets/resource/pipeline/IMS/item/D96_STEEL_SAMPLE_4.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/D96_STEEL_SAMPLE_4.json
+++ b/assets/resource/pipeline/IMS/item/D96_STEEL_SAMPLE_4.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__D96_STEEL_SAMPLE_4_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/D96_STEEL_SAMPLE_4.json
+++ b/assets/resource/pipeline/IMS/item/D96_STEEL_SAMPLE_4.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__D96_STEEL_SAMPLE_4_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ELEMENTARY_COGNITIVE_CARRIER.json
+++ b/assets/resource/pipeline/IMS/item/ELEMENTARY_COGNITIVE_CARRIER.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ELEMENTARY_COGNITIVE_CARRIER.json
+++ b/assets/resource/pipeline/IMS/item/ELEMENTARY_COGNITIVE_CARRIER.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__ELEMENTARY_COGNITIVE_CARRIER_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ELEMENTARY_COGNITIVE_CARRIER.json
+++ b/assets/resource/pipeline/IMS/item/ELEMENTARY_COGNITIVE_CARRIER.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__ELEMENTARY_COGNITIVE_CARRIER_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ELEMENTARY_COMBAT_RECORD.json
+++ b/assets/resource/pipeline/IMS/item/ELEMENTARY_COMBAT_RECORD.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ELEMENTARY_COMBAT_RECORD.json
+++ b/assets/resource/pipeline/IMS/item/ELEMENTARY_COMBAT_RECORD.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__ELEMENTARY_COMBAT_RECORD_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/ELEMENTARY_COMBAT_RECORD.json
+++ b/assets/resource/pipeline/IMS/item/ELEMENTARY_COMBAT_RECORD.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__ELEMENTARY_COMBAT_RECORD_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/HEAVY_CAST_DIE.json
+++ b/assets/resource/pipeline/IMS/item/HEAVY_CAST_DIE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/HEAVY_CAST_DIE.json
+++ b/assets/resource/pipeline/IMS/item/HEAVY_CAST_DIE.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__HEAVY_CAST_DIE_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/HEAVY_CAST_DIE.json
+++ b/assets/resource/pipeline/IMS/item/HEAVY_CAST_DIE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__HEAVY_CAST_DIE_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/INTERMEDIATE_COMBAT_RECORD.json
+++ b/assets/resource/pipeline/IMS/item/INTERMEDIATE_COMBAT_RECORD.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/INTERMEDIATE_COMBAT_RECORD.json
+++ b/assets/resource/pipeline/IMS/item/INTERMEDIATE_COMBAT_RECORD.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__INTERMEDIATE_COMBAT_RECORD_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/INTERMEDIATE_COMBAT_RECORD.json
+++ b/assets/resource/pipeline/IMS/item/INTERMEDIATE_COMBAT_RECORD.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__INTERMEDIATE_COMBAT_RECORD_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/MARK_OF_PERSEVERANCE.json
+++ b/assets/resource/pipeline/IMS/item/MARK_OF_PERSEVERANCE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/MARK_OF_PERSEVERANCE.json
+++ b/assets/resource/pipeline/IMS/item/MARK_OF_PERSEVERANCE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__MARK_OF_PERSEVERANCE_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/MARK_OF_PERSEVERANCE.json
+++ b/assets/resource/pipeline/IMS/item/MARK_OF_PERSEVERANCE.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__MARK_OF_PERSEVERANCE_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/METADIASTIMA_PHOTOEMISSION_TUBE.json
+++ b/assets/resource/pipeline/IMS/item/METADIASTIMA_PHOTOEMISSION_TUBE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/METADIASTIMA_PHOTOEMISSION_TUBE.json
+++ b/assets/resource/pipeline/IMS/item/METADIASTIMA_PHOTOEMISSION_TUBE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__METADIASTIMA_PHOTOEMISSION_TUBE_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/METADIASTIMA_PHOTOEMISSION_TUBE.json
+++ b/assets/resource/pipeline/IMS/item/METADIASTIMA_PHOTOEMISSION_TUBE.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__METADIASTIMA_PHOTOEMISSION_TUBE_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/OROBERYL.json
+++ b/assets/resource/pipeline/IMS/item/OROBERYL.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/OROBERYL.json
+++ b/assets/resource/pipeline/IMS/item/OROBERYL.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__OROBERYL_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/OROBERYL.json
+++ b/assets/resource/pipeline/IMS/item/OROBERYL.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__OROBERYL_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTODISK.json
+++ b/assets/resource/pipeline/IMS/item/PROTODISK.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTODISK.json
+++ b/assets/resource/pipeline/IMS/item/PROTODISK.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__PROTODISK_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTODISK.json
+++ b/assets/resource/pipeline/IMS/item/PROTODISK.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__PROTODISK_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTOHEDRON.json
+++ b/assets/resource/pipeline/IMS/item/PROTOHEDRON.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTOHEDRON.json
+++ b/assets/resource/pipeline/IMS/item/PROTOHEDRON.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__PROTOHEDRON_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTOHEDRON.json
+++ b/assets/resource/pipeline/IMS/item/PROTOHEDRON.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__PROTOHEDRON_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTOPRISM.json
+++ b/assets/resource/pipeline/IMS/item/PROTOPRISM.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTOPRISM.json
+++ b/assets/resource/pipeline/IMS/item/PROTOPRISM.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__PROTOPRISM_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTOPRISM.json
+++ b/assets/resource/pipeline/IMS/item/PROTOPRISM.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__PROTOPRISM_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTOSET.json
+++ b/assets/resource/pipeline/IMS/item/PROTOSET.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTOSET.json
+++ b/assets/resource/pipeline/IMS/item/PROTOSET.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__PROTOSET_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/PROTOSET.json
+++ b/assets/resource/pipeline/IMS/item/PROTOSET.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__PROTOSET_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/QUADRANT_FITTING_FLUID.json
+++ b/assets/resource/pipeline/IMS/item/QUADRANT_FITTING_FLUID.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/QUADRANT_FITTING_FLUID.json
+++ b/assets/resource/pipeline/IMS/item/QUADRANT_FITTING_FLUID.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__QUADRANT_FITTING_FLUID_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/QUADRANT_FITTING_FLUID.json
+++ b/assets/resource/pipeline/IMS/item/QUADRANT_FITTING_FLUID.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__QUADRANT_FITTING_FLUID_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/TACHYON_SCREENING_LATTICE.json
+++ b/assets/resource/pipeline/IMS/item/TACHYON_SCREENING_LATTICE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/TACHYON_SCREENING_LATTICE.json
+++ b/assets/resource/pipeline/IMS/item/TACHYON_SCREENING_LATTICE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__TACHYON_SCREENING_LATTICE_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/TACHYON_SCREENING_LATTICE.json
+++ b/assets/resource/pipeline/IMS/item/TACHYON_SCREENING_LATTICE.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__TACHYON_SCREENING_LATTICE_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/TRIPHASIC_NANOFLAKE.json
+++ b/assets/resource/pipeline/IMS/item/TRIPHASIC_NANOFLAKE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/TRIPHASIC_NANOFLAKE.json
+++ b/assets/resource/pipeline/IMS/item/TRIPHASIC_NANOFLAKE.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__TRIPHASIC_NANOFLAKE_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/TRIPHASIC_NANOFLAKE.json
+++ b/assets/resource/pipeline/IMS/item/TRIPHASIC_NANOFLAKE.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__TRIPHASIC_NANOFLAKE_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/T_CREDS.json
+++ b/assets/resource/pipeline/IMS/item/T_CREDS.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^[1-9]"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/T_CREDS.json
+++ b/assets/resource/pipeline/IMS/item/T_CREDS.json
@@ -98,7 +98,8 @@
                 ],
                 "expected": [
                     "^[1-9]"
-                ]
+                ],
+                "color_filter": "__T_CREDS_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/T_CREDS.json
+++ b/assets/resource/pipeline/IMS/item/T_CREDS.json
@@ -98,8 +98,7 @@
                 ],
                 "expected": [
                     "^[1-9]"
-                ],
-                "color_filter": "__T_CREDS_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/VALLEY_STOCK_BILL.json
+++ b/assets/resource/pipeline/IMS/item/VALLEY_STOCK_BILL.json
@@ -138,7 +138,8 @@
                 ],
                 "expected": [
                     "^[1-9]"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/VALLEY_STOCK_BILL.json
+++ b/assets/resource/pipeline/IMS/item/VALLEY_STOCK_BILL.json
@@ -138,8 +138,7 @@
                 ],
                 "expected": [
                     "^[1-9]"
-                ],
-                "color_filter": "__VALLEY_STOCK_BILL_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/VALLEY_STOCK_BILL.json
+++ b/assets/resource/pipeline/IMS/item/VALLEY_STOCK_BILL.json
@@ -138,7 +138,8 @@
                 ],
                 "expected": [
                     "^[1-9]"
-                ]
+                ],
+                "color_filter": "__VALLEY_STOCK_BILL_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/WULING_ARTIFICING_CATALYST.json
+++ b/assets/resource/pipeline/IMS/item/WULING_ARTIFICING_CATALYST.json
@@ -99,7 +99,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/WULING_ARTIFICING_CATALYST.json
+++ b/assets/resource/pipeline/IMS/item/WULING_ARTIFICING_CATALYST.json
@@ -99,7 +99,8 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ]
+                ],
+                "color_filter": "__WULING_ARTIFICING_CATALYST_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/WULING_ARTIFICING_CATALYST.json
+++ b/assets/resource/pipeline/IMS/item/WULING_ARTIFICING_CATALYST.json
@@ -99,8 +99,7 @@
                 ],
                 "expected": [
                     "^\\d+$"
-                ],
-                "color_filter": "__WULING_ARTIFICING_CATALYST_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/WULING_STOCK_BILL.json
+++ b/assets/resource/pipeline/IMS/item/WULING_STOCK_BILL.json
@@ -138,7 +138,8 @@
                 ],
                 "expected": [
                     "^[1-9]"
-                ]
+                ],
+                "only_rec": true
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/WULING_STOCK_BILL.json
+++ b/assets/resource/pipeline/IMS/item/WULING_STOCK_BILL.json
@@ -138,8 +138,7 @@
                 ],
                 "expected": [
                     "^[1-9]"
-                ],
-                "color_filter": "__WULING_STOCK_BILL_COUNT_TEXT_COLOR"
+                ]
             }
         },
         "pre_delay": 0,

--- a/assets/resource/pipeline/IMS/item/WULING_STOCK_BILL.json
+++ b/assets/resource/pipeline/IMS/item/WULING_STOCK_BILL.json
@@ -138,7 +138,8 @@
                 ],
                 "expected": [
                     "^[1-9]"
-                ]
+                ],
+                "color_filter": "__WULING_STOCK_BILL_COUNT_TEXT_COLOR"
             }
         },
         "pre_delay": 0,


### PR DESCRIPTION
给物品数量识别没加only_rec
会导致det模型在小图中异常识别

## Summary by Sourcery

通过在相关流水线中引入并标准化基于颜色的过滤机制，改进 IMS 物品数量识别。

Bug Fixes:
- 在 IMS 物品流水线中添加基于颜色的过滤，以缓解异常数量识别问题。

Enhancements:
- 在多个 IMS 物品数量检测流水线中统一颜色过滤参数，以实现行为一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve IMS item quantity recognition by introducing and standardizing color-based filtering across affected pipelines.

Bug Fixes:
- Add color-based filtering to IMS item pipelines to mitigate abnormal quantity recognition issues.

Enhancements:
- Align color filter parameters across multiple IMS item quantity detection pipelines for consistent behavior.

</details>

Bug 修复：
- 通过在受影响的 IMS 物品流水线配置中引入基于颜色的过滤，缓解物品数量识别异常问题。

增强项：
- 对多个 IMS 物品流水线的配置进行统一，使其在数量检测时使用一致的颜色过滤参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在相关流水线中引入并标准化基于颜色的过滤机制，改进 IMS 物品数量识别。

Bug Fixes:
- 在 IMS 物品流水线中添加基于颜色的过滤，以缓解异常数量识别问题。

Enhancements:
- 在多个 IMS 物品数量检测流水线中统一颜色过滤参数，以实现行为一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve IMS item quantity recognition by introducing and standardizing color-based filtering across affected pipelines.

Bug Fixes:
- Add color-based filtering to IMS item pipelines to mitigate abnormal quantity recognition issues.

Enhancements:
- Align color filter parameters across multiple IMS item quantity detection pipelines for consistent behavior.

</details>

</details>