### PR TITLE
fix(MapNavigator): 录制拆到提权子进程而不再重启整个服务

### DIFF
--- a/tools/MapNavigator/README.md
+++ b/tools/MapNavigator/README.md
@@ -244,6 +244,8 @@ uv run main.py
 - `connectors.py`: 录制连接器抽象，以及各 controller 建连实现。
 - `settings_store.py`: 本地用户连接偏好持久化。
 - `recording_service.py`: Maa Agent 录制线程与数据采集，不直接耦合具体 controller 类型。
+- `record_worker.py`: 提权录制子进程。Windows 非管理员时录制跑在这里，与后端用回连 socket 通信（服务自身不重启、不提权）。
+- `clipboard.py`: 系统剪贴板写入（G 热键复制坐标）。
 - `basenav_preview.py`: BaseNav `.nav` 加载与 A\* 路线预览计算。
 - `json_import.py`: JSON/JSONC 导入解析与动作语义校验。
 - `maptracker_compat.py`: `MapTracker*` 节点到 Base 坐标系的兼容转换表。

--- a/tools/MapNavigator/clipboard.py
+++ b/tools/MapNavigator/clipboard.py
@@ -1,0 +1,36 @@
+"""系统剪贴板写入 (G 热键用)。
+
+录制中游戏持有焦点, 前端拿不到 `navigator.clipboard` 权限, 只能由后端直接写。
+serve.py 与提权录制子进程 record_worker.py 共用本模块。
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Callable
+
+
+def copy_to_clipboard(text: str, log: Callable[[str], None] | None = None) -> bool:
+    """写系统剪贴板。优先 pyperclip, 失败退到各平台命令行工具。"""
+    try:
+        import pyperclip
+
+        pyperclip.copy(text)
+        return True
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        if sys.platform == "darwin":
+            subprocess.run(["pbcopy"], input=text.encode("utf-8"), check=True)
+            return True
+        if sys.platform == "win32":
+            # Windows 'clip' 读 UTF-16LE
+            subprocess.run(["clip"], input=text.encode("utf-16-le"), check=True)
+            return True
+        subprocess.run(["xclip", "-selection", "clipboard"], input=text.encode("utf-8"), check=True)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        if log is not None:
+            log(f"剪贴板写入失败: {exc}")
+        return False

--- a/tools/MapNavigator/connection_models.py
+++ b/tools/MapNavigator/connection_models.py
@@ -91,3 +91,45 @@ class RecordingSessionConfig:
         elif self.kind == "wlroots":
             return f"WlRoots / {self.wlroots.wlr_socket_path or '未指定 socket'}"
         return f"Win32 / {self.win32.window_title}"
+
+
+def session_config_from_payload(payload: dict[str, Any]) -> RecordingSessionConfig:
+    """前端连接面板的 JSON -> 录制会话配置。缺字段一律回退到各自默认值。
+
+    住在这里而不是 serve.py: 提权录制子进程 (record_worker.py) 拿到的是同一份原始
+    payload, 必须和后端走完全一样的解析。
+    """
+    kind = payload.get("kind", "win32")
+    if kind == "adb":
+        adb = payload.get("adb") or {}
+        cfg = adb.get("config")
+        return RecordingSessionConfig(
+            kind="adb",
+            adb=AdbConnectionConfig(
+                adb_path=str(adb.get("adb_path", "") or ""),
+                address=str(adb.get("address", "") or ""),
+                config=cfg if isinstance(cfg, dict) else {},
+            ),
+        )
+    elif kind == "playcover":
+        playcover = payload.get("playcover") or {}
+        return RecordingSessionConfig(
+            kind="playcover",
+            playcover=PlayCoverConnectionConfig(
+                address=str(playcover.get("address", "127.0.0.1:1717") or "127.0.0.1:1717"),
+                uuid=str(playcover.get("uuid", "maa.playcover") or "maa.playcover"),
+            ),
+        )
+    elif kind == "wlroots":
+        wlroots = payload.get("wlroots") or {}
+        return RecordingSessionConfig(
+            kind="wlroots",
+            wlroots=WlRootsConnectionConfig(
+                wlr_socket_path=str(wlroots.get("wlr_socket_path", "") or ""),
+            ),
+        )
+    win = payload.get("win32") or {}
+    return RecordingSessionConfig(
+        kind="win32",
+        win32=Win32ConnectionConfig(window_title=str(win.get("window_title", "Endfield") or "Endfield")),
+    )

--- a/tools/MapNavigator/key_listener.py
+++ b/tools/MapNavigator/key_listener.py
@@ -4,11 +4,7 @@
 - ``start()`` / ``stop()``：启停后台监听线程。
 - ``register(key_name, callback)``：注册按键回调（按下瞬间触发，内置防抖）。
 - ``unregister_all()``：清除所有注册的回调。
-- ``ensure_privileges()``：检测并尝试获取必要的系统权限。
-
-Windows 注意事项：
-    监听全局按键需要以管理员身份运行。
-    调用 ``ensure_privileges()`` 会自动检测并弹出 UAC 提权请求。
+- ``ensure_privileges()``：检测必要的系统权限。
 
 macOS 注意事项：
     首次运行时需要在 *系统设置 → 隐私与安全性 → 输入监控* 中授权终端或 Python。
@@ -109,16 +105,12 @@ def stop() -> None:
 def ensure_privileges() -> bool:
     """检测当前进程是否具备全局按键监听所需的系统权限。
 
