### PR TITLE
feat(MapNavigator): 新增游戏走路模式切换

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.cpp
+++ b/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.cpp
@@ -104,6 +104,7 @@ DesktopInputBackend::DesktopInputBackend(
     const std::vector<int32_t> managed_keys {
         key_codes_.move_forward, key_codes_.move_left, key_codes_.move_backward,
         key_codes_.move_right,   key_codes_.interact,  key_codes_.jump,
+        key_codes_.walk_toggle,
     };
     background_managed_keys_enabled_ = TrySetBackgroundManagedKeys(ctrl_, managed_keys);
     LogInfo << backend_name_ << " backend background managed keys." << VAR(controller_type_) << VAR(background_managed_keys_enabled_);
@@ -191,6 +192,11 @@ void DesktopInputBackend::TriggerSprintSync()
     MouseRightDownSync(0);
     SleepIfNeeded(kActionSprintPressMs);
     MouseRightUpSync(0);
+}
+
+void DesktopInputBackend::ToggleWalkModeSync()
+{
+    ClickKeySync(key_codes_.walk_toggle, kActionWalkTogglePressMs);
 }
 
 void DesktopInputBackend::ResetForwardWalkSync(int release_millis)
@@ -325,6 +331,7 @@ DesktopKeyCodes MakeDesktopKeyCodes()
         .move_right = 'D',    // 0x44
         .interact = 'F',      // 0x46
         .jump = 0x20,         // VK_SPACE
+        .walk_toggle = 0x11,  // VK_CONTROL — 走/跑切换
     };
 }
 

--- a/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.h
+++ b/agent/cpp-algo/source/MapNavigator/Backend/Desktop/desktop_input_backend.h
@@ -16,6 +16,7 @@ struct DesktopKeyCodes
     int32_t move_right = 0;
     int32_t interact = 0;
     int32_t jump = 0;
+    int32_t walk_toggle = 0;
 };
 
 class DesktopInputBackend : public IInputBackend
@@ -33,12 +34,14 @@ public:
     SteeringTransportProfile steering_transport_profile() const override;
 
     bool supports_sprint() const override { return true; }
+    bool supports_walk_toggle() const override { return true; }
 
     void SetMovementStateSync(bool forward, bool left, bool backward, bool right, int delay_millis) override;
     void TriggerJumpSync(int hold_millis) override;
     void TriggerInteractSync(int hold_millis) override;
     void PulseForwardSync(int hold_millis) override;
     void TriggerSprintSync() override;
+    void ToggleWalkModeSync() override;
     void ResetForwardWalkSync(int release_millis) override;
     void ClickMouseLeftSync() override;
     void MouseRightDownSync(int delay_millis) override;

--- a/agent/cpp-algo/source/MapNavigator/Backend/backend.h
+++ b/agent/cpp-algo/source/MapNavigator/Backend/backend.h
@@ -31,12 +31,15 @@ public:
     virtual SteeringTransportProfile steering_transport_profile() const = 0;
 
     virtual bool supports_sprint() const { return true; }
+    // Backends with no walk binding report false; walk requests are then no-ops and the run stays at jogging speed.
+    virtual bool supports_walk_toggle() const { return false; }
 
     virtual void SetMovementStateSync(bool forward, bool left, bool backward, bool right, int delay_millis) = 0;
     virtual void TriggerJumpSync(int hold_millis) = 0;
     virtual void TriggerInteractSync(int hold_millis) = 0;
     virtual void PulseForwardSync(int hold_millis) = 0;
     virtual void TriggerSprintSync() = 0;
+    virtual void ToggleWalkModeSync() {}
     virtual void ResetForwardWalkSync(int release_millis) = 0;
     virtual void ClickMouseLeftSync() = 0;
     virtual void MouseRightDownSync(int delay_millis) = 0;

--- a/agent/cpp-algo/source/MapNavigator/action_wrapper.cpp
+++ b/agent/cpp-algo/source/MapNavigator/action_wrapper.cpp
@@ -53,6 +53,11 @@ bool ActionWrapper::SupportsSprint() const
     return backend_->supports_sprint();
 }
 
