### PR TITLE
feat(MapNavigator): web 工具支持 wlroots

### DIFF
--- a/tools/MapNavigator/README.md
+++ b/tools/MapNavigator/README.md
@@ -6,7 +6,7 @@ MapNavigator 是用于 C++ MapNavigator 模块使用的地图路径录制与编�
 
 当前支持：
 
-- 通过统一的录制连接层在 `Win32` 与 `ADB` 之间切换。
+- 通过统一的录制连接层在 `Win32`、`ADB` 与 `WlRoots`（Linux Wayland）之间切换。
 - 录制地图路径并按区域切换浏览。
 - 导入已有 JSON/JSONC，递归搜索可识别的 `path` 数据并显示。
 - 导入 `MapTrackerMove` / `MapTrackerAssertLocation` 时自动按兼容表转换到 `MapNavigator` / `MapLocateAssertLocation` 的 Base 坐标系。
@@ -23,6 +23,11 @@ MapNavigator 是用于 C++ MapNavigator 模块使用的地图路径录制与编�
 
 - `HEADING` 是无坐标控制节点，不属于 GUI 常规点编辑与导出模型，建议在导出 `path` 后手工补回或维护。
 - 运行时 `sprint_threshold` 的语义是“前方连续可跑段长度阈值”，不是只看当前点距离。
+
+## WlRoots 连接（Linux Wayland）
+
+- 游戏合成器需支持 `wlr-screencopy-unstable-v1` 协议；建议游戏跑在嵌套合成器（如 gamescope）上，**不要连接当前桌面会话的 socket**（连错会截到桌面而不是游戏）。
+- socket 路径是完整路径（如 `/run/user/1000/wayland-0`），不一定是 `$WAYLAND_DISPLAY` 指向的那个；下拉候选来自 `$XDG_RUNTIME_DIR` 下的实际 socket 枚举。
 
 ## 复制格式
 

--- a/tools/MapNavigator/connection_models.py
+++ b/tools/MapNavigator/connection_models.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 
-ConnectionKind = Literal["win32", "adb", "playcover"]
+ConnectionKind = Literal["win32", "adb", "playcover", "wlroots"]
 
 
 @dataclass(frozen=True)
@@ -60,6 +60,19 @@ class PlayCoverConnectionConfig:
 
 
 @dataclass(frozen=True)
+class WlRootsConnectionConfig:
+    """WlRoots (Linux Wayland) 录制所需的连接配置。
+
+    wlr_socket_path 是合成器的 Wayland socket 完整路径, 例如
+    ``/run/user/1000/wayland-0``。注意它不一定是 ``$WAYLAND_DISPLAY`` 指向的
+    那个 socket —— 游戏通常跑在嵌套合成器 (如 gamescope) 上, 连错成桌面会话会
+    截到桌面而不是游戏。
+    """
+
+    wlr_socket_path: str = ""
+
+
+@dataclass(frozen=True)
 class RecordingSessionConfig:
     """一次录制会话的完整连接配置。"""
 
@@ -67,6 +80,7 @@ class RecordingSessionConfig:
     win32: Win32ConnectionConfig = field(default_factory=Win32ConnectionConfig)
     adb: AdbConnectionConfig = field(default_factory=AdbConnectionConfig)
     playcover: PlayCoverConnectionConfig = field(default_factory=PlayCoverConnectionConfig)
+    wlroots: WlRootsConnectionConfig = field(default_factory=WlRootsConnectionConfig)
 
     def display_name(self) -> str:
         if self.kind == "adb":
@@ -74,4 +88,6 @@ class RecordingSessionConfig:
             return f"ADB / {target}"
         elif self.kind == "playcover":
             return f"PlayCover / {self.playcover.uuid}"
+        elif self.kind == "wlroots":
+            return f"WlRoots / {self.wlroots.wlr_socket_path or '未指定 socket'}"
         return f"Win32 / {self.win32.window_title}"

--- a/tools/MapNavigator/connectors.py
+++ b/tools/MapNavigator/connectors.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 import ctypes
 import inspect
 import json
+import os
 import shutil
 import subprocess
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
-from connection_models import AdbConnectionConfig, AdbDeviceInfo, RecordingSessionConfig, Win32ConnectionConfig, PlayCoverConnectionConfig
-from runtime import AGENT_DIR, MaaRuntime, RESOURCE_ADB_DIR
+from connection_models import (
+    AdbConnectionConfig,
+    AdbDeviceInfo,
+    PlayCoverConnectionConfig,
+    RecordingSessionConfig,
+    Win32ConnectionConfig,
+    WlRootsConnectionConfig,
+)
+from runtime import AGENT_DIR, MaaRuntime, RESOURCE_ADB_DIR, RESOURCE_WLROOTS_DIR
 
 DEFAULT_ADB_INPUT_METHODS = 1 | 2 | 4
 DEFAULT_ADB_SCREENCAP_METHODS = 1 | 2 | 4 | 64
