### PR TITLE
fix(MapNavigator): 扣除已发出未兑现的转向,删除冗余的阻尼项

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -75,9 +75,13 @@ constexpr int32_t kForwardHoldReassertTicks = 3;
 constexpr int32_t kForwardHoldFutileReassertsBeforeRecovery = 2;
 // How many navigate ticks a heading reference stays usable for. Sized to match the wall-clock cap this
 // replaced at the loop period of a fast machine, so nothing changes there; on a slow one it stretches
-// with the loop instead of silently discarding the damping term.
+// with the loop instead of silently discarding the rate.
 constexpr uint64_t kSteeringRateMaxGapTicks = 4;
 constexpr int32_t kSteeringRateReferenceMs = 100;
+// How long a sent turn may still be owed before it is written off. Measured on device the game yaws at about
+// 100 deg/s, so a capped command needs some 300ms to land; past double that the drag was swallowed, and holding
+// the debt any longer would suppress steering against a turn that is never arriving.
+constexpr int64_t kSteeringPendingLifetimeMs = 600;
 // Turn batches one tick may spend. The backend's per-batch cap is a per-drag reliability limit, not a budget
 // for the whole tick: a slow loop gets fewer, longer ticks, so one batch each would shrink the turn achieved
 // per metre walked just as the lag makes more of it necessary. Bounded so a misread heading cannot spin far.

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -170,7 +170,7 @@ struct LateralBypassState
     }
 };
 
-// Previous-tick heading, used to estimate the agent's own turn rate for the steering damping term. Only the
+// Previous-tick heading, used to estimate the agent's own turn rate for the implausible-rate glitch check. Only the
 // physical heading is tracked here; the rate is gated at the call site on the elapsed gap and on plausibility,
 // so a stale entry after a recovery / relocation pause simply yields a zero rate that tick rather than a spike.
 // The cmd_* fields are diagnostic only: they hold the last turn actually sent to the controller so a later tick
@@ -187,6 +187,11 @@ struct SteeringRateState
     std::chrono::steady_clock::time_point cmd_at {};
     // Which way a near-about-face turn was committed to, held until it is well under way. Zero means free.
     int turn_latch_sign = 0;
+    // Degrees already sent that the heading has not shown yet, and the heading they are counted from. A turn
+    // takes a few ticks to finish while the controller re-decides every tick, so without this running total the
+    // same error is commanded over and over before any of it lands.
+    double pending_turn_deg = 0.0;
+    double pending_ref_heading_deg = 0.0;
 
     void Reset()
     {
@@ -199,6 +204,8 @@ struct SteeringRateState
         has_cmd = false;
         cmd_at = {};
         turn_latch_sign = 0;
+        pending_turn_deg = 0.0;
+        pending_ref_heading_deg = 0.0;
     }
 };
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -1344,7 +1344,7 @@ bool NavigationStateMachine::TickNavigate()
         const bool heading_changed = std::abs(heading_rate_raw_delta_deg) > kSteeringHeadingChangeEpsilonDeg;
         // Staleness is counted in ticks, not milliseconds: the reference goes stale after so many missed chances
         // to observe a change, and slow frame capture stretches those chances out without making them fewer. A
-        // wall-clock cap threw the damping term away on exactly the slow loops that need it most.
+        // wall-clock cap threw the rate away on exactly the slow loops that need it most.
         if (heading_changed && heading_rate_gap_ms > 0 && heading_rate_gap_ticks <= kSteeringRateMaxGapTicks) {
             heading_rate_deg =
                 heading_rate_raw_delta_deg * static_cast<double>(kSteeringRateReferenceMs) / static_cast<double>(heading_rate_gap_ms);
@@ -1362,12 +1362,30 @@ bool NavigationStateMachine::TickNavigate()
         runtime_state_.steering_rate.has_prev = true;
     }
 
