### PR TITLE
fix(EnvironmentMonitoring): 修复多个任务的路径

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FloraObservationPoint.json
@@ -379,14 +379,14 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        93.33,
-                        185
+                        69.1,
+                        129.69
                     ],
                     "target_tier": "Wuling_L4_330"
                 },
                 {
                     "action": "HEADING",
-                    "angle": 0
+                    "angle": 173
                 }
             ]
         },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
@@ -379,22 +379,14 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        93.33,
-                        185
-                    ],
-                    "target_tier": "Wuling_L4_330"
-                },
-                {
-                    "action": "RUN",
-                    "target": [
-                        123.45,
-                        185.91
+                        69.1,
+                        129.69
                     ],
                     "target_tier": "Wuling_L4_330"
                 },
                 {
                     "action": "HEADING",
-                    "angle": 88.69999999999999
+                    "angle": 173
                 }
             ]
         },
@@ -427,7 +419,7 @@
     },
     "HangingVinesAdjustCamera": {
         "desc": "垂藤任务中调整朝向",
-        "max_hit": 3,
+        "max_hit": 1,
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/CleansingJade.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToCleansingJade"
+            "CleansingJadeInQuickTeleportMap"
         ]
     },
     "AlreadyTrackedCleansingJade": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToCleansingJade"
+            "CleansingJadeOpenTrackedMissionMap"
         ]
     },
     "CleansingJadeOpenTrackedMissionMap": {
@@ -340,10 +340,10 @@
         "custom_recognition_param": {
             "zone_id": "Wuling_Base",
             "target": [
-                731.08,
-                2405.14,
-                14.77,
-                14.78
+                0,
+                0,
+                1,
+                1
             ]
         },
         "pre_delay": 0,
@@ -360,7 +360,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneEnterWorldWulingJingyuValley4"
+                "SceneAnyEnterWorld"
             ]
         },
         "post_delay": 0,
@@ -378,11 +378,11 @@
             "path": [
                 {
                     "action": "ZONE",
-                    "zone_id": "Wuling_L1_277"
+                    "zone_id": "Wuling_Base"
                 },
                 [
-                    82.7,
-                    228.2
+                    726.02,
+                    2405
                 ],
                 {
                     "action": "HEADING",

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -465,14 +465,14 @@
             {
                 "action": "NAVMESH",
                 "target": [
-                    93.33,
-                    185
+                    69.1,
+                    129.69
                 ],
                 "target_tier": "Wuling_L4_330"
             }
         ],
         "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenDown",
-        "Heading": 0
+        "Heading": 173
     },
     {
         "MissionId": "m1m64",

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -157,22 +157,15 @@
         "MissionId": "m1m33",
         "Name": "“漱玉”",
         "Id": "CleansingJade",
-        "EnterMap": "SceneEnterWorldWulingJingyuValley4",
-        "NavZoneId": "Wuling_Base",
-        "NavAssert": [
-            731.08,
-            2405.14,
-            14.77,
-            14.78
-        ],
+        "QuickTeleport": true,
         "NavPath": [
             {
                 "action": "ZONE",
-                "zone_id": "Wuling_L1_277"
+                "zone_id": "Wuling_Base"
             },
             [
-                82.7,
-                228.2
+                726.02,
+                2405
             ]
         ],
         "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenUp",

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -453,23 +453,15 @@
             {
                 "action": "NAVMESH",
                 "target": [
-                    93.33,
-                    185
-                ],
-                "target_tier": "Wuling_L4_330"
-            },
-            {
-                "action": "RUN",
-                "target": [
-                    123.45,
-                    185.91
+                    69.1,
+                    129.69
                 ],
                 "target_tier": "Wuling_L4_330"
             }
         ],
         "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenUp",
-        "CameraMaxHit": 3,
-        "Heading": 88.7
+        "CameraMaxHit": 1,
+        "Heading": 173
     },
     {
         "MissionId": "m1m63",


### PR DESCRIPTION
垂藤/植物观察点快速传送后在上面的传送点，并不在下面。（感谢 @hoshino-kakera 提供的点位）
漱玉现在并不属于分层地图。

## Summary by Sourcery

修正特定观察点和传送点的环境监控任务配置。

Bug Fixes:
- 修复 Flora 观察点的传送目的地，使玩家被传送到正确的标记石位置。
- 修正 Hanging Vines 传送点，使快速旅行落在预期的上方标记点，而不是下方。
- 更新 Cleansing Jade 任务配置，使其不再被视为分层地图系统的一部分。

Enhancements:
- 对齐 EnvironmentMonitoring 路线配置，使其与受影响终端的最新任务路径保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct environment monitoring task configurations for specific observation and teleport points.

Bug Fixes:
- Fix Flora observation point teleport destination to place players at the correct marker stone location.
- Correct Hanging Vines teleport point so fast travel lands on the intended upper marker rather than below.
- Update Cleansing Jade task configuration so it is no longer treated as part of the layered map system.

Enhancements:
- Align EnvironmentMonitoring routes configuration with updated task paths for the affected terminals.

</details>