### PR TITLE
feat: 选剑演武接入 IMS 奖励播报

### DIFF
--- a/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
+++ b/assets/resource/pipeline/TrialOfSwordmancy/TrialOfSwordmancyFight.json
@@ -159,6 +159,34 @@
         "all_of": [
             "WhiteConfirmButtonType1"
         ],
+        "pre_wait_freezes": {
+            "target": [
+                590,
+                297,
+                100,
+                100
+            ],
+            "time": 80
+        },
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "AddItemData",
+        "custom_action_param": {
+            "items": {
+                "WULING_STOCK_BILL": "WULING_STOCK_BILL"
+            }
+        },
+        "post_delay": 0,
+        "next": [
+            "TrialOfSwordmancyFightSuccessContinue"
+        ]
+    },
+    "TrialOfSwordmancyFightSuccessContinue": {
+        "desc": "点击再次演算",
+        "recognition": "And",
+        "all_of": [
+            "WhiteConfirmButtonType1"
+        ],
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "RepeatUntilFoundAction",


### PR DESCRIPTION
## Summary by Sourcery

将 IMS 奖励广播支持集成到 TrialOfSwordmancy 战斗流水线配置中。

新功能：
- 为 TrialOfSwordmancy 战斗模式添加基于 IMS 的奖励广播配置。

增强内容：
- 调整 TrialOfSwordmancy 战斗资源流水线设置，以支持外部奖励上报。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate IMS reward broadcast support into the TrialOfSwordmancy fight pipeline configuration.

New Features:
- Add IMS-based reward broadcast configuration for the TrialOfSwordmancy fight mode.

Enhancements:
- Adjust TrialOfSwordmancy fight resource pipeline settings to support external reward reporting.

</details>