### PR TITLE
fix(ci): 修复check报错

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install MaaFW Linux runtime libraries
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libpipewire-0.3-dev libdbus-1-dev
+          sudo apt-get install -y libpipewire-0.3-0 libdbus-1-3
 
       - name: Run maa-checker
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,6 +52,12 @@ jobs:
         with:
           enable-cache: true
 
+      # MaaFW 5.13+ Linux 包链接 PipeWire；ubuntu-latest 默认未安装
+      - name: Install MaaFW Linux runtime libraries
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libpipewire-0.3-dev libdbus-1-dev
+
       - name: Run maa-checker
         run: |
           pnpm i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # MaaFW 5.13+ Linux 包链接 PipeWire；ubuntu-latest 默认未安装
+      - name: Install MaaFW Linux runtime libraries
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libpipewire-0.3-dev libdbus-1-dev
+
       - name: Run maa-tools test
         run: pnpm test
 
@@ -67,6 +73,12 @@ jobs:
           cache-dependency-path: |
             agent/go-service/go.mod
             agent/go-service/go.sum
+
+      # MaaFW 5.13+ Linux 包链接 PipeWire；ubuntu-latest 默认未安装
+      - name: Install MaaFW Linux runtime libraries
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libpipewire-0.3-dev libdbus-1-dev
 
       - name: Build and install
         run: python -u tools/build_and_install.py --ci --os linux --arch x86_64 # without cpp-algo


### PR DESCRIPTION
MaaFW latest Linux binaries link libpipewire; ubuntu-latest CI images do not ship it, so pnpm check/test fail loading maa-node.

## Sourcery 总结

在 CI 中安装 MaaFW 所需的 Linux 库，以防止在 `ubuntu-latest` 上的检查和测试失败。

错误修复（Bug Fixes）：
- 安装 MaaFW Linux 二进制文件所需的 PipeWire 和 D-Bus 开发库，以便 CI 检查和测试可以成功加载 `maa-node`。

CI：
- 在测试和检查工作流中添加 MaaFW Linux 运行时库的安装与配置步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 CI 中安装 MaaFW 的 Linux 运行时依赖，以防止 Ubuntu 上的检查和测试失败。

Bug 修复：
- 安装 MaaFW 所需的 Linux 库，使 CI 检查和测试能够在 Ubuntu runner 上成功加载 `maa-node`。

CI：
- 配置 check 和 test 工作流，以安装所需的 PipeWire 和 D-Bus 运行时依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Install MaaFW Linux runtime dependencies in CI to prevent Ubuntu check and test failures.

Bug Fixes:
- Install MaaFW's required Linux libraries so CI checks and tests can load `maa-node` successfully on Ubuntu runners.

CI:
- Configure the check and test workflows to install the required PipeWire and D-Bus runtime dependencies.

</details>

Bug Fixes（错误修复）:
- 安装 MaaFW 所需的 Linux 库，使 CI 检查和测试能够在 Ubuntu runner 上成功加载 `maa-node`。

CI:
- 配置测试和检查工作流，以安装 MaaFW 的 PipeWire 和 D-Bus 运行时依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 CI 中安装 MaaFW 的 Linux 运行时依赖，以防止 Ubuntu 上的检查和测试失败。

Bug 修复：
- 安装 MaaFW 所需的 Linux 库，使 CI 检查和测试能够在 Ubuntu runner 上成功加载 `maa-node`。

CI：
- 配置 check 和 test 工作流，以安装所需的 PipeWire 和 D-Bus 运行时依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Install MaaFW Linux runtime dependencies in CI to prevent Ubuntu check and test failures.

Bug Fixes:
- Install MaaFW's required Linux libraries so CI checks and tests can load `maa-node` successfully on Ubuntu runners.

CI:
- Configure the check and test workflows to install the required PipeWire and D-Bus runtime dependencies.

</details>

</details>

</details>