### PR TITLE
fix(MapNavigator): bootstrap 续接不再只按最近点判定

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -100,6 +100,10 @@ constexpr double kBootstrapOwnershipProjectionFrontThreshold = 0.35;
 constexpr double kBootstrapOwnershipProjectionMiddleThreshold = 0.60;
 constexpr double kBootstrapOwnershipContinueBiasDistance = 0.5;
 constexpr double kBootstrapOwnershipMaxDistance = 18.0;
+// Off-line bootstrap: skipping waypoints needs evidence, not just "this one happens to be nearest".
+// Standing on a point, or being clear of every earlier point by this margin, counts as evidence.
+constexpr double kBootstrapOwnershipStandingDistance = 1.5;
+constexpr double kBootstrapOwnershipDecisiveMargin = 5.0;
 constexpr double kSerialRouteHeadingEpsilon = 2.0;
 constexpr double kSerialRouteDeviationThreshold = 1.5;
 constexpr double kSerialRouteDeviationFailThreshold = 3.0;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -263,9 +263,9 @@ std::optional<BootstrapContinueCandidate> FindProjectedContinueCandidate(const s
     return best_candidate;
 }
 
-std::optional<BootstrapWaypointCandidate> FindNearestReachableWaypoint(const std::vector<Waypoint>& path, const NaviPosition& position)
+std::vector<BootstrapWaypointCandidate> CollectReachableWaypoints(const std::vector<Waypoint>& path, const NaviPosition& position)
 {
-    std::optional<BootstrapWaypointCandidate> best_candidate;
+    std::vector<BootstrapWaypointCandidate> candidates;
     for (size_t index = 0; index < path.size(); ++index) {
         const Waypoint& waypoint = path[index];
         if (!IsZoneCompatible(waypoint, position.zone_id)) {
@@ -277,11 +277,34 @@ std::optional<BootstrapWaypointCandidate> FindNearestReachableWaypoint(const std
             continue;
         }
 
-        if (!best_candidate.has_value() || distance < best_candidate->distance) {
-            best_candidate = BootstrapWaypointCandidate { .index = index, .distance = distance };
-        }
+        candidates.push_back(BootstrapWaypointCandidate { .index = index, .distance = distance });
     }
-    return best_candidate;
+    return candidates;
+}
+
+// Walk back along the route while each predecessor is still within the ownership radius of the anchor.
+// Distances are anchor-relative, not chained, so the walk-back stays bounded; positionless waypoints
+// (ZONE / HEADING markers) end it, and leading markers alone mean the route head.
+size_t RewindToEarliestNearby(const std::vector<Waypoint>& path, const NaviPosition& position, size_t index)
+{
+    const Waypoint& anchor = path[index];
+    size_t rewound = index;
+    while (rewound > 0) {
+        const Waypoint& previous = path[rewound - 1];
+        if (!IsZoneCompatible(previous, position.zone_id)) {
+            break;
+        }
+        if (std::hypot(previous.x - anchor.x, previous.y - anchor.y) > kBootstrapOwnershipMaxDistance) {
+            break;
+        }
+        --rewound;
+    }
+
+    const auto rewound_begin = path.begin() + static_cast<std::ptrdiff_t>(rewound);
+    if (std::none_of(path.begin(), rewound_begin, [](const Waypoint& waypoint) { return waypoint.HasPosition(); })) {
+        return 0;
+    }
+    return rewound;
 }
 
 std::optional<BootstrapContinueCandidate> ResolveBootstrapContinueCandidate(const std::vector<Waypoint>& path, const NaviPosition& position)
@@ -291,15 +314,53 @@ std::optional<BootstrapContinueCandidate> ResolveBootstrapContinueCandidate(cons
         return projected;
     }
 
-    const std::optional<BootstrapWaypointCandidate> nearest_waypoint = FindNearestReachableWaypoint(path, position);
-    if (!nearest_waypoint.has_value()) {
+    // Off the line, "nearest" alone decided ownership and lost whole clusters of waypoints to
+    // sub-metre gaps. Skipping now needs evidence; without it the route is resumed further back.
+    const std::vector<BootstrapWaypointCandidate> reachable = CollectReachableWaypoints(path, position);
+    if (reachable.empty()) {
         return std::nullopt;
     }
 
+    // Standing on a waypoint. Earliest one wins so a loop route's coincident head is not read as its tail.
+    const auto standing = std::find_if(reachable.begin(), reachable.end(), [](const BootstrapWaypointCandidate& candidate) {
+        return candidate.distance <= kBootstrapOwnershipStandingDistance;
+    });
+    if (standing != reachable.end()) {
+        return BootstrapContinueCandidate {
+            .continue_index = standing->index,
+            .route_distance = standing->distance,
+            .reason = "standing_on_waypoint",
+        };
+    }
+
+    const BootstrapWaypointCandidate* nearest = &reachable.front();
+    for (const BootstrapWaypointCandidate& candidate : reachable) {
+        if (candidate.distance < nearest->distance) {
+            nearest = &candidate;
+        }
+    }
+
+    double nearest_before = std::numeric_limits<double>::infinity();
+    for (const BootstrapWaypointCandidate& candidate : reachable) {
+        if (candidate.index >= nearest->index) {
+            break;
+        }
+        nearest_before = std::min(nearest_before, candidate.distance);
+    }
+
+    // Clear of everything earlier by a wide margin: the route really is behind us.
+    if (nearest->distance + kBootstrapOwnershipDecisiveMargin < nearest_before) {
+        return BootstrapContinueCandidate {
+            .continue_index = nearest->index,
+            .route_distance = nearest->distance,
+            .reason = "decisive_nearest",
+        };
+    }
+
     return BootstrapContinueCandidate {
-        .continue_index = nearest_waypoint->index,
-        .route_distance = nearest_waypoint->distance,
-        .reason = "nearest_waypoint",
+        .continue_index = RewindToEarliestNearby(path, position, nearest->index),
+        .route_distance = nearest->distance,
+        .reason = "rewound_to_earliest",
     };
 }
 
@@ -307,10 +368,10 @@ std::optional<DynamicAnchor>
     ResolveBootstrapNavmeshAnchor(const NaviParam& param, NavigationSession* session, const NaviPosition& position, size_t start_index)
 {
     const size_t path_size = session->current_path().size();
-    std::optional<DynamicAnchor> best_anchor;
-    double best_cost = std::numeric_limits<double>::infinity();
+    std::optional<DynamicAnchor> anchor;
+    double anchor_cost = std::numeric_limits<double>::infinity();
     int planned_count = 0;
-    int skipped_count = 0;
+    int unreachable_count = 0;
 
     for (size_t index = std::min(start_index, path_size); index < path_size; ++index) {
         const Waypoint& waypoint = session->CurrentPathAt(index);
@@ -336,30 +397,26 @@ std::optional<DynamicAnchor>
 
         const navmesh::WorldPoint start { .x = position.x, .y = position.y };
         const navmesh::WorldPoint goal { .x = waypoint.x, .y = waypoint.y };
-        if (std::hypot(goal.x - start.x, goal.y - start.y) < best_cost) {
-            // 只钉终点: 够不到那张面的候选就不该被选中
-            const auto route = PlanNavmeshRoute(param, position.zone_id, start, goal, waypoint.target_deck_y);
-            if (route) {
-                ++planned_count;
-                if (route->cost < best_cost) {
-                    best_cost = route->cost;
-                    best_anchor = { *canonical_index, waypoint };
-                }
-            }
+        // 只钉终点: 够不到那张面的候选就不该被选中。第一个规划得通的点就是入口 ——
+        // 再往后比价挑更近的, 等于在归属判定之后又做一次"就近吞点"。
+        ++planned_count;
+        const auto route = PlanNavmeshRoute(param, position.zone_id, start, goal, waypoint.target_deck_y);
+        if (route) {
+            anchor_cost = route->cost;
+            anchor = { *canonical_index, waypoint };
+            break;
         }
-        else {
-            ++skipped_count;
-        }
+        ++unreachable_count;
         if (IsRequiredSemanticAnchor(waypoint)) {
             break;
         }
     }
 
-    if (best_anchor) {
-        LogInfo << "Bootstrap navmesh anchor selected." << VAR(best_anchor->first) << VAR(best_cost) << VAR(planned_count)
-                << VAR(skipped_count) << VAR(start_index);
+    if (anchor) {
+        LogInfo << "Bootstrap navmesh anchor selected." << VAR(anchor->first) << VAR(anchor_cost) << VAR(planned_count)
+                << VAR(unreachable_count) << VAR(start_index);
     }
-    return best_anchor;
+    return anchor;
 }
 
 std::optional<DynamicAnchor> ResolveBootstrapAnchor(const NaviParam& param, NavigationSession* session, const NaviPosition& position)

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -288,10 +288,14 @@ std::vector<BootstrapWaypointCandidate> CollectReachableWaypoints(const std::vec
 size_t RewindToEarliestNearby(const std::vector<Waypoint>& path, const NaviPosition& position, size_t index)
 {
     const Waypoint& anchor = path[index];
+    if (!anchor.HasPosition()) {
+        return index;
+    }
+
     size_t rewound = index;
     while (rewound > 0) {
         const Waypoint& previous = path[rewound - 1];
-        if (!IsZoneCompatible(previous, position.zone_id)) {
+        if (!previous.HasPosition() || !IsZoneCompatible(previous, position.zone_id)) {
             break;
         }
         if (std::hypot(previous.x - anchor.x, previous.y - anchor.y) > kBootstrapOwnershipMaxDistance) {
@@ -340,16 +344,16 @@ std::optional<BootstrapContinueCandidate> ResolveBootstrapContinueCandidate(cons
         }
     }
 
-    double nearest_before = std::numeric_limits<double>::infinity();
+    std::optional<double> nearest_before;
     for (const BootstrapWaypointCandidate& candidate : reachable) {
         if (candidate.index >= nearest->index) {
             break;
         }
-        nearest_before = std::min(nearest_before, candidate.distance);
+        nearest_before = nearest_before ? std::min(*nearest_before, candidate.distance) : candidate.distance;
     }
 
-    // Clear of everything earlier by a wide margin: the route really is behind us.
-    if (nearest->distance + kBootstrapOwnershipDecisiveMargin < nearest_before) {
+    // Nothing earlier to lose, or clear of all of it by a wide margin: the route really is behind us.
+    if (!nearest_before.has_value() || nearest->distance + kBootstrapOwnershipDecisiveMargin < *nearest_before) {
         return BootstrapContinueCandidate {
             .continue_index = nearest->index,
             .route_distance = nearest->distance,
@@ -370,8 +374,7 @@ std::optional<DynamicAnchor>
     const size_t path_size = session->current_path().size();
     std::optional<DynamicAnchor> anchor;
     double anchor_cost = std::numeric_limits<double>::infinity();
-    int planned_count = 0;
-    int unreachable_count = 0;
+    int plan_attempts = 0;
 
     for (size_t index = std::min(start_index, path_size); index < path_size; ++index) {
         const Waypoint& waypoint = session->CurrentPathAt(index);
@@ -399,22 +402,22 @@ std::optional<DynamicAnchor>
         const navmesh::WorldPoint goal { .x = waypoint.x, .y = waypoint.y };
         // 只钉终点: 够不到那张面的候选就不该被选中。第一个规划得通的点就是入口 ——
         // 再往后比价挑更近的, 等于在归属判定之后又做一次"就近吞点"。
-        ++planned_count;
+        ++plan_attempts;
         const auto route = PlanNavmeshRoute(param, position.zone_id, start, goal, waypoint.target_deck_y);
         if (route) {
             anchor_cost = route->cost;
             anchor = { *canonical_index, waypoint };
             break;
         }
-        ++unreachable_count;
         if (IsRequiredSemanticAnchor(waypoint)) {
             break;
         }
     }
 
+    // plan_attempts - 1 waypoints ahead of the anchor turned out unreachable.
     if (anchor) {
-        LogInfo << "Bootstrap navmesh anchor selected." << VAR(anchor->first) << VAR(anchor_cost) << VAR(planned_count)
-                << VAR(unreachable_count) << VAR(start_index);
+        LogInfo << "Bootstrap navmesh anchor selected." << VAR(anchor->first) << VAR(anchor_cost) << VAR(plan_attempts)
+                << VAR(start_index);
     }
     return anchor;
 }


### PR DESCRIPTION
## Summary by Sourcery

改进引导（bootstrap）路径续接逻辑和导航网格（navmesh）锚点选择，以避免错误地跳过附近航点，并选取更可靠的锚点。

增强内容：
- 修改引导续接逻辑，以考虑所有可达航点，优先选择“站在点上”的情况，并将回溯目标设为最早的附近航点，而不是盲目使用最近的航点。
- 引入“站立距离”和“决断裕度”阈值，在离线引导时需要更强的证据才允许跳过更早的航点。
- 简化导航网格锚点解析逻辑，只选择第一个具有成功规划路径的航点，并在遇到不可到达或需要特定语义锚点的航点时立即停止扫描。
- 调整引导导航网格锚点的日志记录，以反映新的选择逻辑，以及对已规划和不可到达候选项的计数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve bootstrap route continuation and navmesh anchoring to avoid incorrectly skipping nearby waypoints and to select more reliable anchors.

Enhancements:
- Change bootstrap continuation to consider all reachable waypoints, prefer standing-on-point cases, and rewind to the earliest nearby waypoint instead of blindly using the nearest.
- Introduce standing distance and decisive margin thresholds to require stronger evidence before skipping earlier waypoints during off-line bootstrap.
- Simplify navmesh anchor resolution to choose the first waypoint with a successfully planned route and stop scanning once an unreachable or required semantic anchor is encountered.
- Adjust bootstrap navmesh anchor logging to reflect the new selection logic and counters for planned and unreachable candidates.

</details>