### PR TITLE
fix: 选剑演武处理跨日自由演算

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCoating.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyCoating.json
@@ -319,7 +319,7 @@
         },
         "post_delay": 0,
         "next": [
-            "TrialOfSwordmancyCoatingMain"
+            "TrialOfSwordmancyMain"
         ]
     }
 }

--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyDaily.json
@@ -324,7 +324,7 @@
         },
         "post_delay": 0,
         "next": [
-            "TrialOfSwordmancyDailyMain"
+            "TrialOfSwordmancyMain"
         ]
     }
 }


### PR DESCRIPTION
其实是之前的 PR 处理的跨日自由演算，但忘记改出口了

## Summary by Sourcery

Bug Fixes:
- 修复在 TrialOfSwordmancy 每日配置中跨日计算处理不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect handling of cross-day calculations in TrialOfSwordmancy daily configuration.

</details>