+    // Settle the turn already sent against what the heading actually moved, so the controller discounts what is
+    // still in flight instead of commanding the same error again. Only motion toward the debt pays it down, and
+    // an unpaid debt expires, so a swallowed drag can never leave steering suppressed against a turn never coming.
+    SteeringRateState& steering_rate = runtime_state_.steering_rate;
+    if (steering_rate.pending_turn_deg != 0.0) {
+        const int64_t pending_age_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - steering_rate.cmd_at).count();
+        if (pending_age_ms >= kSteeringPendingLifetimeMs) {
+            steering_rate.pending_turn_deg = 0.0;
+        }
+        else {
+            const double landed = NaviMath::NormalizeAngle(current_heading - steering_rate.pending_ref_heading_deg);
+            const double owed = std::abs(steering_rate.pending_turn_deg);
+            steering_rate.pending_turn_deg = std::clamp(steering_rate.pending_turn_deg - landed, -owed, owed);
+        }
+    }
+    steering_rate.pending_ref_heading_deg = current_heading;
+
     const double heading_error = NaviMath::NormalizeAngle(effective_route_heading - current_heading);
     const SteeringCommand steering = SteeringController::Update(
         heading_error,
         heading_rate_deg,
         motion_controller_->IsMovingForward(),
-        runtime_state_.steering_rate.turn_latch_sign);
+        steering_rate.turn_latch_sign,
+        steering_rate.pending_turn_deg);
 
     motion_controller_->SetForwardState(true);
 
@@ -1379,10 +1397,11 @@ bool NavigationStateMachine::TickNavigate()
         }
     }
     if (issued_delta_deg != 0.0) {
-        runtime_state_.steering_rate.cmd_heading_deg = current_heading;
-        runtime_state_.steering_rate.cmd_delta_deg = issued_delta_deg;
-        runtime_state_.steering_rate.cmd_at = now;
-        runtime_state_.steering_rate.has_cmd = true;
+        steering_rate.cmd_heading_deg = current_heading;
+        steering_rate.cmd_delta_deg = issued_delta_deg;
+        steering_rate.cmd_at = now;
+        steering_rate.has_cmd = true;
+        steering_rate.pending_turn_deg += issued_delta_deg;
     }
 
     // Closed the loop on the forward hold: the keydown goes out once on the transition, so a swallowed one

--- a/agent/cpp-algo/source/MapNavigator/steering_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/steering_controller.cpp
@@ -14,11 +14,8 @@ namespace
 constexpr double kHeadingDeadband = 6.6;
 constexpr double kMovingMaxCmd = 90.0;
 constexpr double kTurningMaxCmd = 70.0;
-constexpr double kKp = 0.45;
-constexpr double kHeadingRateDampingGain = 0.5;
-constexpr double kHeadingRateDeadbandDeg = 3.0;
+constexpr double kKp = 1.0;
 constexpr double kHeadingRatePlausibleMaxDeg = 60.0;
-constexpr double kHeadingRateDampingCapDeg = 14.0;
 // An about-face has no shorter side, so at the antipode a degree of heading jitter flips the command a full 360
 // and the agent alternates left and right forever without crossing. Latch the direction on entry and hold it
 // until the turn is well under way; either side reaches the target, so the latched one is never the wrong one.
@@ -27,7 +24,12 @@ constexpr double kTurnLatchExitDeg = 120.0;
 
 } // namespace
 
