### PR TITLE
feat(ci): 打包调试符号到 Actions artifact 供 DMP 崩溃分析

### DIFF
--- a/.agents/skills/dmp-analysis/SKILL.md
+++ b/.agents/skills/dmp-analysis/SKILL.md
@@ -9,6 +9,7 @@ description: 分析 Windows 崩溃转储文件（.dmp），诊断 MaaEnd 及其�
 
 - Windows minidump (.dmp) files from MaaEnd.
 - `MaaEnd.dmp` crashes almost always originate in **MaaFramework** (C++) or **MXU** (Rust/Tauri), not MaaEnd's Go code.
+- MaaEnd 自有 agent 是独立进程，崩溃时产生各自的 DMP：`cpp-algo.exe.<pid>.dmp`、`go-service.exe.<pid>.dmp`，符号来自 MaaEnd 自己的 Actions artifact（见 5.3 节，不随 release 发布）。
 - Only x86_64 covered below; for aarch64, substitute `x86_64` → `aarch64` in all download URLs.
 
 ## Prerequisites
@@ -64,16 +65,17 @@ Match this with `maafw.log` entries tagged `[Px18188]` to pinpoint the exact cra
 
 DMP module version info is frequently empty/unavailable. Prefer log and config sources:
 
-| Priority | Source                          | How                                                             |
-| -------- | ------------------------------- | --------------------------------------------------------------- |
-| 1        | `mxu-tauri.log`                 | `maa_init success, version: v5.x.x`                             |
-| 2        | `go-service.log`                | `client_maafw_version` / `client_version` in PI environment log |
-| 3        | Config files from logs package  | `interface.json`, `maa_option.json`                             |
-| 4        | Issue text                      | User-reported version                                           |
-| 5        | Module list in stackwalk output | Version column (often shows `?`)                                |
+| Priority | Source | How |
+| --- | --- | --- |
+| 1 | `mxu-tauri.log` | `maa_init success, version: v5.x.x` |
+| 2 | `go-service.log` | `client_maafw_version` / `client_version` in PI environment log |
+| 3 | Config files from logs package | `interface.json`, `maa_option.json` |
+| 4 | Issue text | User-reported version |
+| 5 | Module list in stackwalk output | Version column (often shows `?`) |
 
 Record:
 
+- **MaaEnd version** (e.g. `v0.8.0`; used to fetch MaaEnd symbols in 5.3)
 - **MaaFramework version** (e.g. `5.9.2`)
 - **MXU version** (e.g. `1.21.2`)
 
@@ -90,17 +92,17 @@ unzip -joq "$WORK/maa-fw.zip" 'symbol/*.pdb' -d "$WORK/pdb/"
 
 PDB files inside `symbol/`:
 
-| PDB                     | Corresponding Module                                    |
-| ----------------------- | ------------------------------------------------------- |
-| MaaFramework.pdb        | MaaFramework.dll — core pipeline runtime                |
-| MaaUtils.pdb            | MaaUtils.dll — utility library                          |
-| MaaToolkit.pdb          | MaaToolkit.dll — toolkit                                |
-| MaaWin32ControlUnit.pdb | MaaWin32ControlUnit.dll — Win32 controller              |
-| MaaAdbControlUnit.pdb   | MaaAdbControlUnit.dll — ADB controller                  |
-| MaaAgentServer.pdb      | MaaAgentServer.dll — agent server                       |
-| MaaAgentClient.pdb      | MaaAgentClient.dll — agent client                       |
-| MaaPiCli.pdb            | MaaPiCli.exe — CLI entry                                |
-| Others                  | GamepadControlUnit, CustomControlUnit, NodeServer, Node |
+| PDB | Corresponding Module |
+| --- | --- |
+| MaaFramework.pdb | MaaFramework.dll — core pipeline runtime |
+| MaaUtils.pdb | MaaUtils.dll — utility library |
+| MaaToolkit.pdb | MaaToolkit.dll — toolkit |
+| MaaWin32ControlUnit.pdb | MaaWin32ControlUnit.dll — Win32 controller |
+| MaaAdbControlUnit.pdb | MaaAdbControlUnit.dll — ADB controller |
+| MaaAgentServer.pdb | MaaAgentServer.dll — agent server |
+| MaaAgentClient.pdb | MaaAgentClient.dll — agent client |
+| MaaPiCli.pdb | MaaPiCli.exe — CLI entry |
+| Others | GamepadControlUnit, CustomControlUnit, NodeServer, Node |
 
 #### MXU
 
