### PR TITLE
fix(MapNavigator): 拉直判据改由规划器出航点

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -503,6 +503,7 @@ navmesh::BaseNavRouteResult PlanCorridorRoute(
     result.path.zone_name = request.zone_name;
     result.path.points = std::move(plan.points);
     result.path.clearance = std::move(plan.clearance);
+    result.path.waypoints = std::move(plan.waypoints);
     result.cost = plan.length;
     return result;
 }
@@ -1244,7 +1245,20 @@ bool AppendGeneratedNavmeshWaypoints(
     // reach and survives; grid staircase and out-and-back spikes collapse into a single leg. What this
     // replaced asked the same question once across the entire leg — which no route of any length passes — so
     // every raw vertex was kept instead, down to 0.25px stair steps, and the follower had to steer them.
+    const auto emit_corner = [&](size_t index) {
+        out_path.emplace_back(world_path.points[index].x, world_path.points[index].y, ActionType::RUN);
+        out_path.back().strict_arrival = false;
+        out_path.back().corridor_clearance = clearance_at(index);
+    };
     const auto restore_corners_to = [&](size_t anchor) {
+        // 规划器自己拉直过的路线直接照抄下标。它那边看得到窗口挡线格图和起点所在面的高度,
+        // 这里只有网格面一张判据,叠层处会顺着楼下那层把捷径判成可走。跨度对不上时仍走下面这条。
+        if (!world_path.waypoints.empty() && prev == 0 && anchor + 1 == total) {
+            for (size_t index = 0; index + 1 < world_path.waypoints.size(); ++index) {
+                emit_corner(world_path.waypoints[index]);
+            }
+            return;
+        }
         if (drivability_planner == nullptr || anchor <= prev + 1) {
             return;
         }
@@ -1277,9 +1291,7 @@ bool AppendGeneratedNavmeshWaypoints(
             if (reach >= anchor) {
                 return;
             }
-            out_path.emplace_back(world_path.points[reach].x, world_path.points[reach].y, ActionType::RUN);
-            out_path.back().strict_arrival = false;
-            out_path.back().corridor_clearance = clearance_at(reach);
+            emit_corner(reach);
             cursor = reach;
         }
     };

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -249,14 +249,15 @@ std::optional<double> BaseNavPlanner::groundHeightNearIndexed(
     return best;
 }
 
-bool BaseNavPlanner::segmentHeightWalkable(uint16_t zone_id, const WorldPoint& a, const WorldPoint& b) const
+bool BaseNavPlanner::segmentHeightWalkable(uint16_t zone_id, const WorldPoint& a, const WorldPoint& b, std::optional<double> seed_height)
+    const
 {
     if (pack_.findZone(zone_id) == nullptr) {
         return false;
     }
     const double length = std::hypot(b.x - a.x, b.y - a.y);
     const int samples = std::max(1, static_cast<int>(length / kRoutePullSampleStep));
-    std::optional<double> previous;
+    std::optional<double> previous = seed_height;
     // 缓存上一采样点命中的三角形:相邻采样多落在同一三角形内,命中则复用其高度,省去 candidateTriangles
     // 扫描,且结果与完整扫描等价。
     uint32_t cached = kInvalidTriangle;
@@ -413,9 +414,14 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
     return best;
 }
 
-bool BaseNavPlanner::isRouteSegmentDrivable(uint16_t zone_id, const WorldPoint& a, const WorldPoint& b, double half_width) const
+bool BaseNavPlanner::isRouteSegmentDrivable(
+    uint16_t zone_id,
+    const WorldPoint& a,
+    const WorldPoint& b,
+    double half_width,
+    std::optional<double> seed_height) const
 {
-    if (!segmentHeightWalkable(zone_id, a, b)) {
+    if (!segmentHeightWalkable(zone_id, a, b, seed_height)) {
         return false;
     }
     const double dx = b.x - a.x;
@@ -435,7 +441,7 @@ bool BaseNavPlanner::isRouteSegmentDrivable(uint16_t zone_id, const WorldPoint& 
     for (const double side : { 1.0, -1.0 }) {
         const double ox = -uy * half_width * side;
         const double oy = ux * half_width * side;
-        if (!segmentHeightWalkable(zone_id, { .x = head.x + ox, .y = head.y + oy }, { .x = tail.x + ox, .y = tail.y + oy })) {
+        if (!segmentHeightWalkable(zone_id, { .x = head.x + ox, .y = head.y + oy }, { .x = tail.x + ox, .y = tail.y + oy }, seed_height)) {
             return false;
         }
     }

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -80,7 +80,14 @@ public:
     // decide whether a collapsed straight leg stays on walkable mesh. `half_width` gives the leg a body:
     // both flanks must hold up too, so a line a dimensionless point could thread is rejected on behalf of
     // a character that has width. Zero keeps the bare centre-line test.
-    bool isRouteSegmentDrivable(uint16_t zone_id, const WorldPoint& a, const WorldPoint& b, double half_width = 0.0) const;
+    // `seed_height` 是 a 点所在面的高度。缺省时首个采样点无参照,叠层处取最低面,判据会顺着楼下那层
+    // 一路走通;给出后整段采样都锚在起点这层上。
+    bool isRouteSegmentDrivable(
+        uint16_t zone_id,
+        const WorldPoint& a,
+        const WorldPoint& b,
+        double half_width = 0.0,
+        std::optional<double> seed_height = std::nullopt) const;
 
     // RecastNav 复用
     const std::vector<uint32_t>& adjacencyOffsets() const { return adjacency_offsets_; }
@@ -120,7 +127,8 @@ private:
         groundHeightNearIndexed(uint16_t zone_id, const WorldPoint& point, std::optional<double> reference, uint32_t& out_triangle) const;
     // 直线路段可行性判据:沿 a→b 采样,要求每点在网格内、且相邻采样的地面高度跳变不超过
     // kBridgeMaxHeightDelta。共面重叠缝全程平坦判可走,绕墙捷径因踩墙跳变判不可走。
-    bool segmentHeightWalkable(uint16_t zone_id, const WorldPoint& a, const WorldPoint& b) const;
+    bool segmentHeightWalkable(uint16_t zone_id, const WorldPoint& a, const WorldPoint& b, std::optional<double> seed_height = std::nullopt)
+        const;
 };
 
 const char* ToString(BaseNavRouteStatus status);

--- a/agent/cpp-algo/source/Navmesh/NavmeshTypes.h
+++ b/agent/cpp-algo/source/Navmesh/NavmeshTypes.h
@@ -21,6 +21,8 @@ struct WorldPath
     std::vector<WorldPoint> points;
     // 与 points 等长的逐点通道半宽 px; 为空表示该路径不是 navmesh 规划出来的
     std::vector<double> clearance;
+    // 规划器给的驱动航点下标(不含起点,末位恒为 points.size()-1); 为空则由航点侧自行拉直
+    std::vector<size_t> waypoints;
     std::vector<size_t> segment_breaks;
 };
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -49,6 +49,8 @@ struct RouteDiag
     std::vector<std::string> warn;
     std::vector<WorldPoint> xwall;
     std::vector<double> clearance;
+    std::vector<double> height; // 逐点所在面的高度; 层预言机走不通时清空
+    std::vector<size_t> waypoints;
     bool crossed_barrier = false;
     double snap_start = 0.0;
     double snap_goal = 0.0;
@@ -402,9 +404,63 @@ std::optional<WindowInfo> buildWindow(
     return info;
 }
 
+// 贪心拉直:从上一个提交点出发,沿折线尽量往前够,一条直线走不通就把它停下的那个顶点收进航点。
+// 判据两条都要过 —— 网格面高度连续(带起点高度), 以及窗口挡线格图不允许这条弦跨墙。
+// 前者单独用会顺着叠层的下一层走通, 后者补的正是那一刀。
+void PullWaypoints(
+    const std::vector<WorldPoint>& pts,
+    RouteDiag& dg,
+    const BaseNavPlanner& pl,
+    uint16_t zid,
+    const Blockers& blk,
+    bool has_layer)
+{
+    if (!has_layer || pts.size() < 2) {
+        return;
+    }
+    // 一次拉直最多吞掉多少个顶点。纯成本上界:每多够一个都要把整条弦重测一遍,不封顶就是平方级。
+    // 撞到上界只是把顶点留在原地,是安全的那一侧。
+    constexpr size_t kMaxPullSpan = 64;
+    const size_t anchor = pts.size() - 1;
+    size_t cursor = 0;
+    while (cursor + 1 < anchor) {
+        // 捷径不得比它吞掉的最窄处更窄:那个宽度是路线自己判定这段通道需要的,拉直这一层不比它更懂。
+        double swallowed = std::numeric_limits<double>::infinity();
+        const std::optional<double> seed = cursor < dg.height.size() ? std::optional<double>(dg.height[cursor]) : std::nullopt;
+        size_t reach = cursor;
+        const size_t reach_limit = std::min(anchor, cursor + kMaxPullSpan);
+        while (reach < reach_limit) {
+            const WorldPoint& a = pts[cursor];
+            const WorldPoint& c = pts[reach + 1];
+            const double required = std::isfinite(swallowed) ? swallowed : 0.0;
+            if (!pl.isRouteSegmentDrivable(zid, a, c, required, seed) || blk.blocked(a, c)) {
+                break;
+            }
+            swallowed = std::min(swallowed, reach + 1 < dg.clearance.size() ? dg.clearance[reach + 1] : 0.0);
+            ++reach;
+        }
+        // 连折线自己的下一条边都过不了判据时,把那个顶点原样留下仍是手上最好的答案,也保证循环往前走。
+        if (reach == cursor) {
+            ++reach;
+        }
+        if (reach >= anchor) {
+            break;
+        }
+        dg.waypoints.push_back(reach);
+        cursor = reach;
+    }
+    dg.waypoints.push_back(anchor);
+}
+
 // goal_deck: 终点所在面的高度。不声明时终点集是该格全部 span,先够到哪张停哪张
-std::optional<std::vector<WorldPoint>>
-    routeWindow(const WindowInfo& info, const WorldPoint& s, const WorldPoint& g, RouteDiag& dg, std::optional<double> goal_deck)
+std::optional<std::vector<WorldPoint>> routeWindow(
+    const WindowInfo& info,
+    const WorldPoint& s,
+    const WorldPoint& g,
+    RouteDiag& dg,
+    std::optional<double> goal_deck,
+    const BaseNavPlanner& pl,
+    uint16_t zid)
 {
     const int64_t nx = info.nx;
     const int64_t ny = info.ny;
@@ -945,6 +1001,29 @@ std::optional<std::vector<WorldPoint>>
         const int64_t cy = std::min(std::max(static_cast<int64_t>(std::floor((p.y - info.y0) / kCS)), int64_t { 0 }), ny - 1);
         dg.clearance.push_back(static_cast<double>(dist.at(cy, cx)));
     }
+    // 逐点所在面的高度:从起点那张 span 出发,沿线段链式游走,每步在游走到的候选里取与上一点最近的一张。
+    // 起点高度是唯一的外部输入,后面全由它推出来,叠层处不会串到楼下那层。
+    if (lyo_p != nullptr && !out.empty()) {
+        std::vector<float> cur { lyo_h };
+        dg.height.push_back(static_cast<double>(lyo_h));
+        for (size_t i = 1; i < out.size(); ++i) {
+            const auto nxt = lyo_p->walk({ out[i - 1], out[i] }, cur);
+            if (!nxt.has_value() || nxt->empty()) {
+                dg.height.clear();
+                break;
+            }
+            cur = *nxt;
+            const double ref = dg.height.back();
+            double nearest_h = static_cast<double>(cur.front());
+            for (const float v : cur) {
+                if (std::fabs(static_cast<double>(v) - ref) < std::fabs(nearest_h - ref)) {
+                    nearest_h = static_cast<double>(v);
+                }
+            }
+            dg.height.push_back(nearest_h);
+        }
+    }
+    PullWaypoints(out, dg, pl, zid, blk_gray, lyo_p != nullptr);
     return out;
 }
 
@@ -1089,7 +1168,7 @@ RecastPlanResult RecastNavEngine::planLocked(
         auto info = buildWindow(wo, grid_, *gz, zc, start, ss->point, goal, h0, gdk, x0, y0, x1, y1, blocked_local, blocked_points, err);
         if (info.has_value()) {
             RouteDiag dg;
-            auto line = routeWindow(*info, start, goal, dg, gdk);
+            auto line = routeWindow(*info, start, goal, dg, gdk, planner_, zc.zone_id);
             if (line.has_value()) {
                 // 锚点远 = 走廊出窗,同触界扩窗,否则末段盲跳穿墙
                 if (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius) {
@@ -1129,6 +1208,7 @@ RecastPlanResult RecastNavEngine::planLocked(
                         res.wall_cross = dg.xwall;
                         res.snap_start = dg.snap_start;
                         res.snap_goal = dg.snap_goal;
+                        res.waypoints = std::move(dg.waypoints);
                         return res;
                     }
                     err = "终线触界,扩窗重跑";

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -27,6 +27,9 @@ struct RecastPlanResult
     std::vector<WorldPoint> wall_cross; // 不可避穿墙步的格心
     double snap_start = 0.0;            // 起/终点到可走格锚点距离 px
     double snap_goal = 0.0;
+    // 贪心拉直后的驱动航点下标(points 的下标,不含起点,末位恒为 points.size()-1)。
+    // 空 = 该腿没有层预言机,拉直交给调用方。
+    std::vector<size_t> waypoints;
 };
 
 class RecastNavEngine


### PR DESCRIPTION
## Summary by Sourcery

通过导航网格路由和路径扩展传播由规划器提供的“拉直”航点，并基于支持图层的高度采样进行锚定，从而避免在堆叠几何体之间出现非法捷径。

New Features:
- 在导航网格路由结果和世界路径中添加规划器生成的航点索引，供下游使用方据此进行驱动。
- 引入贪心式的规划器内部路径拉直策略，在有图层预言器可用时同时遵守高度连续性和阻塞网格约束。

Enhancements:
- 拓展线段可驱动性检查，增加可选的初始高度参数，以便在堆叠网格上保持采样停留在起始图层。
- 沿已路由的窗口逐点计算表面高度，并用这些高度来引导拉直决策，而非仅依赖通用的高度可行性判断。
- 更新航点扩展逻辑，在规划器提供航点时优先复用这些航点，否则回退到本地拉直策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Propagate planner-provided straightened waypoints through navmesh routing and path expansion, anchored to layer-aware height sampling to avoid illegal shortcuts across stacked geometry.

New Features:
- Add planner-generated waypoint indices to navmesh route results and world paths for downstream consumers to drive against.
- Introduce greedy in-planner path straightening that respects both height continuity and blocker grids when a layer oracle is available.

Enhancements:
- Extend segment drivability checks with an optional seed height so sampling stays on the starting layer across stacked meshes.
- Compute per-point surface heights along routed windows and use them to seed straightening decisions instead of relying solely on generic height walkability.
- Update waypoint expansion logic to reuse planner-supplied waypoints when available and fall back to local straightening otherwise.

</details>