### PR TITLE
fix(MapNavigator): 落水自救先站定再整段回头

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -131,10 +131,12 @@ constexpr int32_t kLocalizationLossUnstickIntervalMs = kObstacleRecoveryMinTrigg
 constexpr int32_t kLocalizationLossTimeoutMs = kDynamicRecoveryTotalTimeoutMs;
 
 // River-fall recovery (see navigator-river-fall-teleport-gap): black-screen loss = fell in water, teleported to
-// shore facing it. Turn 180° away then pulse inland until clear; hard clock bounds thin-shore re-fall loops.
+// shore facing it. Stand still until the arrow is readable again, turn 180° once, then pulse inland until clear;
+// hard clock bounds thin-shore re-fall loops.
 constexpr int32_t kRiverFallRecoveryTimeoutMs = kDynamicRecoveryTotalTimeoutMs;   // 30s clean fail-fast
 constexpr double kRiverFallRecoveryClearDistance = kDynamicRecoveryResetDistance; // walked 2m clear of shore
 constexpr int32_t kRiverFallRecoveryPulseMs = kPostHeadingForwardPulseMs;         // proven heading-commit pulse
+constexpr int32_t kRiverFallRecoverySettleMs = 2000;                             // 上岸后的读数要等它稳下来
 
 // Off-route wedge watchdog. Corridor progress (what the stall clocks see) keeps advancing while the authored
 // cursor is pinned far off-route, so a bad latch wanders with zero route progress until the action hard-fails.

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -141,15 +141,21 @@ struct LocalizationLossState
 struct RiverFallRecoveryState
 {
     NaviPosition anchor_pos {};
-    // Post-fall facing (minimap arrow = toward water); recovery turns to water_heading + 180 to face inland.
+    // Facing read AFTER the settle, not at arm time (minimap arrow = toward water); the about-face turns 180 off it.
     double water_heading = 0.0;
     bool pending = false;
+    // Stood still long enough for the arrow to be trustworthy again / the 180 has gone out. Both one-shot: the turn
+    // must not be recomputed from a half-turned arrow, only committed by walking.
+    bool settled = false;
+    bool turned = false;
 
     void Reset()
     {
         anchor_pos = {};
         water_heading = 0.0;
         pending = false;
+        settled = false;
+        turned = false;
     }
 };
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -616,12 +616,14 @@ bool NavigationStateMachine::ArmRiverFallRecoveryIfBlackScreenLoss(const char* v
     if (!runtime_state_.localization_loss.saw_black_screen) {
         return false;
     }
+    // Full reset first: a re-fall must redo the settle and the about-face, not inherit the last episode's one-shots.
+    runtime_state_.river_fall.Reset();
     runtime_state_.river_fall.pending = true;
     runtime_state_.river_fall.anchor_pos = *position_;
-    // Post-fall facing points at the water (the infinite-jump invariant); recovery turns to water_heading + 180.
+    // Arm-time facing, logged so a post-mortem can tell it apart from the settled read the about-face actually uses.
     runtime_state_.river_fall.water_heading = NaviMath::NormalizeAngle(position_->angle);
     // River-fall owns the recovery: the pre-fall dynamic-recovery anchor is stale after the teleport, and a live
-    // recovery's escaped-obstacle check (runs before the river-fall block) would otherwise pre-empt the about-face.
+    // recovery's escaped-obstacle check (runs before the river-fall block) would otherwise pre-empt the escape.
     runtime_state_.recovery.Reset();
     session_->ResetHardProgress();
     LogInfo << "River-fall recovery armed (black-screen loss recovered)." << VAR(via) << VAR(position_->x) << VAR(position_->y)
@@ -1123,24 +1125,37 @@ bool NavigationStateMachine::TickNavigate()
                 stalled_ms);
         }
         const double rf_displacement = std::hypot(position_->x - rf.anchor_pos.x, position_->y - rf.anchor_pos.y);
-        const double rf_target_heading = NaviMath::NormalizeAngle(rf.water_heading + 180.0);
-        const double rf_heading_error = NaviMath::NormalizeAngle(rf_target_heading - current_heading);
         if (rf_displacement >= kRiverFallRecoveryClearDistance) {
             rf.Reset();
-            LogInfo << "River-fall recovery cleared; resuming navigation." << VAR(rf_displacement) << VAR(rf_heading_error);
+            LogInfo << "River-fall recovery cleared; resuming navigation." << VAR(rf_displacement) << VAR(current_heading);
             return ResumeAfterEscape("river_fall_recovered");
         }
         motion_controller_->SetForwardState(false);
