### PR TITLE
fix: 更新模板匹配逻辑以支持 A3 匹配区域的正确遮罩

### DIFF
--- a/agent/go-service/ims/add_item_data.go
+++ b/agent/go-service/ims/add_item_data.go
@@ -195,14 +195,21 @@ func (a *AddItemData) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 					break
 				}
 				// Still mask so a bad OCR box does not block other stacks.
-				if masked := paintItemHitRegion(workImg, detail); masked {
-					log.Info().
+				if !paintItemHitRegion(workImg, detail) {
+					log.Warn().
 						Str("component", componentAddItemData).
 						Str("item_id", itemID).
 						Str("node", nodeName).
 						Int("hit_index", hitIndex).
-						Msg("masked non-positive hit region")
+						Msg("failed to mask non-positive hit region, stop rescanning this item")
+					break
 				}
+				log.Info().
+					Str("component", componentAddItemData).
+					Str("item_id", itemID).
+					Str("node", nodeName).
+					Int("hit_index", hitIndex).
+					Msg("masked non-positive hit region")
 				continue
 			}
 			hits = append(hits, recognizedItemAdd{itemID: itemID, node: nodeName, qty: qty})
@@ -333,65 +340,45 @@ func workingRGBA(img image.Image) *image.RGBA {
 	return minicv.ImageConvertRGBA(img)
 }
 