-    - Windows：检测是否以管理员身份运行，若否则弹出 UAC 提权并重启。
+    - Windows：是否以管理员身份运行。
     - macOS：提示用户授权输入监控权限。
     - Linux：通常不需要特殊权限（X11），直接放行。
-
-    Returns:
-        True 表示权限就绪，可以继续运行。
-        False 表示已触发提权重启，当前进程应退出。
     """
     if sys.platform == "win32":
-        return _ensure_windows_admin()
+        return _has_windows_admin()
     if sys.platform == "darwin":
         _warn_macos_permissions()
         return True
@@ -126,33 +118,14 @@ def ensure_privileges() -> bool:
     return True
 
 
-def _ensure_windows_admin() -> bool:
-    """Windows: 检测管理员权限，若不足则通过 UAC 提权重启。"""
+def _has_windows_admin() -> bool:
+    """Windows: 检测管理员权限。"""
     try:
         import ctypes
-        if ctypes.windll.shell32.IsUserAnAdmin():
-            return True
+        return bool(ctypes.windll.shell32.IsUserAnAdmin())
     except Exception:
         # 无法检测时假定有权限，让 pynput 自行报错
         return True
-
-    print("当前未以管理员身份运行，正在请求提权...")
-    try:
-        import ctypes
-        # 用 runas 动词触发 UAC 弹窗，以管理员身份重新启动当前脚本
-        params = " ".join(f'"{arg}"' for arg in sys.argv)
-        ret = ctypes.windll.shell32.ShellExecuteW(
-            None, "runas", sys.executable, params, None, 1
-        )
-        # ShellExecuteW 返回值 > 32 表示成功
-        if ret > 32:
-            return False  # 提权成功，当前进程应退出
-    except Exception as exc:
-        print(f"提权失败: {exc}")
-
-    # 提权失败或用户取消，继续以普通权限运行
-    print("Warning: 未能获取管理员权限，全局热键可能在游戏窗口前台时不生效。")
-    return True
 
 
 def _warn_macos_permissions() -> None:

--- a/tools/MapNavigator/record_worker.py
+++ b/tools/MapNavigator/record_worker.py
@@ -1,0 +1,275 @@
+"""提权录制子进程: 只跑录制, 由 serve.py 用 runas 拉起并回连它的 127.0.0.1 端口。
+
+热键要管理员权限, 但服务是长驻进程不能自己 runas 重启 (会另起一整套服务并丢掉页面
+状态), 所以只把录制这一段拆出来提权。
+
+协议 (NDJSON):
+    -> {"type":"hello","token":...}       父进程校验后才继续
+    <- {"type":"start","config":{...}}    前端原始 payload
+    -> 录制事件, 与进程内录制推给前端的 JSON 完全一致
+    <- {"type":"stop"}                    随后本进程发 finished
+socket EOF 即退出 —— 父进程 kill 不掉更高完整性级别的进程, 只能靠这个避免孤儿。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import sys
+import threading
+import traceback
+from pathlib import Path
+
+# 与 serve.py 同样的 bare-name import 约定: 本目录必须在 sys.path 最前。
+# 提权子进程的工作目录不可靠 (ShellExecuteW 给的是全新环境), 不能指望 cwd。
+_TOOL_DIR = Path(__file__).resolve().parent
+if str(_TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOL_DIR))
+
+from clipboard import copy_to_clipboard  # noqa: E402
+from connection_models import session_config_from_payload  # noqa: E402
+
+CONNECT_TIMEOUT_SECONDS = 30.0
+# 收到 stop 后等录制线程交出 finished 的宽限期 (一轮采样可能正卡在识别调用里)。
+STOP_GRACE_SECONDS = 20.0
+# 半关闭后等父进程收完并回关的上限。
+LINGER_SECONDS = 5.0
+
+
+class _Channel:
+    """回连 socket 的 NDJSON 读写封装。
+
+    send 会被录制线程和 pynput 热键线程并发调用, 故加锁。
+    """
+
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+        self._send_lock = threading.Lock()
+        self._recv_buffer = b""
+        self._closed = False
+
+    def send(self, payload: dict) -> None:
+        line = (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
+        with self._send_lock:
+            if self._closed:
+                return
+            try:
+                self._sock.sendall(line)
+            except OSError:
+                self._closed = True
+
+    def recv(self) -> dict | None:
+        """读下一条消息; 返回 None 表示对端关闭 (父进程没了 -> 本进程该退出)。"""
+        while True:
+            newline = self._recv_buffer.find(b"\n")
+            if newline >= 0:
+                line = self._recv_buffer[:newline]
+                self._recv_buffer = self._recv_buffer[newline + 1:]
+                if not line.strip():
+                    continue
+                try:
+                    msg = json.loads(line.decode("utf-8"))
+                except (ValueError, UnicodeDecodeError):
+                    continue
+                return msg if isinstance(msg, dict) else {}
+            try:
+                chunk = self._sock.recv(65536)
+            except OSError:
+                return None
+            if not chunk:
+                return None
+            self._recv_buffer += chunk
+
+    def half_close(self) -> None:
+        """只发 FIN 不关 socket。直接 close 在 Windows 上会退化成 RST, 把对端收到但
+        还没读的数据一起冲掉 (实测 4/14 的会话因此丢了最后那条 finished/error)。
+        """
+        with self._send_lock:
+            self._closed = True
+            try:
+                self._sock.shutdown(socket.SHUT_WR)
+            except OSError:
+                pass
+
+    def drain(self, linger: float) -> None:
+        """半关闭后等对端读完回关。只在没有 reader 线程占着读端时调。"""
+        try:
+            self._sock.settimeout(linger)
+            while self._sock.recv(65536):
+                pass
+        except OSError:
+            pass
+
+    def close(self) -> None:
+        self._closed = True
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+
+def _log(channel: _Channel, message: str) -> None:
+    """子进程没有可见控制台 (SW_HIDE), 日志只能回传给父进程。"""
+    channel.send({"type": "log", "message": message})
+
+
+class _ChannelStream:
+    """把 print/traceback 按行转成 log 消息回传父进程。
+
+    recording_service 全程用 print 打诊断, 子进程窗口是隐藏的, 不接过来就全丢了。
+    """
+
+    def __init__(self, channel: _Channel) -> None:
+        self._channel = channel
+        self._buffer = ""
+        self._lock = threading.Lock()
+
+    def write(self, text: str) -> int:
+        with self._lock:
+            self._buffer += text
+            lines = self._buffer.split("\n")
+            self._buffer = lines.pop()
+            pending = [line for line in lines if line.strip()]
+        for line in pending:
+            self._channel.send({"type": "log", "message": line})
+        return len(text)
+
+    def flush(self) -> None:
+        with self._lock:
+            line, self._buffer = self._buffer, ""
+        if line.strip():
+            self._channel.send({"type": "log", "message": line})
+
+    def isatty(self) -> bool:
+        return False
+
+
+def run(host: str, port: int, token: str) -> int:
+    sock = socket.create_connection((host, port), timeout=CONNECT_TIMEOUT_SECONDS)
+    sock.settimeout(None)
+    channel = _Channel(sock)
+    stopped = threading.Event()
+    reader: threading.Thread | None = None
+
+    try:
+        channel.send({"type": "hello", "token": token})
+        sys.stdout = sys.stderr = _ChannelStream(channel)  # type: ignore[assignment]
+
+        first = channel.recv()
+        if first is None:
+            return 1
+        if first.get("type") != "start":
+            channel.send({"type": "error", "message": f"协议错误: 期待 start, 收到 {first.get('type')!r}"})
+            return 1
+
+        from recording_service import LivePosition, RecordingService  # noqa: PLC0415
+        from runtime import configure_runtime_env, load_maa_runtime  # noqa: PLC0415
+
+        # 提权进程拿到的是全新环境块, 父进程 lifespan 里设的变量不会继承过来。
+        configure_runtime_env()
+
+        runtime = load_maa_runtime()
+        if runtime is None:
+            channel.send({"type": "error", "message": "maafw 运行时不可用, 无法录制 (缺少 maafw 依赖或初始化失败)。"})
+            return 1
+
+        def on_finished(points: list) -> None:
+            channel.send({"type": "finished", "points": points})
+            stopped.set()
+
+        def on_error(message: str) -> None:
+            channel.send({"type": "error", "message": message})
+            stopped.set()
+
+        def on_clipboard(coord: str, status: str) -> None:
+            # 本进程已提权, 由它直接写剪贴板 (游戏持有焦点)。
+            copy_to_clipboard(coord, log=lambda m: _log(channel, m))
+            channel.send({"type": "toast", "coord": coord, "status": status})
+
+        def on_live_position(position: LivePosition) -> None:
+            channel.send(
+                {
+                    "type": "position",
+                    "x": position.x,
+                    "y": position.y,
+                    "zone": position.zone,
+                    "rot": position.rot,
+                }
+            )
+
+        service = RecordingService(
+            runtime=runtime,
+            on_status=lambda text, color: channel.send({"type": "status", "text": text, "color": color}),
+            on_finished=on_finished,
+            on_error=on_error,
+            on_locator_detail=lambda text: channel.send({"type": "locator", "text": text}),
+            on_clipboard=on_clipboard,
+            on_force_waypoint=lambda x, y, zone: channel.send(
+                {"type": "force_waypoint", "x": x, "y": y, "zone": zone}
+            ),
+            on_live_position=on_live_position,
+        )
+        service.start(session_config_from_payload(first.get("config") or {}))
+
+        # 读父进程指令直到 stop 或 EOF; EOF = 父进程没了, 必须停录制并退出。
+        def read_parent() -> None:
+            parent_gone = False
+            try:
+                while True:
+                    msg = channel.recv()
+                    if msg is None:
+                        parent_gone = True
+                        break
+                    if msg.get("type") == "stop":
+                        break
+            finally:
+                try:
+                    service.stop()  # 非阻塞: 只清标志, 录制线程随后自己走 on_finished
+                except Exception:  # noqa: BLE001
+                    pass
+                if parent_gone:
+                    stopped.set()  # 已经没人收 finished 了, 直接退
+                elif not stopped.wait(STOP_GRACE_SECONDS):
+                    # 录制线程卡在采样调用里没能发出 finished, 不能无限等。
+                    _log(channel, f"停止后 {STOP_GRACE_SECONDS:.0f}s 未收到 finished, 强制退出。")
+                    channel.send({"type": "error", "message": "录制停止超时, 已强制结束子进程。"})
+                    stopped.set()
+
+        reader = threading.Thread(target=read_parent, daemon=True)
+        reader.start()
+        stopped.wait()
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        try:
+            channel.send({"type": "error", "message": f"录制子进程异常: {exc}"})
+            _log(channel, traceback.format_exc())
+        except Exception:  # noqa: BLE001
+            pass
+        return 1
+    finally:
+        stream = sys.stdout
+        if isinstance(stream, _ChannelStream):
+            stream.flush()
+            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
+        # 半关闭 -> 等父进程收完最后一条消息后回关, 再真正 close (见 half_close)。
+        channel.half_close()
+        if reader is not None and reader.is_alive():
+            reader.join(LINGER_SECONDS)  # reader 占着读端, 由它读到 EOF
+        else:
+            channel.drain(LINGER_SECONDS)
+        channel.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="MapNavigator 提权录制子进程 (由 serve.py 拉起)")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--token", required=True)
+    args = parser.parse_args()
+    return run(args.host, args.port, args.token)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/MapNavigator/web/serve.py
+++ b/tools/MapNavigator/web/serve.py
@@ -373,11 +373,20 @@ class ElevatedRecordingBridge:
 
         async def on_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
             # 只认第一个通过 token 校验的连接; 其余一律丢弃。
