### PR TITLE
fix:修复切换账号后,物品数量仍使用上一个账号的缓存

### DIFF
--- a/assets/resource/pipeline/AccountSwitch.json
+++ b/assets/resource/pipeline/AccountSwitch.json
@@ -360,6 +360,40 @@
         "custom_action": "CaptureUid",
         "custom_action_param": {
             "clear_cache": true
-        }
+        },
+        "next": [
+            "__AccountSwitchResetImsFirstScan"
+        ]
+    },
+    "__AccountSwitchResetImsFirstScan": {
+        "desc": "清空 IMS 首次库存扫描标记：重新打开各地区 Begin，关闭商店 Completed，切号后会再次真正扫库",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverride",
+                "custom_action_param": {
+                    "resource_override": true,
+                    "patch": {
+                        "SyncItemDataBegin": {
+                            "enabled": true
+                        },
+                        "SyncShopItemDataBegin": {
+                            "enabled": true
+                        },
+                        "SyncShopItemDataCompleted": {
+                            "enabled": false
+                        },
+                        "SyncValuablesItemDataBegin": {
+                            "enabled": true
+                        }
+                    }
+                }
+            }
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": []
     }
 }


### PR DESCRIPTION
## 由 Sourcery 提供的总结

错误修复：
- 修复物品数量缓存问题，以确保在切换账户时不再显示上一账户的数量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix item quantity caching so that switching accounts no longer shows counts from the previous account.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

错误修复：
- 修复物品数量缓存问题，以确保在切换账户时不再显示上一账户的数量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix item quantity caching so that switching accounts no longer shows counts from the previous account.

</details>

</details>