### PR TITLE
chore: 抢委托改选项 default

### DIFF
--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsCommon.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsCommon.json
@@ -301,7 +301,7 @@
         "desc": "价格下限配置仓库（不实际识别；expected 由 tasks 覆写为用户输入，go 读取 expected[0]）",
         "recognition": "OCR",
         "expected": [
-            "16.3"
+            "15.9"
         ]
     }
 }

--- a/assets/tasks/SeizeDeliveryJobs.json
+++ b/assets/tasks/SeizeDeliveryJobs.json
@@ -28,7 +28,7 @@
                 {
                     "name": "Reward",
                     "label": "$task.SeizeDeliveryJobsReward.inputs.Reward.label",
-                    "default": "16.3",
+                    "default": "15.9",
                     "pipeline_type": "string",
                     "pattern_msg": "$task.SeizeDeliveryJobsReward.inputs.Reward.pattern_msg",
                     "verify": "^\\d+(\\.\\d+)?$"
@@ -44,7 +44,7 @@
         },
         "SeizeDeliveryJobsCommissionSource": {
             "type": "select",
-            "default_case": "WulingCity",
+            "default_case": "Unlimited",
             "label": "$task.SeizeDeliveryJobsCommissionSource.label",
             "cases": [
                 {
@@ -94,6 +94,7 @@
         },
         "SeizeDeliveryJobsSpecifyDeliveryPointWulingCity": {
             "type": "switch",
+            "default_case": "No",
             "label": "$task.SeizeDeliveryJobsSpecifyDeliveryPoint.label",
             "cases": [
                 {
@@ -168,6 +169,7 @@
         },
         "SeizeDeliveryJobsSpecifyDeliveryPointTestArea": {
             "type": "switch",
+            "default_case": "No",
             "label": "$task.SeizeDeliveryJobsSpecifyDeliveryPoint.label",
             "cases": [
                 {
@@ -232,6 +234,7 @@
         },
         "SeizeDeliveryJobsSpecifyDeliveryPointUnlimited": {
             "type": "switch",
+            "default_case": "No",
             "label": "$task.SeizeDeliveryJobsSpecifyDeliveryPoint.label",
             "cases": [
                 {
@@ -358,7 +361,7 @@
         },
         "SeizeDeliveryJobsRepeatCount": {
             "type": "select",
-            "default_case": "1",
+            "default_case": "3",
             "label": "$task.SeizeDeliveryJobsRepeatCount.label",
             "description": "$task.SeizeDeliveryJobsRepeatCount.description",
             "cases": [


### PR DESCRIPTION
## Summary by Sourcery

更新 SeizeDeliveryJobs 流水线和任务定义的默认配置选项。

杂项更新：
- 调整 `SeizeDeliveryJobsCommon` 流水线配置中的默认设置。
- 更新 `SeizeDeliveryJobs` 任务配置，使其与新的默认值保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update default configuration options for the SeizeDeliveryJobs pipeline and task definitions.

Chores:
- Adjust default settings in SeizeDeliveryJobsCommon pipeline config.
- Update SeizeDeliveryJobs task configuration to align with new defaults.

</details>