### PR TITLE
chore: Prettier 忽略 Markdown 文件

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,6 +23,9 @@ package-lock.json
 agent/go-service/go.sum
 agent/go-service/vendor/
 
+# Markdown 使用 markdownlint 格式化
+**/*.md
+
 # 其他
 *.min.js
 *.min.css


### PR DESCRIPTION
## Summary by Sourcery

Build:
- 修改 `.prettierignore`，以变更哪些 Markdown 文件被排除在格式化之外。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Modify .prettierignore to change which Markdown files are excluded from formatting.

</details>