### PR TITLE
feat(MapNavigator): INTERACT 升级为异步交互,提示触发统一使用距离闸

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/async_prompt_action.cpp
+++ b/agent/cpp-algo/source/MapNavigator/async_prompt_action.cpp
@@ -1,0 +1,341 @@
+#include "async_prompt_action.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <MaaFramework/MaaAPI.h>
+#include <MaaUtils/ImageIo.h>
+#include <MaaUtils/Logger.h>
+#include <meojson/json.hpp>
+
+#include "motion_controller.h"
+#include "navi_math.h"
+#include "navigation_session.h"
+#include "prompt_scan_profile.h"
+#include "roi_template_scanner.h"
+
+#include "../utils.h"
+
+namespace mapnavigator
+{
+
+namespace
+{
+
+// override 是合并进节点而非替换, 所以只写调用方拥有的两件事: 截断共用出口的 next(子任务到此返回), 以及
+// 路线给的文本。roi/action/key 一律留在 pipeline 里。
+std::string BuildRunOverride(const AsyncPromptActionSpec& spec, const std::vector<std::string>* expected)
+{
+    json::object exit_node;
+    exit_node["next"] = json::array {};
+
+    json::object root;
+    root[spec.exit_node] = std::move(exit_node);
+
+    if (expected != nullptr && !expected->empty()) {
+        json::array expected_list;
+        for (const std::string& text : *expected) {
+            expected_list.emplace_back(text);
+        }
+        json::object param;
+        param["expected"] = std::move(expected_list);
+        json::object recognition;
+        recognition["param"] = std::move(param);
+        json::object recognition_node;
+        recognition_node["recognition"] = std::move(recognition);
+        root[spec.recognition_node] = std::move(recognition_node);
+    }
+
+    return json::value(std::move(root)).dumps();
+}
+
+// 同一个入口, 但识别节点什么都不做: 这趟只为把模型的冷启动付掉
+std::string BuildPreWarmOverride(const AsyncPromptActionSpec& spec)
+{
+    json::object do_nothing;
+    do_nothing["type"] = "DoNothing";
+
+    json::object recognition_node;
+    recognition_node["action"] = std::move(do_nothing);
+    recognition_node["next"] = json::array {};
+
+    json::object exit_node;
+    exit_node["next"] = json::array {};
+
+    json::object root;
+    root[spec.recognition_node] = std::move(recognition_node);
+    root[spec.exit_node] = std::move(exit_node);
+    return json::value(std::move(root)).dumps();
+}
+
+// 出厂预筛: 先读本类自己的 scan 节点, 老资源里没有这个节点时回落到内置图标与识别节点自己的 ROI。
+PromptScanProfile DefaultScanProfile(
+    MaaContext* context,
+    const AsyncPromptActionSpec& spec,
+    const cv::Rect& fallback_roi,
+    std::string_view controller_type)
+{
+    PromptScanProfile profile;
+    if (spec.default_scan_node != nullptr && TryLoadPromptScanProfile(context, spec.default_scan_node, controller_type, &profile)) {
+        return profile;
+    }
+
+    profile = PromptScanProfile {};
+    profile.base_roi = fallback_roi;
+    profile.threshold = kPromptIconMatchThreshold;
+    const std::filesystem::path icon_path = std::filesystem::absolute(get_exe_dir() / ".." / kPromptIconRelativePath);
+    profile.templ = MAA_NS::imread(icon_path, cv::IMREAD_GRAYSCALE);
+    if (profile.templ.empty()) {
+        LogError << "Prompt icon template not loaded." << VAR(spec.tag) << VAR(MAA_NS::path_to_utf8_string(icon_path));
+    }
+    return profile;
+}
+
+} // namespace
+
+void RunPromptSubtask(MaaContext* context, const AsyncPromptActionSpec& spec, const std::vector<std::string>* expected)
+{
+    if (context == nullptr) {
+        return;
+    }
+
+    const std::string pipeline_override = BuildRunOverride(spec, expected);
+    const MaaTaskId sub_id = MaaContextRunTask(context, spec.entry_node, pipeline_override.c_str());
+    if (sub_id == MaaInvalidId) {
+        LogWarn << "Prompt subtask failed to dispatch." << VAR(spec.tag) << VAR(spec.entry_node);
+        return;
+    }
+    utils::SleepFor(kPromptPostSleepMs);
+}
+
+AsyncPromptAction::AsyncPromptAction(
+    const AsyncPromptActionSpec& spec,
+    MaaContext* context,
+    NavigationSession* session,
+    const NaviPosition* position)
+    : spec_(spec)
+    , context_(context)
+    , session_(session)
+    , position_(position)
+{
+}
+
+AsyncPromptAction::~AsyncPromptAction() = default;
+
+bool AsyncPromptAction::RouteHasPoint() const
+{
+    if (session_ == nullptr) {
+        return false;
+    }
+    const std::vector<Waypoint>& path = session_->original_path();
+    return std::any_of(path.begin(), path.end(), [this](const Waypoint& waypoint) { return spec_.Matches(waypoint); });
+}
+
+bool AsyncPromptAction::RouteEndsWithPoint() const
+{
+    return LastWaypointOfThisKind() != nullptr;
+}
+
+void AsyncPromptAction::Start(const cv::Rect& fallback_roi, std::string_view controller_type)
+{
+    if (started_ || !RouteHasPoint()) {
+        return;
+    }
+    fallback_roi_ = fallback_roi;
+    controller_type_ = controller_type;
+    started_ = true;
+
+    for (const Waypoint& waypoint : session_->original_path()) {
+        if (spec_.Matches(waypoint)) {
+            BuildScanner(waypoint.interact_scan);
+            break;
+        }
+    }
+    // 疾跑抑制按 NearestDistanceSq 逐拍算, 不整条线压掉: 两个点之间照样跑
+}
+
+void AsyncPromptAction::Stop()
+{
+    scanner_.reset();
+    scan_node_.clear();
+    started_ = false;
+}
+
+void AsyncPromptAction::SubmitFrame(const cv::Mat& frame)
+{
+    if (scanner_ != nullptr) {
+        scanner_->SubmitFrame(frame);
+    }
+}
+
+void AsyncPromptAction::PreWarmRecognition()
+{
+    if (context_ == nullptr || !RouteHasPoint()) {
+        return;
+    }
+
+    LogInfo << "Pre-warming the prompt recognition model while the agent is stopped." << VAR(spec_.tag);
+    const std::string pipeline_override = BuildPreWarmOverride(spec_);
+    MaaContextRunTask(context_, spec_.entry_node, pipeline_override.c_str());
+}
+
+double AsyncPromptAction::NearestDistanceSq() const
+{
+    if (!started_ || session_ == nullptr || position_ == nullptr || !position_->valid) {
+        return -1.0;
+    }
+
+    double nearest_sq = -1.0;
+    for (const Waypoint& waypoint : session_->current_path()) {
+        if (!spec_.Matches(waypoint)) {
+            continue;
+        }
+        const double dx = waypoint.x - position_->x;
+        const double dy = waypoint.y - position_->y;
+        const double distance_sq = dx * dx + dy * dy;
+        if (nearest_sq < 0.0 || distance_sq < nearest_sq) {
+            nearest_sq = distance_sq;
+        }
+    }
+    return nearest_sq;
+}
+
+bool AsyncPromptAction::TryTriggerWhileWalking(MotionController* motion_controller, double waypoint_distance, size_t node_idx)
+{
+    if (context_ == nullptr || !started_ || motion_controller == nullptr) {
+        return false;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if (last_trigger_at_.time_since_epoch().count() != 0 && now - last_trigger_at_ < std::chrono::milliseconds(kPromptScanIntervalMs)) {
+        return false;
+    }
+
+    // 提示图标是全局的, 路过任何可交互物都会闪, 所以只在自家语义点附近才动手, 带宽同走路模式的激活带。
+    const std::vector<std::string>* expected = nullptr;
+    bool in_band = false;
+    if (spec_.text_from_route) {
+        // 这一下命中就把点算走完, 所以还要求正走向的就是它: 蹭到别家的提示会静默消掉本点
+        const Waypoint* waypoint = CurrentWaypointOfThisKind();
+        EnsureScannerFor(waypoint);
+        in_band = waypoint != nullptr && waypoint_distance <= kPromptTriggerBandWu;
+        if (in_band) {
+            expected = &waypoint->interact_text;
+        }
+    }
+    else {
+        // 共用表那类不消费路点, 所以按离最近的同类点多远来算, 已走过的点也算: 提示常常是走过头才弹出来
+        const double nearest_sq = NearestDistanceSq();
+        in_band = nearest_sq >= 0.0 && nearest_sq <= kPromptTriggerBandWu * kPromptTriggerBandWu;
+    }
+
+    // 无论带内带外都读闩: 带外看到的提示当场作废, 否则跨进带内的第一拍就拿老观测开火, 而那时本点的提示还没弹。
+    // 松预筛停不死整条线: 点名目标那类每次误停花掉自己一个点, 共用表那类两次停车之间照样往前挪。
+    if (!ConsumeDetection() || !in_band) {
+        return false; // 后台没报, 这一拍零成本
+    }
+
+    last_trigger_at_ = now;
+    LogInfo << "Async prompt flagged — stopping for authoritative recognition." << VAR(spec_.tag) << VAR(waypoint_distance)
+            << VAR(node_idx);
+    motion_controller->SetForwardState(false);
+    utils::SleepFor(kStopWaitMs);
+    RunPromptSubtask(context_, spec_, expected);
+    return true;
+}
+
+bool AsyncPromptAction::TryTriggerAtRouteTail()
+{
+    if (context_ == nullptr || !started_) {
+        return false;
+    }
+
+    const Waypoint* waypoint = LastWaypointOfThisKind();
+    if (spec_.text_from_route && waypoint == nullptr) {
+        return false;
+    }
+    EnsureScannerFor(waypoint);
+    if (!ConsumeDetection()) {
+        return false;
+    }
+
+    LogInfo << "Route tail prompt flagged — running the authoritative recognition before finishing." << VAR(spec_.tag);
+    RunPromptSubtask(context_, spec_, waypoint != nullptr ? &waypoint->interact_text : nullptr);
+    return true;
+}
+
+void AsyncPromptAction::ForgetDetection()
+{
+    ConsumeDetection();
+}
+
+void AsyncPromptAction::EnsureScannerFor(const Waypoint* waypoint)
+{
+    if (waypoint == nullptr || waypoint->interact_scan == scan_node_) {
+        return;
+    }
+    BuildScanner(waypoint->interact_scan);
+}
+
+// 空串 = 用出厂预筛。节点坏了也照样记下名字: 否则每一拍都会重读一遍同一个坏节点。
+void AsyncPromptAction::BuildScanner(const std::string& scan_node)
+{
+    scanner_.reset();
+    scan_node_ = scan_node;
+
+    PromptScanProfile profile;
+    if (scan_node.empty()) {
+        profile = DefaultScanProfile(context_, spec_, fallback_roi_, controller_type_);
+    }
+    else if (!TryLoadPromptScanProfile(context_, scan_node, controller_type_, &profile)) {
+        LogError << "Points naming this scan node get no pre-filter; they stop on arrival instead." << VAR(spec_.tag)
+                 << VAR(scan_node);
+        return;
+    }
+    if (profile.templ.empty()) {
+        LogError << "Prompt scan template is empty; these points stop on arrival instead." << VAR(spec_.tag) << VAR(scan_node);
+        return;
+    }
+
+    scanner_ = std::make_unique<RoiTemplateScanner>(spec_.tag, profile.base_roi, profile.templ, profile.mask, profile.threshold);
+    LogInfo << "Async prompt scanner started." << VAR(spec_.tag) << VAR(scan_node) << VAR(profile.base_roi.x)
+            << VAR(profile.base_roi.y) << VAR(profile.base_roi.width) << VAR(profile.base_roi.height) << VAR(profile.templ.cols)
+            << VAR(profile.templ.rows) << VAR(profile.threshold);
+}
+
+bool AsyncPromptAction::ConsumeDetection()
+{
+    return scanner_ != nullptr && scanner_->ConsumeDetection();
+}
+
+// 一条线可带多个业务的交互点, 只认当前要走到的那个; nullptr = 这一拍不该停车
+const Waypoint* AsyncPromptAction::CurrentWaypointOfThisKind() const
+{
+    if (session_ == nullptr || !session_->HasCurrentWaypoint()) {
+        return nullptr;
+    }
+
+    const Waypoint& waypoint = session_->CurrentWaypoint();
+    return spec_.Matches(waypoint) ? &waypoint : nullptr;
+}
+
+const Waypoint* AsyncPromptAction::LastWaypointOfThisKind() const
+{
+    if (session_ == nullptr) {
+        return nullptr;
+    }
+
+    const std::vector<Waypoint>& path = session_->original_path();
+    for (auto it = path.rbegin(); it != path.rend(); ++it) {
+        if (!it->HasPosition()) {
+            continue;
+        }
+        return spec_.Matches(*it) ? &*it : nullptr;
+    }
+    return nullptr;
+}
+
+} // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/async_prompt_action.h
+++ b/agent/cpp-algo/source/MapNavigator/async_prompt_action.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <opencv2/core.hpp>
+
+#include "navi_config.h"
+#include "navi_domain_types.h"
+
+struct MaaContext;
+
+namespace mapnavigator
+{
+
+class MotionController;
+class RoiTemplateScanner;
+struct NavigationSession;
+
+// One kind of prompt-driven waypoint action: a background pre-filter watches the on-screen prompt while the agent
+// walks, and the pipeline node named here makes the authoritative call. The kinds differ only here.
+struct AsyncPromptActionSpec
+{
+    ActionType action;
+    const char* tag;               // scanner label carried into the logs
+    const char* entry_node;        // subtask entry the nav thread runs
+    const char* recognition_node;  // fallback ROI source, pre-warm target, injection target for the route's text
+    const char* exit_node;         // subtask exit; its next is truncated so the subtask returns instead of going on
+    const char* default_scan_node; // TemplateMatch node holding this kind's default pre-filter; nullptr = built in
+    bool text_from_route;          // false = the node owns one shared table (collect)
+
+    bool Matches(const Waypoint& waypoint) const
+    {
+        return waypoint.action == action && waypoint.HasPosition() && (!text_from_route || !waypoint.interact_text.empty());
+    }
+
+    // A route that named its target also said which point the prompt belongs to, so a hit completes that point.
+    bool CompletesWaypointOnTrigger() const { return text_from_route; }
+};
+
+// One shared name table for every collectible, so nothing here is route-configurable.
+inline constexpr AsyncPromptActionSpec kCollectPromptSpec {
+    .action = ActionType::COLLECT,
+    .tag = "collect",
+    .entry_node = kCollectEntryNode,
+    .recognition_node = kCollectRecognitionNode,
+    .exit_node = kCollectExitNode,
+    .default_scan_node = nullptr,
+    .text_from_route = false,
+};
+
+// Interaction prompts differ per business, so the route supplies both recognitions: the text the shared node looks
+// for once stopped, and the pre-filter node that decides when to stop. The action stays the interact key either way.
+inline constexpr AsyncPromptActionSpec kInteractPromptSpec {
+    .action = ActionType::INTERACT,
+    .tag = "interact",
+    .entry_node = kInteractEntryNode,
+    .recognition_node = kInteractRecognitionNode,
+    .exit_node = kInteractExitNode,
+    .default_scan_node = kInteractScanNode,
+    .text_from_route = true,
+};
+
+// Runs one prompt subtask and waits out the settle after it. expected replaces the recognition node's authored text
+// list for this one run; nullptr or empty leaves the node's own table in place.
+void RunPromptSubtask(MaaContext* context, const AsyncPromptActionSpec& spec, const std::vector<std::string>* expected);
+
+// Owns one kind's pre-filter and pacing. A route without this kind of point costs one bool check per tick.
+class AsyncPromptAction
+{
+public:
+    AsyncPromptAction(
+        const AsyncPromptActionSpec& spec,
+        MaaContext* context,
+        NavigationSession* session,
+        const NaviPosition* position);
+    ~AsyncPromptAction();
+
+    AsyncPromptAction(const AsyncPromptAction&) = delete;
+    AsyncPromptAction& operator=(const AsyncPromptAction&) = delete;
+
+    const AsyncPromptActionSpec& spec() const { return spec_; }
+    bool armed() const { return started_; }
+
+    // Whether this run has any point of this kind at all, and whether the last positioned one is of this kind.
+    bool RouteHasPoint() const;
+    bool RouteEndsWithPoint() const;
+
+    // fallback_roi is the recognition node's own ROI, used by the built-in pre-filter when no scan node supplies one.
+    void Start(const cv::Rect& fallback_roi, std::string_view controller_type);
+    void Stop();
+    void SubmitFrame(const cv::Mat& frame);
+
+    // Pays the recognition model's cold start while the agent is stopped, never on a walking tick.
+    void PreWarmRecognition();
+
+    // Squared distance to the nearest point of this kind; -1 when not armed, unlocalized, or none are left.
+    double NearestDistanceSq() const;
+
+    // Stops for the authoritative recognition. true = the tick was spent, and a route-named kind's waypoint is
+    // now walked (see CompletesWaypointOnTrigger).
+    bool TryTriggerWhileWalking(MotionController* motion_controller, double waypoint_distance, size_t node_idx);
+    // Not paced: the caller stands still at the route tail and gives this its own window.
+    bool TryTriggerAtRouteTail();
+
+    // Drops a latched observation without acting on it.
+    void ForgetDetection();
+
+private:
+    const Waypoint* CurrentWaypointOfThisKind() const;
+    const Waypoint* LastWaypointOfThisKind() const;
+
+    // Only the point being walked to can fire, so one scanner is enough; it re-points when that point's scan
+    // node changes. Rebuilding drops the old latch with the old scanner, which is what we want.
+    void EnsureScannerFor(const Waypoint* waypoint);
+    void BuildScanner(const std::string& scan_node);
+    bool ConsumeDetection();
+
+    AsyncPromptActionSpec spec_;
+    MaaContext* context_;
+    NavigationSession* session_;
+    const NaviPosition* position_;
+    cv::Rect fallback_roi_ {};
+    std::string controller_type_;
+    std::string scan_node_;
+    std::unique_ptr<RoiTemplateScanner> scanner_;
+    bool started_ = false;
+    std::chrono::steady_clock::time_point last_trigger_at_ {};
+};
+
+} // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -236,41 +236,49 @@ constexpr double kPostTurnForwardCommitMinDegrees = 15.0;
 constexpr const char* kDefaultNavmeshRelativePath = "assets/resource/model/map/navmesh/base.nav";
 constexpr const char* kDefaultCompressedNavmeshRelativePath = "assets/resource/model/map/navmesh/base.nav.gz";
 
-constexpr const char* kDefaultCollectEntry = "AutoCollectClickStart";
-constexpr const char* kCollectPipelineOverride = R"({"AutoCollectClickEnd":{"next":[]}})";
-constexpr int32_t kCollectPostSleepMs = 80;
+// Prompt-driven actions (collect / async interact), three nodes per kind: entry, authoritative recognition, exit.
+// The recognition node is also the ROI source, the pre-warm target and where the route's text is injected.
+constexpr const char* kCollectEntryNode = "AutoCollectClickStart";
+constexpr const char* kCollectRecognitionNode = "AutoCollectClick";
+constexpr const char* kCollectExitNode = "AutoCollectClickEnd";
+constexpr const char* kInteractEntryNode = "MapNavigatorInteractStart";
+constexpr const char* kInteractRecognitionNode = "MapNavigatorInteract";
+constexpr const char* kInteractExitNode = "MapNavigatorInteractEnd";
+constexpr int32_t kPromptPostSleepMs = 80;
 
-constexpr const char* kCollectPrewarmOverride =
-    R"({"AutoCollectClick":{"action":{"type":"DoNothing"},"next":[]},"AutoCollectClickEnd":{"next":[]}})";
-constexpr const char* kCollectRoiNode = "AutoCollectClick";
 // Resolution every pipeline ROI is authored against; the scanner rescales it to whatever the frame really is.
 constexpr int32_t kPipelineRoiBaseWidth = 1280;
 constexpr int32_t kPipelineRoiBaseHeight = 720;
 
-constexpr const char* kCollectIconRelativePath = "resource/image/RealTimeTask/AutoPick.png";
-constexpr double kCollectIconMatchThreshold = 0.75;
-constexpr int32_t kCollectLabelBrightThreshold = 210; // 0-255 luma; near-white glyphs survive, grass (~200) drops
-constexpr int32_t kCollectLabelMorphWidth = 8;        // horizontal close width that merges glyphs into a word
-constexpr int32_t kCollectLabelMinWidth = 24;         // ~2-char CJK name floor (the 5-char label measured 78px)
-constexpr int32_t kCollectLabelMinHeight = 7;         // reject thin specks (label glyph row ~14px)
-constexpr int32_t kCollectLabelMaxHeight = 26;        // reject tall non-text structures
-constexpr double kCollectLabelMaxFill = 0.80;         // text is sparse (label fill ~0.4-0.66); solid blob = panel/icon
-// Sole pacing gate for detection-triggered collects; the clock only advances on an actual attempt.
-constexpr int32_t kCollectScanIntervalMs = 1200;
+// Every interactable raises the same prompt icon, so both kinds share this pre-filter. The threshold is loose on
+// purpose: it only decides whether the subtask is worth running, and the subtask recognizes again before acting.
+// These are the last resort: the shipped scan node below carries the same values, and a route may name its own.
+constexpr const char* kPromptIconRelativePath = "resource/image/RealTimeTask/AutoPick.png";
+constexpr double kPromptIconMatchThreshold = 0.75;
+// TemplateMatch node holding the interact pre-filter's roi/template/threshold, so a business whose prompt looks
+// different or sits elsewhere retargets it in JSON. Missing (old resources, new agent) -> the constants above.
+constexpr const char* kInteractScanNode = "MapNavigatorInteractScan";
+// The bands and pacing below are shared by both kinds: both need the prompt to stay on screen long enough to act on.
+// Sole pacing gate for detection-triggered attempts; the clock only advances on an actual attempt.
+constexpr int32_t kPromptScanIntervalMs = 1200;
 // Collect points sit 2.1-3.7 apart, closer than the normal 3.25 band, which swallows a whole run of them.
 constexpr double kCollectArrivalBandWu = 1.5;
 // Tightening must not add a way to get stuck: this long without progress falls back to the normal band.
 constexpr int32_t kCollectArrivalRelaxMs = 6000;
-// The route ends the tick the last collect point is consumed, so the scanner never gets a second chance.
+// The route ends the tick the last such point is consumed, so the scanner never gets a second chance.
 constexpr int32_t kCollectTailGraceMs = 1500;
 constexpr double kCollectSprintSuppressBandWu = 8.0;
 constexpr int32_t kSprintCancelReleaseMs = 60;
 
-// Walk near collect points so the interact prompt stays up long enough to act on. Enter/exit differ for
+// Walk near these points so the interact prompt stays up long enough to act on. Enter/exit differ for
 // hysteresis (each press flips game state); the enter band stays inside the sprint-suppress band.
 constexpr double kCollectWalkEnterBandWu = 3.0;
 constexpr double kCollectWalkExitBandWu = 4.5;
 static_assert(kCollectWalkEnterBandWu < kCollectSprintSuppressBandWu, "walk band must sit inside the sprint-suppress band");
+
+// Acting on a prompt is gated on the same band that engages walking: the prompt icon fires for every interactable
+// on screen, so without this a route carrying one such point would stop at strangers all the way along.
+constexpr double kPromptTriggerBandWu = kCollectWalkEnterBandWu;
 
 // Walking halves both speed and turn rate, so jogging-sized windows are doubled while engaged.
 constexpr int32_t kWalkModeSlowFactor = 2;

--- a/agent/cpp-algo/source/MapNavigator/navi_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navi_controller.cpp
@@ -1,7 +1,10 @@
+#include <mutex>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include <MaaFramework/MaaAPI.h>
 #include <MaaUtils/Logger.h>
 
 #include "../MapLocator/MapLocateAction.h"
@@ -18,6 +21,46 @@
 namespace mapnavigator
 {
 
+namespace
+{
+
+// 导航期间调起的交互子任务是 pipeline, 它的 next 能被接回导航动作本身。子任务同步调起, 那会在同一条 nav
+// 线程上套第二层导航: 两层抢同一个控制器与定位器, 而且能无限套下去。这道闸把栈深封死在 1, 按 tasker 分,
+// 一个进程里跑多台设备时互不误伤。
+std::mutex g_navigating_taskers_mutex;
+std::set<MaaTasker*> g_navigating_taskers;
+
+class NavigationEntryGuard
+{
+public:
+    explicit NavigationEntryGuard(MaaTasker* tasker)
+        : tasker_(tasker)
+    {
+        const std::lock_guard<std::mutex> lock(g_navigating_taskers_mutex);
+        taken_ = g_navigating_taskers.insert(tasker).second;
+    }
+
+    ~NavigationEntryGuard()
+    {
+        if (!taken_) {
+            return;
+        }
+        const std::lock_guard<std::mutex> lock(g_navigating_taskers_mutex);
+        g_navigating_taskers.erase(tasker_);
+    }
+
+    NavigationEntryGuard(const NavigationEntryGuard&) = delete;
+    NavigationEntryGuard& operator=(const NavigationEntryGuard&) = delete;
+
+    bool taken() const { return taken_; }
+
+private:
+    MaaTasker* tasker_;
+    bool taken_ = false;
+};
+
+} // namespace
+
 NaviController::NaviController(MaaContext* ctx)
     : ctx_(ctx)
 {
@@ -25,6 +68,13 @@ NaviController::NaviController(MaaContext* ctx)
 
 bool NaviController::Navigate(const NaviParam& param)
 {
+    // 先取闸再做任何事: 作者的图若无限重试这个被拒的节点, 每次都必须是零成本的。
+    const NavigationEntryGuard entry_guard(MaaContextGetTasker(ctx_));
+    if (!entry_guard.taken()) {
+        LogError << "Refusing to nest navigation: this tasker is already navigating.";
+        return false;
+    }
+
     ActionWrapper action_wrapper(ctx_);
     PositionProvider position_provider(action_wrapper.GetCtrl(), maplocator::getOrInitLocator());
     position_provider.ResetTracking();

--- a/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include <meojson/json.hpp>
 
@@ -16,7 +17,9 @@ namespace mapnavigator
 // SPRINT   - 到达该点时触发一次右键冲刺
 // JUMP     - 到达该点时按下空格
 // FIGHT    - 到达该点时刹车，左键攻击一次
-// INTERACT - 到达该点时刹车，狂按F键
+// INTERACT - 到达该点时刹车交互一次。路线给了 interact_text 则升级为异步交互：行进中检测到交互提示就停车
+//            跑一次子任务，到点时再兜底一次；没给文本就保持原语义——到点狂按F键。interact_scan 只换预筛看
+//            什么，得配着 interact_text 用。动作恒为交互键，不可换。
 // TRANSFER - 精确抵达该点后停住，等待机关/跳板/回传等把角色转移到下一段可达路径
 // PORTAL   - 跨区过渡节点，触发后进入盲走等待区域切换
 // HEADING  - 无坐标朝向节点，执行时只调整镜头到指定角度，再按下W继续前进
@@ -69,6 +72,11 @@ struct Waypoint
     // NAVMESH only: height of the overlapping deck this waypoint sits on. Pins the goal span for the leg
     // ending here and the start span for the leg leaving it. Unset -> full span set, unchanged.
     std::optional<double> target_deck_y;
+    // INTERACT 专用: 该点的提示文字, 停车后当 OCR expected 用。留空则不做这次确认, 该点也就不算异步交互
+    std::vector<std::string> interact_text;
+    // INTERACT 专用: 行进预筛读 roi/template/threshold 的 TemplateMatch 节点, 留给提示长得不一样的业务;
+    // 留空用出厂那份
+    std::string interact_scan;
 
     double GetLookahead() const
     {
@@ -82,12 +90,12 @@ struct Waypoint
     }
 
     // 到点判定圈半径, 通道比判定圈还窄时按通道收紧, 否则角色会提前弃点直奔下一点, 抄出撞墙的弦
-    // 采集点另按 kCollectArrivalBandWu 收紧(点距比常规判定圈还小), relax_collect 是够不着时的退让
-    double ArrivalBand(double position_quantum, bool relax_collect = false) const
+    // 提示驱动的点另按 kCollectArrivalBandWu 收紧(点距比常规判定圈还小), relax_tight_band 是够不着时的退让
+    double ArrivalBand(double position_quantum, bool relax_tight_band = false) const
     {
         const bool strict = RequiresStrictArrival();
         double band = strict ? GetLookahead() + position_quantum : GetLookahead() + kWaypointArrivalSlack + position_quantum;
-        if (action == ActionType::COLLECT && !relax_collect) {
+        if (StopsOnPromptDetection() && !relax_tight_band) {
             band = std::min(band, kCollectArrivalBandWu);
         }
         if (strict || corridor_clearance <= 0.0) {
@@ -105,6 +113,13 @@ struct Waypoint
                || action == ActionType::FIGHT || action == ActionType::TRANSFER || action == ActionType::PORTAL
                || action == ActionType::NAVMESH || action == ActionType::DIG;
     }
+
+    // 路线说了停下后认什么才走异步交互。只换预筛不给文本的点走不通: 共用识别节点里的占位文本没被顶掉, 停下来
+    // 也认不出东西, 所以那种点退回原语义而不是白停一次。
+    bool IsAsyncInteract() const { return action == ActionType::INTERACT && !interact_text.empty(); }
+
+    // 走到跟前才算数的点: 交互提示得在屏幕上待得住, 所以判定圈、疾跑抑制、切走路都按同一套来
+    bool StopsOnPromptDetection() const { return action == ActionType::COLLECT || IsAsyncInteract(); }
 
     bool HasPosition() const { return has_position; }
 

--- a/agent/cpp-algo/source/MapNavigator/navi_param_parser.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navi_param_parser.cpp
@@ -16,6 +16,8 @@
 
 #include <MaaUtils/Logger.h>
 
+#include "navi_config.h"
+
 namespace mapnavigator
 {
 
@@ -89,6 +91,39 @@ struct NaviActionListInput
 
         actions_ = input.as<std::vector<ActionType>>();
         return std::all_of(actions_.begin(), actions_.end(), is_valid_action_type);
+    }
+};
+
+// A string or an array of strings. Empty is rejected rather than ignored: empty text matches anything on the
+// recognition side, which is exactly the press-on-any-prompt behaviour these fields exist to avoid.
+struct NaviTextListInput
+{
+    std::vector<std::string> texts_;
+
+    bool check_json(const json::value& input) const
+    {
+        NaviTextListInput parsed;
+        return parsed.from_json(input);
+    }
+
+    bool from_json(const json::value& input)
+    {
+        texts_.clear();
+
+        if (input.is_string()) {
+            if (input.as_string().empty()) {
+                return false;
+            }
+            texts_.push_back(input.as_string());
+            return true;
+        }
+
+        if (!input.is<std::vector<std::string>>()) {
+            return false;
+        }
+
+        texts_ = input.as<std::vector<std::string>>();
+        return !texts_.empty() && std::all_of(texts_.begin(), texts_.end(), [](const std::string& text) { return !text.empty(); });
     }
 };
 
@@ -205,6 +240,47 @@ struct NaviWaypointObjectPresenceInput
         MEO_OPT MEO_KEY("target") target_)
 };
 
+// Read from a point and from the route root alike, as its own pass over the same object: MEO_OPT MEO_KEY spends three
+// macro arguments per key and the macro tops out at 64, so a single block holds at most 21 keys.
+struct NaviInteractInput
+{
+    NaviTextListInput interact_text_;
+    NaviTextListInput interactText_;
+    std::string interact_scan_;
+    std::string interactScan_;
+
+    MEO_FROMJSON(
+        MEO_OPT MEO_KEY("interact_text") interact_text_,
+        MEO_OPT MEO_KEY("interactText") interactText_,
+        MEO_OPT MEO_KEY("interact_scan") interact_scan_,
+        MEO_OPT MEO_KEY("interactScan") interactScan_)
+
+    const std::vector<std::string>& texts() const
+    {
+        return interact_text_.texts_.empty() ? interactText_.texts_ : interact_text_.texts_;
+    }
+
+    const std::string& scan() const { return interact_scan_.empty() ? interactScan_ : interact_scan_; }
+};
+
+struct NaviInteractSpec
+{
+    std::vector<std::string> texts;
+    std::string scan;
+};
+
+bool read_interact_spec(const json::value& input, NaviInteractSpec& out_spec)
+{
+    NaviInteractInput flat;
+    if (!flat.from_json(input)) {
+        return false;
+    }
+
+    out_spec.texts = flat.texts();
+    out_spec.scan = flat.scan();
+    return true;
+}
+
 struct NaviWaypointInput
 {
     double x_ = 0.0;
@@ -212,6 +288,8 @@ struct NaviWaypointInput
     std::vector<ActionType> actions_;
     std::string zone_id_;
     std::string target_tier_;
+    std::vector<std::string> interact_text_;
+    std::string interact_scan_;
     std::optional<double> target_deck_y_;
     bool strict_arrival_ = false;
     double angle_ = 0.0;
@@ -253,7 +331,12 @@ struct NaviWaypointInput
         }
         applyPresence(presence, object_input);
 
-        fromObject(object_input);
+        NaviInteractSpec interact_spec;
+        if (!read_interact_spec(input, interact_spec)) {
+            return false;
+        }
+
+        fromObject(object_input, interact_spec);
         return true;
     }
 
@@ -294,13 +377,15 @@ private:
         return true;
     }
 
-    void fromObject(const NaviWaypointObjectInput& object_input)
+    void fromObject(const NaviWaypointObjectInput& object_input, const NaviInteractSpec& interact_spec)
     {
         appendActions(object_input.action_);
         appendActions(object_input.actions_);
 
         zone_id_ = resolveZoneId(object_input);
         target_tier_ = resolveTargetTier(object_input);
+        interact_text_ = interact_spec.texts;
+        interact_scan_ = interact_spec.scan;
         target_deck_y_ = resolveTargetDeckY(object_input);
         strict_arrival_ = resolveStrictArrival(object_input);
         x_ = object_input.x_;
@@ -573,13 +658,67 @@ void append_expanded_waypoints(
     }
 }
 
+// Fill in the interact text on the INTERACT points of [from_index, end); empty leaves them plain INTERACT.
+void apply_interact_text(const std::vector<std::string>& interact_text, std::vector<Waypoint>& waypoints, size_t from_index)
+{
+    if (interact_text.empty()) {
+        return;
+    }
+    for (size_t index = from_index; index < waypoints.size(); ++index) {
+        if (waypoints[index].action == ActionType::INTERACT && waypoints[index].interact_text.empty()) {
+            waypoints[index].interact_text = interact_text;
+        }
+    }
+}
+
+// Same, for the node the walking pre-filter reads its roi/template/threshold from.
+void apply_interact_scan(const std::string& interact_scan, std::vector<Waypoint>& waypoints, size_t from_index)
+{
+    if (interact_scan.empty()) {
+        return;
+    }
+    for (size_t index = from_index; index < waypoints.size(); ++index) {
+        if (waypoints[index].action == ActionType::INTERACT && waypoints[index].interact_scan.empty()) {
+            waypoints[index].interact_scan = interact_scan;
+        }
+    }
+}
+
+// Runs after the route-wide defaults land, so a point holding only the scan node is not flagged. The pre-filter
+// only decides when to stop; with no text there is nothing to confirm, so the point falls back to plain INTERACT.
+void warn_scan_without_text(const std::vector<Waypoint>& waypoints)
+{
+    for (size_t index = 0; index < waypoints.size(); ++index) {
+        const Waypoint& waypoint = waypoints[index];
+        if (!waypoint.interact_scan.empty() && waypoint.interact_text.empty()) {
+            LogWarn << "Waypoint names a prompt scan node without any interact text; it stays a plain INTERACT."
+                    << VAR(index) << VAR(waypoint.interact_scan);
+        }
+    }
+}
+
 std::string resolve_waypoint_zone_id(const NaviWaypointInput& input, const std::string& zone_context)
 {
     return input.zone_id_.empty() ? zone_context : input.zone_id_;
 }
 
+// Only INTERACT points read these fields; elsewhere they are dropped. Not worth rejecting the route over, but the
+// missing piece is the action rather than anything the author can see in the interact fields themselves.
+void warn_unusable_interact_fields(const NaviWaypointInput& input)
+{
+    if (input.interact_text_.empty() && input.interact_scan_.empty()) {
+        return;
+    }
+    if (std::find(input.actions_.begin(), input.actions_.end(), ActionType::INTERACT) != input.actions_.end()) {
+        return;
+    }
+    LogWarn << "Waypoint carries interact fields without an INTERACT action; they do nothing here."
+            << VAR(input.interact_text_.size()) << VAR(input.interact_scan_);
+}
+
 bool append_parsed_waypoint(const NaviWaypointInput& input, std::vector<Waypoint>& out_waypoints, std::string& zone_context)
 {
+    warn_unusable_interact_fields(input);
     const std::string zone_id = resolve_waypoint_zone_id(input, zone_context);
     const ActionType primary_action = input.actions_.empty() ? ActionType::RUN : input.actions_.front();
 
@@ -631,7 +770,11 @@ bool append_parsed_waypoint(const NaviWaypointInput& input, std::vector<Waypoint
     if (has_legacy_position || has_tier_target) {
         const double target_x = input.has_target_ ? input.target_.at(0) : input.x_;
         const double target_y = input.has_target_ ? input.target_.at(1) : input.y_;
+        const size_t first_expanded = out_waypoints.size();
         append_expanded_waypoints(target_x, target_y, input.actions_, zone_id, input.target_tier_, input.strict_arrival_, out_waypoints);
+        // One coordinate may carry several actions and expand into several waypoints; only the INTERACT ones take these.
+        apply_interact_text(input.interact_text_, out_waypoints, first_expanded);
+        apply_interact_scan(input.interact_scan_, out_waypoints, first_expanded);
         if (!zone_id.empty()) {
             zone_context = zone_id;
         }
@@ -680,6 +823,13 @@ bool TryParseNaviParam(const json::value& custom_action_param, NaviParam& out_pa
         return false;
     }
 
+    // Route-wide default, written once at the top level; a point's own value wins.
+    NaviInteractSpec route_interact;
+    if (!read_interact_spec(custom_action_param, route_interact)) {
+        LogError << "Failed to deserialize " << caller_name_text << " interact defaults." << VAR(custom_action_param);
+        return false;
+    }
+
     NaviParam param = build_navi_param(input);
     std::string zone_context = param.map_name;
 
@@ -695,6 +845,10 @@ bool TryParseNaviParam(const json::value& custom_action_param, NaviParam& out_pa
             return false;
         }
     }
+
+    apply_interact_text(route_interact.texts, param.path, 0);
+    apply_interact_scan(route_interact.scan, param.path, 0);
+    warn_scan_without_text(param.path);
 
     out_param = std::move(param);
     return true;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -1,9 +1,8 @@
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
-#include <filesystem>
 #include <limits>
-#include <memory>
 #include <optional>
 #include <string>
 #include <thread>
@@ -11,12 +10,11 @@
 #include <vector>
 
 #include <MaaFramework/MaaAPI.h>
-#include <MaaUtils/ImageIo.h>
 #include <MaaUtils/Logger.h>
-#include <meojson/json.hpp>
 
 #include "action_executor.h"
 #include "action_wrapper.h"
+#include "async_prompt_action.h"
 #include "latency_observer.h"
 #include "motion_controller.h"
 #include "navi_config.h"
@@ -24,7 +22,7 @@
 #include "navigation_state_machine.h"
 #include "navmesh_path_expander.h"
 #include "position_provider.h"
-#include "roi_template_scanner.h"
+#include "prompt_scan_profile.h"
 #include "route_tracker.h"
 #include "semantic_nodes.h"
 #include "sensitivity_observer.h"
@@ -37,93 +35,6 @@ namespace mapnavigator
 
 namespace
 {
-
-// Pull the collect-label ROI from the pipeline node (single source of truth) rather than hardcoding it:
-// MaaContextGetNodeData returns the node's resolved JSON, so editing AutoCollectClick.json's roi
-// automatically retargets the async scanner. The roi is authored in the 1280x720 base frame.
-bool ReadRoiArray(const json::value& holder, cv::Rect* out)
-{
-    if (!holder.is_array()) {
-        return false;
-    }
-    const auto& arr = holder.as_array();
-    if (arr.size() < 4) {
-        return false;
-    }
-    for (size_t i = 0; i < 4; ++i) {
-        if (!arr.at(i).is_number()) {
-            return false;
-        }
-    }
-    out->x = static_cast<int>(std::lround(arr.at(0).as_double()));
-    out->y = static_cast<int>(std::lround(arr.at(1).as_double()));
-    out->width = static_cast<int>(std::lround(arr.at(2).as_double()));
-    out->height = static_cast<int>(std::lround(arr.at(3).as_double()));
-    return out->width > 0 && out->height > 0;
-}
-
-bool ParseRoiFromNode(MaaContext* context, const char* node_name, cv::Rect* out)
-{
-    if (context == nullptr || node_name == nullptr) {
-        return false;
-    }
-
-    ScopedStringBuffer buffer;
-    if (buffer.Get() == nullptr || !MaaContextGetNodeData(context, node_name, buffer.Get())) {
-        LogWarn << "Pipeline ROI: MaaContextGetNodeData failed." << VAR(node_name);
-        return false;
-    }
-    const char* raw = MaaStringBufferGet(buffer.Get());
-    if (raw == nullptr || raw[0] == '\0') {
-        LogWarn << "Pipeline ROI: empty node data." << VAR(node_name);
-        return false;
-    }
-
-    const auto parsed = json::parse(raw);
-    if (!parsed || !parsed->is_object()) {
-        LogWarn << "Pipeline ROI: node JSON is not an object." << VAR(node_name);
-        return false;
-    }
-    const auto& node = parsed->as_object();
-
-    // Canonical shape: { "recognition": { "param": { "roi": [x,y,w,h] } } }. Fall back to flatter shapes in
-    // case the framework serializes the loaded node differently.
-    if (node.contains("recognition") && node.at("recognition").is_object()) {
-        const auto& reco = node.at("recognition").as_object();
-        if (reco.contains("param") && reco.at("param").is_object()) {
-            const auto& param = reco.at("param").as_object();
-            if (param.contains("roi") && ReadRoiArray(param.at("roi"), out)) {
-                return true;
-            }
-        }
-        if (reco.contains("roi") && ReadRoiArray(reco.at("roi"), out)) {
-            return true;
-        }
-    }
-    if (node.contains("roi") && ReadRoiArray(node.at("roi"), out)) {
-        return true;
-    }
-
-    LogWarn << "Pipeline ROI: no usable roi array in node data." << VAR(node_name);
-    return false;
-}
-
-bool RouteHasCollectWaypoint(const std::vector<Waypoint>& path)
-{
-    return std::any_of(path.begin(), path.end(), [](const Waypoint& wp) { return wp.action == ActionType::COLLECT; });
-}
-
-// 末尾的无坐标节点(ZONE/HEADING)不算, 看的是最后一个真正要走到的点是不是采集点
-bool RouteEndsWithCollectWaypoint(const std::vector<Waypoint>& path)
-{
-    for (auto it = path.rbegin(); it != path.rend(); ++it) {
-        if (!it->HasPosition()) {
-            continue;
-        }
-        return it->action == ActionType::COLLECT;
-    }
-    return false;
-}
 
 struct BootstrapWaypointCandidate
 {
@@ -481,6 +392,8 @@ NavigationStateMachine::NavigationStateMachine(
     , position_(position)
     , should_stop_(std::move(should_stop))
     , maa_context_(maa_context)
+    , collect_prompt_(kCollectPromptSpec, maa_context, session, position)
+    , interact_prompt_(kInteractPromptSpec, maa_context, session, position)
     , device_recovery_(maa_context, motion_controller, position_provider, session, position)
     , walk_mode_(action_wrapper)
 {
@@ -497,12 +410,10 @@ bool NavigationStateMachine::Run()
         return false;
     }
 
-    // Absorb the collect-OCR cold start here, while the avatar is still stopped after Bootstrap and before
-    // the first forward press, so it can never land on a while-walking scan tick and freeze the thread.
-    PreWarmCollectOcr();
+    // Pay the recognition cold start while still stopped, so it can never land on a walking tick.
+    PreWarmPromptRecognition();
 
-    // Spin up the background detectors (the collectible one is a no-op unless the route has a COLLECT
-    // waypoint). They run off the nav thread on pure OpenCV; the nav loop only reacts to their flags.
+    // Background detectors, off the nav thread on pure OpenCV; the nav loop only reacts to their flags.
     StartScanners();
 
     while (!should_stop_() && session_->phase() != NaviPhase::Finished && session_->phase() != NaviPhase::Failed) {
@@ -518,7 +429,7 @@ bool NavigationStateMachine::Run()
         session_->HasSatisfiedFinalSuccess(*position_, "navigation_complete");
     }
 
-    TryCollectAtRouteTail();
+    TryRunPromptSubtaskAtRouteTail();
 
     StopScanners();
     StopMotion();
@@ -1161,7 +1072,7 @@ bool NavigationStateMachine::TickNavigate()
     }
 
     const Waypoint waypoint = session_->CurrentWaypoint();
-    if (TryScanApproachCollect(route, waypoint)) {
+    if (TryRunPromptSubtaskWhileWalking(route)) {
         return true;
     }
 
@@ -1169,11 +1080,11 @@ bool NavigationStateMachine::TickNavigate()
     if (waypoint.action == ActionType::PORTAL) {
         arrival_distance = std::max(arrival_distance, kPortalCommitDistance);
     }
-    // 采集点判定圈收窄了, 真站不上去(硬性无进展这么久)就放回常规值, 别多出一种卡死
-    else if (waypoint.action == ActionType::COLLECT && session_->HardStalledMs(now) > kCollectArrivalRelaxMs) {
-        const double relaxed = waypoint.ArrivalBand(kMeasurementDefaultPositionQuantum, /*relax_collect=*/true);
+    // 提示驱动的点判定圈收窄了, 真站不上去(硬性无进展这么久)就放回常规值, 别多出一种卡死
+    else if (waypoint.StopsOnPromptDetection() && session_->HardStalledMs(now) > kCollectArrivalRelaxMs) {
+        const double relaxed = waypoint.ArrivalBand(kMeasurementDefaultPositionQuantum, /*relax_tight_band=*/true);
         if (relaxed > arrival_distance && route.waypoint_distance <= relaxed) {
-            LogInfo << "Collect arrival band relaxed after no progress." << VAR(session_->current_node_idx())
+            LogInfo << "Prompt-point arrival band relaxed after no progress." << VAR(session_->current_node_idx())
                     << VAR(route.waypoint_distance) << VAR(arrival_distance) << VAR(relaxed);
         }
         arrival_distance = std::max(arrival_distance, relaxed);
@@ -1615,10 +1526,9 @@ bool NavigationStateMachine::TickNavigate()
     latency::RecordStage(latency::Stage::Other, std::max<int64_t>(0, tick_compute_ms - capture_ms - steer_send_ms));
     latency::RecordTick(maa_context_, runtime_state_.flow.tick_seq, tick_gap_ms);
 
-    // Collect routes: keep sprint for travel but drop to walking speed once near a COLLECT point (cancels any
-    // active sprint), so the detection-stop can land before we overrun the collectible. No-op off collect
-    // routes. Must run before the sprint gate below so a freshly-entered zone suppresses this tick's sprint.
-    UpdateCollectSprintSuppression();
+    // Keep sprint for travel but drop to walking near a prompt-driven point (cancelling an active sprint), so the
+    // detection-stop lands before we overrun it. Must precede the sprint gate below.
+    UpdatePromptSprintSuppression();
 
     // Balanced sprint gate: burst only when the agent already points down the corridor (heading aligned)
     // and no sharp turn is imminent within the scan window. No clearance term — it reads near zero on
@@ -1729,20 +1639,24 @@ NavigationStateMachine::~NavigationStateMachine()
     StopScanners();
 }
 
+std::array<AsyncPromptAction*, 2> NavigationStateMachine::PromptActions()
+{
+    return { &collect_prompt_, &interact_prompt_ };
+}
+
 void NavigationStateMachine::StartScanners()
 {
-    StartCollectScanner();
+    StartPromptScanners();
     StartDeviceProbe();
 
     if (position_provider_ == nullptr) {
         return;
     }
-    // One observer for both consumers, bound once. Binding it per scanner would let whichever one stops first
-    // silently cut the other's frame supply.
+    // One observer for every consumer, bound once. Binding it per scanner would let whichever one stops first
+    // silently cut the others' frame supply.
     position_provider_->SetFrameObserver([this](const cv::Mat& frame) {
-        if (collect_scanner_ != nullptr) {
-            collect_scanner_->SubmitFrame(frame);
-        }
+        collect_prompt_.SubmitFrame(frame);
+        interact_prompt_.SubmitFrame(frame);
         device_recovery_.SubmitFrame(frame);
     });
 }
@@ -1755,95 +1669,71 @@ void NavigationStateMachine::StopScanners()
     if (motion_controller_ != nullptr) {
         motion_controller_->SetSprintSuppressed(false);
     }
-    collect_scanner_.reset();
+    collect_prompt_.Stop();
+    interact_prompt_.Stop();
     device_recovery_.Stop();
 }
 
-void NavigationStateMachine::StartCollectScanner()
+void NavigationStateMachine::StartPromptScanners()
 {
-    if (collect_scanner_ != nullptr) {
-        return;
-    }
+    for (AsyncPromptAction* prompt : PromptActions()) {
+        if (prompt->armed() || !prompt->RouteHasPoint()) {
+            continue;
+        }
 
-    if (!RouteHasCollectWaypoint(session_->original_path())) {
-        return;
+        cv::Rect base_roi;
+        if (!TryReadNodeRoi(maa_context_, prompt->spec().recognition_node, &base_roi)) {
+            LogWarn << "Async prompt scanner not started: could not read its ROI from the pipeline." << VAR(prompt->spec().tag)
+                    << VAR(prompt->spec().recognition_node);
+            continue;
+        }
+        prompt->Start(base_roi, action_wrapper_->controller_type());
     }
-
-    cv::Rect base_roi;
-    if (!ParseRoiFromNode(maa_context_, kCollectRoiNode, &base_roi)) {
-        LogWarn << "Async collectible scanner not started: could not read collect ROI from pipeline." << VAR(kCollectRoiNode);
-        return;
-    }
-
-    const std::filesystem::path icon_path = std::filesystem::absolute(get_exe_dir() / ".." / kCollectIconRelativePath);
-    const cv::Mat icon_template = MAA_NS::imread(icon_path, cv::IMREAD_GRAYSCALE);
-    if (icon_template.empty()) {
-        LogWarn << "Collect icon template not loaded; falling back to bright-text heuristic."
-                << VAR(MAA_NS::path_to_utf8_string(icon_path));
-    }
-    else {
-        LogInfo << "Collect icon template loaded." << VAR(MAA_NS::path_to_utf8_string(icon_path)) << VAR(icon_template.cols)
-                << VAR(icon_template.rows);
-    }
-
-    collect_scanner_ = std::make_unique<RoiTemplateScanner>("collect", base_roi, icon_template, kCollectIconMatchThreshold, true);
-    LogInfo << "Async collectible scanner started." << VAR(base_roi.x) << VAR(base_roi.y) << VAR(base_roi.width) << VAR(base_roi.height);
-    // NOTE: sprint is NOT suppressed for the whole route — that killed fast travel. Suppression is driven per
-    // tick in TickNavigate (UpdateCollectSprintSuppression), enabled only when the avatar is within
-    // kCollectSprintSuppressBandWu of a COLLECT waypoint, so travel between collect points still sprints.
 }
 
 void NavigationStateMachine::StartDeviceProbe()
 {
     cv::Rect base_roi;
-    if (!ParseRoiFromNode(maa_context_, kObstacleDeviceProbeNode, &base_roi)) {
+    if (!TryReadNodeRoi(maa_context_, kObstacleDeviceProbeNode, &base_roi)) {
         LogWarn << "Blocking-device probe not started: could not read its ROI from the pipeline." << VAR(kObstacleDeviceProbeNode);
         return;
     }
     device_recovery_.Start(base_roi);
 }
 
-// Squared distance to the nearest COLLECT point; -1 when there is no collect route or no position.
-double NavigationStateMachine::NearestCollectDistanceSq() const
+double NavigationStateMachine::NearestPromptDistanceSq() const
 {
-    if (collect_scanner_ == nullptr || session_ == nullptr || position_ == nullptr || !position_->valid) {
-        return -1.0;
-    }
-
     double nearest_sq = -1.0;
-    for (const Waypoint& waypoint : session_->current_path()) {
-        if (waypoint.action != ActionType::COLLECT || !waypoint.HasPosition()) {
-            continue;
-        }
-        const double dx = waypoint.x - position_->x;
-        const double dy = waypoint.y - position_->y;
-        const double distance_sq = dx * dx + dy * dy;
-        if (nearest_sq < 0.0 || distance_sq < nearest_sq) {
+    for (const AsyncPromptAction* prompt : { &collect_prompt_, &interact_prompt_ }) {
+        const double distance_sq = prompt->NearestDistanceSq();
+        if (distance_sq >= 0.0 && (nearest_sq < 0.0 || distance_sq < nearest_sq)) {
             nearest_sq = distance_sq;
         }
     }
     return nearest_sq;
 }
 
-void NavigationStateMachine::UpdateCollectSprintSuppression()
+void NavigationStateMachine::UpdatePromptSprintSuppression()
 {
-    if (collect_scanner_ == nullptr || motion_controller_ == nullptr) {
-        return; // not a collect route — leave sprint behaviour entirely untouched
+    if (motion_controller_ == nullptr) {
+        return;
     }
 
-    const double nearest_sq = NearestCollectDistanceSq();
-    const bool near_collect = nearest_sq >= 0.0 && nearest_sq <= kCollectSprintSuppressBandWu * kCollectSprintSuppressBandWu;
-    motion_controller_->SetSprintSuppressed(near_collect);
+    const double nearest_sq = NearestPromptDistanceSq();
+    // 这条线上没有提示驱动的点时 nearest_sq < 0, 疾跑行为一点不碰
+    const bool approaching_prompt = nearest_sq >= 0.0 && nearest_sq <= kCollectSprintSuppressBandWu * kCollectSprintSuppressBandWu;
+    motion_controller_->SetSprintSuppressed(approaching_prompt);
 }
 
-// Walk mode's only decision point: engaged on the last few units of a collect approach, released everywhere else
-// (travel legs, recovery, turn-in-place nodes, before motion is confirmed).
+// Walk mode's only decision point: engaged on the last few units of an approach to a prompt-driven point,
+// released everywhere else (travel legs, recovery, turn-in-place nodes, before motion is confirmed).
 void NavigationStateMachine::UpdateWalkMode(NaviPhase phase)
 {
-    const double nearest_sq = NearestCollectDistanceSq();
+    const double nearest_sq = NearestPromptDistanceSq();
     const bool recovering = runtime_state_.recovery.active || runtime_state_.cross_tier_escape.active;
     const ActionType action = session_->HasCurrentWaypoint() ? session_->CurrentWaypoint().action : ActionType::HEADING;
-    const bool plain_approach = action == ActionType::COLLECT || action == ActionType::RUN || action == ActionType::NAVMESH;
+    const bool plain_approach = action == ActionType::COLLECT || action == ActionType::INTERACT || action == ActionType::RUN
+                               || action == ActionType::NAVMESH;
     if (phase != NaviPhase::Navigate || nearest_sq < 0.0 || recovering || !plain_approach
         || !runtime_state_.route.startup_motion_confirmed) {
         walk_mode_.Request(false);
@@ -1855,80 +1745,94 @@ void NavigationStateMachine::UpdateWalkMode(NaviPhase phase)
     walk_mode_.Request(nearest_sq <= band * band);
     const bool walking = walk_mode_.engaged();
     if (walking != was_engaged) {
-        const double nearest_collect = std::sqrt(nearest_sq);
-        LogInfo << "Walk mode boundary crossed." << VAR(walking) << VAR(nearest_collect) << VAR(position_->x) << VAR(position_->y);
+        const double nearest_prompt_point = std::sqrt(nearest_sq);
+        LogInfo << "Walk mode boundary crossed." << VAR(walking) << VAR(nearest_prompt_point) << VAR(position_->x) << VAR(position_->y);
     }
 }
 
-void NavigationStateMachine::PreWarmCollectOcr()
+void NavigationStateMachine::PreWarmPromptRecognition()
 {
-    if (maa_context_ == nullptr) {
-        return;
+    for (AsyncPromptAction* prompt : PromptActions()) {
+        prompt->PreWarmRecognition();
     }
-
-    if (!RouteHasCollectWaypoint(session_->original_path())) {
-        return;
-    }
-
-    LogInfo << "Pre-warming collect OCR model before navigation (absorbs one-time cold start while stopped).";
-    MaaContextRunTask(maa_context_, kDefaultCollectEntry, kCollectPrewarmOverride);
 }
 
-bool NavigationStateMachine::TryScanApproachCollect(const RouteTrackingState& route, const Waypoint& waypoint)
+bool NavigationStateMachine::TryRunPromptSubtaskWhileWalking(const RouteTrackingState& route)
 {
-    (void)waypoint;
-    if (maa_context_ == nullptr || collect_scanner_ == nullptr || !route.startup_motion_confirmed) {
+    if (!route.startup_motion_confirmed) {
         return false;
     }
 
-    const auto now = std::chrono::steady_clock::now();
-    if (collect_scan_last_at_.time_since_epoch().count() != 0
-        && now - collect_scan_last_at_ < std::chrono::milliseconds(kCollectScanIntervalMs)) {
-        return false;
+    const std::array<AsyncPromptAction*, 2> prompts = PromptActions();
+    for (size_t index = 0; index < prompts.size(); ++index) {
+        if (!prompts[index]->TryTriggerWhileWalking(motion_controller_, route.waypoint_distance, session_->current_node_idx())) {
+            continue;
+        }
+        // 屏幕上一次只弹一个提示, 一次观测只值一次停车: 清掉另一类的闩, 免得同一个提示被停两次
+        for (size_t other = 0; other < prompts.size(); ++other) {
+            if (other != index) {
+                prompts[other]->ForgetDetection();
+            }
+        }
+        if (prompts[index]->spec().CompletesWaypointOnTrigger()) {
+            CompleteWaypointAfterPromptTrigger();
+        }
+        return true;
     }
-
-    if (!collect_scanner_->ConsumeDetection()) {
-        return false; // background worker has not flagged a collectible — keep walking, zero cost this tick
-    }
-
-    // No displacement gate: multi-item spots are authored as the same coordinate repeated, and the
-    // authoritative OCR only clicks known collectible names, so a stale flag costs one stutter at most.
-    collect_scan_last_at_ = now;
-
-    LogInfo << "Async collectible flagged — stopping for authoritative collect." << VAR(route.waypoint_distance)
-            << VAR(session_->current_node_idx());
-    motion_controller_->SetForwardState(false);
-    utils::SleepFor(kStopWaitMs);
-    MaaContextRunTask(maa_context_, kDefaultCollectEntry, kCollectPipelineOverride);
-    utils::SleepFor(kCollectPostSleepMs);
-    return true;
+    return false;
 }
 
-// 最后一个采集点被吃掉的同一拍路线就结束、扫描器随即销毁, 行进中的检测再没机会报第二次。
-// 收尾时停下来单独给一个窗口, 不走冷却, 只试一次。
-// 放在成功判定之后: 这里超时或采集失败都不该把跑成功的线路翻成失败。
-void NavigationStateMachine::TryCollectAtRouteTail()
+// 提示就是游戏说的「够近了」, 所以命中即算走完, 不再往前挪那几个单位: 交互一开界面角色就不动了、
+// 小地图也没了, 剩下那段永远走不完, 一次成功的交互会被拖成到达超时判败。
+void NavigationStateMachine::CompleteWaypointAfterPromptTrigger()
 {
-    if (maa_context_ == nullptr || collect_scanner_ == nullptr || should_stop_() || session_->phase() != NaviPhase::Finished
-        || !RouteEndsWithCollectWaypoint(session_->original_path())) {
+    if (!session_->HasCurrentWaypoint()) {
+        return;
+    }
+
+    const ActionType action = session_->CurrentWaypoint().action;
+    const std::optional<size_t> consumed_absolute_node_idx = session_->CurrentAbsoluteNodeIndex();
+    session_->NoteCanonicalFinalGoalConsumed(consumed_absolute_node_idx, *position_, "async_prompt_completed");
+    session_->AdvanceToNextWaypoint(action, "async_prompt_completed");
+    runtime_state_.OnWaypointAdvance();
+    if (!session_->HasCurrentWaypoint()) {
+        session_->NoteRouteTailConsumed(*position_, "route_tail_consumed");
+        return;
+    }
+    SelectPhaseForCurrentWaypoint("async_prompt_completed");
+}
+
+// 最后一个点被吃掉的同一拍路线就结束、扫描器随即销毁, 行进中的检测没机会报第二次, 所以收尾单独给一个窗口。
+// 放在成功判定之后, 这里失败不该翻掉跑成功的线路。只服务共用表那类: 点名目标的那类每个点必定恰好跑一次。
+void NavigationStateMachine::TryRunPromptSubtaskAtRouteTail()
+{
+    if (maa_context_ == nullptr || should_stop_() || session_->phase() != NaviPhase::Finished) {
+        return;
+    }
+
+    AsyncPromptAction* tail_prompt = nullptr;
+    for (AsyncPromptAction* prompt : PromptActions()) {
+        if (prompt->armed() && !prompt->spec().CompletesWaypointOnTrigger() && prompt->RouteEndsWithPoint()) {
+            tail_prompt = prompt;
+            break;
+        }
+    }
+    if (tail_prompt == nullptr) {
         return;
     }
 
     StopMotion();
-    utils::SleepFor(kStopWaitMs); // 先站定, 还在滑行就点容易白点一次
+    utils::SleepFor(kStopWaitMs); // 先站定, 还在滑行就动手容易白按一次
     const auto started_at = std::chrono::steady_clock::now();
     while (!should_stop_()) {
-        if (collect_scanner_->ConsumeDetection()) {
-            LogInfo << "Route tail collectible flagged — collecting before finishing." << VAR(session_->current_node_idx());
-            MaaContextRunTask(maa_context_, kDefaultCollectEntry, kCollectPipelineOverride);
-            utils::SleepFor(kCollectPostSleepMs);
+        if (tail_prompt->TryTriggerAtRouteTail()) {
             return;
         }
 
         const int64_t elapsed_ms =
             std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started_at).count();
         if (elapsed_ms >= kCollectTailGraceMs) {
-            LogInfo << "Route tail collect grace expired with nothing flagged." << VAR(elapsed_ms);
+            LogInfo << "Route tail prompt grace expired with nothing flagged." << VAR(tail_prompt->spec().tag) << VAR(elapsed_ms);
             return;
         }
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <array>
 #include <chrono>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
 
+#include "async_prompt_action.h"
 #include "nav_run_controller.h"
 #include "navi_controller.h"
 #include "navigation_runtime_state.h"
@@ -20,7 +22,6 @@ class IActionExecutor;
 class ActionWrapper;
 class MotionController;
 class PositionProvider;
-class RoiTemplateScanner;
 struct RouteTrackingState;
 
 class NavigationStateMachine
@@ -69,15 +70,18 @@ private:
     void StopMotion();
     bool FailNavigation(const char* reason, const char* log_message, double current_distance, double yaw_error, int64_t stalled_ms);
 
-    bool TryScanApproachCollect(const RouteTrackingState& route, const Waypoint& waypoint);
-    void TryCollectAtRouteTail();
-    void PreWarmCollectOcr();
+    std::array<AsyncPromptAction*, 2> PromptActions();
+    bool TryRunPromptSubtaskWhileWalking(const RouteTrackingState& route);
+    void CompleteWaypointAfterPromptTrigger();
+    void TryRunPromptSubtaskAtRouteTail();
+    void PreWarmPromptRecognition();
     void StartScanners();
     void StopScanners();
-    void StartCollectScanner();
+    void StartPromptScanners();
     void StartDeviceProbe();
-    void UpdateCollectSprintSuppression();
-    double NearestCollectDistanceSq() const;
+    void UpdatePromptSprintSuppression();
+    // Squared distance to the nearest prompt-driven point; -1 when the route has none or the agent is unlocalized.
+    double NearestPromptDistanceSq() const;
     void UpdateWalkMode(NaviPhase phase);
 
     const NaviParam& param_;
@@ -93,8 +97,9 @@ private:
     NavRunController nav_run_controller_ {};
     std::chrono::steady_clock::time_point last_global_relocalize_at_ {};
 
-    std::unique_ptr<RoiTemplateScanner> collect_scanner_;
-    std::chrono::steady_clock::time_point collect_scan_last_at_ {};
+    // Two instances of one flow; they differ only in the pipeline node names and who supplies the text.
+    AsyncPromptAction collect_prompt_;
+    AsyncPromptAction interact_prompt_;
 
     ObstacleDeviceRecovery device_recovery_;
     // Declared last so its destructor runs first — restores jogging while its collaborators are still alive.

--- a/agent/cpp-algo/source/MapNavigator/obstacle_device_recovery.cpp
+++ b/agent/cpp-algo/source/MapNavigator/obstacle_device_recovery.cpp
@@ -45,14 +45,12 @@ void ObstacleDeviceRecovery::Start(const cv::Rect& base_roi)
     const std::filesystem::path template_path = std::filesystem::absolute(get_exe_dir() / ".." / kObstacleDeviceTemplateRelativePath);
     const cv::Mat button_template = MAA_NS::imread(template_path, cv::IMREAD_GRAYSCALE);
     if (button_template.empty()) {
-        // No text fallback here: a bright blob says nothing about whether an interact button is on screen, and
-        // a false positive costs a subtask run in the middle of a stall.
         LogWarn << "Blocking-device probe not started: interact button template not loaded."
                 << VAR(MAA_NS::path_to_utf8_string(template_path));
         return;
     }
 
-    scanner_ = std::make_unique<RoiTemplateScanner>("device", base_roi, button_template, kObstacleDeviceMatchThreshold, false);
+    scanner_ = std::make_unique<RoiTemplateScanner>("device", base_roi, button_template, cv::Mat(), kObstacleDeviceMatchThreshold);
     LogInfo << "Blocking-device probe started." << VAR(base_roi.x) << VAR(base_roi.y) << VAR(base_roi.width) << VAR(base_roi.height);
 }
 

--- a/agent/cpp-algo/source/MapNavigator/prompt_scan_profile.cpp
+++ b/agent/cpp-algo/source/MapNavigator/prompt_scan_profile.cpp
@@ -1,0 +1,304 @@
+#include "prompt_scan_profile.h"
+
+#include <cmath>
+#include <filesystem>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include <MaaFramework/MaaAPI.h>
+#include <MaaUtils/ImageIo.h>
+#include <MaaUtils/Logger.h>
+#include <meojson/json.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include "controller_type_utils.h"
+#include "navi_config.h"
+
+#include "../utils.h"
+
+namespace mapnavigator
+{
+
+namespace
+{
+
+// purpose == nullptr 时一声不出: 存在性探测本来就允许没有这个节点。
+std::optional<json::object> ReadNodeObject(MaaContext* context, const std::string& node_name, const char* purpose)
+{
+    if (context == nullptr || node_name.empty()) {
+        return std::nullopt;
+    }
+
+    ScopedStringBuffer buffer;
+    if (buffer.Get() == nullptr || !MaaContextGetNodeData(context, node_name.c_str(), buffer.Get())) {
+        if (purpose != nullptr) {
+            LogWarn << purpose << ": MaaContextGetNodeData failed." << VAR(node_name);
+        }
+        return std::nullopt;
+    }
+    const char* raw = MaaStringBufferGet(buffer.Get());
+    if (raw == nullptr || raw[0] == '\0') {
+        if (purpose != nullptr) {
+            LogWarn << purpose << ": empty node data." << VAR(node_name);
+        }
+        return std::nullopt;
+    }
+
+    const auto parsed = json::parse(raw);
+    if (!parsed || !parsed->is_object()) {
+        if (purpose != nullptr) {
+            LogWarn << purpose << ": node JSON is not an object." << VAR(node_name);
+        }
+        return std::nullopt;
+    }
+    return parsed->as_object();
+}
+
+// 框架回吐的节点恒为 { "recognition": { "type": ..., "param": { ... } } }, 不接受别的形状。
+const json::object* RecognitionParam(const json::object& node)
+{
+    if (!node.contains("recognition") || !node.at("recognition").is_object()) {
+        return nullptr;
+    }
+    const auto& reco = node.at("recognition").as_object();
+    if (!reco.contains("param") || !reco.at("param").is_object()) {
+        return nullptr;
+    }
+    return &reco.at("param").as_object();
+}
+
+const json::value* FindRecognitionParam(const json::object& node, const char* key)
+{
+    const json::object* param = RecognitionParam(node);
+    return param != nullptr && param->contains(key) ? &param->at(key) : nullptr;
+}
+
+std::string ReadRecognitionType(const json::object& node)
+{
+    if (!node.contains("recognition") || !node.at("recognition").is_object()) {
+        return {};
+    }
+    const auto& reco = node.at("recognition").as_object();
+    return reco.contains("type") && reco.at("type").is_string() ? reco.at("type").as_string() : std::string {};
+}
+
+bool ReadRoiArray(const json::value& holder, cv::Rect* out)
+{
+    if (!holder.is_array()) {
+        return false;
+    }
+    const auto& arr = holder.as_array();
+    if (arr.size() < 4) {
+        return false;
+    }
+    for (size_t i = 0; i < 4; ++i) {
+        if (!arr.at(i).is_number()) {
+            return false;
+        }
+    }
+    out->x = static_cast<int>(std::lround(arr.at(0).as_double()));
+    out->y = static_cast<int>(std::lround(arr.at(1).as_double()));
+    out->width = static_cast<int>(std::lround(arr.at(2).as_double()));
+    out->height = static_cast<int>(std::lround(arr.at(3).as_double()));
+    return out->width > 0 && out->height > 0;
+}
+
+// 作者可以写单值, 但框架回吐时 template 与 threshold 恒为数组。预筛只跑一张图, 多给的当写错处理。
+bool ReadSingleString(const json::value& holder, std::string* out)
+{
+    if (!holder.is_array() || holder.as_array().size() != 1 || !holder.as_array().at(0).is_string()) {
+        return false;
+    }
+    *out = holder.as_array().at(0).as_string();
+    return true;
+}
+
+bool ReadBool(const json::value& holder, bool* out)
+{
+    if (!holder.is_boolean()) {
+        return false;
+    }
+    *out = holder.as_boolean();
+    return true;
+}
+
+bool ReadSingleNumber(const json::value& holder, double* out)
+{
+    if (!holder.is_array() || holder.as_array().size() != 1 || !holder.as_array().at(0).is_number()) {
+        return false;
+    }
+    *out = holder.as_array().at(0).as_double();
+    return true;
+}
+
+// 框架先加载 ./resource, 再把控制器自己的 overlay 叠上去, 所以 overlay 里的同名图会胜出; 这里照同一个
+// 顺序找, 基础资源永远排最后。云游戏与本地 ADB 在控制器类型上无法区分, 所以 resource_cloud_adb 不参与。
+std::vector<std::filesystem::path> ResourceImageRoots(std::string_view controller_type)
+{
+    const std::filesystem::path install_dir = std::filesystem::absolute(get_exe_dir() / "..");
+
+    std::vector<std::string> dirs;
+    if (IsPlayCoverControllerType(controller_type)) {
+        dirs.emplace_back("resource_playcover");
+        dirs.emplace_back("resource_adb");
+    }
+    else if (IsAdbLikeControllerType(controller_type)) {
+        dirs.emplace_back("resource_adb");
+    }
+    else if (IsWlrootsLikeControllerType(controller_type)) {
+        dirs.emplace_back("resource_wlroots");
+    }
+    else if (EqualsIgnoreCase(controller_type, "macos")) {
+        dirs.emplace_back("resource_macos");
+    }
+    dirs.emplace_back("resource");
+
+    std::vector<std::filesystem::path> roots;
+    roots.reserve(dirs.size());
+    for (const std::string& dir : dirs) {
+        roots.push_back(install_dir / dir / "image");
+    }
+    return roots;
+}
+
+std::string DescribeRoots(const std::vector<std::filesystem::path>& roots)
+{
+    std::string text;
+    for (const std::filesystem::path& root : roots) {
+        if (!text.empty()) {
+            text += " | ";
+        }
+        text += MAA_NS::path_to_utf8_string(root);
+    }
+    return text;
+}
+
+} // namespace
+
+bool TryReadNodeRoi(MaaContext* context, const std::string& node_name, cv::Rect* out)
+{
+    const auto node = ReadNodeObject(context, node_name, "Pipeline ROI");
+    if (!node) {
+        return false;
+    }
+
+    const json::value* roi = FindRecognitionParam(*node, "roi");
+    if (roi == nullptr || !ReadRoiArray(*roi, out)) {
+        LogWarn << "Pipeline ROI: no usable roi array in node data." << VAR(node_name);
+        return false;
+    }
+    return true;
+}
+
+bool TryLoadPromptScanProfile(
+    MaaContext* context,
+    const std::string& scan_node,
+    std::string_view controller_type,
+    PromptScanProfile* out)
+{
+    const auto node = ReadNodeObject(context, scan_node, "Prompt scan node");
+    if (!node) {
+        return false;
+    }
+
+    const std::string type = ReadRecognitionType(*node);
+    if (!EqualsIgnoreCase(type, "TemplateMatch")) {
+        LogError << "Prompt scan node must recognize by TemplateMatch." << VAR(scan_node) << VAR(type);
+        return false;
+    }
+
+    cv::Rect base_roi;
+    const json::value* roi_value = FindRecognitionParam(*node, "roi");
+    if (roi_value == nullptr || !ReadRoiArray(*roi_value, &base_roi)) {
+        LogError << "Prompt scan node has no usable roi array." << VAR(scan_node);
+        return false;
+    }
+    // 相对上一个节点的偏移 ROI 在这里没有参照物: 预筛每帧独立跑, 只收基础帧里的绝对坐标。
+    if (base_roi.x < 0 || base_roi.y < 0 || base_roi.x + base_roi.width > kPipelineRoiBaseWidth
+        || base_roi.y + base_roi.height > kPipelineRoiBaseHeight) {
+        LogError << "Prompt scan roi must be absolute and inside the authored base frame." << VAR(scan_node) << VAR(base_roi.x)
+                 << VAR(base_roi.y) << VAR(base_roi.width) << VAR(base_roi.height);
+        return false;
+    }
+
+    std::string relative_path;
+    const json::value* template_value = FindRecognitionParam(*node, "template");
+    if (template_value == nullptr || !ReadSingleString(*template_value, &relative_path) || relative_path.empty()) {
+        LogError << "Prompt scan node needs exactly one template path." << VAR(scan_node);
+        return false;
+    }
+
+    double threshold = kPromptIconMatchThreshold;
+    const json::value* threshold_value = FindRecognitionParam(*node, "threshold");
+    if (threshold_value != nullptr && !ReadSingleNumber(*threshold_value, &threshold)) {
+        LogError << "Prompt scan node needs exactly one threshold." << VAR(scan_node);
+        return false;
+    }
+    if (threshold <= 0.0 || threshold > 1.0) {
+        LogError << "Prompt scan threshold must sit in (0, 1]." << VAR(scan_node) << VAR(threshold);
+        return false;
+    }
+
+    const std::vector<std::filesystem::path> roots = ResourceImageRoots(controller_type);
+    std::filesystem::path resolved;
+    for (const std::filesystem::path& root : roots) {
+        const std::filesystem::path candidate = root / relative_path;
+        if (std::filesystem::exists(candidate)) {
+            resolved = candidate;
+            break;
+        }
+    }
+    if (resolved.empty()) {
+        LogError << "Prompt scan template not found under any loaded resource tree." << VAR(scan_node) << VAR(relative_path)
+                 << VAR(DescribeRoots(roots));
+        return false;
+    }
+
+    bool green_mask = false;
+    const json::value* green_mask_value = FindRecognitionParam(*node, "green_mask");
+    if (green_mask_value != nullptr && !ReadBool(*green_mask_value, &green_mask)) {
+        LogError << "Prompt scan green_mask must be a boolean." << VAR(scan_node);
+        return false;
+    }
+
+    // 纯绿被排除在匹配之外, 与 pipeline 的 TemplateMatch 同判据; 全不透明时按没有掩码处理。
+    cv::Mat mask;
+    cv::Mat templ;
+    if (green_mask) {
+        const cv::Mat color = MAA_NS::imread(resolved, cv::IMREAD_COLOR);
+        if (!color.empty()) {
+            cv::inRange(color, cv::Scalar(0, 255, 0), cv::Scalar(0, 255, 0), mask);
+            mask = ~mask;
+            if (cv::countNonZero(mask) == mask.rows * mask.cols) {
+                mask.release();
+            }
+            cv::cvtColor(color, templ, cv::COLOR_BGR2GRAY);
+        }
+    }
+    else {
+        templ = MAA_NS::imread(resolved, cv::IMREAD_GRAYSCALE);
+    }
+    if (templ.empty()) {
+        LogError << "Prompt scan template failed to decode." << VAR(scan_node) << VAR(MAA_NS::path_to_utf8_string(resolved));
+        return false;
+    }
+    // cv::matchTemplate 的硬前提。这里不放过, 后台线程每帧都会踩上去; 而 cpp-algo 不留 try/catch。
+    if (templ.cols > base_roi.width || templ.rows > base_roi.height) {
+        LogError << "Prompt scan template is larger than its roi." << VAR(scan_node) << VAR(templ.cols) << VAR(templ.rows)
+                 << VAR(base_roi.width) << VAR(base_roi.height);
+        return false;
+    }
+
+    out->scan_node = scan_node;
+    out->base_roi = base_roi;
+    out->templ = templ;
+    out->mask = mask;
+    out->threshold = threshold;
+    LogInfo << "Prompt scan profile loaded from the pipeline." << VAR(scan_node) << VAR(MAA_NS::path_to_utf8_string(resolved))
+            << VAR(threshold) << VAR(green_mask) << VAR(base_roi.x) << VAR(base_roi.y) << VAR(base_roi.width)
+            << VAR(base_roi.height);
+    return true;
+}
+
+} // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/prompt_scan_profile.h
+++ b/agent/cpp-algo/source/MapNavigator/prompt_scan_profile.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include <opencv2/core.hpp>
+
+struct MaaContext;
+
+namespace mapnavigator
+{
+
+// What one walking pre-filter looks at. Authored as an ordinary TemplateMatch node so the pipeline stays the
+// single source of truth for the scan region, the icon and how strict the match is, and so a platform overlay
+// retargets it for free. A route names the node; nothing here is a route-level number.
+struct PromptScanProfile
+{
+    std::string scan_node;            // node it was read from; empty = the shipped default
+    cv::Rect base_roi {};             // in the authored base frame
+    cv::Mat templ;                    // grayscale, base scale
+    cv::Mat mask;                     // CV_8UC1 match mask; empty = match the whole template
+    double threshold = 0.0;
+};
+
+// Scan ROI of any node, read out of the pipeline rather than hardcoded, so editing that node retargets whoever
+// reads it. Authored in the base frame.
+bool TryReadNodeRoi(MaaContext* context, const std::string& node_name, cv::Rect* out);
+
+// Reads roi / template / threshold out of one TemplateMatch node and loads the template off disk; nothing else in
+// the node is read. Every precondition the matcher and the scanner have is checked here, so a mis-authored node
+// costs one error line and no pre-filter instead of misbehaving at walking speed.
+// controller_type picks which resource overlay the template path resolves against; the caller already holds it.
+bool TryLoadPromptScanProfile(
+    MaaContext* context,
+    const std::string& scan_node,
+    std::string_view controller_type,
+    PromptScanProfile* out);
+
+} // namespace mapnavigator

--- a/agent/cpp-algo/source/MapNavigator/roi_template_scanner.cpp
+++ b/agent/cpp-algo/source/MapNavigator/roi_template_scanner.cpp
@@ -1,6 +1,7 @@
 #include "roi_template_scanner.h"
 
 #include <cmath>
+#include <limits>
 #include <utility>
 
 #include <opencv2/imgproc.hpp>
@@ -28,8 +29,8 @@ cv::Rect ScaledRoi(const cv::Size& frame_size, const cv::Rect& base_roi)
     return roi & cv::Rect(0, 0, frame_size.width, frame_size.height);
 }
 
-// Collapse a BGRA/BGR/gray ROI to one channel, shared by both detectors. Lives here (not utils.h) so this
-// framework-free worker TU doesn't pull in the framework headers utils.h includes.
+// Collapse a BGRA/BGR/gray ROI to one channel. Lives here (not utils.h) so this framework-free worker TU
+// doesn't pull in the framework headers utils.h includes.
 cv::Mat ToGray(const cv::Mat& roi)
 {
     cv::Mat gray;
@@ -47,61 +48,25 @@ cv::Mat ToGray(const cv::Mat& roi)
     return gray;
 }
 
-// Fallback detector: threshold bright pixels, close horizontally so a word's glyphs merge into one blob, then
-// look for a connected component shaped like a short, wide, sparse text run. Input is already grayscale.
-bool HasLabelLikeText(const cv::Mat& gray, const std::string& tag)
-{
-    if (gray.empty()) {
-        return false;
-    }
-
-    cv::Mat bright;
-    cv::threshold(gray, bright, kCollectLabelBrightThreshold, 255, cv::THRESH_BINARY);
-
-    cv::Mat joined;
-    const cv::Mat kernel = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(kCollectLabelMorphWidth, 1));
-    cv::morphologyEx(bright, joined, cv::MORPH_CLOSE, kernel);
-
-    cv::Mat labels;
-    cv::Mat stats;
-    cv::Mat centroids;
-    const int n = cv::connectedComponentsWithStats(joined, labels, stats, centroids, 8, CV_32S);
-
-    int best_w = 0;
-    for (int i = 1; i < n; ++i) { // 0 is the background component
-        const int w = stats.at<int>(i, cv::CC_STAT_WIDTH);
-        const int h = stats.at<int>(i, cv::CC_STAT_HEIGHT);
-        const int area = stats.at<int>(i, cv::CC_STAT_AREA);
-        if (h < kCollectLabelMinHeight || h > kCollectLabelMaxHeight) {
-            continue; // too thin to be a glyph row, or too tall to be one
-        }
-        const double fill = static_cast<double>(area) / (static_cast<double>(w) * static_cast<double>(h));
-        if (fill > kCollectLabelMaxFill) {
-            continue; // a near-solid block is a panel/icon, not sparse text
-        }
-        if (w > best_w) {
-            best_w = w;
-        }
-    }
-
-    if (best_w > 0) {
-        LogDebug << "RoiTemplateScanner text candidate." << VAR(tag) << VAR(best_w);
-    }
-    return best_w >= kCollectLabelMinWidth;
-}
-
-// Primary detector. Template and ROI share base scale, so it matches at native size (no rescale); a glyph is
-// far harder for terrain to fake than a bright blob. Already gray.
-bool MatchesTemplate(const cv::Mat& gray, const cv::Mat& templ, double threshold, const std::string& tag)
+// Template and ROI share base scale, so it matches at native size (no rescale). Already gray.
+bool MatchesTemplate(const cv::Mat& gray, const cv::Mat& templ, const cv::Mat& mask, double threshold, const std::string& tag)
 {
     if (gray.empty() || templ.empty() || gray.rows < templ.rows || gray.cols < templ.cols) {
         return false;
     }
 
     cv::Mat result;
-    cv::matchTemplate(gray, templ, result, cv::TM_CCOEFF_NORMED);
+    cv::matchTemplate(gray, templ, result, cv::TM_CCOEFF_NORMED, mask);
+
+    // Masked normalized correlation has no divide-by-zero guard: a flat window yields inf/nan, and inf would top the
+    // score. With every cell rejected minMaxLoc hands back 0, which is below any threshold.
+    cv::Mat finite;
+    if (!mask.empty()) {
+        constexpr double kFloatLimit = static_cast<double>(std::numeric_limits<float>::max());
+        cv::inRange(result, -kFloatLimit, kFloatLimit, finite);
+    }
     double max_val = 0.0;
-    cv::minMaxLoc(result, nullptr, &max_val, nullptr, nullptr);
+    cv::minMaxLoc(result, nullptr, &max_val, nullptr, nullptr, finite);
     if (max_val >= 0.5) { // log near matches to calibrate the threshold without flooding
         LogDebug << "RoiTemplateScanner template match." << VAR(tag) << VAR(max_val);
     }
@@ -114,13 +79,13 @@ RoiTemplateScanner::RoiTemplateScanner(
     std::string tag,
     const cv::Rect& base_roi,
     const cv::Mat& templ,
-    double match_threshold,
-    bool allow_text_fallback)
+    const cv::Mat& mask,
+    double match_threshold)
     : tag_(std::move(tag))
     , base_roi_(base_roi)
     , template_(templ)
+    , mask_(mask)
     , match_threshold_(match_threshold)
-    , allow_text_fallback_(allow_text_fallback)
 {
     worker_ = std::thread(&RoiTemplateScanner::WorkerLoop, this);
 }
@@ -181,15 +146,7 @@ void RoiTemplateScanner::WorkerLoop()
             cv::resize(roi, normalized, base_roi_.size(), 0, 0, cv::INTER_AREA);
         }
 
-        const cv::Mat gray = ToGray(normalized);
-        bool hit = false;
-        if (!template_.empty()) {
-            hit = MatchesTemplate(gray, template_, match_threshold_, tag_);
-        }
-        else if (allow_text_fallback_) {
-            hit = HasLabelLikeText(gray, tag_);
-        }
-        if (hit) {
+        if (MatchesTemplate(ToGray(normalized), template_, mask_, match_threshold_, tag_)) {
             detected_.store(true);
         }
     }

--- a/agent/cpp-algo/source/MapNavigator/roi_template_scanner.h
+++ b/agent/cpp-algo/source/MapNavigator/roi_template_scanner.h
@@ -19,9 +19,9 @@ class RoiTemplateScanner
 public:
     // base_roi: scan region in the pipeline's authored base resolution (not live-frame). Frames are cropped to
     // the rescaled region and normalized back to base_roi's size, so detection runs in one resolution-
-    // independent pixel space. templ: grayscale, base scale. allow_text_fallback lets a caller whose template
-    // failed to load drop to the bright-text-blob heuristic instead of detecting nothing at all.
-    RoiTemplateScanner(std::string tag, const cv::Rect& base_roi, const cv::Mat& templ, double match_threshold, bool allow_text_fallback);
+    // independent pixel space. templ: grayscale, base scale, never empty. mask: CV_8UC1 the size of templ,
+    // empty to match the whole template.
+    RoiTemplateScanner(std::string tag, const cv::Rect& base_roi, const cv::Mat& templ, const cv::Mat& mask, double match_threshold);
     ~RoiTemplateScanner();
 
     RoiTemplateScanner(const RoiTemplateScanner&) = delete;
@@ -40,9 +40,9 @@ private:
 
     std::string tag_;
     cv::Rect base_roi_;
-    cv::Mat template_; // grayscale; empty → the text heuristic if allowed, otherwise nothing is ever flagged
+    cv::Mat template_; // grayscale, base scale
+    cv::Mat mask_;     // empty = whole template
     double match_threshold_;
-    bool allow_text_fallback_;
     std::thread worker_;
     std::mutex mutex_;
     std::condition_variable cv_;

--- a/agent/cpp-algo/source/MapNavigator/semantic_nodes.cpp
+++ b/agent/cpp-algo/source/MapNavigator/semantic_nodes.cpp
@@ -9,6 +9,7 @@
 #include <MaaUtils/Logger.h>
 
 #include "action_wrapper.h"
+#include "async_prompt_action.h"
 #include "motion_controller.h"
 #include "navi_config.h"
 #include "navi_math.h"
@@ -569,6 +570,32 @@ Result HandleArrivalSemantic(const Context& ctx, const Waypoint& waypoint, doubl
         }
         else {
             SelectPhaseForCurrentWaypoint(ctx, "dig_completed");
+        }
+
+        result.consumed = true;
+        result.stay_in_current_tick = true;
+        return result;
+    }
+
+    // Fallback once the point is reached: run the same authoritative subtask the walking detector would. No prompt
+    // means there is nothing to interact with here, so the route advances anyway rather than failing.
+    if (waypoint.IsAsyncInteract() && ctx.maa_context != nullptr) {
+        StopMotionAndCommitment(ctx);
+
+        LogInfo << "Action: INTERACT reached, running the authoritative recognition." << VAR(actual_distance)
+                << VAR(waypoint.interact_text.size()) << VAR(waypoint.interact_scan);
+        RunPromptSubtask(ctx.maa_context, kInteractPromptSpec, &waypoint.interact_text);
+
+        ctx.session->NoteCanonicalFinalGoalConsumed(arrived_absolute_node_idx, *ctx.position, "async_interact_completed");
+        ctx.session->AdvanceToNextWaypoint(waypoint.action, "async_interact_completed");
+        ctx.runtime_state->OnWaypointAdvance();
+        ctx.runtime_state->route.Reset();
+
+        if (!ctx.session->HasCurrentWaypoint()) {
+            ctx.session->NoteRouteTailConsumed(*ctx.position, "route_tail_consumed");
+        }
+        else {
+            SelectPhaseForCurrentWaypoint(ctx, "async_interact_completed");
         }
 
         result.consumed = true;

--- a/assets/resource/pipeline/MapNavigator/Interact.json
+++ b/assets/resource/pipeline/MapNavigator/Interact.json
@@ -1,0 +1,67 @@
+{
+    "MapNavigatorInteractStart": {
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "MapNavigatorInteract",
+            "MapNavigatorInteractEnd"
+        ]
+    },
+    "MapNavigatorInteract": {
+        "desc": "异步交互：只对路线点明的交互提示动手",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    755,
+                    330,
+                    297,
+                    312
+                ],
+                // 由路线点上的 interact_text 注入替换。留着这个占位是为了没注入时谁都对不上，不会误按。
+                "expected": [
+                    "__MapNavigatorInteractTextNotInjected__"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "action": "ClickKey",
+        "key": 70, // F 交互；可通过全局设置 KeymapInteract 改绑
+        "post_delay": 0,
+        "next": [
+            "MapNavigatorInteractEnd"
+        ],
+        "focus": {
+            "Node.Recognition.Succeeded": "识别到交互提示",
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    //子任务出口：由 MapNavigator 以 MaaContextRunTask 调起，跑到这里就结束、返回引擎
+    "MapNavigatorInteractEnd": {
+        "pre_delay": 0,
+        "post_delay": 0
+    },
+    // 行进中的预筛：只决定要不要停车，停下后由上面的节点按路线给的文字再认一次才动手，所以 threshold 可以松。
+    // MapNavigator 直接读这里的 roi/template/threshold，不派发这个节点。提示长得不一样的业务照这个抄一份，
+    // 在路线点上写 interact_scan 点名自己那份即可。roi 写 1280x720 基准帧的绝对坐标。
+    "MapNavigatorInteractScan": {
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    755,
+                    330,
+                    297,
+                    312
+                ],
+                "template": "RealTimeTask/AutoPick.png",
+                "threshold": 0.75
+            }
+        }
+    }
+}

--- a/assets/resource_adb/pipeline/MapNavigator/Interact.json
+++ b/assets/resource_adb/pipeline/MapNavigator/Interact.json
@@ -1,0 +1,11 @@
+{
+    // 触屏没有 F 键，改点识别到的提示本身；roi 与 expected 沿用主资源
+    "MapNavigatorInteract": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "AutoAltClickAction"
+            }
+        }
+    }
+}

--- a/assets/resource_macos/pipeline/MacOSKeyMap.json
+++ b/assets/resource_macos/pipeline/MacOSKeyMap.json
@@ -170,6 +170,14 @@
             }
         }
     },
+    "MapNavigatorInteract": {
+        "action": {
+            "type": "ClickKey",
+            "param": {
+                "key": 3
+            }
+        }
+    },
     "MapTrackerOpenWorld_GetOffZipline": {
         "action": {
             "type": "ClickKey",

--- a/assets/tasks/setting/Keymap.json
+++ b/assets/tasks/setting/Keymap.json
@@ -49,6 +49,9 @@
                 "AutoCollectClick": {
                     "key": "{KeymapInteract.primary}"
                 },
+                "MapNavigatorInteract": {
+                    "key": "{KeymapInteract.primary}"
+                },
                 "AutoPickFalls": {
                     "key": "{KeymapInteract.primary}"
                 },

--- a/docs/en_us/developers/components/map-navigator.md
+++ b/docs/en_us/developers/components/map-navigator.md
@@ -97,6 +97,8 @@ Controls the character to move automatically along a given path and execute addi
 - `map_name`: String, empty by default. Used as the initial area context. If the `path` already contains a `ZONE` declaration node, this usually does not need to be filled additionally.
 - `arrival_timeout`: Positive integer, `60000` by default. Maximum allowed time in milliseconds for a single target point to remain unreached before being considered failed.
 - `sprint_threshold`: Positive real number, `25.0` by default. The "length of continuously runnable segment ahead" threshold used for automatic sprint judgment, rather than just looking at the straight-line distance to the current point.
+- `interact_text`: String or array of strings, empty by default. Route-wide default for the interact prompt text, see [Async Interaction](#async-interaction-interact). The field also supports camelCase `interactText`; text written on a waypoint wins, and the route-wide value only fills in the `INTERACT` points that carry none of their own. An empty string or an empty array is rejected outright (the whole parameter parse fails) rather than treated as absent, because empty text matches anything on the recognition side.
+- `interact_scan`: String, empty by default. Route-wide default for the walking pre-filter node, see [Replacing the Icon Pre-filter](#replacing-the-icon-pre-filter). The field also supports camelCase `interactScan`; a node named on a waypoint wins, and an empty string counts as absent (falling back to the shipped one).
 - Other unknown top-level fields: Currently ignored silently without causing errors.
 
 #### `path` Data Structure
@@ -141,11 +143,26 @@ When a coordinate was authored directly on a tier basemap, use the object form t
 
 `target_tier` only describes the coordinate frame of this node. It does not switch zones, update following nodes, or replace the `ZONE` / `PORTAL` semantics required for an actual area transition. Existing arrays and object points without `target_tier` retain their previous behavior.
 
+The object form is also how an `INTERACT` point declares the prompt text it came for (and, when needed, `interact_scan`). The array form `[x, y, "INTERACT"]` has no slot for these fields, so async interaction requires the object form:
+
+```json
+{
+    "action": "INTERACT",
+    "target": [
+        331,
+        1578
+    ],
+    "interact_text": "登记"
+}
+```
+
+Only `INTERACT` points can take these fields — on any other action they are ignored, with one `carries interact fields without an INTERACT action` line in the log.
+
 - `RUN`: Ordinary movement point.
 - `SPRINT`: Perform a sprint once upon arrival.
 - `JUMP`: Jump upon arrival.
 - `FIGHT`: Attack once upon arrival.
-- `INTERACT`: Interact upon arrival.
+- `INTERACT`: Interact upon arrival. With `interact_text` it becomes an async interaction instead, see [Async Interaction](#async-interaction-interact).
 - `TRANSFER`: Stop upon arrival, wait for external force to move the character to the next path segment, then continue navigation from subsequent points.
 - `PORTAL`: Cross-area transition point, upon triggering, enter blind walk to wait for area switch.
 - `HEADING`: Adjust the camera to a specified orientation, then press `W` once.
@@ -491,7 +508,7 @@ Non-coordinate control nodes like `HEADING` are not part of this GUI action chai
 
 Usually, the only fine-tuning you really need to do is:
 
-1. Change key interaction points to `INTERACT` and check `Strict` (points recorded with the X key are already strict arrival by default).
+1. Change key interaction points to `INTERACT` and check `Strict` (points recorded with the X key are already strict arrival by default). When the prompt text has to be confirmed before pressing, add `interact_text` to that point after exporting — see [Async Interaction](#async-interaction-interact).
 2. Change points that require jumping, sprinting, external teleportation, or map transitions to the corresponding action (e.g., `JUMP` / `SPRINT` / `TRANSFER` / `PORTAL`).
 3. Check whether the two points before and after an area transition fall in reasonable locations.
 
@@ -621,3 +638,151 @@ For all `COLLECT`, `DIG`, and strict arrival points, the sprint on the entire pr
 2. Use the MapNavigator tool to record the path. In the GUI, change the action of the collection target points to `Collect` or `Dig`, copy the `path`, and paste it into the `custom_action_param.path` of the `Goto` node.
 3. Register the new route entry in `interface.json` / the task entry JSON.
 4. No changes are needed to `AutoCollectClick.json`, `AutoCollectDig.json`, or any cpp-algo source files.
+
+---
+
+## Async Interaction INTERACT
+
+### Concept
+
+`INTERACT` carries two meanings, decided by whether the waypoint has `interact_text`:
+
+- **Without it**: press the interact key once upon arrival. This is the historical behavior; existing routes are unaffected.
+- **With it**: the point becomes an **async interaction**. On the last stretch toward that point, a background pre-filter watches for the interact prompt; when the prompt shows up the navigator stops and hands over to a Pipeline subtask, which OCRs the prompt and presses the interact key only when the text matches `interact_text`. The prompt showing up is the game's own confirmation that the character is in range, so that press completes the point — the little distance left is not walked.
+
+The reason the route has to supply the text: there are far too many kinds of interactable, and the prompt wording differs per business, so no single shared table can enumerate them. Collectible names *are* a shared table, which is why `COLLECT` keeps its text in the Pipeline node; interact text has to be injected by whichever route uses it.
+
+What a route may customize is those two recognitions — when to stop, and whether this is the one:
+
+| Field | Replaces | Left out |
+| --------------- | ----------------------------------------------------------- | ----------------------------------------------- |
+| `interact_scan` | The icon pre-filter that decides **when to stop** while walking | The shipped one, looking for the default icon |
+| `interact_text` | The OCR text that decides **whether this is it** once stopped | The point is not async; it interacts on arrival |
+
+**The action is not customizable — it is always the interact key** (F on Windows, a key code on macOS, a tap on the recognized prompt on touch controllers). Everything past the UI the interaction opens belongs to the outer Pipeline; navigation returns once the point is done. See [Replacing the Icon Pre-filter](#replacing-the-icon-pre-filter).
+
+### Writing Method
+
+Write the interaction point in the object form and add `interact_text`:
+
+```json
+"path": [
+    { "action": "ZONE", "zone_id": "Wuling_Base" },
+    [405, 1592],
+    { "action": "INTERACT", "target": [331, 1578], "interact_text": "登记" }
+]
+```
+
+- `interact_text` accepts a string or an array of strings; any one of them matching is enough to press.
+- The text is matched against the OCR result as a **regular expression**, the same semantics as Pipeline's `expected`. Copy the in-game wording as-is; escape regex metacharacters yourself if the wording contains any.
+- When a whole route belongs to one business, put `interact_text` at the top level of `custom_action_param` as the default, see [Node Parameters](#node-parameters).
+- A single route may mix interaction points from several businesses, and mix them with `COLLECT` / `DIG`, in any number.
+- **No trailing `true` is needed**: `INTERACT` is already handled with strict arrival semantics.
+
+In the GUI: walk up to the interactable normally while recording, change that point's action to `INTERACT` after stopping, then add `interact_text` to it by hand after exporting the `path` (the editor does not emit this field yet).
+
+### Writing Text That Survives OCR
+
+OCR is not always reliable, which is why this field is **a set of** regular expressions rather than one literal line. List every variant:
+
+```json
+{
+    "action": "INTERACT",
+    "target": [331, 1578],
+    "interact_text": [
+        "^登记$", // anchored short verb, so other words in the ROI cannot latch on
+        "^登記$", // traditional
+        "(?i)^Register$", // (?i) ignores case
+        "(?i)^Sign\\s*In$" // \\s* absorbs spaces OCR splits in
+    ]
+}
+```
+
+Rules of thumb:
+
+- **Anchor first.** Matching is "contains", not whole-string equality, so for a short verb prompt like 登记 write `^登记$`; an unanchored `登记` matches any text in the same ROI that contains those characters.
+- **Prefer too narrow over too wide.** A miss only wastes one visit to the point (navigation does not fail, see below), whereas a false match presses the key at the wrong thing.
+- **List variants one per line instead of expecting one pattern to cover every language.** Write simplified, traditional, English and Japanese separately; the syntax is Perl-flavoured, so inline flags such as `(?i)` are available. Remember that a backslash is doubled in JSON.
+- **Leading and trailing spaces need no handling** — the recognized text is trimmed before matching; `\\s*` is only for spaces split into the middle of the text.
+- **JSONC comments work.** Note which language or which UI each line covers, and keep the reason when a line is disabled.
+- **A malformed regex does not fail silently.** The injected text is validity-checked first, and an invalid pattern makes the whole subtask refuse to dispatch, logging `regex invalid`, `failed to override_pipeline` and `Prompt subtask failed to dispatch` in sequence; the point simply does not press, and navigation still does not fail.
+- A ready-made model is `AutoPickInteractive` in `assets/resource/pipeline/RealTimeTask/AutoPick.json`: it mixes item names with verbs like `^采集$` and `^打开$` in one table, and records why a few lines are left out.
+
+Reuse boundary: within one route a shared table goes at the top level of `custom_action_param` (see [Node Parameters](#node-parameters)); reuse across routes currently means writing the table once per route JSON.
+
+### Replacing the Icon Pre-filter
+
+On the last stretch toward an interaction point, a background pass looks for the prompt icon at a fixed cadence and stops only on a hit. This step only decides whether stopping is worth it — after the stop, `interact_text` has to confirm before anything is pressed — so it can afford to be loose.
+
+The shipped one is an ordinary Pipeline node, `MapNavigatorInteractScan`, with its `roi` / `template` / `threshold` written right there. When the prompt icon looks different, or does not appear in the default region, copy it, adjust it, and name it with `interact_scan`:
+
+```json
+"MyBusinessInteractScan": {
+    "recognition": {
+        "type": "TemplateMatch",
+        "param": {
+            "roi": [755, 330, 297, 312],
+            "template": "MyBusiness/InteractHint.png",
+            "threshold": 0.75
+        }
+    }
+}
+```
+
+```json
+{
+    "action": "INTERACT",
+    "target": [331, 1578],
+    "interact_text": "登记",
+    "interact_scan": "MyBusinessInteractScan"
+}
+```
+
+- This node is **never dispatched**; MapNavigator only reads those three parameters out of it. It therefore needs no `action`, no `next`, and does not have to hang off any chain.
+- `recognition.type` must be `TemplateMatch`, `template` must be exactly one image, and `threshold` exactly one number (defaulting to `0.75`). `roi` must be absolute coordinates in the 1280×720 base frame — the offset-from-previous-node form is not supported, since the pre-filter runs independently per frame and has no "previous node".
+- `template` resolves as a path under `image/`, the same as anywhere else in the Pipeline, and a platform overlay's same-named image wins as usual — so swapping the image for touch backends only means adding one under `resource_adb`.
+- If any of the above does not hold, the log carries one `Prompt scan node ...` line and **the points naming it fall back to "recognize once upon precise arrival"**. It does not take the route down with it and it does not silently press the wrong thing.
+- At most 4 pre-filters are armed per route (one background thread each). One node named by several points counts once. Anything beyond that reports `Prompt scan node dropped at the cap`, and those points fall back to arrival recognition too.
+- **A pre-filter needs `interact_text` alongside it.** A point naming only `interact_scan` falls back to the plain meaning (press the interact key on arrival) with the pre-filter inert, and logs one `names a prompt scan node without any interact text` line. The text may live on the point or be inherited from the route root.
+- A loose threshold cannot stall navigation: one pre-filter hit completes the point, so a pre-filter that fires on anything only spends its own points one by one and the route still drains forward. Those points do not actually interact, though, so set the threshold from the icon itself.
+
+### Arrival Determination and Movement
+
+Async interaction points use the same set of values as collection points, all runtime-managed, with nothing for the path author to control:
+
+- The arrival radius is tightened to a smaller value, relaxing back to the ordinary radius only when the point stays out of reach for a long time.
+- Automatic sprint is disabled for the whole segment approaching such a point, preventing overshoot.
+- The last stretch automatically switches from running to walking, so the character is less likely to run past the prompt's trigger range.
+
+The pre-filter only runs **while that point is the one being walked to and the last stretch has been entered**, at a fixed cadence, and a tick where the background reported nothing costs nothing; a route with no async interaction points is therefore unaffected. Passing other interactables further away cannot be mistaken for this point's prompt.
+
+### Fallback and Failure Semantics
+
+- If the prompt never shows up on the way, **the authoritative recognition still runs once upon precise arrival** — a missed pre-filter does not skip the point. Every async interaction point therefore gets exactly one authoritative recognition: a hit on the way completes it, and otherwise arrival makes it up.
+- **Async interaction never fails navigation.** The key press only happens when OCR matches the injected text; navigation itself does not verify that the interaction actually took place, and does not error out because no prompt was recognized. Whether the interaction succeeded has to be validated by the outer Pipeline (for example, the UI that should appear afterwards).
+
+When the interaction opens a UI (a registration desk, a commission board), **make that point the last one of the route**: once the UI is up the character stops moving and the minimap is covered, so later points cannot be walked. This is the same author-side discipline as plain `INTERACT` without `interact_text` — async or not makes no difference here.
+
+The `MapNavigatorInteract` node ships with a placeholder text that can never match, so a route that injects no `interact_text` recognizes nothing there and cannot press by mistake.
+
+### Files Path Authors Need to Care About
+
+| File | Responsibility | When Changes Are Needed |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| The business's own route JSON | The `MapNavigateAction` node, interaction coordinates and `interact_text` | Add interaction points, change wording |
+| `assets/resource/pipeline/MapNavigator/Interact.json` | Async interaction subtask, entry point `MapNavigatorInteractStart`, holds the prompt ROI and the key action; the shipped pre-filter `MapNavigatorInteractScan` lives here too | When the prompt region, the default interact key or the shipped pre-filter changes |
+| `assets/tasks/setting/Keymap.json` | Interact key rebinding; `KeymapInteract` applies to this node as well | Add or remove nodes affected by rebinding |
+| `assets/resource_macos/pipeline/MacOSKeyMap.json` | macOS key-code overrides, listed alongside the other interact-key nodes | Add or remove nodes that press the interact key |
+| `assets/resource_adb/pipeline/MapNavigator/Interact.json` | On ADB / cloud / PlayCover, taps the recognized prompt box instead (a touchscreen has no F key) | When the touchscreen action changes |
+
+**In most cases, path authors only need to modify their own route JSON.**
+
+### Parts Path Authors Do Not Need to Touch
+
+The following files are maintained by cpp-algo developers; path authors do not need to modify them:
+
+- `agent/cpp-algo/source/MapNavigator/async_prompt_action.h` / `.cpp`: the shared implementation of prompt-driven actions, used by both `COLLECT` and async `INTERACT`.
+- `agent/cpp-algo/source/MapNavigator/prompt_scan_profile.h` / `.cpp`: reading the pre-filter parameters out of a Pipeline node, and the validation chain around it.
+- `agent/cpp-algo/source/MapNavigator/navi_config.h`: subtask node names, pre-filter cadence and last-resort constants, arrival values and others.
+- `agent/cpp-algo/source/MapNavigator/navi_param_parser.cpp`: parsing of `interact_text` / `interact_scan` and propagation of the route-wide defaults.
+- `agent/cpp-algo/source/MapNavigator/semantic_nodes.cpp`: the fallback execution logic upon arrival.

--- a/docs/zh_cn/developers/components/map-navigator.md
+++ b/docs/zh_cn/developers/components/map-navigator.md
@@ -12,6 +12,7 @@ MapNavigator 是 MaaEnd 的寻路组件：给定目标位置，自动规划路�
 - [节点参数](#节点参数)
 - [`NAVMESH` 寻路原理](#navmesh-寻路原理)
 - [采集与挖掘 `COLLECT` / `DIG`](#采集与挖掘-collect--dig)
+- [异步交互 `INTERACT`](#异步交互-interact)
 - [实践建议](#实践建议)
 
 ## 快速上手
@@ -194,7 +195,7 @@ uv run main.py
 
 通常需要修改的只有三处：
 
-1. 将关键交互点改为 `INTERACT` 并标记严格（`X` 录入的点默认已是严格）。
+1. 将关键交互点改为 `INTERACT` 并标记严格（`X` 录入的点默认已是严格）。需要先确认提示文字再按键时，导出后为该点补写 `interact_text`，见[异步交互](#异步交互-interact)。
 2. 将需要跳跃、冲刺、等待传送、过图的点改为对应动作。
 3. 检查跨区域前后两个点的位置是否合理。
 
@@ -260,6 +261,23 @@ uv run main.py
 
 `target_tier` 与 `ZONE` 含义不同：前者只说明当前 `target` 是在哪张底图上点出的，后者声明路线执行与区域校验上下文。给普通点填写 `target_tier` 不会触发层级切换。
 
+**`INTERACT` 点声明交互提示文字**时同样改用对象格式，`interact_text` 即该点要识别的提示文字：
+
+```json
+{
+    "action": "INTERACT",
+    "target": [
+        331,
+        1578
+    ],
+    "interact_text": "登记"
+}
+```
+
+数组写法 `[x, y, "INTERACT"]` 没有放这些字段的位置，需要异步交互就必须写成对象形式；不写 `interact_text` 的 `INTERACT` 保留原语义（到点后直接按一次交互键）。详见[异步交互](#异步交互-interact)。
+
+这两个字段只有 `INTERACT` 点接得住，写在别的动作上会被忽略并在日志里留一行 `carries interact fields without an INTERACT action`。
+
 `NAVMESH` 是例外：它是语义寻路节点，必须使用带 `target` 的对象，不能写成 `[x, y, "NAVMESH"]`：
 
 ```json
@@ -280,7 +298,7 @@ uv run main.py
 | `SPRINT` | 冲刺一次 |
 | `JUMP` | 跳跃一次 |
 | `FIGHT` | 攻击一次 |
-| `INTERACT` | 交互一次 |
+| `INTERACT` | 交互一次；写了 `interact_text` 时升级为异步交互，见[异步交互](#异步交互-interact) |
 | `COLLECT` | 采集：停止移动，触发 OCR 识别并点击采集，见[采集与挖掘](#采集与挖掘-collect--dig) |
 | `DIG` | 挖掘：停止移动，触发挖掘子任务，见[采集与挖掘](#采集与挖掘-collect--dig) |
 | `NAVMESH` | 从当前定位自动规划路线并移动到 `target`；必须使用上方对象格式 |
@@ -350,8 +368,23 @@ uv run main.py
 | `map_name` | 空 | 初始区域上下文。`path` 中已有 `ZONE` 声明时通常无需填写 |
 | `arrival_timeout` | `60000` | 单个点允许的最长到达时间，超时判定失败，单位毫秒 |
 | `sprint_threshold` | `25.0` | 自动冲刺的判定阈值，依据**前方连续可跑段的长度**而非当前点的直线距离 |
+| `interact_text` | 空 | 整条路线的交互提示文字默认值，见[异步交互](#异步交互-interact) |
+| `interact_scan` | 空 | 整条路线的行进预筛节点默认值，见[换掉图标预筛](#换掉图标预筛) |
 
 顶层未知字段会被静默忽略，不报错。
+
+`interact_text` 接受一个字符串或字符串数组，也接受驼峰写法 `interactText`；`interact_scan` 接受一个字符串，驼峰写法 `interactScan`。两者都是写在点上的优先，路线级只补给那些自己没写的 `INTERACT` 点。一条路线的交互点通常属于同一业务，此时写在这里比逐点重复更省事：
+
+```json
+"custom_action_param": {
+    "interact_text": ["登记", "接取委托"],
+    "path": [
+        ...
+    ]
+}
+```
+
+`interact_text` 的空字符串与空数组会被直接拒绝（整个节点参数解析失败），不会当作没写：空文本在识别侧等同于「什么都匹配」，见提示就按键。`interact_scan` 写空字符串等同于没写，回落到出厂的那一份。
 
 ### 执行结果
 
@@ -490,6 +523,154 @@ uv run main.py
 2. 使用工具录制路径，将采集目标点动作改为 `COLLECT` 或 `DIG`，复制 `path` 并粘贴到 `Goto` 节点的 `custom_action_param.path`。
 3. 在 `interface.json` / 任务入口 JSON 中注册新路线入口。
 4. 无需修改 `AutoCollectClick.json`、`AutoCollectDig.json` 及任何 cpp-algo 源文件。
+
+---
+
+## 异步交互 `INTERACT`
+
+### 概念
+
+`INTERACT` 有两种语义，由路径点上有没有 `interact_text` 决定：
+
+- **不写**：到点后直接按一次交互键。这是历史行为，已有路线不受影响。
+- **写了**：升级为**异步交互**。走向该点的最后一段时后台持续预筛交互提示图标，出现提示就停车，交给 Pipeline 子任务 OCR 确认提示文字，只有命中 `interact_text` 才按交互键；提示既然弹了就说明游戏认为已在范围内，因此这一下按完该点即算走完，不再往前挪剩下那点距离。
+
+之所以要路线自己给文本：可交互物的种类太多，交互提示文字逐业务不同，一张通用名字表穷举不完。采集的名字表是通用的，所以 `COLLECT` 的文本留在 Pipeline 节点里；交互的文本必须由用它的那条路线注入。
+
+路线能定制的就是这一停一认两次识别，各管一段：
+
+| 字段 | 换掉的是 | 不写时 |
+| --------------- | --------------------------------- | ------------------------------ |
+| `interact_scan` | 行进中决定**何时停车**的图标预筛 | 用出厂那份，找默认提示图标 |
+| `interact_text` | 停车后决定**是不是它**的 OCR 文字 | 这个点不算异步交互，到点直接交互 |
+
+**动作不可定制，恒为交互键**（Windows 按 F、macOS 走按键号、触屏端点击识别到的提示框）。交互打开界面之后的一切归外层 Pipeline，导航跑完这个点就返回。详见[换掉图标预筛](#换掉图标预筛)。
+
+### 写法
+
+在 `path` 中把交互点写成对象形式，加 `interact_text`：
+
+```json
+"path": [
+    { "action": "ZONE", "zone_id": "Wuling_Base" },
+    [405, 1592],
+    { "action": "INTERACT", "target": [331, 1578], "interact_text": "登记" }
+]
+```
+
+- `interact_text` 收字符串或字符串数组；数组内任一条命中即按键。
+- 文本按 OCR 结果做**正则匹配**，与 Pipeline 的 `expected` 语义一致。中文提示直接照抄游戏里的字即可，含正则元字符时需自行转义。
+- 一整条路线共用同一业务时，把 `interact_text` 写在 `custom_action_param` 顶层作为默认值，见[节点参数](#节点参数)。
+- 同一条路线可以混排多个业务的交互点、混排 `COLLECT` 与 `DIG`，数量不限。
+- **不需要**再补末尾的 `true`：`INTERACT` 本身即按严格到达语义处理。
+
+工具中的操作方式：录制时正常走到交互物旁，停止录制后将该点动作改为 `INTERACT`，导出 `path` 后手动为该点补写 `interact_text`（编辑器目前不产出这个字段）。
+
+### 文本怎么填才抗得住 OCR
+
+OCR 不总是可靠，所以这个字段本来就是**一组**正则，而不是一句原文。按习惯写法列全变体：
+
+```json
+{
+    "action": "INTERACT",
+    "target": [331, 1578],
+    "interact_text": [
+        "^登记$", // 锚定短动词，避免提示区里别的字蹭上
+        "^登記$", // 繁体
+        "(?i)^Register$", // (?i) 忽略大小写
+        "(?i)^Sign\\s*In$" // \\s* 吃掉 OCR 多切出来的空格
+    ]
+}
+```
+
+几条经验：
+
+- **锚定优先。** 匹配用的是「包含即命中」而非整串相等，所以提示是「登记」这类短动词时写 `^登记$`；不锚定的 `登记` 会被同 ROI 里任何含这两个字的文本命中。
+- **宁窄勿宽。** 漏识别只是这个点白跑一次（导航不失败，见下节），误识别却会对着别的东西按键。
+- **变体逐条列，别指望一条模式吃下所有语言。** 简繁、英文、日文各写一条；语法是 Perl 风格，`(?i)` 这类内联标志可用。JSON 里反斜杠要写两个。
+- **首尾空格不用管**，识别结果在匹配前已经去过首尾空白；`\\s*` 只用于吃掉文本中间被切开的空格。
+- **JSONC 注释可用**，建议给每条写清它对应哪种语言或哪个界面，禁用某条时把原因也留下。
+- **正则写坏了不会静默失效。** 注入前会做一次合法性校验，不合法则整个子任务不予派发，日志里连着出现 `regex invalid`、`failed to override_pipeline` 与 `Prompt subtask failed to dispatch`；这一点表现为不按键，但不会让导航失败。
+- 现成范本见 `assets/resource/pipeline/RealTimeTask/AutoPick.json` 的 `AutoPickInteractive`：它把物名与 `^采集$`、`^打开$` 一类动词混在一张表里，并注明了哪几条为什么不启用。
+
+复用的边界：同一条路线内共用一张表，写在 `custom_action_param` 顶层即可（见[节点参数](#节点参数)）；跨路线复用目前需要在各自的路线 JSON 里各写一份。
+
+### 换掉图标预筛
+
+走向交互点的最后一段里，后台每隔固定节拍在屏幕上找一次提示图标，找到才停车。这一步只决定「值不值得停车」，停下后还要由 `interact_text` 再确认一次才按键，所以它可以很松。
+
+出厂的那一份就是一个普通 Pipeline 节点 `MapNavigatorInteractScan`，`roi` / `template` / `threshold` 都写在里面。提示图标长得不一样、或者不出现在默认区域时，照抄一份改成自己的，再用 `interact_scan` 点名：
+
+```json
+"MyBusinessInteractScan": {
+    "recognition": {
+        "type": "TemplateMatch",
+        "param": {
+            "roi": [755, 330, 297, 312],
+            "template": "MyBusiness/InteractHint.png",
+            "threshold": 0.75
+        }
+    }
+}
+```
+
+```json
+{
+    "action": "INTERACT",
+    "target": [331, 1578],
+    "interact_text": "登记",
+    "interact_scan": "MyBusinessInteractScan"
+}
+```
+
+- 这个节点**不会被派发执行**，MapNavigator 只读它这三个参数。所以它不需要 `action`、不需要 `next`，也不必接在任何链上。
+- `recognition.type` 必须是 `TemplateMatch`，`template` 只能给一张图，`threshold` 只能给一个数（不填按 `0.75`）。`roi` 必须是 1280×720 基准帧里的绝对坐标，不支持相对上一节点的偏移写法——预筛每帧独立跑，没有「上一个节点」。
+- `template` 按 `image/` 下的相对路径解析，与 Pipeline 里的写法一致；平台 overlay 里同名图会照常胜出，所以触屏端要换图时在 `resource_adb` 下补一份即可。
+- 以上任一条不满足，日志里会出现一行 `Prompt scan node ...`，**点名它的那些点退化为「精确到点后再识别」**，不会连累整条路线，也不会静默按错。
+- 一条路线最多同时武装 4 份预筛（每份一个后台线程）。同一个节点名被多个点点名只算一份。超出的会报 `Prompt scan node dropped at the cap`，那些点同样退化为到点识别。
+- **预筛得配着 `interact_text` 用。** 只写 `interact_scan` 的点会退回原语义（到点直接按一次交互键），预筛不生效，日志里留一行 `names a prompt scan node without any interact text`。文本可以写在点上，也可以写在路线根上由这些点继承。
+- 阈值调松不会把导航拖死：预筛命中一次就把该点算走完，所以一份见啥都报的预筛只会把自己的点一个个花掉，路线仍然往前排空。但那些点也就没真交互上，阈值该按图标本身定。
+
+### 到点判定与移动
+
+异步交互点与采集点使用同一组判定值，全部由运行时控制，路线作者无法也无需干预：
+
+- 到点判定圈按更小的半径收紧，长时间够不着时才退让到常规半径。
+- 临近该点的整段路禁用自动疾跑，避免冲过头。
+- 更近的一段自动从跑动切换为走路，减少冲过提示触发范围。
+
+预筛只在**正走向该点、且已进入最后一段**时按固定节拍尝试，后台没报提示时这一拍零成本；因此一条不含异步交互点的路线不受任何影响。远处路过别的可交互物不会被误认成这个点的提示。
+
+### 兜底与失败语义
+
+- 途中没等到提示时，**精确到点后仍会执行一次权威识别**，不会因为预筛漏了就整点跳过。因此每个异步交互点必定恰好跑一次权威识别：途中命中即走完，没命中则到点补跑。
+- **异步交互不会让导航失败。** 按键只发生在 OCR 命中注入文本时；导航本身不校验交互是否真的发生，也不因为没识别到提示而报错。交互到底成不成，需要外层 Pipeline 自己验收（例如交互后应出现的界面）。
+
+交互会打开界面（登记台、委托板一类）时，**建议把该点作为路线的最后一个点**：界面一开角色就不再移动、小地图也被盖住，后面的点走不了。这与不写 `interact_text` 的 `INTERACT` 是同一条作者纪律，异步与否都一样。
+
+`MapNavigatorInteract` 节点里预置了一条永远匹配不上的占位文本，路线没注入 `interact_text` 时该节点识别不到任何东西，因此不会误按。
+
+### 相关文件
+
+| 文件 | 职责 | 何时需要修改 |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ---------------------------------- |
+| 业务自己的路线 JSON | `MapNavigateAction` 节点、交互坐标与 `interact_text` | 新增交互点、改文案 |
+| `assets/resource/pipeline/MapNavigator/Interact.json` | 异步交互子任务，入口 `MapNavigatorInteractStart`，含提示 ROI 与按键动作；出厂预筛 `MapNavigatorInteractScan` 也在这里 | 提示区域、交互按键或出厂预筛的默认值变化 |
+| `assets/tasks/setting/Keymap.json` | 交互键改绑，`KeymapInteract` 会同时作用于该节点 | 增删受改绑影响的节点 |
+| `assets/resource_macos/pipeline/MacOSKeyMap.json` | macOS 下的按键号覆盖，与其他交互键节点同列 | 增删会按交互键的节点 |
+| `assets/resource_adb/pipeline/MapNavigator/Interact.json` | ADB / 云游戏 / PlayCover 下改为点击识别到的提示框（触屏没有 F 键） | 触屏端的动作方式变化 |
+
+**绝大多数情况下只需修改业务自己的路线 JSON。**
+
+### 无需修改的部分
+
+以下文件由 cpp-algo 维护者负责，路线作者无需修改：
+
+- `agent/cpp-algo/source/MapNavigator/async_prompt_action.h` / `.cpp`：提示驱动动作的公共实现，`COLLECT` 与异步 `INTERACT` 共用一套。
+- `agent/cpp-algo/source/MapNavigator/prompt_scan_profile.h` / `.cpp`：从 Pipeline 节点读预筛参数，以及那一串校验。
+- `agent/cpp-algo/source/MapNavigator/navi_config.h`：子任务节点名、预筛节拍与兜底常量、判定值等。
+- `agent/cpp-algo/source/MapNavigator/navi_param_parser.cpp`：`interact_text` / `interact_scan` 的解析与路线级默认值下发。
+- `agent/cpp-algo/source/MapNavigator/semantic_nodes.cpp`：到点后的兜底执行逻辑。
 
 ---
 


### PR DESCRIPTION
## Summary by Sourcery

升级基于提示词驱动的导航交互，使其支持异步的 `INTERACT` 处理，同时保留旧版交互行为。

New Features:
- 新增异步 `INTERACT` 航路点：可检测屏幕上的交互提示，通过 Pipeline 识别验证配置文本，并在无需精确最终位移的情况下触发交互。
- 支持在航路点和路径级别配置 `interact_text` 正则表达式及 `interact_node` 覆写，包括 camelCase 别名和校验。
- 统一 `COLLECT` 和异步 `INTERACT` 行为的提示词驱动处理逻辑，共享后台检测、移动控制和到达回退行为。

Bug Fixes:
- 防止在游戏打开交互 UI 后，由提示触发的交互卡在“剩余距离”状态无法继续。
- 通过将检测限制在当前接近过程和已配置的提示航路点上，避免错误的提示触发停靠。

Enhancements:
- 收紧并协调基于提示驱动的航路点的到达判定、冲刺抑制和行走行为。
- 预热提示识别，并支持在路径尾部处理交互提示，同时避免将识别缺失视为导航失败。

Documentation:
- 在中文和英文的 MapNavigator 指南中，记录异步 `INTERACT` 配置、提示匹配、自定义识别节点、移动行为以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade prompt-driven navigation interactions to support asynchronous INTERACT handling while preserving legacy interaction behavior.

New Features:
- Add asynchronous INTERACT waypoints that detect on-screen prompts, verify configured text through Pipeline recognition, and trigger interaction without requiring precise final movement.
- Support waypoint- and route-level interact_text regular expressions and interact_node overrides, including camelCase aliases and validation.
- Unify prompt-driven processing for COLLECT and asynchronous INTERACT actions with shared background detection, movement control, and arrival fallback behavior.

Bug Fixes:
- Prevent prompt-triggered interactions from becoming stuck on the remaining distance after the game opens an interaction UI.
- Avoid false prompt-triggered stops by restricting detection to the active approach and the configured prompt waypoint.

Enhancements:
- Tighten and coordinate arrival, sprint suppression, and walking behavior for prompt-driven waypoints.
- Pre-warm prompt recognition and support route-tail prompt handling without turning recognition misses into navigation failures.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, custom recognition nodes, movement behavior, and failure semantics in Chinese and English MapNavigator guides.

</details>

## Summary by Sourcery

升级 MapNavigator，以支持经提示验证的异步交互，同时保留传统的 `INTERACT` 行为。

新特性：
- 新增异步 `INTERACT` 航点，在触发交互之前，先检测并通过 OCR 验证已配置的屏幕提示。
- 支持在航点和路线层级配置 `interact_text`/`interact_scan`，包括驼峰式别名、继承机制以及配置校验。

错误修复：
- 防止在打开交互界面后，由提示触发的交互仍然卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前目标路径上，防止在同一任务器上发生嵌套导航。

改进优化：
- 通过共享基础设施，统一 `COLLECT` 与异步 `INTERACT` 的提示检测、移动控制、到达处理、识别预热以及路线末尾回退逻辑。

文档：
- 在中文版和英文版 MapNavigator 指南中，记录异步 `INTERACT` 配置、提示匹配、扫描节点自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator to support prompt-verified asynchronous interactions while preserving legacy INTERACT behavior.

New Features:
- Add asynchronous INTERACT waypoints that detect and OCR-verify configured on-screen prompts before triggering interaction.
- Support waypoint- and route-level interact_text/interact_scan configuration with camelCase aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from remaining stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active target approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan-node customization, movement behavior, fallback handling, and failure semantics in Chinese and English MapNavigator guides.

</details>

新功能：
- 添加异步 INTERACT 航点，在触发交互之前检测并验证已配置的屏幕提示。
- 支持在航点和路线级别配置 `interact_text` 正则表达式和 `interact_scan` 覆盖，并提供别名和校验。

错误修复：
- 防止在打开交互界面后，由提示触发的交互仍然卡在剩余距离处理逻辑中。
- 将提示处理限制在当前激活的目标接近路径上，避免在无关可交互对象处产生误停。
- 防止在同一 tasker 上发生嵌套导航执行。

增强：
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理以及路线尾部回退逻辑。
- 收紧基于提示驱动的到达判定、冲刺抑制、步行行为以及识别预热策略。

文档：
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 配置、提示匹配、扫描节点自定义、移动行为以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，以支持经提示验证的异步交互，同时保留传统的 `INTERACT` 行为。

新特性：
- 新增异步 `INTERACT` 航点，在触发交互之前，先检测并通过 OCR 验证已配置的屏幕提示。
- 支持在航点和路线层级配置 `interact_text`/`interact_scan`，包括驼峰式别名、继承机制以及配置校验。

错误修复：
- 防止在打开交互界面后，由提示触发的交互仍然卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前目标路径上，防止在同一任务器上发生嵌套导航。

改进优化：
- 通过共享基础设施，统一 `COLLECT` 与异步 `INTERACT` 的提示检测、移动控制、到达处理、识别预热以及路线末尾回退逻辑。

文档：
- 在中文版和英文版 MapNavigator 指南中，记录异步 `INTERACT` 配置、提示匹配、扫描节点自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator to support prompt-verified asynchronous interactions while preserving legacy INTERACT behavior.

New Features:
- Add asynchronous INTERACT waypoints that detect and OCR-verify configured on-screen prompts before triggering interaction.
- Support waypoint- and route-level interact_text/interact_scan configuration with camelCase aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from remaining stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active target approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan-node customization, movement behavior, fallback handling, and failure semantics in Chinese and English MapNavigator guides.

</details>

</details>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

</details>

新功能：
- 在保留现有基于到达事件的交互行为的同时，新增通过提示词验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式以及提示扫描配置文件，包含别名、继承与校验能力。

错误修复：
- 防止在打开交互 UI 之后，由提示触发的交互仍卡在基于距离的到达处理流程中。
- 将提示检测限制在当前激活的接近过程上，并防止在同一任务器上发生嵌套导航。

增强：
- 通过共享基础设施统一 COLLECT 与异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

文档：
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

</details>

新功能：
- 在保留现有基于到达事件的交互行为的同时，新增通过提示词验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式以及提示扫描配置文件，包含别名、继承与校验能力。

错误修复：
- 防止在打开交互 UI 之后，由提示触发的交互仍卡在基于距离的到达处理流程中。
- 将提示检测限制在当前激活的接近过程上，并防止在同一任务器上发生嵌套导航。

增强：
- 通过共享基础设施统一 COLLECT 与异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

文档：
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

</details>

</details>

</details>

新功能：
- 新增经提示验证的异步 `INTERACT` 航点，同时保留现有基于到达事件的交互行为。
- 支持在航点和路线级别配置交互文本模式和提示扫描配置文件，并提供别名、继承机制以及校验功能。

缺陷修复：
- 防止由提示触发的交互在打开交互界面后仍被卡在基于距离的到达处理逻辑中。
- 将由提示触发的行为限制在当前目标的接近流程中，防止在同一任务器上出现嵌套导航。

增强改进：
- 通过共享基础设施统一 `COLLECT` 与异步 `INTERACT` 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

文档：
- 在中文版和英文版 MapNavigator 指南中，补充异步 `INTERACT` 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义的相关文档说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

</details>

新功能：
- 在保留现有基于到达事件的交互行为的同时，新增通过提示词验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式以及提示扫描配置文件，包含别名、继承与校验能力。

错误修复：
- 防止在打开交互 UI 之后，由提示触发的交互仍卡在基于距离的到达处理流程中。
- 将提示检测限制在当前激活的接近过程上，并防止在同一任务器上发生嵌套导航。

增强：
- 通过共享基础设施统一 COLLECT 与异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

文档：
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

</details>

新功能：
- 在保留现有基于到达事件的交互行为的同时，新增通过提示词验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式以及提示扫描配置文件，包含别名、继承与校验能力。

错误修复：
- 防止在打开交互 UI 之后，由提示触发的交互仍卡在基于距离的到达处理流程中。
- 将提示检测限制在当前激活的接近过程上，并防止在同一任务器上发生嵌套导航。

增强：
- 通过共享基础设施统一 COLLECT 与异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

文档：
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级 MapNavigator，使其在保留传统 INTERACT 行为的同时，支持经提示验证的异步交互。

New Features:
- 在保留现有基于到达的交互行为的前提下，新增经提示验证的异步 INTERACT 航点。
- 支持在路线级和航点级配置交互文本模式和提示扫描配置文件，提供别名、继承及校验能力。

Bug Fixes:
- 防止提示触发的交互在打开交互 UI 后卡在基于距离的到达处理逻辑中。
- 将提示触发的动作限制在当前激活的接近流程中，防止在同一任务器上发生嵌套导航。

Enhancements:
- 通过共享基础设施统一 COLLECT 和异步 INTERACT 的提示检测、移动控制、到达处理、识别预热以及路线尾部回退逻辑。

Documentation:
- 在中文版和英文版的 MapNavigator 指南中，记录异步 INTERACT 的配置方式、提示匹配、扫描自定义、移动行为、回退处理以及失败语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade MapNavigator with prompt-verified asynchronous interactions while retaining legacy INTERACT behavior.

New Features:
- Add prompt-verified asynchronous INTERACT waypoints while preserving the existing arrival-based interaction behavior.
- Support route- and waypoint-level interaction text patterns and prompt scan profiles with aliases, inheritance, and validation.

Bug Fixes:
- Prevent prompt-triggered interactions from getting stuck in distance-based arrival handling after opening an interaction UI.
- Restrict prompt-triggered actions to the active approach and prevent nested navigation on the same tasker.

Enhancements:
- Unify COLLECT and asynchronous INTERACT prompt detection, movement control, arrival handling, recognition warm-up, and route-tail fallback through shared infrastructure.

Documentation:
- Document asynchronous INTERACT configuration, prompt matching, scan customization, movement behavior, fallback handling, and failure semantics in the Chinese and English MapNavigator guides.

</details>

</details>

</details>

</details>

</details>