### PR TITLE
perf: 刷理智前输出理智

### DIFF
--- a/agent/go-service/common/focusocr/action.go
+++ b/agent/go-service/common/focusocr/action.go
@@ -1,0 +1,93 @@
+package focusocr
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/recogtarget"
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+const componentName = "FocusOCRAction"
+
+var _ maa.CustomActionRunner = &Action{}
+
+// Action screenshots, runs a Pipeline recognition node, and maafocus-prints the OCR hit.
+type Action struct{}
+
+type params struct {
+	Node  string `json:"node"`
+	Focus string `json:"focus"`
+}
+
+func (a *Action) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
+	if ctx == nil || arg == nil || ctx.GetTasker() == nil || ctx.GetTasker().GetController() == nil {
+		log.Error().Str("component", componentName).Msg("nil context, arg, tasker or controller")
+		return false
+	}
+
+	var p params
+	if err := json.Unmarshal([]byte(arg.CustomActionParam), &p); err != nil {
+		log.Error().Err(err).Str("component", componentName).Msg("parse params failed")
+		return false
+	}
+	p.Node = strings.TrimSpace(p.Node)
+	if p.Node == "" {
+		log.Error().Str("component", componentName).Msg("node is required")
+		return false
+	}
+
+	ctrl := ctx.GetTasker().GetController()
+	ctrl.PostScreencap().Wait()
+	img, err := ctrl.CacheImage()
+	if err != nil || img == nil {
+		log.Error().Err(err).Str("component", componentName).Msg("screencap failed")
+		return false
+	}
+
+	detail, err := ctx.RunRecognition(p.Node, img)
+	if err != nil || detail == nil || !detail.Hit {
+		log.Error().Err(err).Str("component", componentName).Str("node", p.Node).Msg("recognition miss")
+		return false
+	}
+	selected, err := recogtarget.SelectDetail(ctx, p.Node, detail)
+	if err != nil || selected == nil || selected.Results == nil {
+		log.Error().Err(err).Str("component", componentName).Str("node", p.Node).Msg("no ocr detail")
+		return false
+	}
+
+	hits := selected.Results.Filtered
+	if len(hits) == 0 {
+		hits = selected.Results.All
+	}
+	text := firstOCRText(hits)
+	if text == "" {
+		log.Error().Str("component", componentName).Msg("ocr text empty")
+		return false
+	}
+	focus := text
+	if f := strings.TrimSpace(p.Focus); f != "" {
+		focus = fmt.Sprintf(f, text)
+	}
+	maafocus.Print(ctx, focus)
+	return true
+}
+
+func firstOCRText(hits []*maa.RecognitionResult) string {
+	for _, hit := range hits {
+		if hit == nil {
+			continue
+		}
+		ocr, ok := hit.AsOCR()
+		if !ok || ocr == nil {
+			continue
+		}
+		if text := strings.TrimSpace(ocr.Text); text != "" {
+			return text
+		}
+	}
+	return ""
+}

--- a/agent/go-service/common/focusocr/register.go
+++ b/agent/go-service/common/focusocr/register.go
@@ -1,0 +1,7 @@
+package focusocr
+
+import maa "github.com/MaaXYZ/maa-framework-go/v4"
+
+func Register() {
+	maa.AgentServerRegisterCustomAction(componentName, &Action{})
+}