+bool ActionWrapper::SupportsWalkToggle() const
+{
+    return backend_->supports_walk_toggle();
+}
+
 void ActionWrapper::SetMovementStateSync(bool forward, bool left, bool backward, bool right, int delay_millis)
 {
     backend_->SetMovementStateSync(forward, left, backward, right, delay_millis);
@@ -76,6 +81,11 @@ void ActionWrapper::PulseForwardSync(int hold_millis)
 void ActionWrapper::TriggerSprintSync()
 {
     backend_->TriggerSprintSync();
+}
+
+void ActionWrapper::ToggleWalkModeSync()
+{
+    backend_->ToggleWalkModeSync();
 }
 
 void ActionWrapper::ResetForwardWalkSync(int release_millis)

--- a/agent/cpp-algo/source/MapNavigator/action_wrapper.h
+++ b/agent/cpp-algo/source/MapNavigator/action_wrapper.h
@@ -26,12 +26,14 @@ public:
     double DefaultTurnUnitsPerDegree() const;
     SteeringTransportProfile SteeringProfile() const;
     bool SupportsSprint() const;
+    bool SupportsWalkToggle() const;
 
     void SetMovementStateSync(bool forward, bool left, bool backward, bool right, int delay_millis);
     void TriggerJumpSync(int hold_millis);
     void TriggerInteractSync(int hold_millis);
     void PulseForwardSync(int hold_millis);
     void TriggerSprintSync();
+    void ToggleWalkModeSync();
     void ResetForwardWalkSync(int release_millis);
     void ClickMouseLeftSync();
 

--- a/agent/cpp-algo/source/MapNavigator/motion_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/motion_controller.cpp
@@ -9,6 +9,7 @@
 #include "latency_observer.h"
 #include "motion_controller.h"
 #include "navi_config.h"
+#include "walk_mode.h"
 
 namespace mapnavigator
 {
@@ -189,6 +190,7 @@ bool MotionController::TriggerSprint()
     ClearPendingSteering();
     ArmSteeringQuietPeriod();
     action_wrapper_->TriggerSprintSync();
+    walkmode::NoteSprintTriggered();
     sprint_active_ = true;
     LogInfo << "Sprint state armed.";
     return true;

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -256,6 +256,10 @@ constexpr double kCollectRetryMinMoveWu = 2.5;
 constexpr double kCollectSprintSuppressBandWu = 8.0;
 constexpr int32_t kSprintCancelReleaseMs = 60;
 
+// Walking halves both speed and turn rate, so jogging-sized windows are doubled while engaged.
+constexpr int32_t kWalkModeSlowFactor = 2;
+constexpr int32_t kActionWalkTogglePressMs = 30;
+
 // Blocking-device removal: a device parked in the way is carried off instead of jumped over. The probe reads
 // the same ROI the pipeline's interact-button check uses, so the JSON stays the single source of truth. Its
 // threshold sits below the pipeline default (0.7) on purpose: the probe only decides whether the subtask is

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -412,6 +412,7 @@ NavigationStateMachine::NavigationStateMachine(
     , should_stop_(std::move(should_stop))
     , maa_context_(maa_context)
     , device_recovery_(maa_context, motion_controller, position_provider, session, position)
+    , walk_mode_(action_wrapper)
 {
     LogInfo << "Navigation route runner selected. backend=orchestrated";
 }
@@ -1420,10 +1421,13 @@ bool NavigationStateMachine::TickNavigate()
     // Settle the turn already sent against what the heading actually moved, so the controller discounts what is
     // still in flight instead of commanding the same error again. Only motion toward the debt pays it down, and
     // an unpaid debt expires, so a swallowed drag can never leave steering suppressed against a turn never coming.
+    // Walking turns at about half rate: a jogging-sized lifetime expires mid-turn and the loop re-commands it.
+    const int64_t pending_lifetime_ms =
+        walk_mode_.engaged() ? kSteeringPendingLifetimeMs * kWalkModeSlowFactor : kSteeringPendingLifetimeMs;
     SteeringRateState& steering_rate = runtime_state_.steering_rate;
     if (steering_rate.pending_turn_deg != 0.0) {
         const int64_t pending_age_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - steering_rate.cmd_at).count();
-        if (pending_age_ms >= kSteeringPendingLifetimeMs) {
+        if (pending_age_ms >= pending_lifetime_ms) {
             steering_rate.pending_turn_deg = 0.0;
         }
         else {
@@ -1488,7 +1492,11 @@ bool NavigationStateMachine::TickNavigate()
     }
     flow.last_steer_position = *position_;
     flow.has_last_steer_position = true;
-    if (flow.motionless_hold_ticks >= kForwardHoldReassertTicks) {
+    // At walking speed one tick's step sits under the position quantum, so a straight walk reads as motionless.
+    // Widen the window rather than lower the threshold — the threshold is what rejects quantization noise.
+    const int32_t hold_reassert_ticks =
+        walk_mode_.engaged() ? kForwardHoldReassertTicks * kWalkModeSlowFactor : kForwardHoldReassertTicks;
+    if (flow.motionless_hold_ticks >= hold_reassert_ticks) {
         ++flow.futile_forward_reasserts;
         LogWarn << "Forward hold produced no motion; re-sending it." << VAR(flow.motionless_hold_ticks) << VAR(heading_error)
                 << VAR(flow.futile_forward_reasserts) << VAR(position_->x) << VAR(position_->y);

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -11,6 +11,7 @@
 #include "navigation_runtime_state.h"
 #include "navigation_session.h"
 #include "obstacle_device_recovery.h"
+#include "walk_mode.h"
 
 namespace mapnavigator
 {
@@ -96,6 +97,8 @@ private:
     bool collect_attempt_pos_valid_ = false;
 
     ObstacleDeviceRecovery device_recovery_;
+    // Declared last so its destructor runs first — restores jogging while its collaborators are still alive.
+    walkmode::Toggle walk_mode_;
 };
 
 } // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/walk_mode.cpp
+++ b/agent/cpp-algo/source/MapNavigator/walk_mode.cpp
@@ -1,0 +1,59 @@
+#include "walk_mode.h"
+
+#include <MaaUtils/Logger.h>
+
+#include "action_wrapper.h"
+
+namespace mapnavigator::walkmode
+{
+
+namespace
+{
+// The game's toggle state, not a run's — hence process-global.
+bool g_walking = false;
+}
+
+bool Engaged()
+{
+    return g_walking;
+}
+
+void NoteSprintTriggered()
+{
+    if (!g_walking) {
+        return;
+    }
+    g_walking = false;
+    LogInfo << "Walk mode cleared by sprint (the game leaves walking on its own).";
+}
+
+Toggle::Toggle(ActionWrapper* action_wrapper)
+    : action_wrapper_(action_wrapper)
+{
+    // Survived into a new run = the last one failed to unwind; put the game back before navigating.
+    if (g_walking) {
+        LogWarn << "Walk mode belief survived the previous run; restoring jogging before navigating.";
+        Request(false);
+    }
+}
+
+Toggle::~Toggle()
+{
+    Request(false);
+}
+
+void Toggle::Request(bool walk)
+{
+    if (walk == g_walking) {
+        return;
+    }
+    if (action_wrapper_ == nullptr || !action_wrapper_->SupportsWalkToggle()) {
+        return; // no binding on this backend
+    }
+
+    action_wrapper_->ToggleWalkModeSync();
+    g_walking = walk;
+    LogInfo << (walk ? "Walk mode engaged (game walking speed)." : "Walk mode released (back to jogging).");
+}
+
+} // namespace mapnavigator::walkmode

--- a/agent/cpp-algo/source/MapNavigator/walk_mode.h
+++ b/agent/cpp-algo/source/MapNavigator/walk_mode.h
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace mapnavigator
+{
+class ActionWrapper;
+}
+
+namespace mapnavigator::walkmode
+{
+
+// The game's walk toggle is a press-to-flip state that outlives a single run, so the belief is process-global
+// and the restore is a destructor.
+bool Engaged();
+
+// Sprint leaves walking on its own — adopt that instead of sending a key.
+void NoteSprintTriggered();
+
+class Toggle
+{
+public:
+    explicit Toggle(ActionWrapper* action_wrapper);
+    // Restores jogging on every exit path: success, failure, user stop, exception unwind.
+    ~Toggle();
+
+    Toggle(const Toggle&) = delete;
+    Toggle& operator=(const Toggle&) = delete;
+
+    // Idempotent; a no-op on backends with no binding — the belief only moves with a real press.
+    void Request(bool walk);
+    bool engaged() const { return Engaged(); }
+
+private:
+    ActionWrapper* action_wrapper_ = nullptr;
+};
+
+} // namespace mapnavigator::walkmode


### PR DESCRIPTION
## Summary by Sourcery

为游戏添加步行/慢跑模式切换支持，并将步行模式感知集成到导航和运动控制中。

新功能：
- 引入一个进程全局的步行模式切换抽象，用于在多次运行之间跟踪并恢复游戏的步行/慢跑状态。
- 通过输入后端和 `ActionWrapper` 暴露步行模式切换能力，包括为步行切换控制提供桌面端键位绑定。

改进：
- 在启用步行模式时，调整转向挂起的持续时间以及前进按住重申的时间窗口，以适应降低后的速度和转向速率。
- 确保在激活冲刺时自动清除控制器中的步行模式状态，以符合游戏中的实际行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for game walk/jog mode toggling and integrate walk mode awareness into navigation and motion control.

New Features:
- Introduce a process-global walk mode toggle abstraction that tracks and restores the game’s walk/jog state across runs.
- Expose walk mode toggle capability through the input backend and ActionWrapper, including a desktop key binding for the walk toggle control.

Enhancements:
- Adjust steering pending lifetime and forward hold reassert windows when walk mode is engaged to account for reduced speed and turn rate.
- Ensure sprint activation automatically clears walk mode state in the controller to mirror in-game behavior.

</details>