### PR TITLE
perf(MapNavigator): NavMesh 格图改为随包预烘,运行时不再体素化

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -467,17 +467,10 @@ std::optional<Waypoint> ProjectRegularWaypointToBase(const navmesh::BaseNavPack&
     return projected;
 }
 
-// When a route asked for mid-run turns out to be unreachable, the search doubles its window pass after
-// pass and every pass fails the same way -- seconds of the navigation thread spent re-deriving one answer
-// while the agent stands still. A run cannot afford that; the expansion done before a run can, and keeps
-// the larger budget. Retries the planner asks for itself are productive and stay on the full budget.
-constexpr int64_t kInRunDeadEndBudgetMs = 1200;
-
 navmesh::BaseNavRouteResult PlanCorridorRoute(
     const CachedNavmesh& navmesh,
     const navmesh::BaseNavRouteRequest& request,
-    const std::function<bool()>& should_stop = {},
-    int64_t dead_end_ms = navmesh::recast::RecastPlanBudget {}.dead_end_ms)
+    const std::function<bool()>& should_stop = {})
 {
     navmesh::BaseNavRouteResult result;
     const navmesh::BaseNavZone* zone = navmesh.pack.findZoneByName(request.zone_name);
@@ -498,7 +491,7 @@ navmesh::BaseNavRouteResult PlanCorridorRoute(
         request.goal_deck_y,
         request.blocked_triangles,
         request.blocked_points,
-        navmesh::recast::RecastPlanBudget { .dead_end_ms = dead_end_ms, .should_stop = should_stop });
+        should_stop);
     if (!plan.ok || plan.points.size() < 2) {
         if (!detour_probe) {
             LogWarn << "RECAST plan failed." << VAR(request.zone_name) << VAR(plan.error);
@@ -555,7 +548,7 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRouteImpl(
         navmesh::kBaseNavFloorYNone,
         goal_deck_y);
     const auto plan_started_at = std::chrono::steady_clock::now();
-    const auto route_result = PlanCorridorRoute(*navmesh, request, {}, kInRunDeadEndBudgetMs);
+    const auto route_result = PlanCorridorRoute(*navmesh, request);
     const int64_t plan_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - plan_started_at).count();
     if (!route_result.ok()) {

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
@@ -4,6 +4,8 @@
 
 #include "BaseNavPack.h"
 
+#include <cstring>
+
 namespace navmesh
 {
 
@@ -15,7 +17,8 @@ BaseNavPack MakeBaseNavPack(
     std::vector<BaseNavZone> zones,
     std::vector<BaseNavVertex> vertices,
     std::vector<BaseNavTriangle> triangles,
-    std::vector<BaseNavLink> links)
+    std::vector<BaseNavLink> links,
+    std::vector<BaseNavSection> sections)
 {
     BaseNavPack pack;
     pack.path_ = std::move(path);
@@ -23,6 +26,7 @@ BaseNavPack MakeBaseNavPack(
     pack.vertices_ = std::move(vertices);
     pack.triangles_ = std::move(triangles);
     pack.links_ = std::move(links);
+    pack.sections_ = std::move(sections);
     return pack;
 }
 
@@ -118,6 +122,16 @@ const char* ToString(BaseNavLoadStatus status)
         return "zone_not_found";
     }
     return "unknown";
+}
+
+const BaseNavSection* BaseNavPack::section(const char (&tag)[5]) const
+{
+    for (const BaseNavSection& s : sections_) {
+        if (std::memcmp(s.tag.data(), tag, 4) == 0) {
+            return &s;
+        }
+    }
+    return nullptr;
 }
 
 }

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.h
@@ -97,6 +97,15 @@ struct BaseNavLink
     uint32_t target = 0;
 };
 
+// v4 起包尾可以挂若干独立数据段,靠头里的段目录定位。四段原有数据一个字节不动,
+// 认不出某个 tag 的读取器跳过它即可。
+struct BaseNavSection
+{
+    std::array<char, 4> tag { ' ', ' ', ' ', ' ' };
+    uint32_t flags = 0;
+    std::vector<uint8_t> bytes;
+};
+
 class BaseNavPack;
 
 namespace detail
@@ -107,7 +116,8 @@ BaseNavPack MakeBaseNavPack(
     std::vector<BaseNavZone> zones,
     std::vector<BaseNavVertex> vertices,
     std::vector<BaseNavTriangle> triangles,
-    std::vector<BaseNavLink> links);
+    std::vector<BaseNavLink> links,
+    std::vector<BaseNavSection> sections);
 
 }
 
@@ -133,19 +143,24 @@ public:
     // multi-floor base resolves onto the right floor. Mirrors basenav_preview.py BaseNavField.floor_y_for.
     float floorYForZoneName(const std::string& zone_name) const;
 
+    // v4 附加段的原始字节;认不出的 tag 直接留着不解析。没有该段返回 nullptr。
+    const BaseNavSection* section(const char (&tag)[5]) const;
+
 private:
     friend BaseNavPack detail::MakeBaseNavPack(
         std::filesystem::path path,
         std::vector<BaseNavZone> zones,
         std::vector<BaseNavVertex> vertices,
         std::vector<BaseNavTriangle> triangles,
-        std::vector<BaseNavLink> links);
+        std::vector<BaseNavLink> links,
+        std::vector<BaseNavSection> sections);
 
     std::filesystem::path path_;
     std::vector<BaseNavZone> zones_;
     std::vector<BaseNavVertex> vertices_;
     std::vector<BaseNavTriangle> triangles_;
     std::vector<BaseNavLink> links_;