-SteeringCommand SteeringController::Update(double heading_error, double heading_rate_deg, bool moving_forward, int& turn_latch_sign)
+SteeringCommand SteeringController::Update(
+    double heading_error,
+    double heading_rate_deg,
+    bool moving_forward,
+    int& turn_latch_sign,
+    double pending_turn_deg)
 {
     SteeringCommand command;
     const double rate_magnitude = std::abs(heading_rate_deg);
@@ -47,21 +49,22 @@ SteeringCommand SteeringController::Update(double heading_error, double heading_
         heading_error = std::abs(heading_error) * turn_latch_sign;
     }
 
+    // Discount the turn already sent that the heading has not shown yet. The game needs several ticks to yaw a
+    // capped command while this runs every tick, so commanding the raw error each time sends it many times over,
+    // overshoots, then hunts back — the left-right weave. Clamping the discount between zero and the error keeps
+    // the remainder on the same side as the error, so this can only ever soften a command, never reverse one.
+    const double pending = std::clamp(pending_turn_deg, std::min(0.0, heading_error), std::max(0.0, heading_error));
+    const double effective_error = heading_error - pending;
+
     // Deadband gates the P term only: it suppresses chasing sub-noise heading error on a straight. A real corner
     // still drives a large error, so large turns are never blocked here.
-    const double p_term = std::abs(heading_error) < kHeadingDeadband ? 0.0 : heading_error * kKp;
-    // Damping is applied regardless of the P deadband — arresting an overshoot near alignment is the whole point.
-    // The implausible-rate ceiling is already handled by the early return above, so only the low deadband remains.
-    double damping = 0.0;
-    if (rate_magnitude >= kHeadingRateDeadbandDeg) {
-        damping = std::clamp(-kHeadingRateDampingGain * heading_rate_deg, -kHeadingRateDampingCapDeg, kHeadingRateDampingCapDeg);
-    }
+    const double p_term = std::abs(effective_error) < kHeadingDeadband ? 0.0 : effective_error * kKp;
     const double max_cmd = moving_forward ? kMovingMaxCmd : kTurningMaxCmd;
-    const double cmd = std::clamp(p_term + damping, -max_cmd, max_cmd);
+    const double cmd = std::clamp(p_term, -max_cmd, max_cmd);
     command.yaw_delta_deg = cmd;
     command.issued = std::abs(cmd) >= 2.0;
-    LogDebug << "SteeringController update." << VAR(heading_error) << VAR(heading_rate_deg) << VAR(damping) << VAR(moving_forward)
-             << VAR(turn_latch_sign) << VAR(cmd);
+    LogDebug << "SteeringController update." << VAR(heading_error) << VAR(pending) << VAR(heading_rate_deg)
+             << VAR(moving_forward) << VAR(turn_latch_sign) << VAR(cmd);
     return command;
 }
 

--- a/agent/cpp-algo/source/MapNavigator/steering_controller.h
+++ b/agent/cpp-algo/source/MapNavigator/steering_controller.h
@@ -13,7 +13,13 @@ class SteeringController
 {
 public:
     // turn_latch_sign carries the committed direction of a near-about-face turn across ticks; see the .cpp.
-    static SteeringCommand Update(double heading_error, double heading_rate_deg, bool moving_forward, int& turn_latch_sign);
+    // pending_turn_deg is the turn already sent that the heading has not shown yet; the caller keeps the tally.
+    static SteeringCommand Update(
+        double heading_error,
+        double heading_rate_deg,
+        bool moving_forward,
+        int& turn_latch_sign,
+        double pending_turn_deg);
 };
 
 } // namespace mapnavigator


### PR DESCRIPTION
- fix #4897

## Summary by Sourcery

调整转向控制，以考虑已发出但尚未完成的转向指令，并移除航向变化率阻尼，从而改善转向行为和稳定性。

Bug Fixes:
- 防止对同一次转向重复施加过度指令，避免车辆在转弯时出现左右摇摆。

Enhancements:
- 随时间跟踪待执行的转向角度，并使未完成的转向在超时后失效，以保持控制响应性。
- 调整转向比例增益，并简化转向控制器，仅依赖航向误差，而不再使用单独的阻尼项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust steering control to account for already-issued but not yet realized turns and remove heading-rate damping, improving turn behavior and stability.

Bug Fixes:
- Prevent repeated over-commanding of the same turn that caused left-right weaving around corners.

Enhancements:
- Track pending steering rotation over time and expire unlanded turns to keep control responsive.
- Tune steering proportional gain and simplify steering controller by relying solely on heading error without a separate damping term.

</details>