@@ -124,11 +133,44 @@ class PlayCoverRecordingConnector(RecordingConnector):
                 raise RuntimeError(f"PlayCover 附加资源失败: {exc}") from exc
 
 
+class WlRootsRecordingConnector(RecordingConnector):
+    """基于 WlRoots (Linux Wayland 合成器) 建立录制连接。"""
+
+    def __init__(self, runtime: MaaRuntime, config: WlRootsConnectionConfig) -> None:
+        super().__init__(runtime)
+        self._config = config
+
+    def connect(self) -> Any:
+        if self._runtime.WlRootsController is None:
+            raise RuntimeError("当前 maafw Python 运行时不支持 WlRootsController (仅 Linux 支持)。")
+
+        socket_path = self._config.wlr_socket_path.strip()
+        if not socket_path:
+            raise RuntimeError("未指定 Wayland socket 路径。")
+
+        # use_win32_vk_code 与 assets/interface.json 的 Wlroots 控制器条目保持一致:
+        # MaaEnd pipeline 的按键动作按 Win32 VK 码表书写。MapNavigator 录制只截图不投递
+        # 按键, 该参数对录制无实际影响, 但连接器不应自创与项目约定不同的取值。
+        controller = self._runtime.WlRootsController(wlr_socket_path=socket_path, use_win32_vk_code=True)
+        controller.post_connection().wait()
+        return controller
+
+    def attach_resource(self, resource: Any) -> None:
+        attach_path = getattr(resource, "post_path", None)
+        if callable(attach_path) and RESOURCE_WLROOTS_DIR.exists():
+            try:
+                attach_path(str(RESOURCE_WLROOTS_DIR)).wait()
+            except Exception as exc:
+                raise RuntimeError(f"附加 WlRoots 资源失败: {exc}") from exc
+
+
 def build_recording_connector(runtime: MaaRuntime, session: RecordingSessionConfig) -> RecordingConnector:
     if session.kind == "adb":
         return AdbRecordingConnector(runtime, session.adb)
     elif session.kind == "playcover":
         return PlayCoverRecordingConnector(runtime, session.playcover)
+    elif session.kind == "wlroots":
+        return WlRootsRecordingConnector(runtime, session.wlroots)
     return Win32RecordingConnector(runtime, session.win32)
 
 
@@ -184,6 +226,36 @@ def list_adb_devices(adb_path: str) -> list[AdbDeviceInfo]:
             )
         )
     return devices
+
+
+def list_wlroots_sockets() -> list[str]:
+    """枚举 $XDG_RUNTIME_DIR 下名字含 wayland 的 socket 路径。
+
+    用「名字含 wayland」而不是 `wayland-*` 前缀, 是为了覆盖 `niri.wayland-1.1238.sock`
+    这类非标准前缀的真实合成器 socket。只做枚举, 不验证协议支持。
+    """
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR", "").strip()
+    if not runtime_dir:
+        uid = getattr(os, "getuid", lambda: 0)()
+        runtime_dir = f"/run/user/{uid}"
+
+    root = Path(runtime_dir)
+    if not root.is_dir():
+        return []
+
+    found: list[str] = []
+    try:
+        for entry in root.iterdir():
+            if "wayland" not in entry.name:
+                continue
+            try:
+                if entry.is_socket():
+                    found.append(str(entry))
+            except OSError:
+                continue
+    except OSError:
+        return []
+    return sorted(found)
 
 
 def find_game_window(expected_title: str) -> int:

--- a/tools/MapNavigator/runtime.py
+++ b/tools/MapNavigator/runtime.py
@@ -14,6 +14,7 @@ MAAFW_BIN_DIR = INSTALL_DIR / "maafw"
 RESOURCE_DIR = PROJECT_ROOT / "assets" / "resource"
 MAP_IMAGE_DIR = RESOURCE_DIR / "image"
 RESOURCE_ADB_DIR = PROJECT_ROOT / "assets" / "resource_adb"
+RESOURCE_WLROOTS_DIR = PROJECT_ROOT / "assets" / "resource_wlroots"
 
 
 def _resolve_cpp_agent_executable() -> Path:
