### PR TITLE
fix(cpp-algo): 崩溃时写 minidump 并补齐入口守卫

### DIFF
--- a/agent/cpp-algo/source/CMakeLists.txt
+++ b/agent/cpp-algo/source/CMakeLists.txt
@@ -15,7 +15,8 @@ if(LINUX)
 endif()
 
 if(WIN32)
-    target_link_libraries(cpp-algo PRIVATE WebView2::WebView2)
+    # dbghelp 静态链接，而不是崩溃时 LoadLibrary，以免撞上 loader lock。
+    target_link_libraries(cpp-algo PRIVATE WebView2::WebView2 dbghelp)
     target_compile_definitions(cpp-algo PRIVATE MAAEND_HAVE_WEBVIEW2)
 
     add_custom_command(TARGET cpp-algo POST_BUILD

--- a/agent/cpp-algo/source/Common/CrashHandler.cpp
+++ b/agent/cpp-algo/source/Common/CrashHandler.cpp
@@ -1,0 +1,200 @@
+#include "CrashHandler.h"
+
+#include <atomic>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iterator>
+#include <string>
+#include <system_error>
+
+#include <MaaUtils/Logger.h>
+
+#ifdef _WIN32
+
+#include <MaaUtils/SafeWindows.hpp>
+
+#include <dbghelp.h>
+
+#endif
+
+namespace common
+{
+
+namespace
+{
+
+// 重入多半是转储过程自己又炸了，安静退出好过写出半截文件。
+std::atomic_flag g_dumping;
+
+// 只在转储写完之后调用：它会分配内存，而 bad_alloc 正是可能的死因之一。
+void LogTerminating(const char* source)
+{
+    // 有无待决异常足以分辨 abort 和未接住的抛出，异常内容本身在转储里。
+    const bool uncaught_exception = std::current_exception() != nullptr;
+    LogError << "Process terminating." << VAR(source) << VAR(uncaught_exception);
+}
+
+#ifdef _WIN32
+
+// 崩溃退出码，外部据此认出这是非正常退出。
+constexpr int kCrashExitCode = 3;
+
+// 转储目录绝对路径，以反斜杠结尾。崩溃时只往后拼文件名，不做任何分配。
+wchar_t g_dump_dir[MAX_PATH] = {};
+
+// 还得放得下 cpp-algo-YYYYMMDD-HHMMSS-PID.dmp：拼接越界会撞进非法参数钩子，
+// 而那时转储标记已置位，结果是既无转储也无日志的静默退出。余量不够就不装。
+constexpr size_t kDumpNameReserve = 48;
+
+void WriteDump(EXCEPTION_POINTERS* exception_pointers)
+{
+    if (g_dump_dir[0] == L'\0') {
+        return;
+    }
+
+    SYSTEMTIME now {};
+    GetLocalTime(&now);
+
+    wchar_t path[MAX_PATH] = {};
+    const int written = swprintf_s(
+        path,
+        L"%scpp-algo-%04u%02u%02u-%02u%02u%02u-%lu.dmp",
+        g_dump_dir,
+        static_cast<unsigned>(now.wYear),
+        static_cast<unsigned>(now.wMonth),
+        static_cast<unsigned>(now.wDay),
+        static_cast<unsigned>(now.wHour),
+        static_cast<unsigned>(now.wMinute),
+        static_cast<unsigned>(now.wSecond),
+        GetCurrentProcessId());
+    if (written < 0) {
+        return;
+    }
+
+    HANDLE file = CreateFileW(path, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        return;
+    }
+
+    MINIDUMP_EXCEPTION_INFORMATION info {};
+    info.ThreadId = GetCurrentThreadId();
+    info.ExceptionPointers = exception_pointers;
+    info.ClientPointers = FALSE;
+
+    // 带上被间接引用的内存，栈上的对象才能在调试器里展开。
+    const MINIDUMP_TYPE type = static_cast<MINIDUMP_TYPE>(MiniDumpWithIndirectlyReferencedMemory | MiniDumpScanMemory);
+    const BOOL ok = MiniDumpWriteDump(
+        GetCurrentProcess(),
+        GetCurrentProcessId(),
+        file,
+        type,
+        exception_pointers != nullptr ? &info : nullptr,
+        nullptr,
+        nullptr);
+    const DWORD dump_error = ok ? 0 : GetLastError();
+
+    CloseHandle(file);
+
+    const std::wstring dump_path(path);
+    if (ok) {
+        LogError << "Crash dump written." << VAR(dump_path);
+    }
+    else {
+        LogError << "Failed to write crash dump." << VAR(dump_path) << VAR(dump_error);
+    }
+}
+
+LONG WINAPI OnUnhandledException(EXCEPTION_POINTERS* exception_pointers)
+{
+    if (!g_dumping.test_and_set()) {
+        WriteDump(exception_pointers);
+        const DWORD exception_code = exception_pointers != nullptr && exception_pointers->ExceptionRecord != nullptr
+                                         ? exception_pointers->ExceptionRecord->ExceptionCode
+                                         : 0;
+        LogError << "Process terminating on unhandled structured exception." << VAR(exception_code);
+    }
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+// abort() 走 __fastfail，不经过用户态异常分发，所以转储得在这里自己写。
+// 写完直接 _exit：再往下走会重新进入 abort，二次终止只会丢掉刚写的现场。
+[[noreturn]] void OnTerminate()
+{
+    if (!g_dumping.test_and_set()) {
+        WriteDump(nullptr);
+        LogTerminating("terminate");
+    }
+    _exit(kCrashExitCode);
+}
+
+[[noreturn]] void OnAbortSignal(int)
+{
+    if (!g_dumping.test_and_set()) {
+        WriteDump(nullptr);
+        LogError << "Process aborted.";
+    }
+    _exit(kCrashExitCode);
+}
+
+// CRT 判定参数非法时直接终止进程，上面两个钩子都看不到。
+void OnInvalidParameter(const wchar_t*, const wchar_t*, const wchar_t*, unsigned int, uintptr_t)
+{
+    if (!g_dumping.test_and_set()) {
+        WriteDump(nullptr);
+        LogError << "Process terminating on invalid CRT parameter.";
+    }
+    _exit(kCrashExitCode);
+}
+
+#else
+
+[[noreturn]] void OnTerminate()
+{
+    if (!g_dumping.test_and_set()) {
+        LogTerminating("terminate");
+    }
+    std::abort();
+}
+
+#endif
+
+} // namespace
+
+void InstallCrashHandler(const std::filesystem::path& dump_dir)
+{
+    std::error_code ec;
+    const std::filesystem::path absolute_dir = std::filesystem::absolute(dump_dir, ec);
+    if (ec) {
+        LogWarn << "Failed to resolve crash dump directory; crash handler disabled." << VAR(dump_dir) << VAR(ec.message());
+        return;
+    }
+
+    std::filesystem::create_directories(absolute_dir, ec);
+    if (ec) {
+        LogWarn << "Failed to create crash dump directory; crash handler disabled." << VAR(absolute_dir) << VAR(ec.message());
+        return;
+    }
+
+#ifdef _WIN32
+    const std::wstring prefix = absolute_dir.wstring() + L'\\';
+    if (prefix.size() + kDumpNameReserve >= std::size(g_dump_dir)) {
+        LogWarn << "Crash dump directory path is too long; crash handler disabled." << VAR(absolute_dir);
+        return;
+    }
+    prefix.copy(g_dump_dir, prefix.size());
+    g_dump_dir[prefix.size()] = L'\0';
+
+    SetUnhandledExceptionFilter(OnUnhandledException);
+    std::set_terminate(OnTerminate);
+    std::signal(SIGABRT, OnAbortSignal);
+    _set_invalid_parameter_handler(OnInvalidParameter);
+#else
+    std::set_terminate(OnTerminate);
+#endif
+
+    LogInfo << "Crash handler installed." << VAR(absolute_dir);
+}
+
+} // namespace common

--- a/agent/cpp-algo/source/Common/CrashHandler.cpp
+++ b/agent/cpp-algo/source/Common/CrashHandler.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <csignal>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <exception>
 #include <iterator>
@@ -44,8 +45,7 @@ constexpr int kCrashExitCode = 3;
 // 转储目录绝对路径，以反斜杠结尾。崩溃时只往后拼文件名，不做任何分配。
 wchar_t g_dump_dir[MAX_PATH] = {};
 
-// 还得放得下 cpp-algo-YYYYMMDD-HHMMSS-PID.dmp：拼接越界会撞进非法参数钩子，
-// 而那时转储标记已置位，结果是既无转储也无日志的静默退出。余量不够就不装。
+// 还得放得下 cpp-algo-YYYYMMDD-HHMMSS-PID.dmp，余量不够就不装。
 constexpr size_t kDumpNameReserve = 48;
 
 void WriteDump(EXCEPTION_POINTERS* exception_pointers)
@@ -57,9 +57,13 @@ void WriteDump(EXCEPTION_POINTERS* exception_pointers)
     SYSTEMTIME now {};
     GetLocalTime(&now);
 
+    // 用 _TRUNCATE 而不是 swprintf_s：后者拼不下时会撞进非法参数钩子，而那时转储标记已置位，
+    // 结果是既无转储也无日志的静默退出。这样即便文件名格式改长到超出 kDumpNameReserve，也只是失败返回。
     wchar_t path[MAX_PATH] = {};
-    const int written = swprintf_s(
+    const int written = _snwprintf_s(
         path,
+        std::size(path),
+        _TRUNCATE,
         L"%scpp-algo-%04u%02u%02u-%02u%02u%02u-%lu.dmp",
         g_dump_dir,
         static_cast<unsigned>(now.wYear),

--- a/agent/cpp-algo/source/Common/CrashHandler.h
+++ b/agent/cpp-algo/source/Common/CrashHandler.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <filesystem>
+
+namespace common
+{
+
+// 安装崩溃转储处理器，只在 main() 启动阶段调用一次。
+// Windows 下挂四个钩子覆盖互不相交的死法：结构化异常、未接住的 C++ 异常、SIGABRT、
+// CRT 非法参数；非 Windows 只装 terminate 记日志。
+// dump_dir 在此解析成绝对路径并建好，崩溃时只做定长拼接，不分配也不依赖当前工作目录。
+void InstallCrashHandler(const std::filesystem::path& dump_dir);
+
+} // namespace common

--- a/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocateAction.cpp
@@ -96,13 +96,22 @@ fs::path getExeDir()
     return get_exe_dir();
 }
 
+// 参数由 pipeline 提供，字段类型不由本模块保证。解析失败退回默认值，与不传参数同路。
 template <typename T>
 T ParseCustomRecognitionParam(const char* custom_recognition_param)
 {
-    if (custom_recognition_param && std::strlen(custom_recognition_param) > 0) {
-        return json::parse(custom_recognition_param).value_or(json::object {}).as<T>();
+    if (custom_recognition_param == nullptr || std::strlen(custom_recognition_param) == 0) {
+        return T {};
     }
-    return T {};
+
+    const auto parsed = json::parse(custom_recognition_param);
+    T value {};
+    if (!parsed || !value.from_json(*parsed)) {
+        // from_json 中途失败会留下写了一半的字段，整个丢掉重来。
+        LogWarn << "Invalid param, using defaults" << VAR(custom_recognition_param);
+        return T {};
+    }
+    return value;
 }
 
 template <typename T>

--- a/agent/cpp-algo/source/MapNavigator/controller_info_utils.cpp
+++ b/agent/cpp-algo/source/MapNavigator/controller_info_utils.cpp
@@ -1,8 +1,10 @@
 #include <optional>
 
 #include <MaaFramework/Utility/MaaBuffer.h>
+#include <MaaUtils/Logger.h>
 #include <meojson/json.hpp>
 
+#include "../utils.h"
 #include "controller_info_utils.h"
 
 namespace mapnavigator
@@ -25,19 +27,24 @@ ControllerInfo ParseControllerInfo(MaaController* controller)
         return {};
     }
 
-    MaaStringBuffer* buffer = MaaStringBufferCreate();
-    if (buffer == nullptr) {
+    ScopedStringBuffer buffer;
+    if (buffer.Get() == nullptr || !MaaControllerGetInfo(controller, buffer.Get())) {
         return {};
     }
 
-    if (!MaaControllerGetInfo(controller, buffer)) {
-        MaaStringBufferDestroy(buffer);
+    const char* raw = MaaStringBufferGet(buffer.Get());
+    if (raw == nullptr) {
         return {};
     }
 
-    const char* raw = MaaStringBufferGet(buffer);
-    ControllerInfo info = json::parse(raw).value().as<ControllerInfo>();
-    MaaStringBufferDestroy(buffer);
+    // 格式不由本模块保证。解析失败按「拿不到信息」处理，与 controller 为空同路。
+    const auto parsed = json::parse(raw);
+    ControllerInfo info;
+    if (!parsed || !info.from_json(*parsed)) {
+        LogWarn << "Failed to parse controller info" << VAR(raw);
+        return {};
+    }
+
     return info;
 }
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_session.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_session.cpp
@@ -14,6 +14,13 @@ namespace mapnavigator
 namespace
 {
 
+// Stands in for an out-of-range element; has_position is false, so callers take their no-position branch.
+const Waypoint& EmptyWaypoint()
+{
+    static const Waypoint empty {};
+    return empty;
+}
+
 size_t ResolveCanonicalFinalGoalIndex(const std::vector<Waypoint>& path)
 {
     for (size_t index = path.size(); index > 0; --index) {
@@ -86,7 +93,10 @@ bool NavigationSession::HasCanonicalFinalGoal() const
 
 const Waypoint& NavigationSession::CanonicalFinalGoal() const
 {
-    assert(HasCanonicalFinalGoal() && "CanonicalFinalGoal requires a position node.");
+    if (!HasCanonicalFinalGoal()) {
+        LogError << "CanonicalFinalGoal requires a position node." << VAR(canonical_final_goal_index_) << VAR(original_path_.size());
+        return EmptyWaypoint();
+    }
     return original_path_[canonical_final_goal_index_];
 }
 
@@ -192,25 +202,33 @@ bool NavigationSession::HasCurrentWaypoint() const
 
 const Waypoint& NavigationSession::CurrentWaypoint() const
 {
-    RequireCurrentWaypoint("CurrentWaypoint");
+    if (!RequireCurrentWaypoint("CurrentWaypoint")) {
+        return EmptyWaypoint();
+    }
     return current_path_[current_node_idx_];
 }
 
 const Waypoint& NavigationSession::CurrentPathAt(size_t index) const
 {
-    RequireWaypointIndex(index, "CurrentPathAt");
+    if (!RequireWaypointIndex(index, "CurrentPathAt")) {
+        return EmptyWaypoint();
+    }
     return current_path_[index];
 }
 
 std::optional<size_t> NavigationSession::CanonicalIndexAtCurrent() const
 {
-    RequireCurrentWaypoint("CanonicalIndexAtCurrent");
+    if (!RequireCurrentWaypoint("CanonicalIndexAtCurrent")) {
+        return std::nullopt;
+    }
     return CanonicalIndexAtCurrentPath(current_node_idx_);
 }
 
 std::optional<size_t> NavigationSession::CanonicalIndexAtCurrentPath(size_t index) const
 {
-    RequireWaypointIndex(index, "CanonicalIndexAtCurrentPath");
+    if (!RequireWaypointIndex(index, "CanonicalIndexAtCurrentPath")) {
+        return std::nullopt;
+    }
     if (index < generated_prefix_size_) {
         return std::nullopt;
     }
@@ -229,7 +247,9 @@ void NavigationSession::UpdateCurrentZone(const std::string& zone_id)
 
 void NavigationSession::AdvanceToNextWaypoint(const char* reason)
 {
-    RequireCurrentWaypoint(reason);
+    if (!RequireCurrentWaypoint(reason)) {
+        return;
+    }
     ++current_node_idx_;
     ResetProgress();
     ResetHardProgress();
@@ -238,14 +258,18 @@ void NavigationSession::AdvanceToNextWaypoint(const char* reason)
 void NavigationSession::AdvanceToNextWaypoint(ActionType expected_action, const char* reason)
 {
     (void)expected_action;
-    RequireCurrentWaypoint(reason);
+    if (!RequireCurrentWaypoint(reason)) {
+        return;
+    }
     assert(current_path_[current_node_idx_].action == expected_action && "Unexpected action while advancing waypoint.");
     AdvanceToNextWaypoint(reason);
 }
 
 void NavigationSession::SkipPastWaypoint(size_t waypoint_idx, const char* reason)
 {
-    RequireWaypointIndex(waypoint_idx, reason);
+    if (!RequireWaypointIndex(waypoint_idx, reason)) {
+        return;
+    }
     assert(waypoint_idx >= current_node_idx_ && "SkipPastWaypoint cannot move backward.");
     current_node_idx_ = waypoint_idx + 1;
     ResetProgress();
@@ -325,7 +349,12 @@ void NavigationSession::ResetHardProgress()
 
 void NavigationSession::ApplyDynamicOverlay(std::vector<Waypoint> generated_prefix, size_t continue_index, const NaviPosition& pos)
 {
-    assert(continue_index <= original_path_.size() && "Dynamic overlay continue index is out of range.");
+    // An out-of-range index would hand the insert below a reversed range, which wraps into a huge allocation.
+    if (continue_index > original_path_.size()) {
+        LogError << "Dynamic overlay continue index is out of range." << VAR(continue_index) << VAR(original_path_.size());
+        continue_index = original_path_.size();
+    }
+
     const bool retargeted = continue_index != path_origin_index_;
     current_path_ = std::move(generated_prefix);
     const size_t generated_count = current_path_.size();
@@ -360,17 +389,22 @@ void NavigationSession::UpdatePhase(NaviPhase next_phase, const char* reason)
     phase_ = next_phase;
 }
 
-void NavigationSession::RequireCurrentWaypoint(const char* reason) const
+bool NavigationSession::RequireCurrentWaypoint(const char* reason) const
 {
-    (void)reason;
-    assert(HasCurrentWaypoint() && "Current waypoint is required.");
+    if (HasCurrentWaypoint()) {
+        return true;
+    }
+    LogError << "Current waypoint is required." << VAR(reason) << VAR(current_node_idx_) << VAR(current_path_.size());
+    return false;
 }
 
-void NavigationSession::RequireWaypointIndex(size_t index, const char* reason) const
+bool NavigationSession::RequireWaypointIndex(size_t index, const char* reason) const
 {
-    (void)index;
-    (void)reason;
-    assert(index < current_path_.size() && "Waypoint index is out of range.");
+    if (index < current_path_.size()) {
+        return true;
+    }
+    LogError << "Waypoint index is out of range." << VAR(reason) << VAR(index) << VAR(current_path_.size());
+    return false;
 }
 
 } // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/navigation_session.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_session.h
@@ -93,8 +93,9 @@ private:
     std::chrono::steady_clock::time_point hard_last_progress_time_ {};
     bool hard_progress_initialized_ = false;
 
-    void RequireCurrentWaypoint(const char* reason) const;
-    void RequireWaypointIndex(size_t index, const char* reason) const;
+    // False when out of range, so callers fall back instead of indexing past the end.
+    bool RequireCurrentWaypoint(const char* reason) const;
+    bool RequireWaypointIndex(size_t index, const char* reason) const;
     void RecordFinalArrivalEvidence(
         const NaviPosition& position,
         bool verified_at_tail_consumption,

--- a/agent/cpp-algo/source/MapNavigator/navigation_session.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_session.h
@@ -94,8 +94,8 @@ private:
     bool hard_progress_initialized_ = false;
 
     // False when out of range, so callers fall back instead of indexing past the end.
-    bool RequireCurrentWaypoint(const char* reason) const;
-    bool RequireWaypointIndex(size_t index, const char* reason) const;
+    [[nodiscard]] bool RequireCurrentWaypoint(const char* reason) const;
+    [[nodiscard]] bool RequireWaypointIndex(size_t index, const char* reason) const;
     void RecordFinalArrivalEvidence(
         const NaviPosition& position,
         bool verified_at_tail_consumption,

--- a/agent/cpp-algo/source/RecoGrid/GridClassifier.cpp
+++ b/agent/cpp-algo/source/RecoGrid/GridClassifier.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <map>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace recogrid
@@ -36,7 +37,8 @@ struct DirectMaskKey
 
 struct DirectTemplateKey
 {
-    std::uintptr_t data = 0;
+    // 用模板 id 而不是像素指针：模板释放后新 Mat 可能落到同一地址，指针会命中错项。
+    std::string id;
     int rows = 0;
     int cols = 0;
     int type = 0;
@@ -131,13 +133,7 @@ DirectTemplateEntry GetDirectTemplateEntry(const GridClassifyTemplate& entry, cv
     static std::map<DirectTemplateKey, DirectTemplateEntry> cache;
 
     const DirectTemplateKey key {
-        reinterpret_cast<std::uintptr_t>(entry.image.data),
-        entry.image.rows,
-        entry.image.cols,
-        entry.image.type(),
-        size.width,
-        size.height,
-        MakeDirectMaskKey(maskRatios),
+        entry.id, entry.image.rows, entry.image.cols, entry.image.type(), size.width, size.height, MakeDirectMaskKey(maskRatios),
     };
 
     const auto iter = cache.find(key);

--- a/agent/cpp-algo/source/main.cpp
+++ b/agent/cpp-algo/source/main.cpp
@@ -1,8 +1,10 @@
+#include <filesystem>
 #include <iostream>
 
 #include <MaaAgentServer/MaaAgentServerAPI.h>
 #include <MaaToolkit/MaaToolkitAPI.h>
 
+#include "Common/CrashHandler.h"
 #include "Common/ParentProcessWatcher.h"
 #include "EssenceGridScan/EssenceGridScan.h"
 #include "IconRecognition/IconRecognitionRecognition.h"
@@ -37,7 +39,11 @@ int main(int argc, char** argv)
 
     // std::cout << "Hello, cpp-algo!" << std::endl;
 
-    MaaToolkitConfigInitOption("./debug/cpp-algo", "{}");
+    constexpr const char* kUserPath = "./debug/cpp-algo";
+    MaaToolkitConfigInitOption(kUserPath, "{}");
+
+    // 转储落到 maa.log 同一目录，报 issue 打包日志时会一并带上。
+    common::InstallCrashHandler(std::filesystem::path(kUserPath) / "debug");
 
     MaaAgentServerRegisterCustomRecognition("MyReco1", ChildCustomRecognitionCallback, nullptr);
     MaaAgentServerRegisterCustomRecognition("MapLocateRecognition", maplocator::MapLocateRecognitionRun, nullptr);

--- a/agent/cpp-algo/source/my_reco_1/my_reco_1.cpp
+++ b/agent/cpp-algo/source/my_reco_1/my_reco_1.cpp
@@ -35,6 +35,11 @@ MaaBool ChildCustomRecognitionCallback(
 
     // sample for OpenCV APIs
     cv::Mat img = to_mat(image);
+    if (img.empty()) {
+        LogError << "Empty image";
+        return false;
+    }
+
     cv::Mat hsv;
     cv::cvtColor(img, hsv, cv::COLOR_BGR2HSV);
 


### PR DESCRIPTION
## Summary by Sourcery

添加崩溃处理以及更安全的导航／会话和 JSON 解析行为，以提高健壮性和诊断能力。

新功能：
- 引入跨平台崩溃处理器，在 Windows 上写入 minidump，并记录进程终止的详细信息。
- 在 `cpp-algo` 启动过程中自动设置崩溃转储目录，并将其集成进去，使转储文件与日志文件放在同一位置。

缺陷修复：
- 通过对索引使用进行保护并返回安全的回退结果，防止在导航会话中访问越界的航点。
- 修复当 `MaaControllerGetInfo` 调用失败或返回格式错误的 JSON 时，可能出现的控制器信息解析无效问题。
- 通过基于稳定的模板 ID 而不是图像数据指针进行缓存，避免错误识别网格模板。
- 在自定义识别回调中处理空图像，避免处理无效的 OpenCV 矩阵。
- 确保动态叠加（dynamic overlay）的继续索引被限制在原始路径大小范围内，以避免反向区间和大规模内存分配。
- 使自定义识别参数解析在遇到无效或不完整 JSON 时更加健壮，使用默认值回退，而不是构造半填充对象。

增强：
- 在导航航点、索引或控制器信息解析失败时添加详细日志，以帮助调试。
- 通过静态链接 `dbghelp` 并写入包含间接引用内存的更丰富的 minidump，改进 Windows 上的崩溃诊断。
- 通过 `terminate`、`SIGABRT` 和无效参数钩子配合结构化日志，优化 Windows 及其他平台上的终止处理。

构建：
- 在 Windows 上将 `cpp-algo` 链接到 `dbghelp`，以支持生成 minidump。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add crash handling and safer navigation/session and JSON parsing behaviors to improve robustness and diagnostics.

New Features:
- Introduce a cross-platform crash handler that writes Windows minidumps and logs process termination details.
- Add automatic crash dump directory setup and integration into cpp-algo startup so dumps are colocated with logs.

Bug Fixes:
- Prevent out-of-range waypoint access in navigation sessions by guarding index usage and returning safe fallbacks.
- Fix potential invalid controller info parsing when MaaControllerGetInfo fails or returns malformed JSON.
- Avoid misidentifying grid templates by caching on stable template IDs instead of image data pointers.
- Handle empty images in custom recognition callback to avoid processing invalid OpenCV matrices.
- Ensure dynamic overlay continue indices are clamped to the original path size to avoid reversed ranges and large allocations.
- Make custom recognition parameter parsing robust to invalid or partial JSON, falling back to defaults instead of constructing half-populated objects.

Enhancements:
- Add detailed logging when navigation waypoints, indices, or controller info parsing fail to aid debugging.
- Improve crash diagnostics on Windows by statically linking dbghelp and writing richer minidumps with indirectly referenced memory.
- Refine termination handling on Windows and other platforms via terminate, SIGABRT, and invalid-parameter hooks with structured logging.

Build:
- Link cpp-algo against dbghelp on Windows to support minidump generation.

</details>