### PR TITLE
feat(MapNavigator): 增强自动采集,收紧判定圈并接近时切走路

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -251,10 +251,22 @@ constexpr int32_t kCollectLabelMinWidth = 24;         // ~2-char CJK name floor 
 constexpr int32_t kCollectLabelMinHeight = 7;         // reject thin specks (label glyph row ~14px)
 constexpr int32_t kCollectLabelMaxHeight = 26;        // reject tall non-text structures
 constexpr double kCollectLabelMaxFill = 0.80;         // text is sparse (label fill ~0.4-0.66); solid blob = panel/icon
-constexpr int32_t kCollectScanIntervalMs = 1500;
-constexpr double kCollectRetryMinMoveWu = 2.5;
+// Sole pacing gate for detection-triggered collects; the clock only advances on an actual attempt.
+constexpr int32_t kCollectScanIntervalMs = 1200;
+// Collect points sit 2.1-3.7 apart, closer than the normal 3.25 band, which swallows a whole run of them.
+constexpr double kCollectArrivalBandWu = 1.5;
+// Tightening must not add a way to get stuck: this long without progress falls back to the normal band.
+constexpr int32_t kCollectArrivalRelaxMs = 6000;
+// The route ends the tick the last collect point is consumed, so the scanner never gets a second chance.
+constexpr int32_t kCollectTailGraceMs = 1500;
 constexpr double kCollectSprintSuppressBandWu = 8.0;
 constexpr int32_t kSprintCancelReleaseMs = 60;
+
+// Walk near collect points so the interact prompt stays up long enough to act on. Enter/exit differ for
+// hysteresis (each press flips game state); the enter band stays inside the sprint-suppress band.
+constexpr double kCollectWalkEnterBandWu = 3.0;
+constexpr double kCollectWalkExitBandWu = 4.5;
+static_assert(kCollectWalkEnterBandWu < kCollectSprintSuppressBandWu, "walk band must sit inside the sprint-suppress band");
 
 // Walking halves both speed and turn rate, so jogging-sized windows are doubled while engaged.
 constexpr int32_t kWalkModeSlowFactor = 2;

--- a/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
@@ -25,7 +25,7 @@ namespace mapnavigator
 // COLLECT  - 仅作为"开启采集扫描"的路径点：经过时按普通路点直接推进，不再到点停车。
 //            采集完全由行进中的异步图标检测驱动——检测到采集物才立即停车并触发
 //            AutoCollectClickStart 子任务（OCR + AutoAltClickAction），没有采集物时不空停。
-//            （检测命中后有位移防卡死门限，避免被一直匹配到的非采集物困住）
+//            （检测只受冷却限速，误报由 OCR 名称白名单挡下，最多白停一次）
 // DIG      - 触发 AutoCollectDigStart pipeline 子任务（无条件 Click target=true 两次），用于挖掘点。
 //            与 COLLECT 不同，DIG 仍是精确抵达后停车触发（挖掘是定点动作，非行进检测）
 #define NAVI_ACTION_TYPES(X) \

--- a/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
@@ -82,13 +82,15 @@ struct Waypoint
     }
 
     // 到点判定圈半径, 通道比判定圈还窄时按通道收紧, 否则角色会提前弃点直奔下一点, 抄出撞墙的弦