@@ -62,6 +63,7 @@ class MaaRuntime:
     Win32Controller: Any
     AdbController: Any
     PlayCoverController: Any
+    WlRootsController: Any
     Tasker: Any
     AgentClient: Any
     Toolkit: Any
@@ -94,6 +96,11 @@ def load_maa_runtime() -> MaaRuntime | None:
         PlayCoverController = None
 
     try:
+        from maa.controller import WlRootsController
+    except ImportError:
+        WlRootsController = None
+
+    try:
         from maa.toolkit import Toolkit
     except ImportError:
         Toolkit = None
@@ -104,6 +111,7 @@ def load_maa_runtime() -> MaaRuntime | None:
         Win32Controller=Win32Controller,
         AdbController=AdbController,
         PlayCoverController=PlayCoverController,
+        WlRootsController=WlRootsController,
         Tasker=Tasker,
         AgentClient=AgentClient,
         Toolkit=Toolkit,

--- a/tools/MapNavigator/settings_store.py
+++ b/tools/MapNavigator/settings_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -11,15 +12,31 @@ from connection_models import ConnectionKind
 SETTINGS_DIR = Path.home() / ".maaend"
 SETTINGS_PATH = SETTINGS_DIR / "mapnavigator.json"
 
-CONNECTION_KINDS: tuple[ConnectionKind, ...] = ("win32", "adb", "playcover")
+CONNECTION_KINDS: tuple[ConnectionKind, ...] = ("win32", "adb", "playcover", "wlroots")
+
+
+def default_wlroots_socket_path() -> str:
+    """默认 Wayland socket 路径: ``$XDG_RUNTIME_DIR/wayland-0``。
+
+    不跟 ``$WAYLAND_DISPLAY`` 走 —— 游戏通常跑在嵌套合成器 (如 gamescope) 上,
+    桌面会话的 socket 才是 ``$WAYLAND_DISPLAY`` 指向的那个, 连错会截到桌面。
+    """
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR", "").strip()
+    if runtime_dir:
+        return os.path.join(runtime_dir, "wayland-0")
+    uid = getattr(os, "getuid", lambda: 0)()
+    return f"/run/user/{uid}/wayland-0"
 
 
 def supported_connection_kinds() -> tuple[ConnectionKind, ...]:
-    """当前系统真正能连上的方式：句柄只有 Windows 有，PlayCover 只有 macOS 有，ADB 到处都有。"""
+    """当前系统真正能连上的方式：句柄只有 Windows 有，PlayCover 只有 macOS 有，
+    WlRoots 只有 Linux 有，ADB 到处都有。"""
     if sys.platform == "win32":
         return ("win32", "adb")
     if sys.platform == "darwin":
         return ("playcover", "adb")
+    if sys.platform.startswith("linux"):
+        return ("wlroots", "adb")
     return ("adb",)
 
 
@@ -37,6 +54,7 @@ class MapNavigatorSettings:
     win32_window_title: str = "Endfield"
     playcover_uuid: str = "maa.playcover"
     playcover_address: str = "127.0.0.1:1717"
+    wlroots_socket_path: str = field(default_factory=default_wlroots_socket_path)
     recent_adb_targets: list[str] = field(default_factory=list)
 
 
@@ -66,6 +84,7 @@ class MapNavigatorSettingsStore:
             "win32_window_title": payload.get("win32_window_title", defaults.win32_window_title),
             "playcover_uuid": payload.get("playcover_uuid", defaults.playcover_uuid),
             "playcover_address": payload.get("playcover_address", defaults.playcover_address),
+            "wlroots_socket_path": payload.get("wlroots_socket_path", defaults.wlroots_socket_path),
             "recent_adb_targets": payload.get("recent_adb_targets", defaults.recent_adb_targets),
         }
         if merged["connection_kind"] not in CONNECTION_KINDS:
@@ -73,6 +92,8 @@ class MapNavigatorSettingsStore:
         if not isinstance(merged["recent_adb_targets"], list):
             merged["recent_adb_targets"] = []
         merged["recent_adb_targets"] = [str(item) for item in merged["recent_adb_targets"] if str(item).strip()]
+        if not str(merged["wlroots_socket_path"] or "").strip():
+            merged["wlroots_socket_path"] = defaults.wlroots_socket_path
         return MapNavigatorSettings(**merged)
 
     def save(self, settings: MapNavigatorSettings) -> None:

--- a/tools/MapNavigator/web/serve.py
+++ b/tools/MapNavigator/web/serve.py
@@ -23,7 +23,8 @@
   GET  /api/settings          -> 读取 ~/.maaend/mapnavigator.json
   PUT  /api/settings          -> 写入 ~/.maaend/mapnavigator.json
   GET  /api/adb/devices       -> adb devices -l 枚举 (容错)
