### PR TITLE
fix(MapNavigator): 逃逸成功后清空前进无效计数

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -53,8 +53,8 @@ struct FlowState
     // Consecutive steering ticks that held forward, issued no turn, and saw the fix stay put. The forward hold
     // is edge-triggered, so a dropped keydown looks exactly like this and never repairs itself.
     int32_t motionless_hold_ticks = 0;
-    // Consecutive re-sends of that hold that moved the agent nowhere. Cleared by any motion, any turn, or
-    // recovery taking over, so it only ever counts a hold that is provably not the thing holding it up.
+    // Consecutive re-sends of that hold that moved the agent nowhere. Cleared by any motion, any turn, or a
+    // recovery escape, so it only ever counts a hold that is provably not the thing holding it up.
     int32_t futile_forward_reasserts = 0;
     NaviPosition last_steer_position {};
     bool has_last_steer_position = false;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -1497,6 +1497,8 @@ void NavigationStateMachine::SelectPhaseForCurrentWaypoint(const char* reason)
 
 bool NavigationStateMachine::ResumeAfterEscape(const char* reason)
 {
+    runtime_state_.flow.futile_forward_reasserts = 0;
+    runtime_state_.flow.motionless_hold_ticks = 0;
     runtime_state_.recovery.Reset();
     runtime_state_.recovery_escalation.Reset();
     runtime_state_.route.ResetTracking();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 在成功执行恢复逃脱后，清除“静止向前保持”和“无效向前重申”计数器，以确保后续导航不会受到之前卡住状态的影响。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Clear motionless forward hold and futile forward reassert counters upon successful recovery escape so subsequent navigation is not affected by previous stuck state.

</details>