-// paintItemHitRegion fills the recognized item card area with green so later
-// TemplateMatch/ColorMatch (green_mask / quality color) skip it. Uses the union
-// of CombinedResult[0] (quality color) and CombinedResult[1] (template) when
-// present; falls back to detail.Box.
+// paintItemHitRegion fills only the best matched item template with green so a
+// later recognition skips that hit without hiding other item cards.
 func paintItemHitRegion(img *image.RGBA, detail *maa.RecognitionDetail) bool {
 	if img == nil || detail == nil {
 		return false
 	}
-	box := itemHitMaskBox(detail)
-	if box[2] <= 0 || box[3] <= 0 {
+	box, ok := bestTemplateMatchBox(detail)
+	if !ok {
 		return false
 	}
 	return fillRectColor(img, box, imsGreenMaskColor)
 }
 
-func itemHitMaskBox(detail *maa.RecognitionDetail) maa.Rect {
-	if detail == nil {
-		return maa.Rect{}
+func bestTemplateMatchBox(detail *maa.RecognitionDetail) (maa.Rect, bool) {
+	templateDetail := findRecognitionDetailByAlgorithm(detail, string(maa.RecognitionTypeTemplateMatch))
+	if templateDetail == nil || templateDetail.Results == nil || templateDetail.Results.Best == nil {
+		return maa.Rect{}, false
 	}
-	rects := make([]maa.Rect, 0, 2)
-	if len(detail.CombinedResult) > 0 && detail.CombinedResult[0] != nil {
-		rects = append(rects, detail.CombinedResult[0].Box)
+
+	result, ok := templateDetail.Results.Best.AsTemplateMatch()
+	if !ok || result == nil || result.Box[2] <= 0 || result.Box[3] <= 0 {
+		return maa.Rect{}, false
 	}
-	if len(detail.CombinedResult) > 1 && detail.CombinedResult[1] != nil {
-		rects = append(rects, detail.CombinedResult[1].Box)
-	}
-	if len(rects) == 0 {
-		return detail.Box
-	}
-	return unionRects(rects...)
+	return result.Box, true
 }
 
-func unionRects(rects ...maa.Rect) maa.Rect {
-	valid := make([]maa.Rect, 0, len(rects))
-	for _, r := range rects {
-		if r[2] > 0 && r[3] > 0 {
-			valid = append(valid, r)
+func findRecognitionDetailByAlgorithm(detail *maa.RecognitionDetail, algorithm string) *maa.RecognitionDetail {
+	if detail == nil {
+		return nil
+	}
+	if detail.Algorithm == algorithm {
+		return detail
+	}
+	for _, child := range detail.CombinedResult {
+		if result := findRecognitionDetailByAlgorithm(child, algorithm); result != nil {
+			return result
 		}
 	}
-	if len(valid) == 0 {
-		return maa.Rect{}
-	}
-	minX, minY := valid[0][0], valid[0][1]
-	maxX, maxY := valid[0][0]+valid[0][2], valid[0][1]+valid[0][3]
-	for _, r := range valid[1:] {
-		if r[0] < minX {
-			minX = r[0]
-		}
-		if r[1] < minY {
-			minY = r[1]
-		}
-		if r[0]+r[2] > maxX {
-			maxX = r[0] + r[2]
-		}
-		if r[1]+r[3] > maxY {
-			maxY = r[1] + r[3]
-		}
-	}
-	return maa.Rect{minX, minY, maxX - minX, maxY - minY}
+	return nil
 }
 
 func fillRectColor(img *image.RGBA, box maa.Rect, c color.RGBA) bool {

--- a/agent/go-service/ims/add_item_data_test.go
+++ b/agent/go-service/ims/add_item_data_test.go
@@ -74,50 +74,68 @@ func TestAddItemDataNeedsContextWhenNotInitialized(t *testing.T) {
 	}
 }
 
-func TestUnionRects(t *testing.T) {
-	got := unionRects(maa.Rect{10, 20, 30, 40}, maa.Rect{25, 10, 20, 15})
-	want := maa.Rect{10, 10, 35, 50}
-	if got != want {
-		t.Fatalf("union=%v, want %v", got, want)
+func TestFindRecognitionDetailByAlgorithmDoesNotDependOnChildOrder(t *testing.T) {
+	templateDetail := &maa.RecognitionDetail{
+		Algorithm: "TemplateMatch",
+		Box:       maa.Rect{700, 280, 120, 100},
 	}
-	if unionRects(maa.Rect{0, 0, 0, 0}, maa.Rect{1, 1, 0, 5}) != (maa.Rect{}) {
-		t.Fatal("expected empty union for invalid rects")
+	detail := &maa.RecognitionDetail{
+		Algorithm: "And",
+		CombinedResult: []*maa.RecognitionDetail{
+			{Algorithm: "ColorMatch", Box: maa.Rect{400, 390, 100, 5}},
+			{
+				Algorithm: "And",
+				CombinedResult: []*maa.RecognitionDetail{
+					{Algorithm: "OCR", Box: maa.Rect{800, 370, 20, 15}},
+					templateDetail,
+				},
+			},
+		},
+	}
+
+	got := findRecognitionDetailByAlgorithm(detail, "TemplateMatch")
+	if got != templateDetail {
+		t.Fatalf("template detail=%p, want %p", got, templateDetail)
 	}
 }
 
-func TestItemHitMaskBox(t *testing.T) {
+func TestBestTemplateMatchBoxRequiresTypedBestResult(t *testing.T) {
 	detail := &maa.RecognitionDetail{
-		Box: maa.Rect{0, 0, 1, 1},
+		Algorithm: "And",
+		Box:       maa.Rect{806, 377, 20, 15},
 		CombinedResult: []*maa.RecognitionDetail{
-			{Box: maa.Rect{100, 200, 50, 10}},
-			{Box: maa.Rect{100, 100, 50, 80}},
+			{Algorithm: "ColorMatch", Box: maa.Rect{416, 392, 96, 3}},
+			{
+				Algorithm: "TemplateMatch",
+				Box:       maa.Rect{768, 299, 96, 79},
+			},
+			{Algorithm: "OCR", Box: maa.Rect{806, 377, 20, 15}},
 		},
 	}
-	got := itemHitMaskBox(detail)
-	want := maa.Rect{100, 100, 50, 110}
-	if got != want {
-		t.Fatalf("mask box=%v, want %v", got, want)
-	}
 
-	fallback := &maa.RecognitionDetail{Box: maa.Rect{7, 8, 9, 10}}
-	if itemHitMaskBox(fallback) != fallback.Box {
-		t.Fatal("expected detail.Box fallback when CombinedResult empty")
+	if box, ok := bestTemplateMatchBox(detail); ok || box != (maa.Rect{}) {
+		t.Fatalf("mask box=%v, ok=%v; want no fallback to detail.Box", box, ok)
 	}
 }
 
-func TestPaintItemHitRegion(t *testing.T) {
-	img := image.NewRGBA(image.Rect(0, 0, 200, 200))
+func TestPaintItemHitRegionDoesNotUseRecognitionDetailBox(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 1280, 720))
 	detail := &maa.RecognitionDetail{
+		Algorithm: "And",
 		CombinedResult: []*maa.RecognitionDetail{
-			{Box: maa.Rect{10, 20, 30, 10}},
-			{Box: maa.Rect{10, 5, 30, 20}},
+			{Algorithm: "ColorMatch", Box: maa.Rect{416, 392, 96, 3}},
+			{Algorithm: "TemplateMatch", Box: maa.Rect{768, 299, 96, 79}},
+			{Algorithm: "OCR", Box: maa.Rect{806, 377, 20, 15}},
 		},
 	}
-	if !paintItemHitRegion(img, detail) {
-		t.Fatal("expected paint success")
+
+	if paintItemHitRegion(img, detail) {
+		t.Fatal("expected masking to fail without TemplateMatch Results.Best")
 	}
-	c := img.RGBAAt(15, 10)
-	if c != (color.RGBA{R: 0, G: 255, B: 0, A: 255}) {
-		t.Fatalf("pixel=%v, want green", c)
+	if got := img.RGBAAt(800, 320); got != (color.RGBA{}) {
+		t.Fatalf("template detail.Box pixel=%v, want untouched", got)
+	}
+	if got := img.RGBAAt(450, 393); got != (color.RGBA{}) {
+		t.Fatalf("quality anchor pixel=%v, want untouched", got)
 	}
 }

--- a/agent/go-service/ims/sync_item_data.go
+++ b/agent/go-service/ims/sync_item_data.go
@@ -238,7 +238,7 @@ func recognizeItemQuantity(ctx *maa.Context, andNode string, img image.Image) (q
 }
 
 // recognizeItemQuantityHit runs the item And node and returns quantity plus the
-// root recognition detail (for A3 hit-region masking via CombinedResult).
+// root recognition detail so A3 can mask the matched TemplateMatch best box.
 func recognizeItemQuantityHit(
 	ctx *maa.Context,
 	andNode string,


### PR DESCRIPTION
## Summary by Sourcery

优化物品命中区域的遮罩逻辑，使其依赖最佳模板匹配结果，并相应调整日志和测试。

Enhancements:
- 将物品命中遮罩改为使用最佳 `TemplateMatch` 结果的框，而不是使用联合或回退矩形，这样只会遮罩被匹配到的卡牌。
- 添加一个递归辅助函数，用于按算法查找识别详情，并更新数量识别相关注释，以反映基于 `TemplateMatch` 的遮罩行为。

Tests:
- 用针对按算法查找详情、最佳模板结果要求以及避免遮罩到非预期区域的遮罩行为的测试，替换掉原有的联合矩形和通用遮罩框测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine item hit-region masking to rely on the best template match result and adjust logging and tests accordingly.

Enhancements:
- Change item hit masking to use the best TemplateMatch result box instead of union or fallback rectangles so only the matched card is masked.
- Add a recursive helper to locate recognition details by algorithm and update quantity recognition comments to reflect TemplateMatch-based masking.

Tests:
- Replace union-rect and generic mask box tests with coverage for algorithm-based detail lookup, best-template result requirements, and masking behavior that avoids unintended regions.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化物品命中区域的遮罩逻辑，使其依赖最佳模板匹配结果，并相应调整日志和测试。

Enhancements:
- 将物品命中遮罩改为使用最佳 `TemplateMatch` 结果的框，而不是使用联合或回退矩形，这样只会遮罩被匹配到的卡牌。
- 添加一个递归辅助函数，用于按算法查找识别详情，并更新数量识别相关注释，以反映基于 `TemplateMatch` 的遮罩行为。

Tests:
- 用针对按算法查找详情、最佳模板结果要求以及避免遮罩到非预期区域的遮罩行为的测试，替换掉原有的联合矩形和通用遮罩框测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine item hit-region masking to rely on the best template match result and adjust logging and tests accordingly.

Enhancements:
- Change item hit masking to use the best TemplateMatch result box instead of union or fallback rectangles so only the matched card is masked.
- Add a recursive helper to locate recognition details by algorithm and update quantity recognition comments to reflect TemplateMatch-based masking.

Tests:
- Replace union-rect and generic mask box tests with coverage for algorithm-based detail lookup, best-template result requirements, and masking behavior that avoids unintended regions.

</details>

</details>