-    double ArrivalBand(double position_quantum) const
+    // 采集点另按 kCollectArrivalBandWu 收紧(点距比常规判定圈还小), relax_collect 是够不着时的退让
+    double ArrivalBand(double position_quantum, bool relax_collect = false) const
     {
-        if (RequiresStrictArrival()) {
-            return GetLookahead() + position_quantum;
+        const bool strict = RequiresStrictArrival();
+        double band = strict ? GetLookahead() + position_quantum : GetLookahead() + kWaypointArrivalSlack + position_quantum;
+        if (action == ActionType::COLLECT && !relax_collect) {
+            band = std::min(band, kCollectArrivalBandWu);
         }
-        const double band = GetLookahead() + kWaypointArrivalSlack + position_quantum;
-        if (corridor_clearance <= 0.0) {
+        if (strict || corridor_clearance <= 0.0) {
             return band;
         }
         return std::min(band, std::max(corridor_clearance, kMinArrivalBand));

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -113,6 +113,18 @@ bool RouteHasCollectWaypoint(const std::vector<Waypoint>& path)
     return std::any_of(path.begin(), path.end(), [](const Waypoint& wp) { return wp.action == ActionType::COLLECT; });
 }
 
+// 末尾的无坐标节点(ZONE/HEADING)不算, 看的是最后一个真正要走到的点是不是采集点
+bool RouteEndsWithCollectWaypoint(const std::vector<Waypoint>& path)
+{
+    for (auto it = path.rbegin(); it != path.rend(); ++it) {
+        if (!it->HasPosition()) {
+            continue;
+        }
+        return it->action == ActionType::COLLECT;
+    }
+    return false;
+}
+
 struct BootstrapWaypointCandidate
 {
     size_t index = std::numeric_limits<size_t>::max();
@@ -148,9 +160,7 @@ bool IsRequiredSemanticAnchor(const Waypoint& waypoint)
 
 double ArrivalBandForStartupBypass(const Waypoint& waypoint)
 {
-    double arrival_band = waypoint.RequiresStrictArrival()
-                              ? waypoint.GetLookahead() + kMeasurementDefaultPositionQuantum
-                              : waypoint.GetLookahead() + kWaypointArrivalSlack + kMeasurementDefaultPositionQuantum;
+    double arrival_band = waypoint.ArrivalBand(kMeasurementDefaultPositionQuantum);
     if (waypoint.action == ActionType::PORTAL) {
         arrival_band = std::max(arrival_band, kPortalCommitDistance);
     }
@@ -448,6 +458,8 @@ bool NavigationStateMachine::Run()
         session_->HasSatisfiedFinalSuccess(*position_, "navigation_complete");
     }
 
+    TryCollectAtRouteTail();
+
     StopScanners();
     StopMotion();
 
@@ -493,6 +505,9 @@ bool NavigationStateMachine::Bootstrap()
 
 bool NavigationStateMachine::TickPhase(NaviPhase phase)
 {
+    // Ahead of every early return, so no branch or phase can strand the game in walking mode.
+    UpdateWalkMode(phase);
+
     switch (phase) {
     case NaviPhase::Bootstrap:
         SelectPhaseForCurrentWaypoint("bootstrap_dispatch");
@@ -1090,8 +1105,19 @@ bool NavigationStateMachine::TickNavigate()
         return true;
     }
 
-    const double arrival_distance =
-        waypoint.action == ActionType::PORTAL ? std::max(route.arrival_band, kPortalCommitDistance) : route.arrival_band;
+    double arrival_distance = route.arrival_band;
+    if (waypoint.action == ActionType::PORTAL) {
+        arrival_distance = std::max(arrival_distance, kPortalCommitDistance);
+    }
+    // 采集点判定圈收窄了, 真站不上去(硬性无进展这么久)就放回常规值, 别多出一种卡死
+    else if (waypoint.action == ActionType::COLLECT && session_->HardStalledMs(now) > kCollectArrivalRelaxMs) {
+        const double relaxed = waypoint.ArrivalBand(kMeasurementDefaultPositionQuantum, /*relax_collect=*/true);
+        if (relaxed > arrival_distance && route.waypoint_distance <= relaxed) {
+            LogInfo << "Collect arrival band relaxed after no progress." << VAR(session_->current_node_idx())
+                    << VAR(route.waypoint_distance) << VAR(arrival_distance) << VAR(relaxed);
+        }
+        arrival_distance = std::max(arrival_distance, relaxed);
+    }
     if (route.waypoint_distance <= arrival_distance) {
         if (!route.startup_motion_confirmed) {
             LogDebug << "Arrival advance blocked before startup movement confirmed." << VAR(session_->current_node_idx())
@@ -1718,28 +1744,61 @@ void NavigationStateMachine::StartDeviceProbe()
     device_recovery_.Start(base_roi);
 }
 
+// Squared distance to the nearest COLLECT point; -1 when there is no collect route or no position.
+double NavigationStateMachine::NearestCollectDistanceSq() const
+{
+    if (collect_scanner_ == nullptr || session_ == nullptr || position_ == nullptr || !position_->valid) {
+        return -1.0;
+    }
+
+    double nearest_sq = -1.0;
+    for (const Waypoint& waypoint : session_->current_path()) {
+        if (waypoint.action != ActionType::COLLECT || !waypoint.HasPosition()) {
+            continue;
+        }
+        const double dx = waypoint.x - position_->x;
+        const double dy = waypoint.y - position_->y;
+        const double distance_sq = dx * dx + dy * dy;
+        if (nearest_sq < 0.0 || distance_sq < nearest_sq) {
+            nearest_sq = distance_sq;
+        }
+    }
+    return nearest_sq;
+}
+
 void NavigationStateMachine::UpdateCollectSprintSuppression()
 {
     if (collect_scanner_ == nullptr || motion_controller_ == nullptr) {
         return; // not a collect route — leave sprint behaviour entirely untouched
     }
 
-    bool near_collect = false;
-    if (position_ != nullptr && position_->valid && session_ != nullptr) {
-        const double band_sq = kCollectSprintSuppressBandWu * kCollectSprintSuppressBandWu;
-        for (const Waypoint& waypoint : session_->current_path()) {
-            if (waypoint.action != ActionType::COLLECT || !waypoint.HasPosition()) {
-                continue;
-            }
-            const double dx = waypoint.x - position_->x;
-            const double dy = waypoint.y - position_->y;
-            if (dx * dx + dy * dy <= band_sq) {
-                near_collect = true;
-                break;
-            }
-        }
-    }
+    const double nearest_sq = NearestCollectDistanceSq();
+    const bool near_collect = nearest_sq >= 0.0 && nearest_sq <= kCollectSprintSuppressBandWu * kCollectSprintSuppressBandWu;
     motion_controller_->SetSprintSuppressed(near_collect);
+}
+
+// Walk mode's only decision point: engaged on the last few units of a collect approach, released everywhere else
+// (travel legs, recovery, turn-in-place nodes, before motion is confirmed).
+void NavigationStateMachine::UpdateWalkMode(NaviPhase phase)
+{
+    const double nearest_sq = NearestCollectDistanceSq();
+    const bool recovering = runtime_state_.recovery.active || runtime_state_.cross_tier_escape.active;
+    const ActionType action = session_->HasCurrentWaypoint() ? session_->CurrentWaypoint().action : ActionType::HEADING;
+    const bool plain_approach = action == ActionType::COLLECT || action == ActionType::RUN || action == ActionType::NAVMESH;
+    if (phase != NaviPhase::Navigate || nearest_sq < 0.0 || recovering || !plain_approach
+        || !runtime_state_.route.startup_motion_confirmed) {
+        walk_mode_.Request(false);
+        return;
+    }
+
+    const bool was_engaged = walk_mode_.engaged();
+    const double band = was_engaged ? kCollectWalkExitBandWu : kCollectWalkEnterBandWu;
+    walk_mode_.Request(nearest_sq <= band * band);
+    const bool walking = walk_mode_.engaged();
+    if (walking != was_engaged) {
+        const double nearest_collect = std::sqrt(nearest_sq);
+        LogInfo << "Walk mode boundary crossed." << VAR(walking) << VAR(nearest_collect) << VAR(position_->x) << VAR(position_->y);
+    }
 }
 
 void NavigationStateMachine::PreWarmCollectOcr()
@@ -1773,21 +1832,9 @@ bool NavigationStateMachine::TryScanApproachCollect(const RouteTrackingState& ro
         return false; // background worker has not flagged a collectible — keep walking, zero cost this tick
     }
 
-    if (collect_attempt_pos_valid_ && position_ != nullptr && position_->valid) {
-        const bool zone_changed =
-            !collect_attempt_pos_.zone_id.empty() && !position_->zone_id.empty() && collect_attempt_pos_.zone_id != position_->zone_id;
-        const double moved = std::hypot(position_->x - collect_attempt_pos_.x, position_->y - collect_attempt_pos_.y);
-        if (!zone_changed && moved < kCollectRetryMinMoveWu) {
-            LogDebug << "Collect detection suppressed (anti-stuck): not past the last attempt yet." << VAR(moved);
-            return false;
-        }
-    }
-
+    // No displacement gate: multi-item spots are authored as the same coordinate repeated, and the
+    // authoritative OCR only clicks known collectible names, so a stale flag costs one stutter at most.
     collect_scan_last_at_ = now;
-    if (position_ != nullptr && position_->valid) {
-        collect_attempt_pos_ = *position_;
-        collect_attempt_pos_valid_ = true;
-    }
 
     LogInfo << "Async collectible flagged — stopping for authoritative collect." << VAR(route.waypoint_distance)
             << VAR(session_->current_node_idx());
@@ -1796,6 +1843,39 @@ bool NavigationStateMachine::TryScanApproachCollect(const RouteTrackingState& ro
     MaaContextRunTask(maa_context_, kDefaultCollectEntry, kCollectPipelineOverride);
     utils::SleepFor(kCollectPostSleepMs);
     return true;
+}
+
+// 最后一个采集点被吃掉的同一拍路线就结束、扫描器随即销毁, 行进中的检测再没机会报第二次。
+// 收尾时停下来单独给一个窗口, 冷却和位移门槛都不走, 只试一次。
+// 放在成功判定之后: 这里超时或采集失败都不该把跑成功的线路翻成失败。
+void NavigationStateMachine::TryCollectAtRouteTail()
+{
+    if (maa_context_ == nullptr || collect_scanner_ == nullptr || should_stop_() || session_->phase() != NaviPhase::Finished
+        || !RouteEndsWithCollectWaypoint(session_->original_path())) {
+        return;
+    }
+
+    StopMotion();
+    utils::SleepFor(kStopWaitMs); // 先站定, 还在滑行就点容易白点一次
+    const auto started_at = std::chrono::steady_clock::now();
+    while (!should_stop_()) {
+        if (collect_scanner_->ConsumeDetection()) {
+            LogInfo << "Route tail collectible flagged — collecting before finishing." << VAR(session_->current_node_idx());
+            MaaContextRunTask(maa_context_, kDefaultCollectEntry, kCollectPipelineOverride);
+            utils::SleepFor(kCollectPostSleepMs);
+            return;
+        }
+
+        const int64_t elapsed_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started_at).count();
+        if (elapsed_ms >= kCollectTailGraceMs) {
+            LogInfo << "Route tail collect grace expired with nothing flagged." << VAR(elapsed_ms);
+            return;
+        }
+
+        CaptureCurrentPosition(false); // 只为把新画面喂给检测器
+        utils::SleepFor(kTargetTickMs);
+    }
 }
 
 bool NavigationStateMachine::FailNavigation(

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -1846,7 +1846,7 @@ bool NavigationStateMachine::TryScanApproachCollect(const RouteTrackingState& ro
 }
 
 // 最后一个采集点被吃掉的同一拍路线就结束、扫描器随即销毁, 行进中的检测再没机会报第二次。
-// 收尾时停下来单独给一个窗口, 冷却和位移门槛都不走, 只试一次。
+// 收尾时停下来单独给一个窗口, 不走冷却, 只试一次。
 // 放在成功判定之后: 这里超时或采集失败都不该把跑成功的线路翻成失败。
 void NavigationStateMachine::TryCollectAtRouteTail()
 {

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -70,12 +70,15 @@ private:
     bool FailNavigation(const char* reason, const char* log_message, double current_distance, double yaw_error, int64_t stalled_ms);
 
     bool TryScanApproachCollect(const RouteTrackingState& route, const Waypoint& waypoint);
+    void TryCollectAtRouteTail();
     void PreWarmCollectOcr();
     void StartScanners();
     void StopScanners();
     void StartCollectScanner();
     void StartDeviceProbe();
     void UpdateCollectSprintSuppression();
+    double NearestCollectDistanceSq() const;
+    void UpdateWalkMode(NaviPhase phase);
 
     const NaviParam& param_;
     ActionWrapper* action_wrapper_;
@@ -92,9 +95,6 @@ private:
 
     std::unique_ptr<RoiTemplateScanner> collect_scanner_;
     std::chrono::steady_clock::time_point collect_scan_last_at_ {};
-    // Anti-stuck: position of the last detection-triggered collect attempt.
-    NaviPosition collect_attempt_pos_ {};
-    bool collect_attempt_pos_valid_ = false;
 
     ObstacleDeviceRecovery device_recovery_;
     // Declared last so its destructor runs first — restores jogging while its collaborators are still alive.


### PR DESCRIPTION
采集点判定圈 1.5 + 卡住 6s 退让、冷却 1500ms→1200ms、删掉重试距离门、尾点补一次采集窗口、接近采集点自动切走路（进 3.0 出 4.5）

## Summary by Sourcery

收集点处理更加严格且更健壮，包括接近、检测以及路线完成时的行为，并在收集点附近引入自动步行模式。

新功能：
- 添加步行模式：在接近收集航路点时自动开启，在远离或离开导航阶段后自动关闭。
- 在路线末尾添加收集宽限窗口：在最后一个收集航路点被消耗后，尝试进行最后一次收集。
- 暴露一个辅助工具，用于检测路线是否以收集航路点结束，并计算最近收集航路点的距离，以便进行行为决策。

缺陷修复：
- 在长时间没有进展后，放宽收集航路点的紧缩到达半径，以避免新的卡死场景。
- 移除基于位移的、用于检测触发收集的重试门槛，以便在同一坐标的多物品点可以被完全收集。
- 确保在所有导航阶段中一致更新步行模式，避免游戏停留在步行状态而无法恢复。

增强改进：
- 在启动绕过逻辑中复用航路点 `ArrivalBand` 辅助工具，并扩展其以支持收集场景下的专门收紧与放宽。
- 收窄收集航路点的到达带，并调整相关带，使冲刺抑制和步行模式的滞后行为在收集点附近保持一致。
- 优化冲刺抑制逻辑：改为基于最近收集航路点的距离，而不是通过内联距离检查进行迭代。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten and make more robust collect-point handling, including approach, detection, and route completion behavior, while introducing an automatic walk mode near collection points.

New Features:
- Add a walk mode that automatically engages when approaching collect waypoints and disengages after moving away or leaving navigate phases.
- Add a route-tail collect grace window to attempt one final collection after the last collect waypoint is consumed.
- Expose a helper to detect whether a route ends with a collect waypoint and to compute the nearest collect waypoint distance for behavior decisions.

Bug Fixes:
- Relax the tightened arrival radius for collect waypoints after prolonged lack of progress to avoid new stuck scenarios.
- Remove the displacement-based retry gate for detection-triggered collects so multi-item spots at the same coordinate can be fully collected.
- Ensure walk mode is consistently updated for all navigation phases so the game is not left stranded in walking state.

Enhancements:
- Reuse the waypoint ArrivalBand helper in startup-bypass logic and extend it to support collect-specific tightening and relaxation.
- Narrow the arrival band for collect waypoints and adjust related bands so sprint suppression and walk mode hysteresis align around collect points.
- Refine sprint suppression logic by basing it on the nearest collect waypoint distance rather than iterating with inline distance checks.

</details>