### PR TITLE
fix(AutoEcoFarm): 修复工业设备选项偶发点击失效

### DIFF
--- a/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
+++ b/assets/resource/pipeline/AutoEcoFarm/CommonNodes/AutoEcoFarmPhotoMode.json
@@ -455,6 +455,10 @@
         "box_index": 1,
         "pre_delay": 0,
         "action": "Click",
+        "target": [
+            305,
+            246
+        ],
         "post_wait_freezes": {
             "time": 200,
             "target": [


### PR DESCRIPTION
## 关联 Issue

Related to #4923（生态农场部分）

## 问题原因

工业设备勾选图标能够正常识别，但 Pipeline 默认会在识别框内随机选择点击位置。日志中失败时点击到了 `[298,253]`，操作虽然被框架判定为成功，但界面状态没有变化，最终在验证未勾选状态时超时。

## 修改内容

为 `_AutoEcoFarmHideFactoryFacilities` 指定已验证可用的点击坐标 `[305,246]`，避免随机点击落入无效区域。

保留原有的状态驱动流程：

1. 识别工业设备选项及已勾选图标。
2. 取消勾选。
3. 独立验证图标已变为未勾选状态。
4. 验证成功后关闭设置面板。

## Summary by Sourcery

Bug Fixes:
- 防止出现间歇性故障：工业设备选项看起来已成功点击，但由于点击落在 UI 中无效区域，复选框状态未发生变化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent intermittent failures where industrial equipment options appear successfully clicked but the checkbox state does not change due to clicks landing in an ineffective area of the UI.

</details>