-        utils::SleepFor(kStopWaitMs);
-        int turn_units = static_cast<int>(std::lround(rf_heading_error * action_wrapper_->DefaultTurnUnitsPerDegree()));
-        if (turn_units == 0) {
-            turn_units = rf_heading_error > 0.0 ? 1 : -1;
+        // 站定两秒再动。上岸那一瞬的箭头读数是最不可信的(尖端会翻转、追踪还在 hold), 拿它算转身
+        // 就是赌运气 —— 三次落水里有一次读成 -1°, 目标算出来正好等于当前朝向, 等于没转就往前走。
+        if (!rf.settled) {
+            rf.settled = true;
+            utils::SleepFor(kRiverFallRecoverySettleMs);
+            LogInfo << "River-fall recovery settling before the about-face." << VAR(rf_displacement) << VAR(position_->x)
+                    << VAR(position_->y);
+            return true;
         }
-        action_wrapper_->SendViewDeltaSync(turn_units, 0);
+        // 180° 只发一次, 发完就认。之前是每拍拿转到一半的箭头重算误差再补发, 转身还没兑现就先迈了步,
+        // 于是每一拍都朝着还没转完的方向往水里走 —— 两次再落水都紧跟着恢复自己的前进脉冲。
+        if (!rf.turned) {
+            rf.turned = true;
+            rf.water_heading = current_heading;
+            const int turn_units = static_cast<int>(std::lround(180.0 * action_wrapper_->DefaultTurnUnitsPerDegree()));
+            action_wrapper_->SendViewDeltaSync(turn_units, 0);
+            utils::SleepFor(kWaitAfterFirstTurnMs);
+            LogInfo << "River-fall recovery about-face issued." << VAR(rf.water_heading) << VAR(turn_units) << VAR(rf_displacement);
+        }
+        // 视角转完了, 角色朝向要迈一步才会跟上(见 navigator-turn-requires-forward-step), 而这一步是
+        // 按相机方向走的, 所以它离水而去。
         action_wrapper_->PulseForwardSync(kRiverFallRecoveryPulseMs);
         motion_controller_->SetForwardState(false);
-        LogInfo << "River-fall recovery turn+pulse." << VAR(rf_heading_error) << VAR(turn_units) << VAR(rf_displacement)
-                << VAR(position_->x) << VAR(position_->y);
+        LogInfo << "River-fall recovery inland pulse." << VAR(current_heading) << VAR(rf_displacement) << VAR(position_->x)
+                << VAR(position_->y);
         return true;
     }
 


### PR DESCRIPTION
## Summary by Sourcery

改进河瀑恢复逻辑，在传送后确保可以可靠地以 180° 方向远离水域逃离。

Bug Fixes（错误修复）:
- 在每次黑屏失败时重置河瀑恢复状态，避免在不同回合之间重复使用过期的一次性标志。
- 防止在河瀑恢复期间出现重复的部分转向和错误的朝向读数，从而避免将智能体再次送回水域方向。

Enhancements（增强）:
- 在河瀑恢复中引入“稳定后再转向”的一次性流程：先等待朝向稳定，再执行一次 180° 掉头，并通过一次向内脉冲来确认这一转向。
- 扩展河瀑恢复的运行时状态，加入“已稳定”和“已转向”标志，并更新日志记录，以更好地区分“挥臂时间”和“稳定后朝向”。

Documentation（文档）:
- 在配置注释中澄清河瀑恢复行为，包括在转向前需要保持静止，以及设置“稳定超时”的原因。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve river-fall recovery to ensure a reliable 180° escape away from water after teleport.

Bug Fixes:
- Reset river-fall recovery state on each black-screen loss to avoid reusing stale one-shot flags between episodes.
- Prevent repeated partial turns and misread headings that could send the agent back toward the water during river-fall recovery.

Enhancements:
- Introduce a settle-and-turn one-shot flow in river-fall recovery, waiting for a stable heading before issuing a single 180° about-face and committing it with an inland pulse.
- Extend river-fall recovery runtime state with flags for settled and turned, and update logging to better distinguish arm-time and post-settle headings.

Documentation:
- Clarify river-fall recovery behavior in configuration comments, including the need to stand still before turning and the rationale for the settle timeout.

</details>