-  POST /api/connection/check  -> 主动探测当前连接配置是否可达 (win32 窗口 / adb 设备 / playcover 端口)
+  GET  /api/wlroots/sockets   -> $XDG_RUNTIME_DIR 下 Wayland socket 枚举 (供 datalist)
+  POST /api/connection/check  -> 主动探测当前连接配置是否可达 (win32 窗口 / adb 设备 / playcover 端口 / wlroots socket)
   POST /api/locate-once       -> 单次游戏内定位 (临时连接, 取第 3 个有效帧的 x/y/zone)
   POST /api/import/analyze    -> 解析上传 JSON (路线/Assert); 缺 zone 时回片段供前端指定
   POST /api/import/finalize   -> 按片段 zone 指定定稿导入 (convert_maptracker+infer+normalize)
@@ -70,11 +71,18 @@ from basenav_preview import (  # noqa: E402
 )
 from connection_models import (  # noqa: E402
     AdbConnectionConfig,
+    PlayCoverConnectionConfig,
     RecordingSessionConfig,
     Win32ConnectionConfig,
-    PlayCoverConnectionConfig,
+    WlRootsConnectionConfig,
 )
-from connectors import build_recording_connector, find_game_window, list_adb_devices, resolve_adb_path  # noqa: E402
+from connectors import (  # noqa: E402
+    build_recording_connector,
+    find_game_window,
+    list_adb_devices,
+    list_wlroots_sockets,
+    resolve_adb_path,
+)
 from model import normalize_zone_id, resolve_zone_image  # noqa: E402
 from recastnav import DECK_BAND  # noqa: E402
 from recastnav_route import RecastEngine  # noqa: E402
@@ -95,6 +103,7 @@ from settings_store import (  # noqa: E402
     MapNavigatorSettings,
     MapNavigatorSettingsStore,
     default_connection_kind,
+    default_wlroots_socket_path,
     supported_connection_kinds,
 )
 
@@ -380,6 +389,14 @@ def _build_session_config(payload: dict[str, Any]) -> RecordingSessionConfig:
             playcover=PlayCoverConnectionConfig(
                 address=str(playcover.get("address", "127.0.0.1:1717") or "127.0.0.1:1717"),
                 uuid=str(playcover.get("uuid", "maa.playcover") or "maa.playcover"),
+            ),
+        )
+    elif kind == "wlroots":
+        wlroots = payload.get("wlroots") or {}
+        return RecordingSessionConfig(
+            kind="wlroots",
+            wlroots=WlRootsConnectionConfig(
+                wlr_socket_path=str(wlroots.get("wlr_socket_path", "") or ""),
             ),
         )
     win = payload.get("win32") or {}
@@ -763,6 +780,8 @@ async def api_put_settings(payload: dict[str, Any] = Body(default_factory=dict))
         win32_window_title=str(payload.get("win32_window_title", current.win32_window_title)),
         playcover_uuid=str(payload.get("playcover_uuid", current.playcover_uuid)),
         playcover_address=str(payload.get("playcover_address", current.playcover_address)),
+        wlroots_socket_path=str(payload.get("wlroots_socket_path", current.wlroots_socket_path)).strip()
+        or default_wlroots_socket_path(),
         recent_adb_targets=recent,
     )
     try:
@@ -777,7 +796,8 @@ async def api_connection_check(payload: dict[str, Any] = Body(default_factory=di
     """主动探测当前连接配置是否可达 (不建立录制会话)。
 
     win32 = 窗口句柄查找; adb = 设备枚举 (网络地址先 adb connect); playcover = PlayTools
-    端口 TCP 探活 + PlayCover.app 安装检查。探测均为阻塞调用 (adb 子进程 / socket 超时),
+    端口 TCP 探活 + PlayCover.app 安装检查; wlroots = socket 存在性 + 类型检查
+    (协议支持无法廉价验证, 由真实截图时兜底)。探测均为阻塞调用 (adb 子进程 / socket 超时),
     必须在 threadpool 中执行, 否则会卡住事件循环上的其他请求 (前端输入防抖会频繁触发本端点)。
     """
 
@@ -846,6 +866,25 @@ async def api_connection_check(payload: dict[str, Any] = Body(default_factory=di
                 return {"connected": False, "message": "未在默认位置找到 PlayCover.app 安装"}
             return {"connected": True, "message": f"PlayCover 在线, 端口: {address}"}
 
+        if kind == "wlroots":
+            if not sys.platform.startswith("linux"):
+                return {"connected": False, "message": "非 Linux 环境不支持 WlRoots 连接"}
+            socket_path = str(payload.get("wlroots_socket_path", current.wlroots_socket_path)).strip()
+            if not socket_path:
+                return {"connected": False, "message": "未指定 Wayland socket 路径"}
+            try:
+                socket_path_obj = Path(socket_path)
+                if not socket_path_obj.exists():
+                    return {"connected": False, "message": f"Wayland socket 不存在: {socket_path}"}
+                if not socket_path_obj.is_socket():
+                    return {"connected": False, "message": f"路径存在但不是 socket: {socket_path}"}
+            except OSError as exc:  # noqa: BLE001
+                return {"connected": False, "message": f"Wayland socket 检测异常: {exc}"}
+            runtime = get_runtime()
+            if runtime is None or getattr(runtime, "WlRootsController", None) is None:
+                return {"connected": False, "message": "当前运行环境未提供 WlRoots 库支持"}
+            return {"connected": True, "message": f"WlRoots 在线: {socket_path}"}
+
         return {"connected": False, "message": f"未知连接类型: {kind}"}
 
     return await run_in_threadpool(_check)
@@ -875,6 +914,17 @@ async def api_adb_devices(adb_path: str = "") -> dict[str, Any]:
         return await run_in_threadpool(_list)
     except Exception as exc:  # noqa: BLE001
         return {"devices": [], "error": str(exc)}
+
+
+@app.get("/api/wlroots/sockets")
+async def api_wlroots_sockets() -> dict[str, Any]:
+    """枚举 $XDG_RUNTIME_DIR 下名字含 wayland 的 socket, 供前端 datalist 候选。
+
+    只做目录枚举 + socket 判断, 不验证合成器是否支持 wlr-screencopy —— 那要真实
+    截图才知道, 由连接状态探测 / 录制时兜底。
+    """
+    sockets = await run_in_threadpool(list_wlroots_sockets)
+    return {"sockets": sockets, "default": default_wlroots_socket_path()}
 
 
 # --- 导入 / 导出 (Option 1: 复用未改动的 json_import.py + maptracker_compat.py) --------
@@ -1331,6 +1381,7 @@ async def api_locate_once(payload: dict[str, Any] = Body(default_factory=dict)) 
             "win32": {"window_title": current.win32_window_title},
             "adb": {"adb_path": current.adb_path, "address": current.adb_address},
             "playcover": {"address": current.playcover_address, "uuid": current.playcover_uuid},
+            "wlroots": {"wlr_socket_path": current.wlroots_socket_path},
         }
     session_config = _build_session_config(cfg_payload)
 

--- a/tools/MapNavigator/web/static/index.html
+++ b/tools/MapNavigator/web/static/index.html
@@ -40,6 +40,7 @@
             <select id="connection-kind-combo" class="combo">
               <option value="win32">Windows 窗口句柄</option>
               <option value="adb">Android ADB 桥接</option>
+              <option value="wlroots">WlRoots (Linux Wayland)</option>
               <option value="playcover">PlayCover (macOS)</option>
             </select>
           </div>
@@ -74,6 +75,17 @@
             </div>
             <div class="sidebar-row" style="margin-top: 4px">
               <button id="btn-refresh-adb" class="btn btn-secondary btn-sm" type="button" style="width: 100%">检测并刷新设备</button>
+            </div>
+          </div>
+
+          <div id="wlroots-group" class="conn-group" hidden>
+            <div class="sidebar-row select-row">
+              <label class="sidebar-label" for="wlroots-socket-entry">Wayland socket</label>
+              <input id="wlroots-socket-entry" class="entry entry-wlroots" type="text" list="wlroots-socket-list" placeholder="例如 /run/user/1000/wayland-0" />
+              <datalist id="wlroots-socket-list"></datalist>
+            </div>
+            <div class="sidebar-row" style="margin-top: 4px">
+              <button id="btn-refresh-wlroots" class="btn btn-secondary btn-sm" type="button" style="width: 100%">检测并刷新 socket</button>
             </div>
           </div>
           </div>

--- a/tools/MapNavigator/web/static/js/main.js
+++ b/tools/MapNavigator/web/static/js/main.js
@@ -226,6 +226,10 @@ class MapNavigatorApp {
       adbTargetInput: $('adb-target-combo'),
       adbTargetList: $('adb-target-list'),
       btnRefreshAdb: $('btn-refresh-adb'),
+      wlrootsGroup: $('wlroots-group'),
+      wlrootsSocketEntry: $('wlroots-socket-entry'),
+      wlrootsSocketList: $('wlroots-socket-list'),
+      btnRefreshWlroots: $('btn-refresh-wlroots'),
       connectionSummary: $('connection-summary'),
       astarDisplayZoneCombo: $('astar-display-zone-combo'),
       astarZoneCombo: $('astar-zone-combo'),
@@ -298,6 +302,10 @@ class MapNavigatorApp {
         adbTargetInput: this.els.adbTargetInput,
         adbTargetList: this.els.adbTargetList,
         btnRefreshAdb: this.els.btnRefreshAdb,
+        wlrootsGroup: this.els.wlrootsGroup,
+        wlrootsSocketEntry: this.els.wlrootsSocketEntry,
+        wlrootsSocketList: this.els.wlrootsSocketList,
+        btnRefreshWlroots: this.els.btnRefreshWlroots,
         summary: this.els.connectionSummary,
       });
       this.recording = new RecordingController({

--- a/tools/MapNavigator/web/static/js/rpc.js
+++ b/tools/MapNavigator/web/static/js/rpc.js
@@ -358,6 +358,15 @@ export function getAdbDevices(adbPath = '') {
   return getJson(`/api/adb/devices${q}`);
 }
 
+/**
+ * Enumerate Wayland sockets under `$XDG_RUNTIME_DIR` (name contains "wayland"),
+ * plus the computed default socket path.
+ * @returns {Promise<{sockets:string[], default:string}>}
+ */
+export function getWlrootsSockets() {
+  return getJson('/api/wlroots/sockets');
+}
+
 // --- recording (WebSocket) -----------------------------------------------------------
 
 /**

--- a/tools/MapNavigator/web/static/js/ui/connection.js
+++ b/tools/MapNavigator/web/static/js/ui/connection.js
@@ -10,19 +10,20 @@
  * @module ui/connection
  */
 
-import { getPlatform, getSettings, putSettings, getAdbDevices, checkConnection } from '../rpc.js';
+import { getPlatform, getSettings, putSettings, getAdbDevices, getWlrootsSockets, checkConnection } from '../rpc.js';
 import { setStatus } from './toast.js';
 
 export class ConnectionPanel {
   /**
    * @param {Object} els bound DOM elements:
    *   {kindCombo, win32Group, win32Entry, playcoverGroup, playcoverAddrEntry, playcoverUuidEntry,
-   *    adbGroup, adbPathEntry, adbTargetInput, adbTargetList, btnRefreshAdb, summary}
+   *    adbGroup, adbPathEntry, adbTargetInput, adbTargetList, btnRefreshAdb,
+   *    wlrootsGroup, wlrootsSocketEntry, wlrootsSocketList, btnRefreshWlroots, summary}
    */
   constructor(els) {
     this.els = els;
     this.statusDot = document.getElementById('status-dot');
-    /** @type {{connection_kind:string, adb_path:string, adb_address:string, win32_window_title:string, playcover_address:string, playcover_uuid:string, recent_adb_targets:string[]}} */
+    /** @type {{connection_kind:string, adb_path:string, adb_address:string, win32_window_title:string, playcover_address:string, playcover_uuid:string, wlroots_socket_path:string, recent_adb_targets:string[]}} */
     this.settings = {
       connection_kind: '',
       adb_path: '',
@@ -30,15 +31,17 @@ export class ConnectionPanel {
       win32_window_title: 'Endfield',
       playcover_address: '127.0.0.1:1717',
       playcover_uuid: 'maa.playcover',
+      wlroots_socket_path: '',
       recent_adb_targets: [],
     };
     this._devicesLoadedOnce = false;
+    this._socketsLoadedOnce = false;
     this._persistTimer = 0;
     this._checkTimer = 0;
     /** @type {boolean} last observed connected state; drives auto-collapse on the rising edge. */
     this._wasConnected = false;
     /** @type {{platform:string, supported_kinds:string[], default_kind:string}} */
-    this.platform = { platform: '', supported_kinds: ['win32', 'adb', 'playcover'], default_kind: 'win32' };
+    this.platform = { platform: '', supported_kinds: ['win32', 'adb', 'playcover', 'wlroots'], default_kind: 'win32' };
   }
 
   /**
@@ -70,6 +73,7 @@ export class ConnectionPanel {
     this.els.playcoverUuidEntry.value = this.settings.playcover_uuid || 'maa.playcover';
     this.els.adbPathEntry.value = this.settings.adb_path || '';
     this.els.adbTargetInput.value = this.settings.adb_address || '';
+    this.els.wlrootsSocketEntry.value = this.settings.wlroots_socket_path || '';
 
     this._wire();
     this.syncControls();
@@ -77,6 +81,9 @@ export class ConnectionPanel {
 
     if (this.kind() === 'adb' && !this._devicesLoadedOnce) {
       await this.refreshDevices();
+    }
+    if (this.kind() === 'wlroots' && !this._socketsLoadedOnce) {
+      await this.refreshWlrootsSockets();
     }
   }
 
@@ -95,6 +102,7 @@ export class ConnectionPanel {
       this.refreshSummary();
       this.persist();
       if (this.kind() === 'adb' && !this._devicesLoadedOnce) this.refreshDevices();
+      if (this.kind() === 'wlroots' && !this._socketsLoadedOnce) this.refreshWlrootsSockets();
     });
     this.els.win32Entry.addEventListener('input', () => {
       this.refreshSummary();
@@ -121,6 +129,15 @@ export class ConnectionPanel {
       this.persist();
     });
     this.els.btnRefreshAdb.addEventListener('click', () => this.refreshDevices());
+    this.els.wlrootsSocketEntry.addEventListener('input', () => {
+      this.refreshSummary();
+      this._persistDebounced();
+    });
+    this.els.wlrootsSocketEntry.addEventListener('change', () => {
+      this.refreshSummary();
+      this.persist();
+    });
+    this.els.btnRefreshWlroots.addEventListener('click', () => this.refreshWlrootsSockets());
   }
 
   /**
@@ -143,7 +160,7 @@ export class ConnectionPanel {
     this.persist();
   }
 
-  /** @returns {'win32'|'adb'|'playcover'} the active connection kind */
+  /** @returns {'win32'|'adb'|'playcover'|'wlroots'} the active connection kind */
   kind() {
     return this.els.kindCombo.value || this.platform.default_kind;
   }
@@ -153,6 +170,7 @@ export class ConnectionPanel {
     const k = this.kind();
     if (k === 'adb') return 'ADB';
     if (k === 'playcover') return 'PlayCover';
+    if (k === 'wlroots') return 'WlRoots';
     return 'Win32';
   }
 
@@ -162,6 +180,7 @@ export class ConnectionPanel {
     this.els.win32Group.hidden = (k !== 'win32');
     this.els.playcoverGroup.hidden = (k !== 'playcover');
     this.els.adbGroup.hidden = (k !== 'adb');
+    this.els.wlrootsGroup.hidden = (k !== 'wlroots');
   }
 
   /** Update the summary line. @returns {void} */
@@ -173,6 +192,9 @@ export class ConnectionPanel {
     } else if (k === 'playcover') {
       const addr = this.els.playcoverAddrEntry.value.trim() || '127.0.0.1:1717';
       this.els.summary.textContent = `PlayCover: ${addr}`;
+    } else if (k === 'wlroots') {
+      const socketPath = this.els.wlrootsSocketEntry.value.trim();
+      this.els.summary.textContent = socketPath ? `WlRoots: ${socketPath}` : 'WlRoots: 未指定 socket';
     } else {
       const title = this.els.win32Entry.value.trim();
       this.els.summary.textContent = `Win32: ${title || 'Endfield'}`;
@@ -219,6 +241,7 @@ export class ConnectionPanel {
       playcover_address: this.els.playcoverAddrEntry.value.trim(),
       adb_path: this.els.adbPathEntry.value.trim(),
       adb_address: this.els.adbTargetInput.value.trim(),
+      wlroots_socket_path: this.els.wlrootsSocketEntry.value.trim(),
     };
 
     try {
@@ -335,6 +358,42 @@ export class ConnectionPanel {
     }
   }
 
+  /**
+   * Enumerate Wayland sockets from the backend, refill the datalist, auto-select
+   * the default when the target is empty, and persist. Never throws to the caller.
+   * @returns {Promise<void>}
+   */
+  async refreshWlrootsSockets() {
+    let result;
+    try {
+      result = await getWlrootsSockets();
+    } catch (err) {
+      setStatus(`刷新 Wayland socket 失败: ${err && err.message ? err.message : err}`, '#ef4444');
+      return;
+    }
+    this._socketsLoadedOnce = true;
+    const sockets = Array.isArray(result.sockets) ? result.sockets : [];
+
+    const list = this.els.wlrootsSocketList;
+    if (list) {
+      list.textContent = '';
+      for (const socketPath of sockets) {
+        const opt = document.createElement('option');
+        opt.value = socketPath;
+        list.appendChild(opt);
+      }
+    }
+
+    const current = this.els.wlrootsSocketEntry.value.trim();
+    if (!current) {
+      this.els.wlrootsSocketEntry.value = result.default || '';
+      this.refreshSummary();
+    }
+
+    await this.persist();
+    setStatus(`已刷新 Wayland socket，共 ${sockets.length} 个。`, '#10b981');
+  }
+
   /** Debounced settings persist for high-frequency text input. @returns {void} */
   _persistDebounced() {
     if (this._persistTimer) window.clearTimeout(this._persistTimer);
@@ -358,6 +417,7 @@ export class ConnectionPanel {
       win32_window_title: this.els.win32Entry.value.trim() || 'Endfield',
       playcover_address: this.els.playcoverAddrEntry.value.trim() || '127.0.0.1:1717',
       playcover_uuid: this.els.playcoverUuidEntry.value.trim() || 'maa.playcover',
+      wlroots_socket_path: this.els.wlrootsSocketEntry.value.trim(),
       recent_adb_targets: this._mergeRecent([target]),
     };
     try {
@@ -370,7 +430,7 @@ export class ConnectionPanel {
 
   /**
    * The recording session config for the current target (tk `_build_recording_session`).
-   * @returns {{kind:'win32'|'adb'|'playcover', win32:{window_title:string}, adb:{adb_path:string, address:string}, playcover:{uuid:string}}}
+   * @returns {{kind:'win32'|'adb'|'playcover'|'wlroots', win32:{window_title:string}, adb:{adb_path:string, address:string}, playcover:{uuid:string}, wlroots:{wlr_socket_path:string}}}
    */
   buildSession() {
     return {
@@ -383,6 +443,9 @@ export class ConnectionPanel {
       playcover: {
         address: this.els.playcoverAddrEntry.value.trim(),
         uuid: this.els.playcoverUuidEntry.value.trim() || 'maa.playcover',
+      },
+      wlroots: {
+        wlr_socket_path: this.els.wlrootsSocketEntry.value.trim(),
       },
     };
   }


### PR DESCRIPTION
## Summary by Sourcery

在 MapNavigator 中添加 WlRoots（Linux Wayland）作为一等录制连接类型，包括后端运行时支持、Web UI 集成、设置持久化以及连接检查。

New Features:
- 引入 `WlRootsConnectionConfig`，并扩展录制会话以支持 `wlroots` 连接类型。
- 添加 `WlRootsRecordingConnector`，使用 Maa 运行时中的 `WlRootsController`，并附加 `wlroots` 特定资源。
- 暴露一个 API 端点和前端 RPC，用于在 `$XDG_RUNTIME_DIR` 下枚举 Wayland 套接字，以便在 Web UI 中进行选择。
- 扩展 Web 连接面板，加入 `WlRoots` 专用的控制和会话构建，包括自动填充的摘要和默认值。

Enhancements:
- 更新各平台的支持连接类型，使 Linux 使用 `WlRoots` 作为其主要的非 ADB 连接方式。
- 从 Maa 运行时加载 `WlRootsController`，并注册 `wlroots` 资源目录供 MapNavigator 使用。
- 添加 `WlRoots` 的连接检查逻辑，在录制之前验证套接字是否存在、类型是否正确以及运行时是否支持。

Documentation:
- 更新 MapNavigator 的 README，记录 `WlRoots`（Linux Wayland）的连接要求和使用方式，包括套接字选择行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add WlRoots (Linux Wayland) as a first-class recording connection type in MapNavigator, including backend runtime support, web UI integration, settings persistence, and connection checking.

New Features:
- Introduce WlRootsConnectionConfig and extend recording sessions to support a wlroots connection kind.
- Add a WlRootsRecordingConnector that uses the Maa runtime WlRootsController and attaches wlroots-specific resources.
- Expose an API endpoint and frontend RPC to enumerate Wayland sockets under $XDG_RUNTIME_DIR for selection in the web UI.
- Extend the web connection panel with WlRoots-specific controls and session building, including auto-populated summaries and defaults.

Enhancements:
- Update supported connection kinds per platform so Linux uses WlRoots as its primary non-ADB connection.
- Load WlRootsController from the Maa runtime and register wlroots resource directory for use by MapNavigator.
- Add connection checking logic for WlRoots to validate socket existence, type, and runtime support before recording.

Documentation:
- Update MapNavigator README to document WlRoots (Linux Wayland) connectivity requirements and usage, including socket selection behavior.

</details>