### PR TITLE
refactor(EnvironmentMonitoring): 剩余观察点改用 MapNavigator 定位与朝向

### DIFF
--- a/.agents/skills/environment-monitoring-add-route/SKILL.md
+++ b/.agents/skills/environment-monitoring-add-route/SKILL.md
@@ -61,7 +61,7 @@ argument-hint: "可选：观察点名称，以及录制好的 EnterMap、NavZone
 | `NavPath`  | MapNavigator `path` 数组 | `MapNavigateAction` | 普通可通行路线；普通传送配置 `NavZoneId` / `NavAssert`，快捷传送可从固定落点直接开始 |
 | 传送后直拍 | 不配置地图字段           | 可选转向后拍照      | 传送落点已经满足拍照条件；可配置 `Heading`，但不配置地图断言或寻路字段               |
 
-`MapName` / `MapAssert` / `MapPath` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY` / `MapGoal` 只为未迁移的存量路线保留，新增或改写路线不要再使用。寻路只适合普通可通行路线，不负责战斗、剧情、过图、机关或交互。传送后直拍必须经过游戏实测确认；不能因为缺少路线数据就把未适配条目写成直拍。遇到这些情况不要用更多重试或硬延迟掩盖，应保留未适配状态或重新设计真实可通行路线。
+`MapName` / `MapAssert` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY` 是单目标点的简写，只为存量路线保留，新增或改写路线一律用 `NavPath`。寻路只适合普通可通行路线，不负责战斗、剧情、过图、机关或交互。传送后直拍必须经过游戏实测确认；不能因为缺少路线数据就把未适配条目写成直拍。遇到这些情况不要用更多重试或硬延迟掩盖，应保留未适配状态或重新设计真实可通行路线。
 
 仅含 `NAVMESH` 的 `NavPath` 不需要前置 `ZONE`：运行时会从 MapLocator 当前定位自动确定起点区域。`ZONE` 只为后续手录坐标点声明和校验分区；多分区或过图路径应保留录制工具导出的 `ZONE`，不要擅自删改。
 
@@ -72,8 +72,7 @@ argument-hint: "可选：观察点名称，以及录制好的 EnterMap、NavZone
 | `target_deck_y`                | 仅写在 `NavPath` 的 `NAVMESH` 动作中。目标点底下压着多张可走面（走廊 / 天桥 / 屋顶）时，填 MapNavigator 重叠面列表读出的那一层高度；不要手估 |
 | `CameraMaxHit`                 | 摄像头最大滑屏次数，默认 2；只有实测需要其他值时才写                                                                                         |
 | `Replace`                      | OCR 易混字符替换表 `[["误识别", "正确字符"], ...]`；仅有实际误识别证据时填写                                                                 |
-| `Heading`                      | 可选。进入拍照模式前的角色朝向，范围 `[0, 360)`；直拍路线会在传送后独立调用 `MapTrackerToward`                                               |
-| `NoEnsureInitialMovementState` | 仅对 `MapPath` / `MapGoal` 的 MapTracker 动作有意义。起点紧贴桥边、悬崖等危险地形时设为 `true`；默认 `false` 时省略                          |
+| `Heading`                      | 可选。进入拍照模式前的角色朝向，范围 `[0, 360)`；直拍路线会在传送后生成只含 `HEADING` 动作的 `MapNavigateAction`                            |
 | `QuickTeleport`                | 可选布尔值，默认 `false`。启用后依次点击任务地图的“前往传送”和“传送”，不调用 `EnterMap`；此时 `EnterMap` 可省略                              |
 
 所有坐标均使用 720p（1280×720）基准，并与录制工具所用地图体系保持一致。
@@ -135,10 +134,10 @@ node .agents/skills/environment-monitoring-add-route/check_missing.mjs
 - 严格 JSON：双引号、无注释、无尾随逗号、4 空格缩进；
 - `NavPath` 的每个坐标对和动作对象按项目 Prettier 规则展开；
 - 寻路路线配置 `NavPath`；普通传送同时配置 `NavZoneId` / `NavAssert`，快捷传送可省略二者；
-- 切换到 `NavPath` 时删除遗留的 `MapName`、`MapAssert`、`MapPath`、`MapTarget`、`MapTargetTier`、`MapTargetDeckY`、`MapGoal` 和 `NoEnsureInitialMovementState`；
+- 切换到 `NavPath` 时删除简写形式的 `MapName`、`MapAssert`、`MapTarget`、`MapTargetTier` 和 `MapTargetDeckY`；
 - 传送后直拍不增加开关字段，删除全部新旧地图断言与寻路字段；按实测结果可保留 `Heading`；
 - 终点落在重叠可走面上时必须在对应 `NAVMESH` 动作标 `target_deck_y`，数值从工具读、不要手估；作者点不得压成单个 NAVMESH 目标，需要逐段；
-- 默认值不写：`CameraMaxHit: 2`、`NoEnsureInitialMovementState: false`、`QuickTeleport: false`；
+- 默认值不写：`CameraMaxHit: 2`、`QuickTeleport: false`；
 - 不确定的可选值直接省略，不写占位值或 TODO 注释；
 - 不手改 `Name` / `Id` 排序或 locale 失败提示，这些内容由同步器维护。
 

--- a/.agents/skills/environment-monitoring-add-route/SKILL.md
+++ b/.agents/skills/environment-monitoring-add-route/SKILL.md
@@ -61,7 +61,7 @@ argument-hint: "可选：观察点名称，以及录制好的 EnterMap、NavZone
 | `NavPath`  | MapNavigator `path` 数组 | `MapNavigateAction` | 普通可通行路线；普通传送配置 `NavZoneId` / `NavAssert`，快捷传送可从固定落点直接开始 |
 | 传送后直拍 | 不配置地图字段           | 可选转向后拍照      | 传送落点已经满足拍照条件；可配置 `Heading`，但不配置地图断言或寻路字段               |
 
-`MapName` / `MapAssert` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY` 是单目标点的简写，只为存量路线保留，新增或改写路线一律用 `NavPath`。寻路只适合普通可通行路线，不负责战斗、剧情、过图、机关或交互。传送后直拍必须经过游戏实测确认；不能因为缺少路线数据就把未适配条目写成直拍。遇到这些情况不要用更多重试或硬延迟掩盖，应保留未适配状态或重新设计真实可通行路线。
+寻路只适合普通可通行路线，不负责战斗、剧情、过图、机关或交互。传送后直拍必须经过游戏实测确认；不能因为缺少路线数据就把未适配条目写成直拍。遇到这些情况不要用更多重试或硬延迟掩盖，应保留未适配状态或重新设计真实可通行路线。
 
 仅含 `NAVMESH` 的 `NavPath` 不需要前置 `ZONE`：运行时会从 MapLocator 当前定位自动确定起点区域。`ZONE` 只为后续手录坐标点声明和校验分区；多分区或过图路径应保留录制工具导出的 `ZONE`，不要擅自删改。
 
@@ -134,8 +134,7 @@ node .agents/skills/environment-monitoring-add-route/check_missing.mjs
 - 严格 JSON：双引号、无注释、无尾随逗号、4 空格缩进；
 - `NavPath` 的每个坐标对和动作对象按项目 Prettier 规则展开；
 - 寻路路线配置 `NavPath`；普通传送同时配置 `NavZoneId` / `NavAssert`，快捷传送可省略二者；
-- 切换到 `NavPath` 时删除简写形式的 `MapName`、`MapAssert`、`MapTarget`、`MapTargetTier` 和 `MapTargetDeckY`；
-- 传送后直拍不增加开关字段，删除全部新旧地图断言与寻路字段；按实测结果可保留 `Heading`；
+- 传送后直拍不增加开关字段，不配置任何地图断言与寻路字段；按实测结果可保留 `Heading`；
 - 终点落在重叠可走面上时必须在对应 `NAVMESH` 动作标 `target_deck_y`，数值从工具读、不要手估；作者点不得压成单个 NAVMESH 目标，需要逐段；
 - 默认值不写：`CameraMaxHit: 2`、`QuickTeleport: false`；
 - 不确定的可选值直接省略，不写占位值或 TODO 注释；

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FeranmutHeart.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/FeranmutHeart.json
@@ -336,18 +336,14 @@
     "GoToFeranmutHeartStartPos": {
         "desc": "在巨兽心脏任务开始位置附近",
         "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition": "MapLocateAssertLocation",
         "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "^map\\d+_lv\\d+$",
-                    "target": [
-                        0,
-                        0,
-                        1,
-                        1
-                    ]
-                }
+            "zone_id": "Wuling_Base",
+            "target": [
+                0,
+                0,
+                1,
+                1
             ]
         },
         "pre_delay": 0,
@@ -377,9 +373,14 @@
         "desc": "在巨兽心脏传送点调整拍照朝向",
         "pre_delay": 0,
         "action": "Custom",
-        "custom_action": "MapTrackerToward",
+        "custom_action": "MapNavigateAction",
         "custom_action_param": {
-            "angle": 270
+            "path": [
+                {
+                    "action": "HEADING",
+                    "angle": 270
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -336,18 +336,14 @@
     "GoToPeachTreeAtBabblesSHomeStartPos": {
         "desc": "在念念家的桃树任务开始位置附近",
         "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition": "MapLocateAssertLocation",
         "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "^map\\d+_lv\\d+$",
-                    "target": [
-                        0,
-                        0,
-                        1,
-                        1
-                    ]
-                }
+            "zone_id": "Wuling_Base",
+            "target": [
+                0,
+                0,
+                1,
+                1
             ]
         },
         "pre_delay": 0,
@@ -377,9 +373,14 @@
         "desc": "在念念家的桃树传送点调整拍照朝向",
         "pre_delay": 0,
         "action": "Custom",
-        "custom_action": "MapTrackerToward",
+        "custom_action": "MapNavigateAction",
         "custom_action_param": {
-            "angle": 66
+            "path": [
+                {
+                    "action": "HEADING",
+                    "angle": 66
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Thillu.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/Thillu.json
@@ -336,18 +336,14 @@
     "GoToThilluStartPos": {
         "desc": "在表象任务开始位置附近",
         "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition": "MapLocateAssertLocation",
         "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "^map\\d+_lv\\d+$",
-                    "target": [
-                        0,
-                        0,
-                        1,
-                        1
-                    ]
-                }
+            "zone_id": "Wuling_Base",
+            "target": [
+                0,
+                0,
+                1,
+                1
             ]
         },
         "pre_delay": 0,
@@ -377,9 +373,14 @@
         "desc": "在表象传送点调整拍照朝向",
         "pre_delay": 0,
         "action": "Custom",
-        "custom_action": "MapTrackerToward",
+        "custom_action": "MapNavigateAction",
         "custom_action_param": {
-            "angle": 270
+            "path": [
+                {
+                    "action": "HEADING",
+                    "angle": 270
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/ObservantSableChestedFowlbeast.json
@@ -336,18 +336,14 @@
     "GoToObservantSableChestedFowlbeastStartPos": {
         "desc": "在东张西望的黑腹雉羽兽任务开始位置附近",
         "recognition": "Custom",
-        "custom_recognition": "MapTrackerAssertLocation",
+        "custom_recognition": "MapLocateAssertLocation",
         "custom_recognition_param": {
-            "expected": [
-                {
-                    "map_name": "^map\\d+_lv\\d+$",
-                    "target": [
-                        0,
-                        0,
-                        1,
-                        1
-                    ]
-                }
+            "zone_id": "Wuling_Base",
+            "target": [
+                0,
+                0,
+                1,
+                1
             ]
         },
         "pre_delay": 0,
@@ -377,9 +373,14 @@
         "desc": "在东张西望的黑腹雉羽兽传送点调整拍照朝向",
         "pre_delay": 0,
         "action": "Custom",
-        "custom_action": "MapTrackerToward",
+        "custom_action": "MapNavigateAction",
         "custom_action_param": {
-            "angle": 0
+            "path": [
+                {
+                    "action": "HEADING",
+                    "angle": 0
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/docs/en_us/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/en_us/developers/tasks/environment-monitoring-maintain.md
@@ -160,8 +160,7 @@ The default export of `data.mjs` is an array, where each element = the rendering
 | `Name` | Comes from the Chinese name in `environment_monitoring.json`; `MissionId` is only used by `model.mjs` to match `routes.json` and is not passed to the template |
 | `GoToMonitoringTerminal` | Determined by `Station` |
 | `EnterMap` | `routes.json[*].EnterMap`; any defined Pipeline node name is allowed, without a required prefix, as long as the node can complete and return normally when run as a SubTask |
-| `NavZoneId` / `NavAssert` / `NavPath` | The preferred route form in `routes.json[*]`. `NavPath` is required; regular teleports also require `NavZoneId` / `NavAssert`, while `QuickTeleport` may omit both. Generates `MapLocateAssertLocation` + `MapNavigateAction`; `Heading` appends a `HEADING` action. Do not combine these fields with the shorthand map fields below. |
-| `MapName` / `MapAssert` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY` | Single-target shorthand. Generates `MapLocateAssertLocation` + a `MapNavigateAction` `NAVMESH` target; `MapTargetTier` and `MapTargetDeckY` optionally become `target_tier` and `target_deck_y`. Use the preferred form above for new routes. |
+| `NavZoneId` / `NavAssert` / `NavPath` | The route form in `routes.json[*]`. `NavPath` is required; regular teleports also require `NavZoneId` / `NavAssert`, while `QuickTeleport` may omit both. Generates `MapLocateAssertLocation` + `MapNavigateAction`; `Heading` appends a `HEADING` action. |
 | `CameraSwipeDirection` | `routes.json[*]`, must be one of `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` |
 | `CameraMaxHit` | `routes.json[*].CameraMaxHit`, defaults to `2`; corresponds to the maximum hit count for the `${Id}AdjustCamera` swipe action |
 | `OcrReplace` | Passed through from `routes.json[*].Replace` to `Check${Id}Text.replace` and `In${Id}Mission.replace`; used to configure task-specific OCR replacement pairs for the task list and mission detail page, without affecting route adaptation checks |
@@ -216,8 +215,8 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 Teleporting and pathfinding for observation points is handled entirely by MapLocator and MapNavigator:
 
-- `MapLocateAssertLocation` (Recognition): Judges whether the current position is within the `NavAssert` / `MapAssert` rectangle based on the minimap. Regular teleport routes use it to decide whether `EnterMap` is needed; quick-teleport routes start from a fixed landing point and may omit the assertion.
-- `MapNavigateAction` (Action): Uses `NavPath` directly as its path. `NavZoneId` selects the coordinate zone for `NavAssert`; a `NAVMESH` action in `NavPath` may carry `target_tier` for a cross-tier target and `target_deck_y` for one of several overlapping walkable decks. The `MapTarget` shorthand produces a single `NAVMESH` action, with `MapTargetTier` / `MapTargetDeckY` mapping to `target_tier` / `target_deck_y`.
+- `MapLocateAssertLocation` (Recognition): Judges whether the current position is within the `NavAssert` rectangle based on the minimap. Regular teleport routes use it to decide whether `EnterMap` is needed; quick-teleport routes start from a fixed landing point and may omit the assertion.
+- `MapNavigateAction` (Action): Uses `NavPath` directly as its path. `NavZoneId` selects the coordinate zone for `NavAssert`; a `NAVMESH` action in `NavPath` may carry `target_tier` for a cross-tier target and `target_deck_y` for one of several overlapping walkable decks.
 - `${Id}TakePhoto` (wrapper): Sets the task-specific `EnvironmentMonitoringBackToTerminal` and `EnvironmentMonitoringAdjustCamera` anchors before entering the shared photo flow.
 - Direct-photo routes perform no pathfinding; when `Heading` is set, the generator emits a `MapNavigateAction` whose path contains only a `HEADING` action, turning the character in place before the photo. Both route forms start their action right after teleporting and never re-verify the landing point.
 
@@ -236,11 +235,10 @@ Every fully adapted entry needs metadata, `CameraSwipeDirection`, and one telepo
 | Type | Map and route fields | Location assertion | Runtime behavior |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------- |
 | Metadata only | `MissionId` / `Name` / `Id` only | Omit | Accept and track only; no teleport or photo |
