### PR TITLE
fix:修复wlroots中不会将鼠标移开

### DIFF
--- a/agent/go-service/ims/add_item_data.go
+++ b/agent/go-service/ims/add_item_data.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/control"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/minicv"
@@ -19,6 +18,8 @@ import (
 
 const (
 	componentAddItemData = "AddItemData"
+	// Pipeline node that moves the cursor off reward icons; ADB overlays DoNothing.
+	nodeIMSA3MouseMoveReset = "IMSA3MouseMoveReset"
 	// Safety cap when mask_hit_region keeps re-scanning the same item ID.
 	addItemDataMaxHitsPerItem = 32
 )
@@ -123,7 +124,7 @@ func (a *AddItemData) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 		return false
 	}
 	ctrl := tasker.GetController()
-	moveCursorTopLeftIfWin32(ctrl)
+	resetCursorBeforeRecognition(ctx, ctrl)
 	img, err := ctrl.CacheImage()
 	if err != nil || img == nil {
 		log.Error().
@@ -299,32 +300,27 @@ func parseAddItemDataParam(raw string) (addItemDataParam, error) {
 	return params, nil
 }
 
-// moveCursorTopLeftIfWin32 moves the cursor to the top-left corner before A3
-// recognition so it does not occlude reward icons. Win32 only; pressure 0 means
-// move-only (no click). Non-Win32 controllers are skipped.
-func moveCursorTopLeftIfWin32(ctrl *maa.Controller) {
-	if ctrl == nil {
+// resetCursorBeforeRecognition runs IMSA3MouseMoveReset before A3 recognition
+// so the cursor does not occlude reward icons. Controller-specific behavior is
+// owned by Pipeline overlays (e.g. ADB DoNothing). Screencap is refreshed
+// afterwards so CacheImage reflects any cursor change.
+func resetCursorBeforeRecognition(ctx *maa.Context, ctrl *maa.Controller) {
+	if ctx == nil || ctrl == nil {
 		return
 	}
-	controlType, err := control.GetControlType(ctrl)
-	if err != nil {
+	if _, err := ctx.RunAction(nodeIMSA3MouseMoveReset, maa.Rect{0, 0, 0, 0}, "", nil); err != nil {
 		log.Warn().
 			Err(err).
 			Str("component", componentAddItemData).
-			Msg("failed to resolve controller type, skip cursor move")
+			Str("node", nodeIMSA3MouseMoveReset).
+			Msg("failed to run IMSA3MouseMoveReset before recognition")
 		return
 	}
-	if controlType != control.CONTROL_TYPE_WIN32 {
-		return
-	}
-	ctrl.PostTouchMove(0, 0, 0, 0).Wait()
 	ctrl.PostScreencap().Wait()
 	log.Info().
 		Str("component", componentAddItemData).
-		Str("controller_type", controlType).
-		Int("x", 0).
-		Int("y", 0).
-		Msg("moved cursor to top-left before recognition")
+		Str("node", nodeIMSA3MouseMoveReset).
+		Msg("ran IMSA3MouseMoveReset before recognition")
 }
 
 func workingRGBA(img image.Image) *image.RGBA {

--- a/assets/resource/pipeline/IMS/AddItemData.json
+++ b/assets/resource/pipeline/IMS/AddItemData.json
@@ -1,4 +1,21 @@
 {
+    "IMSA3MouseMoveReset": {
+        "desc": "IMS A3：识别前将鼠标移到左上角，避免遮挡奖励图标；ADB 等触摸资源包覆盖为 DoNothing",
+        "pre_delay": 0,
+        "action": {
+            "type": "TouchMove",
+            "param": {
+                "target": [
+                    0,
+                    0,
+                    1,
+                    1
+                ]
+            }
+        },
+        "post_delay": 200,
+        "rate_limit": 0
+    },
     "AddItemDataOnRewards": {
         "desc": "IMS A3 最佳实践模板：奖励关闭按钮可见且奖励区静止后，累加识别到的物品数量，再关闭奖励界面。items 省略时使用 data/IMS/items.json 的 a3 全量清单；业务侧可按需覆盖 items，并替换识别节点（奖励界面 ROI 可能与培养素材页不同）",
         "recognition": {

--- a/assets/resource_adb/pipeline/IMS/AddItemData.json
+++ b/assets/resource_adb/pipeline/IMS/AddItemData.json
@@ -1,0 +1,9 @@
+{
+    "IMSA3MouseMoveReset": {
+        "desc": "ADB 无鼠标光标遮挡，识别前无需移动",
+        "pre_delay": 0,
+        "action": "DoNothing",
+        "post_delay": 0,
+        "rate_limit": 0
+    }
+}


### PR DESCRIPTION
去掉A3中原本的直接判断控制器,从而移开鼠标

现在改成,识别前会执行指定节点动作
由pipeline来进行覆盖这个动作来实现对应控制器的识别前预处理

## Summary by Sourcery

在 A3 奖励识别之前使用管线节点来重置光标，而不是硬编码仅适用于 Win32 的光标移动，从而实现与平台无关的光标处理（包括 wlroots/ADB）。

Bug 修复：
- 在非 Win32 环境（如 wlroots）中，防止鼠标光标在 AddItemData 识别过程中遮挡奖励图标。

增强功能：
- 将识别前的光标处理通过 `IMSA3MouseMoveReset` 管线节点进行，并在之后刷新屏幕截图，以确保缓存图像的一致性。
- 从 `AddItemData` 中移除对控制器类型的直接检查，改为使用基于管线的行为来适配不同后端，包括 ADB。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use a pipeline node to reset the cursor before A3 reward recognition instead of hard‑coding a Win32‑only cursor move, enabling platform‑agnostic cursor handling (including wlroots/ADB).

Bug Fixes:
- Prevent the mouse cursor from occluding reward icons during AddItemData recognition across non‑Win32 environments such as wlroots.

Enhancements:
- Route pre‑recognition cursor handling through the IMSA3MouseMoveReset pipeline node and refresh screencap afterwards for consistent cache images.
- Remove direct controller type inspection from AddItemData in favor of pipeline‑driven behavior for different backends, including ADB.

</details>

## Summary by Sourcery

通过管线节点路由 AddItemData 预识别阶段的光标处理，使奖励图标在不同控制器后端上都不会被光标遮挡。

Bug Fixes:
- 确保在非 Win32 后端（如 wlroots）上进行 AddItemData 识别时，将鼠标光标移动离开 A3 奖励图标。

Enhancements:
- 用 `IMSA3MouseMoveReset` 管线节点和后续的屏幕截图刷新来替换 AddItemData 中基于控制器类型的特定光标移动逻辑，从而实现与平台无关的行为。
- 为 AddItemData 引入基于 ADB 的管线配置，使其预识别行为通过叠加层进行控制，而不是依赖硬编码逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route AddItemData pre-recognition cursor handling through a pipeline node so reward icons are not occluded across different controller backends.

Bug Fixes:
- Ensure the mouse cursor is moved off A3 reward icons during AddItemData recognition on non-Win32 backends such as wlroots.

Enhancements:
- Replace controller-type-specific cursor movement in AddItemData with the IMSA3MouseMoveReset pipeline node and subsequent screencap refresh to enable platform-agnostic behavior.
- Introduce ADB-specific pipeline configuration for AddItemData so its pre-recognition behavior is controlled via overlays rather than hardcoded logic.

</details>