### PR TITLE
refactor(BetterSliding): 移除 GreenMask 参数，固定启用绿色掩码

### DIFF
--- a/agent/go-service/bettersliding/handlers.go
+++ b/agent/go-service/bettersliding/handlers.go
@@ -92,7 +92,6 @@ func (a *BetterSlidingAction) handleMain(ctx *maa.Context, _ *maa.CustomActionAr
 		a.SliderQuantityOnlyRec,
 		a.AvailableQuantityOnlyRec,
 		a.SwipeButton,
-		a.GreenMask,
 	)
 
 	resetOverride, err := buildResetSwipeOverride(a.Direction, a.ResetBeforeFindStart)
@@ -126,7 +125,6 @@ func (a *BetterSlidingAction) handleMain(ctx *maa.Context, _ *maa.CustomActionAr
 		Ints("slider_quantity_roi", a.SliderQuantityBox).
 		Ints("available_quantity_roi", a.AvailableQuantityBox).
 		Bool("available_quantity_explicit", a.AvailableQuantityExplicit).
-		Bool("green_mask", a.GreenMask).
 		Bool("slider_quantity_filter_enabled", a.SliderQuantityFilter != nil).
 		Bool("available_quantity_filter_enabled", a.AvailableQuantityFilter != nil).
 		Bool("slider_quantity_only_rec", a.SliderQuantityOnlyRec).
@@ -251,7 +249,6 @@ func (a *BetterSlidingAction) handleGetSliderMaxQuantity(ctx *maa.Context, arg *
 			nodeBetterSlidingDone,
 			buttonTarget{},
 			0,
-			a.GreenMask,
 		); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
@@ -295,7 +292,7 @@ func (a *BetterSlidingAction) handleGetSliderMaxQuantity(ctx *maa.Context, arg *
 		return false
 	}
 	if nextNode != "" {
-		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nextNode, buttonTarget{}, 0, a.GreenMask); err != nil {
+		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nextNode, buttonTarget{}, 0); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
 				Int("slider_max_quantity", a.sliderMaxQuantity).
@@ -519,7 +516,7 @@ func (a *BetterSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.Cus
 
 	switch {
 	case currentQuantity == a.TargetQuantity:
-		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingDone, buttonTarget{}, 0, a.GreenMask); err != nil {
+		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingDone, buttonTarget{}, 0); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
 				Int("current_quantity", currentQuantity).
@@ -541,7 +538,7 @@ func (a *BetterSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.Cus
 	case currentQuantity < a.TargetQuantity:
 		diff := a.TargetQuantity - currentQuantity
 		repeat := clampClickRepeat(diff)
-		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingIncreaseQuantity, a.IncreaseButton, repeat, a.GreenMask); err != nil {
+		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingIncreaseQuantity, a.IncreaseButton, repeat); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
 				Int("current_quantity", currentQuantity).
@@ -569,7 +566,7 @@ func (a *BetterSlidingAction) handleCheckQuantity(ctx *maa.Context, arg *maa.Cus
 	default:
 		diff := currentQuantity - a.TargetQuantity
 		repeat := clampClickRepeat(diff)
-		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingDecreaseQuantity, a.DecreaseButton, repeat, a.GreenMask); err != nil {
+		if err := overrideCheckQuantityBranch(ctx, arg.CurrentTaskName, nodeBetterSlidingDecreaseQuantity, a.DecreaseButton, repeat); err != nil {
 			logEvent := a.logger.Error().
 				Err(err).
 				Int("current_quantity", currentQuantity).

--- a/agent/go-service/bettersliding/normalize.go
+++ b/agent/go-service/bettersliding/normalize.go
@@ -229,7 +229,6 @@ func isSwipeOnlyMode(params betterSlidingParam) bool {
 	return !params.presence.TargetQuantity &&
 		!params.presence.SliderQuantity &&
 		!params.presence.AvailableQuantity &&
-		!params.presence.GreenMask &&
 		!params.presence.IncreaseButton &&
 		!params.presence.DecreaseButton &&
 		!params.presence.OutOfRangeOverrideEnable &&

--- a/agent/go-service/bettersliding/overrides.go
+++ b/agent/go-service/bettersliding/overrides.go
@@ -74,7 +74,6 @@ func buildMainInitializationOverride(
 	sliderQuantityOnlyRec bool,
 	availableQuantityOnlyRec bool,
 	swipeButton string,
-	greenMask bool,
 ) map[string]any {
 	override := map[string]any{
 		nodeBetterSlidingSwipeToMax: map[string]any{
@@ -94,7 +93,7 @@ func buildMainInitializationOverride(
 			"recognition": map[string]any{
 				"param": map[string]any{
 					"template":   []string{swipeButton},
-					"green_mask": greenMask,
+					"green_mask": defaultGreenMask,
 				},
 			},
 		}
@@ -159,7 +158,7 @@ func buildMainInitializationOverride(
 	return override
 }
 
-func buildCheckQuantityBranchOverride(nextNode string, target buttonTarget, repeat int, greenMask bool) map[string]any {
+func buildCheckQuantityBranchOverride(nextNode string, target buttonTarget, repeat int) map[string]any {
 	if nextNode != nodeBetterSlidingIncreaseQuantity && nextNode != nodeBetterSlidingDecreaseQuantity {
 		return map[string]any{}
 	}
@@ -170,7 +169,7 @@ func buildCheckQuantityBranchOverride(nextNode string, target buttonTarget, repe
 
 	if target.template != "" {
 		helperNode := resolveButtonHelperNode(nextNode)
-		override[helperNode] = buildTemplateMatchButtonHelperOverride(target.template, greenMask)
+		override[helperNode] = buildTemplateMatchButtonHelperOverride(target.template)
 		override[nextNode] = buildTemplateMatchButtonOverride(helperNode, repeat)
 		return override
 	}
@@ -187,8 +186,8 @@ func buildCheckQuantityBranchOverride(nextNode string, target buttonTarget, repe
 	return override
 }
 
-func overrideCheckQuantityBranch(ctx *maa.Context, currentNode string, nextNode string, target buttonTarget, repeat int, greenMask bool) error {
-	if override := buildCheckQuantityBranchOverride(nextNode, target, repeat, greenMask); len(override) > 0 {
+func overrideCheckQuantityBranch(ctx *maa.Context, currentNode string, nextNode string, target buttonTarget, repeat int) error {
+	if override := buildCheckQuantityBranchOverride(nextNode, target, repeat); len(override) > 0 {
 		if err := ctx.OverridePipeline(override); err != nil {
 			return fmt.Errorf("%w: %w", errCheckQuantityBranchPipelineOverride, err)
 		}
@@ -228,12 +227,12 @@ func buildNodeEnableOverride(nodeName string, enabled bool) map[string]any {
 	}
 }
 
-func buildTemplateMatchButtonHelperOverride(template string, greenMask bool) map[string]any {
+func buildTemplateMatchButtonHelperOverride(template string) map[string]any {
 	return map[string]any{
 		"recognition": map[string]any{
 			"param": map[string]any{
 				"template":   []string{template},
-				"green_mask": greenMask,
+				"green_mask": defaultGreenMask,
 			},
 		},
 	}

--- a/agent/go-service/bettersliding/params.go
+++ b/agent/go-service/bettersliding/params.go
@@ -17,7 +17,6 @@ type parsedBetterSlidingParams struct {
 	availableQuantityFilter       *quantityFilterParam
 	sliderQuantityOnlyRec         bool
 	availableQuantityOnlyRec      bool
-	greenMask                     bool
 	direction                     string
 	increaseButton                buttonTarget
 	decreaseButton                buttonTarget
@@ -45,7 +44,6 @@ func detectBetterSlidingParamPresence(rawParam string) (betterSlidingParamPresen
 		TargetQuantity:                hasNonNullRawKey(rawKeys, "TargetQuantity"),
 		SliderQuantity:                sliderQuantityPresent,
 		AvailableQuantity:             hasNonNullRawKey(rawKeys, "AvailableQuantity"),
-		GreenMask:                     hasNonNullRawKey(rawKeys, "GreenMask"),
 		Direction:                     hasNonNullRawKey(rawKeys, "Direction"),
 		IncreaseButton:                hasNonNullRawKey(rawKeys, "IncreaseButton"),
 		DecreaseButton:                hasNonNullRawKey(rawKeys, "DecreaseButton"),
@@ -158,7 +156,6 @@ func (a *BetterSlidingAction) normalizeActionParams(params betterSlidingParam) (
 			availableQuantityFilter:       nil,
 			sliderQuantityOnlyRec:         false,
 			availableQuantityOnlyRec:      false,
-			greenMask:                     params.GreenMask,
 			direction:                     direction,
 			increaseButton:                buttonTarget{},
 			decreaseButton:                buttonTarget{},
@@ -242,7 +239,6 @@ func (a *BetterSlidingAction) normalizeActionParams(params betterSlidingParam) (
 		availableQuantityFilter:       availableQuantityFilter,
 		sliderQuantityOnlyRec:         sliderQuantityOnlyRec,
 		availableQuantityOnlyRec:      availableQuantityOnlyRec,
-		greenMask:                     params.GreenMask,
 		direction:                     strings.ToLower(strings.TrimSpace(params.Direction)),
 		increaseButton:                increaseButton,
 		decreaseButton:                decreaseButton,
@@ -271,7 +267,6 @@ func (a *BetterSlidingAction) applyActionParams(params parsedBetterSlidingParams
 	a.AvailableQuantityFilter = params.availableQuantityFilter
 	a.SliderQuantityOnlyRec = params.sliderQuantityOnlyRec
 	a.AvailableQuantityOnlyRec = params.availableQuantityOnlyRec
-	a.GreenMask = params.greenMask
 	a.Direction = params.direction
 	a.IncreaseButton = params.increaseButton
 	a.DecreaseButton = params.decreaseButton
@@ -296,7 +291,6 @@ func (a *BetterSlidingAction) logParsedActionParams() {
 		Str("direction", a.Direction).
 		Interface("increase_button", a.IncreaseButton.logValue()).
 		Interface("decrease_button", a.DecreaseButton.logValue()).
-		Bool("green_mask", a.GreenMask).
 		Bool("slider_quantity_filter_enabled", a.SliderQuantityFilter != nil).
 		Bool("available_quantity_filter_enabled", a.AvailableQuantityFilter != nil).
 		Bool("slider_quantity_only_rec", a.SliderQuantityOnlyRec).

--- a/agent/go-service/bettersliding/types.go
+++ b/agent/go-service/bettersliding/types.go
@@ -9,7 +9,6 @@ type betterSlidingParam struct {
 	TargetQuantity                int                        `json:"TargetQuantity"`
 	SliderQuantity                quantityParam              `json:"SliderQuantity"`
 	AvailableQuantity             quantityParam              `json:"AvailableQuantity"`
-	GreenMask                     bool                       `json:"GreenMask"`
 	Direction                     string                     `json:"Direction"`
 	IncreaseButton                any                        `json:"IncreaseButton"`
 	DecreaseButton                any                        `json:"DecreaseButton"`
@@ -29,7 +28,6 @@ type betterSlidingParamPresence struct {
 	TargetQuantity                bool
 	SliderQuantity                bool
 	AvailableQuantity             bool
-	GreenMask                     bool
 	Direction                     bool
 	IncreaseButton                bool
 	DecreaseButton                bool
@@ -73,7 +71,6 @@ type quantityFilterParam struct {
 //   - SliderQuantity.OnlyRec: enable only_rec for the slider quantity OCR node
 //   - AvailableQuantity.Filter: optional color filter for available quantity OCR
 //   - AvailableQuantity.OnlyRec: enable only_rec for available quantity OCR
-//   - GreenMask: map to green_mask in TemplateMatch for slider/button templates
 //   - Direction: swipe direction (left/right/up/down)
 //   - IncreaseButton: increase button template path or coordinates
 //   - DecreaseButton: decrease button template path or coordinates
@@ -97,7 +94,6 @@ type BetterSlidingAction struct {
 	AvailableQuantityFilter       *quantityFilterParam
 	SliderQuantityOnlyRec         bool
 	AvailableQuantityOnlyRec      bool
-	GreenMask                     bool
 	Direction                     string
 	IncreaseButton                buttonTarget
 	DecreaseButton                buttonTarget
@@ -146,5 +142,9 @@ const (
 )
 
 var defaultCenterPointOffset = [2]int{-10, 0}
+
+// defaultGreenMask 是 BetterSliding 按钮模板匹配默认启用的绿色掩码开关。
+// BetterSliding 对 SwipeButton / IncreaseButton / DecreaseButton 的模板匹配固定开启绿色掩码。
+const defaultGreenMask = true
 
 var _ maa.CustomActionRunner = &BetterSlidingAction{}

--- a/assets/resource/pipeline/AutoStockStaple/General/Item.json
+++ b/assets/resource/pipeline/AutoStockStaple/General/Item.json
@@ -247,7 +247,6 @@
                     "DecreaseButton": "AutoStockpile/DecreaseButton.png",
                     "Direction": "right",
                     "IncreaseButton": "AutoStockpile/IncreaseButton.png",
-                    "GreenMask": true,
                     "SliderQuantity": {
                         "Box": [
                             375,

--- a/assets/resource/pipeline/AutoStockpile/Purchase.json
+++ b/assets/resource/pipeline/AutoStockpile/Purchase.json
@@ -81,7 +81,6 @@
                     "DecreaseButton": "AutoStockpile/DecreaseButton.png",
                     "Direction": "right",
                     "IncreaseButton": "AutoStockpile/IncreaseButton.png",
-                    "GreenMask": true,
                     "TargetQuantity": 1,
                     "SliderQuantity": {
                         "Box": [

--- a/assets/resource/pipeline/BetterSliding/Helper.json
+++ b/assets/resource/pipeline/BetterSliding/Helper.json
@@ -23,7 +23,7 @@
                 "template": [
                     "BetterSliding/SwipeButton.png"
                 ],
-                "green_mask": false,
+                "green_mask": true,
                 "threshold": [
                     0.8
                 ],
@@ -42,7 +42,7 @@
                 "template": [
                     "BetterSliding/SwipeButton.png"
                 ],
-                "green_mask": false,
+                "green_mask": true,
                 "threshold": [
                     0.8
                 ],

--- a/assets/resource/pipeline/SellProduct/ValleyIV/InfraStation.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/InfraStation.json
@@ -1212,7 +1212,6 @@
         "action": "Custom",
         "custom_action": "BetterSliding",
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
@@ -1216,7 +1216,6 @@
         "action": "Custom",
         "custom_action": "BetterSliding",
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
@@ -1214,7 +1214,6 @@
         "action": "Custom",
         "custom_action": "BetterSliding",
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
@@ -1214,7 +1214,6 @@
         "action": "Custom",
         "custom_action": "BetterSliding",
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
@@ -1224,7 +1224,6 @@
         "action": "Custom",
         "custom_action": "BetterSliding",
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
@@ -1214,7 +1214,6 @@
         "action": "Custom",
         "custom_action": "BetterSliding",
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource_adb/pipeline/AutoStockStaple/General/Item.json
+++ b/assets/resource_adb/pipeline/AutoStockStaple/General/Item.json
@@ -33,7 +33,6 @@
                     "DecreaseButton": "AutoStockpile/DecreaseButton.png",
                     "Direction": "right",
                     "IncreaseButton": "AutoStockpile/IncreaseButton.png",
-                    "GreenMask": true,
                     "SliderQuantity": {
                         "Box": [
                             304,

--- a/assets/resource_adb/pipeline/AutoStockpile/Purchase.json
+++ b/assets/resource_adb/pipeline/AutoStockpile/Purchase.json
@@ -20,7 +20,6 @@
                     "ClampTargetToSliderMax": true,
                     "DecreaseButton": "AutoStockpile/DecreaseButton.png",
                     "Direction": "right",
-                    "GreenMask": true,
                     "IncreaseButton": "AutoStockpile/IncreaseButton.png",
                     "SliderQuantity": {
                         "Box": [

--- a/assets/resource_adb/pipeline/SellProduct/ValleyIV/InfraStation.json
+++ b/assets/resource_adb/pipeline/SellProduct/ValleyIV/InfraStation.json
@@ -25,7 +25,6 @@
     },
     "SellProductInfraStationBetterSliding": {
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource_adb/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
+++ b/assets/resource_adb/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
@@ -25,7 +25,6 @@
     },
     "SellProductReconstructionHQBetterSliding": {
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource_adb/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
+++ b/assets/resource_adb/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
@@ -25,7 +25,6 @@
     },
     "SellProductRefugeeCampBetterSliding": {
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource_adb/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
+++ b/assets/resource_adb/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
@@ -25,7 +25,6 @@
     },
     "SellProductCardiacRemediationStationBetterSliding": {
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource_adb/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
+++ b/assets/resource_adb/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
@@ -25,7 +25,6 @@
     },
     "SellProductSkyKingFlatsConstructionSiteBetterSliding": {
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/assets/resource_adb/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
+++ b/assets/resource_adb/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
@@ -25,7 +25,6 @@
     },
     "SellProductXiranflowCloudseederStationBetterSliding": {
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/docs/en_us/developers/components/better-sliding.md
+++ b/docs/en_us/developers/components/better-sliding.md
@@ -22,7 +22,7 @@ Suitable for scenarios where you want to slide to the maximum/minimum. Parameter
 | `ResetBeforeFindStart` | `bool` | No | When `true`, first swipes toward the minimum before matching the slider start position, then performs the swipe. Default `false`. |
 
 > [!note]
-> When matching the `SwipeButton` internally, the CustomAction sets `GreenMask` to `true`. For the green masking method, please refer to the default template.
+> When matching the `SwipeButton` internally, the CustomAction always enables the green mask (`green_mask: true`). For the green masking method, please refer to the default template. This is the default behavior and cannot be turned off via any parameter.
 
 ### Example
 
@@ -88,12 +88,14 @@ In addition to the 5 fields above, all other parameters can only be read from `c
 | `AvailableQuantity.Filter` | `object` | No | Color filter parameters for available-quantity OCR. Used only when `AvailableQuantity` is explicitly provided. |
 | `SliderQuantity.OnlyRec` | `bool` | No | Whether to enable `only_rec` for slider-quantity OCR. Default `false`. |
 | `AvailableQuantity.OnlyRec` | `bool` | No | Whether to enable `only_rec` for `BetterSlidingGetAvailableQuantity`. |
-| `GreenMask` | `bool` | No | When locating buttons using a template path, whether to enable green mask filtering for template matching. Default `false`. Applies to `IncreaseButton` and `DecreaseButton`. |
 | `CenterPointOffset` | `int[2]` | No | Click offset relative to the center point of the slider's recognition box `[x, y]`, negative values left/up, positive right/down. Default `[-10, 0]`. |
 | `ClampTargetToSliderMax` | `bool` | No | When `true`, a target above `sliderMaxQuantity` is clamped to the maximum selectable slider quantity. Default `false`. |
 | `SwipeButton` | `string` | No | Custom slider template path, overrides the default template of the `BetterSlidingSwipeButton` node. Default `""` (uses the shared default template). |
 | `OutOfRangeOverrideEnable` | `string` | No | When the resolved target is outside the slidable range, enables the specified Pipeline node and returns success. Default `""`. |
 | `TargetReachableOverrideEnable` | `string` | No | When the resolved target needs no clamping and falls within `[1, sliderMaxQuantity]`, enables the specified Pipeline node. Default `""`. |
+
+> [!note]
+> When matching `SwipeButton`, `IncreaseButton`, or `DecreaseButton` via a template path, the CustomAction always enables the green mask (`green_mask: true`); this cannot be turned off via any parameter. Please prepare your template images following the default template's green masking method (paint non-matching regions green, RGB: (0, 255, 0)).
 
 ### Outcome Node Contract
 

--- a/docs/zh_cn/developers/components/better-sliding.md
+++ b/docs/zh_cn/developers/components/better-sliding.md
@@ -22,7 +22,7 @@
 | `ResetBeforeFindStart` | `bool` | 否 | 为 `true` 时，先向最小方向滑动复位，再匹配滑块起始位置并执行滑动。默认 `false`。 |
 
 > [!note]
-> Custom内部在对`SwipeButton`进行匹配时，`GreenMask`设置为`true`，涂绿方式可参考默认模板
+> Custom 内部匹配 `SwipeButton` 时固定开启绿色掩码（`green_mask: true`），涂绿方式可参考默认模板。该行为为默认行为，无需也不能通过参数关闭。
 
 ### 示例
 
@@ -88,12 +88,14 @@
 | `AvailableQuantity.Filter` | `object` | 否 | 可用总量 OCR 的颜色过滤参数。仅在显式提供 `AvailableQuantity` 时使用。 |
 | `SliderQuantity.OnlyRec` | `bool` | 否 | 是否为滑条数量 OCR 节点启用 `only_rec`。默认 `false`。 |
 | `AvailableQuantity.OnlyRec` | `bool` | 否 | 是否为 `BetterSlidingGetAvailableQuantity` 启用 `only_rec`。 |
-| `GreenMask` | `bool` | 否 | 使用模板路径定位按钮时，是否对模板匹配启用绿色掩膜过滤。默认 `false`。对`IncreaseButton`与`DecreaseButton`生效 |
 | `CenterPointOffset` | `int[2]` | 否 | 相对滑块识别框中心点的点击偏移 `[x, y]`，负数向左/上，正数向右/下。默认 `[-10, 0]`。 |
 | `ClampTargetToSliderMax` | `bool` | 否 | 为 `true` 时，若目标超过 `sliderMaxQuantity`，则钳制为滑条最大可选数量继续执行。默认 `false`。 |
 | `SwipeButton` | `string` | 否 | 自定义滑块模板路径，覆盖 `BetterSlidingSwipeButton` 节点的默认模板。默认 `""`（使用共享默认模板）。 |
 | `OutOfRangeOverrideEnable` | `string` | 否 | 当解析后的目标超出可滑动范围时，将指定 Pipeline 节点的 `enabled` 设为 `true`，然后返回成功。默认 `""`。 |
 | `TargetReachableOverrideEnable` | `string` | 否 | 当解析后的目标无需钳制且位于 `[1, sliderMaxQuantity]` 时，将指定 Pipeline 节点的 `enabled` 设为 `true`。默认 `""`。 |
+
+> [!note]
+> `SwipeButton`、`IncreaseButton`、`DecreaseButton` 使用模板路径匹配时，Custom 内部固定开启绿色掩码（`green_mask: true`），无需也无法通过参数关闭。请按默认模板的涂绿方式处理模板图片（不参与匹配的部分涂绿 RGB: (0, 255, 0)）。
 
 ### 结果节点契约
 

--- a/tools/pipeline-generate/SellProduct/pipeline-adb-template.jsonc
+++ b/tools/pipeline-generate/SellProduct/pipeline-adb-template.jsonc
@@ -25,7 +25,6 @@
     },
     "SellProduct${LocationId}BetterSliding": {
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {

--- a/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
+++ b/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
@@ -1187,7 +1187,6 @@
         "action": "Custom",
         "custom_action": "BetterSliding",
         "custom_action_param": {
-            "GreenMask": true,
             "TargetQuantity": 999999,
             "ClampTargetToSliderMax": true,
             "AvailableQuantity": {


### PR DESCRIPTION
BetterSliding 对 SwipeButton / IncreaseButton / DecreaseButton 的模板 匹配固定开启绿色掩码，不再允许通过 GreenMask 参数关闭。

- 删除 params/types/presence 中的 GreenMask 字段与解析逻辑
- 以 defaultGreenMask=true 常量代替动态传入的 green_mask
- normalize.go 中 isSwipeOnlyMode 不再依赖 GreenMask 判定
- Helper.json/generate 模板与各任务 Pipeline 移除 GreenMask 配置
- 同步更新中英文文档，说明绿色掩码为默认行为且不可关闭

## Summary by Sourcery

使 BetterSliding 在进行按钮模板匹配时始终使用绿色遮罩，并移除已废弃的配置选项。

增强内容：
- 修复 BetterSliding 模板匹配，使其在 SwipeButton、IncreaseButton 和 DecreaseButton 上始终启用绿色遮罩。
- 移除 GreenMask 参数及相关流水线配置，使绿色遮罩行为不再可配置。
- 更新 BetterSliding 文档，说明固定的绿色遮罩行为及模板要求。

文档：
- 用英文和中文记录 BetterSliding 模板匹配中强制使用绿色遮罩的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make BetterSliding always use green masking for button template matching and remove the obsolete configuration option.

Enhancements:
- Fix BetterSliding template matching to always enable the green mask for SwipeButton, IncreaseButton, and DecreaseButton.
- Remove the GreenMask parameter and related pipeline configuration so green-mask behavior is no longer configurable.
- Update BetterSliding documentation to describe the fixed green-mask behavior and template requirements.

Documentation:
- Document the mandatory green mask behavior for BetterSliding template matching in English and Chinese.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 BetterSliding 在进行按钮模板匹配时始终使用绿色遮罩，并移除已废弃的配置选项。

增强内容：
- 修复 BetterSliding 模板匹配，使其在 SwipeButton、IncreaseButton 和 DecreaseButton 上始终启用绿色遮罩。
- 移除 GreenMask 参数及相关流水线配置，使绿色遮罩行为不再可配置。
- 更新 BetterSliding 文档，说明固定的绿色遮罩行为及模板要求。

文档：
- 用英文和中文记录 BetterSliding 模板匹配中强制使用绿色遮罩的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make BetterSliding always use green masking for button template matching and remove the obsolete configuration option.

Enhancements:
- Fix BetterSliding template matching to always enable the green mask for SwipeButton, IncreaseButton, and DecreaseButton.
- Remove the GreenMask parameter and related pipeline configuration so green-mask behavior is no longer configurable.
- Update BetterSliding documentation to describe the fixed green-mask behavior and template requirements.

Documentation:
- Document the mandatory green mask behavior for BetterSliding template matching in English and Chinese.

</details>

</details>