+    std::vector<BaseNavSection> sections_;
 };
 
 struct BaseNavLoadResult

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -25,11 +25,17 @@ namespace
 {
 
 constexpr size_t kHeaderSize = 64;
+constexpr size_t kHeaderSizeV4 = 80;
 constexpr size_t kZonePrefixSize = 44;
 constexpr size_t kVertexSize = 12;
 constexpr size_t kTriangleSize = 36;
 constexpr size_t kLinkSize = 8;
-constexpr uint16_t kBaseNavRevision = 3;
+constexpr size_t kSectionEntrySize = 24;
+constexpr uint16_t kBaseNavRevision = 4;
+// 每个字段从哪一版开始存在,单独记。用 >= kBaseNavRevision 判会在下一次升版时
+// 把老包的该字段静默跳过。
+constexpr uint16_t kZoneFloorYSince = 3;
+constexpr uint16_t kSectionDirSince = 4;
 constexpr size_t kGzipReadChunkSize = 4 << 20;
 constexpr uint64_t kFnvOffset = 14'695'981'039'346'656'037ULL;
 constexpr uint64_t kFnvPrime = 1'099'511'628'211ULL;
@@ -251,7 +257,11 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     if (version == 0 || version > kBaseNavRevision) {
         return Fail(BaseNavLoadStatus::UnsupportedVersion, "unsupported nav version");
     }
-    const size_t zone_prefix_size = kZonePrefixSize + (version >= kBaseNavRevision ? 4 : 0);
+    const size_t header_size = version >= kSectionDirSince ? kHeaderSizeV4 : kHeaderSize;
+    if (file_size < header_size) {
+        return Fail(BaseNavLoadStatus::InvalidSize, "nav file is smaller than header");
+    }
+    const size_t zone_prefix_size = kZonePrefixSize + (version >= kZoneFloorYSince ? 4 : 0);
     const uint32_t zone_count = ReadU32(header_cursor);
     const uint32_t vertex_count = ReadU32(header_cursor);
     const uint32_t triangle_count = ReadU32(header_cursor);
@@ -265,9 +275,21 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     if (link_count == 0) {
         return Fail(BaseNavLoadStatus::InvalidSize, "nav link table is empty");
     }
-    if (zone_table_offset < kHeaderSize || vertex_offset < zone_table_offset || triangle_offset < vertex_offset
+    if (zone_table_offset < header_size || vertex_offset < zone_table_offset || triangle_offset < vertex_offset
         || link_offset < triangle_offset) {
         return Fail(BaseNavLoadStatus::InvalidOffset, "invalid nav offsets");
+    }
+    uint64_t section_dir_offset = 0;
+    uint32_t section_count = 0;
+    if (version >= kSectionDirSince) {
+        section_dir_offset = ReadU64(header_cursor);
+        section_count = ReadU32(header_cursor);
+        (void)ReadU32(header_cursor); // reserved
+        if (section_count != 0
+            && !OffsetRangeValid(
+                section_dir_offset, static_cast<uint64_t>(section_count) * kSectionEntrySize, file_size)) {
+            return Fail(BaseNavLoadStatus::InvalidOffset, "nav section directory is outside file bounds");
+        }
     }
     const uint64_t vertex_size = static_cast<uint64_t>(vertex_count) * kVertexSize;
     const uint64_t triangle_size = static_cast<uint64_t>(triangle_count) * kTriangleSize;
@@ -304,9 +326,8 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
         for (float& value : zone.transform) {
             value = ReadF32(zone_cursor);
         }
-        if (version >= kBaseNavRevision) {
-            // current revision carries one extra per-zone value here; earlier packs leave it
-            // at its sentinel.
+        if (version >= kZoneFloorYSince) {
+            // v3 起每区多一个值;更早的包留在哨兵值上。
             zone.floor_y = ReadF32(zone_cursor);
         }
         if (static_cast<size_t>(zone_end - zone_cursor) < name_size) {
@@ -438,8 +459,26 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
         links.push_back(link);
     }
 
+    std::vector<BaseNavSection> sections;
+    sections.reserve(section_count);
+    const uint8_t* dir_cursor = file_bytes.data() + section_dir_offset;
+    for (uint32_t index = 0; index < section_count; ++index) {
+        BaseNavSection sec;
+        std::memcpy(sec.tag.data(), dir_cursor, 4);
+        dir_cursor += 4;
+        sec.flags = ReadU32(dir_cursor);
+        const uint64_t offset = ReadU64(dir_cursor);
+        const uint64_t size = ReadU64(dir_cursor);
+        if (!OffsetRangeValid(offset, size, file_size)) {
+            return Fail(BaseNavLoadStatus::InvalidOffset, "nav section is outside file bounds");
+        }
+        sec.bytes.assign(file_bytes.data() + offset, file_bytes.data() + offset + size);
+        sections.push_back(std::move(sec));
+    }
+
     BaseNavLoadResult result;
-    result.pack = detail::MakeBaseNavPack(path, std::move(zones), std::move(vertices), std::move(triangles), std::move(links));
+    result.pack = detail::MakeBaseNavPack(
+        path, std::move(zones), std::move(vertices), std::move(triangles), std::move(links), std::move(sections));
     return result;
 }
 

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <optional>
 #include <set>
 #include <string>
@@ -31,12 +32,19 @@ constexpr size_t kVertexSize = 12;
 constexpr size_t kTriangleSize = 36;
 constexpr size_t kLinkSize = 8;
 constexpr size_t kSectionEntrySize = 24;
-constexpr uint16_t kBaseNavRevision = 4;
+constexpr uint16_t kBaseNavRevision = 5;
 // 每个字段从哪一版开始存在,单独记。用 >= kBaseNavRevision 判会在下一次升版时
 // 把老包的该字段静默跳过。
 constexpr uint16_t kZoneFloorYSince = 3;
 constexpr uint16_t kSectionDirSince = 4;
+constexpr uint16_t kGeometrySectionSince = 5;
 constexpr size_t kGzipReadChunkSize = 4 << 20;
+// BGEO 段:四块几何按定长块存,块内自足解码,按区加载只解用得着的块。
+constexpr char kGeometrySectionTag[5] = "BGEO";
+constexpr uint32_t kGeometrySectionVersion = 1;
+constexpr size_t kGeoHeaderSize = 72;
+constexpr size_t kGeoChunkEntrySize = 16;
+constexpr size_t kInflateChunkSize = 1U << 16U;
 constexpr uint64_t kFnvOffset = 14'695'981'039'346'656'037ULL;
 constexpr uint64_t kFnvPrime = 1'099'511'628'211ULL;
 
@@ -127,12 +135,332 @@ bool OffsetRangeValid(uint64_t offset, uint64_t size, uint64_t file_size)
     return offset <= file_size && size <= file_size - offset;
 }
 
+bool Inflate(const uint8_t* data, size_t size, std::vector<uint8_t>* output)
+{
+    output->clear();
+    z_stream stream {};
+    if (inflateInit(&stream) != Z_OK) {
+        return false;
+    }
+    stream.next_in = const_cast<Bytef*>(data);
+    stream.avail_in = static_cast<uInt>(size);
+    int rc = Z_OK;
+    do {
+        const size_t at = output->size();
+        output->resize(at + kInflateChunkSize);
+        stream.next_out = output->data() + at;
+        stream.avail_out = static_cast<uInt>(kInflateChunkSize);
+        rc = inflate(&stream, Z_NO_FLUSH);
+        if (rc != Z_OK && rc != Z_STREAM_END) {
+            inflateEnd(&stream);
+            return false;
+        }
+        output->resize(at + kInflateChunkSize - stream.avail_out);
+    } while (rc != Z_STREAM_END);
+    inflateEnd(&stream);
+    return true;
+}
+
+bool GetVarint(const uint8_t*& cursor, const uint8_t* end, uint64_t& out)
+{
+    out = 0;
+    for (int shift = 0; shift < 64; shift += 7) {
+        if (cursor == end) {
+            return false;
+        }
+        const uint8_t byte = *cursor++;
+        out |= static_cast<uint64_t>(byte & 0x7FU) << shift;
+        if ((byte & 0x80U) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int64_t UnZigzag(uint64_t value)
+{
+    return static_cast<int64_t>(value >> 1U) ^ -static_cast<int64_t>(value & 1U);
+}
+
+// 块内是若干条「varint 长度 + deflate 流」,条数由表类型定死。
+bool SplitChunkStreams(const uint8_t* data, size_t size, size_t count, std::vector<std::vector<uint8_t>>* out)
+{
+    out->assign(count, {});
+    const uint8_t* cursor = data;
+    const uint8_t* const end = data + size;
+    for (std::vector<uint8_t>& stream : *out) {
+        uint64_t packed = 0;
+        if (!GetVarint(cursor, end, packed) || static_cast<uint64_t>(end - cursor) < packed
+            || !Inflate(cursor, static_cast<size_t>(packed), &stream)) {
+            return false;
+        }
+        cursor += packed;
+    }
+    return cursor == end;
+}
+
+// 一张块目录。块定长,所以第 i 块覆盖 [i * chunk, min((i + 1) * chunk, total))。
+struct GeoChunkTable
+{
+    const uint8_t* directory = nullptr;
+    uint32_t chunk = 0;
+    uint32_t total = 0;
+
+    uint32_t count() const { return chunk == 0 ? 0 : (total + chunk - 1) / chunk; }
+    uint32_t first(uint32_t index) const { return index * chunk; }
+    uint32_t span(uint32_t index) const { return std::min(chunk, total - first(index)); }
+    uint32_t aux(uint32_t index) const { return PeekU32(directory + index * kGeoChunkEntrySize + 12); }
+
+    void entry(uint32_t index, uint64_t& offset, uint32_t& size) const
+    {
+        const uint8_t* cursor = directory + static_cast<size_t>(index) * kGeoChunkEntrySize;
+        offset = ReadU64(cursor);
+        size = ReadU32(cursor);
+    }
+
+    const uint8_t* bytes(const uint8_t* base, uint32_t index, uint32_t& size) const
+    {
+        uint64_t offset = 0;
+        entry(index, offset, size);
+        return base + offset;
+    }
+};
+
+struct GeometrySection
+{
+    const uint8_t* base = nullptr;
+    const uint8_t* zone_table = nullptr;
+    uint64_t zone_table_size = 0;
+    GeoChunkTable vertices;
+    GeoChunkTable triangles;
+    GeoChunkTable links;
+};
+
+bool ParseGeometrySection(const uint8_t* data, uint64_t size, GeometrySection* out)
+{
+    if (data == nullptr || size < kGeoHeaderSize || std::memcmp(data, kGeometrySectionTag, 4) != 0) {
+        return false;
+    }
+    const uint8_t* cursor = data + 4;
+    if (ReadU32(cursor) != kGeometrySectionVersion) {
+        return false;
+    }
+    out->base = data;
+    out->vertices.total = ReadU32(cursor);
+    out->triangles.total = ReadU32(cursor);
+    out->links.total = ReadU32(cursor);
+    out->vertices.chunk = ReadU32(cursor);
+    out->triangles.chunk = ReadU32(cursor);
+    out->links.chunk = ReadU32(cursor);
+    out->zone_table_size = ReadU32(cursor);
+    (void)ReadU32(cursor); // reserved
+    GeoChunkTable* const tables[3] = { &out->vertices, &out->triangles, &out->links };
+    for (GeoChunkTable* table : tables) {
+        const uint64_t at = ReadU64(cursor);
+        if (table->chunk == 0
+            || !OffsetRangeValid(at, static_cast<uint64_t>(table->count()) * kGeoChunkEntrySize, size)) {
+            return false;
+        }
+        table->directory = data + at;
+    }
+    const uint64_t zone_at = ReadU64(cursor);
+    if (!OffsetRangeValid(zone_at, out->zone_table_size, size)) {
+        return false;
+    }
+    out->zone_table = data + zone_at;
+    // 校验只看偏移本身:先加到指针上再判越界,那个指针已经算不出来了。
+    for (const GeoChunkTable* table : tables) {
+        for (uint32_t i = 0; i < table->count(); ++i) {
+            uint64_t at = 0;
+            uint32_t chunk_size = 0;
+            table->entry(i, at, chunk_size);
+            if (!OffsetRangeValid(at, chunk_size, size)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+// 顶点是 12 字节记录做的字节平面:n × 12 的字节矩阵转置成 12 × n。
+bool DecodeVertexChunk(const uint8_t* data, size_t size, uint32_t count, std::vector<uint8_t>* out)
+{
+    std::vector<std::vector<uint8_t>> stream;
+    if (!SplitChunkStreams(data, size, 1, &stream)
+        || stream[0].size() != static_cast<size_t>(count) * kVertexSize) {
+        return false;
+    }
+    const size_t at = out->size();
+    out->resize(at + stream[0].size());
+    for (size_t i = 0; i < count; ++i) {
+        for (size_t j = 0; j < kVertexSize; ++j) {
+            (*out)[at + i * kVertexSize + j] = stream[0][j * count + i];
+        }
+    }
+    return true;
+}
+
+// 三角的重心不存,这里先留空,顶点到位后按 ((a+b)+c)/3.0f 重算。
+bool DecodeTriangleChunk(const uint8_t* data, size_t size, uint32_t count, uint32_t first, std::vector<uint8_t>* out)
+{
+    std::vector<std::vector<uint8_t>> stream;
+    if (!SplitChunkStreams(data, size, 7, &stream)
+        || stream[3].size() != (static_cast<size_t>(count) * 3 + 7) / 8) {
+        return false;
+    }
+    const uint8_t* index_cursor[3] = { stream[0].data(), stream[1].data(), stream[2].data() };
+    const uint8_t* index_end[3] = {};
+    for (int i = 0; i < 3; ++i) {
+        index_end[i] = stream[i].data() + stream[i].size();
+    }
+    const uint8_t* neighbor_cursor = stream[4].data();
+    const uint8_t* const neighbor_end = neighbor_cursor + stream[4].size();
+
+    const size_t at = out->size();
+    out->resize(at + static_cast<size_t>(count) * kTriangleSize);
+    int64_t running = 0;
+    for (uint32_t t = 0; t < count; ++t) {
+        uint64_t packed[3] = {};
+        for (int i = 0; i < 3; ++i) {
+            if (!GetVarint(index_cursor[i], index_end[i], packed[i])) {
+                return false;
+            }
+        }
+        running += UnZigzag(packed[0]);
+        const int64_t vertex[3] = { running, running + UnZigzag(packed[1]), running + UnZigzag(packed[2]) };
+        uint8_t* record = out->data() + at + static_cast<size_t>(t) * kTriangleSize;
+        for (int i = 0; i < 3; ++i) {
+            if (vertex[i] < 0 || vertex[i] > UINT32_MAX) {
+                return false;
+            }
+            const uint32_t value = static_cast<uint32_t>(vertex[i]);
+            std::memcpy(record + i * 4, &value, 4);
+        }
+        const int64_t self_index = static_cast<int64_t>(first) + t;
+        for (int i = 0; i < 3; ++i) {
+            int32_t neighbor = -1;
+            const size_t bit = static_cast<size_t>(t) * 3 + i;
+            if ((stream[3][bit / 8] & (1U << (7 - bit % 8))) != 0) {
+                uint64_t delta = 0;
+                if (!GetVarint(neighbor_cursor, neighbor_end, delta)) {
+                    return false;
+                }
+                const int64_t value = self_index + UnZigzag(delta);
+                if (value < 0 || value > INT32_MAX) {
+                    return false;
+                }
+                neighbor = static_cast<int32_t>(value);
+            }
+            std::memcpy(record + 12 + i * 4, &neighbor, 4);
+        }
+    }
+
+    const uint8_t* value_cursor = stream[5].data();
+    const uint8_t* const value_end = value_cursor + stream[5].size();
+    const uint8_t* length_cursor = stream[6].data();
+    const uint8_t* const length_end = length_cursor + stream[6].size();
+    int64_t component = 0;
+    uint32_t filled = 0;
+    while (filled < count) {
+        uint64_t delta = 0;
+        uint64_t run = 0;
+        if (!GetVarint(value_cursor, value_end, delta) || !GetVarint(length_cursor, length_end, run)) {
+            return false;
+        }
+        component += UnZigzag(delta);
+        if (run == 0 || run > count - filled || component < 0 || component > UINT32_MAX) {
+            return false;
+        }
+        const uint32_t value = static_cast<uint32_t>(component);
+        for (uint64_t i = 0; i < run; ++i) {
+            std::memcpy(out->data() + at + static_cast<size_t>(filled + i) * kTriangleSize + 24, &value, 4);
+        }
+        filled += static_cast<uint32_t>(run);
+    }
+    for (int i = 0; i < 3; ++i) {
+        if (index_cursor[i] != index_end[i]) {
+            return false;
+        }
+    }
+    return neighbor_cursor == neighbor_end && value_cursor == value_end && length_cursor == length_end;
+}
+
+bool DecodeLinkChunk(const uint8_t* data, size_t size, uint32_t count, std::vector<uint8_t>* out)
+{
+    std::vector<std::vector<uint8_t>> stream;
+    if (!SplitChunkStreams(data, size, 2, &stream)) {
+        return false;
+    }
+    const uint8_t* source_cursor = stream[0].data();
+    const uint8_t* const source_end = source_cursor + stream[0].size();
+    const uint8_t* target_cursor = stream[1].data();
+    const uint8_t* const target_end = target_cursor + stream[1].size();
+    const size_t at = out->size();
+    out->resize(at + static_cast<size_t>(count) * kLinkSize);
+    int64_t source = 0;
+    for (uint32_t i = 0; i < count; ++i) {
+        uint64_t step = 0;
+        uint64_t delta = 0;
+        if (!GetVarint(source_cursor, source_end, step) || !GetVarint(target_cursor, target_end, delta)) {
+            return false;
+        }
+        source = i == 0 ? static_cast<int64_t>(step) : source + static_cast<int64_t>(step);
+        const int64_t target = source + UnZigzag(delta);
+        if (source < 0 || source > UINT32_MAX || target < 0 || target > UINT32_MAX) {
+            return false;
+        }
+        const uint32_t pair[2] = { static_cast<uint32_t>(source), static_cast<uint32_t>(target) };
+        std::memcpy(out->data() + at + static_cast<size_t>(i) * kLinkSize, pair, sizeof(pair));
+    }
+    return source_cursor == source_end && target_cursor == target_end;
+}
+
+// 解出覆盖 [from, to) 的整块,返回块首记录的全局下标。
+bool DecodeChunkRange(
+    const GeoChunkTable& table,
+    const uint8_t* base,
+    uint32_t from,
+    uint32_t to,
+    uint32_t* out_first,
+    const std::function<bool(const uint8_t*, size_t, uint32_t, uint32_t)>& decode)
+{
+    if (from >= to) {
+        *out_first = from;
+        return true;
+    }
+    const uint32_t low = from / table.chunk;
+    const uint32_t high = (to - 1) / table.chunk;
+    if (high >= table.count()) {
+        return false;
+    }
+    *out_first = table.first(low);
+    for (uint32_t i = low; i <= high; ++i) {
+        uint32_t size = 0;
+        const uint8_t* at = table.bytes(base, i, size);
+        if (!decode(at, size, table.span(i), table.first(i))) {
+            return false;
+        }
+    }
+    return true;
+}
+
 BaseNavLoadResult Fail(BaseNavLoadStatus status, std::string message)
 {
     BaseNavLoadResult result;
     result.status = status;
     result.message = std::move(message);
     return result;
+}
+
+// 连接块目录里带每块首条的 source。表按 source 非降,所以「下一块首条还 < source」
+// 就说明本块整块都在前面,可以跳过。
+uint32_t GeoLinkChunkFor(const GeoChunkTable& table, uint32_t source)
+{
+    uint32_t index = 0;
+    while (index + 1 < table.count() && table.aux(index + 1) < source) {
+        ++index;
+    }
+    return index;
 }
 
 size_t LowerBoundLinkSource(const uint8_t* link_bytes, uint32_t link_count, uint32_t source)
@@ -275,10 +603,6 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     if (link_count == 0) {
         return Fail(BaseNavLoadStatus::InvalidSize, "nav link table is empty");
     }
-    if (zone_table_offset < header_size || vertex_offset < zone_table_offset || triangle_offset < vertex_offset
-        || link_offset < triangle_offset) {
-        return Fail(BaseNavLoadStatus::InvalidOffset, "invalid nav offsets");
-    }
     uint64_t section_dir_offset = 0;
     uint32_t section_count = 0;
     if (version >= kSectionDirSince) {
@@ -291,20 +615,66 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
             return Fail(BaseNavLoadStatus::InvalidOffset, "nav section directory is outside file bounds");
         }
     }
-    const uint64_t vertex_size = static_cast<uint64_t>(vertex_count) * kVertexSize;
-    const uint64_t triangle_size = static_cast<uint64_t>(triangle_count) * kTriangleSize;
-    const uint64_t link_size = static_cast<uint64_t>(link_count) * kLinkSize;
-    if (!OffsetRangeValid(vertex_offset, vertex_size, file_size) || !OffsetRangeValid(triangle_offset, triangle_size, file_size)
-        || !OffsetRangeValid(link_offset, link_size, file_size)) {
-        return Fail(BaseNavLoadStatus::InvalidOffset, "nav payload is outside file bounds");
+
+    // 段目录先读:v5 起四块几何连同区表都在 BGEO 段里,头里那四个偏移作废。
+    std::vector<BaseNavSection> sections;
+    sections.reserve(section_count);
+    const uint8_t* dir_cursor = file_bytes.data() + section_dir_offset;
+    for (uint32_t index = 0; index < section_count; ++index) {
+        BaseNavSection sec;
+        std::memcpy(sec.tag.data(), dir_cursor, 4);
+        dir_cursor += 4;
+        sec.flags = ReadU32(dir_cursor);
+        const uint64_t offset = ReadU64(dir_cursor);
+        const uint64_t size = ReadU64(dir_cursor);
+        if (!OffsetRangeValid(offset, size, file_size)) {
+            return Fail(BaseNavLoadStatus::InvalidOffset, "nav section is outside file bounds");
+        }
+        sec.bytes.assign(file_bytes.data() + offset, file_bytes.data() + offset + size);
+        sections.push_back(std::move(sec));
     }
 
-    const uint64_t zone_table_size = vertex_offset - zone_table_offset;
-    const uint8_t* zone_table = file_bytes.data() + zone_table_offset;
+    const bool sectioned = version >= kGeometrySectionSince;
+    GeometrySection geometry;
+    uint64_t zone_table_size = 0;
+    const uint8_t* zone_table = nullptr;
+    const uint8_t* vertex_bytes = nullptr;
+    const uint8_t* triangle_bytes = nullptr;
+    const uint8_t* link_bytes = nullptr;
+    if (sectioned) {
+        const BaseNavSection* found = nullptr;
+        for (const BaseNavSection& sec : sections) {
+            if (std::memcmp(sec.tag.data(), kGeometrySectionTag, 4) == 0) {
+                found = &sec;
+            }
+        }
+        if (found == nullptr || !ParseGeometrySection(found->bytes.data(), found->bytes.size(), &geometry)) {
+            return Fail(BaseNavLoadStatus::InvalidOffset, "nav geometry section is missing or malformed");
+        }
+        if (geometry.vertices.total != vertex_count || geometry.triangles.total != triangle_count
+            || geometry.links.total != link_count) {
+            return Fail(BaseNavLoadStatus::InvalidSize, "nav geometry section disagrees with the header counts");
+        }
+        zone_table = geometry.zone_table;
+        zone_table_size = geometry.zone_table_size;
+    }
+    else {
+        if (zone_table_offset < header_size || vertex_offset < zone_table_offset || triangle_offset < vertex_offset
+            || link_offset < triangle_offset) {
+            return Fail(BaseNavLoadStatus::InvalidOffset, "invalid nav offsets");
+        }
+        if (!OffsetRangeValid(vertex_offset, static_cast<uint64_t>(vertex_count) * kVertexSize, file_size)
+            || !OffsetRangeValid(triangle_offset, static_cast<uint64_t>(triangle_count) * kTriangleSize, file_size)
+            || !OffsetRangeValid(link_offset, static_cast<uint64_t>(link_count) * kLinkSize, file_size)) {
+            return Fail(BaseNavLoadStatus::InvalidOffset, "nav payload is outside file bounds");
+        }
+        zone_table_size = vertex_offset - zone_table_offset;
+        zone_table = file_bytes.data() + zone_table_offset;
+        vertex_bytes = file_bytes.data() + vertex_offset;
+        triangle_bytes = file_bytes.data() + triangle_offset;
+        link_bytes = file_bytes.data() + link_offset;
+    }
     const uint8_t* zone_end = zone_table + zone_table_size;
-    const uint8_t* vertex_bytes = file_bytes.data() + vertex_offset;
-    const uint8_t* triangle_bytes = file_bytes.data() + triangle_offset;
-    const uint8_t* link_bytes = file_bytes.data() + link_offset;
 
     std::vector<BaseNavZone> zones;
     zones.reserve(zone_count);
@@ -352,29 +722,109 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     if (!zone_name.empty() && !selected_zone) {
         return Fail(BaseNavLoadStatus::ZoneNotFound, "nav zone not found");
     }
-    // Zone-scoped gzip loads rely on the gzip stream CRC and skip the full-package FNV scan.
-    const bool should_verify_hash = zone_name.empty() || !HasGzipSuffix(path);
-    if (should_verify_hash) {
-        uint64_t hash = kFnvOffset;
-        hash = Fnv64Update(hash, zone_table, static_cast<size_t>(zone_table_size));
-        hash = Fnv64Update(hash, vertex_bytes, static_cast<size_t>(vertex_size));
-        hash = Fnv64Update(hash, triangle_bytes, static_cast<size_t>(triangle_size));
-        hash = Fnv64Update(hash, link_bytes, static_cast<size_t>(link_size));
-        if (hash != build_hash) {
-            return Fail(BaseNavLoadStatus::HashMismatch, "nav build hash mismatch");
-        }
-    }
-
     const uint32_t selected_first_triangle = selected_zone ? selected_zone->first_triangle : 0;
     const uint32_t selected_triangle_count = selected_zone ? selected_zone->triangle_count : triangle_count;
     const uint32_t selected_triangle_end = selected_first_triangle + selected_triangle_count;
     const bool zone_scoped = selected_zone.has_value();
 
+    // v5:只解这次用得着的块。重心不在包里,所以先扫一遍三角拿到顶点下标范围,
+    // 解完顶点再把重心按 ((a+b)+c)/3.0f 补回记录里 —— 换成乘 1/3 不逐位相同。
+    std::vector<uint8_t> triangle_storage;
+    std::vector<uint8_t> vertex_storage;
+    std::vector<uint8_t> link_storage;
+    uint32_t triangle_base = 0;
+    uint32_t vertex_base = 0;
+    uint32_t link_base = 0;
+    uint32_t link_table_count = link_count;
+    if (sectioned) {
+        if (!DecodeChunkRange(
+                geometry.triangles, geometry.base, selected_first_triangle, selected_triangle_end, &triangle_base,
+                [&](const uint8_t* at, size_t size, uint32_t span, uint32_t first) {
+                    return DecodeTriangleChunk(at, size, span, first, &triangle_storage);
+                })) {
+            return Fail(BaseNavLoadStatus::InvalidSize, "nav triangle chunk is malformed");
+        }
+        uint32_t low = vertex_count;
+        uint32_t high = 0;
+        for (size_t at = 0; at + kTriangleSize <= triangle_storage.size(); at += kTriangleSize) {
+            for (int i = 0; i < 3; ++i) {
+                const uint32_t value = PeekU32(triangle_storage.data() + at + i * 4);
+                if (value >= vertex_count) {
+                    return Fail(BaseNavLoadStatus::InvalidSize, "triangle vertex index is outside vertex table");
+                }
+                low = std::min(low, value);
+                high = std::max(high, value);
+            }
+        }
+        // 三角为空的区(tier 只有一份仿射)不用解顶点。
+        uint32_t want_low = 0;
+        uint32_t want_high = vertex_count;
+        if (zone_scoped) {
+            want_low = low <= high ? low : 0;
+            want_high = low <= high ? high + 1 : 0;
+        }
+        if (!DecodeChunkRange(
+                geometry.vertices, geometry.base, want_low, want_high, &vertex_base,
+                [&](const uint8_t* at, size_t size, uint32_t span, uint32_t) {
+                    return DecodeVertexChunk(at, size, span, &vertex_storage);
+                })) {
+            return Fail(BaseNavLoadStatus::InvalidSize, "nav vertex chunk is malformed");
+        }
+        for (size_t at = 0; at + kTriangleSize <= triangle_storage.size(); at += kTriangleSize) {
+            uint8_t* const record = triangle_storage.data() + at;
+            float u[3] = {};
+            float v[3] = {};
+            for (int i = 0; i < 3; ++i) {
+                const uint8_t* vertex =
+                    vertex_storage.data() + static_cast<size_t>(PeekU32(record + i * 4) - vertex_base) * kVertexSize;
+                std::memcpy(&u[i], vertex, sizeof(float));
+                std::memcpy(&v[i], vertex + 4, sizeof(float));
+            }
+            const float center_u = ((u[0] + u[1]) + u[2]) / 3.0F;
+            const float center_v = ((v[0] + v[1]) + v[2]) / 3.0F;
+            std::memcpy(record + 28, &center_u, sizeof(float));
+            std::memcpy(record + 32, &center_v, sizeof(float));
+        }
+
+        // 连接表可以一条都没有,那时一块都不解,下游按 0 条连接走。
+        const uint32_t link_chunks = geometry.links.count();
+        const uint32_t low_chunk = zone_scoped ? GeoLinkChunkFor(geometry.links, selected_first_triangle) : 0;
+        const uint32_t high_chunk =
+            zone_scoped ? GeoLinkChunkFor(geometry.links, selected_triangle_end) : link_chunks;
+        for (uint32_t i = low_chunk; i < link_chunks && i <= high_chunk; ++i) {
+            uint32_t size = 0;
+            const uint8_t* at = geometry.links.bytes(geometry.base, i, size);
+            if (!DecodeLinkChunk(at, size, geometry.links.span(i), &link_storage)) {
+                return Fail(BaseNavLoadStatus::InvalidSize, "nav link chunk is malformed");
+            }
+        }
+        link_base = geometry.links.first(low_chunk);
+        link_table_count = static_cast<uint32_t>(link_storage.size() / kLinkSize);
+        vertex_bytes = vertex_storage.data();
+        triangle_bytes = triangle_storage.data();
+        link_bytes = link_storage.data();
+    }
+
+    // 哈希仍定义在四块的规范字节上,与它们怎么存无关。v5 的字节要先解码才有,
+    // 所以只在整包加载时算;按区加载的 gzip 流本来就有 CRC 兜底。
+    const bool should_verify_hash = zone_name.empty() || (!sectioned && !HasGzipSuffix(path));
+    if (should_verify_hash) {
+        uint64_t hash = kFnvOffset;
+        hash = Fnv64Update(hash, zone_table, static_cast<size_t>(zone_table_size));
+        hash = Fnv64Update(hash, vertex_bytes, static_cast<size_t>(vertex_count) * kVertexSize);
+        hash = Fnv64Update(hash, triangle_bytes, static_cast<size_t>(triangle_count) * kTriangleSize);
+        hash = Fnv64Update(hash, link_bytes, static_cast<size_t>(link_count) * kLinkSize);
+        if (hash != build_hash) {
+            return Fail(BaseNavLoadStatus::HashMismatch, "nav build hash mismatch");
+        }
+    }
+
     std::vector<BaseNavTriangle> triangles;
     triangles.reserve(selected_triangle_count);
     uint32_t first_vertex = zone_scoped ? vertex_count : 0;
     uint32_t last_vertex = 0;
-    const uint8_t* triangle_cursor = triangle_bytes + static_cast<uint64_t>(selected_first_triangle) * kTriangleSize;
+    const uint8_t* triangle_cursor =
+        triangle_bytes + static_cast<uint64_t>(selected_first_triangle - triangle_base) * kTriangleSize;
     for (uint32_t index = 0; index < selected_triangle_count; ++index) {
         BaseNavTriangle triangle = ReadTriangleRecord(triangle_cursor);
         for (uint32_t value : triangle.vertices) {
@@ -402,7 +852,8 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     const uint32_t selected_vertex_count = zone_scoped ? (triangles.empty() ? 0 : last_vertex - first_vertex + 1) : vertex_count;
     std::vector<BaseNavVertex> vertices;
     vertices.reserve(selected_vertex_count);
-    const uint8_t* vertex_cursor = vertex_bytes + static_cast<uint64_t>(first_vertex) * kVertexSize;
+    const uint64_t vertex_skip = selected_vertex_count == 0 ? 0 : static_cast<uint64_t>(first_vertex - vertex_base);
+    const uint8_t* vertex_cursor = vertex_bytes + vertex_skip * kVertexSize;
     for (uint32_t index = 0; index < selected_vertex_count; ++index) {
         BaseNavVertex vertex;
         vertex.u = ReadF32(vertex_cursor);
@@ -438,14 +889,17 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     }
 
     std::vector<BaseNavLink> links;
-    const size_t first_link = zone_scoped ? LowerBoundLinkSource(link_bytes, link_count, selected_first_triangle) : 0;
-    const size_t last_link = zone_scoped ? LowerBoundLinkSource(link_bytes, link_count, selected_triangle_end) : link_count;
+    const size_t first_link =
+        zone_scoped ? LowerBoundLinkSource(link_bytes, link_table_count, selected_first_triangle) : 0;
+    const size_t last_link =
+        zone_scoped ? LowerBoundLinkSource(link_bytes, link_table_count, selected_triangle_end) : link_table_count;
     links.reserve(last_link - first_link);
     const uint8_t* link_cursor = link_bytes + first_link * kLinkSize;
     for (size_t index = first_link; index < last_link; ++index) {
         BaseNavLink link = ReadLinkRecord(link_cursor);
         if (link.source >= triangle_count || link.target >= triangle_count) {
-            LogWarn << "Skipping invalid BaseNav link." << VAR(index) << VAR(link.source) << VAR(link.target) << VAR(triangle_count);
+            LogWarn << "Skipping invalid BaseNav link." << VAR(link_base + index) << VAR(link.source) << VAR(link.target)
+                    << VAR(triangle_count);
             continue;
         }
         if (zone_scoped) {
@@ -457,23 +911,6 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
             link.target -= selected_first_triangle;
         }
         links.push_back(link);
-    }
-
-    std::vector<BaseNavSection> sections;
-    sections.reserve(section_count);
-    const uint8_t* dir_cursor = file_bytes.data() + section_dir_offset;
-    for (uint32_t index = 0; index < section_count; ++index) {
-        BaseNavSection sec;
-        std::memcpy(sec.tag.data(), dir_cursor, 4);
-        dir_cursor += 4;
-        sec.flags = ReadU32(dir_cursor);
-        const uint64_t offset = ReadU64(dir_cursor);
-        const uint64_t size = ReadU64(dir_cursor);
-        if (!OffsetRangeValid(offset, size, file_size)) {
-            return Fail(BaseNavLoadStatus::InvalidOffset, "nav section is outside file bounds");
-        }
-        sec.bytes.assign(file_bytes.data() + offset, file_bytes.data() + offset + size);
-        sections.push_back(std::move(sec));
     }
 
     BaseNavLoadResult result;

--- a/agent/cpp-algo/source/Navmesh/RecastNavBake.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavBake.cpp
@@ -1,0 +1,48 @@
+#include "RecastNavBake.h"
+
+#include <utility>
+
+namespace navmesh::recast
+{
+
+BakedWalls BakeWalls(WallOracle& wo, double x0, double y0, int64_t nx, int64_t ny)
+{
+    BakedWalls out;
+    const auto widx = wo.wallsInBbox(x0 - 4, y0 - 4, x0 + static_cast<double>(nx) * kCS + 4, y0 + static_cast<double>(ny) * kCS + 4);
+    out.p0.reserve(widx.size());
+    out.p1.reserve(widx.size());
+    out.h0.reserve(widx.size());
+    out.h1.reserve(widx.size());
+    out.hh.reserve(widx.size());
+    for (const int64_t i : widx) {
+        out.p0.push_back(wo.P0[static_cast<size_t>(i)]);
+        out.p1.push_back(wo.P1[static_cast<size_t>(i)]);
+        out.h0.push_back(wo.H0[static_cast<size_t>(i)]);
+        out.h1.push_back(wo.H1[static_cast<size_t>(i)]);
+        out.hh.push_back(wo.HH[static_cast<size_t>(i)]);
+    }
+    return out;
+}
+
+BakedCells BakeCells(const ZoneClean& zc, WallOracle& wo, double x0, double y0, int64_t nx, int64_t ny)
+{
+    BakedCells out;
+    out.x0 = x0;
+    out.y0 = y0;
+    out.nx = nx;
+    out.ny = ny;
+    out.rcs = Rasterize(zc.mesh.V, zc.mesh.H, zc.mesh.T, x0, y0, nx, ny);
+    AppendSeamBridge(out.rcs, nx, ny);
+    out.st = BuildSpans(out.rcs.cell, out.rcs.h);
+
+    BakedWalls walls = BakeWalls(wo, x0, y0, nx, ny);
+    out.wallP0 = std::move(walls.p0);
+    out.wallP1 = std::move(walls.p1);
+    out.wallH0 = std::move(walls.h0);
+    out.wallH1 = std::move(walls.h1);
+    out.wallHH = std::move(walls.hh);
+    out.dead = StampWalls(out.wallP0, out.wallP1, out.wallHH, x0, y0, nx, ny, out.st);
+    return out;
+}
+
+}

--- a/agent/cpp-algo/source/Navmesh/RecastNavBake.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavBake.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "NavmeshTypes.h"
+#include "RecastNavGrid.h"
+#include "RecastNavZone.h"
+
+namespace navmesh::recast
+{
+
+// 一块矩形范围内的立面。取窗口外扩 4px 内的,与盖章口径一致。
+struct BakedWalls
+{
+    std::vector<WorldPoint> p0;
+    std::vector<WorldPoint> p1;
+    std::vector<double> h0;
+    std::vector<double> h1;
+    std::vector<double> hh;
+};
+
+BakedWalls BakeWalls(WallOracle& wo, double x0, double y0, int64_t nx, int64_t ny);
+
+// 一块矩形范围内、只由区几何与墙决定的体素数据。起点、终点、封堵都不参与,
+// 所以同一矩形任何时候烤出来的都一样,可以离线算好存进包里。
+struct BakedCells
+{
+    double x0 = 0.0;
+    double y0 = 0.0;
+    int64_t nx = 0;
+    int64_t ny = 0;
+    RasterCells rcs;           // 面内采样,corein 判据要按采样高度逐个比
+    SpanTable st;              // 补缝并按 kMergeH 合并后的 span 表
+    std::vector<uint8_t> dead; // 逐 span: 被立面盖章
+    std::vector<WorldPoint> wallP0;
+    std::vector<WorldPoint> wallP1;
+    std::vector<double> wallH0;
+    std::vector<double> wallH1;
+    std::vector<double> wallHH;
+};
+
+// 矩形左下角 (x0,y0)、nx×ny 格。墙取窗口外扩 4px 内的,与盖章口径一致。
+BakedCells BakeCells(const ZoneClean& zc, WallOracle& wo, double x0, double y0, int64_t nx, int64_t ny);
+
+}

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -336,6 +336,52 @@ std::vector<uint8_t> Flood(int64_t seed, const SpanTable& st, int64_t nx)
     return vis;
 }
 
+std::vector<int32_t> LabelRegions(const SpanTable& st, int64_t nx)
+{
+    const int64_t n = static_cast<int64_t>(st.sp_h.size());
+    std::vector<int32_t> parent(static_cast<size_t>(n));
+    std::iota(parent.begin(), parent.end(), 0);
+    const auto find = [&](int32_t a) {
+        while (parent[static_cast<size_t>(a)] != a) {
+            parent[static_cast<size_t>(a)] = parent[static_cast<size_t>(parent[static_cast<size_t>(a)])];
+            a = parent[static_cast<size_t>(a)];
+        }
+        return a;
+    };
+    // Flood 的邻接是对称的,所以只朝 +x/+y 合并一遍就够
+    const int64_t dirs[2][2] = { { 1, 0 }, { 0, 1 } };
+    for (int64_t ci = 0; ci < static_cast<int64_t>(st.occ.size()); ++ci) {
+        const int64_t cid = st.occ[static_cast<size_t>(ci)];
+        const int64_t gx = cid % nx;
+        for (const auto& d : dirs) {
+            if (d[0] != 0 && gx + d[0] >= nx) {
+                continue;
+            }
+            const int64_t j = occFind(st.occ, cid + d[1] * nx + d[0]);
+            if (j < 0) {
+                continue;
+            }
+            for (int64_t r = 0; r < st.ccnt[static_cast<size_t>(ci)]; ++r) {
+                const int64_t u = st.cstart[static_cast<size_t>(ci)] + r;
+                for (int64_t slot = 0; slot < st.K; ++slot) {
+                    if (!(std::fabs(st.HK[j * st.K + slot] - st.sp_h[static_cast<size_t>(u)]) <= 3.0f)) {
+                        continue;
+                    }
+                    const int32_t a = find(static_cast<int32_t>(u));
+                    const int32_t b = find(static_cast<int32_t>(st.IK[j * st.K + slot]));
+                    if (a != b) {
+                        parent[static_cast<size_t>(a)] = b;
+                    }
+                }
+            }
+        }
+    }
+    for (int64_t i = 0; i < n; ++i) {
+        parent[static_cast<size_t>(i)] = find(static_cast<int32_t>(i));
+    }
+    return parent;
+}
+
 std::vector<uint8_t> SpanReach(int64_t seed, const SpanTable& st, const std::vector<uint8_t>& ok, int64_t nx, int64_t ny)
 {
     std::vector<uint8_t> vis(st.sp_h.size(), 0);
@@ -494,58 +540,6 @@ std::vector<uint8_t> WallsAtLayer(
         }
     }
     return keep;
-}
-
-WallSegments ClipWallsAtLayerInterpolated(
-    const std::vector<WorldPoint>& p0,
-    const std::vector<WorldPoint>& p1,
-    const std::vector<double>& h0,
-    const std::vector<double>& h1,
-    const Grid<float>& lh,
-    double ox,
-    double oy)
-{
-    WallSegments out;
-    const auto lerp = [](const WorldPoint& a, const WorldPoint& b, double t) {
-        return WorldPoint { a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t };
-    };
-    for (size_t i = 0; i < p0.size(); ++i) {
-        const double length = std::hypot(p1[i].x - p0[i].x, p1[i].y - p0[i].y);
-        const int64_t steps = sampleSteps(length, 0.4);
-        bool open = false;
-        double open_t = 0.0;
-        // 同一条三角边可能沿途穿过上下叠层。按局部层高切段，不能因其中一点
-        // 命中上层就把整条边投影到下层。
-        for (int64_t k = 0; k < steps - 1; ++k) {
-            const double t0 = static_cast<double>(k) / static_cast<double>(steps - 1);
-            const double t1 = static_cast<double>(k + 1) / static_cast<double>(steps - 1);
-            const double t = (t0 + t1) / 2.0;
-            const double sx = p0[i].x + (p1[i].x - p0[i].x) * t;
-            const double sy = p0[i].y + (p1[i].y - p0[i].y) * t;
-            const int64_t gx = static_cast<int64_t>(std::floor((sx - ox) / kCS));
-            const int64_t gy = static_cast<int64_t>(std::floor((sy - oy) / kCS));
-            bool keep = false;
-            if (gx >= 0 && gx < lh.nx && gy >= 0 && gy < lh.ny) {
-                const float layer_height = lh.at(gy, gx);
-                const double edge_height = h0[i] + (h1[i] - h0[i]) * t;
-                keep = !std::isnan(layer_height) && std::abs(static_cast<double>(layer_height) - edge_height) <= kQH;
-            }
-            if (keep && !open) {
-                open = true;
-                open_t = t0;
-            }
-            if (!keep && open) {
-                out.p0.push_back(lerp(p0[i], p1[i], open_t));
-                out.p1.push_back(lerp(p0[i], p1[i], t0));
-                open = false;
-            }
-        }
-        if (open) {
-            out.p0.push_back(lerp(p0[i], p1[i], open_t));
-            out.p1.push_back(p1[i]);
-        }
-    }
-    return out;
 }
 
 WallCsr BuildWallIndex(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny)

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -120,6 +120,10 @@ SpanTable PackSpans(std::vector<int64_t> cell, std::vector<float> h, std::vector
 
 std::vector<uint8_t> Flood(int64_t seed, const SpanTable& st, int64_t nx);
 
+// Flood 的无种子版本:逐 span 给出所在的连通类号。邻接关系与 Flood 逐条相同,
+// 所以 Flood(seed) 命中的正是种子那一类,类号可以离线算好。
+std::vector<int32_t> LabelRegions(const SpanTable& st, int64_t nx);
+
 std::vector<uint8_t> SpanReach(int64_t seed, const SpanTable& st, const std::vector<uint8_t>& ok, int64_t nx, int64_t ny);
 
 Grid<float> Clearance(const Mask& mask);
@@ -138,21 +142,6 @@ std::vector<uint8_t> WallsAtLayer(
     const std::vector<WorldPoint>& p0,
     const std::vector<WorldPoint>& p1,
     const std::vector<double>& hh,
-    const Grid<float>& lh,
-    double ox,
-    double oy);
-
-struct WallSegments
-{
-    std::vector<WorldPoint> p0;
-    std::vector<WorldPoint> p1;
-};
-
-WallSegments ClipWallsAtLayerInterpolated(
-    const std::vector<WorldPoint>& p0,
-    const std::vector<WorldPoint>& p1,
-    const std::vector<double>& h0,
-    const std::vector<double>& h1,
     const Grid<float>& lh,
     double ox,
     double oy);

--- a/agent/cpp-algo/source/Navmesh/RecastNavGridIO.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGridIO.cpp
@@ -12,9 +12,11 @@ namespace navmesh::recast
 namespace
 {
 
-constexpr uint32_t kGridSectionVersion = 2;
+constexpr uint32_t kGridSectionVersion = 3;
+constexpr uint32_t kGridSectionVersionColumnar = 2;
 constexpr size_t kGridHeaderSize = 40;
 constexpr size_t kGridTileEntrySize = 48;
+constexpr size_t kGridZoneMinSize = 28;
 constexpr size_t kInflateChunk = 1U << 16U;
 
 // 定长小端字段。越界就停在原地并记下失败,调用方查一次即可。
@@ -94,6 +96,11 @@ bool GetVarint(const uint8_t*& p, const uint8_t* end, uint64_t& out)
         }
     }
     return false;
+}
+
+int64_t UnZigzag(uint64_t value)
+{
+    return static_cast<int64_t>(value >> 1U) ^ -static_cast<int64_t>(value & 1U);
 }
 
 }
@@ -190,6 +197,225 @@ bool DecodeGridTile(const uint8_t* data, size_t len, GridTile& out)
     return true;
 }
 
+bool DecodeGridTileV3(const uint8_t* data, size_t len, int32_t nx, GridTile& out)
+{
+    out = GridTile {};
+    if (data == nullptr || nx <= 0) {
+        return false;
+    }
+    const uint8_t* p = data;
+    const uint8_t* const end = data + len;
+
+    uint64_t n = 0;
+    if (!GetVarint(p, end, n)) {
+        return false;
+    }
+    if (n == 0) {
+        return p == end;
+    }
+    if (static_cast<size_t>(end - p) < sizeof(float)) {
+        return false;
+    }
+    float hmin = 0.0F;
+    std::memcpy(&hmin, p, sizeof(float));
+    p += sizeof(float);
+
+    // 类号字典的长度就是本瓦的类号数,不另存。
+    uint64_t regions = 0;
+    uint64_t ncell = 0;
+    uint64_t kmax = 0;
+    if (!GetVarint(p, end, regions) || !GetVarint(p, end, ncell) || !GetVarint(p, end, kmax)) {
+        return false;
+    }
+    if (ncell == 0 || ncell > n || kmax == 0 || kmax > n || regions == 0 || regions > n || n > UINT32_MAX) {
+        return false;
+    }
+    const size_t select_size = static_cast<size_t>(kmax) * kGridFieldCount;
+    if (static_cast<size_t>(end - p) < select_size) {
+        return false;
+    }
+    const uint8_t* const select = p;
+    p += select_size;
+
+    std::vector<uint8_t> stream[kGridStreamCount];
+    for (std::vector<uint8_t>& s : stream) {
+        uint64_t packed = 0;
+        if (!GetVarint(p, end, packed) || static_cast<uint64_t>(end - p) < packed
+            || !Inflate(p, static_cast<size_t>(packed), s)) {
+            return false;
+        }
+        p += packed;
+    }
+    if (p != end) {
+        return false;
+    }
+    // 每条记录给每条残差流至少一个字节,每个格给格号流与层数流各至少一个,类号同理。
+    // 流已经解开了,流长就是这几个计数的现成上界:先卡住,再按计数开数组。
+    if (n > stream[3].size() || ncell > stream[0].size() || ncell > stream[1].size()
+        || regions > stream[2].size()) {
+        return false;
+    }
+
+    // 格号、每格层数,以及该格首条记录在 rec 里的下标。
+    std::vector<int64_t> cell(static_cast<size_t>(ncell));
+    std::vector<uint64_t> depth(static_cast<size_t>(ncell));
+    std::vector<size_t> base(static_cast<size_t>(ncell));
+    const uint8_t* pc = stream[0].data();
+    const uint8_t* pk = stream[1].data();
+    const uint8_t* const pc_end = pc + stream[0].size();
+    const uint8_t* const pk_end = pk + stream[1].size();
+    int64_t running_cell = 0;
+    size_t running_base = 0;
+    for (size_t i = 0; i < static_cast<size_t>(ncell); ++i) {
+        uint64_t step = 0;
+        if (!GetVarint(pc, pc_end, step) || !GetVarint(pk, pk_end, depth[i]) || depth[i] == 0
+            || depth[i] > kmax) {
+            return false;
+        }
+        running_cell += static_cast<int64_t>(step);
+        cell[i] = running_cell;
+        base[i] = running_base;
+        running_base += static_cast<size_t>(depth[i]);
+    }
+    if (pc != pc_end || pk != pk_end || running_base != static_cast<size_t>(n)) {
+        return false;
+    }
+
+    std::vector<uint32_t> dictionary(static_cast<size_t>(regions));
+    const uint8_t* pd = stream[2].data();
+    const uint8_t* const pd_end = pd + stream[2].size();
+    for (uint32_t& id : dictionary) {
+        uint64_t value = 0;
+        if (!GetVarint(pd, pd_end, value) || value > UINT32_MAX) {
+            return false;
+        }
+        id = static_cast<uint32_t>(value);
+    }
+    if (pd != pd_end) {
+        return false;
+    }
+
+    out.regions = static_cast<uint32_t>(regions);
+    out.rec.assign(static_cast<size_t>(n), GridSpanRec {});
+    for (size_t i = 0; i < static_cast<size_t>(ncell); ++i) {
+        for (uint64_t j = 0; j < depth[i]; ++j) {
+            out.rec[base[i] + static_cast<size_t>(j)].cell = cell[i];
+        }
+    }
+
+    // 每层的活格表按格号升序建一次,五个字段共用。逐字段逐层扫全格的话,扫到的
+    // 格次是记录数的好几倍,而记录本身只有 n 条。列号同理,除法只做 ncell 次。
+    std::vector<uint32_t> layer_cell(static_cast<size_t>(n));
+    std::vector<size_t> layer_at(static_cast<size_t>(kmax) + 1, 0);
+    for (size_t i = 0; i < static_cast<size_t>(ncell); ++i) {
+        layer_at[static_cast<size_t>(depth[i])] += 1;
+    }
+    // 直方图先倒着累成「第 L 层有多少活格」,再正着累成起点。
+    for (size_t d = static_cast<size_t>(kmax), live = 0; d >= 1; --d) {
+        live += layer_at[d];
+        layer_at[d] = live;
+    }
+    for (size_t layer = 0; layer < static_cast<size_t>(kmax); ++layer) {
+        layer_at[layer + 1] += layer_at[layer];
+    }
+    std::vector<size_t> cursor(layer_at.begin(), layer_at.end() - 1);
+    std::vector<int32_t> column_of(static_cast<size_t>(ncell));
+    for (size_t i = 0; i < static_cast<size_t>(ncell); ++i) {
+        column_of[i] = static_cast<int32_t>(cell[i] % nx);
+        for (uint64_t layer = 0; layer < depth[i]; ++layer) {
+            layer_cell[cursor[static_cast<size_t>(layer)]++] = static_cast<uint32_t>(i);
+        }
+    }
+
+    // 高度与类号下标先落在临时列里:高度要等标志位解出来才知道是不是 fill 的占位 0。
+    std::vector<int64_t> height_q(static_cast<size_t>(n), 0);
+    std::vector<int64_t> region_index(static_cast<size_t>(n), 0);
+    std::vector<int64_t> above(static_cast<size_t>(ncell), 0);
+    std::vector<int64_t> current(static_cast<size_t>(ncell), 0);
+    std::vector<int64_t> column(static_cast<size_t>(nx), 0);
+    std::vector<uint64_t> column_layer(static_cast<size_t>(nx), 0);
+    uint64_t layer_stamp = 0;
+
+    for (int field = 0; field < kGridFieldCount; ++field) {
+        const uint8_t* q = stream[3 + field].data();
+        const uint8_t* const q_end = q + stream[3 + field].size();
+        for (uint64_t layer = 0; layer < kmax; ++layer) {
+            const uint8_t how = select[static_cast<size_t>(field) * kmax + layer];
+            if (how != kGridPredUp && (how != kGridPredDown || layer == 0)) {
+                return false;
+            }
+            ++layer_stamp;
+            for (size_t k = layer_at[static_cast<size_t>(layer)]; k < layer_at[static_cast<size_t>(layer) + 1]; ++k) {
+                const size_t i = layer_cell[k];
+                uint64_t packed = 0;
+                if (!GetVarint(q, q_end, packed)) {
+                    return false;
+                }
+                const int64_t residual = UnZigzag(packed);
+                int64_t value = 0;
+                if (how == kGridPredUp) {
+                    const auto x = static_cast<size_t>(column_of[i]);
+                    value = column_layer[x] == layer_stamp ? column[x] + residual : residual;
+                    column[x] = value;
+                    column_layer[x] = layer_stamp;
+                }
+                else {
+                    value = above[i] + residual;
+                }
+                current[i] = value;
+
+                const size_t at = base[i] + static_cast<size_t>(layer);
+                GridSpanRec& r = out.rec[at];
+                switch (field) {
+                case 0:
+                    if (value < 0) {
+                        return false;
+                    }
+                    height_q[at] = value;
+                    break;
+                case 1:
+                    if (value < 0 || static_cast<uint64_t>(value) >= regions) {
+                        return false;
+                    }
+                    region_index[at] = value;
+                    break;
+                case 2:
+                    if (value < 0 || value > UINT16_MAX) {
+                        return false;
+                    }
+                    r.clr = static_cast<uint16_t>(value);
+                    break;
+                case 3:
+                    if (value < 0 || value > UINT8_MAX) {
+                        return false;
+                    }
+                    r.flags = static_cast<uint8_t>(value);
+                    break;
+                default:
+                    if (value < 0 || value > UINT8_MAX) {
+                        return false;
+                    }
+                    r.steps = static_cast<uint8_t>(value);
+                    break;
+                }
+            }
+            above.swap(current);
+        }
+        if (q != q_end) {
+            return false;
+        }
+    }
+
+    for (size_t i = 0; i < static_cast<size_t>(n); ++i) {
+        GridSpanRec& r = out.rec[i];
+        r.rid = dictionary[static_cast<size_t>(region_index[i])];
+        r.h = (r.flags & kGridFlagFill) != 0
+            ? 0.0F
+            : static_cast<float>(static_cast<double>(hmin) + static_cast<double>(height_q[i]) / 64.0);
+    }
+    return true;
+}
+
 bool GridPack::parse(const uint8_t* data, size_t len, std::string& err)
 {
     base_ = nullptr;
@@ -212,16 +438,24 @@ bool GridPack::parse(const uint8_t* data, size_t len, std::string& err)
         err = "GRID header is truncated";
         return false;
     }
-    if (version != kGridSectionVersion) {
+    if (version != kGridSectionVersion && version != kGridSectionVersionColumnar) {
         err = "GRID section version " + std::to_string(version) + " is not supported";
         return false;
     }
+    version_ = version;
     // 格边长是判据常数,包和运行端对不上就整包不认:两边的格心不重合,烘出来的一切都错位。
     if (std::abs(cell_size_ - kCS) > 1e-12) {
         err = "GRID cell size does not match the runtime grid";
         return false;
     }
 
+    // 一个区目录项最少 28 字节(名长、名字、两个原点、类号数、瓦数),照它先卡一遍数量。
+    if (static_cast<size_t>(cur.end - cur.p) < static_cast<size_t>(zone_count) * kGridZoneMinSize) {
+        err = "GRID zone directory is truncated";
+        return false;
+    }
+    // 瓦的两边由段头的瓦边长与围裙定死(格心比格边多一格),后面按 nx 开的数组照它开。
+    const int64_t max_side = static_cast<int64_t>((tile_px_ + 2.0 * apron_px_) / cell_size_) + 2;
     zones_.resize(zone_count);
     for (uint32_t i = 0; i < zone_count; ++i) {
         GridZoneDir& z = zones_[i];
@@ -253,7 +487,8 @@ bool GridPack::parse(const uint8_t* data, size_t len, std::string& err)
             cur.u64(r.offset);
             cur.u32(r.len);
             cur.u32(r.records);
-            if (r.nx <= 0 || r.ny <= 0 || r.offset > len || r.len > len - r.offset) {
+            if (!cur.ok || r.nx <= 0 || r.ny <= 0 || r.nx > max_side || r.ny > max_side
+                || r.offset > len || r.len > len - r.offset) {
                 err = "GRID tile of zone '" + z.name + "' points outside the section";
                 return false;
             }
@@ -282,6 +517,10 @@ bool GridPack::decodeTile(const GridTileRef& t, GridTile& out) const
     }
     if (t.records == 0) {
         return true;
+    }
+    if (version_ == kGridSectionVersion) {
+        // v3 的载荷是逐流压的,整块不再套一层 deflate。
+        return DecodeGridTileV3(base_ + t.offset, t.len, t.nx, out) && out.rec.size() == t.records;
     }
     std::vector<uint8_t> raw;
     if (!Inflate(base_ + t.offset, t.len, raw)) {

--- a/agent/cpp-algo/source/Navmesh/RecastNavGridIO.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGridIO.cpp
@@ -1,0 +1,314 @@
+#include "RecastNavGridIO.h"
+
+#include <cstring>
+
+#include <zlib.h>
+
+#include "RecastNavGrid.h"
+
+namespace navmesh::recast
+{
+
+namespace
+{
+
+constexpr uint32_t kGridSectionVersion = 2;
+constexpr size_t kGridHeaderSize = 40;
+constexpr size_t kGridTileEntrySize = 48;
+constexpr size_t kInflateChunk = 1U << 16U;
+
+// 定长小端字段。越界就停在原地并记下失败,调用方查一次即可。
+struct Cursor
+{
+    const uint8_t* p = nullptr;
+    const uint8_t* end = nullptr;
+    bool ok = true;
+
+    bool take(size_t n, const uint8_t*& at)
+    {
+        if (!ok || static_cast<size_t>(end - p) < n) {
+            ok = false;
+            return false;
+        }
+        at = p;
+        p += n;
+        return true;
+    }
+
+    template <typename T>
+    bool read(T& out)
+    {
+        const uint8_t* at = nullptr;
+        if (!take(sizeof(T), at)) {
+            return false;
+        }
+        std::memcpy(&out, at, sizeof(T));
+        return true;
+    }
+
+    bool u32(uint32_t& out) { return read(out); }
+    bool u64(uint64_t& out) { return read(out); }
+    bool i32(int32_t& out) { return read(out); }
+    bool f64(double& out) { return read(out); }
+};
+
+// 瓦载荷不带原长,所以按块解到流末尾。
+bool Inflate(const uint8_t* data, size_t len, std::vector<uint8_t>& out)
+{
+    out.clear();
+    z_stream zs {};
+    if (inflateInit(&zs) != Z_OK) {
+        return false;
+    }
+    zs.next_in = const_cast<Bytef*>(data);
+    zs.avail_in = static_cast<uInt>(len);
+    int rc = Z_OK;
+    do {
+        const size_t at = out.size();
+        out.resize(at + kInflateChunk);
+        zs.next_out = out.data() + at;
+        zs.avail_out = static_cast<uInt>(kInflateChunk);
+        rc = inflate(&zs, Z_NO_FLUSH);
+        if (rc != Z_OK && rc != Z_STREAM_END) {
+            inflateEnd(&zs);
+            return false;
+        }
+        out.resize(at + kInflateChunk - zs.avail_out);
+    } while (rc != Z_STREAM_END);
+    inflateEnd(&zs);
+    return true;
+}
+
+// 变长整数,低 7 位一组小端在前。走过头就报错,不越界读。
+bool GetVarint(const uint8_t*& p, const uint8_t* end, uint64_t& out)
+{
+    out = 0;
+    for (int shift = 0; shift < 64; shift += 7) {
+        if (p == end) {
+            return false;
+        }
+        const uint8_t b = *p++;
+        out |= static_cast<uint64_t>(b & 0x7FU) << shift;
+        if ((b & 0x80U) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}
+
+bool DecodeGridTile(const uint8_t* data, size_t len, GridTile& out)
+{
+    out = GridTile {};
+    if (data == nullptr) {
+        return false;
+    }
+    const uint8_t* p = data;
+    const uint8_t* const end = data + len;
+
+    uint64_t n = 0;
+    if (!GetVarint(p, end, n)) {
+        return false;
+    }
+    if (n == 0) {
+        return p == end;
+    }
+    if (static_cast<size_t>(end - p) < sizeof(float)) {
+        return false;
+    }
+    float hmin = 0.0F;
+    std::memcpy(&hmin, p, sizeof(float));
+    p += sizeof(float);
+
+    uint64_t regions = 0;
+    uint64_t ncell = 0;
+    if (!GetVarint(p, end, regions) || !GetVarint(p, end, ncell)) {
+        return false;
+    }
+
+    // 六列各自长度前缀,顺序与写入端一致:格、高、类号、标志、断口、净空。
+    const uint8_t* col[6] = {};
+    const uint8_t* col_end[6] = {};
+    for (int i = 0; i < 6; ++i) {
+        uint64_t clen = 0;
+        if (!GetVarint(p, end, clen) || static_cast<uint64_t>(end - p) < clen) {
+            return false;
+        }
+        col[i] = p;
+        col_end[i] = p + clen;
+        p += clen;
+    }
+    if (p != end) {
+        return false;
+    }
+
+    out.regions = static_cast<uint32_t>(regions);
+    out.rec.reserve(static_cast<size_t>(n));
+    int64_t cell = 0;
+    for (uint64_t i = 0; i < ncell; ++i) {
+        uint64_t delta = 0;
+        uint64_t k = 0;
+        if (!GetVarint(col[0], col_end[0], delta) || !GetVarint(col[0], col_end[0], k)) {
+            return false;
+        }
+        cell += static_cast<int64_t>(delta);
+        for (uint64_t j = 0; j < k; ++j) {
+            if (out.rec.size() >= static_cast<size_t>(n)) {
+                return false;
+            }
+            uint64_t hq = 0;
+            uint64_t rid = 0;
+            uint64_t clr = 0;
+            if (!GetVarint(col[1], col_end[1], hq) || !GetVarint(col[2], col_end[2], rid)
+                || !GetVarint(col[5], col_end[5], clr)) {
+                return false;
+            }
+            if (col[3] == col_end[3] || col[4] == col_end[4]) {
+                return false;
+            }
+            GridSpanRec r {};
+            r.cell = cell;
+            r.rid = static_cast<uint32_t>(rid);
+            r.clr = static_cast<uint16_t>(clr);
+            r.flags = *col[3]++;
+            r.steps = *col[4]++;
+            r.h = (r.flags & kGridFlagFill) != 0
+                ? 0.0F
+                : static_cast<float>(static_cast<double>(hmin) + static_cast<double>(hq) / 64.0);
+            out.rec.push_back(r);
+        }
+    }
+    if (out.rec.size() != static_cast<size_t>(n)) {
+        return false;
+    }
+    for (int i = 0; i < 6; ++i) {
+        if (col[i] != col_end[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool GridPack::parse(const uint8_t* data, size_t len, std::string& err)
+{
+    base_ = nullptr;
+    len_ = 0;
+    zones_.clear();
+    if (data == nullptr || len < kGridHeaderSize) {
+        err = "GRID section is truncated";
+        return false;
+    }
+    if (std::memcmp(data, kGridSectionTag, 4) != 0) {
+        err = "GRID section has a bad magic";
+        return false;
+    }
+    Cursor cur { data + 4, data + len };
+    uint32_t version = 0;
+    uint32_t zone_count = 0;
+    uint32_t reserved = 0;
+    if (!cur.u32(version) || !cur.f64(cell_size_) || !cur.f64(tile_px_) || !cur.f64(apron_px_)
+        || !cur.u32(zone_count) || !cur.u32(reserved)) {
+        err = "GRID header is truncated";
+        return false;
+    }
+    if (version != kGridSectionVersion) {
+        err = "GRID section version " + std::to_string(version) + " is not supported";
+        return false;
+    }
+    // 格边长是判据常数,包和运行端对不上就整包不认:两边的格心不重合,烘出来的一切都错位。
+    if (std::abs(cell_size_ - kCS) > 1e-12) {
+        err = "GRID cell size does not match the runtime grid";
+        return false;
+    }
+
+    zones_.resize(zone_count);
+    for (uint32_t i = 0; i < zone_count; ++i) {
+        GridZoneDir& z = zones_[i];
+        uint32_t name_len = 0;
+        uint32_t tile_count = 0;
+        if (!cur.u32(name_len)) {
+            err = "GRID zone directory is truncated";
+            return false;
+        }
+        const size_t padded = (static_cast<size_t>(name_len) + 3) / 4 * 4;
+        const uint8_t* name_bytes = nullptr;
+        if (!cur.take(padded, name_bytes) || !cur.f64(z.x0) || !cur.f64(z.y0)
+            || !cur.u32(z.global_regions) || !cur.u32(tile_count)) {
+            err = "GRID zone directory is truncated";
+            return false;
+        }
+        z.name.assign(reinterpret_cast<const char*>(name_bytes), name_len);
+        if (static_cast<size_t>(cur.end - cur.p) < static_cast<size_t>(tile_count) * kGridTileEntrySize) {
+            err = "GRID tile directory of zone '" + z.name + "' is truncated";
+            return false;
+        }
+        z.tiles.resize(tile_count);
+        for (uint32_t t = 0; t < tile_count; ++t) {
+            GridTileRef& r = z.tiles[t];
+            int32_t* const fields[8] = { &r.gx0, &r.gy0, &r.nx, &r.ny, &r.px0, &r.px1, &r.py0, &r.py1 };
+            for (int32_t* f : fields) {
+                cur.i32(*f);
+            }
+            cur.u64(r.offset);
+            cur.u32(r.len);
+            cur.u32(r.records);
+            if (r.nx <= 0 || r.ny <= 0 || r.offset > len || r.len > len - r.offset) {
+                err = "GRID tile of zone '" + z.name + "' points outside the section";
+                return false;
+            }
+        }
+    }
+    base_ = data;
+    len_ = len;
+    return true;
+}
+
+const GridZoneDir* GridPack::findZone(const std::string& name) const
+{
+    for (const GridZoneDir& z : zones_) {
+        if (z.name == name) {
+            return &z;
+        }
+    }
+    return nullptr;
+}
+
+bool GridPack::decodeTile(const GridTileRef& t, GridTile& out) const
+{
+    out = GridTile {};
+    if (base_ == nullptr) {
+        return false;
+    }
+    if (t.records == 0) {
+        return true;
+    }
+    std::vector<uint8_t> raw;
+    if (!Inflate(base_ + t.offset, t.len, raw)) {
+        return false;
+    }
+    return DecodeGridTile(raw.data(), raw.size(), out) && out.rec.size() == t.records;
+}
+
+std::vector<const GridTileRef*> GridTilesInRect(
+    const GridZoneDir& zone,
+    int64_t gx0,
+    int64_t gy0,
+    int64_t gx1,
+    int64_t gy1)
+{
+    std::vector<const GridTileRef*> hit;
+    for (const GridTileRef& t : zone.tiles) {
+        const int64_t ox0 = t.gx0 + t.px0;
+        const int64_t ox1 = t.gx0 + t.px1;
+        const int64_t oy0 = t.gy0 + t.py0;
+        const int64_t oy1 = t.gy0 + t.py1;
+        if (ox0 > gx1 || ox1 < gx0 || oy0 > gy1 || oy1 < gy0) {
+            continue;
+        }
+        hit.push_back(&t);
+    }
+    return hit;
+}
+
+}

--- a/agent/cpp-algo/source/Navmesh/RecastNavGridIO.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGridIO.h
@@ -30,6 +30,13 @@ inline constexpr uint8_t kGridFlagCore = 0x04;  // 补洞封缝后的核心掩�
 inline constexpr uint8_t kGridFlagGhost = 0x08; // 补出来的格,高度由邻格传播
 inline constexpr uint8_t kGridFlagFill = 0x10;  // 补出来的格且无高度可传播
 
+// v3 瓦载荷:五个字段各一条残差流,前面三条是格号、层数、类号字典。
+inline constexpr int kGridFieldCount = 5;
+inline constexpr int kGridStreamCount = 3 + kGridFieldCount;
+// 残差的预测子。编码端逐字段逐层挑一个写进选择子,解码端只照做。
+inline constexpr uint8_t kGridPredUp = 0;   // 面内上邻:同列上一个存在的格
+inline constexpr uint8_t kGridPredDown = 1; // 同格下一层
+
 // steps 的位序对应的 4 个规范方向,与 StepBreaks 扫的顺序一致。
 inline constexpr int64_t kGridStepDx[4] = { 1, 0, 1, 1 };
 inline constexpr int64_t kGridStepDy[4] = { 0, 1, 1, -1 };
@@ -46,8 +53,11 @@ struct GridTile
     std::vector<GridSpanRec> rec;
 };
 
-// 解一块瓦的载荷(已解压)。字节走完且自洽才返回 true。
+// 解一块 v2 瓦的载荷(已解压)。字节走完且自洽才返回 true。
 bool DecodeGridTile(const uint8_t* data, size_t len, GridTile& out);
+
+// 解一块 v3 瓦。段里的原始字节直接进,内部逐流 inflate;差分要瓦宽 nx。
+bool DecodeGridTileV3(const uint8_t* data, size_t len, int32_t nx, GridTile& out);
 
 // 段目录里的一块瓦。格号全是全局的(gx0 = llround(ox / kCS)),自有矩形
 // [px0,px1]×[py0,py1] 是瓦内格号闭区间,各瓦互不重叠且拼起来覆盖全区。
@@ -93,6 +103,7 @@ public:
 private:
     const uint8_t* base_ = nullptr;
     size_t len_ = 0;
+    uint32_t version_ = 0;
     double cell_size_ = 0.0;
     double tile_px_ = 0.0;
     double apron_px_ = 0.0;

--- a/agent/cpp-algo/source/Navmesh/RecastNavGridIO.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGridIO.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace navmesh::recast
+{
+
+inline constexpr char kGridSectionTag[5] = "BGRD";
+
+// GRID 段一块瓦的逐 span 记录。一格可以挂多条:同列的几层地面各一条,
+// 补出来的格没有实体 span 时挂一条 ghost 或 fill。
+struct GridSpanRec
+{
+    int64_t cell = 0; // 瓦内格号 y * nx + x
+    uint32_t rid = 0; // 全区类号
+    float h = 0.0F;
+    uint16_t clr = 0;  // 净空的平方格距,还原用 GridClearance
+    uint8_t flags = 0; // kGridFlag*
+    uint8_t steps = 0; // 4 向各 2 位:禁 c->b、禁 b->c
+};
+
+inline constexpr uint8_t kGridFlagDead = 0x01;  // 墙压过的 span
+inline constexpr uint8_t kGridFlagWalk = 0x02;  // 既在层里又在核心里
+inline constexpr uint8_t kGridFlagCore = 0x04;  // 补洞封缝后的核心掩码
+inline constexpr uint8_t kGridFlagGhost = 0x08; // 补出来的格,高度由邻格传播
+inline constexpr uint8_t kGridFlagFill = 0x10;  // 补出来的格且无高度可传播
+
+// steps 的位序对应的 4 个规范方向,与 StepBreaks 扫的顺序一致。
+inline constexpr int64_t kGridStepDx[4] = { 1, 0, 1, 1 };
+inline constexpr int64_t kGridStepDy[4] = { 0, 1, 1, -1 };
+
+// 净空存的是整数平方格距,还原表达式与 Clearance 的返回值逐位相同。
+inline float GridClearance(uint16_t q)
+{
+    return std::min(std::sqrt(static_cast<float>(q)) * 0.25F, 12.0F);
+}
+
+struct GridTile
+{
+    uint32_t regions = 0; // 本瓦出现的类号数
+    std::vector<GridSpanRec> rec;
+};
+
+// 解一块瓦的载荷(已解压)。字节走完且自洽才返回 true。
+bool DecodeGridTile(const uint8_t* data, size_t len, GridTile& out);
+
+// 段目录里的一块瓦。格号全是全局的(gx0 = llround(ox / kCS)),自有矩形
+// [px0,px1]×[py0,py1] 是瓦内格号闭区间,各瓦互不重叠且拼起来覆盖全区。
+struct GridTileRef
+{
+    int32_t gx0 = 0;
+    int32_t gy0 = 0;
+    int32_t nx = 0;
+    int32_t ny = 0;
+    int32_t px0 = 0;
+    int32_t px1 = -1;
+    int32_t py0 = 0;
+    int32_t py1 = -1;
+    uint64_t offset = 0; // 相对段首
+    uint32_t len = 0;
+    uint32_t records = 0;
+};
+
+struct GridZoneDir
+{
+    std::string name;
+    double x0 = 0.0;
+    double y0 = 0.0;
+    uint32_t global_regions = 0;
+    std::vector<GridTileRef> tiles;
+};
+
+// 包里 GRID 段的目录。段字节归 BaseNavPack 持有,这里只记指针,
+// 所以 GridPack 的寿命不能长过它解析的那个包。
+class GridPack
+{
+public:
+    bool parse(const uint8_t* data, size_t len, std::string& err);
+    bool valid() const { return base_ != nullptr; }
+    double cellSize() const { return cell_size_; }
+    double tilePx() const { return tile_px_; }
+    double apronPx() const { return apron_px_; }
+    const std::vector<GridZoneDir>& zones() const { return zones_; }
+    const GridZoneDir* findZone(const std::string& name) const;
+    // 解一块瓦:按需 inflate 再解码,不缓存。空瓦返回空 GridTile。
+    bool decodeTile(const GridTileRef& t, GridTile& out) const;
+
+private:
+    const uint8_t* base_ = nullptr;
+    size_t len_ = 0;
+    double cell_size_ = 0.0;
+    double tile_px_ = 0.0;
+    double apron_px_ = 0.0;
+    std::vector<GridZoneDir> zones_;
+};
+
+// 自有矩形与全局格矩形 [gx0,gx1]×[gy0,gy1] 相交的瓦。
+std::vector<const GridTileRef*> GridTilesInRect(
+    const GridZoneDir& zone,
+    int64_t gx0,
+    int64_t gy0,
+    int64_t gx1,
+    int64_t gy1);
+
+}

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -1,7 +1,8 @@
 #include "RecastNavRoute.h"
 
+#include "RecastNavBake.h"
+
 #include <algorithm>
-#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <limits>
@@ -31,10 +32,6 @@ struct WindowInfo
     Grid<float> dist;
     std::vector<WorldPoint> wP0;
     std::vector<WorldPoint> wP1;
-    std::vector<WorldPoint> sourceWallP0;
-    std::vector<WorldPoint> sourceWallP1;
-    std::vector<double> sourceWallH0;
-    std::vector<double> sourceWallH1;
     WallCsr wcsr;
     StepBarrier sev;
     std::vector<WorldPoint> segA;
@@ -57,73 +54,202 @@ struct RouteDiag
     double snap_goal = 0.0;
 };
 
+// 窗口里从预烘图解出来的记录。格号已换成窗口格号,窗外的与不属于本瓦自有矩形的
+// 都已剔除;一格只归一块瓦,所以同格的记录必然来自同一块瓦、按 (类号, 高) 排好。
+struct GridWindow
+{
+    std::vector<GridSpanRec> rec;
+    std::vector<int64_t> head; // 逐格: 记录链表头,无记录为 -1
+    std::vector<int64_t> next; // 逐记录: 同格的下一条
+};
+
+bool loadGridWindow(
+    const GridPack& gp,
+    const GridZoneDir& gz,
+    int64_t wgx0,
+    int64_t wgy0,
+    int64_t nx,
+    int64_t ny,
+    GridWindow& out)
+{
+    GridTile tile;
+    for (const GridTileRef* t : GridTilesInRect(gz, wgx0, wgy0, wgx0 + nx - 1, wgy0 + ny - 1)) {
+        if (t->records == 0) {
+            continue;
+        }
+        if (!gp.decodeTile(*t, tile)) {
+            return false;
+        }
+        for (GridSpanRec& r : tile.rec) {
+            const int64_t ix = r.cell % t->nx;
+            const int64_t iy = r.cell / t->nx;
+            if (ix < t->px0 || ix > t->px1 || iy < t->py0 || iy > t->py1) {
+                continue;
+            }
+            const int64_t wx = t->gx0 + ix - wgx0;
+            const int64_t wy = t->gy0 + iy - wgy0;
+            if (wx < 0 || wx >= nx || wy < 0 || wy >= ny) {
+                continue;
+            }
+            r.cell = wy * nx + wx;
+            out.rec.push_back(r);
+        }
+    }
+    out.head.assign(static_cast<size_t>(nx * ny), -1);
+    out.next.assign(out.rec.size(), -1);
+    for (size_t i = out.rec.size(); i-- > 0;) {
+        const auto c = static_cast<size_t>(out.rec[i].cell);
+        out.next[i] = out.head[c];
+        out.head[c] = static_cast<int64_t>(i);
+    }
+    return true;
+}
+
+// 起点格里高度离 h0 最近的那条真 span 定类。类选错整条线就落在另一层上。
+int64_t pickStartRec(const GridWindow& gw, int64_t cell, double h0)
+{
+    int64_t best = -1;
+    double bd = 0.0;
+    for (int64_t i = gw.head[static_cast<size_t>(cell)]; i >= 0; i = gw.next[static_cast<size_t>(i)]) {
+        const GridSpanRec& r = gw.rec[static_cast<size_t>(i)];
+        if ((r.flags & (kGridFlagGhost | kGridFlagFill)) != 0) {
+            continue;
+        }
+        const double d = std::fabs(static_cast<double>(r.h) - h0);
+        if (best < 0 || d < bd) {
+            best = i;
+            bd = d;
+        }
+    }
+    return best;
+}
+
+// 终点声明了面时改由终点定类:终点格附近带内、能走的那条,先按格距再按高度差挑。
+// 起点那侧只在这个类里选面,所以起点二维吸附落在屋顶上也不会把线拉到别层去。
+int64_t pickDeckRec(const GridWindow& gw, int64_t nx, int64_t ny, int64_t gcx, int64_t gcy, double deck)
+{
+    const auto rad = static_cast<int64_t>(std::ceil(kSnapRadius / kCS));
+    int64_t best = -1;
+    int64_t bcell_d = 0;
+    double bh_d = 0.0;
+    for (int64_t y = std::max<int64_t>(gcy - rad, 0); y <= std::min<int64_t>(gcy + rad, ny - 1); ++y) {
+        for (int64_t x = std::max<int64_t>(gcx - rad, 0); x <= std::min<int64_t>(gcx + rad, nx - 1); ++x) {
+            const int64_t cd = (x - gcx) * (x - gcx) + (y - gcy) * (y - gcy);
+            if (best >= 0 && cd > bcell_d) {
+                continue;
+            }
+            for (int64_t i = gw.head[static_cast<size_t>(y * nx + x)]; i >= 0; i = gw.next[static_cast<size_t>(i)]) {
+                const GridSpanRec& r = gw.rec[static_cast<size_t>(i)];
+                if ((r.flags & kGridFlagWalk) == 0 || (r.flags & kGridFlagFill) != 0) {
+                    continue;
+                }
+                const double hd = std::fabs(static_cast<double>(r.h) - deck);
+                if (hd > kDeckBand) {
+                    continue;
+                }
+                if (best < 0 || cd < bcell_d || (cd == bcell_d && hd < bh_d)) {
+                    best = i;
+                    bcell_d = cd;
+                    bh_d = hd;
+                }
+            }
+        }
+    }
+    return best;
+}
+
+// 点到最近核心格的格距 × kCS,与窗口里的 near() 同口径,只是在全区图上量。
+// 搜索半径取判据的两倍,够不着的点只报这个下界,反正它已经在闸外了。
+double coreAnchorPx(const GridPack& gp, const GridZoneDir& gz, const WorldPoint& p)
+{
+    const double cs = gp.cellSize();
+    const double reach = kSnapRadius * 2.0;
+    const auto cx = static_cast<int64_t>(std::floor(p.x / cs));
+    const auto cy = static_cast<int64_t>(std::floor(p.y / cs));
+    const auto rad = static_cast<int64_t>(std::ceil(reach / cs));
+    int64_t best = -1;
+    GridTile tile;
+    for (const GridTileRef* t : GridTilesInRect(gz, cx - rad, cy - rad, cx + rad, cy + rad)) {
+        if (t->records == 0 || !gp.decodeTile(*t, tile)) {
+            continue;
+        }
+        for (const GridSpanRec& r : tile.rec) {
+            if ((r.flags & kGridFlagCore) == 0) {
+                continue;
+            }
+            const int64_t ix = r.cell % t->nx;
+            const int64_t iy = r.cell / t->nx;
+            if (ix < t->px0 || ix > t->px1 || iy < t->py0 || iy > t->py1) {
+                continue;
+            }
+            const int64_t dx = t->gx0 + ix - cx;
+            const int64_t dy = t->gy0 + iy - cy;
+            const int64_t d = dx * dx + dy * dy;
+            if (best < 0 || d < best) {
+                best = d;
+            }
+        }
+    }
+    return best < 0 ? reach : std::sqrt(static_cast<double>(best)) * cs;
+}
+
 std::optional<WindowInfo> buildWindow(
-    const ZoneClean& zc,
     WallOracle& wo,
+    const GridPack& gp,
+    const GridZoneDir& gz,
+    const ZoneClean& zc,
     const WorldPoint& s,
     const WorldPoint& s_snap,
+    const WorldPoint& g,
     double h0,
+    std::optional<double> goal_deck,
     double x0,
     double y0,
     double x1,
     double y1,
     const std::vector<int32_t>& blocked_local,
     const std::vector<WorldPoint>& blocked_points,
-    bool layered_core,
-    std::optional<double> layer_hint,
     std::string& err)
 {
     const int64_t nx = static_cast<int64_t>(std::ceil((x1 - x0) / kCS));
     const int64_t ny = static_cast<int64_t>(std::ceil((y1 - y0) / kCS));
-    RasterCells rcs = Rasterize(zc.mesh.V, zc.mesh.H, zc.mesh.T, x0, y0, nx, ny);
-    AppendSeamBridge(rcs, nx, ny);
-    const SpanTable st = BuildSpans(rcs.cell, rcs.h);
-
-    const auto widx = wo.wallsInBbox(x0 - 4, y0 - 4, x0 + static_cast<double>(nx) * kCS + 4, y0 + static_cast<double>(ny) * kCS + 4);
-    std::vector<WorldPoint> p0;
-    std::vector<WorldPoint> p1;
-    std::vector<double> wh0;
-    std::vector<double> wh1;
-    std::vector<double> hh;
-    for (const int64_t i : widx) {
-        p0.push_back(wo.P0[static_cast<size_t>(i)]);
-        p1.push_back(wo.P1[static_cast<size_t>(i)]);
-        wh0.push_back(wo.H0[static_cast<size_t>(i)]);
-        wh1.push_back(wo.H1[static_cast<size_t>(i)]);
-        hh.push_back(wo.HH[static_cast<size_t>(i)]);
+    // 窗口原点是对齐过的,所以它落在全局格线上,窗口格与烘焙格一一对上
+    const int64_t wgx0 = std::llround(x0 / kCS);
+    const int64_t wgy0 = std::llround(y0 / kCS);
+    GridWindow gw;
+    if (!loadGridWindow(gp, gz, wgx0, wgy0, nx, ny, gw)) {
+        err = "预烘格图解不开";
+        return std::nullopt;
     }
-    const std::vector<uint8_t> dead = layered_core ? std::vector<uint8_t>() : StampWalls(p0, p1, hh, x0, y0, nx, ny, st);
 
+    const auto cell_at = [&](int64_t cx, int64_t cy) {
+        return cx < 0 || cx >= nx || cy < 0 || cy >= ny ? -1 : cy * nx + cx;
+    };
     int64_t gx = static_cast<int64_t>((s.x - x0) / kCS);
     int64_t gy = static_cast<int64_t>((s.y - y0) / kCS);
-    int64_t cell0 = gy * nx + gx;
-    auto occ_it = std::lower_bound(st.occ.begin(), st.occ.end(), cell0);
-    if (occ_it == st.occ.end() || *occ_it != cell0) {
+    int64_t cell0 = cell_at(gx, gy);
+    int64_t start_rec = cell0 >= 0 ? pickStartRec(gw, cell0, h0) : -1;
+    if (start_rec < 0) {
         // 起点离网时其所在格无体素,退用按楼层吸附过的起点定种子
         gx = static_cast<int64_t>((s_snap.x - x0) / kCS);
         gy = static_cast<int64_t>((s_snap.y - y0) / kCS);
-        cell0 = gy * nx + gx;
-        occ_it = std::lower_bound(st.occ.begin(), st.occ.end(), cell0);
+        cell0 = cell_at(gx, gy);
+        start_rec = cell0 >= 0 ? pickStartRec(gw, cell0, h0) : -1;
     }
-    if (occ_it == st.occ.end() || *occ_it != cell0) {
+    if (start_rec < 0) {
         err = "起点格无体素 (gx=" + std::to_string(gx) + ",gy=" + std::to_string(gy) + ")";
         return std::nullopt;
     }
-    const int64_t j = occ_it - st.occ.begin();
-    int64_t seed = -1;
-    float best = 0.0F;
-    for (int64_t k = 0; k < st.K; ++k) {
-        const int64_t sid = st.IK[static_cast<size_t>(j * st.K + k)];
-        if (sid < 0) {
-            continue;
+    uint32_t region = gw.rec[static_cast<size_t>(start_rec)].rid;
+    if (goal_deck.has_value()) {
+        const int64_t deck_rec = pickDeckRec(
+            gw, nx, ny, static_cast<int64_t>((g.x - x0) / kCS), static_cast<int64_t>((g.y - y0) / kCS), *goal_deck);
+        if (deck_rec < 0) {
+            err = "终点附近没有声明的面 (deck=" + std::to_string(*goal_deck) + ")";
+            return std::nullopt;
         }
-        const float d = std::fabs(st.sp_h[static_cast<size_t>(sid)] - static_cast<float>(h0));
-        if (seed < 0 || d < best) {
-            seed = sid;
-            best = d;
-        }
+        region = gw.rec[static_cast<size_t>(deck_rec)].rid;
     }
-    const std::vector<uint8_t> vis = Flood(seed, st, nx);
 
     WindowInfo info;
     info.x0 = x0;
@@ -131,109 +257,48 @@ std::optional<WindowInfo> buildWindow(
     info.nx = nx;
     info.ny = ny;
     info.lay = Mask(nx, ny, 0);
+    info.core = Mask(nx, ny, 0);
+    info.dist = Grid<float>(nx, ny, 0.0F);
     info.lh = Grid<float>(nx, ny, std::numeric_limits<float>::quiet_NaN());
-    for (size_t si = 0; si < vis.size(); ++si) {
-        if (vis[si] != 0) {
-            info.lay.v[static_cast<size_t>(st.sp_cell[si])] = 1;
-            info.lh.v[static_cast<size_t>(st.sp_cell[si])] = st.sp_h[si];
-        }
-    }
-    // 声明面只参与墙的局部选层；旧 core 仍用原来的层图，避免成功线路被恢复逻辑改写。
-    Grid<float> wall_lh = info.lh;
-    if (layer_hint.has_value()) {
-        std::fill(wall_lh.v.begin(), wall_lh.v.end(), std::numeric_limits<float>::quiet_NaN());
-        for (size_t row = 0; row < st.occ.size(); ++row) {
-            int64_t best_span = -1;
-            double best_delta = 0.0;
-            for (int64_t k = 0; k < st.K; ++k) {
-                const int64_t sid = st.IK[row * static_cast<size_t>(st.K) + static_cast<size_t>(k)];
-                if (sid < 0 || vis[static_cast<size_t>(sid)] == 0) {
-                    continue;
-                }
-                const double delta = std::abs(static_cast<double>(st.sp_h[static_cast<size_t>(sid)]) - *layer_hint);
-                if (best_span < 0 || delta < best_delta) {
-                    best_span = sid;
-                    best_delta = delta;
-                }
+    std::vector<uint8_t> stepbits(static_cast<size_t>(nx * ny), 0);
+    std::vector<int64_t> sp_cell;
+    std::vector<float> sp_h;
+    // 表里留着别的类的 span:层判据要看整列,少一层就会从楼板底下穿过去
+    for (const GridSpanRec& r : gw.rec) {
+        const bool ghost = (r.flags & kGridFlagGhost) != 0;
+        const bool fill = (r.flags & kGridFlagFill) != 0;
+        const auto cell = static_cast<size_t>(r.cell);
+        if (r.rid == region) {
+            const bool core = (r.flags & kGridFlagCore) != 0;
+            if ((r.flags & kGridFlagWalk) != 0 || !core) {
+                info.lay.v[cell] = 1;
             }
-            if (best_span >= 0) {
-                wall_lh.v[static_cast<size_t>(st.occ[row])] = st.sp_h[static_cast<size_t>(best_span)];
+            if (core) {
+                info.core.v[cell] = 1;
+            }
+            info.dist.v[cell] = GridClearance(r.clr);
+            stepbits[cell] |= r.steps;
+            if (!ghost && !fill && (std::isnan(info.lh.v[cell]) || r.h > info.lh.v[cell])) {
+                info.lh.v[cell] = r.h;
             }
         }
+        if (fill || (ghost && r.rid != region)) {
+            continue;
+        }
+        sp_cell.push_back(r.cell);
+        sp_h.push_back(r.h);
+        info.vis3.push_back(static_cast<uint8_t>(r.rid == region));
     }
-    if (layered_core) {
-        info.lh = wall_lh;
-    }
-    info.sourceWallP0 = p0;
-    info.sourceWallP1 = p1;
-    info.sourceWallH0 = wh0;
-    info.sourceWallH1 = wh1;
-    if (layer_hint.has_value()) {
-        WallSegments walls = ClipWallsAtLayerInterpolated(p0, p1, wh0, wh1, wall_lh, x0, y0);
-        info.wP0 = std::move(walls.p0);
-        info.wP1 = std::move(walls.p1);
-    }
-    else {
-        const std::vector<uint8_t> keep = WallsAtLayer(p0, p1, hh, info.lh, x0, y0);
-        for (size_t i = 0; i < keep.size(); ++i) {
-            if (keep[i] != 0) {
-                info.wP0.push_back(p0[i]);
-                info.wP1.push_back(p1[i]);
-            }
+
+    const BakedWalls walls = BakeWalls(wo, x0, y0, nx, ny);
+    const std::vector<uint8_t> keep = WallsAtLayer(walls.p0, walls.p1, walls.hh, info.lh, x0, y0);
+    for (size_t i = 0; i < keep.size(); ++i) {
+        if (keep[i] != 0) {
+            info.wP0.push_back(walls.p0[i]);
+            info.wP1.push_back(walls.p1[i]);
         }
     }
     info.wcsr = BuildWallIndex(info.wP0, info.wP1, x0, y0, nx, ny);
-    Mask wallcell(nx, ny, 0);
-    if (layered_core) {
-        for (size_t cell = 0; cell < wallcell.v.size(); ++cell) {
-            wallcell.v[cell] = static_cast<uint8_t>(info.wcsr.start[cell + 1] > info.wcsr.start[cell]);
-        }
-    }
-    else {
-        for (size_t si = 0; si < dead.size(); ++si) {
-            if (dead[si] != 0) {
-                wallcell.v[static_cast<size_t>(st.sp_cell[si])] = 1;
-            }
-        }
-    }
-    info.lay = FillHoles(info.lay, kHoleMaxCells, &wallcell);
-    Mask corein(nx, ny, 0);
-    std::vector<int64_t> span_row;
-    if (layered_core) {
-        span_row.assign(static_cast<size_t>(nx * ny), -1);
-        for (size_t row = 0; row < st.occ.size(); ++row) {
-            span_row[static_cast<size_t>(st.occ[row])] = static_cast<int64_t>(row);
-        }
-    }
-    for (size_t ci = 0; ci < rcs.cell.size(); ++ci) {
-        if (rcs.ins[ci] == 0) {
-            continue;
-        }
-        bool matches = false;
-        if (layered_core) {
-            const int64_t row_index = span_row[static_cast<size_t>(rcs.cell[ci])];
-            if (row_index >= 0) {
-                const size_t row = static_cast<size_t>(row_index);
-                for (int64_t k = 0; k < st.K && !matches; ++k) {
-                    const int64_t sid = st.IK[row * static_cast<size_t>(st.K) + static_cast<size_t>(k)];
-                    matches = sid >= 0 && vis[static_cast<size_t>(sid)] != 0
-                              && std::fabs(rcs.h[ci] - st.sp_h[static_cast<size_t>(sid)]) <= static_cast<float>(kQH);
-                }
-            }
-        }
-        else {
-            const float lf = info.lh.v[static_cast<size_t>(rcs.cell[ci])];
-            matches = !std::isnan(lf) && std::fabs(rcs.h[ci] - lf) <= static_cast<float>(kQH);
-        }
-        if (matches) {
-            corein.v[static_cast<size_t>(rcs.cell[ci])] = 1;
-        }
-    }
-    for (size_t i = 0; i < corein.v.size(); ++i) {
-        corein.v[i] = static_cast<uint8_t>(corein.v[i] != 0 && info.lay.v[i] != 0);
-    }
-    info.core = FillHoles(corein, kHoleMaxCells, &wallcell);
-    info.core = CloseCracks(info.core, info.lay, &wallcell);
 
     if (!blocked_local.empty()) {
         std::vector<std::array<int32_t, 3>> bt;
@@ -274,37 +339,42 @@ std::optional<WindowInfo> buildWindow(
         }
     }
 
-    info.sev = StepBreaks(st, vis, info.lay, x0, y0);
+    // 禁步面按烘出来的位还原。位序与方向表是写入方定的,方向倒序的那一位对应反向键;
+    // 只有正交两向出线段,对角步不挡视线。封堵盖掉的格不再出面,与它被移出可走层一致。
+    const int64_t nc = nx * ny;
+    for (int i = 0; i < 4; ++i) {
+        const int64_t dx = kGridStepDx[i];
+        const int64_t dy = kGridStepDy[i];
+        for (int64_t c = 0; c < nc; ++c) {
+            const uint8_t bits = static_cast<uint8_t>(stepbits[static_cast<size_t>(c)] >> (2 * i)) & 0x03U;
+            if (bits == 0 || info.lay.v[static_cast<size_t>(c)] == 0) {
+                continue;
+            }
+            const int64_t ax = c % nx + dx;
+            const int64_t ay = c / nx + dy;
+            if (ax < 0 || ax >= nx || ay < 0 || ay >= ny) {
+                continue;
+            }
+            const int64_t b = ay * nx + ax;
+            if ((bits & 0x01U) != 0) {
+                info.sev.steps.insert(c * nc + b);
+            }
+            if ((bits & 0x02U) != 0) {
+                info.sev.steps.insert(b * nc + c);
+            }
+            if (dx != 0 && dy != 0) {
+                continue;
+            }
+            const double px = x0 + static_cast<double>(c % nx + dx) * kCS;
+            const double py = y0 + static_cast<double>(c / nx + dy) * kCS;
+            info.sev.p0.push_back({ px, py });
+            info.sev.p1.push_back({ px + static_cast<double>(dy) * kCS, py + static_cast<double>(dx) * kCS });
+        }
+    }
 
     info.h0 = h0;
-    std::vector<uint8_t> have(static_cast<size_t>(nx * ny), 0);
-    for (size_t si = 0; si < vis.size(); ++si) {
-        if (vis[si] != 0) {
-            have[static_cast<size_t>(st.sp_cell[si])] = 1;
-        }
-    }
-    std::vector<int64_t> ghost;
-    for (int64_t c = 0; c < nx * ny && !info.sev.t0.empty(); ++c) {
-        if (info.lay.v[static_cast<size_t>(c)] != 0 && have[static_cast<size_t>(c)] == 0
-            && std::isfinite(info.sev.t0[static_cast<size_t>(c)])) {
-            ghost.push_back(c);
-        }
-    }
-    info.vis3 = vis;
-    if (ghost.empty()) {
-        info.st3 = st;
-    }
-    else {
-        std::vector<int64_t> gc3 = st.sp_cell;
-        std::vector<float> gh3 = st.sp_h;
-        for (const int64_t c : ghost) {
-            gc3.push_back(c);
-            gh3.push_back(info.sev.t0[static_cast<size_t>(c)]);
-            info.vis3.push_back(1);
-        }
-        info.st3 = PackSpans(std::move(gc3), std::move(gh3), &info.vis3);
-    }
-    info.cidx.assign(static_cast<size_t>(nx * ny), -1);
+    info.st3 = PackSpans(std::move(sp_cell), std::move(sp_h), &info.vis3);
+    info.cidx.assign(static_cast<size_t>(nc), -1);
     for (size_t ci = 0; ci < info.st3.occ.size(); ++ci) {
         info.cidx[static_cast<size_t>(info.st3.occ[ci])] = static_cast<int64_t>(ci);
     }
@@ -313,7 +383,7 @@ std::optional<WindowInfo> buildWindow(
     float best3 = 0.0F;
     for (int64_t k = 0; k < info.st3.K; ++k) {
         const int64_t sid = info.st3.IK[static_cast<size_t>(sj * info.st3.K + k)];
-        if (sid < 0) {
+        if (sid < 0 || info.vis3[static_cast<size_t>(sid)] == 0) {
             continue;
         }
         const float d = std::fabs(info.st3.sp_h[static_cast<size_t>(sid)] - static_cast<float>(h0));
@@ -322,106 +392,21 @@ std::optional<WindowInfo> buildWindow(
             best3 = d;
         }
     }
+    if (seed3 < 0) {
+        err = "起点格没有与终点同类的面";
+        return std::nullopt;
+    }
     info.reach3 = SpanReach(seed3, info.st3, info.vis3, nx, ny);
 
     info.segA = info.wP0;
     info.segA.insert(info.segA.end(), info.sev.p0.begin(), info.sev.p0.end());
     info.segB = info.wP1;
     info.segB.insert(info.segB.end(), info.sev.p1.begin(), info.sev.p1.end());
-    info.dist = Clearance(info.core);
-    return info;
-}
-
-bool layerWallClear(
-    const WindowInfo& info,
-    const LayerOracle& layer_oracle,
-    const std::vector<WorldPoint>& line,
-    float start_height,
-    std::optional<double> goal_deck)
-{
-    struct Hit
-    {
-        double route_t = 0.0;
-        double wall_height = 0.0;
-    };
-
-    constexpr double kIntersectionEpsilon = 1e-7;
-    // 拉直后的终线再对原始墙边逐交点验层。候选在交点若只剩与墙同高的
-    // 连续层就判死；上层墙与下层路线平面重叠时则不会互相误伤。
-    std::vector<float> heights { start_height };
-    for (size_t segment = 1; segment < line.size(); ++segment) {
-        const WorldPoint& p = line[segment - 1];
-        const WorldPoint& q = line[segment];
-        const double route_x = q.x - p.x;
-        const double route_y = q.y - p.y;
-        const double route_min_x = std::min(p.x, q.x);
-        const double route_max_x = std::max(p.x, q.x);
-        const double route_min_y = std::min(p.y, q.y);
-        const double route_max_y = std::max(p.y, q.y);
-        std::vector<Hit> hits;
-        for (size_t wall = 0; wall < info.sourceWallP0.size(); ++wall) {
-            const WorldPoint& a = info.sourceWallP0[wall];
-            const WorldPoint& b = info.sourceWallP1[wall];
-            if (std::max(a.x, b.x) < route_min_x || std::min(a.x, b.x) > route_max_x || std::max(a.y, b.y) < route_min_y
-                || std::min(a.y, b.y) > route_max_y) {
-                continue;
-            }
-            const double wall_x = b.x - a.x;
-            const double wall_y = b.y - a.y;
-            const double den = route_x * wall_y - route_y * wall_x;
-            if (std::abs(den) <= 1e-12) {
-                continue;
-            }
-            const double offset_x = a.x - p.x;
-            const double offset_y = a.y - p.y;
-            const double route_t = (offset_x * wall_y - offset_y * wall_x) / den;
-            const double wall_t = (offset_x * route_y - offset_y * route_x) / den;
-            if (route_t <= kIntersectionEpsilon || route_t >= 1.0 - kIntersectionEpsilon || wall_t <= kIntersectionEpsilon
-                || wall_t >= 1.0 - kIntersectionEpsilon) {
-                continue;
-            }
-            hits.push_back({ route_t, info.sourceWallH0[wall] + (info.sourceWallH1[wall] - info.sourceWallH0[wall]) * wall_t });
-        }
-        std::stable_sort(hits.begin(), hits.end(), [](const Hit& a, const Hit& b) { return a.route_t < b.route_t; });
-
-        WorldPoint cursor = p;
-        for (size_t first = 0; first < hits.size();) {
-            size_t last = first + 1;
-            while (last < hits.size() && std::abs(hits[last].route_t - hits[first].route_t) <= kIntersectionEpsilon) {
-                ++last;
-            }
-            const WorldPoint crossing {
-                p.x + route_x * hits[first].route_t,
-                p.y + route_y * hits[first].route_t,
-            };
-            auto at_crossing = layer_oracle.walk({ cursor, crossing }, heights);
-            if (!at_crossing.has_value()) {
-                return false;
-            }
-            std::erase_if(*at_crossing, [&](float height) {
-                for (size_t hit = first; hit < last; ++hit) {
-                    if (std::abs(static_cast<double>(height) - hits[hit].wall_height) <= kQH) {
-                        return true;
-                    }
-                }
-                return false;
-            });
-            if (at_crossing->empty()) {
-                return false;
-            }
-            heights = std::move(*at_crossing);
-            cursor = crossing;
-            first = last;
-        }
-        auto at_end = layer_oracle.walk({ cursor, q }, heights);
-        if (!at_end.has_value()) {
-            return false;
-        }
-        heights = std::move(*at_end);
+    // 烘出来的净空是没封堵时的;盖掉格子会让通道变窄,代价场得按盖过的核心重算
+    if (!blocked_local.empty() || !blocked_points.empty()) {
+        info.dist = Clearance(info.core);
     }
-    return !goal_deck.has_value() || std::any_of(heights.begin(), heights.end(), [&](float height) {
-        return std::abs(static_cast<double>(height) - *goal_deck) <= kDeckBand;
-    });
+    return info;
 }
 
 // goal_deck: 终点所在面的高度。不声明时终点集是该格全部 span,先够到哪张停哪张
@@ -429,11 +414,8 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const WindowInfo& info,
     const WorldPoint& s,
     const WorldPoint& g,
-    bool climb_faces,
     RouteDiag& dg,
-    std::optional<double> goal_deck = std::nullopt,
-    bool hard_walls = false,
-    bool validate_layer_walls = false)
+    std::optional<double> goal_deck)
 {
     const int64_t nx = info.nx;
     const int64_t ny = info.ny;
@@ -561,19 +543,6 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         }
         return best >= 0 && bd <= kDeckBand ? best : -1;
     };
-    // 起点的面只由起点自己的高度决定, 终点的声明不参与。h0 来自二维吸附,
-    // 重叠处可能落在屋顶, 所以终点声明了面时起点层不再当已知, 按 h0 由近到远逐张试
-    const auto seedsOf = [&](const std::vector<int64_t>& vs) -> std::vector<int64_t> {
-        if (!goal_deck.has_value()) {
-            return std::vector<int64_t> { atSeedLayer(vs) };
-        }
-        const auto h0 = static_cast<float>(info.h0);
-        std::vector<int64_t> out = vs;
-        std::stable_sort(out.begin(), out.end(), [&](const int64_t a, const int64_t b) {
-            return std::fabs(st3.sp_h[static_cast<size_t>(a)] - h0) < std::fabs(st3.sp_h[static_cast<size_t>(b)] - h0);
-        });
-        return out;
-    };
     // 终点声明是硬的: 收敛到单张 span, 匹配不上交空集让本级失败
     const auto goalsOf = [&](const std::vector<int64_t>& vs) {
         if (!goal_deck.has_value()) {
@@ -590,30 +559,29 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         return std::nullopt;
     }
 
+    // 禁步面是硬的,墙边只罚分:窄处绕不开时宁可贴着走也不判不连通
     const double BIGP = static_cast<double>(nx * ny) * kCS * (1.0 + kLam);
-    const std::unordered_set<int64_t>* faces = hard_walls ? &blocked_steps : (climb_faces ? nullptr : &info.sev.steps);
-    const std::unordered_set<int64_t>* soft = hard_walls ? nullptr : (climb_faces ? &blocked_steps : &bn);
-    const double* soft_penalty = hard_walls ? nullptr : &BIGP;
+    const std::unordered_set<int64_t>* faces = &info.sev.steps;
+    const std::unordered_set<int64_t>* soft = &bn;
+    const double* soft_penalty = &BIGP;
     Mask on3 = cw3;
-    // 起点层不确定时按 seedsOf 的次序逐张试, 第一张走通的就是它所在的面
+    // 可走集已经限死在终点那张面所属的类里, 起点这侧只剩层内挑高度
     const auto search = [&](const std::vector<uint8_t>& use,
                             const Mask& c3,
                             const std::vector<int64_t>& svs,
                             const std::vector<int64_t>& gs) -> std::optional<std::vector<int64_t>> {
-        for (const int64_t sd : seedsOf(svs)) {
-            auto r = SpanAstar(st3, use, info.cidx, c3, sd, gs, mult, soft, soft_penalty, faces);
-            if (r.has_value()) {
-                return r;
-            }
+        const int64_t sd = atSeedLayer(svs);
+        if (sd < 0) {
+            return std::nullopt;
         }
-        return std::nullopt;
+        return SpanAstar(st3, use, info.cidx, c3, sd, gs, mult, soft, soft_penalty, faces);
     };
     std::optional<std::vector<int64_t>> qs;
     if (as_->x == ag_->x && as_->y == ag_->y) {
         const std::vector<int64_t> vs = pick(*as_, useW);
         const std::vector<int64_t> gs = goalsOf(vs);
         if (!goal_deck.has_value()) {
-            qs = std::vector<int64_t> { seedsOf(vs).front() };
+            qs = std::vector<int64_t> { atSeedLayer(vs) };
         }
         else if (!gs.empty()) {
             qs = std::vector<int64_t> { gs.front() };
@@ -633,7 +601,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
                 const std::vector<int64_t> vs = pick(*ac_, useC);
                 const std::vector<int64_t> gs = goalsOf(vs);
                 if (!goal_deck.has_value()) {
-                    qs = std::vector<int64_t> { seedsOf(vs).front() };
+                    qs = std::vector<int64_t> { atSeedLayer(vs) };
                 }
                 else if (!gs.empty()) {
                     qs = std::vector<int64_t> { gs.front() };
@@ -682,10 +650,8 @@ std::optional<std::vector<WorldPoint>> routeWindow(
                 list += (list.empty() ? "" : ", ") + std::string(buf);
             }
             std::snprintf(buf, sizeof(buf), "%.2f", *goal_deck);
-            // 声明的面在表里就是这一跳连不上, 不在表里是这个坐标底下没有那张面
-            const std::string tail = atDeck(gv, *goal_deck) >= 0 ? "这一跳连不上, 拆成多段" : "该坐标下没有这张面";
-            dg.err = "目标面不可达 (声明 " + std::string(buf) + ", 终点格里的面 " + (list.empty() ? std::string("无") : "[" + list + "]")
-                     + ") — " + tail;
+            dg.err = "目标面不可达 (声明 " + std::string(buf) + ", 终点格里的面 "
+                     + (list.empty() ? std::string("无") : "[" + list + "]") + ")";
             return std::nullopt;
         }
         std::tie(as_, dsa) = near(walk, sc);
@@ -984,11 +950,6 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     if (out.size() > 2) {
         out = WidenCorners(out, blk_gray, dist, info.x0, info.y0, kCS, &cfl, lyo_p, lyo_h);
     }
-    if (validate_layer_walls
-        && (!qs.has_value() || !layerWallClear(info, lyo, out, st3.sp_h[static_cast<size_t>(qs->front())], goal_deck))) {
-        dg.err = "终线穿过当前层墙体";
-        return std::nullopt;
-    }
     dg.clearance.reserve(out.size());
     for (const auto& p : out) {
         const int64_t cx = std::min(std::max(static_cast<int64_t>(std::floor((p.x - info.x0) / kCS)), int64_t { 0 }), nx - 1);
@@ -1004,6 +965,14 @@ RecastNavEngine::RecastNavEngine(const BaseNavPack& pack, const BaseNavPlanner& 
     : pack_(pack)
     , planner_(planner)
 {
+    const BaseNavSection* sec = pack_.section(kGridSectionTag);
+    if (sec == nullptr) {
+        grid_error_ = "包里没有预烘格图段";
+        return;
+    }
+    if (!grid_.parse(sec->bytes.data(), sec->bytes.size(), grid_error_)) {
+        grid_ = GridPack();
+    }
 }
 
 RecastNavEngine::ZoneEntry& RecastNavEngine::zoneEntry(const std::string& name)
@@ -1029,10 +998,10 @@ RecastPlanResult RecastNavEngine::plan(
     float goal_deck_y,
     const std::vector<uint32_t>& blocked,
     const std::vector<WorldPoint>& blocked_points,
-    const RecastPlanBudget& budget)
+    const std::function<bool()>& should_stop)
 {
     const std::lock_guard<std::mutex> lock(mutex_);
-    return planLocked(zone_name, start, goal, start_floor_y, goal_floor_y, goal_deck_y, blocked, blocked_points, budget);
+    return planLocked(zone_name, start, goal, start_floor_y, goal_floor_y, goal_deck_y, blocked, blocked_points, should_stop);
 }
 
 RecastPlanResult RecastNavEngine::planLocked(
@@ -1044,9 +1013,18 @@ RecastPlanResult RecastNavEngine::planLocked(
     float goal_deck_y,
     const std::vector<uint32_t>& blocked,
     const std::vector<WorldPoint>& blocked_points,
-    const RecastPlanBudget& budget)
+    const std::function<bool()>& should_stop)
 {
     RecastPlanResult res;
+    if (!grid_.valid()) {
+        res.error = grid_error_;
+        return res;
+    }
+    const GridZoneDir* gz = grid_.findZone(zone_name);
+    if (gz == nullptr) {
+        res.error = "区没有预烘格图 (" + zone_name + ")";
+        return res;
+    }
     ZoneEntry& ze = zoneEntry(zone_name);
     if (!ze.zc->valid()) {
         res.error = ze.zc->error();
@@ -1078,160 +1056,49 @@ RecastPlanResult RecastNavEngine::planLocked(
     }
     const double h0 = triHeightOf(zc.mesh, ss->tri);
 
-    const double margins[4] = { kMargin, kMargin * 2, kMargin * 4, kMargin * 8 };
-    const int pass_count = (blocked.empty() && blocked_points.empty()) ? 8 : 1;
-    const auto plan_started_at = std::chrono::steady_clock::now();
-    const auto elapsed_ms = [&plan_started_at] {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - plan_started_at).count();
-    };
-    int64_t prev_cells = 0;
-    int64_t prev_ms = 0;
+    // 端点接不上可走层的腿在全区图上就能判掉。全区核心是任何窗口内核心的超集,
+    // 量出来的锚距是窗口里那把尺子的下界,过不了这道闸的腿换多大的窗口也接不上。
+    const double zsa = coreAnchorPx(grid_, *gz, start);
+    const double zga = coreAnchorPx(grid_, *gz, goal);
+    if (zsa > kSnapRadius || zga > kSnapRadius) {
+        char buf[128];
+        std::snprintf(buf, sizeof(buf), "端点接不上可走层 (起 %.1fpx / 终 %.1fpx, 疑似不连通)", zsa, zga);
+        res.error = buf;
+        return res;
+    }
+
+    // 扩窗只留两档。59 条生产腿里 ×100 与 ×200 零成功,只在必败腿上把时间烧掉。
+    constexpr int kWidenSteps = 2;
+    const double margins[kWidenSteps] = { kMargin, kMargin * 2 };
+    const int pass_count = (blocked.empty() && blocked_points.empty()) ? kWidenSteps : 1;
     std::string last_err;
-    bool widen_requested = false;
     for (int pass = 0; pass < pass_count; ++pass) {
-        const int mi = pass % 4;
-        const bool climb_faces = pass >= 4;
-        const double x0 = std::min(start.x, goal.x) - margins[mi];
-        const double y0 = std::min(start.y, goal.y) - margins[mi];
-        const double x1 = std::max(start.x, goal.x) + margins[mi];
-        const double y1 = std::max(start.y, goal.y) + margins[mi];
+        const bool last_margin = pass + 1 == kWidenSteps;
+        // 窗口边界对齐到全局网格。原点直接取 min-margin 时, 起点差 0.06px 就换一套体素相位,
+        // 同一段路两次规划得到的格子划分不同; 对齐后相位只由世界坐标决定, 与起终点无关。
+        const double x0 = std::floor((std::min(start.x, goal.x) - margins[pass]) / kCS) * kCS;
+        const double y0 = std::floor((std::min(start.y, goal.y) - margins[pass]) / kCS) * kCS;
+        const double x1 = std::ceil((std::max(start.x, goal.x) + margins[pass]) / kCS) * kCS;
+        const double y1 = std::ceil((std::max(start.y, goal.y) + margins[pass]) / kCS) * kCS;
         const int64_t nx = static_cast<int64_t>(std::ceil((x1 - x0) / kCS));
         const int64_t ny = static_cast<int64_t>(std::ceil((y1 - y0) / kCS));
         if (nx * ny > kMaxCells) {
             res.error = "窗口过大 (" + std::to_string(nx) + "×" + std::to_string(ny) + " 格)";
             return res;
         }
-        // 本档窗口按上一档实测速度外推,预算装不下就停在已有结论上。终点不连通时每档都是
-        // 同一个失败,而窗口面积逐档翻番,跑满四档能到分钟级;短途窗口小,外推值远在预算内。
-        if (pass > 0) {
-            if (budget.should_stop && budget.should_stop()) {
-                res.error = "规划已取消";
-                return res;
-            }
-            const int64_t projected_ms = prev_cells > 0 ? prev_ms * (nx * ny) / prev_cells : 0;
-            // 上一档主动要求扩窗(锚点出窗/终线触界)是有结论的重试,下一档通常就成,按整次预算走。
-            // 没要求就是同一个失败重来一遍,只把窗口翻番,用更紧的上限收住。
-            const int64_t limit = widen_requested ? budget.wall_ms : std::min(budget.wall_ms, budget.dead_end_ms);
-            if (elapsed_ms() + projected_ms > limit) {
-                char buf[192];
-                std::snprintf(
-                    buf,
-                    sizeof(buf),
-                    "%s (扩窗预算耗尽: 已用 %lldms, 下档 %lld×%lld 格约需 %lldms)",
-                    last_err.empty() ? "路线失败" : last_err.c_str(),
-                    static_cast<long long>(elapsed_ms()),
-                    static_cast<long long>(nx),
-                    static_cast<long long>(ny),
-                    static_cast<long long>(projected_ms));
-                res.error = buf;
-                return res;
-            }
+        if (pass > 0 && should_stop && should_stop()) {
+            res.error = "规划已取消";
+            return res;
         }
-        const int64_t pass_started_ms = elapsed_ms();
-        widen_requested = false;
         std::string err;
-        auto info = buildWindow(zc, wo, start, ss->point, h0, x0, y0, x1, y1, blocked_local, blocked_points, false, std::nullopt, err);
+        auto info = buildWindow(wo, grid_, *gz, zc, start, ss->point, goal, h0, gdk, x0, y0, x1, y1, blocked_local, blocked_points, err);
         if (info.has_value()) {
             RouteDiag dg;
-            auto line = routeWindow(*info, start, goal, climb_faces, dg, gdk);
-            const bool same_deck_recovery = gdk.has_value() && std::abs(h0 - *gdk) <= kDeckBand;
-            if (same_deck_recovery && !line.has_value()) {
-                // 成功的旧线路原样保留：f4768a05 明确保留不可避免的软约束步，
-                // 恢复寻路不能借声明面反向改写它。仅在旧拓扑确实失败时换稳定相位重建。
-                std::string recovery_err;
-                const double recovery_x0 = std::floor((x0 - kCS / 2.0) / kCS) * kCS + kCS / 2.0;
-                const double recovery_y0 = std::floor((y0 - kCS / 2.0) / kCS) * kCS + kCS / 2.0;
-                const double recovery_x1 = recovery_x0 + std::ceil((x1 - recovery_x0) / kCS) * kCS;
-                const double recovery_y1 = recovery_y0 + std::ceil((y1 - recovery_y0) / kCS) * kCS;
-                const int64_t recovery_nx = static_cast<int64_t>(std::ceil((recovery_x1 - recovery_x0) / kCS));
-                const int64_t recovery_ny = static_cast<int64_t>(std::ceil((recovery_y1 - recovery_y0) / kCS));
-                std::optional<WindowInfo> recovery_info;
-                if (recovery_nx * recovery_ny > kMaxCells) {
-                    recovery_err = "恢复窗口过大 (" + std::to_string(recovery_nx) + "×" + std::to_string(recovery_ny) + " 格)";
-                }
-                else {
-                    recovery_info = buildWindow(
-                        zc,
-                        wo,
-                        start,
-                        ss->point,
-                        h0,
-                        recovery_x0,
-                        recovery_y0,
-                        recovery_x1,
-                        recovery_y1,
-                        blocked_local,
-                        blocked_points,
-                        false,
-                        gdk,
-                        recovery_err);
-                }
-                if (recovery_info.has_value()) {
-                    RouteDiag recovery_dg;
-                    auto recovery_line = routeWindow(*recovery_info, start, goal, false, recovery_dg, gdk, false, true);
-                    if (recovery_line.has_value() && !recovery_dg.crossed_barrier) {
-                        info = std::move(recovery_info);
-                        line = std::move(recovery_line);
-                        dg = std::move(recovery_dg);
-                    }
-                    else {
-                        dg = std::move(recovery_dg);
-                    }
-                }
-                else {
-                    dg.err = std::move(recovery_err);
-                }
-                if (!line.has_value()) {
-                    // 稳定相位仍无安全终线时，退回完整分层且墙体硬约束的保守路径。
-                    const double hard_x0 = std::floor(x0 / kCS) * kCS;
-                    const double hard_y0 = std::floor(y0 / kCS) * kCS;
-                    const double hard_x1 = std::ceil(x1 / kCS) * kCS;
-                    const double hard_y1 = std::ceil(y1 / kCS) * kCS;
-                    const int64_t hard_nx = static_cast<int64_t>(std::ceil((hard_x1 - hard_x0) / kCS));
-                    const int64_t hard_ny = static_cast<int64_t>(std::ceil((hard_y1 - hard_y0) / kCS));
-                    std::string hard_err;
-                    std::optional<WindowInfo> hard_info;
-                    if (hard_nx * hard_ny > kMaxCells) {
-                        hard_err = "恢复窗口过大 (" + std::to_string(hard_nx) + "×" + std::to_string(hard_ny) + " 格)";
-                    }
-                    else {
-                        hard_info = buildWindow(
-                            zc,
-                            wo,
-                            start,
-                            ss->point,
-                            h0,
-                            hard_x0,
-                            hard_y0,
-                            hard_x1,
-                            hard_y1,
-                            blocked_local,
-                            blocked_points,
-                            true,
-                            gdk,
-                            hard_err);
-                    }
-                    if (hard_info.has_value()) {
-                        RouteDiag hard_dg;
-                        auto hard_line = routeWindow(*hard_info, start, goal, false, hard_dg, gdk, true, true);
-                        if (hard_line.has_value() && !hard_dg.crossed_barrier) {
-                            info = std::move(hard_info);
-                            line = std::move(hard_line);
-                            dg = std::move(hard_dg);
-                        }
-                        else {
-                            dg = std::move(hard_dg);
-                        }
-                    }
-                    else {
-                        dg.err = std::move(hard_err);
-                    }
-                }
-            }
+            auto line = routeWindow(*info, start, goal, dg, gdk);
             if (line.has_value()) {
                 // 锚点远 = 走廊出窗,同触界扩窗,否则末段盲跳穿墙
                 if (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius) {
-                    if (mi == 3) {
+                    if (last_margin) {
                         char buf[128];
                         std::snprintf(
                             buf,
@@ -1243,7 +1110,6 @@ RecastPlanResult RecastNavEngine::planLocked(
                         return res;
                     }
                     err = "端点锚点过远,扩窗重跑";
-                    widen_requested = true;
                 }
                 else {
                     double mnx = line->front().x;
@@ -1257,7 +1123,7 @@ RecastPlanResult RecastNavEngine::planLocked(
                         mxy = std::max(mxy, p.y);
                     }
                     const double pad = 2.0;
-                    if (mi == 3 || (mnx > x0 + pad && mxx < x1 - pad && mny > y0 + pad && mxy < y1 - pad)) {
+                    if (last_margin || (mnx > x0 + pad && mxx < x1 - pad && mny > y0 + pad && mxy < y1 - pad)) {
                         res.ok = true;
                         res.points = *line;
                         for (size_t i = 1; i < line->size(); ++i) {
@@ -1271,15 +1137,12 @@ RecastPlanResult RecastNavEngine::planLocked(
                         return res;
                     }
                     err = "终线触界,扩窗重跑";
-                    widen_requested = true;
                 }
             }
             else {
                 err = dg.err.empty() ? "路线失败" : dg.err;
             }
         }
-        prev_ms = std::max<int64_t>(elapsed_ms() - pass_started_ms, 1);
-        prev_cells = nx * ny;
         last_err = err;
     }
     res.error = last_err.empty() ? "路线失败" : last_err;

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -10,6 +10,7 @@
 
 #include "BaseNavPack.h"
 #include "BaseNavPlanner.h"
+#include "RecastNavGridIO.h"
 #include "RecastNavZone.h"
 
 namespace navmesh::recast
@@ -28,15 +29,6 @@ struct RecastPlanResult
     double snap_goal = 0.0;
 };
 
-// 逐档扩窗的预算。窗口面积随边距增长,不可达时每一档都要把整个窗口栅格化再搜一遍,
-// 跑满四档是分钟级。按上一档实测速度外推下一档,装不下就停在已有结论上。
-struct RecastPlanBudget
-{
-    int64_t wall_ms = 6000;            // 整次 plan 的墙钟上限
-    int64_t dead_end_ms = 6000;        // 上一档没要求扩窗时的上限:扩窗改不了结论,别一直把窗口翻番
-    std::function<bool()> should_stop; // 外部取消,逐档之间查
-};
-
 class RecastNavEngine
 {
 public:
@@ -45,7 +37,8 @@ public:
     // start/goal 各带楼层高度(<= kBaseNavFloorYValidMin ⇒ floor 盲吸附);
     // goal_deck_y = 终点所在重叠面的高度,选层用,与吸附用的 floor_y 是两件事;
     // blocked = pack 全局三角形号封堵集,命中格从可走层盖掉;
-    // blocked_points = 世界坐标封堵点,kBlockedPointRadius 半径内的格盖掉
+    // blocked_points = 世界坐标封堵点,kBlockedPointRadius 半径内的格盖掉;
+    // should_stop = 外部取消,两档窗口之间查一次
     RecastPlanResult plan(
         const std::string& zone_name,
         const WorldPoint& start,
@@ -55,7 +48,7 @@ public:
         float goal_deck_y = kBaseNavFloorYNone,
         const std::vector<uint32_t>& blocked = {},
         const std::vector<WorldPoint>& blocked_points = {},
-        const RecastPlanBudget& budget = {});
+        const std::function<bool()>& should_stop = {});
 
 private:
     struct ZoneEntry
@@ -74,12 +67,14 @@ private:
         float goal_deck_y,
         const std::vector<uint32_t>& blocked,
         const std::vector<WorldPoint>& blocked_points,
-        const RecastPlanBudget& budget);
+        const std::function<bool()>& should_stop);
 
     const BaseNavPack& pack_;
     const BaseNavPlanner& planner_;
     std::mutex mutex_;
     std::unordered_map<std::string, ZoneEntry> zones_;
+    GridPack grid_;         // 包里的预烘格图,没有它就没法规划
+    std::string grid_error_;
 };
 
 }

--- a/tools/MapNavigator/README.md
+++ b/tools/MapNavigator/README.md
@@ -178,6 +178,8 @@ assets/resource/model/map/navmesh/base.nav.gz
 assets/resource/model/map/navmesh/base.nav      # optional local fallback
 ```
 
+寻路要求包内带预烘格图段（`BGRD`，见 BaseNav 版本 4）；没有这一段的包仍可显示网格与底图，但点不出线路。
+
 可选 zone：
 
 ```text

--- a/tools/MapNavigator/basenav_geo.py
+++ b/tools/MapNavigator/basenav_geo.py
@@ -1,0 +1,177 @@
+"""BGEO 段解码:把四块几何还原成定长记录的规范字节。
+
+包里四块几何按定长块存,块内自足解码。这里是预览端的整段解码,一次解完所有块,
+返回的字节与旧版包里那四段裸表逐位相同 —— 上层的解析、索引、build hash 都不用动。
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+import numpy as np
+
+
+SECTION_TAG = b"BGEO"
+VERSION = 1
+HEADER_SIZE = 72
+CHUNK_ENTRY_SIZE = 16
+
+VERTEX_SIZE = 12
+TRIANGLE_SIZE = 36
+LINK_SIZE = 8
+
+# 三角块的流数:v0 差分、v1-v0、v2-v0、邻接位图、邻接残差、分量游程值、分量游程长。
+TRIANGLE_STREAMS = 7
+VERTEX_STREAMS = 1
+LINK_STREAMS = 2
+
+# varint 最长 10 字节(64 位 / 每字节 7 位)。
+_VARINT_MAX_BYTES = 10
+
+
+def _varints(stream: bytes) -> np.ndarray:
+    """一条 varint 流全解成 uint64。逐字节位置分层做,不走 Python 循环。"""
+    raw = np.frombuffer(stream, dtype=np.uint8)
+    if raw.size == 0:
+        return np.zeros(0, dtype=np.uint64)
+    tail = (raw & 0x80) == 0
+    # 第 i 个字节属于第 group[i] 个值:每遇到一个结尾字节,组号加一。
+    if not tail[-1]:
+        raise ValueError("varint 流末尾缺结尾字节")
+    group = np.empty(raw.size, dtype=np.int64)
+    group[0] = 0
+    np.cumsum(tail[:-1], out=group[1:])
+    count = int(group[-1]) + 1
+    starts = np.searchsorted(group, np.arange(count))
+    position = np.arange(raw.size, dtype=np.int64) - starts[group]
+    payload = (raw & 0x7F).astype(np.uint64)
+    out = np.zeros(count, dtype=np.uint64)
+    for shift in range(_VARINT_MAX_BYTES):
+        picked = position == shift
+        if not picked.any():
+            break
+        out[group[picked]] |= payload[picked] << np.uint64(7 * shift)
+    return out
+
+
+def _unzigzag(values: np.ndarray) -> np.ndarray:
+    return (values >> np.uint64(1)).astype(np.int64) ^ -(values & np.uint64(1)).astype(np.int64)
+
+
+def _split_streams(chunk: memoryview, count: int) -> list[bytes]:
+    """块载荷 = 若干条「varint 长度 + deflate 流」,条数由表类型定死。"""
+    out = []
+    at = 0
+    for _ in range(count):
+        length = 0
+        shift = 0
+        while True:
+            byte = chunk[at]
+            at += 1
+            length |= (byte & 0x7F) << shift
+            if byte & 0x80 == 0:
+                break
+            shift += 7
+        out.append(zlib.decompress(chunk[at:at + length]))
+        at += length
+    if at != len(chunk):
+        raise ValueError("BGEO 块尾有多余字节")
+    return out
+
+
+def _decode_vertex_chunk(chunk: memoryview, count: int) -> np.ndarray:
+    """顶点做过字节平面重排:n×12 转置成 12×n,这里转回去。"""
+    plane = np.frombuffer(_split_streams(chunk, VERTEX_STREAMS)[0], dtype=np.uint8)
+    if plane.size != count * VERTEX_SIZE:
+        raise ValueError("BGEO 顶点块长度与记录数对不上")
+    return plane.reshape(VERTEX_SIZE, count).T
+
+
+def _decode_triangle_chunk(chunk: memoryview, count: int, first: int) -> np.ndarray:
+    streams = _split_streams(chunk, TRIANGLE_STREAMS)
+    v0 = np.cumsum(_unzigzag(_varints(streams[0])))
+    v1 = v0 + _unzigzag(_varints(streams[1]))
+    v2 = v0 + _unzigzag(_varints(streams[2]))
+
+    bits = np.unpackbits(np.frombuffer(streams[3], dtype=np.uint8))[:count * 3].astype(bool)
+    self_index = np.repeat(np.arange(first, first + count, dtype=np.int64), 3)
+    neighbors = np.full(count * 3, -1, dtype=np.int64)
+    neighbors[bits] = self_index[bits] + _unzigzag(_varints(streams[4]))
+
+    run_value = np.cumsum(_unzigzag(_varints(streams[5])))
+    run_length = _varints(streams[6]).astype(np.int64)
+    components = np.repeat(run_value, run_length)
+    if components.size != count or v0.size != count:
+        raise ValueError("BGEO 三角块的记录数对不上")
+
+    out = np.empty((count, 9), dtype=np.uint32)
+    out[:, 0] = v0
+    out[:, 1] = v1
+    out[:, 2] = v2
+    out[:, 3:6] = neighbors.reshape(count, 3).astype(np.int32).view(np.uint32)
+    out[:, 6] = components
+    return out
+
+
+def _decode_link_chunk(chunk: memoryview, count: int) -> np.ndarray:
+    streams = _split_streams(chunk, LINK_STREAMS)
+    source = np.cumsum(_varints(streams[0]).astype(np.int64))
+    target = source + _unzigzag(_varints(streams[1]))
+    if source.size != count:
+        raise ValueError("BGEO 连接块的记录数对不上")
+    out = np.empty((count, 2), dtype=np.uint32)
+    out[:, 0] = source
+    out[:, 1] = target
+    return out
+
+
+class _ChunkTable:
+    __slots__ = ("section", "directory", "chunk", "total")
+
+    def __init__(self, section: memoryview, directory: int, chunk: int, total: int) -> None:
+        self.section = section
+        self.directory = directory
+        self.chunk = chunk
+        self.total = total
+
+    def __len__(self) -> int:
+        return (self.total + self.chunk - 1) // self.chunk if self.chunk else 0
+
+    def span(self, index: int) -> int:
+        return min(self.chunk, self.total - index * self.chunk)
+
+    def bytes(self, index: int) -> memoryview:
+        at = self.directory + index * CHUNK_ENTRY_SIZE
+        offset, size, _aux = struct.unpack_from("<QII", self.section, at)
+        return self.section[offset:offset + size]
+
+
+def decode_geometry(section: memoryview) -> tuple[memoryview, bytes, bytes, bytes]:
+    """整段解码,返回 (区表, 顶点, 三角, 连接) 四块的规范字节。
+
+    重心不在包里,按 ``((a+b)+c)/3`` 重算 —— float32 下与写成乘 1/3 不逐位相同。
+    """
+    if len(section) < HEADER_SIZE or bytes(section[0:4]) != SECTION_TAG:
+        raise ValueError("BGEO 段头不对")
+    version, vertex_count, triangle_count, link_count = struct.unpack_from("<4I", section, 4)
+    if version != VERSION:
+        raise ValueError("unsupported BGEO version")
+    vertex_chunk, triangle_chunk, link_chunk, zone_size, _reserved = struct.unpack_from("<5I", section, 20)
+    vertex_dir, triangle_dir, link_dir, zone_at = struct.unpack_from("<4Q", section, 40)
+
+    table = _ChunkTable(section, vertex_dir, vertex_chunk, vertex_count)
+    vertices = np.concatenate([_decode_vertex_chunk(table.bytes(i), table.span(i)) for i in range(len(table))]).tobytes()
+    table = _ChunkTable(section, triangle_dir, triangle_chunk, triangle_count)
+    triangles = np.concatenate(
+        [_decode_triangle_chunk(table.bytes(i), table.span(i), i * triangle_chunk) for i in range(len(table))]
+    )
+    table = _ChunkTable(section, link_dir, link_chunk, link_count)
+    links = np.concatenate([_decode_link_chunk(table.bytes(i), table.span(i)) for i in range(len(table))])
+
+    coord = np.frombuffer(vertices, dtype=np.float32).reshape(vertex_count, 3)[:, :2]
+    corner = coord[triangles[:, 0:3].astype(np.int64)]
+    center = ((corner[:, 0] + corner[:, 1]) + corner[:, 2]) / np.float32(3.0)
+    triangles[:, 7:9] = center.view(np.uint32)
+
+    return section[zone_at:zone_at + zone_size], vertices, triangles.tobytes(), links.tobytes()

--- a/tools/MapNavigator/basenav_preview.py
+++ b/tools/MapNavigator/basenav_preview.py
@@ -10,11 +10,14 @@ from pathlib import Path
 
 import numpy as np
 
+from basenav_geo import SECTION_TAG as GEOMETRY_TAG, decode_geometry
+
 
 MAGIC = b"BNAV"
-VERSION = 4  # v4 appends a section directory to the header; zone records are unchanged from v3
+VERSION = 5  # v5 moves the four geometry blocks into the BGEO section; the header offsets go unused
 VERSION_MIN = 2  # oldest on-disk version still accepted; v2 zone records lack floor_y -> FLOOR_Y_NONE
 SECTION_DIR_SINCE = 4  # header carries section_dir_offset/section_count from this version on
+GEOMETRY_SECTION_SINCE = 5  # zone table + vertices + triangles + links live in the BGEO section
 FNV_OFFSET = 14695981039346656037
 FNV_PRIME = 1099511628211
 # Sentinel floor height for tier zones whose dominant walkable floor is unknown (the two
@@ -699,14 +702,6 @@ def _read_basenav(
     link_offset = int(header_values[10])
     build_hash = int(header_values[11])
 
-    if zone_table_offset < header_size:
-        raise ValueError("invalid BaseNav zone offset")
-    if vertex_offset < zone_table_offset:
-        raise ValueError("invalid BaseNav vertex offset")
-    if triangle_offset < vertex_offset:
-        raise ValueError("invalid BaseNav triangle offset")
-    if link_offset < triangle_offset:
-        raise ValueError("invalid BaseNav link offset")
     if link_count <= 0:
         raise ValueError("BaseNav v2 requires link table")
 
@@ -722,10 +717,27 @@ def _read_basenav(
                 raise ValueError("BaseNav section is outside file bounds")
             sections[tag] = data[offset:offset + size]
 
-    zone_table = data[zone_table_offset:vertex_offset]
-    vertex_data = data[vertex_offset:vertex_offset + VERTEX_STRUCT.size * vertex_count]
-    triangle_data = data[triangle_offset:triangle_offset + TRIANGLE_STRUCT.size * triangle_count]
-    link_data = data[link_offset:link_offset + LINK_STRUCT.size * link_count]
+    if version >= GEOMETRY_SECTION_SINCE:
+        if GEOMETRY_TAG not in sections:
+            raise ValueError("BaseNav geometry section is missing")
+        zone_table, vertex_data, triangle_data, link_data = decode_geometry(sections[GEOMETRY_TAG])
+        zone_table_offset = 0
+        vertex_offset = len(zone_table)
+        data_for_zones = zone_table
+    else:
+        if zone_table_offset < header_size:
+            raise ValueError("invalid BaseNav zone offset")
+        if vertex_offset < zone_table_offset:
+            raise ValueError("invalid BaseNav vertex offset")
+        if triangle_offset < vertex_offset:
+            raise ValueError("invalid BaseNav triangle offset")
+        if link_offset < triangle_offset:
+            raise ValueError("invalid BaseNav link offset")
+        zone_table = data[zone_table_offset:vertex_offset]
+        vertex_data = data[vertex_offset:vertex_offset + VERTEX_STRUCT.size * vertex_count]
+        triangle_data = data[triangle_offset:triangle_offset + TRIANGLE_STRUCT.size * triangle_count]
+        link_data = data[link_offset:link_offset + LINK_STRUCT.size * link_count]
+        data_for_zones = data
     # build hash 校验是逐字节串行的 FNV-1a,无法矢量化;挪到后台线程,显示后再核对(见 _DeferredVerifier)。
     verifier = _DeferredVerifier((zone_table, vertex_data, triangle_data, link_data), build_hash)
 
@@ -734,10 +746,10 @@ def _read_basenav(
     cursor = zone_table_offset
     zone_struct = ZONE_STRUCT if version >= 3 else ZONE_STRUCT_V2
     for _index in range(zone_count):
-        values = zone_struct.unpack_from(data, offset=cursor)
+        values = zone_struct.unpack_from(data_for_zones, offset=cursor)
         cursor += zone_struct.size
         name_size = int(values[2])
-        name = data[cursor:cursor + name_size].tobytes().decode("utf-8")
+        name = bytes(data_for_zones[cursor:cursor + name_size]).decode("utf-8")
         cursor += name_size
         zones.append(
             _BaseNavZone(

--- a/tools/MapNavigator/basenav_preview.py
+++ b/tools/MapNavigator/basenav_preview.py
@@ -12,8 +12,9 @@ import numpy as np
 
 
 MAGIC = b"BNAV"
-VERSION = 3  # v3 appends a per-zone float `floor_y` to each zone record; v2 had none
+VERSION = 4  # v4 appends a section directory to the header; zone records are unchanged from v3
 VERSION_MIN = 2  # oldest on-disk version still accepted; v2 zone records lack floor_y -> FLOOR_Y_NONE
+SECTION_DIR_SINCE = 4  # header carries section_dir_offset/section_count from this version on
 FNV_OFFSET = 14695981039346656037
 FNV_PRIME = 1099511628211
 # Sentinel floor height for tier zones whose dominant walkable floor is unknown (the two
@@ -39,6 +40,8 @@ SNAP_FALLBACK_RADIUS = 16.0  # snap 初查(按调用方半径)无果时的兜底
 TIER_FLAG = 0x0001
 
 HEADER_STRUCT = struct.Struct("<4sHHIIIIQQQQQ")
+HEADER_TAIL_STRUCT = struct.Struct("<QII")  # v4 header tail: 段目录偏移 + 段数 + 保留字
+SECTION_STRUCT = struct.Struct("<4sIQQ")  # 段目录一项: tag + flags + offset + size
 ZONE_STRUCT = struct.Struct("<HHIIIIff4ff")  # v3: ...transform(4f) + floor_y(f)
 ZONE_STRUCT_V2 = struct.Struct("<HHIIIIff4f")  # v2: legacy zone record without floor_y
 VERTEX_STRUCT = struct.Struct("<fff")
@@ -182,7 +185,7 @@ class BaseNavField:
     def __init__(self, path: Path, bin_size: float = INDEX_BIN_SIZE, progress_callback=None) -> None:
         self.path = path
         self.bin_size = bin_size
-        self.zones, self.vertices, self.triangles, self._arrays, self._verifier = _read_basenav(
+        self.zones, self.vertices, self.triangles, self._arrays, self._verifier, self.sections = _read_basenav(
             path, progress_callback=progress_callback
         )
         self.zone_by_id = {zone.zone_id: zone for zone in self.zones}
@@ -669,7 +672,7 @@ class BaseNavField:
 
 def _read_basenav(
     path: Path, progress_callback=None
-) -> tuple[list[_BaseNavZone], np.ndarray, np.ndarray, _NavArrays, _DeferredVerifier]:
+) -> tuple[list[_BaseNavZone], np.ndarray, np.ndarray, _NavArrays, _DeferredVerifier, dict[bytes, memoryview]]:
     data = _read_basenav_bytes_mv(path)
     _report_progress(progress_callback, 0.03)
     if len(data) < HEADER_STRUCT.size:
@@ -682,6 +685,10 @@ def _read_basenav(
     if not (VERSION_MIN <= version <= VERSION):
         raise ValueError("unsupported BaseNav version")
 
+    header_size = HEADER_STRUCT.size + (HEADER_TAIL_STRUCT.size if version >= SECTION_DIR_SINCE else 0)
+    if len(data) < header_size:
+        raise ValueError("file is smaller than BaseNav header")
+
     zone_count = int(header_values[3])
     vertex_count = int(header_values[4])
     triangle_count = int(header_values[5])
@@ -692,7 +699,7 @@ def _read_basenav(
     link_offset = int(header_values[10])
     build_hash = int(header_values[11])
 
-    if zone_table_offset < HEADER_STRUCT.size:
+    if zone_table_offset < header_size:
         raise ValueError("invalid BaseNav zone offset")
     if vertex_offset < zone_table_offset:
         raise ValueError("invalid BaseNav vertex offset")
@@ -702,6 +709,18 @@ def _read_basenav(
         raise ValueError("invalid BaseNav link offset")
     if link_count <= 0:
         raise ValueError("BaseNav v2 requires link table")
+
+    # 段目录挂在四块原始段之外,build hash 不含它;段字节是 data 上的零拷贝切片。
+    sections: dict[bytes, memoryview] = {}
+    if version >= SECTION_DIR_SINCE:
+        section_dir_offset, section_count, _reserved = HEADER_TAIL_STRUCT.unpack_from(data, HEADER_STRUCT.size)
+        if section_count and section_dir_offset + section_count * SECTION_STRUCT.size > len(data):
+            raise ValueError("BaseNav section directory is outside file bounds")
+        for index in range(section_count):
+            tag, _flags, offset, size = SECTION_STRUCT.unpack_from(data, section_dir_offset + index * SECTION_STRUCT.size)
+            if offset + size > len(data):
+                raise ValueError("BaseNav section is outside file bounds")
+            sections[tag] = data[offset:offset + size]
 
     zone_table = data[zone_table_offset:vertex_offset]
     vertex_data = data[vertex_offset:vertex_offset + VERTEX_STRUCT.size * vertex_count]
@@ -765,7 +784,7 @@ def _read_basenav(
     _report_progress(progress_callback, 0.36)
 
     arrays = _NavArrays(tri_v, tri_n, vu, vv, vh, link_src, link_tgt)
-    return zones, vertices, triangles, arrays, verifier
+    return zones, vertices, triangles, arrays, verifier, sections
 
 
 def _read_basenav_bytes_mv(path: Path) -> memoryview:

--- a/tools/MapNavigator/recastnav.py
+++ b/tools/MapNavigator/recastnav.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import heapq
 import math
-from collections import deque
 
 import numpy as np
 
@@ -10,7 +9,6 @@ CS = 0.25          # 体素边长 px
 CLIMB = 3.0        # 相邻格可连通最大高差 px
 SLOPE = 1.0        # 可攀爬坡度上限 tanθ, 抬升超过水平位移的这个倍数即立面, 只能绕行
 UP = SLOPE * CS    # 正交相邻格允许的抬升 px, 斜向按实际水平位移等比放大
-MERGE_H = UP       # 同列 span 合并容差 px, 取 UP 使同层内处处可一步跨到
 QH = 1.0           # 体素取样高差容差 px, 需装下斜面单格起伏与格心取样偏差
 EDT_CAP = 12.0     # 距离场截断 px
 R = 1.75           # 期望余量上限 px
@@ -38,124 +36,11 @@ EPS_PROBE = 0.75   # 真墙探针距离 px
 SNAP_RADIUS = 8.0  # 起终点吸附半径 px
 DECK_BAND = 2.0    # 声明面高度匹配容差 px, 需远小于相邻面间距
 MARGIN = 25.0      # 窗口外扩 px
-HOLE_MAX = max(1, int(round(2.0 / (CS * CS))))  # 封闭小洞填充上限(格 = 2px²)
 MAX_CELLS = 30_000_000
-PLAN_BUDGET_MS = 6000  # 逐档扩窗的墙钟上限,与 RecastNavRoute.h 的 RecastPlanBudget 同步
 
 _NB8 = [(1, 0, 1.0), (-1, 0, 1.0), (0, 1, 1.0), (0, -1, 1.0),
         (1, 1, math.sqrt(2)), (1, -1, math.sqrt(2)),
         (-1, 1, math.sqrt(2)), (-1, -1, math.sqrt(2))]
-
-
-def rasterize(V, H, T, ox, oy, nx, ny, cs=CS, chunk=2_000_000):
-    A, B, C = V[T[:, 0]], V[T[:, 1]], V[T[:, 2]]
-    HA, HB, HC = H[T[:, 0]], H[T[:, 1]], H[T[:, 2]]
-
-    fx = np.stack([A[:, 0], B[:, 0], C[:, 0]], 1)
-    fy = np.stack([A[:, 1], B[:, 1], C[:, 1]], 1)
-    ix0 = np.floor((fx.min(1) - ox) / cs).astype(np.int64)
-    ix1 = np.floor((fx.max(1) - ox) / cs).astype(np.int64)
-    iy0 = np.floor((fy.min(1) - oy) / cs).astype(np.int64)
-    iy1 = np.floor((fy.max(1) - oy) / cs).astype(np.int64)
-    keep = (ix1 >= 0) & (ix0 < nx) & (iy1 >= 0) & (iy0 < ny)
-    if not keep.any():
-        return (np.zeros(0, np.int64), np.zeros(0, np.float32),
-                np.zeros(0, bool))
-    ix0 = np.clip(ix0[keep], 0, nx - 1); ix1 = np.clip(ix1[keep], 0, nx - 1)
-    iy0 = np.clip(iy0[keep], 0, ny - 1); iy1 = np.clip(iy1[keep], 0, ny - 1)
-    A, B, C = A[keep], B[keep], C[keep]
-    HA, HB, HC = HA[keep], HB[keep], HC[keep]
-
-    w = (ix1 - ix0 + 1); h = (iy1 - iy0 + 1); cnt = w * h
-    cum = np.cumsum(cnt)
-    cells, hts, ins = [], [], []
-
-    lo = 0
-    while lo < len(cnt):
-        hi = int(np.searchsorted(cum, (cum[lo - 1] if lo else 0) + chunk)) + 1
-        hi = min(max(hi, lo + 1), len(cnt))
-        sl = slice(lo, hi)
-        c_ = cnt[sl]; tot = int(c_.sum())
-        tid = np.repeat(np.arange(lo, hi), c_)
-        base = np.repeat(np.concatenate(([0], np.cumsum(c_)[:-1])), c_)
-        k = np.arange(tot) - base
-        wr = np.repeat(w[sl], c_)
-        gx = np.repeat(ix0[sl], c_) + k % wr
-        gy = np.repeat(iy0[sl], c_) + k // wr
-        px = ox + (gx + 0.5) * cs
-        py = oy + (gy + 0.5) * cs
-
-        a = A[tid]; b = B[tid]; c = C[tid]
-        ctr = np.stack([px, py], 1)
-        hcs = cs * 0.5
-        v = [a - ctr, b - ctr, c - ctr]
-        ok = np.ones(tot, bool)
-        for ax in (0, 1):
-            lo_ = np.minimum(np.minimum(v[0][:, ax], v[1][:, ax]), v[2][:, ax])
-            hi_ = np.maximum(np.maximum(v[0][:, ax], v[1][:, ax]), v[2][:, ax])
-            ok &= (lo_ <= hcs) & (hi_ >= -hcs)
-        for i in range(3):
-            e = v[(i + 1) % 3] - v[i]
-            n0, n1 = -e[:, 1], e[:, 0]
-            p = np.stack([v[j][:, 0] * n0 + v[j][:, 1] * n1
-                          for j in range(3)], 1)
-            rad = hcs * (np.abs(n0) + np.abs(n1))
-            ok &= (p.min(1) <= rad) & (p.max(1) >= -rad)
-        if ok.any():
-            k2 = np.nonzero(ok)[0]
-            e1 = b[k2] - a[k2]; e2 = c[k2] - a[k2]; q = ctr[k2] - a[k2]
-            den = e1[:, 0] * e2[:, 1] - e1[:, 1] * e2[:, 0]
-            den = np.where(np.abs(den) < 1e-12, 1e-12, den)
-            t_ = (q[:, 0] * e2[:, 1] - q[:, 1] * e2[:, 0]) / den
-            s_ = (e1[:, 0] * q[:, 1] - e1[:, 1] * q[:, 0]) / den
-            inside = (t_ >= -1e-12) & (s_ >= -1e-12) & (t_ + s_ <= 1 + 1e-12)
-            t_ = np.clip(t_, 0.0, 1.0); s_ = np.clip(s_, 0.0, 1.0 - t_)
-            i2 = tid[k2]
-            hz = HA[i2] + t_ * (HB[i2] - HA[i2]) + s_ * (HC[i2] - HA[i2])
-            cells.append(gy[k2] * nx + gx[k2])
-            hts.append(hz.astype(np.float32))
-            ins.append(inside)
-        lo = hi
-
-    cx = (A[:, 0] + B[:, 0] + C[:, 0]) / 3.0
-    cy = (A[:, 1] + B[:, 1] + C[:, 1]) / 3.0
-    gx = np.clip(((cx - ox) / cs).astype(np.int64), 0, nx - 1)
-    gy = np.clip(((cy - oy) / cs).astype(np.int64), 0, ny - 1)
-    inb = (cx >= ox) & (cx < ox + nx * cs) & (cy >= oy) & (cy < oy + ny * cs)
-    cells.append(gy[inb] * nx + gx[inb])
-    hts.append(((HA + HB + HC) / 3.0)[inb].astype(np.float32))
-    ins.append(np.zeros(int(inb.sum()), bool))
-
-    return np.concatenate(cells), np.concatenate(hts), np.concatenate(ins)
-
-
-def spans(cell, hz, merge_h=MERGE_H):
-    o = np.lexsort((hz, cell))
-    cell = cell[o]; hz = hz[o]
-    new = np.empty(len(cell), bool); new[0] = True
-    new[1:] = cell[1:] != cell[:-1]
-    head = np.flatnonzero(new)
-    cnt = np.diff(np.append(head, len(cell)))
-    anc = hz[head].astype(np.float64)
-    for r in range(1, int(cnt.max()) if len(cnt) else 1):
-        sel = np.flatnonzero(cnt > r)
-        if not len(sel):
-            break
-        idx = head[sel] + r
-        over = hz[idx] - anc[sel] > merge_h
-        if not over.any():
-            continue
-        new[idx[over]] = True
-        anc[sel[over]] = hz[idx[over]]
-    sid = np.cumsum(new) - 1
-    n = int(sid[-1]) + 1
-    cntv = np.bincount(sid, minlength=n)
-    sp_h = (np.bincount(sid, weights=hz.astype(np.float64), minlength=n)
-            / cntv).astype(np.float32)
-    sp_cell = cell[new]
-    occ, cstart, ccnt = np.unique(sp_cell, return_index=True,
-                                  return_counts=True)
-    return sp_cell, sp_h, occ, cstart, ccnt
 
 
 def dense_k(sp_h, occ, cstart, ccnt):
@@ -168,85 +53,6 @@ def dense_k(sp_h, occ, cstart, ccnt):
     HK[ci, rank] = sp_h
     IK[ci, rank] = np.arange(len(sp_h))
     return HK, IK, ci
-
-
-def seam_bridge(cell, hz, nx, ny, cs=CS, climb=CLIMB):
-    kb = int(round(0.5 / cs)) - 1
-    if kb <= 0 or not len(cell):
-        return np.zeros(0, np.int64), np.zeros(0, np.float32)
-    sp_cell, sp_h, occ, cstart, ccnt = spans(cell, hz)
-    HK, IK, _ = dense_k(sp_h, occ, cstart, ccnt)
-    K = HK.shape[1]
-    O2 = np.zeros(nx * ny, bool); O2[occ] = True
-    O2 = O2.reshape(ny, nx)
-    E = ~O2
-    idx2 = np.arange(nx * ny).reshape(ny, nx)
-    add_c, add_h = [], []
-    for dy, dx in ((0, 1), (1, 0)):
-        for dl in range(1, kb + 1):
-            for dr in range(1, kb + 2 - dl):
-                m = E.copy()
-                for i in range(1, dl):
-                    m &= _sh(E, i * dy, i * dx)
-                for i in range(1, dr):
-                    m &= _sh(E, -i * dy, -i * dx)
-                m &= _sh(O2, dl * dy, dl * dx)
-                m &= _sh(O2, -dr * dy, -dr * dx)
-                if not m.any():
-                    continue
-                cid = idx2[m]
-                a = cid + dl * (dy * nx + dx)
-                b = cid - dr * (dy * nx + dx)
-                ja = np.searchsorted(occ, a)
-                jb = np.searchsorted(occ, b)
-                # 空槽 inf-inf=nan 会毒化 argmin,两侧用相反哨兵
-                ha = np.where(np.isfinite(HK[ja]), HK[ja], np.float32(1e9))
-                hb = np.where(np.isfinite(HK[jb]), HK[jb], np.float32(-1e9))
-                dh = np.abs(ha[:, :, None] - hb[:, None, :])
-                fl = dh.reshape(len(cid), -1)
-                best = fl.argmin(1)
-                ok = fl[np.arange(len(cid)), best] <= climb
-                if not ok.any():
-                    continue
-                p, q = best // K, best % K
-                hm = (ha[np.arange(len(cid)), p]
-                      + hb[np.arange(len(cid)), q]) * np.float32(0.5)
-                add_c.append(cid[ok]); add_h.append(hm[ok])
-    if not add_c:
-        return np.zeros(0, np.int64), np.zeros(0, np.float32)
-    return np.concatenate(add_c), np.concatenate(add_h).astype(np.float32)
-
-
-def flood(seed, sp_h, occ, HK, IK, sp_ci, nx, climb=CLIMB):
-    vis = np.zeros(len(sp_h), bool)
-    vis[seed] = True
-    F = np.array([seed], np.int64)
-    while len(F):
-        nxt = []
-        cid = occ[sp_ci[F]]
-        gx = cid % nx
-        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
-            tgt = cid + dy * nx + dx
-            good = np.ones(len(F), bool)
-            if dx:
-                good &= (gx + dx >= 0) & (gx + dx < nx)
-            j = np.searchsorted(occ, tgt)
-            good &= (j < len(occ))
-            jj = np.where(good, np.minimum(j, len(occ) - 1), 0)
-            good &= occ[jj] == tgt
-            if not good.any():
-                continue
-            src = F[good]; jj = jj[good]
-            m = np.abs(HK[jj] - sp_h[src][:, None]) <= climb
-            cand = IK[jj][m]
-            cand = cand[cand >= 0]
-            cand = cand[~vis[cand]]
-            if len(cand):
-                cand = np.unique(cand)
-                vis[cand] = True
-                nxt.append(cand)
-        F = np.concatenate(nxt) if nxt else np.zeros(0, np.int64)
-    return vis
 
 
 def span_reach(seed, sp_h, occ, HK, IK, sp_ci, ok, nx, ny,
@@ -422,74 +228,6 @@ class LayerOracle:
         return hq is None or bool((np.abs(cur - hq) <= 1e-3).any())
 
 
-def _step_heights(occ, HK, IK, vis, lay, nx, ny):
-    HV = np.where((IK >= 0) & vis[np.maximum(IK, 0)], HK, np.inf)
-    T = np.full((nx * ny, HV.shape[1]), np.inf, np.float32)
-    T[occ] = np.sort(HV, axis=1)
-    ghost = lay.ravel() & ~np.isfinite(T[:, 0])
-    if ghost.any():
-        gm = ghost.reshape(ny, nx)
-        g = T[:, 0].reshape(ny, nx).copy()
-        for _ in range(int(np.ceil(np.sqrt(HOLE_MAX))) + 1):
-            p = g
-            n = g
-            for dy, dx in ((0, 1), (0, -1), (1, 0), (-1, 0)):
-                s = np.full_like(g, np.inf)
-                s[max(dy, 0):ny + min(dy, 0), max(dx, 0):nx + min(dx, 0)] = \
-                    g[-min(dy, 0):ny - max(dy, 0) or None,
-                      -min(dx, 0):nx - max(dx, 0) or None]
-                n = np.minimum(n, s)
-            g = np.where(gm, n, p)
-            if np.array_equal(g, p):
-                break
-        T[ghost, 0] = g.ravel()[ghost]
-    return T
-
-
-def step_breaks(occ, HK, IK, vis, lay, nx, ny, ox, oy, cs=CS, slope=SLOPE):
-    out = set()
-    NC = nx * ny
-    src = np.nonzero(lay.ravel())[0]
-    if not len(src) or not np.isfinite(slope):
-        return out, (np.zeros((0, 2)), np.zeros((0, 2)))
-    T = _step_heights(occ, HK, IK, vis, lay, nx, ny)
-    K = T.shape[1]
-    src = src[np.isfinite(T[src, 0])]
-    ea, eb = [], []
-    gx, gy = src % nx, src // nx
-    for dx, dy in ((1, 0), (0, 1), (1, 1), (1, -1)):
-        ax, ay = gx + dx, gy + dy
-        m = (ax >= 0) & (ax < nx) & (ay >= 0) & (ay < ny)
-        nb = np.where(m, ay * nx + ax, 0)
-        m &= np.isfinite(T[nb, 0])
-        if not m.any():
-            continue
-        a, b = src[m], nb[m]
-        A, B = T[a], T[b]
-        with np.errstate(invalid="ignore"):
-            d = np.abs(A[:, :, None] - B[:, None, :])
-        d = np.where(np.isfinite(d), d, np.inf).reshape(len(a), -1)
-        k = d.argmin(1)
-        r = np.arange(len(a))
-        bad = d[r, k] > slope * math.hypot(dx, dy) * cs
-        if not bad.any():
-            continue
-        a, b = a[bad], b[bad]
-        up = B[r[bad], k[bad] % K] > A[r[bad], k[bad] // K]
-        frm = np.where(up, a, b)
-        to = np.where(up, b, a)
-        out.update((frm * NC + to).tolist())
-        if dx and dy:
-            continue
-        px = ox + (a % nx + dx) * cs
-        py = oy + (a // nx + dy) * cs
-        ea.append(np.column_stack([px, py]))
-        eb.append(np.column_stack([px + dy * cs, py + dx * cs]))
-    if not ea:
-        return out, (np.zeros((0, 2)), np.zeros((0, 2)))
-    return out, (np.vstack(ea), np.vstack(eb))
-
-
 def clearance(mask, cs=CS, cap=EDT_CAP):
     ny, nx = mask.shape
     Rw = int(np.ceil(cap / cs)) + 1
@@ -516,37 +254,6 @@ def clearance(mask, cs=CS, cap=EDT_CAP):
         np.minimum(best, sh + kk, out=best)
     d = np.sqrt(best) * cs
     return np.minimum(d, cap).astype(np.float32) * mask
-
-
-def stamp_walls(P0, P1, HH, ox, oy, nx, ny, hgrid, cs=CS, hband=MC_HBAND):
-    P0 = np.asarray(P0, float); P1 = np.asarray(P1, float)
-    occ, HK, IK, n_span = hgrid
-    blocked = np.zeros(n_span, bool)
-    if not len(P0):
-        return blocked
-    L = np.hypot(*(P1 - P0).T)
-    steps = np.maximum(np.ceil(L / (cs * 0.4)).astype(np.int64), 1) + 1
-    tid = np.repeat(np.arange(len(P0)), steps)
-    base = np.repeat(np.concatenate(([0], np.cumsum(steps)[:-1])), steps)
-    k = np.arange(int(steps.sum())) - base
-    t = k / np.maximum(np.repeat(steps, steps) - 1, 1)
-    S = P0[tid] + (P1[tid] - P0[tid]) * t[:, None]
-    gx = np.floor((S[:, 0] - ox) / cs).astype(np.int64)
-    gy = np.floor((S[:, 1] - oy) / cs).astype(np.int64)
-    ok = (gx >= 0) & (gx < nx) & (gy >= 0) & (gy < ny)
-    cid = gy[ok] * nx + gx[ok]
-    hh = np.asarray(HH, float)[tid[ok]]
-    j = np.searchsorted(occ, cid)
-    good = (j < len(occ))
-    jj = np.where(good, np.minimum(j, len(occ) - 1), 0)
-    good &= occ[jj] == cid
-    jj = jj[good]; hh = hh[good]
-    if not len(jj):
-        return blocked
-    hit = np.abs(HK[jj] - hh[:, None]) <= hband
-    sid = IK[jj][hit]
-    blocked[sid[sid >= 0]] = True
-    return blocked
 
 
 def walls_at_layer(P0, P1, HH, lh, ox, oy, nx, ny, cs=CS, hband=MC_HBAND):
@@ -641,119 +348,11 @@ def _csr_gather(wid, start, cells):
     return wid[base + off]
 
 
-def comps4(mask):
-    ny, nx = mask.shape
-    lab = np.where(mask, np.arange(ny * nx).reshape(ny, nx), -1)
-    for _ in range(8000):
-        prev = lab.copy()
-        for sh, ax in ((1, 0), (-1, 0), (1, 1), (-1, 1)):
-            n = np.roll(lab, sh, axis=ax)
-            if ax == 0:
-                n[0 if sh > 0 else -1, :] = -1
-            else:
-                n[:, 0 if sh > 0 else -1] = -1
-            m = mask & (n >= 0) & ((lab > n) | (lab < 0))
-            lab[m] = n[m]
-        lab[~mask] = -1
-        if np.array_equal(lab, prev):
-            break
-    return lab
-
-
-def fill_holes(mask, max_cells, protect=None):
-    out = mask.copy()
-    if max_cells <= 0 or not mask.any():
-        return out
-    ny, nx = mask.shape
-    empty = ~mask
-    empty_flat = empty.ravel()
-    visited = np.zeros(ny * nx, bool)
-
-    border = np.zeros_like(mask)
-    border[0, :] = border[-1, :] = border[:, 0] = border[:, -1] = True
-    seeds = empty & border
-    if protect is not None:
-        seeds |= empty & protect
-
-    def mark_neighbors(cid, queue):
-        x = cid % nx
-        if x > 0:
-            n = cid - 1
-            if empty_flat[n] and not visited[n]:
-                visited[n] = True
-                queue.append(n)
-        if x + 1 < nx:
-            n = cid + 1
-            if empty_flat[n] and not visited[n]:
-                visited[n] = True
-                queue.append(n)
-        n = cid - nx
-        if n >= 0 and empty_flat[n] and not visited[n]:
-            visited[n] = True
-            queue.append(n)
-        n = cid + nx
-        if n < ny * nx and empty_flat[n] and not visited[n]:
-            visited[n] = True
-            queue.append(n)
-
-    # 从边界/受保护空格向外漫灌，剩下的空格才可能是需要填掉的小洞。
-    for start in np.flatnonzero(seeds).tolist():
-        if visited[start]:
-            continue
-        visited[start] = True
-        queue = deque([start])
-        while queue:
-            mark_neighbors(queue.popleft(), queue)
-
-    # 对每个未达小洞做有上限的 BFS；超过上限的洞保持原样并整组标记已访问。
-    for start in np.flatnonzero(empty_flat & ~visited).tolist():
-        if visited[start]:
-            continue
-        comp = []
-        visited[start] = True
-        queue = deque([start])
-        too_big = False
-        while queue:
-            cid = queue.popleft()
-            comp.append(cid)
-            if len(comp) > max_cells:
-                too_big = True
-                break
-            mark_neighbors(cid, queue)
-        if too_big:
-            mark_neighbors(cid, queue)
-            while queue:
-                mark_neighbors(queue.popleft(), queue)
-            continue
-        out.ravel()[comp] = True
-    return out
-
-
 def _sh(m, dy, dx):
     ny, nx = m.shape
     out = np.zeros_like(m)
     out[max(0, -dy):ny + min(0, -dy), max(0, -dx):nx + min(0, -dx)] = \
         m[max(0, dy):ny + min(0, dy), max(0, dx):nx + min(0, dx)]
-    return out
-
-
-def close_cracks(core, lay, protect=None):
-    k = max(1, int(round(0.5 / CS)))
-    out = core
-    for _ in range(4):
-        thin = np.zeros_like(out)
-        for dy, dx in ((1, 0), (0, 1)):
-            a = np.zeros_like(out); b = np.zeros_like(out)
-            for i in range(1, k + 1):
-                a |= _sh(out, i * dy, i * dx)
-                b |= _sh(out, -i * dy, -i * dx)
-            thin |= a & b
-        add = ~out & thin & lay
-        if protect is not None:
-            add &= ~protect
-        if not add.any():
-            break
-        out = out | add
     return out
 
 

--- a/tools/MapNavigator/recastnav_grid.py
+++ b/tools/MapNavigator/recastnav_grid.py
@@ -9,7 +9,8 @@ import numpy as np
 from recastnav import CS
 
 TAG = b"BGRD"
-SECTION_VERSION = 2
+SECTION_VERSION = 3
+SECTION_VERSION_COLUMNAR = 2  # 上一版:整块一条 deflate,六列各自长度前缀
 HEADER = struct.Struct("<4sIdddII")  # tag + 版本 + 格边长 + 瓦边长 + 裙边 + 区数 + 保留
 ZONE_HEAD = struct.Struct("<ddII")  # x0 + y0 + 全区类号数 + 瓦数
 TILE = struct.Struct("<8iQII")  # gx0 gy0 nx ny px0 px1 py0 py1 + 偏移 + 长度 + 记录数
@@ -23,6 +24,13 @@ FLAG_FILL = 0x10   # 补出来的格且无高度可传播
 # steps 的位序对应的 4 个规范方向,与烘焙端写入这一列时的顺序一致。
 STEP_DX = (1, 0, 1, 1)
 STEP_DY = (0, 1, 1, -1)
+
+# v3 瓦载荷:五个字段各一条残差流,前面三条是格号、层数、类号字典。
+FIELD_COUNT = 5
+STREAM_COUNT = 3 + FIELD_COUNT
+# 残差的预测子。编码端逐字段逐层挑一个写进选择子,解码端只照做。
+PRED_UP = 0    # 面内上邻:同列上一个存在的格
+PRED_DOWN = 1  # 同格下一层
 
 
 def grid_clearance(q):
@@ -49,6 +57,31 @@ def _varints(buf):
     return np.add.reduceat(contrib, starts)
 
 
+def _unzigzag(v):
+    return (v >> np.uint64(1)).astype(np.int64) ^ -(v & np.uint64(1)).astype(np.int64)
+
+
+def _column_plan(x):
+    """列内累加的排序与分组只跟列号有关,与残差无关,所以拆出来单独建。"""
+    order = np.argsort(x, kind="stable")
+    xs = x[order]
+    head = np.flatnonzero(np.concatenate(([True], xs[1:] != xs[:-1])))
+    group = np.zeros(len(xs), np.int64)
+    group[head] = 1
+    return order, head, np.cumsum(group) - 1
+
+
+def _column_scan(plan, residual):
+    """按列累加:同一列内与上一个存在的格作差,每列首个存绝对值。"""
+    order, head, group = plan
+    running = np.cumsum(residual[order])
+    offset = np.zeros(len(head), np.int64)
+    offset[1:] = running[head[1:] - 1]
+    out = np.empty(len(order), np.int64)
+    out[order] = running - offset[group]
+    return out
+
+
 class GridTile:
     __slots__ = ("regions", "cell", "rid", "h", "clr", "flags", "steps")
 
@@ -70,8 +103,105 @@ def empty_tile():
                     np.zeros(0, np.uint16), np.zeros(0, np.uint8), np.zeros(0, np.uint8))
 
 
+def decode_tile_v3(raw, nx):
+    """解一块 v3 瓦。段里的原始字节直接进,内部逐流解压;差分要瓦宽 nx。"""
+    if not 0 < nx <= 0xFFFF:
+        raise ValueError("grid tile width is out of range")
+    view = memoryview(raw)
+    p = 0
+
+    def varint():
+        nonlocal p
+        val = shift = 0
+        while True:
+            if p >= len(view):
+                raise ValueError("grid tile header is truncated")
+            b = view[p]
+            p += 1
+            val |= (b & 0x7F) << shift
+            if not b & 0x80:
+                return val
+            shift += 7
+
+    n = varint()
+    if n == 0:
+        if p != len(view):
+            raise ValueError("grid tile has trailing bytes")
+        return empty_tile()
+    hmin = struct.unpack_from("<f", view, p)[0]
+    p += 4
+    # 类号字典的长度就是本瓦的类号数,不另存。
+    regions = varint()
+    ncell = varint()
+    kmax = varint()
+    if not (0 < ncell <= n and 0 < kmax <= n and 0 < regions <= n):
+        raise ValueError("grid tile header is out of range")
+    select = np.frombuffer(view[p:p + kmax * FIELD_COUNT], np.uint8).reshape(FIELD_COUNT, kmax)
+    p += kmax * FIELD_COUNT
+
+    stream = []
+    for _ in range(STREAM_COUNT):
+        clen = varint()
+        if p + clen > len(view):
+            raise ValueError("grid tile stream is truncated")
+        stream.append(zlib.decompress(view[p:p + clen]))
+        p += clen
+    if p != len(view):
+        raise ValueError("grid tile has trailing bytes")
+
+    cell = np.cumsum(_varints(stream[0]).astype(np.int64))
+    depth = _varints(stream[1]).astype(np.int64)
+    rid_dict = _varints(stream[2]).astype(np.uint32)
+    if len(cell) != ncell or len(depth) != ncell or int(depth.sum()) != n:
+        raise ValueError("grid tile cell column does not match the record count")
+    if len(rid_dict) != regions or (depth <= 0).any() or (depth > kmax).any():
+        raise ValueError("grid tile dictionary or depth column is invalid")
+    base = np.cumsum(depth) - depth
+    # 列号的取值只有瓦宽那么多种,窄类型排序走的是计数排序,比 int64 快一个量级。
+    column = (cell % nx).astype(np.uint16)
+    # 每层的活格表、落点、列内累加的排序建一次给五个字段共用;逐字段重算的话
+    # 光 argsort 就要白跑五遍。哪层都不按上邻预测就不必建排序。
+    layers = []
+    for layer in range(kmax):
+        live = np.flatnonzero(depth > layer)
+        plan = _column_plan(column[live]) if (select[:, layer] == PRED_UP).any() else None
+        layers.append((live, base[live] + layer, plan))
+
+    value = np.zeros((FIELD_COUNT, n), np.int64)
+    for field in range(FIELD_COUNT):
+        residual = _unzigzag(_varints(stream[3 + field]))
+        if len(residual) != n:
+            raise ValueError("grid tile field stream does not match the record count")
+        above = np.zeros(ncell, np.int64)
+        current = np.zeros(ncell, np.int64)
+        taken = 0
+        for layer, (live, at, plan) in enumerate(layers):
+            how = int(select[field, layer])
+            if how != PRED_UP and (how != PRED_DOWN or layer == 0):
+                raise ValueError("grid tile predictor selector is invalid")
+            part = residual[taken:taken + len(live)]
+            taken += len(live)
+            current[live] = _column_scan(plan, part) if how == PRED_UP else above[live] + part
+            value[field, at] = current[live]
+            above, current = current, above
+
+    hq, region_index, clr, flags, steps = value
+    if (hq < 0).any() or (region_index < 0).any() or (region_index >= regions).any():
+        raise ValueError("grid tile height or region index is out of range")
+    if (clr < 0).any() or (clr > 0xFFFF).any() or (flags < 0).any() or (flags > 0xFF).any():
+        raise ValueError("grid tile clearance or flags is out of range")
+    if (steps < 0).any() or (steps > 0xFF).any():
+        raise ValueError("grid tile steps is out of range")
+
+    flags = flags.astype(np.uint8)
+    h = (np.float64(hmin) + hq.astype(np.float64) / 64.0).astype(np.float32)
+    h[(flags & FLAG_FILL) != 0] = np.float32(0.0)
+    return GridTile(int(regions), np.repeat(cell, depth), rid_dict[region_index], h,
+                    clr.astype(np.uint16), flags, steps.astype(np.uint8))
+
+
 def decode_tile(raw):
-    """解一块瓦的载荷(已解压)。字节走完且自洽才返回。"""
+    """解一块 v2 瓦的载荷(已解压)。字节走完且自洽才返回。"""
     view = memoryview(raw)
     p = 0
 
@@ -150,8 +280,9 @@ class GridPack:
         tag, version, cell_size, tile_px, apron_px, zone_count, _reserved = HEADER.unpack_from(data, 0)
         if tag != TAG:
             raise ValueError("GRID section has a bad magic")
-        if version != SECTION_VERSION:
+        if version not in (SECTION_VERSION, SECTION_VERSION_COLUMNAR):
             raise ValueError(f"GRID section version {version} is not supported")
+        self.version = version
         # 格边长是判据常数,包和运行端对不上就整包不认:两边的格心不重合,烘出来的一切都错位。
         if abs(cell_size - CS) > 1e-12:
             raise ValueError("GRID cell size does not match the runtime grid")
@@ -189,8 +320,12 @@ class GridPack:
         if int(tile["rec"]) == 0:
             return empty_tile()
         off = int(tile["off"])
-        raw = zlib.decompressobj().decompress(bytes(self.data[off:off + int(tile["len"])]))
-        out = decode_tile(raw)
+        raw = self.data[off:off + int(tile["len"])]
+        if self.version == SECTION_VERSION:
+            # v3 的载荷逐流各压各的,整块外面没有 deflate。
+            out = decode_tile_v3(raw, int(tile["g"][2]))
+        else:
+            out = decode_tile(zlib.decompressobj().decompress(bytes(raw)))
         if len(out) != int(tile["rec"]):
             raise ValueError("grid tile record count does not match the directory")
         return out

--- a/tools/MapNavigator/recastnav_grid.py
+++ b/tools/MapNavigator/recastnav_grid.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""包里预烘格图段(BGRD)的解码,与 RecastNavGridIO 同格式同口径。"""
+import struct
+import zlib
+
+import numpy as np
+
+from recastnav import CS
+
+TAG = b"BGRD"
+SECTION_VERSION = 2
+HEADER = struct.Struct("<4sIdddII")  # tag + 版本 + 格边长 + 瓦边长 + 裙边 + 区数 + 保留
+ZONE_HEAD = struct.Struct("<ddII")  # x0 + y0 + 全区类号数 + 瓦数
+TILE = struct.Struct("<8iQII")  # gx0 gy0 nx ny px0 px1 py0 py1 + 偏移 + 长度 + 记录数
+
+FLAG_DEAD = 0x01   # 墙压过的 span
+FLAG_WALK = 0x02   # 既在层里又在核心里
+FLAG_CORE = 0x04   # 补洞封缝后的核心掩码
+FLAG_GHOST = 0x08  # 补出来的格,高度由邻格传播
+FLAG_FILL = 0x10   # 补出来的格且无高度可传播
+
+# steps 的位序对应的 4 个规范方向,与烘焙端写入这一列时的顺序一致。
+STEP_DX = (1, 0, 1, 1)
+STEP_DY = (0, 1, 1, -1)
+
+
+def grid_clearance(q):
+    """净空存的是整数平方格距,还原表达式与 clearance 的返回值逐位相同。"""
+    return np.minimum(np.sqrt(np.asarray(q, np.float32)) * np.float32(0.25),
+                      np.float32(12.0))
+
+
+def _varints(buf):
+    """一列变长整数一次解完。低 7 位一组小端在前,末字节最高位为 0。"""
+    b = np.frombuffer(buf, np.uint8)
+    if not len(b):
+        return np.zeros(0, np.uint64)
+    end = (b & 0x80) == 0
+    if not end[-1]:
+        raise ValueError("grid varint column is truncated")
+    term = np.flatnonzero(end)
+    starts = np.concatenate(([0], term[:-1] + 1))
+    pos = np.arange(len(b)) - np.repeat(starts, np.diff(np.append(starts, len(b))))
+    if pos.max() > 9:
+        raise ValueError("grid varint is longer than 64 bits")
+    # 各字节的 7 位组互不重叠, 段内按位或等价于段内求和
+    contrib = (b & 0x7F).astype(np.uint64) << (7 * pos).astype(np.uint64)
+    return np.add.reduceat(contrib, starts)
+
+
+class GridTile:
+    __slots__ = ("regions", "cell", "rid", "h", "clr", "flags", "steps")
+
+    def __init__(self, regions, cell, rid, h, clr, flags, steps):
+        self.regions = regions
+        self.cell = cell
+        self.rid = rid
+        self.h = h
+        self.clr = clr
+        self.flags = flags
+        self.steps = steps
+
+    def __len__(self):
+        return len(self.cell)
+
+
+def empty_tile():
+    return GridTile(0, np.zeros(0, np.int64), np.zeros(0, np.uint32), np.zeros(0, np.float32),
+                    np.zeros(0, np.uint16), np.zeros(0, np.uint8), np.zeros(0, np.uint8))
+
+
+def decode_tile(raw):
+    """解一块瓦的载荷(已解压)。字节走完且自洽才返回。"""
+    view = memoryview(raw)
+    p = 0
+
+    def varint():
+        nonlocal p
+        val = shift = 0
+        while True:
+            if p >= len(view):
+                raise ValueError("grid tile header is truncated")
+            b = view[p]
+            p += 1
+            val |= (b & 0x7F) << shift
+            if not b & 0x80:
+                return val
+            shift += 7
+
+    n = varint()
+    if n == 0:
+        if p != len(view):
+            raise ValueError("grid tile has trailing bytes")
+        return empty_tile()
+    hmin = struct.unpack_from("<f", view, p)[0]
+    p += 4
+    regions = varint()
+    ncell = varint()
+
+    # 六列各自长度前缀,顺序与写入端一致:格、高、类号、标志、断口、净空。
+    col = []
+    for _ in range(6):
+        clen = varint()
+        if p + clen > len(view):
+            raise ValueError("grid tile column is truncated")
+        col.append(view[p:p + clen])
+        p += clen
+    if p != len(view):
+        raise ValueError("grid tile has trailing bytes")
+
+    pair = _varints(col[0])
+    if len(pair) != 2 * ncell:
+        raise ValueError("grid tile cell column does not match the cell count")
+    k = pair[1::2].astype(np.int64)
+    if int(k.sum()) != n:
+        raise ValueError("grid tile record count does not match the cell column")
+    cell = np.repeat(np.cumsum(pair[0::2].astype(np.int64)), k)
+    hq = _varints(col[1])
+    rid = _varints(col[2])
+    clr = _varints(col[5])
+    flags = np.frombuffer(col[3], np.uint8)
+    steps = np.frombuffer(col[4], np.uint8)
+    if len(hq) != n or len(rid) != n or len(clr) != n or len(flags) != n or len(steps) != n:
+        raise ValueError("grid tile columns do not match the record count")
+
+    h = (np.float64(hmin) + hq.astype(np.float64) / 64.0).astype(np.float32)
+    h[(flags & FLAG_FILL) != 0] = np.float32(0.0)
+    return GridTile(int(regions), cell, rid.astype(np.uint32), h,
+                    clr.astype(np.uint16), flags, steps)
+
+
+class GridZone:
+    __slots__ = ("name", "x0", "y0", "global_regions", "tiles")
+
+    def __init__(self, name, x0, y0, global_regions, tiles):
+        self.name = name
+        self.x0 = x0
+        self.y0 = y0
+        self.global_regions = global_regions
+        self.tiles = tiles  # (gx0, gy0, nx, ny, px0, px1, py0, py1, offset, len, records)
+
+
+class GridPack:
+    """包里 GRID 段的目录。段字节归调用方持有,这里只记一个视图。"""
+
+    def __init__(self, data):
+        if data is None or len(data) < HEADER.size:
+            raise ValueError("GRID section is truncated")
+        tag, version, cell_size, tile_px, apron_px, zone_count, _reserved = HEADER.unpack_from(data, 0)
+        if tag != TAG:
+            raise ValueError("GRID section has a bad magic")
+        if version != SECTION_VERSION:
+            raise ValueError(f"GRID section version {version} is not supported")
+        # 格边长是判据常数,包和运行端对不上就整包不认:两边的格心不重合,烘出来的一切都错位。
+        if abs(cell_size - CS) > 1e-12:
+            raise ValueError("GRID cell size does not match the runtime grid")
+        self.data = memoryview(data)
+        self.cell_size = cell_size
+        self.tile_px = tile_px
+        self.apron_px = apron_px
+        self.zones = {}
+        cursor = HEADER.size
+        for _ in range(zone_count):
+            (name_len,) = struct.unpack_from("<I", data, cursor)
+            cursor += 4
+            padded = (name_len + 3) // 4 * 4
+            name = bytes(self.data[cursor:cursor + name_len]).decode("utf-8")
+            cursor += padded
+            x0, y0, global_regions, tile_count = ZONE_HEAD.unpack_from(data, cursor)
+            cursor += ZONE_HEAD.size
+            tiles = np.frombuffer(
+                self.data[cursor:cursor + tile_count * TILE.size],
+                np.dtype([("g", "<i4", 8), ("off", "<u8"), ("len", "<u4"), ("rec", "<u4")]),
+                count=tile_count,
+            )
+            cursor += tile_count * TILE.size
+            if tile_count and (
+                    (tiles["g"][:, 2] <= 0).any() or (tiles["g"][:, 3] <= 0).any()
+                    or (tiles["off"] + tiles["len"] > len(data)).any()):
+                raise ValueError(f"GRID tile of zone '{name}' points outside the section")
+            self.zones[name] = GridZone(name, x0, y0, global_regions, tiles)
+
+    def zone(self, name):
+        return self.zones.get(name)
+
+    def decode(self, tile):
+        """解一块瓦:按需 inflate 再解码,不缓存。空瓦返回空表。"""
+        if int(tile["rec"]) == 0:
+            return empty_tile()
+        off = int(tile["off"])
+        raw = zlib.decompressobj().decompress(bytes(self.data[off:off + int(tile["len"])]))
+        out = decode_tile(raw)
+        if len(out) != int(tile["rec"]):
+            raise ValueError("grid tile record count does not match the directory")
+        return out
+
+
+def tiles_in_rect(zone, gx0, gy0, gx1, gy1):
+    """自有矩形与全局格矩形 [gx0,gx1]×[gy0,gy1] 相交的瓦。"""
+    g = zone.tiles["g"].astype(np.int64)
+    ox0 = g[:, 0] + g[:, 4]
+    ox1 = g[:, 0] + g[:, 5]
+    oy0 = g[:, 1] + g[:, 6]
+    oy1 = g[:, 1] + g[:, 7]
+    hit = ~((ox0 > gx1) | (ox1 < gx0) | (oy0 > gy1) | (oy1 < gy0))
+    return zone.tiles[hit]
+
+
+class GridWindow:
+    """窗口里从预烘图解出来的记录。格号已换成窗口格号,窗外的与不属于本瓦
+    自有矩形的都已剔除;一格只归一块瓦,所以同格的记录必然来自同一块瓦。"""
+
+    __slots__ = ("cell", "rid", "h", "clr", "flags", "steps")
+
+    def __init__(self, gp, zone, wgx0, wgy0, nx, ny):
+        cols = [[] for _ in range(6)]
+        for tile in tiles_in_rect(zone, wgx0, wgy0, wgx0 + nx - 1, wgy0 + ny - 1):
+            if int(tile["rec"]) == 0:
+                continue
+            t = gp.decode(tile)
+            g = tile["g"]
+            ix = t.cell % int(g[2])
+            iy = t.cell // int(g[2])
+            keep = ((ix >= int(g[4])) & (ix <= int(g[5]))
+                    & (iy >= int(g[6])) & (iy <= int(g[7])))
+            wx = int(g[0]) + ix - wgx0
+            wy = int(g[1]) + iy - wgy0
+            keep &= (wx >= 0) & (wx < nx) & (wy >= 0) & (wy < ny)
+            if not keep.any():
+                continue
+            cols[0].append(wy[keep] * nx + wx[keep])
+            cols[1].append(t.rid[keep])
+            cols[2].append(t.h[keep])
+            cols[3].append(t.clr[keep])
+            cols[4].append(t.flags[keep])
+            cols[5].append(t.steps[keep])
+        empty = (np.zeros(0, np.int64), np.zeros(0, np.uint32), np.zeros(0, np.float32),
+                 np.zeros(0, np.uint16), np.zeros(0, np.uint8), np.zeros(0, np.uint8))
+        self.cell, self.rid, self.h, self.clr, self.flags, self.steps = [
+            np.concatenate(c) if c else e for c, e in zip(cols, empty)]
+
+    def __len__(self):
+        return len(self.cell)

--- a/tools/MapNavigator/recastnav_route.py
+++ b/tools/MapNavigator/recastnav_route.py
@@ -8,193 +8,191 @@ from collections import OrderedDict
 import numpy as np
 
 import recastnav as rc
+import recastnav_grid as rg
 from recastnav import (CAP, CS, DECK_BAND, LAM, LAM_R, MARGIN, MAX_CELLS,
-                       MAXERR, MC_HBAND, PLAN_BUDGET_MS, R, SLIMEPS,
-                       SNAP_RADIUS, TAU)
+                       MAXERR, MC_HBAND, R, SLIMEPS, SNAP_RADIUS, TAU)
 from recastnav_zone import CleanNav, WallOracle
 
 
-def _clip_walls_at_layer_interpolated(P0, P1, H0, H1, lh, ox, oy, nx, ny):
-    """只保留墙边沿途与所选层相交的局部片段。"""
-    P0 = np.asarray(P0, float)
-    P1 = np.asarray(P1, float)
-    if not len(P0):
-        return np.empty((0, 2), float), np.empty((0, 2), float)
-    H0 = np.asarray(H0, float)
-    H1 = np.asarray(H1, float)
-    out0, out1 = [], []
-    for wall in range(len(P0)):
-        length = float(np.hypot(*(P1[wall] - P0[wall])))
-        steps = max(int(math.ceil(length / (CS * 0.4))), 1) + 1
-        open_t = None
-        for k in range(steps - 1):
-            t0 = k / (steps - 1)
-            t1 = (k + 1) / (steps - 1)
-            t = (t0 + t1) / 2.0
-            sample = P0[wall] + (P1[wall] - P0[wall]) * t
-            gx = math.floor((sample[0] - ox) / CS)
-            gy = math.floor((sample[1] - oy) / CS)
-            keep = False
-            if 0 <= gx < nx and 0 <= gy < ny:
-                layer_height = float(lh[gy, gx])
-                edge_height = H0[wall] + (H1[wall] - H0[wall]) * t
-                keep = not math.isnan(layer_height) and abs(
-                    layer_height - edge_height) <= rc.QH
-            if keep and open_t is None:
-                open_t = t0
-            if not keep and open_t is not None:
-                out0.append(P0[wall] + (P1[wall] - P0[wall]) * open_t)
-                out1.append(P0[wall] + (P1[wall] - P0[wall]) * t0)
-                open_t = None
-        if open_t is not None:
-            out0.append(P0[wall] + (P1[wall] - P0[wall]) * open_t)
-            out1.append(P1[wall])
-    return np.asarray(out0, float).reshape(-1, 2), np.asarray(out1, float).reshape(-1, 2)
+def _llround(v):
+    return int(math.floor(v + 0.5)) if v >= 0 else -int(math.floor(-v + 0.5))
 
 
-def build(
-    zc,
-    wo,
-    s,
-    s_snap,
-    h0,
-    x0,
-    y0,
-    x1,
-    y1,
-    *,
-    layered_core=False,
-    layer_hint=None,
-):
+def _last_per_cell(cells, vals, order):
+    """按给定次序取每格最后一条,用于同格多记录时后写的赢。"""
+    if not len(order):
+        return cells[:0], vals[:0]
+    c = cells[order]
+    keep = np.append(c[1:] != c[:-1], True)
+    return c[keep], vals[order][keep]
+
+
+def _pick_start_rec(gw, cell, h0):
+    """起点格里高度离 h0 最近的那条真 span 定类。类选错整条线就落在另一层上。"""
+    idx = np.flatnonzero((gw.cell == cell)
+                         & ((gw.flags & (rg.FLAG_GHOST | rg.FLAG_FILL)) == 0))
+    if not len(idx):
+        return -1
+    return int(idx[int(np.argmin(np.abs(gw.h[idx].astype(np.float64) - h0)))])
+
+
+def _pick_deck_rec(gw, nx, ny, gcx, gcy, deck):
+    """终点声明了面时改由终点定类:终点格附近带内、能走的那条,先按格距再按高度差挑。
+    起点那侧只在这个类里选面,所以起点二维吸附落在屋顶上也不会把线拉到别层去。"""
+    rad = int(math.ceil(SNAP_RADIUS / CS))
+    x = gw.cell % nx
+    y = gw.cell // nx
+    hd = np.abs(gw.h.astype(np.float64) - deck)
+    ok = (((gw.flags & rg.FLAG_WALK) != 0) & ((gw.flags & rg.FLAG_FILL) == 0)
+          & (hd <= DECK_BAND) & (np.abs(x - gcx) <= rad) & (np.abs(y - gcy) <= rad))
+    idx = np.flatnonzero(ok)
+    if not len(idx):
+        return -1
+    cd = (x[idx] - gcx) ** 2 + (y[idx] - gcy) ** 2
+    return int(idx[int(np.lexsort((idx, x[idx], y[idx], hd[idx], cd))[0])])
+
+
+def _core_anchor_px(gp, gz, p):
+    """点到最近核心格的格距 × CS,与窗口里的 near() 同口径,只是在全区图上量。
+    搜索半径取判据的两倍,够不着的点只报这个下界,反正它已经在闸外了。"""
+    cs = gp.cell_size
+    reach = SNAP_RADIUS * 2.0
+    cx = int(math.floor(p[0] / cs))
+    cy = int(math.floor(p[1] / cs))
+    rad = int(math.ceil(reach / cs))
+    best = -1
+    for tile in rg.tiles_in_rect(gz, cx - rad, cy - rad, cx + rad, cy + rad):
+        if int(tile["rec"]) == 0:
+            continue
+        t = gp.decode(tile)
+        g = tile["g"]
+        m = (t.flags & rg.FLAG_CORE) != 0
+        ix = t.cell[m] % int(g[2])
+        iy = t.cell[m] // int(g[2])
+        own = ((ix >= int(g[4])) & (ix <= int(g[5]))
+               & (iy >= int(g[6])) & (iy <= int(g[7])))
+        if not own.any():
+            continue
+        d = ((int(g[0]) + ix[own] - cx) ** 2 + (int(g[1]) + iy[own] - cy) ** 2).min()
+        if best < 0 or d < best:
+            best = int(d)
+    return reach if best < 0 else math.sqrt(best) * cs
+
+
+def build(zc, wo, gp, gz, s, s_snap, g, h0, goal_deck, x0, y0, x1, y1):
     nx = int(np.ceil((x1 - x0) / CS))
     ny = int(np.ceil((y1 - y0) / CS))
-    m = zc.mesh
+    # 窗口原点是对齐过的,所以它落在全局格线上,窗口格与烘焙格一一对上
+    t0 = time.time()
+    try:
+        gw = rg.GridWindow(gp, gz, _llround(x0 / CS), _llround(y0 / CS), nx, ny)
+    except ValueError:
+        return None, "预烘格图解不开"
+    t_grid = time.time() - t0
 
     t0 = time.time()
-    cell, hz, ins = rc.rasterize(m.V, m.H, m.T, x0, y0, nx, ny)
-    bc, bh = rc.seam_bridge(cell, hz, nx, ny)
-    if len(bc):
-        cell = np.concatenate([cell, bc])
-        hz = np.concatenate([hz, bh])
-        ins = np.concatenate([ins, np.zeros(len(bc), bool)])
-    sp_cell, sp_h, occ, cstart, ccnt = rc.spans(cell, hz)
-    HK, IK, sp_ci = rc.dense_k(sp_h, occ, cstart, ccnt)
-    t_vox = time.time() - t0
-
-    widx = wo.walls_in_bbox(x0 - 4, y0 - 4, x0 + nx * CS + 4,
-                            y0 + ny * CS + 4)
-    dead = (None if layered_core else
-            rc.stamp_walls(wo.P0[widx], wo.P1[widx], wo.HH[widx], x0, y0,
-                           nx, ny, (occ, HK, IK, len(sp_h))))
-
     gx = int((s[0] - x0) / CS); gy = int((s[1] - y0) / CS)
-    j = int(np.searchsorted(occ, gy * nx + gx))
-    if j >= len(occ) or occ[j] != gy * nx + gx:
+    inw = 0 <= gx < nx and 0 <= gy < ny
+    start_rec = _pick_start_rec(gw, gy * nx + gx, h0) if inw else -1
+    if start_rec < 0:
         # 起点离网时其所在格无体素,退用按楼层吸附过的起点定种子
         gx = int((s_snap[0] - x0) / CS); gy = int((s_snap[1] - y0) / CS)
-        j = int(np.searchsorted(occ, gy * nx + gx))
-    if j >= len(occ) or occ[j] != gy * nx + gx:
+        inw = 0 <= gx < nx and 0 <= gy < ny
+        start_rec = _pick_start_rec(gw, gy * nx + gx, h0) if inw else -1
+    if start_rec < 0:
         return None, f"起点格无体素 (gx={gx},gy={gy})"
-    cand = IK[j][IK[j] >= 0]
-    seed = int(cand[int(np.argmin(np.abs(sp_h[cand] - h0)))])
+    cell0 = gy * nx + gx
+    region = int(gw.rid[start_rec])
+    if goal_deck is not None:
+        deck_rec = _pick_deck_rec(gw, nx, ny, int((g[0] - x0) / CS),
+                                  int((g[1] - y0) / CS), goal_deck)
+        if deck_rec < 0:
+            return None, f"终点附近没有声明的面 (deck={goal_deck:g})"
+        region = int(gw.rid[deck_rec])
 
-    t0 = time.time()
-    vis = rc.flood(seed, sp_h, occ, HK, IK, sp_ci, nx)
-    t_fl = time.time() - t0
-
+    ghost = (gw.flags & rg.FLAG_GHOST) != 0
+    fill = (gw.flags & rg.FLAG_FILL) != 0
+    same = gw.rid == region
     lay = np.zeros(ny * nx, bool)
+    core = np.zeros(ny * nx, bool)
+    dist = np.zeros(ny * nx, np.float32)
     lh = np.full(ny * nx, np.nan, np.float32)
-    c_ = sp_cell[vis]
-    lay[c_] = True
-    lh[c_] = sp_h[vis]
-    wall_lh = lh.copy()
-    # 声明面只参与墙的局部选层；旧 core 仍沿用原层图，避免改写成功线路。
-    if layer_hint is not None:
-        # The recovery path is tied to a declared deck. Select that deck per column before
-        # filtering walls; otherwise the last reachable upper span can project its walls onto
-        # the lower route even though the lower span is the one being searched.
-        safe_ids = np.maximum(IK, 0)
-        reachable = (IK >= 0) & vis[safe_ids]
-        delta = np.where(reachable, np.abs(sp_h[safe_ids] - layer_hint), np.inf)
-        have = reachable.any(axis=1)
-        best = safe_ids[np.arange(len(occ)), delta.argmin(axis=1)]
-        wall_lh.fill(np.nan)
-        wall_lh[occ[have]] = sp_h[best[have]]
-    if layered_core:
-        lh = wall_lh
-    lay = lay.reshape(ny, nx); lh = lh.reshape(ny, nx)
-    wall_lh = wall_lh.reshape(ny, nx)
-    if layer_hint is not None:
-        wP0, wP1 = _clip_walls_at_layer_interpolated(
-            wo.P0[widx], wo.P1[widx], wo.H0[widx], wo.H1[widx], wall_lh,
-            x0, y0, nx, ny)
-    else:
-        keep = rc.walls_at_layer(wo.P0[widx], wo.P1[widx], wo.HH[widx], lh,
-                                 x0, y0, nx, ny, hband=MC_HBAND)
-        wP0, wP1 = wo.P0[widx][keep], wo.P1[widx][keep]
+    stepbits = np.zeros(ny * nx, np.uint8)
+    is_core = (gw.flags & rg.FLAG_CORE) != 0
+    lay[gw.cell[same & (((gw.flags & rg.FLAG_WALK) != 0) | ~is_core)]] = True
+    core[gw.cell[same & is_core]] = True
+    sc, ss_ = gw.cell[same], gw.steps[same]
+    c, v = _last_per_cell(sc, rg.grid_clearance(gw.clr[same]),
+                          np.argsort(sc, kind="stable"))
+    dist[c] = v
+    for bit in range(8):
+        hit = sc[((ss_ >> bit) & 1) != 0]
+        if len(hit):
+            stepbits[hit] = stepbits[hit] | np.uint8(1 << bit)
+    real = same & ~ghost & ~fill
+    c, v = _last_per_cell(gw.cell[real], gw.h[real],
+                          np.lexsort((gw.h[real], gw.cell[real])))
+    lh[c] = v
+    lay = lay.reshape(ny, nx); core = core.reshape(ny, nx)
+    lh = lh.reshape(ny, nx); dist = dist.reshape(ny, nx)
+
+    widx = wo.walls_in_bbox(x0 - 4, y0 - 4, x0 + nx * CS + 4, y0 + ny * CS + 4)
+    keep = rc.walls_at_layer(wo.P0[widx], wo.P1[widx], wo.HH[widx], lh,
+                             x0, y0, nx, ny, hband=MC_HBAND)
+    wP0, wP1 = wo.P0[widx][keep], wo.P1[widx][keep]
     wid, wstart = rc.wall_index(wP0, wP1, x0, y0, nx, ny)
-    if layered_core:
-        wallcell = np.diff(wstart) > 0
-    else:
-        wallcell = np.zeros(ny * nx, bool)
-        wallcell[sp_cell[dead]] = True
-    lay = rc.fill_holes(lay, rc.HOLE_MAX, protect=wallcell.reshape(ny, nx))
-    sol = np.zeros(ny * nx, bool)
-    ci, hi_ = cell[ins], hz[ins]
-    if layered_core:
-        # A 2-D height slot is ambiguous when two reachable decks overlap the same cell: assigning
-        # ``lh[c] = sp_h`` lets the last span erase the other deck. Match each interior raster sample
-        # against the reachable spans in its own column instead, so an upper deck cannot punch holes
-        # into the lower deck's core mask (or vice versa).
-        rows = np.searchsorted(occ, ci)
-        span_ids = IK[rows]
-        valid = span_ids >= 0
-        safe_ids = np.where(valid, span_ids, 0)
-        okc = np.any(
-            valid & vis[safe_ids]
-            & (np.abs(hi_[:, None] - sp_h[safe_ids]) <= rc.QH), axis=1)
-    else:
-        lf = lh.ravel()
-        okc = ~np.isnan(lf[ci]) & (np.abs(hi_ - lf[ci]) <= rc.QH)
-    sol[ci[okc]] = True
-    core = rc.fill_holes(lay & sol.reshape(ny, nx), rc.HOLE_MAX,
-                         protect=wallcell.reshape(ny, nx))
-    core = rc.close_cracks(core, lay, protect=wallcell.reshape(ny, nx))
 
-    sev, sseg = rc.step_breaks(occ, HK, IK, vis, lay, nx, ny, x0, y0)
+    # 禁步面按烘出来的位还原。位序与方向表是写入方定的,方向倒序的那一位对应反向键;
+    # 只有正交两向出线段,对角步不挡视线。
+    sev = set()
+    ea, eb = [], []
+    flat = lay.ravel()
+    for i in range(4):
+        dx, dy = rg.STEP_DX[i], rg.STEP_DY[i]
+        bits = (stepbits >> (2 * i)) & 0x03
+        cid = np.flatnonzero((bits != 0) & flat)
+        ax, ay = cid % nx + dx, cid // nx + dy
+        m = (ax >= 0) & (ax < nx) & (ay >= 0) & (ay < ny)
+        cid, ax, ay = cid[m], ax[m], ay[m]
+        if not len(cid):
+            continue
+        nb = ay * nx + ax
+        b = bits[cid]
+        fwd = (b & 0x01) != 0
+        rev = (b & 0x02) != 0
+        sev.update((cid[fwd] * (ny * nx) + nb[fwd]).tolist())
+        sev.update((nb[rev] * (ny * nx) + cid[rev]).tolist())
+        if dx and dy:
+            continue
+        px = x0 + (cid % nx + dx) * CS
+        py = y0 + (cid // nx + dy) * CS
+        ea.append(np.column_stack([px, py]))
+        eb.append(np.column_stack([px + dy * CS, py + dx * CS]))
+    sseg = ((np.vstack(ea), np.vstack(eb)) if ea
+            else (np.zeros((0, 2)), np.zeros((0, 2))))
 
-    spC, spH, spV = sp_cell, sp_h, vis
-    spOcc, spHK, spIK, spCi = occ, HK, IK, sp_ci
-    have = np.zeros(ny * nx, bool)
-    have[sp_cell[vis]] = True
-    gh = np.nonzero(lay.ravel() & ~have)[0]
-    if len(gh):
-        T0 = rc._step_heights(occ, HK, IK, vis, lay, nx, ny)[:, 0]
-        gh = gh[np.isfinite(T0[gh])]
-    if len(gh):
-        spC = np.concatenate([sp_cell, gh])
-        spH = np.concatenate([sp_h, T0[gh].astype(np.float32)])
-        spV = np.concatenate([vis, np.ones(len(gh), bool)])
-        o = np.lexsort((spH, spC))
-        spC, spH, spV = spC[o], spH[o], spV[o]
-        spOcc, cst, cct = np.unique(spC, return_index=True, return_counts=True)
-        spHK, spIK, spCi = rc.dense_k(spH, spOcc, cst, cct)
+    # 表里留着别的类的 span:层判据要看整列,少一层就会从楼板底下穿过去
+    inspan = ~(fill | (ghost & ~same))
+    o = np.lexsort((gw.h[inspan], gw.cell[inspan]))
+    spC, spH, spV = gw.cell[inspan][o], gw.h[inspan][o], same[inspan][o]
+    spOcc, cst, cct = np.unique(spC, return_index=True, return_counts=True)
+    spHK, spIK, spCi = rc.dense_k(spH, spOcc, cst, cct)
     cidx = np.full(ny * nx, -1, np.int32)
     cidx[spOcc] = np.arange(len(spOcc), dtype=np.int32)
-    sj = int(cidx[gy * nx + gx])
-    cd = spIK[sj][spIK[sj] >= 0]
-    seedN = int(cd[int(np.argmin(np.abs(spH[cd] - h0)))])
-    reachN = rc.span_reach(seedN, spH, spOcc, spHK, spIK, spCi, spV, nx, ny)
+    cd = spIK[int(cidx[cell0])]
+    cd = cd[(cd >= 0) & spV[np.maximum(cd, 0)]]
+    if not len(cd):
+        return None, "起点格没有与终点同类的面"
+    seedN = int(cd[int(np.argmin(np.abs(spH[cd] - np.float32(h0))))])
+    t_win = time.time() - t0
 
     t0 = time.time()
-    dist = rc.clearance(core)
-    t_edt = time.time() - t0
+    reachN = rc.span_reach(seedN, spH, spOcc, spHK, spIK, spCi, spV, nx, ny)
+    t_reach = time.time() - t0
 
     info = dict(x0=x0, y0=y0, nx=nx, ny=ny, lay=lay, lh=lh, dist=dist,
-                core=core, t_vox=t_vox, t_fl=t_fl, t_edt=t_edt,
+                core=core, t_grid=t_grid, t_win=t_win, t_reach=t_reach,
                 wP0=wP0, wP1=wP1, wid=wid, wstart=wstart,
-                sourceWallP0=wo.P0[widx], sourceWallP1=wo.P1[widx],
-                sourceWallH0=wo.H0[widx], sourceWallH1=wo.H1[widx],
                 sev=sev, sseg=sseg, h0=h0,
                 spC=spC, spH=spH, spOcc=spOcc, spHK=spHK, spIK=spIK,
                 spCi=spCi, cidx=cidx, reachN=reachN)
@@ -231,67 +229,6 @@ def wall_dist(wo, S, hs, pad=CAP):
     return out
 
 
-def _layer_wall_clear(info, lyo, line, start_height, goal_deck):
-    """逐交点验证终线存在一条不穿过同高墙体的连续层。"""
-    eps = 1e-7
-    heights = np.asarray([start_height], np.float32)
-    walls0 = np.asarray(info["sourceWallP0"], float)
-    walls1 = np.asarray(info["sourceWallP1"], float)
-    wall_h0 = np.asarray(info["sourceWallH0"], float)
-    wall_h1 = np.asarray(info["sourceWallH1"], float)
-    for segment in range(1, len(line)):
-        p = np.asarray(line[segment - 1], float)
-        q = np.asarray(line[segment], float)
-        route = q - p
-        hits = []
-        route_lo = np.minimum(p, q)
-        route_hi = np.maximum(p, q)
-        nearby = np.nonzero(
-            (np.maximum(walls0[:, 0], walls1[:, 0]) >= route_lo[0])
-            & (np.minimum(walls0[:, 0], walls1[:, 0]) <= route_hi[0])
-            & (np.maximum(walls0[:, 1], walls1[:, 1]) >= route_lo[1])
-            & (np.minimum(walls0[:, 1], walls1[:, 1]) <= route_hi[1])
-        )[0]
-        for wall in nearby:
-            edge = walls1[wall] - walls0[wall]
-            den = route[0] * edge[1] - route[1] * edge[0]
-            if abs(den) <= 1e-12:
-                continue
-            offset = walls0[wall] - p
-            route_t = (offset[0] * edge[1] - offset[1] * edge[0]) / den
-            wall_t = (offset[0] * route[1] - offset[1] * route[0]) / den
-            if not (eps < route_t < 1.0 - eps and eps < wall_t < 1.0 - eps):
-                continue
-            height = wall_h0[wall] + (wall_h1[wall] - wall_h0[wall]) * wall_t
-            hits.append((route_t, height))
-        hits.sort(key=lambda hit: hit[0])
-
-        cursor = tuple(p)
-        first = 0
-        while first < len(hits):
-            last = first + 1
-            while last < len(hits) and abs(hits[last][0] - hits[first][0]) <= eps:
-                last += 1
-            crossing = tuple(p + route * hits[first][0])
-            at_crossing = lyo.walk((cursor, crossing), heights)
-            if at_crossing is None:
-                return False
-            blocked = np.zeros(len(at_crossing), bool)
-            for _, wall_height in hits[first:last]:
-                blocked |= np.abs(at_crossing - wall_height) <= rc.QH
-            heights = at_crossing[~blocked]
-            if not len(heights):
-                return False
-            cursor = crossing
-            first = last
-        at_end = lyo.walk((cursor, tuple(q)), heights)
-        if at_end is None:
-            return False
-        heights = at_end
-    return goal_deck is None or bool(
-        (np.abs(heights - goal_deck) <= DECK_BAND).any())
-
-
 def metrics(wo, P, h0, info, step=0.25):
     P = np.asarray(P, float)
     L = float(np.hypot(*np.diff(P, axis=0).T).sum())
@@ -312,8 +249,7 @@ def metrics(wo, P, h0, info, step=0.25):
             hug / tot * 100 if tot else 0.0)
 
 
-def route(info, s, g, climb_faces=False, *, goal_deck=None, hard_walls=False,
-          validate_layer_walls=False):
+def route(info, s, g, *, goal_deck=None):
     # goal_deck: 终点所在面的高度。不声明时终点集是该格全部 span,先够到哪张停哪张。
     lay, dist, core = info["lay"], info["dist"], info["core"]
     x0, y0, nx, ny = info["x0"], info["y0"], info["nx"], info["ny"]
@@ -370,13 +306,6 @@ def route(info, s, g, climb_faces=False, *, goal_deck=None, hard_walls=False,
                 best, bd = int(v), d
         return best if best >= 0 and bd <= DECK_BAND else -1
 
-    # 起点的面只由起点自己的高度决定, 终点的声明不参与。h0 来自二维吸附,
-    # 重叠处可能落在屋顶, 所以终点声明了面时起点层不再当已知, 按 h0 由近到远逐张试。
-    def seeds_of(vs):
-        if goal_deck is None:
-            return [at_seed_layer(vs)]
-        return sorted(vs, key=lambda v: abs(float(spH[v]) - info["h0"]))
-
     # 终点声明是硬的: 收敛到单张 span, 匹配不上交空集让本级失败
     def goals_of(vs):
         if goal_deck is None:
@@ -400,26 +329,27 @@ def route(info, s, g, climb_faces=False, *, goal_deck=None, hard_walls=False,
     ag_, dga = near(cw3.reshape(ny, nx), gc)
     if as_ is None:
         return None, {"err": "walk 掩膜为空"}
+    # 禁步面是硬的,墙边只罚分:窄处绕不开时宁可贴着走也不判不连通
     BIGP = nx * ny * CS * (1.0 + LAM)
-    faces = blocked if hard_walls else (None if climb_faces else info["sev"])
-    soft = () if hard_walls else (blocked if climb_faces else bn)
+    faces = info["sev"]
+    soft = bn
     t0 = time.time()
     on3 = cw3
     qs = None
 
+    # 可走集已经限死在终点那张面所属的类里, 起点这侧只剩层内挑高度
     def search(use, c3, svs, gs):
-        for sd in seeds_of(svs):
-            r = rc.span_astar(use, spH, spOcc, spHK, spIK, spCi, cidx, c3,
-                              sd, set(gs), mult, nx, ny, soft, BIGP, faces)
-            if r is not None:
-                return r
-        return None
+        if not svs:
+            return None
+        return rc.span_astar(use, spH, spOcc, spHK, spIK, spCi, cidx, c3,
+                             at_seed_layer(svs), set(gs), mult, nx, ny,
+                             soft, BIGP, faces)
 
     if as_ == ag_:
         vs = pick(as_, useW)
         gs = goals_of(vs)
         if goal_deck is None:
-            qs = [seeds_of(vs)[0]]
+            qs = [at_seed_layer(vs)]
         elif gs:
             qs = [gs[0]]
     else:
@@ -434,7 +364,7 @@ def route(info, s, g, climb_faces=False, *, goal_deck=None, hard_walls=False,
                 vs = pick(ac_, useC)
                 gs = goals_of(vs)
                 if goal_deck is None:
-                    qs = [seeds_of(vs)[0]]
+                    qs = [at_seed_layer(vs)]
                 elif gs:
                     qs = [gs[0]]
             else:
@@ -635,10 +565,6 @@ def route(info, s, g, climb_faces=False, *, goal_deck=None, hard_walls=False,
         line = rc.widen_corners(line, blk_gray, dist, x0, y0, CS, cfl,
                                 lyo=lyo if qs is not None else None,
                                 h=float(spH[qs[0]]) if qs is not None else None)
-    if (validate_layer_walls
-            and (qs is None or not _layer_wall_clear(
-                info, lyo, line, float(spH[qs[0]]), goal_deck))):
-        return None, {"err": "终线穿过当前层墙体", "warn": warn}
     clr = []
     for px, py in line:
         a = min(max(int(math.floor((px - x0) / CS)), 0), nx - 1)
@@ -673,6 +599,10 @@ class RecastEngine:
 
     def __init__(self, field):
         self.nav = CleanNav(field)
+        section = field.sections.get(rg.TAG)
+        if section is None:
+            raise ValueError("包里没有预烘格图段,请换用带 GRID 段的包")
+        self.grid = rg.GridPack(section)
         self._oracles: OrderedDict[str, WallOracle] = OrderedDict()
         self.lock = threading.Lock()
 
@@ -714,6 +644,9 @@ class RecastEngine:
 
     def _plan(self, zone_name, start, goal, floor_y, goal_deck_y=None):
         t_all = time.time()
+        gz = self.grid.zone(zone_name)
+        if gz is None:
+            raise ValueError(f"区没有预烘格图 ({zone_name})")
         zc, wo = self._zone(zone_name)
         s = (float(start[0]), float(start[1]))
         g = (float(goal[0]), float(goal[1]))
@@ -724,134 +657,45 @@ class RecastEngine:
             raise ValueError("终点不在网格附近")
         h0 = float(np.mean(zc.mesh.H[zc.mesh.T[ss[0]]]))
 
-        margins = [MARGIN, MARGIN * 2, MARGIN * 4, MARGIN * 8]
+        # 端点接不上可走层的腿在全区图上就能判掉。全区核心是任何窗口内核心的超集,
+        # 量出来的锚距是窗口里那把尺子的下界,过不了这道闸的腿换多大的窗口也接不上。
+        zsa = _core_anchor_px(self.grid, gz, s)
+        zga = _core_anchor_px(self.grid, gz, g)
+        if zsa > SNAP_RADIUS or zga > SNAP_RADIUS:
+            raise ValueError(f"端点接不上可走层 (起 {zsa:.1f}px / 终 {zga:.1f}px,"
+                             " 疑似不连通)")
+
+        # 扩窗只留两档。59 条生产腿里 ×100 与 ×200 零成功,只在必败腿上把时间烧掉。
+        margins = [MARGIN, MARGIN * 2]
         info = line = dg = None
         last_err = None
-        # 预算只计扩窗本身,不含首次进区的建区开销(与 RecastNavRoute.cpp 的
-        # plan_started_at 同位置);否则冷区第一条线会被建区时间挤爆预算。
-        t_budget = time.time()
-        prev_cells = prev_ms = 0
-        for p in range(len(margins) * 2):
-            i, margin = p % len(margins), margins[p % len(margins)]
-            x0 = min(s[0], g[0]) - margin; y0 = min(s[1], g[1]) - margin
-            x1 = max(s[0], g[0]) + margin; y1 = max(s[1], g[1]) + margin
+        for p, margin in enumerate(margins):
+            last_margin = p + 1 == len(margins)
+            # 窗口边界对齐到全局网格。原点直接取 min-margin 时, 起点差 0.06px 就换一套体素相位,
+            # 同一段路两次规划得到的格子划分不同; 对齐后相位只由世界坐标决定, 与起终点无关。
+            x0 = math.floor((min(s[0], g[0]) - margin) / CS) * CS
+            y0 = math.floor((min(s[1], g[1]) - margin) / CS) * CS
+            x1 = math.ceil((max(s[0], g[0]) + margin) / CS) * CS
+            y1 = math.ceil((max(s[1], g[1]) + margin) / CS) * CS
             nx = int(np.ceil((x1 - x0) / CS))
             ny = int(np.ceil((y1 - y0) / CS))
             if nx * ny > MAX_CELLS:
                 raise ValueError(f"窗口过大 ({nx}×{ny} 格)")
-            # 与 RecastNavRoute.cpp 同步:本档窗口按上一档实测速度外推,预算装不下就停。
-            # 不跟着改的话,预览会算出运行时早已放弃的线。
-            if p > 0:
-                used_ms = int((time.time() - t_budget) * 1000)
-                projected_ms = prev_ms * nx * ny // prev_cells if prev_cells else 0
-                if used_ms + projected_ms > PLAN_BUDGET_MS:
-                    raise ValueError(
-                        f"{last_err or '路线失败'} (扩窗预算耗尽: 已用 {used_ms}ms,"
-                        f" 下档 {nx}×{ny} 格约需 {projected_ms}ms)")
-            t_pass = time.time()
-            info, err = build(zc, wo, s, ss[1], h0, x0, y0, x1, y1)
+            info, err = build(zc, wo, self.grid, gz, s, ss[1], g, h0,
+                              goal_deck_y, x0, y0, x1, y1)
             if err is None:
-                line, dg = route(info, s, g, p >= len(margins),
-                                 goal_deck=goal_deck_y)
-                same_deck_recovery = (
-                    goal_deck_y is not None
-                    and abs(h0 - goal_deck_y) <= DECK_BAND
-                )
-                if same_deck_recovery and line is None:
-                    # 成功的旧线路原样保留；只有旧拓扑失败才换稳定相位恢复。
-                    recovery_x0 = math.floor((x0 - CS / 2.0) / CS) * CS + CS / 2.0
-                    recovery_y0 = math.floor((y0 - CS / 2.0) / CS) * CS + CS / 2.0
-                    recovery_x1 = recovery_x0 + math.ceil(
-                        (x1 - recovery_x0) / CS) * CS
-                    recovery_y1 = recovery_y0 + math.ceil(
-                        (y1 - recovery_y0) / CS) * CS
-                    recovery_nx = math.ceil((recovery_x1 - recovery_x0) / CS)
-                    recovery_ny = math.ceil((recovery_y1 - recovery_y0) / CS)
-                    if recovery_nx * recovery_ny > MAX_CELLS:
-                        recovery_info = None
-                        recovery_err = (
-                            f"恢复窗口过大 ({recovery_nx}×{recovery_ny} 格)")
-                    else:
-                        recovery_info, recovery_err = build(
-                            zc,
-                            wo,
-                            s,
-                            ss[1],
-                            h0,
-                            recovery_x0,
-                            recovery_y0,
-                            recovery_x1,
-                            recovery_y1,
-                            layer_hint=goal_deck_y,
-                        )
-                    if recovery_err is None:
-                        recovery_line, recovery_dg = route(
-                            recovery_info,
-                            s,
-                            g,
-                            goal_deck=goal_deck_y,
-                            validate_layer_walls=True,
-                        )
-                        if (recovery_line is not None and not recovery_dg.get(
-                                "crossed_barrier", False)):
-                            info, line, dg = recovery_info, recovery_line, recovery_dg
-                        else:
-                            dg = recovery_dg
-                    else:
-                        dg = {"err": recovery_err}
-                    if line is None:
-                        # 稳定相位仍失败时，退回完整分层且墙体硬约束的保守路径。
-                        hard_x0 = math.floor(x0 / CS) * CS
-                        hard_y0 = math.floor(y0 / CS) * CS
-                        hard_x1 = math.ceil(x1 / CS) * CS
-                        hard_y1 = math.ceil(y1 / CS) * CS
-                        hard_nx = math.ceil((hard_x1 - hard_x0) / CS)
-                        hard_ny = math.ceil((hard_y1 - hard_y0) / CS)
-                        if hard_nx * hard_ny > MAX_CELLS:
-                            hard_info = None
-                            hard_err = f"恢复窗口过大 ({hard_nx}×{hard_ny} 格)"
-                        else:
-                            hard_info, hard_err = build(
-                                zc,
-                                wo,
-                                s,
-                                ss[1],
-                                h0,
-                                hard_x0,
-                                hard_y0,
-                                hard_x1,
-                                hard_y1,
-                                layered_core=True,
-                                layer_hint=goal_deck_y,
-                            )
-                        if hard_err is None:
-                            hard_line, hard_dg = route(
-                                hard_info,
-                                s,
-                                g,
-                                goal_deck=goal_deck_y,
-                                hard_walls=True,
-                                validate_layer_walls=True,
-                            )
-                            if (hard_line is not None and not hard_dg.get(
-                                    "crossed_barrier", False)):
-                                info, line, dg = hard_info, hard_line, hard_dg
-                            else:
-                                dg = hard_dg
-                        else:
-                            dg = {"err": hard_err}
+                line, dg = route(info, s, g, goal_deck=goal_deck_y)
                 if line is not None:
                     P = np.asarray(line, float)
                     pad = 2.0
                     # 锚点远 = 走廊出窗,同触界扩窗,否则末段盲跳穿墙
-                    far = max(dg["snapd"]) > SNAP_RADIUS
-                    if far:
-                        if i == len(margins) - 1:
+                    if max(dg["snapd"]) > SNAP_RADIUS:
+                        if last_margin:
                             raise ValueError(
                                 f"端点接不上可走层 (起 {dg['snapd'][0]:.1f}px"
                                 f" / 终 {dg['snapd'][1]:.1f}px, 疑似不连通)")
                         err = "端点锚点过远,扩窗重跑"
-                    elif i == len(margins) - 1 or (
+                    elif last_margin or (
                             P[:, 0].min() > x0 + pad
                             and P[:, 0].max() < x1 - pad
                             and P[:, 1].min() > y0 + pad
@@ -861,8 +705,6 @@ class RecastEngine:
                         err = "终线触界,扩窗重跑"
                 else:
                     err = dg.get("err", "路线失败")
-            prev_ms = max(int((time.time() - t_pass) * 1000), 1)
-            prev_cells = nx * ny
             last_err = err
             info = line = dg = None
         else:
@@ -883,8 +725,8 @@ class RecastEngine:
             "snap": {"start": dg["snapd"][0], "goal": dg["snapd"][1]},
             "window": {"x0": info["x0"], "y0": info["y0"],
                        "nx": info["nx"], "ny": info["ny"], "cs": CS},
-            "timing": {"vox": info["t_vox"], "flood": info["t_fl"],
-                       "edt": info["t_edt"], "astar": dg["t_as"],
+            "timing": {"grid": info["t_grid"], "window": info["t_win"],
+                       "reach": info["t_reach"], "astar": dg["t_as"],
                        "pull": dg["t_sp"],
                        "total": time.time() - t_all},
         }


### PR DESCRIPTION
## Summary by Sourcery

将导航网格路由切换为使用 BaseNav 包中的预烘焙网格数据，简化墙体处理，并更新 BaseNav 格式和工具以支持新的几何和网格章节。

新功能：
- 从 BaseNav 包中加载并使用预烘焙导航网格（BGRD）数据进行路线规划。
- 在 C++ 和 Python 工具中添加对 BGEO 几何章节和通用 BaseNav 章节的支持。

缺陷修复：
- 通过基于全局核心网格覆盖范围测量锚点距离，改进对不可达端点的检测。

改进：
- 重构窗口构建和路由逻辑，使其在烘焙的网格跨度和区域上运行，而不是依赖运行时体素化。
- 通过烘焙墙体数据并移除分层核心和分层墙体校验逻辑，简化墙和台阶处理。
- 通过移除基于预算的多轮窗口扩展，并改用更简单的停止回调，降低路线规划的复杂度。
- 使 C++ 和 Python 的 MapNavigator 实现与新的基于网格的管线保持一致，并暴露网格使用的时间统计指标。

文档：
- 在 MapNavigator 的 README 中记录 BaseNav 包必须包含用于路由的预烘焙网格章节这一要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch navmesh routing to use pre-baked grid data from the BaseNav pack, simplify wall handling, and update BaseNav format and tools to support new geometry and grid sections.

New Features:
- Load and use pre-baked navigation grid (BGRD) data from BaseNav packs for route planning.
- Add support for BGEO geometry sections and generic BaseNav sections in both C++ and Python tools.

Bug Fixes:
- Improve detection of unreachable endpoints by measuring anchor distance against global core grid coverage.

Enhancements:
- Refactor window building and routing to operate on baked grid spans and regions instead of runtime voxelization.
- Simplify wall and step handling by baking wall data and removing layered core and layer wall validation logic.
- Reduce route planning complexity by removing multi-pass budget-based window expansion and using a simpler stop callback.
- Align C++ and Python MapNavigator implementations with the new grid-based pipeline and expose timing metrics for grid usage.

Documentation:
- Document the requirement for BaseNav packs to include the pre-baked grid section for routing in MapNavigator README.

</details>