@@ -112,6 +114,48 @@ unzip -joq "$WORK/mxu.zip" 'mxu.pdb' -d "$WORK/pdb/"
 ```
 
 `mxu.pdb` is at the zip root (≈230 MB).
+
+#### MaaEnd（自有符号）
+
+MaaEnd 构建产出独立符号包，**仅存 Actions artifact（默认保留 90 天），不随 release 发布**。artifact 名即版本：`MaaEnd-pdb-win-<arch>-<tag>`，按 `client_version` 精确匹配：
+
+```bash
+MAAEND_VER="<version>"   # e.g. v0.8.0，与 interface.json 中 version 一致
+# 1) 按版本号定位最新 artifact id（--paginate 翻页；同名多次构建时按 created_at 取最新；若返回空说明已过期）
+ART_ID=$(gh api --paginate "repos/MaaEnd/MaaEnd/actions/artifacts?per_page=100" \
+  --jq '.artifacts[] | select(.name == "MaaEnd-pdb-win-x86_64-'"${MAAEND_VER}"'") | [.id, .created_at] | @tsv' \
+  | sort -k2 | tail -1 | cut -f1)
+[ -n "$ART_ID" ] || { echo "symbol artifact expired or not found (90-day retention)"; exit 1; }
+# 2) 下载并解压（GH_TOKEN 需有 actions:read 权限）
+curl -sL -H "Authorization: Bearer $GH_TOKEN" \
+  "https://api.github.com/repos/MaaEnd/MaaEnd/actions/artifacts/$ART_ID/zip" \
+  -o "$WORK/maaend-pdb.zip"
+unzip -joq "$WORK/maaend-pdb.zip" -d "$WORK/maaend-pdb/"
+```
+
+> artifact 过期后无法再下载，需在对应版本提交上本地构建生成符号（`python tools/build_and_install.py --cpp-algo`）。注意：本地构建的 PDB GUID 与用户崩溃时的二进制不一致，只能近似符号化（函数级）；且该命令只构建 cpp-algo，go-service 需另行执行 Go 构建。
+
+包内内容：
+
+| 文件 | 对应模块 | 用途 |
+| --- | --- | --- |
+| `cpp-algo.pdb` | `cpp-algo.exe`（C++ 自定义识别/动作 agent，独立进程） | dump_syms → .sym（与 MaaFramework PDB 流程相同） |
+| `go-service.exe` | `go-service.exe`（Go agent，独立进程） | **Go 工具链不产出 PDB**；该二进制为未剥离 DWARF 的精确构建产物，即调试符号本体 |
+| `symbols-manifest.json` | — | tag / commit / 上游版本，用于版本精确配对与校验 |
+
+- 崩溃模块为 `cpp-algo.exe`：按第 6 节流程转换 `cpp-algo.pdb`。
+- 崩溃模块为 `go-service.exe`：minidump-stackwalk 无法直接符号化 Go 二进制。从无符号输出中取栈帧地址（格式 `go-service.exe + 0xXXXX`，模块内相对偏移 RVA），**推荐用 gdb 解析**（自动处理重定位，无需手工换算）：
+
+  ```bash
+  gdb -batch -ex "core-file $WORK/MaaEnd.dmp" -ex "bt" "$WORK/maaend-pdb/go-service.exe"
+  ```
+
+  或用 `go tool addr2line`（注意：无 `-e` 参数，地址从 stdin 读取，且必须传完整虚拟地址）。Go amd64 PE 默认 image base 为 `0x140000000`，栈帧里的 RVA 需先换算成完整 VA 再传入：
+
+  ```bash
+  # 0xXXXX 替换为栈帧中的 RVA；换算后再解析（实测确认：传纯 RVA 会得到 ? / ?:0）
+  printf '0x%x\n' $((0x140000000 + 0xXXXX)) | go tool addr2line "$WORK/maaend-pdb/go-service.exe"
+  ```
 
 ### 6. Convert PDB → Breakpad .sym
 
@@ -152,6 +196,8 @@ Now stack traces include function names, source paths, and line numbers.
 3. **Faulting module ownership**:
     - `Maa*.dll` → MaaFramework → upstream `MaaXYZ/MaaFramework`
     - `mxu.exe` → MXU → upstream `MistEO/MXU`
+    - `cpp-algo.exe` → MaaEnd 自有 C++ agent → 按 5.3 节从 Actions artifact 获取对应 tag 的符号包
+    - `go-service.exe` → MaaEnd 自有 Go agent → 同上，用包内精确二进制 + addr2line/gdb
     - `onnxruntime_maa.dll`, `opencv_world4_maa.dll`, `fastdeploy_ppocr_maa.dll` → third-party inference/vision
     - `DirectML.dll` → DirectX ML runtime
     - `ViGEmClient.dll` → virtual gamepad

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -450,7 +450,7 @@ jobs:
           } | ConvertTo-Json
           Set-Content -Path "$symbols/symbols-manifest.json" -Value $manifest -Encoding utf8NoBOM
 
-          Compress-Archive -Path "symbols" -DestinationPath "MaaEnd-pdb-win-${{ matrix.arch }}.zip" -Force
+          Compress-Archive -Path "symbols/*" -DestinationPath "MaaEnd-pdb-win-${{ matrix.arch }}.zip" -Force
 
       - name: Package ZIP
         shell: pwsh

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -67,6 +67,11 @@ jobs:
           echo is_release=$is_release | tee -a $GITHUB_OUTPUT
           echo is_prerelease=$is_prerelease | tee -a $GITHUB_OUTPUT
 
+      - id: commit
+        run: |
+          # workflow_dispatch 指定 ref 时 github.sha 是默认分支 sha，这里取实际 checkout 的 commit
+          echo "sha=$(git rev-parse HEAD)" | tee -a $GITHUB_OUTPUT
+
       - id: maafw-latest-release
         uses: step-security/github-action-get-latest-release@v0.8.2
         with:
@@ -87,6 +92,7 @@ jobs:
       is_prerelease: ${{ steps.set_tag.outputs.is_prerelease }}
       maafw_version: ${{ steps.maafw-latest-release.outputs.release }}
       mxu_version: ${{ steps.mxu-latest-release.outputs.release }}
+      commit_sha: ${{ steps.commit.outputs.sha }}
 
   build_and_install:
     needs: meta
@@ -406,12 +412,45 @@ jobs:
           ./rcedit.exe "install/MaaEnd.exe" --set-icon "maaend.ico"
           echo "MaaEnd.exe icon modified successfully"
 
-      - name: Remove cpp-algo debug symbols
+      # 调试符号仅存 Actions artifact（90 天保留，供 DMP 崩溃转储分析），不随 release 发布
+      - name: Package debug symbols
         shell: pwsh
         run: |
-          if (Test-Path "install/agent/cpp-algo.pdb") {
-            Remove-Item "install/agent/cpp-algo.pdb" -Force
+          if (-not (Test-Path "install/agent/cpp-algo.pdb")) {
+            throw "cpp-algo.pdb not found"
           }
+          if (-not (Test-Path "install/agent/go-service.exe")) {
+            throw "go-service.exe not found"
+          }
+
+          $symbols = "symbols"
+          New-Item -ItemType Directory -Force -Path $symbols | Out-Null
+          # cpp-algo PDB：与发布二进制同一次构建产出（GUID 自动配对）
+          Copy-Item "install/agent/cpp-algo.pdb" "$symbols/cpp-algo.pdb" -Force
+          # Go 工具链不产出 PDB：调试符号即未剥离 DWARF 的精确二进制（CI 构建不带 -s -w）
+          Copy-Item "install/agent/go-service.exe" "$symbols/go-service.exe" -Force
+          # 发布包仍不含 PDB（与旧行为一致）：已复制进符号包，从 install 中移除
+          Remove-Item "install/agent/cpp-algo.pdb" -Force
+
+          # go-service 版本自检：-X main.Version 注入的 tag 字符串应存在于二进制中
+          $bytes = [System.IO.File]::ReadAllBytes("$symbols/go-service.exe")
+          $ascii = [System.Text.Encoding]::ASCII.GetString($bytes)
+          if (-not $ascii.Contains("${{ needs.meta.outputs.tag }}")) {
+            throw "go-service.exe does not contain version stamp: ${{ needs.meta.outputs.tag }}"
+          }
+
+          # 符号清单：记录 tag / commit / 上游版本，便于按版本精确配对
+          $manifest = [ordered]@{
+            tag = "${{ needs.meta.outputs.tag }}"
+            arch = "${{ matrix.arch }}"
+            commit = "${{ needs.meta.outputs.commit_sha }}"
+            maafw_version = "${{ needs.meta.outputs.maafw_version }}"
+            mxu_version = "${{ needs.meta.outputs.mxu_version }}"
+            go_service = "unstripped binary with DWARF (Go emits no PDB); resolve with go tool addr2line"
+          } | ConvertTo-Json
+          Set-Content -Path "$symbols/symbols-manifest.json" -Value $manifest -Encoding utf8NoBOM
+
+          Compress-Archive -Path "symbols" -DestinationPath "MaaEnd-pdb-win-${{ matrix.arch }}.zip" -Force
 
       - name: Package ZIP
         shell: pwsh
@@ -422,6 +461,14 @@ jobs:
         with:
           name: MaaEnd-win-${{ matrix.arch }}-zip
           path: "MaaEnd-win-${{ matrix.arch }}.zip"
+
+      # artifact 名即版本号，便于 90 天内按版本检索下载；不带 -zip 后缀，
+      # 避免被 release job 的 MaaEnd-*-zip 下载 pattern 匹配（符号包不发布）
+      - uses: actions/upload-artifact@v6
+        with:
+          name: MaaEnd-pdb-win-${{ matrix.arch }}-${{ needs.meta.outputs.tag }}
+          path: "MaaEnd-pdb-win-${{ matrix.arch }}.zip"
+          retention-days: 90
 
   changelog:
     name: Generate changelog

--- a/agent/cpp-algo/source/CMakeLists.txt
+++ b/agent/cpp-algo/source/CMakeLists.txt
@@ -19,6 +19,10 @@ if(WIN32)
     target_link_libraries(cpp-algo PRIVATE WebView2::WebView2 dbghelp)
     target_compile_definitions(cpp-algo PRIVATE MAAEND_HAVE_WEBVIEW2)
 
+    # 固定产出完整 PDB（/DEBUG:FULL）：CI 符号包依赖行号信息，
+    # 避免 MSVC 默认（历史上有 FASTLINK 默认期）时 dump_syms 拿不到行号。
+    target_link_options(cpp-algo PRIVATE "$<$<CONFIG:RelWithDebInfo>:/DEBUG:FULL>")
+
     add_custom_command(TARGET cpp-algo POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
             "$<TARGET_FILE:WebView2::WebView2>"


### PR DESCRIPTION
## Summary by Sourcery

在 CI 构建产物中打包 Windows 调试符号，用于崩溃后的 DMP 分析，同时避免在正式发行版本中随程序一起发布这些符号。

New Features:
- 将 MaaEnd 的 Windows 调试符号包作为短期保留的 GitHub Actions 构建产物发布，并按版本和架构进行区分，以支持有针对性的 DMP 分析。
- 文档化如何在排查崩溃时获取和使用 MaaEnd 专用符号，包括 `cpp-algo` 的 PDB 文件以及 Go 代理二进制文件。

Enhancements:
- 确保 `cpp-algo` 在 `RelWithDebInfo` 构建中启用完整的 PDB 生成，以便在符号转换时拥有完整的行号信息。
- 扩充 DMP 分析文档，加入关于 MaaEnd 代理崩溃归属、符号查找优先级，以及通过 `gdb` 或 `go tool addr2line` 解析 Go 栈的指导。

CI:
- 在 CI 中新增步骤，用于收集 `cpp-algo` 的 PDB 文件和未去除符号的 `go-service` 二进制文件，校验其内嵌版本标记，生成符号清单，将其归档并作为带版本号的非发行构建产物上传，与主安装包 zip 分离存放。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Package Windows debug symbols in CI artifacts for post-crash DMP analysis without shipping them in releases.

New Features:
- Publish MaaEnd Windows debug symbol bundles as short-retention GitHub Actions artifacts keyed by version and architecture for targeted DMP analysis.
- Document how to retrieve and use MaaEnd-specific symbols, including cpp-algo PDBs and Go agent binaries, when investigating crashes.

Enhancements:
- Ensure cpp-algo is linked with full PDB generation in RelWithDebInfo builds so line information is available for symbol conversion.
- Augment DMP analysis documentation with guidance on MaaEnd agent crash ownership, symbol lookup priority, and Go stack resolution via gdb or go tool addr2line.

CI:
- Add CI steps to collect cpp-algo PDBs and unstripped go-service binaries, validate embedded version stamps, generate a symbol manifest, archive them, and upload as versioned, non-release artifacts separate from main install zips.

</details>