### PR TITLE
fix:修复使用应急理智加强剂功能可以输入超过999的体力数值

### DIFF
--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -958,7 +958,7 @@
     "option.AutoUseSpMedicationMaxSanity.description": "Stop using emergency sanity boosters when current sanity reaches this value",
     "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.label": "Max sanity to use",
     "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.description": "Stop using boosters once sanity reaches this limit",
-    "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg": "Please enter an integer between 1 and 9999",
+    "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg": "Please enter an integer between 1 and 999",
     "task.AutoUseSpMedication.focus.check_sanity_insufficient": "Insufficient sanity, ending task",
     "task.AutoUseSpMedication.focus.check_sanity_sufficient": "Current sanity has reached the configured limit, ending task",
     "task.AutoUseSpMedication.focus.entry_enter_valuables_tab": "Entering valuables tab",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -958,7 +958,7 @@
     "option.AutoUseSpMedicationMaxSanity.description": "現在の理智がこの値に達した場合、緊急理智強化剤の使用を停止します",
     "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.label": "最大使用理智",
     "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.description": "理智がこの上限に達したら使用を停止します",
-    "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg": "1から9999までの整数を入力してください",
+    "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg": "1から999までの整数を入力してください",
     "task.AutoUseSpMedication.focus.check_sanity_insufficient": "理智不足のため、タスクを終了します",
     "task.AutoUseSpMedication.focus.check_sanity_sufficient": "現在の理智が設定上限に達したため、タスクを終了します",
     "task.AutoUseSpMedication.focus.entry_enter_valuables_tab": "貴重品タブに入ります",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -958,7 +958,7 @@
     "option.AutoUseSpMedicationMaxSanity.description": "현재 이성이 이 값에 도달하면 응급 이성 강화제 사용을 중단합니다",
     "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.label": "최대 사용 이성",
     "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.description": "이성이 이 상한에 도달하면 더 이상 사용하지 않습니다",
-    "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg": "1에서 9999 사이의 정수를 입력하세요",
+    "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg": "1에서 999 사이의 정수를 입력하세요",
     "task.AutoUseSpMedication.focus.check_sanity_insufficient": "이성 부족으로 작업을 종료합니다",
     "task.AutoUseSpMedication.focus.check_sanity_sufficient": "현재 이성이 설정한 상한에 도달하여 작업을 종료합니다",
     "task.AutoUseSpMedication.focus.entry_enter_valuables_tab": "귀중품 탭으로 이동합니다",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -958,7 +958,7 @@
     "option.AutoUseSpMedicationMaxSanity.description": "当前理智达到该值时停止继续使用应急理智加强剂",
     "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.label": "最大使用理智",
     "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.description": "理智达到该上限后不再使用应急理智加强剂",
-    "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg": "请输入1到9999之间的整数",
+    "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg": "请输入1到999之间的整数",
     "task.AutoUseSpMedication.focus.check_sanity_insufficient": "理智不足，结束任务",
     "task.AutoUseSpMedication.focus.check_sanity_sufficient": "当前理智已达到设定上限，结束任务",
     "task.AutoUseSpMedication.focus.entry_enter_valuables_tab": "即将进入珍贵物品标签页",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -644,7 +644,7 @@
     "option.AutoUseSpMedicationMaxSanity.description": "當前理智達到該值時停止繼續使用應急理智加強劑",
     "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.label": "最大使用理智",
     "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.description": "理智達到該上限後不再使用應急理智加強劑",
-    "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg": "請輸入1到9999之間的整數",
+    "option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg": "請輸入1到999之間的整數",
     "task.AutoUseSpMedication.focus.check_sanity_insufficient": "理智不足，結束任務",
     "task.AutoUseSpMedication.focus.check_sanity_sufficient": "當前理智已達到設定上限，結束任務",
     "task.AutoUseSpMedication.focus.entry_enter_valuables_tab": "即將進入珍貴物品標籤頁",

--- a/assets/resource/pipeline/AutoUseSpMedication/UseEmergencySanityBooster.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/UseEmergencySanityBooster.json
@@ -24,7 +24,7 @@
             "param": {
                 "custom_recognition": "ExpressionRecognition",
                 "custom_recognition_param": {
-                    "expression": "{AutoUseSpMedicationCurrentSanity}<9999",
+                    "expression": "{AutoUseSpMedicationCurrentSanity}<999",
                     "box_node": "AutoUseSpMedicationCurrentSanity"
                 }
             }
@@ -44,7 +44,7 @@
             "param": {
                 "custom_recognition": "ExpressionRecognition",
                 "custom_recognition_param": {
-                    "expression": "{AutoUseSpMedicationCurrentSanity}>=9999",
+                    "expression": "{AutoUseSpMedicationCurrentSanity}>=999",
                     "box_node": "AutoUseSpMedicationCurrentSanity"
                 }
             }

--- a/assets/tasks/AutoUseSpMedication.json
+++ b/assets/tasks/AutoUseSpMedication.json
@@ -276,10 +276,10 @@
                     "name": "MaxSanity",
                     "label": "$option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.label",
                     "description": "$option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.description",
-                    "default": "9999",
+                    "default": "999",
                     "pipeline_type": "int",
                     "pattern_msg": "$option.AutoUseSpMedicationMaxSanity.inputs.MaxSanity.pattern_msg",
-                    "verify": "^([1-9]\\d{0,3})$"
+                    "verify": "^([1-9]\\d{0,2})$"
                 }
             ],
             "pipeline_override": {


### PR DESCRIPTION
## Summary by Sourcery

将紧急理智增幅器的自动使用功能限定在一个最大体力值之内，并对相关配置进行统一调整。

Bug Fixes:
- 防止在使用紧急理智增幅器自动使用功能时输入超过预期上限的体力值。

Enhancements:
- 调整紧急理智增幅器自动使用的流水线和任务配置，以强制执行新的体力上限。
- 更新本地化界面文案，使其在各个支持的语言中准确反映修正后的紧急理智增幅器行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit the emergency sanity booster auto-use feature to a maximum stamina value and align related configuration.

Bug Fixes:
- Prevent entering stamina values greater than the intended upper limit when using the emergency sanity booster auto-use feature.

Enhancements:
- Adjust auto-use emergency sanity booster pipeline and task configuration to enforce the new stamina limit.
- Update localized interface strings to reflect the corrected emergency sanity booster behavior across supported languages.

</details>