+            # 校验写成显式判断: assert 在 python -O 下会被整条删掉, 等于没校验。
             try:
                 line = await asyncio.wait_for(reader.readline(), timeout=WORKER_CONNECT_TIMEOUT_SECONDS)
                 hello = json.loads(line.decode("utf-8"))
-                assert hello.get("type") == "hello" and hello.get("token") == self._token
             except Exception:  # noqa: BLE001
+                writer.close()
+                return
+            token = hello.get("token") if isinstance(hello, dict) else None
+            if (
+                not isinstance(token, str)
+                or hello.get("type") != "hello"
+                or not secrets.compare_digest(token, self._token)
+            ):
+                _log("丢弃一个握手不合法的回连。")
                 writer.close()
                 return
             if self._connected is not None and not self._connected.done():

--- a/tools/MapNavigator/web/serve.py
+++ b/tools/MapNavigator/web/serve.py
@@ -40,6 +40,7 @@ import asyncio
 import json
 import math
 import os
+import secrets
 import socket
 import struct
 import subprocess
@@ -69,13 +70,8 @@ from basenav_preview import (  # noqa: E402
     _point_in_triangle,
     load_basenav_field,
 )
-from connection_models import (  # noqa: E402
-    AdbConnectionConfig,
-    PlayCoverConnectionConfig,
-    RecordingSessionConfig,
-    Win32ConnectionConfig,
-    WlRootsConnectionConfig,
-)
+from clipboard import copy_to_clipboard  # noqa: E402
+from connection_models import session_config_from_payload  # noqa: E402
 from connectors import (  # noqa: E402
     build_recording_connector,
     find_game_window,
@@ -337,73 +333,154 @@ def get_runtime() -> Any:
         return _runtime_cache
 
 
-# --- 剪贴板 (G 热键: 录制中游戏持有焦点, 必须由后端直接写系统剪贴板) ---------------------
-def _copy_to_clipboard(text: str) -> bool:
-    try:
-        import pyperclip
-
-        pyperclip.copy(text)
-        return True
-    except Exception:  # noqa: BLE001
-        pass
-    try:
-        if sys.platform == "darwin":
-            subprocess.run(["pbcopy"], input=text.encode("utf-8"), check=True)
-            return True
-        if sys.platform == "win32":
-            # Windows 'clip' 读 UTF-16LE
-            subprocess.run(["clip"], input=text.encode("utf-16-le"), check=True)
-            return True
-        subprocess.run(["xclip", "-selection", "clipboard"], input=text.encode("utf-8"), check=True)
-        return True
-    except Exception as exc:  # noqa: BLE001
-        _log(f"剪贴板写入失败: {exc}")
-        return False
-
-
 # --- 设置存储 -------------------------------------------------------------------------
 settings_store = MapNavigatorSettingsStore()
 
 
-# --- 录制会话构造 + 单例守卫 ----------------------------------------------------------
+# --- 录制单例守卫 ---------------------------------------------------------------------
 _recording_lock = threading.Lock()
 
 
-def _build_session_config(payload: dict[str, Any]) -> RecordingSessionConfig:
-    kind = payload.get("kind", "win32")
-    if kind == "adb":
-        adb = payload.get("adb") or {}
-        cfg = adb.get("config")
-        return RecordingSessionConfig(
-            kind="adb",
-            adb=AdbConnectionConfig(
-                adb_path=str(adb.get("adb_path", "") or ""),
-                address=str(adb.get("address", "") or ""),
-                config=cfg if isinstance(cfg, dict) else {},
-            ),
-        )
-    elif kind == "playcover":
-        playcover = payload.get("playcover") or {}
-        return RecordingSessionConfig(
-            kind="playcover",
-            playcover=PlayCoverConnectionConfig(
-                address=str(playcover.get("address", "127.0.0.1:1717") or "127.0.0.1:1717"),
-                uuid=str(playcover.get("uuid", "maa.playcover") or "maa.playcover"),
-            ),
-        )
-    elif kind == "wlroots":
-        wlroots = payload.get("wlroots") or {}
-        return RecordingSessionConfig(
-            kind="wlroots",
-            wlroots=WlRootsConnectionConfig(
-                wlr_socket_path=str(wlroots.get("wlr_socket_path", "") or ""),
-            ),
-        )
-    win = payload.get("win32") or {}
-    return RecordingSessionConfig(
-        kind="win32",
-        win32=Win32ConnectionConfig(window_title=str(win.get("window_title", "Endfield") or "Endfield")),
-    )
+# --- 提权录制子进程 (Windows 非管理员时) -----------------------------------------------
+# 热键要管理员权限, 但本服务是长驻进程不能自己 runas 重启 (会另起一整套服务并丢掉页面
+# 状态), 所以只提权录制这一段。协议见 record_worker.py。
+_WORKER_PY = _PARENT_DIR / "record_worker.py"
+WORKER_CONNECT_TIMEOUT_SECONDS = 30.0  # 计时从 UAC 答复后开始; 子进程冷启 maafw 要好几秒
+SE_ERR_ACCESSDENIED = 5  # ShellExecuteW: 用户拒绝了 UAC
+
+
+class ElevatedRecordingBridge:
+    """拉起提权录制子进程, 并在它与调用方之间转发 NDJSON 消息。
+
+    子进程发来的就是前端协议本身, 故转发是直通, 前端不用改。
+    """
+
+    def __init__(self, elevate: bool = True) -> None:
+        self._elevate = elevate
+        self._server: asyncio.Server | None = None
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._connected: asyncio.Future[tuple[asyncio.StreamReader, asyncio.StreamWriter]] | None = None
+        self._token = secrets.token_hex(16)
+
+    async def spawn(self) -> str | None:
+        """监听回连端口 -> 提权拉起子进程 -> 等它握手。
+
+        返回 None 表示就绪; 否则返回失败原因 (调用方据此回退到进程内录制)。
+        """
+        loop = asyncio.get_running_loop()
+        self._connected = loop.create_future()
+
+        async def on_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            # 只认第一个通过 token 校验的连接; 其余一律丢弃。
+            try:
+                line = await asyncio.wait_for(reader.readline(), timeout=WORKER_CONNECT_TIMEOUT_SECONDS)
+                hello = json.loads(line.decode("utf-8"))
+                assert hello.get("type") == "hello" and hello.get("token") == self._token
+            except Exception:  # noqa: BLE001
+                writer.close()
+                return
+            if self._connected is not None and not self._connected.done():
+                self._connected.set_result((reader, writer))
+            else:
+                writer.close()
+
+        self._server = await asyncio.start_server(on_client, "127.0.0.1", 0)
+        port = self._server.sockets[0].getsockname()[1]
+
+        launched = await run_in_threadpool(self._launch_worker, port)
+        if launched is not None:
+            return launched
+
+        try:
+            self._reader, self._writer = await asyncio.wait_for(
+                self._connected, timeout=WORKER_CONNECT_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            return (
+                f"提权录制子进程 {WORKER_CONNECT_TIMEOUT_SECONDS:.0f}s 内没有回连 "
+                "(可能被安全软件拦截, 或 maafw 依赖加载失败)。"
+            )
+        return None
+
+    def _launch_worker(self, port: int) -> str | None:
+        """拉起子进程。提权分支会阻塞到用户答复 UAC, 故整个方法只在线程池里调。
+
+        用 sys.executable 而非 uv run: 提权子进程拿到的是全新环境块, uv 在那里可能重解析。
+        """
+        if not _WORKER_PY.exists():
+            return f"找不到录制子进程脚本: {_WORKER_PY}"
+        argv = [str(_WORKER_PY), "--port", str(port), "--token", self._token]
+        if not self._elevate:
+            try:
+                subprocess.Popen([sys.executable, *argv], cwd=str(_PARENT_DIR))
+            except Exception as exc:  # noqa: BLE001
+                return f"拉起录制子进程失败: {exc}"
+            return None
+        try:
+            import ctypes
+
+            # SW_HIDE: 不给用户弹一个黑控制台; 子进程日志走 socket 回传。
+            ret = int(
+                ctypes.windll.shell32.ShellExecuteW(
+                    None,
+                    "runas",
+                    sys.executable,
+                    " ".join(f'"{arg}"' for arg in argv),
+                    str(_PARENT_DIR),
+                    0,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            return f"拉起提权录制子进程失败: {exc}"
+        if ret == SE_ERR_ACCESSDENIED:
+            return "已取消提权。"
+        if ret <= 32:
+            return f"拉起提权录制子进程失败 (ShellExecuteW={ret})。"
+        return None
+
+    async def send(self, payload: dict[str, Any]) -> None:
+        if self._writer is None:
+            return
+        self._writer.write((json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8"))
+        try:
+            await self._writer.drain()
+        except Exception:  # noqa: BLE001
+            pass
+
+    async def messages(self):
+        """逐条产出子进程消息; socket EOF 时结束。"""
+        if self._reader is None:
+            return
+        while True:
+            try:
+                line = await self._reader.readline()
+            except Exception as exc:  # noqa: BLE001
+                # 连接被重置等: 必须留痕, 否则和正常 EOF 长得一样, 没法查。
+                _log(f"读取录制子进程失败: {exc!r}")
+                return
+            if not line:
+                return
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except (ValueError, UnicodeDecodeError):
+                continue
+            if isinstance(msg, dict):
+                yield msg
+
+    async def close(self) -> None:
+        # 关 socket 即让子进程自杀 —— 本进程完整性级别更低, kill 不掉它。
+        if self._writer is not None:
+            try:
+                self._writer.close()
+            except Exception:  # noqa: BLE001
+                pass
+        if self._server is not None:
+            self._server.close()
+            try:
+                await self._server.wait_closed()
+            except Exception:  # noqa: BLE001
+                pass
 
 
 # --- FastAPI app ----------------------------------------------------------------------
@@ -1172,6 +1249,76 @@ async def favicon() -> Response:
     return Response(status_code=204)
 
 
+def _recording_worker_mode() -> str:
+    """本次录制走哪条路: 'elevate' 提权子进程 / 'plain' 不提权子进程 / 'inline' 进程内。
+
+    默认只在 Windows 非管理员时提权 —— 已是管理员或非 Windows 时进程内录制本来就好用,
+    没必要多一跳。MAPNAV_RECORD_WORKER 可强制: plain (不提权起子进程, 用于单独验证
+    IPC 链路) / off (强制进程内)。
+    """
+    forced = (os.environ.get("MAPNAV_RECORD_WORKER") or "").strip().lower()
+    if forced == "plain":
+        return "plain"
+    if forced in ("off", "inline"):
+        return "inline"
+    try:
+        # macOS 的输入监控提示也靠这一调用, 别按平台短路掉。
+        privileged = key_listener.ensure_privileges()
+    except Exception as exc:  # noqa: BLE001
+        _log(f"ensure_privileges 异常(按已有权限处理): {exc}")
+        return "inline"
+    if sys.platform != "win32":
+        return "inline"
+    return "inline" if privileged else "elevate"
+
+
+async def _relay_elevated_recording(websocket: WebSocket, bridge: ElevatedRecordingBridge) -> None:
+    """录制子进程 <-> 浏览器 双向转发, 直到录制出结果或任一端断开。
+
+    子进程发的就是前端协议本身, 除 log (只进终端) 外原样转发。
+    """
+
+    async def pump_worker() -> str:
+        async for msg in bridge.messages():
+            kind = msg.get("type")
+            if kind == "log":
+                _log(f"[录制子进程] {msg.get('message', '')}")
+                continue
+            await websocket.send_json(msg)
+            if kind in ("finished", "error"):
+                return str(kind)
+        return "eof"
+
+    async def pump_client() -> str:
+        try:
+            while True:
+                msg = await websocket.receive_json()
+                if isinstance(msg, dict) and msg.get("type") == "stop":
+                    await bridge.send({"type": "stop"})
+        except Exception:  # noqa: BLE001
+            return "disconnected"
+
+    worker_task = asyncio.create_task(pump_worker())
+    client_task = asyncio.create_task(pump_client())
+    try:
+        done, pending = await asyncio.wait(
+            {worker_task, client_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in pending:
+            task.cancel()
+        for task in done:
+            task.exception()  # 取一下, 免得变成 "exception never retrieved"
+        if worker_task in done and worker_task.exception() is None:
+            if worker_task.result() == "eof":
+                # 子进程没给结果就断了 (崩溃/被安全软件杀), 前端得复位。
+                await websocket.send_json(
+                    {"type": "error", "message": "提权录制子进程意外退出 (未返回录制结果)。"}
+                )
+    finally:
+        worker_task.cancel()
+        client_task.cancel()
+
+
 @app.websocket("/ws/record")
 async def ws_record(websocket: WebSocket) -> None:
     await websocket.accept()
@@ -1185,6 +1332,7 @@ async def ws_record(websocket: WebSocket) -> None:
             pass
 
     service: RecordingService | None = None
+    bridge: ElevatedRecordingBridge | None = None
     acquired = False
     try:
         first = await websocket.receive_json()
@@ -1194,29 +1342,40 @@ async def ws_record(websocket: WebSocket) -> None:
         if not isinstance(payload, dict):
             payload = {}
 
+        if not _recording_lock.acquire(blocking=False):
+            await websocket.send_json({"type": "error", "message": "已有录制会话进行中, 请先停止。"})
+            return
+        acquired = True
+
+        # 权限判定仅在录制开始时做 (绝不在服务启动时, 以免顶掉纯编辑用户)。
+        mode = _recording_worker_mode()
+        if mode != "inline":
+            await websocket.send_json(
+                {"type": "status", "text": "● 正在启动录制进程 (需要授权提权)…", "color": "#f59e0b"}
+            )
+            bridge = ElevatedRecordingBridge(elevate=(mode == "elevate"))
+            failure = await bridge.spawn()
+            if failure is None:
+                # maafw 由子进程自己加载, 本进程不碰 (避免两个进程各开一套原生运行时)。
+                await bridge.send({"type": "start", "config": payload})
+                await _relay_elevated_recording(websocket, bridge)
+                return
+            await bridge.close()
+            bridge = None
+            # 提权失败/被拒不能让录制彻底不可用 —— 退回进程内录制, 只是热键可能收不到。
+            warning = (
+                f"{failure} 已退回本进程录制: 游戏窗口在前台时 G/X 热键可能收不到按键。"
+            )
+            _log(warning)
+            await websocket.send_json({"type": "status", "text": warning, "color": "#f59e0b"})
+            await websocket.send_json({"type": "locator", "text": warning})
+
         runtime = get_runtime()
         if runtime is None:
             await websocket.send_json(
                 {"type": "error", "message": "maafw 运行时不可用, 无法录制 (缺少 maafw 依赖或初始化失败)。"}
             )
             return
-
-        # 权限检查仅在录制开始时进行 (绝不在服务启动时, 以免顶掉纯编辑用户)。
-        try:
-            privileges_ok = key_listener.ensure_privileges()
-        except Exception as exc:  # noqa: BLE001
-            _log(f"ensure_privileges 异常(放行): {exc}")
-            privileges_ok = True
-        if not privileges_ok:
-            await websocket.send_json(
-                {"type": "error", "message": "缺少全局按键监听所需权限 (需管理员/输入监控授权)。"}
-            )
-            return
-
-        if not _recording_lock.acquire(blocking=False):
-            await websocket.send_json({"type": "error", "message": "已有录制会话进行中, 请先停止。"})
-            return
-        acquired = True
 
         stop_event = asyncio.Event()
 
@@ -1246,7 +1405,7 @@ async def ws_record(websocket: WebSocket) -> None:
             )
 
         def on_clipboard(coord: str, status: str) -> None:
-            _copy_to_clipboard(coord)  # 后端直接写系统剪贴板 (游戏持有焦点)
+            copy_to_clipboard(coord, log=_log)  # 后端直接写系统剪贴板 (游戏持有焦点)
             push({"type": "toast", "coord": coord, "status": status})
 
         def on_force_waypoint(x: float, y: float, zone: str) -> None:
@@ -1262,7 +1421,7 @@ async def ws_record(websocket: WebSocket) -> None:
             on_force_waypoint=on_force_waypoint,
             on_live_position=on_live_position,
         )
-        service.start(_build_session_config(payload))
+        service.start(session_config_from_payload(payload))
 
         async def read_client():
             try:
@@ -1292,6 +1451,11 @@ async def ws_record(websocket: WebSocket) -> None:
         if service is not None:
             try:
                 service.stop()
+            except Exception:  # noqa: BLE001
+                pass
+        if bridge is not None:
+            try:
+                await bridge.close()  # 关 socket = 子进程自杀 (提权后 kill 不掉它)
             except Exception:  # noqa: BLE001
                 pass
         if acquired:
@@ -1400,7 +1564,7 @@ async def api_locate_once(payload: dict[str, Any] = Body(default_factory=dict)) 
             "playcover": {"address": current.playcover_address, "uuid": current.playcover_uuid},
             "wlroots": {"wlr_socket_path": current.wlroots_socket_path},
         }
-    session_config = _build_session_config(cfg_payload)
+    session_config = session_config_from_payload(cfg_payload)
 
     try:
         res = await run_in_threadpool(do_locate_once, runtime, session_config)


### PR DESCRIPTION
## Summary by Sourcery

在 Windows 上引入一个提升权限的录制工作进程，以避免重启主 MapNavigator 服务的同时仍然支持需要高权限的全局快捷键，并在主服务与工作进程之间共享剪贴板和会话配置的处理逻辑。

新功能：
- 添加一个专用的、提升权限的录制子进程，通过本地 NDJSON 套接字与主服务通信，在 Windows 上处理需要高权限的录制操作。
- 通过环境配置和权限检测，允许在运行时在内联录制、非提升权限的工作进程以及提升权限的工作进程之间进行选择。

改进：
- 重构录制会话配置解析为共享的辅助方法，使主服务和录制工作进程使用完全一致的“payload 到配置”的逻辑。
- 将剪贴板写入逻辑抽取到可复用模块中，由主服务和录制工作进程共同使用。
- 改进录制 WebSocket 流程，使其与提升权限的工作进程集成，包括状态上报，以及在提升失败时优雅地回退到进程内录制。
- 简化按键权限检查，避免自动重启主服务，改为依赖新的基于工作进程的提权模型。

文档：
- 在 MapNavigator 的 README 中记录新的 `record_worker` 子进程和剪贴板模块，阐明它们在 Windows 录制和快捷键行为中的角色。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an elevated recording worker process on Windows to avoid restarting the main MapNavigator service while still supporting privileged global hotkeys, and share clipboard and session config handling between the main service and the worker.

New Features:
- Add a dedicated elevated recording subprocess that communicates with the main service via a local NDJSON socket to handle privileged recording operations on Windows.
- Allow runtime selection between inline recording, non-elevated worker, and elevated worker via environment configuration and privilege detection.

Enhancements:
- Refactor recording session configuration parsing into a shared helper so both the main service and recording worker use identical payload-to-config logic.
- Extract clipboard write logic into a reusable module used by both the main service and the recording worker.
- Improve recording websocket flow to integrate with the elevated worker, including status reporting and graceful fallback to in-process recording when elevation fails.
- Simplify key privilege checks to avoid auto-restarting the main service and rely on the new worker-based elevation model.

Documentation:
- Document the new record_worker subprocess and clipboard module in the MapNavigator README, clarifying their roles in Windows recording and hotkey behaviour.

</details>