### PR TITLE
fix(MapLocator): dual 裁判被喂错预测时夺回主策略

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -904,6 +904,10 @@ private:
     std::vector<MapPosition> coldStartBuffer;
     std::optional<MapPosition> stablePosition;
 
+    // dual 裁判连续判主策略"离预测远"时，记下主策略自己报的位置，用于识别预测被喂错的死锁
+    std::optional<MapPosition> arbiterRejectedPrimary;
+    int arbiterRejectedPrimaryStreak = 0;
+
     TrackingConfig trackingCfg;
     MatchConfig matchCfg;
     ImageProcessingConfig baseImgCfg = { .darkMapThreshold = 20.0,
@@ -1617,6 +1621,8 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
     const bool trackingHeld = trackingResult.has_value() && trackingResult->isHeld;
 
     if (trackingResult && !trackingHeld) {
+        arbiterRejectedPrimaryStreak = 0;
+        arbiterRejectedPrimary.reset();
         return LocateResult {
             .status = LocateStatus::Success,
             .position = trackingResult,
@@ -1646,6 +1652,8 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
             MapPosition verifiedPos = rawPrimaryPos;
             verifiedPos.score = std::max(rawPrimaryPos.score, rawFallbackPos.score);
             verifiedPos = acceptPosition(verifiedPos, now);
+            arbiterRejectedPrimaryStreak = 0;
+            arbiterRejectedPrimary.reset();
 
             return LocateResult {
                 .status = LocateStatus::Success,
@@ -1662,6 +1670,38 @@ std::optional<LocateResult> MapLocator::Impl::tryTrackingLocate(
             MapPosition arbitrated = primaryCloser ? rawPrimaryPos : rawFallbackPos;
             const double arbitratedDistToPred = primaryCloser ? distPrimaryToPred : distFallbackToPred;
             if (arbitratedDistToPred <= kTrackingOutlierDistance) {
+                // 主策略被判"离预测远"却一直指着同一处、分数也不比兜底低：预测已被喂到错的位置，
+                // 再按预测选下去永远出不来。兜底分数更高时不算证据，那种局面本就该信兜底
+                if (!primaryCloser) {
+                    const bool primaryEvidenced = rawPrimaryPos.score >= rawFallbackPos.score;
+                    const bool selfConsistent = primaryEvidenced && arbiterRejectedPrimary.has_value()
+                        && std::hypot(rawPrimaryPos.x - arbiterRejectedPrimary->x, rawPrimaryPos.y - arbiterRejectedPrimary->y)
+                            <= kArbiterReclaimDriftDistance;
+                    arbiterRejectedPrimaryStreak = selfConsistent ? arbiterRejectedPrimaryStreak + 1 : (primaryEvidenced ? 1 : 0);
+                    arbiterRejectedPrimary = primaryEvidenced ? std::optional<MapPosition>(rawPrimaryPos) : std::nullopt;
+                    if (arbiterRejectedPrimaryStreak >= kArbiterReclaimStreak) {
+                        LogWarn << "Dual-Mode arbiter reclaimed by primary" << VAR(rawPrimaryPos.x) << VAR(rawPrimaryPos.y)
+                                << VAR(rawPrimaryPos.score) << VAR(rawFallbackPos.score) << VAR(distPrimaryToPred)
+                                << VAR(distFallbackToPred);
+                        arbiterRejectedPrimaryStreak = 0;
+                        arbiterRejectedPrimary.reset();
+                        // 先 markLost 让 update 跳过速度 EMA，否则这次几十像素的修正会被当成一次高速位移
+                        motionTracker->markLost(1);
+                        MapPosition reclaimed = rawPrimaryPos;
+                        reclaimed.isHeld = false;
+                        reclaimed = acceptPosition(reclaimed, now);
+                        motionTracker->clearVelocity();
+                        return LocateResult {
+                            .status = LocateStatus::Success,
+                            .position = reclaimed,
+                            .debugMessage = "Dual-Mode Arbiter Reclaimed",
+                        };
+                    }
+                }
+                else {
+                    arbiterRejectedPrimaryStreak = 0;
+                    arbiterRejectedPrimary.reset();
+                }
                 arbitrated.isHeld = false;
                 LogInfo << "Dual-Mode arbitrated by motion continuity" << VAR(distPrimaryToPred) << VAR(distFallbackToPred)
                         << VAR(arbitrated.x) << VAR(arbitrated.y) << VAR(arbitrated.score) << VAR(dist);
@@ -2202,6 +2242,8 @@ void MapLocator::Impl::resetTrackingState()
     currentZoneId = "";
     coldStartBuffer.clear();
     stablePosition.reset();
+    arbiterRejectedPrimary.reset();
+    arbiterRejectedPrimaryStreak = 0;
 }
 
 std::optional<MapPosition> MapLocator::Impl::getLastKnownPos() const

--- a/agent/cpp-algo/source/MapLocator/MapTypes.h
+++ b/agent/cpp-algo/source/MapLocator/MapTypes.h
@@ -182,6 +182,10 @@ constexpr double kTrackingOutlierMinScore = 0.78;
 constexpr double kDualVerifyMinScore = 0.45;
 constexpr double kDualVerifyMaxDistance = 4.0;
 constexpr double kDualGlobalVerifyMinScore = 0.50;
+// dual 裁判长期站在 fallback 一侧时的夺回条件：主策略连续 N 帧指着同一处（漂移不超过此距离），
+// 说明是运动预测被喂到了错的位置，把 tracker 搬回主策略
+constexpr int kArbiterReclaimStreak = 5;
+constexpr double kArbiterReclaimDriftDistance = 6.0;
 
 inline bool IsPathHeatmapZone(const std::string& zoneId)
 {


### PR DESCRIPTION
## Summary by Sourcery

在仲裁器持续偏好回退策略而非主策略时，改进双模式地图定位器的行为。

Bug Fixes（错误修复）：
- 当运动预测因被输入错误位置而导致死锁时，通过在仲裁器与主策略持续产生分歧的情况下允许主策略重新获得控制权来检测并打破死锁。

Enhancements（功能增强）：
- 追踪仲裁器对主策略的多次拒绝，当主策略持续报告稳定且具竞争力的位置时，将跟踪权重新交还给主策略。
- 每当跟踪成功、仲裁结果偏向主策略，或跟踪被完全重置时，重置仲裁器拒绝跟踪状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve dual-mode map locator behavior when the arbiter persistently favors the fallback strategy over the primary.

Bug Fixes:
- Detect and break deadlock when motion prediction is fed an incorrect position by allowing the primary strategy to reclaim control after consistent disagreement with the arbiter.

Enhancements:
- Track repeated arbiter rejections of the primary strategy and reclaim tracking to the primary when it consistently reports a stable, competitive position.
- Reset arbiter rejection tracking state whenever tracking succeeds, arbitration favors the primary, or tracking is fully reset.

</details>