--- a/agent/go-service/register.go
+++ b/agent/go-service/register.go
@@ -20,6 +20,7 @@ import (
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/expressionrecognition"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/failurecollector"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/falseaction"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/focusocr"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/listcomplete"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/pipelineoverride"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/common/poststop"
@@ -65,6 +66,7 @@ func registerAll() {
 	clearhitcount.Register()
 	pipelineoverride.Register()
 	expressionrecognition.Register()
+	focusocr.Register()
 	listcomplete.Register()
 	expendable.Register()
 	attachregex.Register()

--- a/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
+++ b/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
@@ -63,7 +63,7 @@
         "post_delay": 0,
         "next": [
             // 如果玩家已唤起了激发的界面
-            "AutoEssenceClickEssenceStartButton",
+            "AutoEssenceClickEssenceStartPrepare",
             // 如果玩家当前已精准处于某个淤积点的交互位置
             "AutoEssenceClickTriggerButton",
             // 如果玩家当前已精准处于某个淤积点的交互位置，并且处于奖励待领取的状态
@@ -175,7 +175,7 @@
         "post_delay": 0,
         "next": [
             "AutoEssenceMistakeFactoryDevice",
-            "AutoEssenceClickEssenceStartButton"
+            "AutoEssenceClickEssenceStartPrepare"
         ]
     },
     "AutoEssenceMistakeFactoryDevice": {
@@ -209,6 +209,35 @@
         "focus": {
             "Node.Action.Starting": "😕误入工业设备界面，点击关闭按钮"
         }
+    },
+    "AutoEssenceClickEssenceStartPrepare": {
+        "desc": "识别开始挑战界面，播报当前理智",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "WhiteConfirmButtonType1",
+                    "AutoEssenceClickEssenceStartButtonText"
+                ],
+                "box_index": 1
+            }
+        },
+        "pre_delay": 0,
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "FocusOCRAction",
+                "custom_action_param": {
+                    "node": "CommonSanityText",
+                    "focus": "当前理智 %s"
+                }
+            }
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoEssenceClickEssenceStartButton"
+        ]
     },
     "AutoEssenceClickEssenceStartButton": {
         "desc": "识别并点击开始界面中的开始挑战按钮",

--- a/assets/resource/pipeline/Common/SanityOCR.json
+++ b/assets/resource/pipeline/Common/SanityOCR.json
@@ -1,0 +1,44 @@
+{
+    "CommonSanityText": {
+        "desc": "在理智标志旁侧 OCR 当前理智文本",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    {
+                        "sub_name": "mind_icon",
+                        "recognition": "TemplateMatch",
+                        "roi": [
+                            -350,
+                            0,
+                            350,
+                            60
+                        ],
+                        "template": [
+                            "SceneManager/MapMind.png"
+                        ]
+                    },
+                    {
+                        "recognition": "OCR",
+                        "roi": "mind_icon",
+                        "roi_offset": [
+                            30,
+                            -5,
+                            60,
+                            10
+                        ],
+                        // 80/135
+                        "expected": [
+                            // @i18n-skip
+                            "\\d+"
+                        ]
+                    }
+                ],
+                "box_index": 1
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    }
+}

--- a/assets/resource/pipeline/Interface/Example/FocusOCRAction.json
+++ b/assets/resource/pipeline/Interface/Example/FocusOCRAction.json
@@ -1,0 +1,39 @@
+{
+    "FocusOCRActionExample": {
+        "desc": "FocusOCRAction 示例：截图后执行 OCR 节点并播报",
+        "recognition": "DirectHit",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "FocusOCRAction",
+                "custom_action_param": {
+                    "node": "FocusOCRActionSampleText",
+                    "focus": "当前理智 %s"
+                }
+            }
+        },
+        "next": [
+            "FocusOCRActionPass"
+        ]
+    },
+    "FocusOCRActionSampleText": {
+        "desc": "示例 OCR 节点，业务侧换成图标旁侧 OCR 或 And(图标, OCR)",
+        "recognition": "OCR",
+        "roi": [
+            1040,
+            8,
+            200,
+            40
+        ],
+        "expected": [
+            ".+"
+        ],
+        "next": []
+    },
+    "FocusOCRActionPass": {
+        "desc": "播报后的后续流程",
+        "recognition": "DirectHit",
+        "action": "DoNothing",
+        "next": []
+    }
+}