-| Photo at teleport | No `MapName` or navigation field; optional `Heading` | Omit | Teleport → optional turn in place → photo |
-| Navigation (preferred) | `NavPath`; regular teleports also add `NavZoneId`; optional `Heading` | `NavAssert`; optional with quick teleport | `MapNavigateAction` follows `NavPath` → photo |
-| `MapTarget` shorthand | `MapName` + `MapTarget`; optional `MapTargetTier` for cross-tier targets and `MapTargetDeckY` for overlapping decks | `MapAssert`; optional with quick teleport | `MapNavigateAction` NAVMESH → photo |
+| Photo at teleport | No navigation field; optional `Heading` | Omit | Teleport → optional turn in place → photo |
+| Navigation | `NavPath`; regular teleports also add `NavZoneId`; optional `Heading` | `NavAssert`; optional with quick teleport | `MapNavigateAction` follows `NavPath` → photo |
 
-`CameraMaxHit` and `Replace` are available to every adapted route and do not define a separate route type. Use photo-at-teleport only after in-game verification; missing route data must remain metadata-only. New routes must use `NavPath`, adding `NavZoneId` / `NavAssert` for regular teleports.
+`CameraMaxHit` and `Replace` are available to every adapted route and do not define a separate route type. Use photo-at-teleport only after in-game verification; missing route data must remain metadata-only. Navigation routes must use `NavPath`, adding `NavZoneId` / `NavAssert` for regular teleports.
 
 ### Main Menu Entry
 
