### PR TITLE
feat(CaptureUid): 新增 output_type 参数支持 hashed/masked/raw 输出

### DIFF
--- a/agent/go-service/autostockpile/selector.go
+++ b/agent/go-service/autostockpile/selector.go
@@ -102,7 +102,7 @@ func (a *SelectItemAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 
 	serverNow := time.Now()
 	serverDate, serverWeekday := serverDateInfo(serverNow, serverLocation)
-	if err := storeDailyGoodsPrices(attach.AllowDataUpload, serverNow, serverLocation, region, captureuid.GetCachedUID(), *data); err != nil {
+	if err := storeDailyGoodsPrices(attach.AllowDataUpload, serverNow, serverLocation, region, captureuid.GetCachedUID(captureuid.OutputTypeHashed), *data); err != nil {
 		log.Warn().
 			Err(err).
 			Str("component", "autostockpile").

--- a/agent/go-service/captureuid/action.go
+++ b/agent/go-service/captureuid/action.go
@@ -8,10 +8,11 @@ import (
 )
 
 type captureUidParam struct {
-	UseCache            *bool `json:"use_cache,omitempty"`
-	StayOnCurrentScreen *bool `json:"stay_on_current_screen,omitempty"`
-	AllowUnknown        *bool `json:"allow_unknown,omitempty"`
-	ClearCache          *bool `json:"clear_cache,omitempty"`
+	UseCache            *bool  `json:"use_cache,omitempty"`
+	StayOnCurrentScreen *bool  `json:"stay_on_current_screen,omitempty"`
+	AllowUnknown        *bool  `json:"allow_unknown,omitempty"`
+	ClearCache          *bool  `json:"clear_cache,omitempty"`
+	OutputType          string `json:"output_type,omitempty"`
 }
 
 type CaptureUidAction struct{}
@@ -34,6 +35,7 @@ func (a *CaptureUidAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 	stayOnCurrentScreen := true
 	allowUnknown := true
 	clearCache := false
+	outputType := OutputTypeHashed
 
 	if arg != nil && arg.CustomActionParam != "" {
 		var params captureUidParam
@@ -54,6 +56,13 @@ func (a *CaptureUidAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 		if params.ClearCache != nil {
 			clearCache = *params.ClearCache
 		}
+		normalized, err := normalizeOutputType(params.OutputType)
+		if err != nil {
+			log.Error().Err(err).Str("component", component).Str("param", arg.CustomActionParam).
+				Msg("CaptureUid: invalid output_type")
+			return false
+		}
+		outputType = normalized
 	}
 
 	if clearCache {
@@ -61,7 +70,7 @@ func (a *CaptureUidAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 		return true
 	}
 
-	uid, err := Capture(ctx, ctrl, useCache, stayOnCurrentScreen, allowUnknown)
+	uid, err := Capture(ctx, ctrl, useCache, stayOnCurrentScreen, allowUnknown, outputType)
 	if err != nil {
 		log.Error().Err(err).Str("component", component).Msg("CaptureUid: capture failed")
 		return false
@@ -71,6 +80,7 @@ func (a *CaptureUidAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool 
 		Bool("use_cache", useCache).
 		Bool("stay_on_current_screen", stayOnCurrentScreen).
 		Bool("allow_unknown", allowUnknown).
+		Str("output_type", string(outputType)).
 		Msg("CaptureUid: done")
 	return true
 }

--- a/agent/go-service/captureuid/capture.go
+++ b/agent/go-service/captureuid/capture.go
@@ -19,21 +19,39 @@ const component = "captureuid"
 
 const saltPath = "debug/record/random_salt.txt"
 
+// OutputType 表示 CaptureUid 捕获结果的输出格式。
+type OutputType string
+
+const (
+	// OutputTypeHashed 输出加盐 SHA-256 哈希的前 16 位十六进制（默认）。
+	OutputTypeHashed OutputType = "hashed"
+	// OutputTypeMasked 输出仅保留开头与末尾各 3 位、中间以 * 打码的形式。
+	OutputTypeMasked OutputType = "masked"
+	// OutputTypeRaw 输出原始 UID 数字。
+	OutputTypeRaw OutputType = "raw"
+)
+
 var (
+	// capturedUid 缓存 OCR 得到的原始 UID 数字；未捕获或失败时为空字符串。
 	capturedUid   string
 	capturedUidMu sync.Mutex
 
 	uidDigitRe = regexp.MustCompile(`\d+`)
+
+	// loadSaltFunc 是加载（或首次生成）盐的注入点，单元测试可替换为固定盐。
+	loadSaltFunc = loadOrCreateSalt
 )
 
-// Capture captures and hashes the player UID.
+// Capture 捕获玩家 UID，并按 outputType 返回格式化结果。
+// 缓存恒存原始 UID 数字，输出时才进行转换，因此 use_cache 命中时也能按任意 outputType 返回。
 //   - useCache: if true and cache has a UID, return cached UID immediately
 //   - stayOnCurrentScreen: if false, navigate to SceneEnterMenuOperationalManual before OCR
 //   - allowUnknown: if true and OCR cannot extract UID, return "unknown" instead of error
-func Capture(ctx *maa.Context, ctrl *maa.Controller, useCache, stayOnCurrentScreen, allowUnknown bool) (string, error) {
+//   - outputType: 输出格式，hashed / masked / raw
+func Capture(ctx *maa.Context, ctrl *maa.Controller, useCache, stayOnCurrentScreen, allowUnknown bool, outputType OutputType) (string, error) {
 	if useCache {
-		if uid := GetCachedUID(); uid != "" {
-			log.Debug().Str("component", component).Str("uid", uid).Msg("returning cached uid")
+		if uid := GetCachedUID(outputType); uid != "" {
+			log.Debug().Str("component", component).Str("uid", uid).Str("output_type", string(outputType)).Msg("returning cached uid")
 			return uid, nil
 		}
 	}
@@ -67,19 +85,16 @@ func Capture(ctx *maa.Context, ctrl *maa.Controller, useCache, stayOnCurrentScre
 		return captureErr(allowUnknown, "uid digit count %d not in [8,12], text=%q", len(digits), text)
 	}
 
-	salt, err := loadOrCreateSalt()
-	if err != nil {
-		return captureErr(allowUnknown, "salt load/create failed: %w", err)
-	}
-
-	hash := sha256.Sum256([]byte(digits + salt))
-	uid := hex.EncodeToString(hash[:])[:16]
-
 	capturedUidMu.Lock()
-	capturedUid = uid
+	capturedUid = digits
 	capturedUidMu.Unlock()
 
-	log.Info().Str("component", component).Str("uid", uid).Msg("captured uid")
+	uid, err := formatUID(digits, outputType)
+	if err != nil {
+		return captureErr(allowUnknown, "format uid: %w", err)
+	}
+
+	log.Info().Str("component", component).Str("uid", uid).Str("output_type", string(outputType)).Msg("captured uid")
 	return uid, nil
 }
 
@@ -91,11 +106,66 @@ func ClearCache() {
 	log.Info().Str("component", component).Msg("uid cache cleared")
 }
 
-// GetCachedUID returns the most recently captured UID (thread-safe).
-func GetCachedUID() string {
+// GetCachedUID 返回最近捕获的原始 UID 按 outputType 转换后的结果（线程安全）。
+// 无缓存时返回空字符串；非法 outputType 记录错误并返回空字符串。
+func GetCachedUID(outputType OutputType) string {
 	capturedUidMu.Lock()
 	defer capturedUidMu.Unlock()
-	return capturedUid
+	uid, err := formatUID(capturedUid, outputType)
+	if err != nil {
+		log.Error().Err(err).Str("component", component).Str("output_type", string(outputType)).Msg("GetCachedUID: format failed")
+		return ""
+	}
+	return uid
+}
+
+// formatUID 将原始 UID 数字按 outputType 转换为输出格式。
+// hashed 保持原算法 SHA-256(uid+盐) 前 16 位十六进制；masked 保留首尾各 3 位；
+// raw 原样返回；空字符串与 "unknown" 在所有模式下原样透传。
+func formatUID(raw string, outputType OutputType) (string, error) {
+	switch outputType {
+	case OutputTypeHashed, OutputTypeMasked, OutputTypeRaw:
+	default:
+		return "", fmt.Errorf("unsupported output_type %q, want hashed|masked|raw", outputType)
+	}
+	if raw == "" || raw == "unknown" {
+		return raw, nil
+	}
+	switch outputType {
+	case OutputTypeHashed:
+		salt, err := loadSaltFunc()
+		if err != nil {
+			return "", fmt.Errorf("salt load/create failed: %w", err)
+		}
+		hash := sha256.Sum256([]byte(raw + salt))
+		return hex.EncodeToString(hash[:])[:16], nil
+	case OutputTypeMasked:
+		return maskUID(raw), nil
+	default:
+		return raw, nil
+	}
+}
+
+// maskUID 保留开头 3 位与末尾 3 位，中间以 * 打码；长度不足 7 位时原样返回。
+func maskUID(uid string) string {
+	if len(uid) <= 6 {
+		return uid
+	}
+	return uid[:3] + strings.Repeat("*", len(uid)-6) + uid[len(uid)-3:]
+}
+
+// normalizeOutputType 校验并规范化 output_type 参数；空字符串按 hashed 处理。
+func normalizeOutputType(s string) (OutputType, error) {
+	if s == "" {
+		return OutputTypeHashed, nil
+	}
+	ot := OutputType(s)
+	switch ot {
+	case OutputTypeHashed, OutputTypeMasked, OutputTypeRaw:
+		return ot, nil
+	default:
+		return "", fmt.Errorf("unsupported output_type %q, want hashed|masked|raw", s)
+	}
 }
 
 func bestOCRText(detail *maa.RecognitionDetail) string {

--- a/agent/go-service/creditshopping/action_record.go
+++ b/agent/go-service/creditshopping/action_record.go
@@ -53,7 +53,7 @@ func (a *RecordShelfSnapshotsAction) Run(ctx *maa.Context, arg *maa.CustomAction
 		slots = ScanShelfSlotsPC(ctx, first)
 	}
 
-	uid, err := captureuid.Capture(ctx, ctrl, true, true, true)
+	uid, err := captureuid.Capture(ctx, ctrl, true, true, true, captureuid.OutputTypeHashed)
 	if err != nil {
 		log.Error().Err(err).Str("component", component).Msg("record shelf: uid capture failed")
 		return true

--- a/agent/go-service/sellproduct/operator/cache.go
+++ b/agent/go-service/sellproduct/operator/cache.go
@@ -55,7 +55,7 @@ type sellProductOperatorSnapshot struct {
 
 // currentSellProductCacheUID 获取 CaptureUID 模块生成的加盐哈希；尚未捕获时使用 unknown 分区。
 func currentSellProductCacheUID() string {
-	uid := captureuid.GetCachedUID()
+	uid := captureuid.GetCachedUID(captureuid.OutputTypeHashed)
 	if uid == "" {
 		return sellProductCacheUnknownUID
 	}

--- a/docs/en_us/developers/components/capture-uid.md
+++ b/docs/en_us/developers/components/capture-uid.md
@@ -1,9 +1,9 @@
 # Developer Manual - CaptureUid Reference Documentation
 
-`CaptureUid` is a generic UID acquisition and caching module. It reads the player UID via screenshot OCR, hashes it with a random salt using SHA-256, and caches it for other subsystems to reference as a pseudonymous identifier.
+`CaptureUid` is a generic UID acquisition and caching module. It reads the player UID via screenshot OCR, caches the raw UID digits, and converts them at output time according to `output_type` — hashed (default), masked, or raw — for other subsystems to reference as a pseudonymous identifier.
 
 > [!important]
-> The original UID is not stored or recorded. Only the hashed pseudonymous identifier is retained for cross-session data correlation.
+> The original UID is kept only in the in-memory cache and is never persisted. Use the default `hashed` pseudonymous identifier when persisting or uploading data.
 
 ## Implementation Files
 
@@ -63,6 +63,7 @@ After switching accounts, the cache must be cleared to prevent reuse of old UIDs
 | `stay_on_current_screen` | `bool` | `true` | Whether to take a screenshot for OCR on the current screen. If `false`, navigates to `SceneEnterMenuOperationalManual` first. |
 | `allow_unknown` | `bool` | `true` | If OCR fails, return `"unknown"` instead of throwing an error. If `false`, OCR failure causes the action to fail. |
 | `clear_cache` | `bool` | `false` | Clear the UID cache and return immediately, without performing screenshot OCR. |
+| `output_type` | `string` | `"hashed"` | Output format: `hashed` (salted SHA-256, first 16 hex characters), `masked` (first and last 3 characters kept, middle replaced with `*`), or `raw` (original UID digits). |
 
 > [!note]
 > When `clear_cache` is `true`, all other parameters are ignored—the action only clears the cache and returns success directly.
@@ -74,14 +75,14 @@ In addition to Pipeline, other Go modules can also call the exported functions f
 ### Get UID (with cache)
 
 ```go
-uid, err := captureuid.Capture(ctx, ctrl, true, true, true)
-// useCache=true, stayOnCurrentScreen=true, allowUnknown=true
+uid, err := captureuid.Capture(ctx, ctrl, true, true, true, captureuid.OutputTypeHashed)
+// useCache=true, stayOnCurrentScreen=true, allowUnknown=true, outputType=hashed
 ```
 
-### Read Cached UID
+### Read Cached UID (converted to the requested output format)
 
 ```go
-uid := captureuid.GetCachedUID()
+uid := captureuid.GetCachedUID(captureuid.OutputTypeMasked)
 // Returns an empty string "" if no cache exists.
 ```
 
@@ -100,14 +101,14 @@ The action executes in the following order:
 3. **Screenshot** — Obtain the current screen via `ctrl.PostScreencap()`.
 4. **OCR** — Recognize text within the ROI region `{60, 690, 155, 25}` and extract all numeric characters.
 5. **Digit Validation** — Verify the extracted number has 8–12 digits. If not, based on `allow_unknown`, either return `"unknown"` or throw an error.
-6. **Hashing** — Read (or generate for the first time) the random salt `debug/record/random_salt.txt`, compute `SHA-256(numeric UID + salt)`, and take the first 16 hexadecimal characters as the pseudonymous identifier.
-7. **Caching** — Store the hash result in an in-memory cache for direct use in subsequent calls.
+6. **Output Formatting** — Convert according to `output_type`: for `hashed`, read (or generate for the first time) the random salt `debug/record/random_salt.txt`, compute `SHA-256(numeric UID + salt)`, and take the first 16 hexadecimal characters; for `masked`, keep the first and last 3 characters and mask the middle with `*`; for `raw`, return the digits unchanged.
+7. **Caching** — Store the raw UID digits in an in-memory cache so subsequent calls can convert them to any `output_type`.
 
 ## Privacy Design
 
-- The original numeric UID is **not stored or recorded**, existing only in memory for the current computation.
+- The original numeric UID is kept only in the in-memory cache and is **never persisted** or written to logs (logs only contain the converted result).
 - A 16-byte salt is randomly generated per installation and saved to `debug/record/random_salt.txt`.
-- The final identifier is `SHA-256(UID digits + salt)[:16]` — a 16-character hexadecimal string, sufficient to identify the same player across sessions but irreversible to the original UID.
+- The `hashed` output is `SHA-256(UID digits + salt)[:16]` — a 16-character hexadecimal string, sufficient to identify the same player across sessions but irreversible to the original UID; use this format when persisting or uploading.
 
 ## Existing Integration
 

--- a/docs/zh_cn/developers/components/capture-uid.md
+++ b/docs/zh_cn/developers/components/capture-uid.md
@@ -1,9 +1,9 @@
 # 开发手册 - CaptureUid 参考文档
 
-`CaptureUid` 是一个通用 UID 获取与缓存模块。它通过截屏 OCR 读取玩家 UID，经随机盐 SHA-256 哈希后缓存，供其他子系统以伪匿名标识符引用。
+`CaptureUid` 是一个通用 UID 获取与缓存模块。它通过截屏 OCR 读取玩家 UID，缓存原始 UID 数字，输出时按 `output_type` 转换为哈希（默认）、打码或原始形式，供其他子系统以伪匿名标识符引用。
 
 > [!important]
-> 原始 UID 不会被存储或记录。仅保留哈希后的伪匿名标识符，用于跨会话关联数据。
+> 原始 UID 仅保存在内存缓存中，不会落盘。需要持久化或上报时，应使用默认的 `hashed` 伪匿名标识符。
 
 ## 实现文件
 
@@ -63,6 +63,7 @@
 | `stay_on_current_screen` | `bool` | `true` | 是否在当前画面截屏 OCR。为 `false` 时先导航至 `SceneEnterMenuOperationalManual` 再截屏。 |
 | `allow_unknown` | `bool` | `true` | OCR 失败时返回 `"unknown"` 而非报错。为 `false` 时 OCR 失败将导致动作失败。 |
 | `clear_cache` | `bool` | `false` | 清空 UID 缓存并立即返回，不执行截屏 OCR。 |
+| `output_type` | `string` | `"hashed"` | 输出格式：`hashed`（加盐 SHA-256 前 16 位十六进制）、`masked`（保留首尾各 3 位，中间以 `*` 打码）、`raw`（原始 UID 数字）。 |
 
 > [!note]
 > `clear_cache` 为 `true` 时，其余参数均不生效——动作仅清空缓存后直接返回成功。
@@ -74,14 +75,14 @@
 ### 获取 UID（带缓存）
 
 ```go
-uid, err := captureuid.Capture(ctx, ctrl, true, true, true)
-// useCache=true, stayOnCurrentScreen=true, allowUnknown=true
+uid, err := captureuid.Capture(ctx, ctrl, true, true, true, captureuid.OutputTypeHashed)
+// useCache=true, stayOnCurrentScreen=true, allowUnknown=true, outputType=hashed
 ```
 
-### 读取缓存 UID
+### 读取缓存 UID（按输出格式转换）
 
 ```go
-uid := captureuid.GetCachedUID()
+uid := captureuid.GetCachedUID(captureuid.OutputTypeMasked)
 // 无缓存时返回空字符串 ""
 ```
 
@@ -100,14 +101,14 @@ captureuid.ClearCache()
 3. **截屏** — 通过 `ctrl.PostScreencap()` 获取当前画面。
 4. **OCR** — 在 ROI 区域 `{60, 690, 155, 25}` 内识别文字，提取所有数字字符。
 5. **数字校验** — 验证提取的数字位数为 8–12 位。不在此范围则按 `allow_unknown` 决定返回 `"unknown"` 或报错。
-6. **哈希** — 读取（或首次生成）随机盐 `debug/record/random_salt.txt`，计算 `SHA-256(数字UID + 盐)` 取前 16 位十六进制作为伪匿名标识符。
-7. **缓存** — 将哈希结果存入内存缓存，供后续调用直接使用。
+6. **输出格式化** — 按 `output_type` 转换：`hashed` 读取（或首次生成）随机盐 `debug/record/random_salt.txt` 并计算 `SHA-256(数字UID + 盐)` 前 16 位十六进制；`masked` 保留首尾各 3 位、中间以 `*` 打码；`raw` 原样返回。
+7. **缓存** — 将原始 UID 数字存入内存缓存，供后续调用按任意 `output_type` 转换使用。
 
 ## 隐私设计
 
-- 原始 UID 数字**不被存储或记录**，仅存在于当次计算的内存中。
+- 原始 UID 数字仅保存在内存缓存中，**不落盘**，也不会写入日志（日志只输出转换后的结果）。
 - 每次安装随机生成 16 字节盐，保存至 `debug/record/random_salt.txt`。
-- 最终标识符为 `SHA-256(UID数字 + 盐)[:16]` — 16 位十六进制字符串，足以跨会话标识同一玩家但无法反推原始 UID。
+- `hashed` 输出为 `SHA-256(UID数字 + 盐)[:16]` — 16 位十六进制字符串，足以跨会话标识同一玩家但无法反推原始 UID；需要持久化或上报时应使用该格式。
 
 ## 现有集成
 


### PR DESCRIPTION
- 缓存恒存原始 UID，输出时按 output_type 转换
- hashed 保持原加盐 SHA-256 前 16 位算法；masked 保留首尾各 3 位、中间打码；raw 原样输出
- 既有调用方（SellProduct/AutoStockpile/CreditShopping）显式使用 hashed，行为不变
- 同步更新中英文 CaptureUid 开发文档

## Summary by Sourcery

为 CaptureUid 添加可配置的输出格式，同时保留现有的哈希行为作为默认设置，并维护内存中的原始 UID 缓存。

新功能：
- 为 CaptureUid 引入 `output_type` 参数，以支持管道动作和 Go 调用方使用哈希、掩码和原始 UID 输出。

增强改进：
- 重构 CaptureUid 以缓存原始 UID 数字，并按需进行转换，从而在不同输出格式之间实现一致复用。
- 添加带类型的 `OutputType` 常量和规范化逻辑，用于验证和默认输出格式。
- 扩展日志记录以包含所选的 UID 输出类型，以提升可观测性。

文档：
- 更新英文和中文的 CaptureUid 开发者文档，描述新的 `output_type` 参数、输出格式、缓存语义以及隐私建议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable output format for CaptureUid while preserving existing hashed behavior as the default and maintaining in-memory raw UID caching.

New Features:
- Introduce an `output_type` parameter to CaptureUid to support hashed, masked, and raw UID outputs for both pipeline actions and Go callers.

Enhancements:
- Refactor CaptureUid to cache raw UID digits and convert them on demand, enabling consistent reuse across different output formats.
- Add typed `OutputType` constants and normalization logic to validate and default the output format.
- Extend logging to include the selected UID output type for better observability.

Documentation:
- Update English and Chinese CaptureUid developer documentation to describe the new `output_type` parameter, output formats, caching semantics, and privacy recommendations.

</details>