--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -1,4 +1,41 @@
 {
+    "ProtocolSpaceEnterSpacePrepare": {
+        "desc": "识别进入协议空间按钮，播报当前理智",
+        "recognition": "Or",
+        "any_of": [
+            "WhiteConfirmButtonType1",
+            {
+                "recognition": "OCR",
+                "roi": [
+                    -250,
+                    -150,
+                    250,
+                    150
+                ],
+                "expected": [
+                    "进入",
+                    "進入",
+                    "Enter"
+                ]
+            }
+        ],
+        "pre_delay": 0,
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "FocusOCRAction",
+                "custom_action_param": {
+                    "node": "CommonSanityText",
+                    "focus": "当前理智 %s"
+                }
+            }
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "ProtocolSpaceEnterSpace"
+        ]
+    },
     "ProtocolSpaceEnterSpace": {
         "desc": "进入协议空间",
         "recognition": "Or",

--- a/assets/resource/pipeline/ProtocolSpace/Prepare.json
+++ b/assets/resource/pipeline/ProtocolSpace/Prepare.json
@@ -49,7 +49,7 @@
         "next": [
             "ProtocolSpacePrepareLock",
             "ProtocolSpaceNormalPrepareChooseReward",
-            "ProtocolSpaceEnterSpace"
+            "ProtocolSpaceEnterSpacePrepare"
         ],
         "focus": {
             "Node.Action.Succeeded": "$task.ProtocolSpace.focus.select_level"
@@ -146,7 +146,7 @@
         "threshold": 0.9,
         "action": "Click",
         "next": [
-            "ProtocolSpaceEnterSpace"
+            "ProtocolSpaceEnterSpacePrepare"
         ]
     },
     "ProtocolSpaceDeepDivePrepareEnter": {
@@ -169,7 +169,7 @@
         "post_delay": 0,
         "next": [
             "ProtocolSpacePrepareLock",
-            "ProtocolSpaceEnterSpace"
+            "ProtocolSpaceEnterSpacePrepare"
         ]
     },
     "ProtocolSpacePrepareLock": {

--- a/docs/en_us/developers/custom.md
+++ b/docs/en_us/developers/custom.md
@@ -82,6 +82,34 @@ The `FalseAction` implementation is located in `agent/go-service/common/falseact
 
 - Parameters: None.
 
+### FocusOCRAction
+
+The `FocusOCRAction` implementation is located in `agent/go-service/common/focusocr`. It takes a screenshot, runs a Pipeline recognition node, picks the first OCR text, and prints it via `maafocus`.
+
+Parameters:
+
+- `node: string`: Required. Pipeline recognition node name (OCR, or an `And` whose `box_index` points at OCR).
+- `focus: string`: Optional. `maafocus` message. `%s` is the OCR text, e.g. `Current sanity: %s`. If omitted, the raw text is printed.
+
+Example file: [`FocusOCRAction.json`](../../../assets/resource/pipeline/Interface/Example/FocusOCRAction.json)
+
+```json
+{
+    "action": {
+        "type": "Custom",
+        "param": {
+            "custom_action": "FocusOCRAction",
+            "custom_action_param": {
+                "node": "CommonSanityText",
+                "focus": "Current sanity: %s"
+            }
+        }
+    }
+}
+```
+
+The node's own recognition still belongs in Pipeline for routing. This Action only screenshots, recognizes, and reports after the node hits.
+
 ### RepeatUntilFoundAction / RepeatUntilNotFoundAction
 
 Both are implemented in `agent/go-service/common/repeataction`. They repeatedly run a built-in or custom action, then poll recognition inside a wait window. They succeed when the wait condition is met, and fail after `repeat_count` attempts without success.
@@ -511,6 +539,7 @@ When writing a Pipeline, the built-in `TemplateMatch` / `OCR` / `Click` / `Swipe
 | Run a series of subtasks in order | `SubTask` |
 | Clear hit count of a node | `ClearHitCount` |
 | Force an Action to fail | `FalseAction` |
+| Screenshot then report Pipeline OCR | `FocusOCRAction` |
 | Repeat an action until a node appears | `RepeatUntilFoundAction` |
 | Repeat an action until a node disappears | `RepeatUntilNotFoundAction` |
 | Actively stop the current task | `PostStop` |

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -84,6 +84,34 @@ Action 节点用于执行自定义动作。常见写法如下：
 
 - 参数：无。
 
+### FocusOCRAction
+
+`FocusOCRAction` 实现位于 `agent/go-service/common/focusocr`。截图后执行指定 Pipeline 识别节点，取出第一条 OCR 文本，再通过 `maafocus` 输出。
+
+参数：
+
+- `node: string`：必填。Pipeline 识别节点名（OCR，或 `And` 且 `box_index` 指向 OCR）。
+- `focus: string`：可选。`maafocus` 文案，`%s` 为 OCR 文本，例如 `当前理智 %s`。省略则输出原文。
+
+示例文件：[`FocusOCRAction.json`](../../../assets/resource/pipeline/Interface/Example/FocusOCRAction.json)
+
+```json
+{
+    "action": {
+        "type": "Custom",
+        "param": {
+            "custom_action": "FocusOCRAction",
+            "custom_action_param": {
+                "node": "CommonSanityText",
+                "focus": "当前理智 %s"
+            }
+        }
+    }
+}
+```
+
+节点自身的 recognition 仍由 Pipeline 负责分流；本 Action 只在命中后截图、识别并播报。
+
 ### RepeatUntilFoundAction / RepeatUntilNotFoundAction
 
 二者实现均位于 `agent/go-service/common/repeataction`，用于反复执行一次内置或自定义动作，每次执行后在等待窗口内轮询识别；条件满足即成功，耗尽次数仍不满足则失败。
@@ -513,6 +541,7 @@ Pipeline 布局与 `ListCompleteRecognition` 相同：将本识别放在滚动�
 | 按顺序跑一组子任务 | `SubTask` |
 | 清零某节点的命中计数 | `ClearHitCount` |
 | 强制让 Action 失败 | `FalseAction` |
+| 截图后播报 Pipeline OCR | `FocusOCRAction` |
 | 重复动作直到节点出现 | `RepeatUntilFoundAction` |
 | 重复动作直到节点消失 | `RepeatUntilNotFoundAction` |
 | 主动停止当前任务 | `PostStop` |

--- a/tools/schema/custom.action.schema.json
+++ b/tools/schema/custom.action.schema.json
@@ -55,6 +55,7 @@
 				"FailureCollectorRunTask",
 				"FailureCollectorReset",
                 "FalseAction",
+                "FocusOCRAction",
                 "ImageCheckSetResultAction",
                 "ImportBluePrintsEnterCodeAction",
                 "ImportBluePrintsFinishAction",
@@ -180,6 +181,34 @@
 					"custom_action_param": { "$ref": "./components/failure_collector.schema.json#/$defs/FinishParam" }
 				},
 				"required": [ "custom_action_param" ]
+			}
+		},
+		{
+			"if": {
+				"properties": {
+					"custom_action": { "const": "FocusOCRAction" }
+				},
+				"required": [ "custom_action" ]
+			},
+			"then": {
+				"type": "object",
+				"required": [ "custom_action_param" ],
+				"properties": {
+					"custom_action_param": {
+						"type": "object",
+						"additionalProperties": false,
+						"required": [ "node" ],
+						"properties": {
+							"node": {
+								"type": "string",
+								"minLength": 1
+							},
+							"focus": {
+								"type": "string"
+							}
+						}
+					}
+				}
 			}
 		},
 		{


### PR DESCRIPTION
close #5053

## Summary by Sourcery

在进行资源消耗型操作前，添加基于 OCR 的健全性（sanity）报告。

新功能：
- 添加一个 `FocusOCRAction`，通过 MaaFocus 报告来自 Pipeline 识别节点的首个 OCR 结果。

文档：
- 在英文和中文开发者指南中记录 `FocusOCRAction` 的用法、参数和示例。

杂项：
- 注册新的自定义动作，并为基于 OCR 的健全性报告添加流水线示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add OCR-based sanity reporting before resource consumption actions.

New Features:
- Add a FocusOCRAction that reports the first OCR result from a Pipeline recognition node through MaaFocus.

Documentation:
- Document FocusOCRAction usage, parameters, and examples in English and Chinese developer guides.

Chores:
- Register the new custom action and add pipeline examples for OCR-based sanity reporting.

</details>