@@ -305,7 +303,7 @@ When the teleport landing point can be photographed directly, use the compact fo
 }
 ```
 
-Do not include `NavZoneId`, `NavAssert`, `NavPath`, or any of the shorthand map fields in this form. `Heading` remains optional; when present, the generator emits a heading-only `MapNavigateAction` after teleporting and then enters the photo flow. The generator recognizes direct photography from a complete teleport/photo configuration with no assertion or navigation fields. A metadata-only entry remains unadapted.
+Do not include `NavZoneId`, `NavAssert`, or `NavPath` in this form. `Heading` remains optional; when present, the generator emits a heading-only `MapNavigateAction` after teleporting and then enters the photo flow. The generator recognizes direct photography from a complete teleport/photo configuration with no assertion or navigation fields. A metadata-only entry remains unadapted.
 
 > [!IMPORTANT]
 >

--- a/docs/en_us/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/en_us/developers/tasks/environment-monitoring-maintain.md
@@ -35,7 +35,7 @@ The core maintenance points for EnvironmentMonitoring are as follows:
 | Generator Config | `tools/pipeline-generate/EnvironmentMonitoring/generator/config.json` | Single observation point output configuration: `outputPattern: "${Station}/${Id}.json"` |
 | Terminal Generator Config | `tools/pipeline-generate/EnvironmentMonitoring/generator/terminals-config.json` | Terminal output configuration merged into a single file: `outputFile: "Terminals.json"` |
 | Multilingual Text | `assets/locales/interface/*.json` | `task.EnvironmentMonitoring.*` label / description (task-level; observation point names use OCR) |
-| Common Component Dependencies | `agent/go-service/maptracker/` / `3rdparty/maa-copilot` | Navigation uses `MapLocateAssertLocation` + `MapNavigateAction`; a small number of legacy routes still use the previous implementation (see [map-locator.md](../components/map-locator.md), [map-navigator.md](../components/map-navigator.md), and [map-tracker.md](../components/map-tracker.md)) |
+| Common Component Dependencies | `agent/cpp-algo/source/MapLocator/`, `agent/cpp-algo/source/MapNavigator/` | Localization and navigation use `MapLocateAssertLocation` + `MapNavigateAction` (see [map-locator.md](../components/map-locator.md) and [map-navigator.md](../components/map-navigator.md)) |
 | Scene Transition Dependencies | `assets/resource/pipeline/SceneManager/`、`Interface/` | `SceneEnterWorldWuling*`, `SceneEnterMenuRegionalDevelopmentWulingEnvironmentMonitoring` (see details in [scene-manager.md](../scene-manager.md)) |
 
 ## Main Flow
@@ -75,8 +75,8 @@ The internal chain for each observation point `{Id}Job` (rendered by `template.j
                        └─ Photo at teleport point
                             └─ GoTo{Id}NotAtStartPos → SubTask: ${EnterMap}
                                  ├─ No Heading → {Id}TakePhoto
-                                 └─ Heading set → GoTo{Id}Move (MapTrackerToward)
-GoTo{Id}Move                         (Navigation, or MapTrackerToward for direct-photo Heading)
+                                 └─ Heading set → GoTo{Id}Move (heading-only turn)
+GoTo{Id}Move                         (MapNavigateAction; heading-only action for direct-photo Heading)
   └─ {Id}TakePhoto
        ├─ anchor: EnvironmentMonitoringBackToTerminal → ${GoToMonitoringTerminal}
        ├─ anchor: EnvironmentMonitoringAdjustCamera   → ${Id}AdjustCamera
@@ -160,16 +160,15 @@ The default export of `data.mjs` is an array, where each element = the rendering
 | `Name` | Comes from the Chinese name in `environment_monitoring.json`; `MissionId` is only used by `model.mjs` to match `routes.json` and is not passed to the template |
 | `GoToMonitoringTerminal` | Determined by `Station` |
 | `EnterMap` | `routes.json[*].EnterMap`; any defined Pipeline node name is allowed, without a required prefix, as long as the node can complete and return normally when run as a SubTask |
-| `NavZoneId` / `NavAssert` / `NavPath` | The preferred route form in `routes.json[*]`. `NavPath` is required; regular teleports also require `NavZoneId` / `NavAssert`, while `QuickTeleport` may omit both. Generates `MapLocateAssertLocation` + `MapNavigateAction`; `Heading` appends a `HEADING` action. Do not combine these fields with the legacy map fields below. |
-| `MapName` / `MapAssert` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY` | Legacy single-target shorthand. Generates `MapLocateAssertLocation` + a `MapNavigateAction` `NAVMESH` target; `MapTargetTier` and `MapTargetDeckY` optionally become `target_tier` and `target_deck_y`. Use the preferred form above for new routes. |
-| `MapPath` / `MapGoal` | Legacy route fields retained only for routes that have not yet been migrated. Do not use them for new routes. |
+| `NavZoneId` / `NavAssert` / `NavPath` | The preferred route form in `routes.json[*]`. `NavPath` is required; regular teleports also require `NavZoneId` / `NavAssert`, while `QuickTeleport` may omit both. Generates `MapLocateAssertLocation` + `MapNavigateAction`; `Heading` appends a `HEADING` action. Do not combine these fields with the shorthand map fields below. |
+| `MapName` / `MapAssert` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY` | Single-target shorthand. Generates `MapLocateAssertLocation` + a `MapNavigateAction` `NAVMESH` target; `MapTargetTier` and `MapTargetDeckY` optionally become `target_tier` and `target_deck_y`. Use the preferred form above for new routes. |
 | `CameraSwipeDirection` | `routes.json[*]`, must be one of `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` |
 | `CameraMaxHit` | `routes.json[*].CameraMaxHit`, defaults to `2`; corresponds to the maximum hit count for the `${Id}AdjustCamera` swipe action |
 | `OcrReplace` | Passed through from `routes.json[*].Replace` to `Check${Id}Text.replace` and `In${Id}Mission.replace`; used to configure task-specific OCR replacement pairs for the task list and mission detail page, without affecting route adaptation checks |
 | `ExpectedText` | Automatically expanded from `mission.names` in `environment_monitoring.json` (5 languages, English converted to flexible regex) |
 | `InExpectedText` | Automatically expanded from `mission.shot_target_names` in `environment_monitoring.json` |
 | `TrackOrGoToNext` / `AfterTrackedNext` | Automatically determined by `data.mjs` based on whether the route is complete: `TrackOrGoToNext` converges to `Track${Id}` / `AlreadyTracked${Id}`, `AfterTrackedNext` is `GoTo${Id}` when adapted, `${Id}NotAdapted` when not adapted |
-| `GoToNext` / `AfterTeleportDescription` / `AfterTeleportNext` | Automatically determined by `data.mjs`: direct-photo routes always perform the configured teleport and enter `${Id}TakePhoto`; `QuickTeleport` with any navigation mode proceeds directly to `GoTo${Id}Move`; regular `NavPath` / `MapTarget` / `MapGoal` routes also proceed directly to `GoTo${Id}Move`, while only legacy `MapPath` routes return to `GoTo${Id}StartPos` to verify the landing point. |
+| `GoToNext` / `AfterTeleportDescription` / `AfterTeleportNext` | Automatically determined by `data.mjs`: direct-photo routes always perform the configured teleport, then enter `GoTo${Id}Move` to turn in place when `Heading` is set, or `${Id}TakePhoto` otherwise; navigation routes proceed directly to `GoTo${Id}Move` after teleporting, without re-verifying the landing point. |
 
 ### Terminal Grouping: `terminals-config.json`
 
@@ -215,15 +214,14 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 ### Pathfinding Components
 
-The teleport and pathfinding flow for observation points combines MapTracker and MapNavigator according to the route type:
+Teleporting and pathfinding for observation points is handled entirely by MapLocator and MapNavigator:
 
-- `MapTrackerAssertLocation` / `MapLocateAssertLocation` (Recognition): Judges whether the current position is within the `NavAssert` / `MapAssert` rectangle based on the minimap. Regular teleport routes use it to decide whether `EnterMap` is needed; quick-teleport routes start from a fixed landing point and may omit the assertion.
-- `MapNavigateAction` (Action): Uses `NavPath` directly as its path. `NavZoneId` selects the coordinate zone for `NavAssert`; a `NAVMESH` action in `NavPath` may carry `target_tier` for a cross-tier target and `target_deck_y` for one of several overlapping walkable decks.
-- Legacy `MapTrackerMove` / `MapTrackerGoal` / `MapNavigateAction` routes continue to consume `MapPath`, `MapGoal`, or the `MapTarget` shorthand respectively; `MapTargetTier` / `MapTargetDeckY` map to `target_tier` / `target_deck_y`.
+- `MapLocateAssertLocation` (Recognition): Judges whether the current position is within the `NavAssert` / `MapAssert` rectangle based on the minimap. Regular teleport routes use it to decide whether `EnterMap` is needed; quick-teleport routes start from a fixed landing point and may omit the assertion.
+- `MapNavigateAction` (Action): Uses `NavPath` directly as its path. `NavZoneId` selects the coordinate zone for `NavAssert`; a `NAVMESH` action in `NavPath` may carry `target_tier` for a cross-tier target and `target_deck_y` for one of several overlapping walkable decks. The `MapTarget` shorthand produces a single `NAVMESH` action, with `MapTargetTier` / `MapTargetDeckY` mapping to `target_tier` / `target_deck_y`.
 - `${Id}TakePhoto` (wrapper): Sets the task-specific `EnvironmentMonitoringBackToTerminal` and `EnvironmentMonitoringAdjustCamera` anchors before entering the shared photo flow.
-- Direct-photo routes perform neither a location assertion nor pathfinding; optional `Heading` invokes standalone `MapTrackerToward`. Quick-teleport routes start navigation directly from the fixed landing point. After a regular teleport, `NavPath` starts immediately, while only legacy `MapPath` verifies `MapAssert` again.
+- Direct-photo routes perform no pathfinding; when `Heading` is set, the generator emits a `MapNavigateAction` whose path contains only a `HEADING` action, turning the character in place before the photo. Both route forms start their action right after teleporting and never re-verify the landing point.
 
-For detailed parameters and coordinate recording methods, see [map-tracker.md](../components/map-tracker.md), [map-locator.md](../components/map-locator.md), and [map-navigator.md](../components/map-navigator.md).
+For detailed parameters and coordinate recording methods, see [map-locator.md](../components/map-locator.md) and [map-navigator.md](../components/map-navigator.md).
 
 ### Teleport Entry
 
@@ -238,10 +236,9 @@ Every fully adapted entry needs metadata, `CameraSwipeDirection`, and one telepo
 | Type | Map and route fields | Location assertion | Runtime behavior |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------- |
 | Metadata only | `MissionId` / `Name` / `Id` only | Omit | Accept and track only; no teleport or photo |
-| Photo at teleport | No `MapName` or navigation field; optional `Heading` | Omit | Teleport → optional `MapTrackerToward` → photo |
+| Photo at teleport | No `MapName` or navigation field; optional `Heading` | Omit | Teleport → optional turn in place → photo |
 | Navigation (preferred) | `NavPath`; regular teleports also add `NavZoneId`; optional `Heading` | `NavAssert`; optional with quick teleport | `MapNavigateAction` follows `NavPath` → photo |
 | `MapTarget` shorthand | `MapName` + `MapTarget`; optional `MapTargetTier` for cross-tier targets and `MapTargetDeckY` for overlapping decks | `MapAssert`; optional with quick teleport | `MapNavigateAction` NAVMESH → photo |
-| Legacy `MapPath` / `MapGoal` | `MapName` + the corresponding field; optional `Heading` / `NoEnsureInitialMovementState` | `MapAssert`; optional with quick teleport | Legacy action → photo |
 
 `CameraMaxHit` and `Replace` are available to every adapted route and do not define a separate route type. Use photo-at-teleport only after in-game verification; missing route data must remain metadata-only. New routes must use `NavPath`, adding `NavZoneId` / `NavAssert` for regular teleports.
 
@@ -308,7 +305,7 @@ When the teleport landing point can be photographed directly, use the compact fo
 }
 ```
 
-Do not include `NavZoneId`, `NavAssert`, `NavPath`, or any legacy map/navigation field in this form. `Heading` remains optional; when present, the generator invokes standalone `MapTrackerToward` after teleporting and then enters the photo flow. The generator recognizes direct photography from a complete teleport/photo configuration with no assertion or navigation fields. A metadata-only entry remains unadapted.
+Do not include `NavZoneId`, `NavAssert`, `NavPath`, or any of the shorthand map fields in this form. `Heading` remains optional; when present, the generator emits a heading-only `MapNavigateAction` after teleporting and then enters the photo flow. The generator recognizes direct photography from a complete teleport/photo configuration with no assertion or navigation fields. A metadata-only entry remains unadapted.
 
 > [!IMPORTANT]
 >
@@ -378,7 +375,7 @@ Before submission, at least check:
 - **Using `Id` as the matching key**: `Id` is only the final template node ID, convenient for searching generated nodes/file names; matching still only looks at `MissionId`.
 - **`Id` drifts from the `environment_monitoring.json` English name**: When the game side changes the English name, the automatically calculated `Id` will change, possibly causing generated file renaming or residual old files; after regeneration, the `Id` in `routes.json` will be synced.
 - **`EnterMap` references a missing node or one that cannot return normally**: Generation does not validate node references or runtime behavior; the route will fail at `GoTo{Id}NotAtStartPos`.
-- **`MapPath` / `MapTarget` / `MapGoal` passes through unlocked areas / battles / interactive objects**: MapTracker and MapNavigateAction do not handle battles, story sequences, map transitions, or mechanism interactions; routes can only select pure traversal segments.
+- **A route passes through locked areas / battles / interactive objects**: The navigation components do not handle battles, story sequences, map transitions, or mechanism interactions; routes can only select pure traversal segments.
 - **Treating missing route data as direct photography**: Use the compact teleport/photo form only after verifying in game that the teleport landing point can complete the photo. Otherwise keep the metadata-only entry unadapted.
 - **New `Station` but `Locations.json` / `EnvironmentMonitoringLoop.next` not synced**: The new terminal cannot be recognized and entered, so all observation points cannot run.
 - **`anchor` placeholder name consistency**: The key name `EnvironmentMonitoringBackToTerminal` for the `anchor` in `template.json` must exactly match the `[Anchor]EnvironmentMonitoringBackToTerminal` in `TakePhoto.json`; otherwise, the anchor mechanism fails.

--- a/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
@@ -172,8 +172,7 @@ MysteriousCryptidGraffiti         → 谜之生物的涂鸦
 | `GoToMonitoringTerminal` | 由 `Station` 决定 |
 | `EnterMap` | `routes.json[*].EnterMap`，默认传送入口；可填写任意已定义、能作为 SubTask 正常返回的 Pipeline 节点名，不限制名称前缀；启用 `QuickTeleport` 时不会使用，可省略 |
 | `QuickTeleport` | `routes.json[*].QuickTeleport`，可选布尔值，默认 `false`；启用后从追踪任务地图依次点击“前往传送”和“传送”，不调用 `EnterMap` |
-| `NavZoneId` / `NavAssert` / `NavPath` | `routes.json[*]`，寻路路线的默认写法；`NavPath` 必填，普通传送还需 `NavZoneId` / `NavAssert`，生成 `MapLocateAssertLocation` + `MapNavigateAction`（`Heading` 会追加 `HEADING` 动作）；配置后不再填写下面那组简写字段，路线自己接管传送落点，传送后不再复核起点 |
-| `MapName` / `MapAssert` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY` | `routes.json[*]`，单目标点的简写，同样生成 `MapLocateAssertLocation` + `MapNavigateAction` 的 `NAVMESH` 目标点，`MapTargetTier` 可选生成 `target_tier`，`MapTargetDeckY` 可选生成 `target_deck_y`；新增路线直接用上面的 `NavPath` 写法 |
+| `NavZoneId` / `NavAssert` / `NavPath` | `routes.json[*]`，寻路路线的写法；`NavPath` 必填，普通传送还需 `NavZoneId` / `NavAssert`，生成 `MapLocateAssertLocation` + `MapNavigateAction`（`Heading` 会追加 `HEADING` 动作）；路线自己接管传送落点，传送后不再复核起点 |
 | `CameraSwipeDirection` | `routes.json[*]`，必须是 `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` 之一 |
 | `CameraMaxHit` | `routes.json[*].CameraMaxHit`，缺省为 `2`；对应 `${Id}AdjustCamera` 滑屏动作的最大命中次数 |
 | `OcrReplace` | 由 `routes.json[*].Replace` 透传到 `Check${Id}Text.replace` 与 `In${Id}Mission.replace`；用于按任务配置任务列表和任务详情页 OCR 的易混字符替换，不影响路线是否已适配的判断 |
@@ -228,8 +227,8 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 观察点的寻路统一交给 MapNavigator：
 
-- `MapLocateAssertLocation`（识别）：根据当前小地图判断是否在 `NavAssert` / `MapAssert` 矩形内，普通传送路线用它决定要不要调用 `EnterMap`；`QuickTeleport` 从固定传送落点直接开始寻路，不进入该节点，可省略 `NavZoneId` / `NavAssert`。
-- `MapNavigateAction`（动作）：`NavPath` 原样作为它的 path，其中 `NAVMESH` 航点可按需携带 `target_tier` / `target_deck_y`；断言坐标取 `NavZoneId` 分区。`MapTarget` 简写会生成一个 `NAVMESH` 动作，`MapTargetTier` / `MapTargetDeckY` 分别透传为 `target_tier` / `target_deck_y`。两种写法传送后都直接进入寻路动作，不再复核起点。
+- `MapLocateAssertLocation`（识别）：根据当前小地图判断是否在 `NavAssert` 矩形内，普通传送路线用它决定要不要调用 `EnterMap`；`QuickTeleport` 从固定传送落点直接开始寻路，不进入该节点，可省略 `NavZoneId` / `NavAssert`。
+- `MapNavigateAction`（动作）：`NavPath` 原样作为它的 path，其中 `NAVMESH` 航点可按需携带 `target_tier` / `target_deck_y`；断言坐标取 `NavZoneId` 分区。传送后直接进入寻路动作，不再复核起点。
 - `${Id}TakePhoto`（包装节点）：为寻路和直拍路线统一设置 `EnvironmentMonitoringBackToTerminal` / `EnvironmentMonitoringAdjustCamera` anchor，再进入公共拍照流程。
 - 传送后直拍不执行寻路，配置 `Heading` 时生成一条只含 `HEADING` 动作的 `MapNavigateAction`，原地调整角色朝向再拍照。
 
@@ -246,13 +245,12 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 所有完整适配条目都需要元数据、`CameraSwipeDirection`，以及 `EnterMap` / `QuickTeleport: true` 中的一种传送入口。不同路线类型的字段组合如下：
 
 | 类型 | 地图与路线字段 | 断言矩形 | 运行行为 |
-| ----------------------------- | ------------------------------------------------------------------------------------------ | --------------------------- | ------------------------------------------ |
+| ----------------------------- | --------------------------------------------------------------- | --------------------------- | ------------------------------------------ |
 | metadata-only | 仅 `MissionId` / `Name` / `Id` | 不填 | 仅接取并追踪，不传送或拍照 |
 | 传送后直拍 | 不填任何地图和寻路字段；可选 `Heading` | 不填 | 传送 →（可选原地调整朝向）→ 拍照 |
-| 寻路（推荐写法） | `NavPath`；普通传送再加 `NavZoneId`，可选 `Heading` | `NavAssert`，快捷传送可省略 | `MapNavigateAction` 寻路 → 拍照 |
-| `MapTarget`（简写） | `MapName` + `MapTarget`；跨层时可加 `MapTargetTier`，目标点有重叠面时可加 `MapTargetDeckY` | `MapAssert`，快捷传送可省略 | `MapNavigateAction` 的 NAVMESH 寻路 → 拍照 |
+| 寻路 | `NavPath`；普通传送再加 `NavZoneId`，可选 `Heading` | `NavAssert`，快捷传送可省略 | `MapNavigateAction` 寻路 → 拍照 |
 
-`CameraMaxHit` 和 `Replace` 适用于所有已适配路线，不改变路线类型。直拍配置只能用于已经游戏实测确认的传送落点；缺少路线数据时继续保留 metadata-only 状态。新增寻路路线一律用 `NavPath`，普通传送再补 `NavZoneId` / `NavAssert`。
+`CameraMaxHit` 和 `Replace` 适用于所有已适配路线，不改变路线类型。直拍配置只能用于已经游戏实测确认的传送落点；缺少路线数据时继续保留 metadata-only 状态。寻路路线一律用 `NavPath`，普通传送再补 `NavZoneId` / `NavAssert`。
 
 ### 主菜单入口
 
@@ -317,7 +315,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 }
 ```
 
-直拍条目不要填写任何地图断言和寻路字段（`NavZoneId` / `NavAssert` / `NavPath`，以及简写形式的 `MapName` / `MapAssert` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY`）。可按实测结果配置 `Heading`，生成器会在传送后先原地调整朝向，再进入拍照流程。生成器根据“传送入口与拍照方向完整，同时没有地图断言和寻路配置”识别直拍模式。仅含 `MissionId` / `Name` / `Id` 的 metadata-only 条目仍然属于未适配。
+直拍条目不要填写任何地图断言和寻路字段（`NavZoneId` / `NavAssert` / `NavPath`）。可按实测结果配置 `Heading`，生成器会在传送后先原地调整朝向，再进入拍照流程。生成器根据“传送入口与拍照方向完整，同时没有地图断言和寻路配置”识别直拍模式。仅含 `MissionId` / `Name` / `Id` 的 metadata-only 条目仍然属于未适配。
 
 > [!IMPORTANT]
 >

--- a/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
+++ b/docs/zh_cn/developers/tasks/environment-monitoring-maintain.md
@@ -35,7 +35,7 @@
 | 生成器配置 | `tools/pipeline-generate/EnvironmentMonitoring/generator/config.json` | 单观察点输出配置：`outputPattern: "${Station}/${Id}.json"` |
 | 终端生成器配置 | `tools/pipeline-generate/EnvironmentMonitoring/generator/terminals-config.json` | 合并到单文件的终端输出配置：`outputFile: "Terminals.json"` |
 | 多语言文案 | `assets/locales/interface/*.json` | `task.EnvironmentMonitoring.*` 的 label / description（任务级；观察点名走 OCR） |
-| 通用组件依赖 | `agent/go-service/maptracker/` / `3rdparty/maa-copilot` | 寻路统一走 `MapLocateAssertLocation` + `MapNavigateAction`；少量尚未迁移的存量路线仍在用原有实现（详见 [map-locator.md](../components/map-locator.md)、[map-navigator.md](../components/map-navigator.md)、[map-tracker.md](../components/map-tracker.md)） |
+| 通用组件依赖 | `agent/cpp-algo/source/MapLocator/`、`agent/cpp-algo/source/MapNavigator/` | 定位与寻路统一走 `MapLocateAssertLocation` + `MapNavigateAction`（详见 [map-locator.md](../components/map-locator.md)、[map-navigator.md](../components/map-navigator.md)） |
 | 场景跳转依赖 | `assets/resource/pipeline/SceneManager/`、`Interface/` | `SceneEnterWorldWuling*`、`SceneEnterMenuRegionalDevelopmentWulingEnvironmentMonitoring`（详见 [scene-manager.md](../scene-manager.md)） |
 
 ## 主流程
@@ -172,16 +172,15 @@ MysteriousCryptidGraffiti         → 谜之生物的涂鸦
 | `GoToMonitoringTerminal` | 由 `Station` 决定 |
 | `EnterMap` | `routes.json[*].EnterMap`，默认传送入口；可填写任意已定义、能作为 SubTask 正常返回的 Pipeline 节点名，不限制名称前缀；启用 `QuickTeleport` 时不会使用，可省略 |
 | `QuickTeleport` | `routes.json[*].QuickTeleport`，可选布尔值，默认 `false`；启用后从追踪任务地图依次点击“前往传送”和“传送”，不调用 `EnterMap` |
-| `NavZoneId` / `NavAssert` / `NavPath` | `routes.json[*]`，寻路路线的默认写法；`NavPath` 必填，普通传送还需 `NavZoneId` / `NavAssert`，生成 `MapLocateAssertLocation` + `MapNavigateAction`（`Heading` 会追加 `HEADING` 动作）；配置后不再填写下面那组遗留字段，路线自己接管传送落点，传送后不再复核起点 |
+| `NavZoneId` / `NavAssert` / `NavPath` | `routes.json[*]`，寻路路线的默认写法；`NavPath` 必填，普通传送还需 `NavZoneId` / `NavAssert`，生成 `MapLocateAssertLocation` + `MapNavigateAction`（`Heading` 会追加 `HEADING` 动作）；配置后不再填写下面那组简写字段，路线自己接管传送落点，传送后不再复核起点 |
 | `MapName` / `MapAssert` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY` | `routes.json[*]`，单目标点的简写，同样生成 `MapLocateAssertLocation` + `MapNavigateAction` 的 `NAVMESH` 目标点，`MapTargetTier` 可选生成 `target_tier`，`MapTargetDeckY` 可选生成 `target_deck_y`；新增路线直接用上面的 `NavPath` 写法 |
-| `MapPath` / `MapGoal` | `routes.json[*]`，遗留字段，只保留给尚未迁移的存量路线，新增路线不要使用 |
 | `CameraSwipeDirection` | `routes.json[*]`，必须是 `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` 之一 |
 | `CameraMaxHit` | `routes.json[*].CameraMaxHit`，缺省为 `2`；对应 `${Id}AdjustCamera` 滑屏动作的最大命中次数 |
 | `OcrReplace` | 由 `routes.json[*].Replace` 透传到 `Check${Id}Text.replace` 与 `In${Id}Mission.replace`；用于按任务配置任务列表和任务详情页 OCR 的易混字符替换，不影响路线是否已适配的判断 |
 | `ExpectedText` | 由 `environment_monitoring.json` 的 `mission.names` 自动展开（5 语言，英文转柔性正则） |
 | `InExpectedText` | 由 `environment_monitoring.json` 的 `mission.shot_target_names` 自动展开 |
 | `TrackOrGoToNext` / `AfterTrackNext` / `AfterAlreadyTrackedNext` | 由 `data.mjs` 根据路线是否完整及 `QuickTeleport` 自动决定：默认进入 `GoTo${Id}`；快捷传送时，开始追踪后等待任务地图，已追踪则先点击定位图标打开任务地图；未适配时进入 `${Id}NotAdapted` |
-| `GoToNext` / `AfterTeleportDescription` / `AfterTeleportNext` | 由 `data.mjs` 根据传送入口和路线类型自动决定：传送后直拍始终执行真实传送并进入 `${Id}TakePhoto`；`QuickTeleport` 与任一寻路方式组合时传送后直接进入 `GoTo${Id}Move`；普通传送的 `NavPath` / `MapTarget` / `MapGoal` 直接进入 `GoTo${Id}Move`，只有 `MapPath` 返回 `GoTo${Id}StartPos` 复核落点 |
+| `GoToNext` / `AfterTeleportDescription` / `AfterTeleportNext` | 由 `data.mjs` 根据传送入口和路线类型自动决定：传送后直拍始终执行真实传送，配置 `Heading` 时先进入 `GoTo${Id}Move` 调整朝向，否则直接进入 `${Id}TakePhoto`；寻路路线传送后直接进入 `GoTo${Id}Move` |
 
 ### 终端分组：`terminals-config.json`
 
@@ -227,13 +226,12 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 ### 寻路组件
 
-观察点的寻路统一交给 MapNavigator，只有少数尚未迁移的存量路线还在跑原有实现：
+观察点的寻路统一交给 MapNavigator：
 
 - `MapLocateAssertLocation`（识别）：根据当前小地图判断是否在 `NavAssert` / `MapAssert` 矩形内，普通传送路线用它决定要不要调用 `EnterMap`；`QuickTeleport` 从固定传送落点直接开始寻路，不进入该节点，可省略 `NavZoneId` / `NavAssert`。
-- `MapNavigateAction`（动作）：`NavPath` 原样作为它的 path，其中 `NAVMESH` 航点可按需携带 `target_tier` / `target_deck_y`；断言坐标取 `NavZoneId` 分区。遗留的 `MapTarget` 简写会生成一个 `NAVMESH` 动作，`MapTargetTier` / `MapTargetDeckY` 分别透传为 `target_tier` / `target_deck_y`。两种写法传送后都直接进入寻路动作，不再复核起点。
+- `MapNavigateAction`（动作）：`NavPath` 原样作为它的 path，其中 `NAVMESH` 航点可按需携带 `target_tier` / `target_deck_y`；断言坐标取 `NavZoneId` 分区。`MapTarget` 简写会生成一个 `NAVMESH` 动作，`MapTargetTier` / `MapTargetDeckY` 分别透传为 `target_tier` / `target_deck_y`。两种写法传送后都直接进入寻路动作，不再复核起点。
 - `${Id}TakePhoto`（包装节点）：为寻路和直拍路线统一设置 `EnvironmentMonitoringBackToTerminal` / `EnvironmentMonitoringAdjustCamera` anchor，再进入公共拍照流程。
-- 传送后直拍不执行地图断言或寻路，配置 `Heading` 时只在原地调整角色朝向再拍照。
-- 存量的 `MapPath` / `MapGoal` 路线仍走原有实现：`MapPath` 在普通传送后会再复核一次 `MapAssert`。这两种写法只保留给还没录制新路线的观察点，不要用于新增路线。
+- 传送后直拍不执行寻路，配置 `Heading` 时生成一条只含 `HEADING` 动作的 `MapNavigateAction`，原地调整角色朝向再拍照。
 
 详细参数与坐标录制方式见 [map-locator.md](../components/map-locator.md) 与 [map-navigator.md](../components/map-navigator.md)。
 
@@ -253,9 +251,8 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 | 传送后直拍 | 不填任何地图和寻路字段；可选 `Heading` | 不填 | 传送 →（可选原地调整朝向）→ 拍照 |
 | 寻路（推荐写法） | `NavPath`；普通传送再加 `NavZoneId`，可选 `Heading` | `NavAssert`，快捷传送可省略 | `MapNavigateAction` 寻路 → 拍照 |
 | `MapTarget`（简写） | `MapName` + `MapTarget`；跨层时可加 `MapTargetTier`，目标点有重叠面时可加 `MapTargetDeckY` | `MapAssert`，快捷传送可省略 | `MapNavigateAction` 的 NAVMESH 寻路 → 拍照 |
-| `MapPath` / `MapGoal`（遗留） | `MapName` + 对应字段；可选 `Heading` / `NoEnsureInitialMovementState` | `MapAssert`，快捷传送可省略 | 原有实现寻路 → 拍照，仅存量路线保留 |
 
-`CameraMaxHit` 和 `Replace` 适用于所有已适配路线，不改变路线类型。直拍配置只能用于已经游戏实测确认的传送落点；缺少路线数据时继续保留 metadata-only 状态。新增寻路路线一律用 `NavPath`，普通传送再补 `NavZoneId` / `NavAssert`；最后两行只是存量路线的现状记录。
+`CameraMaxHit` 和 `Replace` 适用于所有已适配路线，不改变路线类型。直拍配置只能用于已经游戏实测确认的传送落点；缺少路线数据时继续保留 metadata-only 状态。新增寻路路线一律用 `NavPath`，普通传送再补 `NavZoneId` / `NavAssert`。
 
 ### 主菜单入口
 
@@ -320,7 +317,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 }
 ```
 
-直拍条目不要填写任何地图断言和寻路字段（`NavZoneId` / `NavAssert` / `NavPath`，以及遗留的 `MapName` / `MapAssert` / `MapPath` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY` / `MapGoal` / `NoEnsureInitialMovementState`）。可按实测结果配置 `Heading`，生成器会在传送后先原地调整朝向，再进入拍照流程。生成器根据“传送入口与拍照方向完整，同时没有地图断言和寻路配置”识别直拍模式。仅含 `MissionId` / `Name` / `Id` 的 metadata-only 条目仍然属于未适配。
+直拍条目不要填写任何地图断言和寻路字段（`NavZoneId` / `NavAssert` / `NavPath`，以及简写形式的 `MapName` / `MapAssert` / `MapTarget` / `MapTargetTier` / `MapTargetDeckY`）。可按实测结果配置 `Heading`，生成器会在传送后先原地调整朝向，再进入拍照流程。生成器根据“传送入口与拍照方向完整，同时没有地图断言和寻路配置”识别直拍模式。仅含 `MissionId` / `Name` / `Id` 的 metadata-only 条目仍然属于未适配。
 
 > [!IMPORTANT]
 >
@@ -376,7 +373,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 
 1. `tools/pipeline-generate/EnvironmentMonitoring/routes.json` 中新增/修改条目是否字段齐全。
 2. `routes.json` 中新增条目的 `MissionId` 是否能匹配 `environment_monitoring.json` 的 `mission_id`；`Id` 由生成器自动刷新。
-3. 已适配条目的传送入口已在真实 `EnterMap` 与 `QuickTeleport: true` 中至少选择一种，`CameraSwipeDirection` 已填写真实值；直拍路线没有任何地图与寻路字段，新增寻路路线配置 `NavPath`，且普通传送路线补齐真实 `NavZoneId` / `NavAssert`；遗留路线仍在 `MapPath` / `MapTarget` / `MapGoal` 中三选一。
+3. 已适配条目的传送入口已在真实 `EnterMap` 与 `QuickTeleport: true` 中至少选择一种，`CameraSwipeDirection` 已填写真实值；直拍路线没有任何地图与寻路字段，新增寻路路线配置 `NavPath`，且普通传送路线补齐真实 `NavZoneId` / `NavAssert`。
 4. 重生成的 `Terminals.json` 中各 `{Station}MonitoringTerminalLoop.next` 包含全部新 `[JumpBack]{Id}Job`，并以 `EnvironmentMonitoringTerminalFinish` 收尾。
 5. 若填写了 `EnterMap`，其引用的节点确实存在于 `assets/resource/pipeline/`，并能作为 SubTask 完整执行后正常返回。
 6. `CameraSwipeDirection` 是 `EnvironmentMonitoringSwipeScreen{Up/Down/Left/Right}` 四者之一。

--- a/tools/MapNavigator/README.md
+++ b/tools/MapNavigator/README.md
@@ -127,7 +127,7 @@ MapNavigator 是用于 C++ MapNavigator 模块使用的地图路径录制与编�
 1. 打开工具，切换到 `断言模式` 页签。
 2. 点击 `选择断言底图与层级`，选择目标 `zone`。
 3. 在底图上按住左键拖拽，框出一个矩形区域。
-4. 选择复制完整断言节点或仅复制环境监测 `routes.json` 使用的 `MapAssert` 坐标，再点击复制按钮。
+4. 选择复制完整断言节点或仅复制环境监测 `routes.json` 使用的 `NavAssert` 坐标，再点击复制按钮。
 
 ### 导出格式
 
@@ -203,9 +203,7 @@ dung01
 }
 ```
 
-`NAVMESH` 的 `.nav` 区域由运行时根据当前定位自动推断；复制结果不需要填写 `zone_id` / `navmesh_zone`。
-
-复制内容可切换为 `仅坐标（MapTarget）`，此时只复制最后一个目标点的 `[x, y]`，可直接粘贴到环境监测 `routes.json` 的 `MapTarget`。分层底图的状态栏会同时提示应填写的 `MapTargetTier`。
+`NAVMESH` 的 `.nav` 区域由运行时根据当前定位自动推断；复制结果不需要填写 `zone_id` / `navmesh_zone`。复制结果可直接作为环境监测 `routes.json` 中 `NavPath` 的 NAVMESH 动作。
 
 `.nav` 只连接 GLB 自身共享/重叠边，以及同高度的小距离 component bridge；不会为了跨 level 自动补 portal 或 drop link。游戏本身分离的 level 暂保持不可达。
 

--- a/tools/MapNavigator/web/static/index.html
+++ b/tools/MapNavigator/web/static/index.html
@@ -198,7 +198,7 @@
             <label class="sidebar-label" for="assert-copy-format">复制内容</label>
             <select id="assert-copy-format" class="combo copy-format-combo">
               <option value="json">断言节点 JSON</option>
-              <option value="coordinates">仅坐标（MapAssert）</option>
+              <option value="coordinates">仅坐标（NavAssert）</option>
             </select>
           </div>
           <div class="sidebar-row grid-btns-2">
@@ -248,13 +248,6 @@
             <div class="sidebar-hint">点一层预览，「选择」把该层高度写进 target_deck_y</div>
           </div>
 
-          <div class="sidebar-row copy-format-row">
-            <label class="sidebar-label" for="navmesh-copy-format">复制内容</label>
-            <select id="navmesh-copy-format" class="combo copy-format-combo">
-              <option value="json">NAVMESH JSON 配置</option>
-              <option value="coordinates">仅坐标（MapTarget）</option>
-            </select>
-          </div>
           <div class="sidebar-row grid-btns-2">
             <button id="btn-astar-import" class="btn btn-secondary" type="button" title="把 JSON 里的点标成预览点（不写入路线）">导入 JSON</button>
             <button id="btn-copy-navmesh" class="btn btn-secondary" type="button" title="复制最后一个预览点为 NAVMESH 目标（有预览路线时复制整条）">复制 JSON 配置</button>

--- a/tools/MapNavigator/web/static/js/main.js
+++ b/tools/MapNavigator/web/static/js/main.js
@@ -247,7 +247,6 @@ class MapNavigatorApp {
             astarZoneCombo: $("astar-zone-combo"),
             btnClearAstar: $("btn-clear-astar"),
             btnCopyNavmesh: $("btn-copy-navmesh"),
-            navmeshCopyFormat: $("navmesh-copy-format"),
             loadProgress: $("load-progress"),
             loadProgressBar: $("load-progress-bar"),
             loadProgressLabel: $("load-progress-label"),
@@ -662,7 +661,6 @@ class MapNavigatorApp {
         e.astarZoneCombo.addEventListener("change", () => this._onAstarZoneChanged());
         e.btnClearAstar.addEventListener("click", () => this._onClearAstar());
         e.btnCopyNavmesh.addEventListener("click", () => this._copyNavmesh());
-        e.navmeshCopyFormat.addEventListener("change", () => this._syncCopyButtonLabels());
         e.btnAssertLocate.addEventListener("click", () => this._onLocateCurrentPosition("assert"));
         e.btnAstarLocate.addEventListener("click", () => this._onLocateCurrentPosition("astar"));
         e.btnAstarMarkCoord.addEventListener("click", () => this._onAstarMarkCoord());
@@ -2561,8 +2559,7 @@ class MapNavigatorApp {
 
     /** Keep each copy button's label aligned with its selected output format. @returns {void} */
     _syncCopyButtonLabels() {
-        this.els.btnCopyNavmesh.textContent =
-            this.els.navmeshCopyFormat.value === COPY_FORMAT_COORDINATES ? "复制坐标" : "复制 JSON 配置";
+        this.els.btnCopyNavmesh.textContent = "复制 JSON 配置";
         this.els.btnCopyAssert.textContent =
             this.els.assertCopyFormat.value === COPY_FORMAT_COORDINATES ? "复制坐标" : "复制断言 JSON";
     }
@@ -2583,7 +2580,7 @@ class MapNavigatorApp {
         }
     }
 
-    /** Export the assert rect as a full node or a routes.json MapAssert coordinate array. @returns {Promise<void>} */
+    /** Export the assert rect as a full node or a routes.json NavAssert coordinate array. @returns {Promise<void>} */
     async _copyAssert() {
         const zoneId = this._displayZoneId();
         if (!zoneId) {
@@ -2598,7 +2595,7 @@ class MapNavigatorApp {
         try {
             if (this.els.assertCopyFormat.value === COPY_FORMAT_COORDINATES) {
                 await this._copyText(JSON.stringify(target, null, 4));
-                setStatus(`环境监测 MapAssert 坐标已复制: [${target.join(", ")}]`, "#10b981");
+                setStatus(`环境监测 NavAssert 坐标已复制: [${target.join(", ")}]`, "#10b981");
                 return;
             }
             const result = await exportAssert(zoneId, target);
@@ -2613,9 +2610,7 @@ class MapNavigatorApp {
     /**
      * Copy the A* waypoints (all clicked points after the start, in base px) as
      * NAVMESH action payloads — a single object for one target, an array for a
-     * multi-leg route. Coordinate-only output copies the final target for an
-     * EnvironmentMonitoring routes.json `MapTarget`. With no route planned, falls
-     * back to the locate hint.
+     * multi-leg route. With no route planned, falls back to the locate hint.
      * @returns {Promise<void>}
      */
     async _copyNavmesh() {
@@ -2655,17 +2650,10 @@ class MapNavigatorApp {
                 if (this.hintDeck !== null) {
                     payload.target_deck_y = this.hintDeck;
                 }
-                const coordinatesOnly = this.els.navmeshCopyFormat.value === COPY_FORMAT_COORDINATES;
-                await this._copyText(JSON.stringify(coordinatesOnly ? payload.target : payload, null, 4));
-                const tierField = coordinatesOnly ? "MapTargetTier" : "target_tier";
-                const tierNote = tierName ? ` ${tierField}=${tierName}` : "";
-                // 只复制坐标时 deck 落不进剪贴板(它是 routes.json 的另一个键), 所以念给开发者抄。
-                const deckNote =
-                    this.hintDeck === null
-                        ? ""
-                        : ` ${coordinatesOnly ? "MapTargetDeckY" : "target_deck_y"}=${this.hintDeck.toFixed(2)}`;
+                await this._copyText(JSON.stringify(payload, null, 4));
+                const tierNote = tierName ? ` target_tier=${tierName}` : "";
                 setStatus(
-                    `${coordinatesOnly ? "环境监测 MapTarget 坐标" : "NAVMESH 目标"}已复制: zone=${zoneId} target=[${payload.target[0]}, ${payload.target[1]}]${tierNote}${deckNote}`,
+                    `NAVMESH 目标已复制: zone=${zoneId} target=[${payload.target[0]}, ${payload.target[1]}]${tierNote}`,
                     "#10b981",
                 );
                 return;
@@ -2703,18 +2691,7 @@ class MapNavigatorApp {
             targets.push(payload);
         }
 
-        if (this.els.navmeshCopyFormat.value === COPY_FORMAT_COORDINATES) {
-            const target = targets[targets.length - 1];
-            await this._copyText(JSON.stringify(target.target, null, 4));
-            const tierNote = tierName ? ` MapTargetTier=${tierName}` : "";
-            // 只复制坐标时 deck 落不进剪贴板(它是 routes.json 的另一个键), 所以念给开发者抄。
-            const deckNote =
-                target.target_deck_y === undefined ? "" : ` MapTargetDeckY=${target.target_deck_y.toFixed(2)}`;
-            setStatus(
-                `环境监测 MapTarget 坐标已复制: [${target.target[0]}, ${target.target[1]}]${tierNote}${deckNote}`,
-                "#10b981",
-            );
-        } else if (targets.length === 1) {
+        if (targets.length === 1) {
             await this._copyText(JSON.stringify(targets[0], null, 4));
             const tierNote = tierName ? ` target_tier=${tierName}` : "";
             setStatus(

--- a/tools/pipeline-generate/EnvironmentMonitoring/README.md
+++ b/tools/pipeline-generate/EnvironmentMonitoring/README.md
@@ -51,28 +51,14 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
         // 不再调用 EnterMap 配置的 Pipeline 入口节点。
     "NavZoneId": "Wuling_Base",
     "NavAssert": [x, y, w, h],
-    "NavPath": [{ "action": "ZONE", "zone_id": "..." }, [x1, y1], [x2, y2]]
-        // 寻路路线的写法。NavPath 必填，用 tools/MapNavigator/ 的 GUI 工具录制。
+    "NavPath": [{ "action": "ZONE", "zone_id": "..." }, [x1, y1], [x2, y2]],
+        // 寻路路线的写法。寻路时 NavPath 必填，用 tools/MapNavigator/ 的 GUI 工具录制。
         // NavZoneId + NavAssert 渲染为 MapLocateAssertLocation（NavZoneId 分区坐标，
         // tier 分区为 tier 局部坐标）；NavPath 原样作为 MapNavigateAction 的 path
         // （不含 HEADING，朝向仍由 Heading 字段追加）。
         // 普通传送必须有 NavZoneId / NavAssert 用来判断是否调用 EnterMap；
         // 快捷传送不执行起点断言，可同时省略二者。
         // 如果传送点可以直接拍照，则整组字段一起省略。
-    // 下面几个是单目标点的简写字段，只保留给存量路线，新增路线不要使用：
-    // "MapName": "map02_lv001",
-    //     地图标识，填 MapLocate 的 zone_id，与录制工具保持一致。
-    // "MapAssert": [x, y, w, h],
-    //     简写路线的初始位置判断矩形，作用同 NavAssert。
-    // "MapTarget": [x, y],
-    //     单目标点的简写，生成 [{ "action": "NAVMESH", "target": [x, y] }]，默认按 base 坐标解释。
-    // "MapTargetTier": "ValleyIV_L1_171",
-    //     可选，仅用于 MapTarget 路线。目标点与起点不在同一 tier，且 MapTarget 是在
-    //     tier 底图上直接点出的坐标时填写；生成时会透传为 NAVMESH 的 target_tier。
-    // "MapTargetDeckY": 265.37,
-    //     可选，仅用于 MapTarget 路线。目标点所在那张可走面的世界高度；底图是二维的，同一个坐标
-    //     底下可能压着走廊 / 天桥 / 屋顶,不填时先够到哪张停哪张。用 MapNavigator 点中目标后从
-    //     重叠面列表读出,生成时会透传为 NAVMESH 的 target_deck_y。
     "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenUp",
         // 摄像头朝向调整方向，四选一：Up / Down / Left / Right。
     "CameraMaxHit": 2,
@@ -93,9 +79,9 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 }
 ```
 
-> `routes.json` 是严格 JSON：不允许行内注释、不允许尾随逗号。上面的注释只是文档示意，实际文件里要去掉。需要寻路时配置 `NavPath`，普通传送再配置 `NavZoneId` / `NavAssert`；它与简写形式的 `MapTarget` 互斥，只能选一种写法。如果传送点可以直接拍照，则整组地图断言和寻路字段（包括 `MapTargetTier` / `MapTargetDeckY`）都不要填，但可以按实测结果保留可选的 `Heading`。生成器会根据“存在真实传送入口和 `CameraSwipeDirection`，同时没有地图断言和寻路配置”自动进入直拍分支，不需要额外开关字段。
+> `routes.json` 是严格 JSON：不允许行内注释、不允许尾随逗号。上面的注释只是文档示意，实际文件里要去掉。需要寻路时配置 `NavPath`，普通传送再配置 `NavZoneId` / `NavAssert`。如果传送点可以直接拍照，则整组地图断言和寻路字段都不要填，但可以按实测结果保留可选的 `Heading`。生成器会根据“存在真实传送入口和 `CameraSwipeDirection`，同时没有地图断言和寻路配置”自动进入直拍分支，不需要额外开关字段。
 
-> 传送后的处理取决于入口和路线类型：传送后直拍不做位置断言或寻路，配置 `Heading` 时只原地调整朝向，随后进入任务专属拍照包装节点。`QuickTeleport` 的固定传送落点可直接开始寻路，因此允许省略 `NavZoneId` / `NavAssert`。普通传送的寻路路线仍会在决定是否调用 `EnterMap` 前用到断言配置，所以不能省略；传送完成后 `NavPath` / `MapTarget` 直接开始寻路，不再复核起点。
+> 传送后的处理取决于入口和路线类型：传送后直拍不做位置断言或寻路，配置 `Heading` 时只原地调整朝向，随后进入任务专属拍照包装节点。`QuickTeleport` 的固定传送落点可直接开始寻路，因此允许省略 `NavZoneId` / `NavAssert`。普通传送的寻路路线仍会在决定是否调用 `EnterMap` 前用到断言配置，所以不能省略；传送完成后 `NavPath` 直接开始寻路，不再复核起点。
 >
 > 仅含 `NAVMESH` 的 `NavPath` 不需要前置 `ZONE`：导航器会从 MapLocator 当前定位自动确定起点区域。`ZONE` 只为后续手录坐标点声明和校验分区，多分区或过图路径应原样保留录制工具导出的 `ZONE`。
 
@@ -110,12 +96,11 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 所有完整适配条目都需要元数据、`CameraSwipeDirection`，以及 `EnterMap` / `QuickTeleport: true` 中的一种传送入口。其余字段按路线类型填写：
 
 | 类型 | 地图与路线字段 | 断言矩形 | 生成流程 |
-| ----------------------------- | ------------------------------------------------------------------------------------------ | --------------------------- | -------------------------------------------- |
+| ----------------------------- | --------------------------------------------------------------- | --------------------------- | -------------------------------------------- |
 | metadata-only | 仅 `MissionId` / `Name` / `Id` | 不填 | 仅接取并追踪，不传送或拍照 |
 | 传送后直拍 | 不填任何地图和寻路字段；`Heading` 可选 | 不填 | 传送 →（可选原地调整朝向）→ 拍照 |
-| 寻路（推荐写法） | `NavPath`；普通传送再加 `NavZoneId`，可选 `Heading` | `NavAssert`，快捷传送可省略 | `MapNavigateAction` 按 `NavPath` 寻路 → 拍照 |
-| `MapTarget`（简写） | `MapName` + `MapTarget`；跨层时可加 `MapTargetTier`，目标点有重叠面时可加 `MapTargetDeckY` | `MapAssert`，快捷传送可省略 | `MapNavigateAction` 的 NAVMESH 寻路 → 拍照 |
+| 寻路 | `NavPath`；普通传送再加 `NavZoneId`，可选 `Heading` | `NavAssert`，快捷传送可省略 | `MapNavigateAction` 按 `NavPath` 寻路 → 拍照 |
 
-`CameraMaxHit` 和 `Replace` 可用于所有已适配路线，不改变路线类型。直拍必须经过游戏实测确认，不能用来代替尚未录制的路线数据。新增寻路路线一律用 `NavPath`，普通传送再补 `NavZoneId` / `NavAssert`。
+`CameraMaxHit` 和 `Replace` 可用于所有已适配路线，不改变路线类型。直拍必须经过游戏实测确认，不能用来代替尚未录制的路线数据。寻路路线一律用 `NavPath`，普通传送再补 `NavZoneId` / `NavAssert`。
 
 > 完整维护流程见 `docs/zh_cn/developers/tasks/environment-monitoring-maintain.md`。

--- a/tools/pipeline-generate/EnvironmentMonitoring/README.md
+++ b/tools/pipeline-generate/EnvironmentMonitoring/README.md
@@ -59,12 +59,11 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
         // 普通传送必须有 NavZoneId / NavAssert 用来判断是否调用 EnterMap；
         // 快捷传送不执行起点断言，可同时省略二者。
         // 如果传送点可以直接拍照，则整组字段一起省略。
-    // 下面几个是遗留字段，只保留给尚未迁移的存量路线，新增路线不要使用：
+    // 下面几个是单目标点的简写字段，只保留给存量路线，新增路线不要使用：
     // "MapName": "map02_lv001",
-    //     地图标识，与录制工具保持一致：MapTarget 填 MapLocate 的 zone_id，
-    //     MapPath / MapGoal 填原有实现的 map_name。
+    //     地图标识，填 MapLocate 的 zone_id，与录制工具保持一致。
     // "MapAssert": [x, y, w, h],
-    //     遗留路线的初始位置判断矩形，作用同 NavAssert。
+    //     简写路线的初始位置判断矩形，作用同 NavAssert。
     // "MapTarget": [x, y],
     //     单目标点的简写，生成 [{ "action": "NAVMESH", "target": [x, y] }]，默认按 base 坐标解释。
     // "MapTargetTier": "ValleyIV_L1_171",
@@ -74,9 +73,6 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
     //     可选，仅用于 MapTarget 路线。目标点所在那张可走面的世界高度；底图是二维的，同一个坐标
     //     底下可能压着走廊 / 天桥 / 屋顶,不填时先够到哪张停哪张。用 MapNavigator 点中目标后从
     //     重叠面列表读出,生成时会透传为 NAVMESH 的 target_deck_y。
-    // "MapPath": [[x1, y1], [x2, y2]],
-    // "MapGoal": [x, y],
-    //     存量路线的逐点路径 / 自动寻路目标点，走原有实现。
     "CameraSwipeDirection": "EnvironmentMonitoringSwipeScreenUp",
         // 摄像头朝向调整方向，四选一：Up / Down / Left / Right。
     "CameraMaxHit": 2,
@@ -89,9 +85,6 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
         ]
     ],
         // 可选；任务列表和任务详情页 OCR 易混字符替换。
-    // "NoEnsureInitialMovementState": true,
-    //     可选，默认 false，仅遗留的 MapPath 路线使用。一般只在路线起点紧贴桥边、悬崖边等
-    //     危险地形时开启，用于跳过开局的冲刺准备动作，避免角色因为这一步直接掉下桥或掉下悬崖。
     "Heading": 90,
         // 可选；到达拍照点后、进入拍照模式前，先用 MapNavigator 的 HEADING 动作把
         // 角色朝向旋转到该角度（度数，与 MapNavigator 角度约定一致）。未配置时不调整。
@@ -100,9 +93,9 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 }
 ```
 
-> `routes.json` 是严格 JSON：不允许行内注释、不允许尾随逗号。上面的注释只是文档示意，实际文件里要去掉。需要寻路时配置 `NavPath`，普通传送再配置 `NavZoneId` / `NavAssert`；它与遗留的 `MapPath` / `MapTarget` / `MapGoal` 互斥，只能选一种写法。如果传送点可以直接拍照，则整组地图断言和寻路字段（包括 `MapTargetTier` / `MapTargetDeckY`）都不要填，但可以按实测结果保留可选的 `Heading`。生成器会根据“存在真实传送入口和 `CameraSwipeDirection`，同时没有地图断言和寻路配置”自动进入直拍分支，不需要额外开关字段。
+> `routes.json` 是严格 JSON：不允许行内注释、不允许尾随逗号。上面的注释只是文档示意，实际文件里要去掉。需要寻路时配置 `NavPath`，普通传送再配置 `NavZoneId` / `NavAssert`；它与简写形式的 `MapTarget` 互斥，只能选一种写法。如果传送点可以直接拍照，则整组地图断言和寻路字段（包括 `MapTargetTier` / `MapTargetDeckY`）都不要填，但可以按实测结果保留可选的 `Heading`。生成器会根据“存在真实传送入口和 `CameraSwipeDirection`，同时没有地图断言和寻路配置”自动进入直拍分支，不需要额外开关字段。
 
-> 传送后的处理取决于入口和路线类型：传送后直拍不做位置断言或寻路，配置 `Heading` 时只原地调整朝向，随后进入任务专属拍照包装节点。`QuickTeleport` 的固定传送落点可直接开始寻路，因此允许省略 `NavZoneId` / `NavAssert`。普通传送的寻路路线仍会在决定是否调用 `EnterMap` 前用到断言配置，所以不能省略；传送完成后 `NavPath` / `MapTarget` / `MapGoal` 直接开始寻路，只有遗留的 `MapPath` 会再次复核固定起点。
+> 传送后的处理取决于入口和路线类型：传送后直拍不做位置断言或寻路，配置 `Heading` 时只原地调整朝向，随后进入任务专属拍照包装节点。`QuickTeleport` 的固定传送落点可直接开始寻路，因此允许省略 `NavZoneId` / `NavAssert`。普通传送的寻路路线仍会在决定是否调用 `EnterMap` 前用到断言配置，所以不能省略；传送完成后 `NavPath` / `MapTarget` 直接开始寻路，不再复核起点。
 >
 > 仅含 `NAVMESH` 的 `NavPath` 不需要前置 `ZONE`：导航器会从 MapLocator 当前定位自动确定起点区域。`ZONE` 只为后续手录坐标点声明和校验分区，多分区或过图路径应原样保留录制工具导出的 `ZONE`。
 
@@ -122,8 +115,7 @@ pnpm exec maa-pipeline-generate --config terminals-config.json
 | 传送后直拍 | 不填任何地图和寻路字段；`Heading` 可选 | 不填 | 传送 →（可选原地调整朝向）→ 拍照 |
 | 寻路（推荐写法） | `NavPath`；普通传送再加 `NavZoneId`，可选 `Heading` | `NavAssert`，快捷传送可省略 | `MapNavigateAction` 按 `NavPath` 寻路 → 拍照 |
 | `MapTarget`（简写） | `MapName` + `MapTarget`；跨层时可加 `MapTargetTier`，目标点有重叠面时可加 `MapTargetDeckY` | `MapAssert`，快捷传送可省略 | `MapNavigateAction` 的 NAVMESH 寻路 → 拍照 |
-| `MapPath` / `MapGoal`（遗留） | `MapName` + 对应字段；可选 `Heading` / `NoEnsureInitialMovementState` | `MapAssert`，快捷传送可省略 | 原有实现寻路 → 拍照，仅存量路线保留 |
 
-`CameraMaxHit` 和 `Replace` 可用于所有已适配路线，不改变路线类型。直拍必须经过游戏实测确认，不能用来代替尚未录制的路线数据。新增寻路路线一律用 `NavPath`，普通传送再补 `NavZoneId` / `NavAssert`；最后两行只是存量路线的现状记录。
+`CameraMaxHit` 和 `Replace` 可用于所有已适配路线，不改变路线类型。直拍必须经过游戏实测确认，不能用来代替尚未录制的路线数据。新增寻路路线一律用 `NavPath`，普通传送再补 `NavZoneId` / `NavAssert`。
 
 > 完整维护流程见 `docs/zh_cn/developers/tasks/environment-monitoring-maintain.md`。

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/data.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/data.mjs
@@ -59,7 +59,7 @@ export function buildRow(mission) {
                   `GoTo${Id}StartPos`,
                   `GoTo${Id}NotAtStartPos`,
               ];
-    // NavMesh 可处理传送点附近落点，快捷传送的手录路径也可从固定落点开始；普通 MapPath 仍需复核起点。
+    // NavMesh 可处理传送点附近落点，快捷传送的手录路径也可从固定落点开始；MapTarget 路线仍需复核起点。
     const AfterTeleportDescription = route.IsDirectPhoto
         ? route.HasHeading
             ? "传送后调整朝向并拍照"

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/data.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/data.mjs
@@ -59,7 +59,7 @@ export function buildRow(mission) {
                   `GoTo${Id}StartPos`,
                   `GoTo${Id}NotAtStartPos`,
               ];
-    // NavMesh 可处理传送点附近落点，快捷传送的手录路径也可从固定落点开始；MapTarget 路线仍需复核起点。
+    // NavMesh 可处理传送点附近落点，快捷传送的手录路径也可从固定落点开始；未适配条目才需复核起点。
     const AfterTeleportDescription = route.IsDirectPhoto
         ? route.HasHeading
             ? "传送后调整朝向并拍照"

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.mjs
@@ -2,23 +2,6 @@ import {isFieldMissing, sanitizeDisplayName} from "./common.mjs";
 
 export const CAMERA_MAX_HIT_DEFAULT = 2;
 
-export const ROUTE_CONFIG_FIELDS = [
-    "EnterMap",
-    "MapName",
-    "MapAssert",
-    "MapTarget",
-    "MapTargetTier",
-    "MapTargetDeckY",
-    "NavZoneId",
-    "NavAssert",
-    "NavPath",
-    "CameraSwipeDirection",
-    "CameraMaxHit",
-    "Replace",
-    "Heading",
-    "QuickTeleport",
-];
-
 // MapNavigator 路线只要求路径；普通传送还需要起点断言的分区与矩形。
 const NAV_ROUTE_REQUIRED_FIELDS = [
     "NavPath",
@@ -34,8 +17,6 @@ const NAV_ROUTE_FIELDS = [
 
 const ROUTE_RENDER_FIELDS = [
     "EnterMap",
-    "MapName",
-    "MapAssert",
     "CameraSwipeDirection",
 ];
 
@@ -57,12 +38,8 @@ export function collectMissingRouteFields(route) {
     }
 
     const quickTeleport = route.QuickTeleport === true;
-    const hasMapAssert = !isFieldMissing(route.MapAssert);
-    const hasMapTarget = !isFieldMissing(route.MapTarget);
     const navFieldsPresent = collectNavRouteFields(route);
     const hasNavRoute = hasCompleteNavRoute(route);
-    const isDirectPhoto = !hasMapAssert && navFieldsPresent.length === 0 && !hasMapTarget;
-    const canSkipMapAssert = quickTeleport && hasMapTarget;
     const missingFields = [];
 
     if (!quickTeleport && isFieldMissing(route.EnterMap)) {
@@ -71,50 +48,10 @@ export function collectMissingRouteFields(route) {
     if (isFieldMissing(route.CameraSwipeDirection)) {
         missingFields.push("CameraSwipeDirection");
     }
-    if (isDirectPhoto) {
-        const unusedDirectPhotoFields = [
-            "MapName",
-            "MapTargetTier",
-            "MapTargetDeckY",
-        ].filter((field) => !isFieldMissing(route[field]));
-        if (unusedDirectPhotoFields.length > 0) {
-            missingFields.push(`传送后直拍不应配置 ${unusedDirectPhotoFields.join("/")}`);
-        }
-    } else if (navFieldsPresent.length > 0) {
-        if (!hasNavRoute) {
-            const hasAnyAssertField = NAV_ASSERT_FIELDS.some((field) => !isFieldMissing(route[field]));
-            const requiredFields = quickTeleport && !hasAnyAssertField ? NAV_ROUTE_REQUIRED_FIELDS : NAV_ROUTE_FIELDS;
-            missingFields.push(`${requiredFields.join("/")} 必须同时配置`);
-        } else {
-            // Nav 路线自带路径，普通传送另带分区与断言；老的地图字段留着只会两份配置对不上。
-            const unusedNavRouteFields = [
-                "MapName",
-                "MapAssert",
-                "MapTarget",
-                "MapTargetTier",
-            ].filter((field) => !isFieldMissing(route[field]));
-            if (unusedNavRouteFields.length > 0) {
-                missingFields.push(`NavPath 路线不应配置 ${unusedNavRouteFields.join("/")}`);
-            }
-        }
-    } else {
-        if (isFieldMissing(route.MapName)) {
-            missingFields.push("MapName");
-        }
-        if (!canSkipMapAssert && !hasMapAssert) {
-            missingFields.push("MapAssert");
-        }
-        if (!hasMapTarget) {
-            missingFields.push("MapTarget");
-        }
-    }
-
-    if (!isFieldMissing(route.MapTargetTier) && !hasMapTarget) {
-        missingFields.push("MapTargetTier 仅可与 MapTarget 同时使用");
-    }
-
-    if (!isFieldMissing(route.MapTargetDeckY) && !hasMapTarget) {
-        missingFields.push("MapTargetDeckY 仅可与 MapTarget 同时使用");
+    if (navFieldsPresent.length > 0 && !hasNavRoute) {
+        const hasAnyAssertField = NAV_ASSERT_FIELDS.some((field) => !isFieldMissing(route[field]));
+        const requiredFields = quickTeleport && !hasAnyAssertField ? NAV_ROUTE_REQUIRED_FIELDS : NAV_ROUTE_FIELDS;
+        missingFields.push(`${requiredFields.join("/")} 必须同时配置`);
     }
 
     return missingFields;
@@ -124,16 +61,12 @@ export function collectMissingRouteFields(route) {
 // 断言矩形取 1×1 像素，角色永远落不进去，识别必然失败并转去传送分支。
 const UNREACHABLE_ROUTE_PLACEHOLDER = {
     EnterMap: "SceneAnyEnterWorld",
-    MapName: null,
-    MapAssert: [
+    NavAssert: [
         0,
         0,
         1,
         1,
     ],
-    MapTarget: null,
-    MapTargetTier: null,
-    MapTargetDeckY: null,
     NavZoneId: "Wuling_Base",
     CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
 };
@@ -190,42 +123,18 @@ function normalizeHeading(headingRaw, mission, missionName, warn) {
     };
 }
 
-function buildNavigationParams({
-    MapName,
-    MapAssert,
-    MapTarget,
-    MapTargetTier,
-    MapTargetDeckY,
-    NavZoneId,
-    NavAssert,
-    NavPath,
-    hasMapTarget,
-    hasNavRoute,
-    heading,
-}) {
+function buildNavigationParams({NavZoneId, NavAssert, NavPath, hasNavRoute, heading}) {
     // 1. 构建位置断言识别节点
-    // NavPath 优先于 MapTarget 简写；两者都没有时用占位值，渲染出的节点本来就走不到。
-    const useMapShorthand = !hasNavRoute && hasMapTarget;
+    // 没有路线时用占位值，渲染出的节点本来就走不到。
     const MapAssertRecognition = "MapLocateAssertLocation";
     const MapAssertParam = {
-        zone_id: useMapShorthand ? MapName : NavZoneId,
-        target: useMapShorthand ? MapAssert : NavAssert,
+        zone_id: NavZoneId,
+        target: NavAssert,
     };
 
     // 2. 构建导航动作节点
     const RouteAction = "MapNavigateAction";
-    const routeNodes = hasNavRoute
-        ? NavPath
-        : hasMapTarget
-          ? [
-                {
-                    action: "NAVMESH",
-                    target: MapTarget,
-                    ...(!isFieldMissing(MapTargetTier) ? {target_tier: MapTargetTier} : {}),
-                    ...(!isFieldMissing(MapTargetDeckY) ? {target_deck_y: MapTargetDeckY} : {}),
-                },
-            ]
-          : [];
+    const routeNodes = hasNavRoute ? NavPath : [];
     const headingNodes = heading.HasHeading
         ? [
               {
@@ -268,25 +177,15 @@ export function createRouteResolver(routeConfig, options = {}) {
             const missionName = mission?.name?.zh_cn || mission?.missionId || "UnknownMission";
             const override = getRouteOverride(mission, routeOverrides);
             const QuickTeleport = override?.QuickTeleport === true;
-            const hasMapTarget = !isFieldMissing(override?.MapTarget);
             const navFieldsPresent = collectNavRouteFields(override);
             const hasNavRoute = hasCompleteNavRoute(override);
-            const isDirectPhoto = isFieldMissing(override?.MapAssert) && navFieldsPresent.length === 0 && !hasMapTarget;
-            const canSkipMapAssert = QuickTeleport && hasMapTarget;
+            const isDirectPhoto = navFieldsPresent.length === 0;
 
             const resolved = {};
             const missingFields = collectMissingRouteFields(override);
             for (const key of ROUTE_RENDER_FIELDS) {
                 const overrideValue = override?.[key];
                 if (key === "EnterMap" && QuickTeleport) {
-                    resolved[key] = isFieldMissing(overrideValue) ? UNREACHABLE_ROUTE_PLACEHOLDER[key] : overrideValue;
-                    continue;
-                }
-                if (key === "MapAssert" && (canSkipMapAssert || isDirectPhoto)) {
-                    resolved[key] = isFieldMissing(overrideValue) ? UNREACHABLE_ROUTE_PLACEHOLDER[key] : overrideValue;
-                    continue;
-                }
-                if (key === "MapName" && isDirectPhoto) {
                     resolved[key] = isFieldMissing(overrideValue) ? UNREACHABLE_ROUTE_PLACEHOLDER[key] : overrideValue;
                     continue;
                 }
@@ -297,16 +196,7 @@ export function createRouteResolver(routeConfig, options = {}) {
                 }
             }
 
-            const {EnterMap, MapName, MapAssert, CameraSwipeDirection} = resolved;
-            const MapTarget = hasMapTarget ? override.MapTarget : UNREACHABLE_ROUTE_PLACEHOLDER.MapTarget;
-            const MapTargetTier =
-                hasMapTarget && !isFieldMissing(override?.MapTargetTier)
-                    ? override.MapTargetTier
-                    : UNREACHABLE_ROUTE_PLACEHOLDER.MapTargetTier;
-            const MapTargetDeckY =
-                hasMapTarget && !isFieldMissing(override?.MapTargetDeckY)
-                    ? override.MapTargetDeckY
-                    : UNREACHABLE_ROUTE_PLACEHOLDER.MapTargetDeckY;
+            const {EnterMap, CameraSwipeDirection} = resolved;
             const CameraMaxHit = override?.CameraMaxHit ?? CAMERA_MAX_HIT_DEFAULT;
             const Replace = override?.Replace ?? [];
             const heading = normalizeHeading(override?.Heading, mission, missionName, warn);
@@ -329,33 +219,22 @@ export function createRouteResolver(routeConfig, options = {}) {
                 isAdapted,
                 missingFields,
                 EnterMap,
-                MapName,
-                MapAssert,
-                MapTarget,
-                MapTargetTier,
-                MapTargetDeckY,
                 CameraSwipeDirection,
                 CameraMaxHit,
                 Replace,
                 QuickTeleport,
                 IsDirectPhoto: isAdapted && isDirectPhoto,
                 // NavPath 路线传送后交给 MapNavigateAction 自行接管落点，不再复核起点
-                ShouldAssertAfterTeleport: !isDirectPhoto && !hasNavRoute && !hasMapTarget,
+                ShouldAssertAfterTeleport: !isDirectPhoto && !hasNavRoute,
                 ...heading,
                 ...buildNavigationParams({
-                    MapName,
-                    MapAssert,
-                    MapTarget,
-                    MapTargetTier,
-                    MapTargetDeckY,
                     NavZoneId: isFieldMissing(override?.NavZoneId)
                         ? UNREACHABLE_ROUTE_PLACEHOLDER.NavZoneId
                         : override.NavZoneId,
                     NavAssert: isFieldMissing(override?.NavAssert)
-                        ? UNREACHABLE_ROUTE_PLACEHOLDER.MapAssert
+                        ? UNREACHABLE_ROUTE_PLACEHOLDER.NavAssert
                         : override.NavAssert,
                     NavPath: override?.NavPath,
-                    hasMapTarget,
                     hasNavRoute,
                     heading,
                 }),

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.mjs
@@ -6,11 +6,9 @@ export const ROUTE_CONFIG_FIELDS = [
     "EnterMap",
     "MapName",
     "MapAssert",
-    "MapPath",
     "MapTarget",
     "MapTargetTier",
     "MapTargetDeckY",
-    "MapGoal",
     "NavZoneId",
     "NavAssert",
     "NavPath",
@@ -18,7 +16,6 @@ export const ROUTE_CONFIG_FIELDS = [
     "CameraMaxHit",
     "Replace",
     "Heading",
-    "NoEnsureInitialMovementState",
     "QuickTeleport",
 ];
 
@@ -61,18 +58,11 @@ export function collectMissingRouteFields(route) {
 
     const quickTeleport = route.QuickTeleport === true;
     const hasMapAssert = !isFieldMissing(route.MapAssert);
-    const hasMapPath = !isFieldMissing(route.MapPath);
     const hasMapTarget = !isFieldMissing(route.MapTarget);
-    const hasMapGoal = !isFieldMissing(route.MapGoal);
     const navFieldsPresent = collectNavRouteFields(route);
     const hasNavRoute = hasCompleteNavRoute(route);
-    const navigationConfigCount = [
-        hasMapPath,
-        hasMapTarget,
-        hasMapGoal,
-    ].filter(Boolean).length;
-    const isDirectPhoto = !hasMapAssert && navFieldsPresent.length === 0 && navigationConfigCount === 0;
-    const canSkipMapAssert = quickTeleport && navigationConfigCount === 1;
+    const isDirectPhoto = !hasMapAssert && navFieldsPresent.length === 0 && !hasMapTarget;
+    const canSkipMapAssert = quickTeleport && hasMapTarget;
     const missingFields = [];
 
     if (!quickTeleport && isFieldMissing(route.EnterMap)) {
@@ -86,7 +76,6 @@ export function collectMissingRouteFields(route) {
             "MapName",
             "MapTargetTier",
             "MapTargetDeckY",
-            "NoEnsureInitialMovementState",
         ].filter((field) => !isFieldMissing(route[field]));
         if (unusedDirectPhotoFields.length > 0) {
             missingFields.push(`传送后直拍不应配置 ${unusedDirectPhotoFields.join("/")}`);
@@ -101,11 +90,8 @@ export function collectMissingRouteFields(route) {
             const unusedNavRouteFields = [
                 "MapName",
                 "MapAssert",
-                "MapPath",
                 "MapTarget",
                 "MapTargetTier",
-                "MapGoal",
-                "NoEnsureInitialMovementState",
             ].filter((field) => !isFieldMissing(route[field]));
             if (unusedNavRouteFields.length > 0) {
                 missingFields.push(`NavPath 路线不应配置 ${unusedNavRouteFields.join("/")}`);
@@ -118,10 +104,8 @@ export function collectMissingRouteFields(route) {
         if (!canSkipMapAssert && !hasMapAssert) {
             missingFields.push("MapAssert");
         }
-        if (navigationConfigCount === 0) {
-            missingFields.push("MapPath/MapTarget/MapGoal");
-        } else if (navigationConfigCount > 1) {
-            missingFields.push("MapPath/MapTarget/MapGoal 三选一");
+        if (!hasMapTarget) {
+            missingFields.push("MapTarget");
         }
     }
 
@@ -137,25 +121,19 @@ export function collectMissingRouteFields(route) {
 }
 
 // 未适配任务不会进入寻路/拍照分支；这些值只用于渲染模板中不可达的路线节点。
+// 断言矩形取 1×1 像素，角色永远落不进去，识别必然失败并转去传送分支。
 const UNREACHABLE_ROUTE_PLACEHOLDER = {
     EnterMap: "SceneAnyEnterWorld",
-    MapName: "^map\\d+_lv\\d+$",
+    MapName: null,
     MapAssert: [
         0,
         0,
         1,
         1,
     ],
-    MapPath: [
-        [
-            0,
-            0,
-        ],
-    ],
     MapTarget: null,
     MapTargetTier: null,
     MapTargetDeckY: null,
-    MapGoal: null,
     NavZoneId: "Wuling_Base",
     CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
 };
@@ -215,104 +193,63 @@ function normalizeHeading(headingRaw, mission, missionName, warn) {
 function buildNavigationParams({
     MapName,
     MapAssert,
-    MapPath,
     MapTarget,
     MapTargetTier,
     MapTargetDeckY,
-    MapGoal,
     NavZoneId,
     NavAssert,
     NavPath,
-    NoEnsureInitialMovementState,
     hasMapTarget,
-    hasMapGoal,
     hasNavRoute,
-    isDirectPhoto,
     heading,
 }) {
     // 1. 构建位置断言识别节点
-    const MapAssertRecognition = hasMapTarget || hasNavRoute ? "MapLocateAssertLocation" : "MapTrackerAssertLocation";
-    const MapAssertParam =
-        MapAssertRecognition === "MapLocateAssertLocation"
-            ? {
-                  // 使用 MapLocateAssertLocation
-                  zone_id: hasNavRoute ? NavZoneId : MapName,
-                  target: hasNavRoute ? NavAssert : MapAssert,
-              }
-            : {
-                  // 使用 MapTrackerAssertLocation
-                  expected: [
-                      {
-                          map_name: MapName,
-                          target: MapAssert,
-                      },
-                  ],
-              };
+    // NavPath 优先于 MapTarget 简写；两者都没有时用占位值，渲染出的节点本来就走不到。
+    const useMapShorthand = !hasNavRoute && hasMapTarget;
+    const MapAssertRecognition = "MapLocateAssertLocation";
+    const MapAssertParam = {
+        zone_id: useMapShorthand ? MapName : NavZoneId,
+        target: useMapShorthand ? MapAssert : NavAssert,
+    };
 
     // 2. 构建导航动作节点
-    const shouldAdjustDirectPhotoHeading = isDirectPhoto && heading.HasHeading;
-    const RouteAction = shouldAdjustDirectPhotoHeading
-        ? "MapTrackerToward"
-        : hasMapTarget || hasNavRoute
-          ? "MapNavigateAction"
-          : hasMapGoal
-            ? "MapTrackerGoal"
-            : "MapTrackerMove";
-    const mapTrackerExtraParams = {
-        ...(heading.HasHeading
-            ? {
-                  on_finish: {
-                      action: "Custom",
-                      custom_action: "MapTrackerToward",
-                      custom_action_param: {
-                          angle: heading.Heading,
+    const RouteAction = "MapNavigateAction";
+    const routeNodes = hasNavRoute
+        ? NavPath
+        : hasMapTarget
+          ? [
+                {
+                    action: "NAVMESH",
+                    target: MapTarget,
+                    ...(!isFieldMissing(MapTargetTier) ? {target_tier: MapTargetTier} : {}),
+                    ...(!isFieldMissing(MapTargetDeckY) ? {target_deck_y: MapTargetDeckY} : {}),
+                },
+            ]
+          : [];
+    const headingNodes = heading.HasHeading
+        ? [
+              {
+                  action: "HEADING",
+                  angle: heading.Heading,
+              },
+          ]
+        : [];
+    // 传送后直拍只有朝向节点；一个节点都没有时补零度朝向，让不可达节点的参数保持合法。
+    const path = [
+        ...routeNodes,
+        ...headingNodes,
+    ];
+    const RouteActionParam = {
+        path:
+            path.length > 0
+                ? path
+                : [
+                      {
+                          action: "HEADING",
+                          angle: 0,
                       },
-                  },
-              }
-            : {}),
-        ...(NoEnsureInitialMovementState ? {no_ensure_initial_movement_state: true} : {}),
+                  ],
     };
-    const RouteActionParam = shouldAdjustDirectPhotoHeading
-        ? {
-              angle: heading.Heading,
-          }
-        : RouteAction === "MapNavigateAction"
-          ? {
-                // 使用 MapNavigateAction
-                path: [
-                    ...(hasNavRoute
-                        ? NavPath
-                        : [
-                              {
-                                  action: "NAVMESH",
-                                  target: MapTarget,
-                                  ...(!isFieldMissing(MapTargetTier) ? {target_tier: MapTargetTier} : {}),
-                                  ...(!isFieldMissing(MapTargetDeckY) ? {target_deck_y: MapTargetDeckY} : {}),
-                              },
-                          ]),
-                    ...(heading.HasHeading
-                        ? [
-                              {
-                                  action: "HEADING",
-                                  angle: heading.Heading,
-                              },
-                          ]
-                        : []),
-                ],
-            }
-          : RouteAction === "MapTrackerGoal"
-            ? {
-                  // 使用 MapTrackerGoal
-                  map_name: MapName,
-                  target: MapGoal,
-                  ...mapTrackerExtraParams,
-              }
-            : {
-                  // 使用 MapTrackerMove
-                  map_name: MapName,
-                  path: MapPath,
-                  ...mapTrackerExtraParams,
-              };
 
     return {
         MapAssertRecognition,
@@ -331,19 +268,11 @@ export function createRouteResolver(routeConfig, options = {}) {
             const missionName = mission?.name?.zh_cn || mission?.missionId || "UnknownMission";
             const override = getRouteOverride(mission, routeOverrides);
             const QuickTeleport = override?.QuickTeleport === true;
-            const hasMapPath = !isFieldMissing(override?.MapPath);
             const hasMapTarget = !isFieldMissing(override?.MapTarget);
-            const hasMapGoal = !isFieldMissing(override?.MapGoal);
             const navFieldsPresent = collectNavRouteFields(override);
             const hasNavRoute = hasCompleteNavRoute(override);
-            const navigationConfigCount = [
-                hasMapPath,
-                hasMapTarget,
-                hasMapGoal,
-            ].filter(Boolean).length;
-            const isDirectPhoto =
-                isFieldMissing(override?.MapAssert) && navFieldsPresent.length === 0 && navigationConfigCount === 0;
-            const canSkipMapAssert = QuickTeleport && navigationConfigCount === 1;
+            const isDirectPhoto = isFieldMissing(override?.MapAssert) && navFieldsPresent.length === 0 && !hasMapTarget;
+            const canSkipMapAssert = QuickTeleport && hasMapTarget;
 
             const resolved = {};
             const missingFields = collectMissingRouteFields(override);
@@ -369,25 +298,17 @@ export function createRouteResolver(routeConfig, options = {}) {
             }
 
             const {EnterMap, MapName, MapAssert, CameraSwipeDirection} = resolved;
-            const MapPath =
-                navigationConfigCount === 1 && hasMapPath ? override.MapPath : UNREACHABLE_ROUTE_PLACEHOLDER.MapPath;
-            const MapTarget =
-                navigationConfigCount === 1 && hasMapTarget
-                    ? override.MapTarget
-                    : UNREACHABLE_ROUTE_PLACEHOLDER.MapTarget;
+            const MapTarget = hasMapTarget ? override.MapTarget : UNREACHABLE_ROUTE_PLACEHOLDER.MapTarget;
             const MapTargetTier =
-                navigationConfigCount === 1 && hasMapTarget && !isFieldMissing(override?.MapTargetTier)
+                hasMapTarget && !isFieldMissing(override?.MapTargetTier)
                     ? override.MapTargetTier
                     : UNREACHABLE_ROUTE_PLACEHOLDER.MapTargetTier;
             const MapTargetDeckY =
-                navigationConfigCount === 1 && hasMapTarget && !isFieldMissing(override?.MapTargetDeckY)
+                hasMapTarget && !isFieldMissing(override?.MapTargetDeckY)
                     ? override.MapTargetDeckY
                     : UNREACHABLE_ROUTE_PLACEHOLDER.MapTargetDeckY;
-            const MapGoal =
-                navigationConfigCount === 1 && hasMapGoal ? override.MapGoal : UNREACHABLE_ROUTE_PLACEHOLDER.MapGoal;
             const CameraMaxHit = override?.CameraMaxHit ?? CAMERA_MAX_HIT_DEFAULT;
             const Replace = override?.Replace ?? [];
-            const NoEnsureInitialMovementState = override?.NoEnsureInitialMovementState ?? false;
             const heading = normalizeHeading(override?.Heading, mission, missionName, warn);
             const isAdapted = override != null && missingFields.length === 0;
 
@@ -410,29 +331,23 @@ export function createRouteResolver(routeConfig, options = {}) {
                 EnterMap,
                 MapName,
                 MapAssert,
-                MapPath,
                 MapTarget,
                 MapTargetTier,
                 MapTargetDeckY,
-                MapGoal,
                 CameraSwipeDirection,
                 CameraMaxHit,
                 Replace,
-                NoEnsureInitialMovementState,
                 QuickTeleport,
                 IsDirectPhoto: isAdapted && isDirectPhoto,
                 // NavPath 路线传送后交给 MapNavigateAction 自行接管落点，不再复核起点
-                ShouldAssertAfterTeleport:
-                    !isDirectPhoto && !hasNavRoute && (navigationConfigCount !== 1 || (hasMapPath && !QuickTeleport)),
+                ShouldAssertAfterTeleport: !isDirectPhoto && !hasNavRoute && !hasMapTarget,
                 ...heading,
                 ...buildNavigationParams({
                     MapName,
                     MapAssert,
-                    MapPath,
                     MapTarget,
                     MapTargetTier,
                     MapTargetDeckY,
-                    MapGoal,
                     NavZoneId: isFieldMissing(override?.NavZoneId)
                         ? UNREACHABLE_ROUTE_PLACEHOLDER.NavZoneId
                         : override.NavZoneId,
@@ -440,11 +355,8 @@ export function createRouteResolver(routeConfig, options = {}) {
                         ? UNREACHABLE_ROUTE_PLACEHOLDER.MapAssert
                         : override.NavAssert,
                     NavPath: override?.NavPath,
-                    NoEnsureInitialMovementState,
-                    hasMapTarget: navigationConfigCount === 1 && hasMapTarget,
-                    hasMapGoal: navigationConfigCount === 1 && hasMapGoal,
+                    hasMapTarget,
                     hasNavRoute,
-                    isDirectPhoto,
                     heading,
                 }),
             };

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.test.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/route-resolver.test.mjs
@@ -30,7 +30,7 @@ test("metadata-only entries remain unadapted", () => {
     ]);
 });
 
-test("an EnterMap route without map or navigation fields takes photos directly", () => {
+test("an EnterMap route without navigation fields takes photos directly", () => {
     const route = {
         MissionId: mission.missionId,
         Name: "测试观察点",
@@ -60,25 +60,7 @@ test("a QuickTeleport route can take photos directly without EnterMap", () => {
     assert.deepEqual(result.missingFields, []);
 });
 
-test("MapAssert without a navigation field is incomplete rather than direct-photo", () => {
-    const missingFields = collectMissingRouteFields({
-        EnterMap: "SceneEnterWorldTest",
-        MapAssert: [
-            0,
-            0,
-            10,
-            10,
-        ],
-        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
-    });
-
-    assert.deepEqual(missingFields, [
-        "MapName",
-        "MapPath/MapTarget/MapGoal",
-    ]);
-});
-
-test("direct-photo routes support Heading without map configuration", () => {
+test("direct-photo routes support Heading without navigation configuration", () => {
     const result = resolve({
         MissionId: mission.missionId,
         Name: "测试观察点",
@@ -90,18 +72,43 @@ test("direct-photo routes support Heading without map configuration", () => {
 
     assert.equal(result.isAdapted, true);
     assert.equal(result.IsDirectPhoto, true);
-    assert.equal(result.RouteAction, "MapTrackerToward");
-    assert.deepEqual(result.RouteActionParam, {angle: 90});
+    assert.equal(result.RouteAction, "MapNavigateAction");
+    assert.deepEqual(result.RouteActionParam, {
+        path: [
+            {
+                action: "HEADING",
+                angle: 90,
+            },
+        ],
+    });
 });
 
-test("direct-photo routes reject unused map fields", () => {
-    const missingFields = collectMissingRouteFields({
+test("removed map shorthand fields no longer count as a route", () => {
+    // MapTarget 简写已移除：只带旧字段的条目按直拍处理，旧字段被忽略。
+    const result = resolve({
+        MissionId: mission.missionId,
+        Name: "测试观察点",
+        Id: "TestMission",
         EnterMap: "SceneEnterWorldTest",
         MapName: "map02_lv001",
+        MapTarget: [
+            5,
+            5,
+        ],
         CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
     });
 
-    assert.deepEqual(missingFields, ["传送后直拍不应配置 MapName"]);
+    assert.equal(result.isAdapted, true);
+    assert.equal(result.IsDirectPhoto, true);
+    assert.deepEqual(result.missingFields, []);
+    assert.deepEqual(result.RouteActionParam, {
+        path: [
+            {
+                action: "HEADING",
+                angle: 0,
+            },
+        ],
+    });
 });
 
 test("Nav route fields render MapLocateAssertLocation + MapNavigateAction", () => {
@@ -210,36 +217,6 @@ test("QuickTeleport Nav routes only require NavPath", () => {
     assert.deepEqual(result.missingFields, []);
 });
 
-test("Nav route fields cannot be mixed with the map route fields", () => {
-    const missingFields = collectMissingRouteFields({
-        MissionId: mission.missionId,
-        Name: "测试观察点",
-        Id: "TestMission",
-        EnterMap: "SceneEnterWorldTest",
-        MapName: "map02_lv001",
-        MapGoal: [
-            5,
-            5,
-        ],
-        NavZoneId: "Wuling_Base",
-        NavAssert: [
-            0,
-            0,
-            10,
-            10,
-        ],
-        NavPath: [
-            [
-                5,
-                5,
-            ],
-        ],
-        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
-    });
-
-    assert.deepEqual(missingFields, ["NavPath 路线不应配置 MapName/MapGoal"]);
-});
-
 test("incomplete Nav route fields are reported", () => {
     const missingFields = collectMissingRouteFields({
         MissionId: mission.missionId,
@@ -259,61 +236,11 @@ test("incomplete Nav route fields are reported", () => {
     assert.deepEqual(missingFields, ["NavZoneId/NavAssert/NavPath 必须同时配置"]);
 });
 
-test("existing navigation forms remain adapted", () => {
-    const result = resolve({
-        MissionId: mission.missionId,
-        Name: "测试观察点",
-        Id: "TestMission",
-        EnterMap: "SceneEnterWorldTest",
-        MapName: "map02_lv001",
-        MapAssert: [
-            0,
-            0,
-            10,
-            10,
-        ],
-        MapPath: [
-            [
-                5,
-                5,
-            ],
-        ],
-        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
-    });
-
-    assert.equal(result.isAdapted, true);
-    assert.equal(result.IsDirectPhoto, false);
-    assert.deepEqual(result.missingFields, []);
-});
-
-test("QuickTeleport MapPath routes can skip MapAssert", () => {
-    const result = resolve({
-        MissionId: mission.missionId,
-        Name: "测试观察点",
-        Id: "TestMission",
-        QuickTeleport: true,
-        MapName: "map02_lv001",
-        MapPath: [
-            [
-                5,
-                5,
-            ],
-        ],
-        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
-    });
-
-    assert.equal(result.isAdapted, true);
-    assert.equal(result.IsDirectPhoto, false);
-    assert.equal(result.ShouldAssertAfterTeleport, false);
-    assert.equal(result.RouteAction, "MapTrackerMove");
-    assert.deepEqual(result.missingFields, []);
-});
-
-test("non-QuickTeleport MapPath routes still require MapAssert", () => {
+test("QuickTeleport Nav routes with a partial assert still require the full set", () => {
     const missingFields = collectMissingRouteFields({
-        EnterMap: "SceneEnterWorldTest",
-        MapName: "map02_lv001",
-        MapPath: [
+        QuickTeleport: true,
+        NavZoneId: "Wuling_Base",
+        NavPath: [
             [
                 5,
                 5,
@@ -322,31 +249,5 @@ test("non-QuickTeleport MapPath routes still require MapAssert", () => {
         CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
     });
 
-    assert.deepEqual(missingFields, ["MapAssert"]);
-});
-
-test("non-QuickTeleport MapGoal routes still skip the post-teleport assertion", () => {
-    const result = resolve({
-        MissionId: mission.missionId,
-        Name: "测试观察点",
-        Id: "TestMission",
-        EnterMap: "SceneEnterWorldTest",
-        MapName: "map02_lv001",
-        MapAssert: [
-            0,
-            0,
-            10,
-            10,
-        ],
-        MapGoal: [
-            5,
-            5,
-        ],
-        CameraSwipeDirection: "EnvironmentMonitoringSwipeScreenUp",
-    });
-
-    assert.equal(result.isAdapted, true);
-    assert.equal(result.ShouldAssertAfterTeleport, false);
-    assert.equal(result.RouteAction, "MapTrackerGoal");
-    assert.deepEqual(result.missingFields, []);
+    assert.deepEqual(missingFields, ["NavZoneId/NavAssert/NavPath 必须同时配置"]);
 });

--- a/tools/schema/environment_monitoring_routes.schema.json
+++ b/tools/schema/environment_monitoring_routes.schema.json
@@ -9,12 +9,6 @@
         "title": "ObservationPointRoute",
         "additionalProperties": false,
         "dependencies": {
-            "MapTargetTier": [
-                "MapTarget"
-            ],
-            "MapTargetDeckY": [
-                "MapTarget"
-            ],
             "NavZoneId": [
                 "NavAssert",
                 "NavPath"
@@ -36,31 +30,6 @@
                         {
                             "required": [
                                 "EnterMap"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "MapName"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "MapAssert"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "MapTarget"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "MapTargetTier"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "MapTargetDeckY"
                             ]
                         },
                         {
@@ -119,34 +88,9 @@
                     "oneOf": [
                         {
                             "title": "TeleportAndTakePhoto",
-                            "description": "传送点可直接拍照：不配置 MapAssert 和任何寻路字段。",
+                            "description": "传送点可直接拍照：不配置任何断言与寻路字段。",
                             "not": {
                                 "anyOf": [
-                                    {
-                                        "required": [
-                                            "MapAssert"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "MapTarget"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "MapName"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "MapTargetTier"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "MapTargetDeckY"
-                                        ]
-                                    },
                                     {
                                         "required": [
                                             "NavZoneId"
@@ -167,7 +111,7 @@
                         },
                         {
                             "title": "MapNavigatorRoute",
-                            "description": "MapNavigator 路线：NavPath 必填，普通传送还需 NavZoneId / NavAssert，QuickTeleport 可省略二者；不再填写 MapName / MapAssert / MapTarget / MapTargetTier。",
+                            "description": "MapNavigator 路线：NavPath 必填，普通传送还需 NavZoneId / NavAssert，QuickTeleport 可省略二者。",
                             "required": [
                                 "NavPath"
                             ],
@@ -192,79 +136,7 @@
                                         ]
                                     }
                                 }
-                            ],
-                            "not": {
-                                "anyOf": [
-                                    {
-                                        "required": [
-                                            "MapName"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "MapAssert"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "MapTarget"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "MapTargetTier"
-                                        ]
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "title": "MapTargetRoute",
-                            "description": "NAVMESH 单点路线：MapName 与 MapTarget 必填，普通传送还需 MapAssert。",
-                            "required": [
-                                "MapName",
-                                "MapTarget"
-                            ],
-                            "allOf": [
-                                {
-                                    "if": {
-                                        "not": {
-                                            "required": [
-                                                "QuickTeleport"
-                                            ],
-                                            "properties": {
-                                                "QuickTeleport": {
-                                                    "const": true
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "then": {
-                                        "required": [
-                                            "MapAssert"
-                                        ]
-                                    }
-                                }
-                            ],
-                            "not": {
-                                "anyOf": [
-                                    {
-                                        "required": [
-                                            "NavZoneId"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "NavAssert"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "NavPath"
-                                        ]
-                                    }
-                                ]
-                            }
+                            ]
                         }
                     ]
                 }
@@ -293,49 +165,6 @@
                 "examples": [
                     "SceneEnterWorldWulingJingyuValley7",
                     "SceneEnterWorldWulingMarkerStone_Ship2DestinationThenWalkAndFight"
-                ]
-            },
-            "MapName": {
-                "type": "string",
-                "minLength": 1,
-                "description": "仅 MapTarget 路线使用，填写 MapLocate 的 zone_id；新增路线改用 NavZoneId。传送后直拍时省略。",
-                "examples": [
-                    "Wuling_Base",
-                    "Wuling_L4_328"
-                ]
-            },
-            "MapAssert": {
-                "type": "array",
-                "description": "初始位置判断矩形 [x, y, w, h]。普通传送寻路路线必填；QuickTeleport 与 MapTarget 组合时可省略；传送后直拍时必须省略。",
-                "items": {
-                    "type": "number"
-                },
-                "minItems": 4,
-                "maxItems": 4
-            },
-            "MapTarget": {
-                "type": "array",
-                "description": "MapNavigateAction 的 NAVMESH 目标点 [x, y]。未配置 MapTargetTier 时按 base 坐标解释；配置 MapTargetTier 时按对应 tier 坐标解释。适合不依赖交互、过图、机关的普通可达路线；需要手录逐点路径时改用 NavPath。",
-                "items": {
-                    "type": "number"
-                },
-                "minItems": 2,
-                "maxItems": 2
-            },
-            "MapTargetTier": {
-                "type": "string",
-                "minLength": 1,
-                "description": "可选，仅用于 MapTarget 路线。MapTarget 坐标所在的 MapNavigator target_tier 区域名；当目标点与起点不在同一 tier，且 MapTarget 是在 tier 底图上直接点出的坐标时填写。未配置时 MapTarget 按 base 坐标解释。",
-                "examples": [
-                    "ValleyIV_L1_171",
-                    "Wuling_L4_328"
-                ]
-            },
-            "MapTargetDeckY": {
-                "type": "number",
-                "description": "可选，仅用于 MapTarget 路线。目标点所在那张可走面的世界高度。小地图是二维的，同一个坐标底下可能压着两三张面（走廊 / 天桥 / 屋顶）；不配置时寻路取整格的全部面，先够到哪张停哪张。用 MapNavigator 预览工具点中目标后从重叠面列表读出该值，别手估。填了却够不到那张面时会报「目标面不可达」而不是静默走到另一张。",
-                "examples": [
-                    265.37
                 ]
             },
             "NavZoneId": {

--- a/tools/schema/environment_monitoring_routes.schema.json
+++ b/tools/schema/environment_monitoring_routes.schema.json
@@ -50,11 +50,6 @@
                         },
                         {
                             "required": [
-                                "MapPath"
-                            ]
-                        },
-                        {
-                            "required": [
                                 "MapTarget"
                             ]
                         },
@@ -66,11 +61,6 @@
                         {
                             "required": [
                                 "MapTargetDeckY"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "MapGoal"
                             ]
                         },
                         {
@@ -96,11 +86,6 @@
                         {
                             "required": [
                                 "Heading"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "NoEnsureInitialMovementState"
                             ]
                         },
                         {
@@ -144,17 +129,7 @@
                                     },
                                     {
                                         "required": [
-                                            "MapPath"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
                                             "MapTarget"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "MapGoal"
                                         ]
                                     },
                                     {
@@ -170,11 +145,6 @@
                                     {
                                         "required": [
                                             "MapTargetDeckY"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "NoEnsureInitialMovementState"
                                         ]
                                     },
                                     {
@@ -197,7 +167,7 @@
                         },
                         {
                             "title": "MapNavigatorRoute",
-                            "description": "MapNavigator 路线：NavPath 必填，普通传送还需 NavZoneId / NavAssert，QuickTeleport 可省略二者；不再填写 MapName / MapAssert / MapPath / MapTarget / MapTargetTier / MapGoal / NoEnsureInitialMovementState。",
+                            "description": "MapNavigator 路线：NavPath 必填，普通传送还需 NavZoneId / NavAssert，QuickTeleport 可省略二者；不再填写 MapName / MapAssert / MapTarget / MapTargetTier。",
                             "required": [
                                 "NavPath"
                             ],
@@ -237,11 +207,6 @@
                                     },
                                     {
                                         "required": [
-                                            "MapPath"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
                                             "MapTarget"
                                         ]
                                     },
@@ -249,59 +214,29 @@
                                         "required": [
                                             "MapTargetTier"
                                         ]
-                                    },
-                                    {
-                                        "required": [
-                                            "MapGoal"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "NoEnsureInitialMovementState"
-                                        ]
                                     }
                                 ]
                             }
                         },
                         {
+                            "title": "MapTargetRoute",
+                            "description": "NAVMESH 单点路线：MapName 与 MapTarget 必填，普通传送还需 MapAssert。",
                             "required": [
-                                "MapName"
+                                "MapName",
+                                "MapTarget"
                             ],
                             "allOf": [
                                 {
                                     "if": {
                                         "not": {
-                                            "allOf": [
-                                                {
-                                                    "required": [
-                                                        "QuickTeleport"
-                                                    ],
-                                                    "properties": {
-                                                        "QuickTeleport": {
-                                                            "const": true
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "anyOf": [
-                                                        {
-                                                            "required": [
-                                                                "MapPath"
-                                                            ]
-                                                        },
-                                                        {
-                                                            "required": [
-                                                                "MapTarget"
-                                                            ]
-                                                        },
-                                                        {
-                                                            "required": [
-                                                                "MapGoal"
-                                                            ]
-                                                        }
-                                                    ]
+                                            "required": [
+                                                "QuickTeleport"
+                                            ],
+                                            "properties": {
+                                                "QuickTeleport": {
+                                                    "const": true
                                                 }
-                                            ]
+                                            }
                                         }
                                     },
                                     "then": {
@@ -309,23 +244,6 @@
                                             "MapAssert"
                                         ]
                                     }
-                                }
-                            ],
-                            "oneOf": [
-                                {
-                                    "required": [
-                                        "MapPath"
-                                    ]
-                                },
-                                {
-                                    "required": [
-                                        "MapTarget"
-                                    ]
-                                },
-                                {
-                                    "required": [
-                                        "MapGoal"
-                                    ]
                                 }
                             ],
                             "not": {
@@ -380,43 +298,24 @@
             "MapName": {
                 "type": "string",
                 "minLength": 1,
-                "description": "遗留字段，仅 MapTarget / MapPath / MapGoal 路线使用，新增路线改用 NavZoneId。使用 MapTarget 时填写 MapLocate 的 zone_id；MapPath / MapGoal 填写原有实现的 map_name（支持正则）。传送后直拍时省略。",
+                "description": "仅 MapTarget 路线使用，填写 MapLocate 的 zone_id；新增路线改用 NavZoneId。传送后直拍时省略。",
                 "examples": [
-                    "map02_lv001",
-                    "map02_lv002",
-                    "map02_lv003",
-                    "map02_lv004",
-                    "map02_lv004_tier_328",
-                    "^map\\d+_lv\\d+$",
-                    "Wuling_Base"
+                    "Wuling_Base",
+                    "Wuling_L4_328"
                 ]
             },
             "MapAssert": {
                 "type": "array",
-                "description": "初始位置判断矩形 [x, y, w, h]。普通传送寻路路线必填；QuickTeleport 与 MapPath / MapTarget / MapGoal 组合时可省略；传送后直拍时必须省略。",
+                "description": "初始位置判断矩形 [x, y, w, h]。普通传送寻路路线必填；QuickTeleport 与 MapTarget 组合时可省略；传送后直拍时必须省略。",
                 "items": {
                     "type": "number"
                 },
                 "minItems": 4,
                 "maxItems": 4
             },
-            "MapPath": {
-                "type": "array",
-                "description": "遗留字段，只保留给尚未迁移的存量路线，新增路线改用 NavPath。逐点跟随的寻路路径（小地图坐标序列），与 MapTarget / MapGoal 三选一；传送后直拍时省略。",
-                "minItems": 1,
-                "items": {
-                    "type": "array",
-                    "description": "路径点 [x, y]（小地图坐标）。",
-                    "items": {
-                        "type": "number"
-                    },
-                    "minItems": 2,
-                    "maxItems": 2
-                }
-            },
             "MapTarget": {
                 "type": "array",
-                "description": "MapNavigateAction 的 NAVMESH 目标点 [x, y]。未配置 MapTargetTier 时按 base 坐标解释；配置 MapTargetTier 时按对应 tier 坐标解释。与 MapPath / MapGoal 三选一，适合不依赖交互、过图、机关的普通可达路线。",
+                "description": "MapNavigateAction 的 NAVMESH 目标点 [x, y]。未配置 MapTargetTier 时按 base 坐标解释；配置 MapTargetTier 时按对应 tier 坐标解释。适合不依赖交互、过图、机关的普通可达路线；需要手录逐点路径时改用 NavPath。",
                 "items": {
                     "type": "number"
                 },
@@ -438,15 +337,6 @@
                 "examples": [
                     265.37
                 ]
-            },
-            "MapGoal": {
-                "type": "array",
-                "description": "遗留字段，只保留给尚未迁移的存量路线，新增路线改用 NavPath。自动寻路目标点 [x, y]，生成器会把 MapName 作为 map_name、该坐标作为 target 交给原有实现。与 MapPath / MapTarget 三选一。",
-                "items": {
-                    "type": "number"
-                },
-                "minItems": 2,
-                "maxItems": 2
             },
             "NavZoneId": {
                 "type": "string",
@@ -543,10 +433,6 @@
                 "description": "可选；进入拍照模式前把角色朝向旋转到该角度。传送后直拍时只原地调整朝向，不需要任何地图断言或寻路字段。仅影响角色朝向，与摄像头滑屏（CameraSwipeDirection）相互独立。",
                 "minimum": 0,
                 "exclusiveMaximum": 360
-            },
-            "NoEnsureInitialMovementState": {
-                "type": "boolean",
-                "description": "可选，默认 false，仅遗留的 MapPath 路线使用，对应其 no_ensure_initial_movement_state 参数。一般只在路线起点紧贴桥边、悬崖边等危险地形时开启，用于跳过开局的冲刺准备动作，避免角色因为这一步直接掉下桥或掉下悬崖。"
             },
             "QuickTeleport": {
                 "type": "boolean",


### PR DESCRIPTION
## Summary by Sourcery

将 EnvironmentMonitoring 路由生成迁移到基于 MapNavigator 的导航模型，并移除旧版的地图追踪配置。

Enhancements:
- 将 EnvironmentMonitoring 路由统一标准化为基于 MapLocator 和 MapNavigator 的实现，移除基于 MapTracker 的旧版路由处理逻辑和简写地图字段。
- 简化传送（teleport）后的行为，使导航路由可以直接进入 MapNavigateAction，而直接拍照（direct-photo）路由则使用可选的“仅朝向（heading-only）”导航动作。
- 使 MapNavigator 的导出控制与标签与基于 NavPath/NavAssert 的路由编写方式保持一致。

Documentation:
- 更新英文和中文的 EnvironmentMonitoring 维护、生成器及技能文档，以描述仅基于 MapNavigator 的路由模型以及 direct-photo 的语义。

Tests:
- 调整路由解析（route resolver）测试，用于验证 NavPath、仅朝向的 direct-photo 路由，以及旧版地图字段行为的移除。

Chores:
- 收紧路由模式（schema）与编写规范，围绕受支持的基于 NavPath 的配置进行约束。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate EnvironmentMonitoring route generation to the MapNavigator-based navigation model and remove legacy map-tracking configuration.

Enhancements:
- Standardize EnvironmentMonitoring routes on MapLocator and MapNavigator, removing legacy MapTracker-based route handling and shorthand map fields.
- Simplify post-teleport behavior so navigation routes proceed directly to MapNavigateAction and direct-photo routes use an optional heading-only navigation action.
- Align MapNavigator export controls and labels with NavPath/NavAssert-based route authoring.

Documentation:
- Update English and Chinese EnvironmentMonitoring maintenance, generator, and skill documentation to describe the MapNavigator-only route model and direct-photo semantics.

Tests:
- Revise route resolver tests for NavPath validation, heading-only direct-photo routes, and removal of legacy map-field behavior.

Chores:
- Tighten route schema and authoring guidance around the supported NavPath-based configuration.

</details>

改进内容：
- 从 EnvironmentMonitoring 路由解析器中移除遗留的 MapPath/MapGoal/MapTracker 字段和逻辑，改为使用 NavPath 和 MapTarget 这类简写输入来驱动 MapNavigateAction。
- 调整路由校验和缺失字段检查逻辑，将 MapTarget 视为唯一的简写地图导航字段，并收紧直接拍照检测规则。
- 统一导航参数构造方式，使所有适配后的路由（包括带 Heading 的直接拍照路由）都输出 MapLocateAssertLocation 加上一个 MapNavigateAction 路径，并在必要时回退为仅含 heading 的路径。
- 更新传送后流程（post-teleport flows）的生成器行为，使导航路由和直接拍照路由不再重新断言落点位置，并确保 MapTarget 路由始终使用 MapNavigator。
- 修订 EnvironmentMonitoring 的维护文档、生成器文档和技能文档（英文与中文），描述新的仅使用 MapNavigator 的流程，移除遗留的 MapTracker 概念，并澄清推荐的 NavPath/MapTarget 用法以及直接拍照语义。
- 收紧路由 schema 和编写规范，禁止在新路由中使用遗留的地图导航字段，并将剩余的简写 MapTarget 形式仅作为向后兼容选项进行文档说明。

文档：
- 在 EnvironmentMonitoring 的开发者文档中做出澄清：引用 cpp 中的 MapLocator/MapNavigator 组件，描述简化后的路由类型，并在 en_us 与 zh_cn 指南中更新直接拍照和 heading 的行为说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 EnvironmentMonitoring 路由生成迁移到基于 MapNavigator 的导航模型，并移除旧版的地图追踪配置。

Enhancements:
- 将 EnvironmentMonitoring 路由统一标准化为基于 MapLocator 和 MapNavigator 的实现，移除基于 MapTracker 的旧版路由处理逻辑和简写地图字段。
- 简化传送（teleport）后的行为，使导航路由可以直接进入 MapNavigateAction，而直接拍照（direct-photo）路由则使用可选的“仅朝向（heading-only）”导航动作。
- 使 MapNavigator 的导出控制与标签与基于 NavPath/NavAssert 的路由编写方式保持一致。

Documentation:
- 更新英文和中文的 EnvironmentMonitoring 维护、生成器及技能文档，以描述仅基于 MapNavigator 的路由模型以及 direct-photo 的语义。

Tests:
- 调整路由解析（route resolver）测试，用于验证 NavPath、仅朝向的 direct-photo 路由，以及旧版地图字段行为的移除。

Chores:
- 收紧路由模式（schema）与编写规范，围绕受支持的基于 NavPath 的配置进行约束。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate EnvironmentMonitoring route generation to the MapNavigator-based navigation model and remove legacy map-tracking configuration.

Enhancements:
- Standardize EnvironmentMonitoring routes on MapLocator and MapNavigator, removing legacy MapTracker-based route handling and shorthand map fields.
- Simplify post-teleport behavior so navigation routes proceed directly to MapNavigateAction and direct-photo routes use an optional heading-only navigation action.
- Align MapNavigator export controls and labels with NavPath/NavAssert-based route authoring.

Documentation:
- Update English and Chinese EnvironmentMonitoring maintenance, generator, and skill documentation to describe the MapNavigator-only route model and direct-photo semantics.

Tests:
- Revise route resolver tests for NavPath validation, heading-only direct-photo routes, and removal of legacy map-field behavior.

Chores:
- Tighten route schema and authoring guidance around the supported NavPath-based configuration.

</details>

</details>