### PR TITLE
feat(SellProduct): 按选品规则识别并沿用据点当前货品

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -335,6 +335,7 @@ FakesAssemblies/
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
 node_modules/
+.pnpm-store/
 
 # Visual Studio 6 build log
 *.plg

--- a/agent/go-service/sellproduct/goods/current.go
+++ b/agent/go-service/sellproduct/goods/current.go
@@ -3,10 +3,10 @@ package goods
 import (
 	"encoding/json"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/iconrecognition"
+	sellstrategy "github.com/MaaXYZ/MaaEnd/agent/go-service/sellproduct/goods/strategy"
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -26,8 +26,8 @@ type currentGoodsDetail struct {
 }
 
 // CurrentGoodsRecognition 在据点售卖主界面识别当前选中的货品图标。
-// 识别命中且该货品仍值得直接售卖（未尝试、未缺货、未被保留规则排除，
-// 严格优先模式下属于用户优先列表）时才命中，由 Pipeline 决定沿用或换货。
+// 稀有度和单价策略仅在当前货品恰好是下一候选时命中；库存策略依赖列表中的
+// 实时库存，不在主界面沿用当前货品，由 Pipeline 进入选货列表重新扫描。
 type CurrentGoodsRecognition struct{}
 
 var _ maa.CustomRecognitionRunner = (*CurrentGoodsRecognition)(nil)
@@ -39,6 +39,14 @@ func (r *CurrentGoodsRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogniti
 	param, err := parseCurrentGoodsRecognitionParam(arg.CustomRecognitionParam)
 	if err != nil {
 		log.Error().Err(err).Str("component", currentGoodsRecognitionName).Msg("invalid params")
+		return nil, false
+	}
+	policy := priorityPolicySnapshot()
+	if policy.Strategy == sellstrategy.KindStock {
+		log.Debug().
+			Str("component", currentGoodsRecognitionName).
+			Str("location", param.Location).
+			Msg("current goods adoption skipped for stock strategy")
 		return nil, false
 	}
 
@@ -101,13 +109,12 @@ func (r *CurrentGoodsRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogniti
 	}
 
 	match := parsed.Matches[0]
-	policy := priorityPolicySnapshot()
-	if !currentGoodsSellable(param.Location, match.ItemID, policy) {
+	if !currentGoodsMatchesSelection(param.Location, match.ItemID, groups, policy) {
 		log.Debug().
 			Str("component", currentGoodsRecognitionName).
 			Str("location", param.Location).
 			Str("item_id", match.ItemID).
-			Msg("current goods recognized but not sellable")
+			Msg("current goods recognized but not next selection")
 		return nil, false
 	}
 
@@ -144,26 +151,29 @@ func parseCurrentGoodsRecognitionParam(raw string) (*currentGoodsRecognitionPara
 	return &param, nil
 }
 
-// currentGoodsSellable 判断识别到的当前货品是否仍值得直接售卖：
-// 未尝试过、未缺货、未被保留规则排除，且严格优先模式下必须在用户优先列表中。
-func currentGoodsSellable(location, itemID string, policy prioritySelectionPolicy) bool {
-	attempted, outOfStock, _ := prioritySelectionSnapshot(location)
-	if _, done := attempted[itemID]; done {
+// currentGoodsMatchesSelection 判断当前货品是否等于静态策略的下一候选。
+// 稀有度和单价策略可用部署数据提前排序；库存策略必须打开列表读取实时库存。
+func currentGoodsMatchesSelection(
+	location string,
+	itemID string,
+	groups []itemPriorityGroup,
+	policy prioritySelectionPolicy,
+) bool {
+	if policy.Strategy == sellstrategy.KindStock {
 		return false
 	}
-	if _, unavailable := outOfStock[itemID]; unavailable {
-		return false
+
+	groups = prioritizeItemGroups(groups, policy.Preferred, policy.OnlyPreferred)
+	observations := make(map[string]sellstrategy.Candidate, len(groups))
+	for _, group := range groups {
+		observations[group.ItemID] = sellstrategy.Candidate{
+			ItemID:    group.ItemID,
+			Rarity:    group.Rarity,
+			UnitPrice: group.UnitPrice,
+		}
 	}
-	if _, blacklisted := reserveBlacklistedItemsSnapshot()[itemID]; blacklisted {
-		return false
-	}
-	if _, satisfied := reserveSatisfiedItemsSnapshot()[itemID]; satisfied {
-		return false
-	}
-	if policy.OnlyPreferred && !slices.Contains(policy.Preferred, itemID) {
-		return false
-	}
-	return true
+	targetItemID, _ := selectGoodsTarget(location, groups, policy, observations)
+	return targetItemID == itemID
 }
 
 // currentGoodsItemIDFromRecognition 从识别节点的 detail 中解析当前货品 ID，

--- a/agent/go-service/sellproduct/goods/current.go
+++ b/agent/go-service/sellproduct/goods/current.go
@@ -88,8 +88,15 @@ func (r *CurrentGoodsRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogniti
 	}
 	parsed, _, err := iconrecognition.ParseRecognitionDetail(detail)
 	if err != nil {
-		// 未选中货品时槽位为空，IconRecognition 不命中属于正常情况。
-		log.Debug().Err(err).
+		log.Warn().Err(err).
+			Str("component", currentGoodsRecognitionName).
+			Str("location", param.Location).
+			Msg("failed to parse current goods icon recognition detail")
+		return nil, false
+	}
+	// no_match 表示识别正常完成但没有候选达到阈值，交由 Pipeline 回落到换货流程。
+	if isCurrentGoodsNoMatch(parsed.Error) {
+		log.Debug().
 			Str("component", currentGoodsRecognitionName).
 			Str("location", param.Location).
 			Msg("current goods slot is empty or unrecognized")
@@ -130,6 +137,10 @@ func (r *CurrentGoodsRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogniti
 		Score:    match.Score,
 	})
 	return &maa.CustomRecognitionResult{Box: match.CellBox, Detail: string(detailJSON)}, true
+}
+
+func isCurrentGoodsNoMatch(detailErr *iconrecognition.DetailError) bool {
+	return detailErr != nil && detailErr.Code == iconrecognition.ErrorCodeNoMatch
 }
 
 func parseCurrentGoodsRecognitionParam(raw string) (*currentGoodsRecognitionParam, error) {

--- a/agent/go-service/sellproduct/goods/current.go
+++ b/agent/go-service/sellproduct/goods/current.go
@@ -26,8 +26,8 @@ type currentGoodsDetail struct {
 }
 
 // CurrentGoodsRecognition 在据点售卖主界面识别当前选中的货品图标。
-// 稀有度和单价策略仅在当前货品恰好是下一候选时命中；库存策略依赖列表中的
-// 实时库存，不在主界面沿用当前货品，由 Pipeline 进入选货列表重新扫描。
+// 稀有度和单价策略仅在当前货品恰好是下一候选时命中；库存策略只沿用可由
+// 优先槽位直接确定的下一候选，其余情况由 Pipeline 进入选货列表重新扫描库存。
 type CurrentGoodsRecognition struct{}
 
 var _ maa.CustomRecognitionRunner = (*CurrentGoodsRecognition)(nil)
@@ -42,11 +42,11 @@ func (r *CurrentGoodsRecognition) Run(ctx *maa.Context, arg *maa.CustomRecogniti
 		return nil, false
 	}
 	policy := priorityPolicySnapshot()
-	if policy.Strategy == sellstrategy.KindStock {
+	if policy.Strategy == sellstrategy.KindStock && len(policy.Preferred) == 0 {
 		log.Debug().
 			Str("component", currentGoodsRecognitionName).
 			Str("location", param.Location).
-			Msg("current goods adoption skipped for stock strategy")
+			Msg("current goods adoption skipped for stock strategy without preferred items")
 		return nil, false
 	}
 
@@ -162,18 +162,15 @@ func parseCurrentGoodsRecognitionParam(raw string) (*currentGoodsRecognitionPara
 	return &param, nil
 }
 
-// currentGoodsMatchesSelection 判断当前货品是否等于静态策略的下一候选。
-// 稀有度和单价策略可用部署数据提前排序；库存策略必须打开列表读取实时库存。
+// currentGoodsMatchesSelection 判断当前货品是否等于当前选品规则的下一候选。
+// 库存策略只能静态确定优先槽位中的候选；没有可用优先货品时，因库存未知而
+// 不会选中普通候选，Pipeline 会打开列表读取实时库存。
 func currentGoodsMatchesSelection(
 	location string,
 	itemID string,
 	groups []itemPriorityGroup,
 	policy prioritySelectionPolicy,
 ) bool {
-	if policy.Strategy == sellstrategy.KindStock {
-		return false
-	}
-
 	groups = prioritizeItemGroups(groups, policy.Preferred, policy.OnlyPreferred)
 	observations := make(map[string]sellstrategy.Candidate, len(groups))
 	for _, group := range groups {

--- a/agent/go-service/sellproduct/goods/current.go
+++ b/agent/go-service/sellproduct/goods/current.go
@@ -1,0 +1,206 @@
+package goods
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/iconrecognition"
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+const currentGoodsRecognitionName = "SellProductCurrentGoods"
+
+type currentGoodsRecognitionParam struct {
+	Location string `json:"location"`
+	ROI      []int  `json:"roi"`
+}
+
+// currentGoodsDetail 是当前货品识别结果与 adopt 动作之间传递的结构化 detail。
+type currentGoodsDetail struct {
+	Location string  `json:"location"`
+	ItemID   string  `json:"item_id"`
+	Score    float64 `json:"score"`
+}
+
+// CurrentGoodsRecognition 在据点售卖主界面识别当前选中的货品图标。
+// 识别命中且该货品仍值得直接售卖（未尝试、未缺货、未被保留规则排除，
+// 严格优先模式下属于用户优先列表）时才命中，由 Pipeline 决定沿用或换货。
+type CurrentGoodsRecognition struct{}
+
+var _ maa.CustomRecognitionRunner = (*CurrentGoodsRecognition)(nil)
+
+func (r *CurrentGoodsRecognition) Run(ctx *maa.Context, arg *maa.CustomRecognitionArg) (*maa.CustomRecognitionResult, bool) {
+	if ctx == nil || arg == nil || arg.Img == nil {
+		return nil, false
+	}
+	param, err := parseCurrentGoodsRecognitionParam(arg.CustomRecognitionParam)
+	if err != nil {
+		log.Error().Err(err).Str("component", currentGoodsRecognitionName).Msg("invalid params")
+		return nil, false
+	}
+
+	// 候选只保留当前据点的可售物品，缩小 IconRecognition 的模板匹配范围。
+	groupsByLocation, err := loadItemPriorityGroupsFunc()
+	if err != nil {
+		log.Error().Err(err).Str("component", currentGoodsRecognitionName).Msg("failed to load item priorities")
+		return nil, false
+	}
+	groups := groupsByLocation[param.Location]
+	if len(groups) == 0 {
+		log.Error().Str("component", currentGoodsRecognitionName).Str("location", param.Location).
+			Msg("location has no sellable items")
+		return nil, false
+	}
+	itemIDs := make([]string, 0, len(groups))
+	for _, group := range groups {
+		itemIDs = append(itemIDs, group.ItemID)
+	}
+
+	detail, err := ctx.RunRecognitionDirect(
+		maa.RecognitionTypeCustom,
+		&maa.CustomRecognitionParam{
+			ROI:               maa.NewTargetRect(maa.Rect{param.ROI[0], param.ROI[1], param.ROI[2], param.ROI[3]}),
+			CustomRecognition: iconrecognition.CustomRecognitionName,
+			CustomRecognitionParam: iconrecognition.NewParams(
+				iconrecognition.WithGridType(iconrecognition.GridTypeSingleROI),
+				iconrecognition.WithItemIDs(itemIDs...),
+			),
+		},
+		arg.Img,
+	)
+	if err != nil {
+		log.Warn().Err(err).
+			Str("component", currentGoodsRecognitionName).
+			Str("location", param.Location).
+			Msg("current goods icon recognition failed")
+		return nil, false
+	}
+	parsed, _, err := iconrecognition.ParseRecognitionDetail(detail)
+	if err != nil {
+		// 未选中货品时槽位为空，IconRecognition 不命中属于正常情况。
+		log.Debug().Err(err).
+			Str("component", currentGoodsRecognitionName).
+			Str("location", param.Location).
+			Msg("current goods slot is empty or unrecognized")
+		return nil, false
+	}
+	if parsed.Error != nil {
+		log.Warn().
+			Str("component", currentGoodsRecognitionName).
+			Str("location", param.Location).
+			Str("error_code", string(parsed.Error.Code)).
+			Str("error_message", parsed.Error.Message).
+			Msg("current goods icon recognition returned error")
+		return nil, false
+	}
+	if !parsed.Matched || len(parsed.Matches) == 0 {
+		return nil, false
+	}
+
+	match := parsed.Matches[0]
+	policy := priorityPolicySnapshot()
+	if !currentGoodsSellable(param.Location, match.ItemID, policy) {
+		log.Debug().
+			Str("component", currentGoodsRecognitionName).
+			Str("location", param.Location).
+			Str("item_id", match.ItemID).
+			Msg("current goods recognized but not sellable")
+		return nil, false
+	}
+
+	log.Info().
+		Str("component", currentGoodsRecognitionName).
+		Str("location", param.Location).
+		Str("item_id", match.ItemID).
+		Float64("score", match.Score).
+		Msg("current goods recognized")
+	detailJSON, _ := json.Marshal(currentGoodsDetail{
+		Location: param.Location,
+		ItemID:   match.ItemID,
+		Score:    match.Score,
+	})
+	return &maa.CustomRecognitionResult{Box: match.CellBox, Detail: string(detailJSON)}, true
+}
+
+func parseCurrentGoodsRecognitionParam(raw string) (*currentGoodsRecognitionParam, error) {
+	var param currentGoodsRecognitionParam
+	if err := json.Unmarshal([]byte(raw), &param); err != nil {
+		return nil, fmt.Errorf("unmarshal custom_recognition_param: %w", err)
+	}
+	param.Location = strings.TrimSpace(param.Location)
+	if param.Location == "" {
+		return nil, fmt.Errorf("location is empty")
+	}
+	if len(param.ROI) != 4 {
+		return nil, fmt.Errorf("roi length is %d, expected 4", len(param.ROI))
+	}
+	// IconRecognition 的 single_roi 要求正方形 ROI。
+	if param.ROI[2] <= 0 || param.ROI[2] != param.ROI[3] {
+		return nil, fmt.Errorf("roi must be a positive square, got %v", param.ROI)
+	}
+	return &param, nil
+}
+
+// currentGoodsSellable 判断识别到的当前货品是否仍值得直接售卖：
+// 未尝试过、未缺货、未被保留规则排除，且严格优先模式下必须在用户优先列表中。
+func currentGoodsSellable(location, itemID string, policy prioritySelectionPolicy) bool {
+	attempted, outOfStock, _ := prioritySelectionSnapshot(location)
+	if _, done := attempted[itemID]; done {
+		return false
+	}
+	if _, unavailable := outOfStock[itemID]; unavailable {
+		return false
+	}
+	if _, blacklisted := reserveBlacklistedItemsSnapshot()[itemID]; blacklisted {
+		return false
+	}
+	if _, satisfied := reserveSatisfiedItemsSnapshot()[itemID]; satisfied {
+		return false
+	}
+	if policy.OnlyPreferred && !slices.Contains(policy.Preferred, itemID) {
+		return false
+	}
+	return true
+}
+
+// currentGoodsItemIDFromRecognition 从识别节点的 detail 中解析当前货品 ID，
+// 供 adopt 动作读取；识别节点不命中时不会进入 adopt，此处失败视为契约破坏。
+func currentGoodsItemIDFromRecognition(detail *maa.RecognitionDetail) (string, error) {
+	if detail == nil || detail.Results == nil {
+		return "", fmt.Errorf("recognition detail is empty")
+	}
+	result := detail.Results.Best
+	if result == nil && len(detail.Results.All) > 0 {
+		result = detail.Results.All[0]
+	}
+	if result == nil {
+		return "", fmt.Errorf("custom result is empty")
+	}
+	custom, ok := result.AsCustom()
+	if !ok || custom == nil {
+		return "", fmt.Errorf("result is not custom recognition")
+	}
+	return currentGoodsItemIDFromCustomResult(custom)
+}
+
+func currentGoodsItemIDFromCustomResult(result *maa.CustomRecognitionResult) (string, error) {
+	if result == nil {
+		return "", fmt.Errorf("custom result is empty")
+	}
+	return parseCurrentGoodsDetail(result.Detail)
+}
+
+func parseCurrentGoodsDetail(raw string) (string, error) {
+	var parsed currentGoodsDetail
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return "", fmt.Errorf("parse current goods detail: %w", err)
+	}
+	parsed.ItemID = strings.TrimSpace(parsed.ItemID)
+	if parsed.ItemID == "" {
+		return "", fmt.Errorf("item_id is empty")
+	}
+	return parsed.ItemID, nil
+}

--- a/agent/go-service/sellproduct/goods/current_test.go
+++ b/agent/go-service/sellproduct/goods/current_test.go
@@ -1,0 +1,178 @@
+package goods
+
+import (
+	"testing"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+)
+
+// TestParseCurrentGoodsRecognitionParam 校验地点和 ROI 必填，且 ROI 必须为正方形。
+func TestParseCurrentGoodsRecognitionParam(t *testing.T) {
+	if _, err := parseCurrentGoodsRecognitionParam(`{"location":"InfraStation"}`); err == nil {
+		t.Fatal("缺少 roi 应校验失败")
+	}
+
+	param, err := parseCurrentGoodsRecognitionParam(`{"location":"InfraStation","roi":[1177,450,54,54]}`)
+	if err != nil || param.ROI[0] != 1177 || param.ROI[2] != 54 {
+		t.Fatalf("Pipeline ROI 参数 = %+v，错误 = %v", param, err)
+	}
+
+	if _, err = parseCurrentGoodsRecognitionParam(`{"location":" ","roi":[1177,450,54,54]}`); err == nil {
+		t.Fatal("空 location 应校验失败")
+	}
+	if _, err = parseCurrentGoodsRecognitionParam(`{"location":"InfraStation","roi":[1177,450,54,60]}`); err == nil {
+		t.Fatal("非正方形 ROI 应校验失败")
+	}
+	if _, err = parseCurrentGoodsRecognitionParam(`{"location":"InfraStation","roi":[1177,450]}`); err == nil {
+		t.Fatal("长度不足的 ROI 应校验失败")
+	}
+}
+
+// TestCurrentGoodsSellablePolicy 验证沿用判断分别受已尝试、缺货、保留规则和严格优先模式约束。
+func TestCurrentGoodsSellablePolicy(t *testing.T) {
+	resetReserveSession()
+	configurePrioritySession(false, false)
+	policy := priorityPolicySnapshot()
+	if !currentGoodsSellable("Outpost", "item_a", policy) {
+		t.Fatal("默认策略下未处理的物品应可沿用")
+	}
+
+	resetReserveSession()
+	prioritySelectionAdopt("Outpost", "item_a")
+	if currentGoodsSellable("Outpost", "item_a", priorityPolicySnapshot()) {
+		t.Fatal("已尝试物品不应沿用")
+	}
+
+	resetReserveSession()
+	prioritySelectionAdopt("Outpost", "item_a")
+	if _, _, ok := prioritySelectionMarkOutOfStock("Outpost"); !ok {
+		t.Fatal("沿用后的当前物品应可标记缺货")
+	}
+	if currentGoodsSellable("Outpost", "item_a", priorityPolicySnapshot()) {
+		t.Fatal("缺货物品不应沿用")
+	}
+
+	resetReserveSession()
+	registerReserveRule("item_a", reserveBlacklistQuantity)
+	if currentGoodsSellable("Outpost", "item_a", priorityPolicySnapshot()) {
+		t.Fatal("黑名单物品不应沿用")
+	}
+
+	resetReserveSession()
+	registerReserveRule("item_a", 10)
+	setSelectedReserveItem("item_a")
+	if _, _, _, ok := markSelectedReserveSatisfied(); !ok {
+		t.Fatal("保留规则应可标记满足")
+	}
+	if currentGoodsSellable("Outpost", "item_a", priorityPolicySnapshot()) {
+		t.Fatal("保留量已满足的物品不应沿用")
+	}
+
+	resetReserveSession()
+	configurePrioritySession(true, true)
+	resetPreferredPriorityItems(true)
+	registerPriorityItem("item_b")
+	policy = priorityPolicySnapshot()
+	if currentGoodsSellable("Outpost", "item_a", policy) {
+		t.Fatal("严格优先模式下未配置的物品不应沿用")
+	}
+	if !currentGoodsSellable("Outpost", "item_b", policy) {
+		t.Fatal("严格优先模式下优先列表内的物品应可沿用")
+	}
+	resetReserveSession()
+}
+
+// TestPrioritySelectionAdoptMatchesCommitState 验证沿用与换货提交产生的会话状态一致。
+func TestPrioritySelectionAdoptMatchesCommitState(t *testing.T) {
+	resetPrioritySelectionSession()
+	prioritySelectionSetPending("Outpost", "item_pending")
+	prioritySelectionAdopt("Outpost", "item_a")
+	attempted, _, pending := prioritySelectionSnapshot("Outpost")
+	if _, ok := attempted["item_a"]; !ok || pending != "" {
+		t.Fatalf("沿用后状态不符合预期：已尝试 = %v，待选 = %q", attempted, pending)
+	}
+	itemID, _, ok := prioritySelectionMarkOutOfStock("Outpost")
+	if !ok || itemID != "item_a" {
+		t.Fatalf("沿用物品应作为当前物品参与缺货标记：%q, %v", itemID, ok)
+	}
+	resetPrioritySelectionSession()
+}
+
+// TestPrioritySessionAdoptParamAndDetail 校验 adopt 操作的参数与缺失识别结果处理。
+func TestPrioritySessionAdoptParamAndDetail(t *testing.T) {
+	if _, err := parsePrioritySessionActionParam(&maa.CustomActionArg{
+		CustomActionParam: `{"operation":"adopt","location":"InfraStation"}`,
+	}); err != nil {
+		t.Fatalf("adopt 参数应解析成功：%v", err)
+	}
+	if _, err := parsePrioritySessionActionParam(&maa.CustomActionArg{
+		CustomActionParam: `{"operation":"adopt"}`,
+	}); err == nil {
+		t.Fatal("缺少 location 的 adopt 应校验失败")
+	}
+
+	resetPrioritySelectionSession()
+	if (&PrioritySessionAction{}).Run(nil, &maa.CustomActionArg{
+		CustomActionParam: `{"operation":"adopt","location":"InfraStation"}`,
+	}) {
+		t.Fatal("缺少识别 detail 的 adopt 应失败")
+	}
+	resetPrioritySelectionSession()
+}
+
+// TestCurrentGoodsItemIDFromRecognition 校验识别结果缺失、为空或类型错误时均会失败。
+func TestCurrentGoodsItemIDFromRecognition(t *testing.T) {
+	tests := []struct {
+		name   string
+		detail *maa.RecognitionDetail
+	}{
+		{
+			name: "nil detail",
+		},
+		{
+			name:   "nil results",
+			detail: &maa.RecognitionDetail{},
+		},
+		{
+			name: "empty results",
+			detail: &maa.RecognitionDetail{
+				Results: &maa.RecognitionResults{},
+			},
+		},
+		{
+			name: "non-custom best",
+			detail: &maa.RecognitionDetail{
+				Results: &maa.RecognitionResults{
+					Best: &maa.RecognitionResult{},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if itemID, err := currentGoodsItemIDFromRecognition(test.detail); err == nil {
+				t.Fatalf("无效识别结果应解析失败：item_id = %q", itemID)
+			}
+		})
+	}
+}
+
+// TestCurrentGoodsItemIDFromCustomResult 校验合法 Custom 结果的 item_id 成功路径。
+func TestCurrentGoodsItemIDFromCustomResult(t *testing.T) {
+	if _, err := currentGoodsItemIDFromCustomResult(nil); err == nil {
+		t.Fatal("nil Custom 结果应解析失败")
+	}
+	if _, err := currentGoodsItemIDFromCustomResult(&maa.CustomRecognitionResult{
+		Detail: `{"location":"InfraStation"}`,
+	}); err == nil {
+		t.Fatal("缺少 item_id 的 Custom 结果应解析失败")
+	}
+
+	itemID, err := currentGoodsItemIDFromCustomResult(&maa.CustomRecognitionResult{
+		Detail: `{"location":"InfraStation","item_id":"item_a","score":0.91}`,
+	})
+	if err != nil || itemID != "item_a" {
+		t.Fatalf("Custom 结果解析 = %q，错误 = %v", itemID, err)
+	}
+}

--- a/agent/go-service/sellproduct/goods/current_test.go
+++ b/agent/go-service/sellproduct/goods/current_test.go
@@ -3,6 +3,7 @@ package goods
 import (
 	"testing"
 
+	sellstrategy "github.com/MaaXYZ/MaaEnd/agent/go-service/sellproduct/goods/strategy"
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 )
 
@@ -28,44 +29,100 @@ func TestParseCurrentGoodsRecognitionParam(t *testing.T) {
 	}
 }
 
-// TestCurrentGoodsSellablePolicy 验证沿用判断分别受已尝试、缺货、保留规则和严格优先模式约束。
-func TestCurrentGoodsSellablePolicy(t *testing.T) {
+// TestCurrentGoodsMatchesSelectionFollowsStaticStrategy 验证仅沿用静态策略的下一候选，
+// 库存策略始终进入货品列表读取实时库存。
+func TestCurrentGoodsMatchesSelectionFollowsStaticStrategy(t *testing.T) {
+	groups := []itemPriorityGroup{
+		{ItemID: "high_rarity", Rarity: 4, UnitPrice: 30},
+		{ItemID: "high_price", Rarity: 3, UnitPrice: 70},
+	}
+	tests := []struct {
+		name         string
+		strategy     sellstrategy.Kind
+		current      string
+		wantSellable bool
+	}{
+		{name: "rarity best", strategy: sellstrategy.KindRarity, current: "high_rarity", wantSellable: true},
+		{name: "rarity lower", strategy: sellstrategy.KindRarity, current: "high_price"},
+		{name: "price best", strategy: sellstrategy.KindPrice, current: "high_price", wantSellable: true},
+		{name: "price lower", strategy: sellstrategy.KindPrice, current: "high_rarity"},
+		{name: "stock always scans", strategy: sellstrategy.KindStock, current: "high_rarity"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resetReserveSession()
+			policy := prioritySelectionPolicy{Strategy: test.strategy}
+			if got := currentGoodsMatchesSelection("Outpost", test.current, groups, policy); got != test.wantSellable {
+				t.Fatalf("当前货品沿用 = %v，期望 %v", got, test.wantSellable)
+			}
+		})
+	}
+	resetReserveSession()
+}
+
+// TestCurrentGoodsMatchesSelectionPolicy 验证沿用判断复用正式选品的优先顺序和排除规则。
+func TestCurrentGoodsMatchesSelectionPolicy(t *testing.T) {
+	groups := []itemPriorityGroup{
+		{ItemID: "item_a", Rarity: 2, UnitPrice: 10},
+		{ItemID: "item_b", Rarity: 3, UnitPrice: 20},
+	}
+
 	resetReserveSession()
 	configurePrioritySession(false, false)
 	policy := priorityPolicySnapshot()
-	if !currentGoodsSellable("Outpost", "item_a", policy) {
-		t.Fatal("默认策略下未处理的物品应可沿用")
+	if !currentGoodsMatchesSelection("Outpost", "item_b", groups, policy) {
+		t.Fatal("默认稀有度策略应沿用排序第一的物品")
+	}
+	if currentGoodsMatchesSelection("Outpost", "item_a", groups, policy) {
+		t.Fatal("默认稀有度策略不应沿用排序靠后的物品")
 	}
 
 	resetReserveSession()
-	prioritySelectionAdopt("Outpost", "item_a")
-	if currentGoodsSellable("Outpost", "item_a", priorityPolicySnapshot()) {
+	prioritySelectionAdopt("Outpost", "item_b")
+	if currentGoodsMatchesSelection("Outpost", "item_b", groups, priorityPolicySnapshot()) {
 		t.Fatal("已尝试物品不应沿用")
 	}
+	if !currentGoodsMatchesSelection("Outpost", "item_a", groups, priorityPolicySnapshot()) {
+		t.Fatal("应沿用排除已尝试物品后的下一候选")
+	}
 
 	resetReserveSession()
-	prioritySelectionAdopt("Outpost", "item_a")
+	prioritySelectionAdopt("Outpost", "item_b")
 	if _, _, ok := prioritySelectionMarkOutOfStock("Outpost"); !ok {
 		t.Fatal("沿用后的当前物品应可标记缺货")
 	}
-	if currentGoodsSellable("Outpost", "item_a", priorityPolicySnapshot()) {
+	if currentGoodsMatchesSelection("Outpost", "item_b", groups, priorityPolicySnapshot()) {
 		t.Fatal("缺货物品不应沿用")
 	}
 
 	resetReserveSession()
-	registerReserveRule("item_a", reserveBlacklistQuantity)
-	if currentGoodsSellable("Outpost", "item_a", priorityPolicySnapshot()) {
+	registerReserveRule("item_b", reserveBlacklistQuantity)
+	if currentGoodsMatchesSelection("Outpost", "item_b", groups, priorityPolicySnapshot()) {
 		t.Fatal("黑名单物品不应沿用")
 	}
 
 	resetReserveSession()
-	registerReserveRule("item_a", 10)
-	setSelectedReserveItem("item_a")
+	registerReserveRule("item_b", 10)
+	setSelectedReserveItem("item_b")
 	if _, _, _, ok := markSelectedReserveSatisfied(); !ok {
 		t.Fatal("保留规则应可标记满足")
 	}
-	if currentGoodsSellable("Outpost", "item_a", priorityPolicySnapshot()) {
+	if currentGoodsMatchesSelection("Outpost", "item_b", groups, priorityPolicySnapshot()) {
 		t.Fatal("保留量已满足的物品不应沿用")
+	}
+
+	resetReserveSession()
+	configurePrioritySession(true, false)
+	resetPreferredPriorityItems(true)
+	registerPriorityItem("item_a")
+	registerPriorityItem("item_b")
+	policy = priorityPolicySnapshot()
+	if !currentGoodsMatchesSelection("Outpost", "item_a", groups, policy) {
+		t.Fatal("应沿用优先槽位中的第一候选")
+	}
+	if currentGoodsMatchesSelection("Outpost", "item_b", groups, policy) {
+		t.Fatal("不应越过更靠前的优先物品沿用当前货品")
 	}
 
 	resetReserveSession()
@@ -73,11 +130,11 @@ func TestCurrentGoodsSellablePolicy(t *testing.T) {
 	resetPreferredPriorityItems(true)
 	registerPriorityItem("item_b")
 	policy = priorityPolicySnapshot()
-	if currentGoodsSellable("Outpost", "item_a", policy) {
+	if currentGoodsMatchesSelection("Outpost", "item_a", groups, policy) {
 		t.Fatal("严格优先模式下未配置的物品不应沿用")
 	}
-	if !currentGoodsSellable("Outpost", "item_b", policy) {
-		t.Fatal("严格优先模式下优先列表内的物品应可沿用")
+	if !currentGoodsMatchesSelection("Outpost", "item_b", groups, policy) {
+		t.Fatal("严格优先模式应沿用唯一配置的物品")
 	}
 	resetReserveSession()
 }

--- a/agent/go-service/sellproduct/goods/current_test.go
+++ b/agent/go-service/sellproduct/goods/current_test.go
@@ -3,6 +3,7 @@ package goods
 import (
 	"testing"
 
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/iconrecognition"
 	sellstrategy "github.com/MaaXYZ/MaaEnd/agent/go-service/sellproduct/goods/strategy"
 	maa "github.com/MaaXYZ/maa-framework-go/v4"
 )
@@ -26,6 +27,19 @@ func TestParseCurrentGoodsRecognitionParam(t *testing.T) {
 	}
 	if _, err = parseCurrentGoodsRecognitionParam(`{"location":"InfraStation","roi":[1177,450]}`); err == nil {
 		t.Fatal("长度不足的 ROI 应校验失败")
+	}
+}
+
+// TestIsCurrentGoodsNoMatch 验证仅把 IconRecognition 的正常未命中视为回落条件。
+func TestIsCurrentGoodsNoMatch(t *testing.T) {
+	if isCurrentGoodsNoMatch(nil) {
+		t.Fatal("空错误不应视为 no_match")
+	}
+	if !isCurrentGoodsNoMatch(&iconrecognition.DetailError{Code: iconrecognition.ErrorCodeNoMatch}) {
+		t.Fatal("no_match 应视为正常未命中")
+	}
+	if isCurrentGoodsNoMatch(&iconrecognition.DetailError{Code: iconrecognition.ErrorCodeException}) {
+		t.Fatal("exception 不应视为正常未命中")
 	}
 }
 

--- a/agent/go-service/sellproduct/goods/current_test.go
+++ b/agent/go-service/sellproduct/goods/current_test.go
@@ -43,9 +43,9 @@ func TestIsCurrentGoodsNoMatch(t *testing.T) {
 	}
 }
 
-// TestCurrentGoodsMatchesSelectionFollowsStaticStrategy 验证仅沿用静态策略的下一候选，
-// 库存策略始终进入货品列表读取实时库存。
-func TestCurrentGoodsMatchesSelectionFollowsStaticStrategy(t *testing.T) {
+// TestCurrentGoodsMatchesSelectionFollowsStrategy 验证仅沿用当前策略的下一候选；
+// 没有优先货品时，库存策略进入货品列表读取实时库存。
+func TestCurrentGoodsMatchesSelectionFollowsStrategy(t *testing.T) {
 	groups := []itemPriorityGroup{
 		{ItemID: "high_rarity", Rarity: 4, UnitPrice: 30},
 		{ItemID: "high_price", Rarity: 3, UnitPrice: 70},
@@ -71,6 +71,35 @@ func TestCurrentGoodsMatchesSelectionFollowsStaticStrategy(t *testing.T) {
 				t.Fatalf("当前货品沿用 = %v，期望 %v", got, test.wantSellable)
 			}
 		})
+	}
+	resetReserveSession()
+}
+
+// TestCurrentGoodsMatchesSelectionStockPreferred 验证库存策略仍优先处理用户配置的
+// 优先货品，但不会越过更靠前且可用的优先槽位沿用当前货品。
+func TestCurrentGoodsMatchesSelectionStockPreferred(t *testing.T) {
+	groups := []itemPriorityGroup{
+		{ItemID: "item_a", Rarity: 2, UnitPrice: 10},
+		{ItemID: "item_b", Rarity: 3, UnitPrice: 20},
+	}
+
+	resetReserveSession()
+	configurePrioritySession(true, false)
+	configureSelectionStrategy(sellstrategy.KindStock, sellstrategy.Config{})
+	resetPreferredPriorityItems(true)
+	registerPriorityItem("item_a")
+	registerPriorityItem("item_b")
+	policy := priorityPolicySnapshot()
+	if !currentGoodsMatchesSelection("Outpost", "item_a", groups, policy) {
+		t.Fatal("库存策略应沿用第一可用优先货品")
+	}
+	if currentGoodsMatchesSelection("Outpost", "item_b", groups, policy) {
+		t.Fatal("库存策略不应越过第一可用优先货品")
+	}
+
+	prioritySelectionAdopt("Outpost", "item_a")
+	if !currentGoodsMatchesSelection("Outpost", "item_b", groups, priorityPolicySnapshot()) {
+		t.Fatal("第一优先货品已尝试后应沿用第二优先货品")
 	}
 	resetReserveSession()
 }

--- a/agent/go-service/sellproduct/goods/register.go
+++ b/agent/go-service/sellproduct/goods/register.go
@@ -5,6 +5,7 @@ import maa "github.com/MaaXYZ/maa-framework-go/v4"
 // Register 注册货品相关的全部 SellProduct Custom 组件。
 func Register() {
 	maa.AgentServerRegisterCustomRecognition(priorityItemRecognitionName, &PriorityItemRecognition{})
+	maa.AgentServerRegisterCustomRecognition(currentGoodsRecognitionName, &CurrentGoodsRecognition{})
 	maa.AgentServerRegisterCustomAction(reserveSessionActionName, &ReserveSessionAction{})
 	maa.AgentServerRegisterCustomAction(prioritySessionActionName, &PrioritySessionAction{})
 }

--- a/agent/go-service/sellproduct/goods/runtime.go
+++ b/agent/go-service/sellproduct/goods/runtime.go
@@ -142,6 +142,18 @@ func runtimeItemSwitchedMessage(location string, itemID string) string {
 	)
 }
 
+func printRuntimeItemAdopted(ctx *maa.Context, location string, itemID string) {
+	maafocus.Print(ctx, runtimeItemAdoptedMessage(location, itemID))
+}
+
+func runtimeItemAdoptedMessage(location string, itemID string) string {
+	return i18n.T(
+		"sellproduct.runtime.item_adopted",
+		selectiondata.ItemName(itemID),
+		selectiondata.LocationName(location),
+	)
+}
+
 func printRuntimeItemOutOfStock(ctx *maa.Context, location string, itemID string) {
 	maafocus.Print(ctx, runtimeItemOutOfStockMessage(location, itemID))
 }

--- a/agent/go-service/sellproduct/goods/session.go
+++ b/agent/go-service/sellproduct/goods/session.go
@@ -24,6 +24,7 @@ const (
 	priorityOperationResetSelection = "reset_goods_selection"
 	priorityOperationRegister       = "register"
 	priorityOperationCommit         = "commit"
+	priorityOperationAdopt          = "adopt"
 	priorityOperationOutOfStock     = "out_of_stock"
 )
 
@@ -135,6 +136,25 @@ func (a *PrioritySessionAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) 
 		setSelectedReserveItem(itemID)
 		printRuntimeItemSwitched(ctx, param.Location, itemID)
 		return true
+	case priorityOperationAdopt:
+		// 沿用界面识别到的当前货品，效果等同换货提交：记录据点当前物品、
+		// 更新保留规则选中项，后续售卖与缺货标记流程无需区分来源。
+		itemID, err := currentGoodsItemIDFromRecognition(arg.RecognitionDetail)
+		if err != nil {
+			log.Error().Err(err).
+				Str("component", prioritySessionActionName).
+				Str("location", param.Location).
+				Msg("adopt has no recognized current goods")
+			return false
+		}
+		prioritySelectionAdopt(param.Location, itemID)
+		setSelectedReserveItem(itemID)
+		log.Info().Str("component", prioritySessionActionName).
+			Str("location", param.Location).
+			Str("item_id", itemID).
+			Msg("current goods adopted")
+		printRuntimeItemAdopted(ctx, param.Location, itemID)
+		return true
 	case priorityOperationOutOfStock:
 		itemID, marked, ok := prioritySelectionMarkOutOfStock(param.Location)
 		if !ok {
@@ -174,7 +194,7 @@ func parsePrioritySessionActionParam(arg *maa.CustomActionArg) (*prioritySession
 			return nil, fmt.Errorf("invalid selection strategy %q", param.Strategy)
 		}
 	case priorityOperationRegister:
-	case priorityOperationCommit, priorityOperationOutOfStock:
+	case priorityOperationCommit, priorityOperationAdopt, priorityOperationOutOfStock:
 		if param.Location == "" {
 			return nil, fmt.Errorf("location is empty")
 		}
@@ -343,6 +363,20 @@ func prioritySelectionCommit(location string) (string, bool) {
 	delete(prioritySelection.Pending, location)
 	delete(prioritySelection.Exhaustion, location)
 	return itemID, true
+}
+
+// prioritySelectionAdopt 把界面识别到的当前货品登记为据点当前售卖物品，
+// 状态效果与换货提交一致：记录已尝试、清空待选和耗尽观察。
+func prioritySelectionAdopt(location, itemID string) {
+	prioritySelectionMu.Lock()
+	defer prioritySelectionMu.Unlock()
+	if prioritySelection.Attempted[location] == nil {
+		prioritySelection.Attempted[location] = map[string]struct{}{}
+	}
+	prioritySelection.Attempted[location][itemID] = struct{}{}
+	prioritySelection.Current[location] = itemID
+	delete(prioritySelection.Pending, location)
+	delete(prioritySelection.Exhaustion, location)
 }
 
 func prioritySelectionMarkOutOfStock(location string) (string, bool, bool) {

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -109,6 +109,7 @@
     "sellproduct.runtime.operator_cache_rescan": "🔄 The currently assigned operator %s is missing from the operator cache. The cache may be outdated; rescanning the operator list",
     "sellproduct.runtime.restore_skipped": "⚠️ %s has no available post-sale production operator; skipping assignment",
     "sellproduct.runtime.item_switched": "📦 Switched goods: %s (%s)",
+    "sellproduct.runtime.item_adopted": "📦 Keeping current goods: %s (%s)",
     "sellproduct.runtime.item_out_of_stock": "🚫 Confirmed out of stock and excluded: %s (%s)",
     "sellproduct.runtime.usage.target": "selling operator",
     "sellproduct.runtime.usage.restore": "post-sale production operator",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -109,6 +109,7 @@
     "sellproduct.runtime.operator_cache_rescan": "🔄 現在配置中のオペレーター %s がキャッシュに存在しません。キャッシュが古い可能性があるため、オペレーター一覧を再スキャンします",
     "sellproduct.runtime.restore_skipped": "⚠️ %sで利用可能な販売後の生産オペレーターがいないため、配置をスキップします",
     "sellproduct.runtime.item_switched": "📦 商品を切り替えました：%s（%s）",
+    "sellproduct.runtime.item_adopted": "📦 現在の商品をそのまま使用：%s（%s）",
     "sellproduct.runtime.item_out_of_stock": "🚫 在庫切れを確認して除外：%s（%s）",
     "sellproduct.runtime.usage.target": "販売オペレーター",
     "sellproduct.runtime.usage.restore": "販売後の生産オペレーター",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -109,6 +109,7 @@
     "sellproduct.runtime.operator_cache_rescan": "🔄 현재 배치된 오퍼레이터 %s이(가) 오퍼레이터 캐시에 없습니다. 캐시가 오래되었을 수 있으므로 오퍼레이터 목록을 다시 스캔합니다",
     "sellproduct.runtime.restore_skipped": "⚠️ %s에 사용 가능한 판매 후 생산 오퍼레이터가 없어 배치를 건너뜁니다",
     "sellproduct.runtime.item_switched": "📦 상품 전환: %s (%s)",
+    "sellproduct.runtime.item_adopted": "📦 현재 상품 유지: %s (%s)",
     "sellproduct.runtime.item_out_of_stock": "🚫 품절을 확인하여 제외: %s (%s)",
     "sellproduct.runtime.usage.target": "판매 오퍼레이터",
     "sellproduct.runtime.usage.restore": "판매 후 생산 오퍼레이터",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -109,6 +109,7 @@
     "sellproduct.runtime.operator_cache_rescan": "🔄 当前派驻干员 %s 不在干员缓存中，缓存可能已过期，将重新扫描干员列表",
     "sellproduct.runtime.restore_skipped": "⚠️ %s没有可用的售后生产干员，跳过派驻",
     "sellproduct.runtime.item_switched": "📦 已切换货品：%s（%s）",
+    "sellproduct.runtime.item_adopted": "📦 沿用当前货品：%s（%s）",
     "sellproduct.runtime.item_out_of_stock": "🚫 已确认缺货并排除：%s（%s）",
     "sellproduct.runtime.usage.target": "售卖干员",
     "sellproduct.runtime.usage.restore": "售后生产干员",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -109,6 +109,7 @@
     "sellproduct.runtime.operator_cache_rescan": "🔄 當前派駐幹員 %s 不在幹員快取中，快取可能已過期，將重新掃描幹員列表",
     "sellproduct.runtime.restore_skipped": "⚠️ %s沒有可用的售後生產幹員，跳過派駐",
     "sellproduct.runtime.item_switched": "📦 已切換貨品：%s（%s）",
+    "sellproduct.runtime.item_adopted": "📦 沿用目前貨品：%s（%s）",
     "sellproduct.runtime.item_out_of_stock": "🚫 已確認缺貨並排除：%s（%s）",
     "sellproduct.runtime.usage.target": "售賣幹員",
     "sellproduct.runtime.usage.restore": "售後生產幹員",

--- a/assets/resource/pipeline/SellProduct/SellCore.json
+++ b/assets/resource/pipeline/SellProduct/SellCore.json
@@ -126,7 +126,10 @@
                     {
                         "recognition": "OCR",
                         "roi": "SellProductWhiteTextPosition",
+                        // 售卖后据点可能立即生产少量同类货品，1～3 位白色库存故意作为本轮停止信号，
+                        // 避免刚生产的货品被售卖循环重复处理；这也意味着切换后仅剩 1～999 件时会跳过本轮。
                         "expected": [
+                            // @i18n-skip
                             "^[0-9]{1,3}$"
                         ],
                         "only_rec": true

--- a/assets/resource/pipeline/SellProduct/SellCore.json
+++ b/assets/resource/pipeline/SellProduct/SellCore.json
@@ -44,6 +44,7 @@
         "rate_limit": 0,
         "next": [
             "[Anchor]SellProductZeroMoneyHandler",
+            "[Anchor]SellProductCurrentGoodsReady",
             "SellProductChangeGoods"
         ]
     },

--- a/assets/resource/pipeline/SellProduct/ValleyIV/InfraStation.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/InfraStation.json
@@ -25,6 +25,7 @@
         "pre_delay": 0,
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoneyWithTip",
+            "SellProductCurrentGoodsReady": "SellProductInfraStationCurrentGoodsReady",
             "SellProductSelectPriorityItem": "SellProductInfraStationSelectPriorityItem",
             "SellProductPriorityItemsExhausted": "SellProductInfraStationPriorityItemsExhausted",
             "SellProductCommitPriorityItem": "SellProductInfraStationCommitPriorityItem",
@@ -1111,6 +1112,32 @@
         "rate_limit": 0
     },
     // ===== 动态优先级售卖循环 =====
+    "SellProductInfraStationCurrentGoodsReady": {
+        "desc": "基建前站当前选中货品仍可售卖，沿用并跳过更换货品",
+        "recognition": "Custom",
+        "custom_recognition": "SellProductCurrentGoods",
+        "custom_recognition_param": {
+            "location": "InfraStation",
+            "roi": [
+                1177,
+                450,
+                54,
+                54
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SellProductPrioritySession",
+        "custom_action_param": {
+            "operation": "adopt",
+            "location": "InfraStation"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SellProductAtSell"
+        ]
+    },
     "SellProductInfraStationSelectPriorityItem": {
         "desc": "基建前站按当前策略选择下一个未尝试货品",
         "recognition": "Custom",

--- a/assets/resource/pipeline/SellProduct/ValleyIV/InfraStation.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/InfraStation.json
@@ -1113,7 +1113,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductInfraStationCurrentGoodsReady": {
-        "desc": "基建前站当前选中货品仍可售卖，沿用并跳过更换货品",
+        "desc": "基建前站当前选中货品符合静态选品策略，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/ValleyIV/InfraStation.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/InfraStation.json
@@ -1113,7 +1113,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductInfraStationCurrentGoodsReady": {
-        "desc": "基建前站当前选中货品符合静态选品策略，沿用并跳过更换货品",
+        "desc": "基建前站当前选中货品符合当前选品规则，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
@@ -25,6 +25,7 @@
         "pre_delay": 0,
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoneyWithTip",
+            "SellProductCurrentGoodsReady": "SellProductReconstructionHQCurrentGoodsReady",
             "SellProductSelectPriorityItem": "SellProductReconstructionHQSelectPriorityItem",
             "SellProductPriorityItemsExhausted": "SellProductReconstructionHQPriorityItemsExhausted",
             "SellProductCommitPriorityItem": "SellProductReconstructionHQCommitPriorityItem",
@@ -1115,6 +1116,32 @@
         "rate_limit": 0
     },
     // ===== 动态优先级售卖循环 =====
+    "SellProductReconstructionHQCurrentGoodsReady": {
+        "desc": "重建指挥部当前选中货品仍可售卖，沿用并跳过更换货品",
+        "recognition": "Custom",
+        "custom_recognition": "SellProductCurrentGoods",
+        "custom_recognition_param": {
+            "location": "ReconstructionHQ",
+            "roi": [
+                1177,
+                450,
+                54,
+                54
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SellProductPrioritySession",
+        "custom_action_param": {
+            "operation": "adopt",
+            "location": "ReconstructionHQ"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SellProductAtSell"
+        ]
+    },
     "SellProductReconstructionHQSelectPriorityItem": {
         "desc": "重建指挥部按当前策略选择下一个未尝试货品",
         "recognition": "Custom",

--- a/assets/resource/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
@@ -1117,7 +1117,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductReconstructionHQCurrentGoodsReady": {
-        "desc": "重建指挥部当前选中货品仍可售卖，沿用并跳过更换货品",
+        "desc": "重建指挥部当前选中货品符合静态选品策略，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
@@ -1117,7 +1117,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductReconstructionHQCurrentGoodsReady": {
-        "desc": "重建指挥部当前选中货品符合静态选品策略，沿用并跳过更换货品",
+        "desc": "重建指挥部当前选中货品符合当前选品规则，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
@@ -1115,7 +1115,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductRefugeeCampCurrentGoodsReady": {
-        "desc": "难民暂居处当前选中货品符合静态选品策略，沿用并跳过更换货品",
+        "desc": "难民暂居处当前选中货品符合当前选品规则，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
@@ -25,6 +25,7 @@
         "pre_delay": 0,
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoneyWithTip",
+            "SellProductCurrentGoodsReady": "SellProductRefugeeCampCurrentGoodsReady",
             "SellProductSelectPriorityItem": "SellProductRefugeeCampSelectPriorityItem",
             "SellProductPriorityItemsExhausted": "SellProductRefugeeCampPriorityItemsExhausted",
             "SellProductCommitPriorityItem": "SellProductRefugeeCampCommitPriorityItem",
@@ -1113,6 +1114,32 @@
         "rate_limit": 0
     },
     // ===== 动态优先级售卖循环 =====
+    "SellProductRefugeeCampCurrentGoodsReady": {
+        "desc": "难民暂居处当前选中货品仍可售卖，沿用并跳过更换货品",
+        "recognition": "Custom",
+        "custom_recognition": "SellProductCurrentGoods",
+        "custom_recognition_param": {
+            "location": "RefugeeCamp",
+            "roi": [
+                1177,
+                450,
+                54,
+                54
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SellProductPrioritySession",
+        "custom_action_param": {
+            "operation": "adopt",
+            "location": "RefugeeCamp"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SellProductAtSell"
+        ]
+    },
     "SellProductRefugeeCampSelectPriorityItem": {
         "desc": "难民暂居处按当前策略选择下一个未尝试货品",
         "recognition": "Custom",

--- a/assets/resource/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
+++ b/assets/resource/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
@@ -1115,7 +1115,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductRefugeeCampCurrentGoodsReady": {
-        "desc": "难民暂居处当前选中货品仍可售卖，沿用并跳过更换货品",
+        "desc": "难民暂居处当前选中货品符合静态选品策略，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
@@ -25,6 +25,7 @@
         "pre_delay": 0,
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoneyWithTip",
+            "SellProductCurrentGoodsReady": "SellProductCardiacRemediationStationCurrentGoodsReady",
             "SellProductSelectPriorityItem": "SellProductCardiacRemediationStationSelectPriorityItem",
             "SellProductPriorityItemsExhausted": "SellProductCardiacRemediationStationPriorityItemsExhausted",
             "SellProductCommitPriorityItem": "SellProductCardiacRemediationStationCommitPriorityItem",
@@ -1113,6 +1114,32 @@
         "rate_limit": 0
     },
     // ===== 动态优先级售卖循环 =====
+    "SellProductCardiacRemediationStationCurrentGoodsReady": {
+        "desc": "心脏修缮站当前选中货品仍可售卖，沿用并跳过更换货品",
+        "recognition": "Custom",
+        "custom_recognition": "SellProductCurrentGoods",
+        "custom_recognition_param": {
+            "location": "CardiacRemediationStation",
+            "roi": [
+                1177,
+                450,
+                54,
+                54
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SellProductPrioritySession",
+        "custom_action_param": {
+            "operation": "adopt",
+            "location": "CardiacRemediationStation"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SellProductAtSell"
+        ]
+    },
     "SellProductCardiacRemediationStationSelectPriorityItem": {
         "desc": "心脏修缮站按当前策略选择下一个未尝试货品",
         "recognition": "Custom",

--- a/assets/resource/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
@@ -1115,7 +1115,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductCardiacRemediationStationCurrentGoodsReady": {
-        "desc": "心脏修缮站当前选中货品仍可售卖，沿用并跳过更换货品",
+        "desc": "心脏修缮站当前选中货品符合静态选品策略，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
@@ -1115,7 +1115,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductCardiacRemediationStationCurrentGoodsReady": {
-        "desc": "心脏修缮站当前选中货品符合静态选品策略，沿用并跳过更换货品",
+        "desc": "心脏修缮站当前选中货品符合当前选品规则，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
@@ -1125,7 +1125,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductSkyKingFlatsConstructionSiteCurrentGoodsReady": {
-        "desc": "天王坪援建点当前选中货品符合静态选品策略，沿用并跳过更换货品",
+        "desc": "天王坪援建点当前选中货品符合当前选品规则，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
@@ -25,6 +25,7 @@
         "pre_delay": 0,
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoneyWithTip",
+            "SellProductCurrentGoodsReady": "SellProductSkyKingFlatsConstructionSiteCurrentGoodsReady",
             "SellProductSelectPriorityItem": "SellProductSkyKingFlatsConstructionSiteSelectPriorityItem",
             "SellProductPriorityItemsExhausted": "SellProductSkyKingFlatsConstructionSitePriorityItemsExhausted",
             "SellProductCommitPriorityItem": "SellProductSkyKingFlatsConstructionSiteCommitPriorityItem",
@@ -1123,6 +1124,32 @@
         "rate_limit": 0
     },
     // ===== 动态优先级售卖循环 =====
+    "SellProductSkyKingFlatsConstructionSiteCurrentGoodsReady": {
+        "desc": "天王坪援建点当前选中货品仍可售卖，沿用并跳过更换货品",
+        "recognition": "Custom",
+        "custom_recognition": "SellProductCurrentGoods",
+        "custom_recognition_param": {
+            "location": "SkyKingFlatsConstructionSite",
+            "roi": [
+                1177,
+                450,
+                54,
+                54
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SellProductPrioritySession",
+        "custom_action_param": {
+            "operation": "adopt",
+            "location": "SkyKingFlatsConstructionSite"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SellProductAtSell"
+        ]
+    },
     "SellProductSkyKingFlatsConstructionSiteSelectPriorityItem": {
         "desc": "天王坪援建点按当前策略选择下一个未尝试货品",
         "recognition": "Custom",

--- a/assets/resource/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
@@ -1125,7 +1125,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductSkyKingFlatsConstructionSiteCurrentGoodsReady": {
-        "desc": "天王坪援建点当前选中货品仍可售卖，沿用并跳过更换货品",
+        "desc": "天王坪援建点当前选中货品符合静态选品策略，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
@@ -1115,7 +1115,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductXiranflowCloudseederStationCurrentGoodsReady": {
-        "desc": "盈天台建设站当前选中货品符合静态选品策略，沿用并跳过更换货品",
+        "desc": "盈天台建设站当前选中货品符合当前选品规则，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
@@ -25,6 +25,7 @@
         "pre_delay": 0,
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoneyWithTip",
+            "SellProductCurrentGoodsReady": "SellProductXiranflowCloudseederStationCurrentGoodsReady",
             "SellProductSelectPriorityItem": "SellProductXiranflowCloudseederStationSelectPriorityItem",
             "SellProductPriorityItemsExhausted": "SellProductXiranflowCloudseederStationPriorityItemsExhausted",
             "SellProductCommitPriorityItem": "SellProductXiranflowCloudseederStationCommitPriorityItem",
@@ -1113,6 +1114,32 @@
         "rate_limit": 0
     },
     // ===== 动态优先级售卖循环 =====
+    "SellProductXiranflowCloudseederStationCurrentGoodsReady": {
+        "desc": "盈天台建设站当前选中货品仍可售卖，沿用并跳过更换货品",
+        "recognition": "Custom",
+        "custom_recognition": "SellProductCurrentGoods",
+        "custom_recognition_param": {
+            "location": "XiranflowCloudseederStation",
+            "roi": [
+                1177,
+                450,
+                54,
+                54
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SellProductPrioritySession",
+        "custom_action_param": {
+            "operation": "adopt",
+            "location": "XiranflowCloudseederStation"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SellProductAtSell"
+        ]
+    },
     "SellProductXiranflowCloudseederStationSelectPriorityItem": {
         "desc": "盈天台建设站按当前策略选择下一个未尝试货品",
         "recognition": "Custom",

--- a/assets/resource/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
+++ b/assets/resource/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
@@ -1115,7 +1115,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProductXiranflowCloudseederStationCurrentGoodsReady": {
-        "desc": "盈天台建设站当前选中货品仍可售卖，沿用并跳过更换货品",
+        "desc": "盈天台建设站当前选中货品符合静态选品策略，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/assets/resource_adb/pipeline/SellProduct/ValleyIV/InfraStation.json
+++ b/assets/resource_adb/pipeline/SellProduct/ValleyIV/InfraStation.json
@@ -1,4 +1,15 @@
 {
+    "SellProductInfraStationCurrentGoodsReady": {
+        "custom_recognition_param": {
+            "location": "InfraStation",
+            "roi": [
+                1151,
+                393,
+                66,
+                66
+            ]
+        }
+    },
     "SellProductInfraStationSelectPriorityItem": {
         "custom_recognition_param": {
             "location": "InfraStation",

--- a/assets/resource_adb/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
+++ b/assets/resource_adb/pipeline/SellProduct/ValleyIV/ReconstructionHQ.json
@@ -1,4 +1,15 @@
 {
+    "SellProductReconstructionHQCurrentGoodsReady": {
+        "custom_recognition_param": {
+            "location": "ReconstructionHQ",
+            "roi": [
+                1151,
+                393,
+                66,
+                66
+            ]
+        }
+    },
     "SellProductReconstructionHQSelectPriorityItem": {
         "custom_recognition_param": {
             "location": "ReconstructionHQ",

--- a/assets/resource_adb/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
+++ b/assets/resource_adb/pipeline/SellProduct/ValleyIV/RefugeeCamp.json
@@ -1,4 +1,15 @@
 {
+    "SellProductRefugeeCampCurrentGoodsReady": {
+        "custom_recognition_param": {
+            "location": "RefugeeCamp",
+            "roi": [
+                1151,
+                393,
+                66,
+                66
+            ]
+        }
+    },
     "SellProductRefugeeCampSelectPriorityItem": {
         "custom_recognition_param": {
             "location": "RefugeeCamp",

--- a/assets/resource_adb/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
+++ b/assets/resource_adb/pipeline/SellProduct/Wuling/CardiacRemediationStation.json
@@ -1,4 +1,15 @@
 {
+    "SellProductCardiacRemediationStationCurrentGoodsReady": {
+        "custom_recognition_param": {
+            "location": "CardiacRemediationStation",
+            "roi": [
+                1151,
+                393,
+                66,
+                66
+            ]
+        }
+    },
     "SellProductCardiacRemediationStationSelectPriorityItem": {
         "custom_recognition_param": {
             "location": "CardiacRemediationStation",

--- a/assets/resource_adb/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
+++ b/assets/resource_adb/pipeline/SellProduct/Wuling/SkyKingFlatsConstructionSite.json
@@ -1,4 +1,15 @@
 {
+    "SellProductSkyKingFlatsConstructionSiteCurrentGoodsReady": {
+        "custom_recognition_param": {
+            "location": "SkyKingFlatsConstructionSite",
+            "roi": [
+                1151,
+                393,
+                66,
+                66
+            ]
+        }
+    },
     "SellProductSkyKingFlatsConstructionSiteSelectPriorityItem": {
         "custom_recognition_param": {
             "location": "SkyKingFlatsConstructionSite",

--- a/assets/resource_adb/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
+++ b/assets/resource_adb/pipeline/SellProduct/Wuling/XiranflowCloudseederStation.json
@@ -1,4 +1,15 @@
 {
+    "SellProductXiranflowCloudseederStationCurrentGoodsReady": {
+        "custom_recognition_param": {
+            "location": "XiranflowCloudseederStation",
+            "roi": [
+                1151,
+                393,
+                66,
+                66
+            ]
+        }
+    },
     "SellProductXiranflowCloudseederStationSelectPriorityItem": {
         "custom_recognition_param": {
             "location": "XiranflowCloudseederStation",

--- a/docs/en_us/developers/tasks/sell-product-maintain.md
+++ b/docs/en_us/developers/tasks/sell-product-maintain.md
@@ -40,7 +40,7 @@ Per outpost (SellProduct{LocationId}Sell)
 
 SellProductSellLoop (unlimited rounds; vouchers checked first each round)
   ├─ [Anchor]ZeroMoneyHandler     vouchers exhausted → SellProductSellLoopEnd (post-sell)
-  ├─ [Anchor]CurrentGoodsReady    current goods still sellable → adopt → SellProductAtSell
+  ├─ [Anchor]CurrentGoodsReady    current goods match the static strategy → adopt → SellProductAtSell
   └─ SellProductChangeGoods       click "Switch Goods" → ResetGoodsSelection → ChangeGoodsRelay
        ├─ [Anchor]SelectPriorityItem → SelectNewGoodConfirm → [Anchor]CommitPriorityItem
        │    → SellProductAtSell: re-check vouchers → out of stock → [Anchor]MarkOutOfStock
@@ -77,9 +77,9 @@ Task-level termination: if outpost management is locked, SceneManager cannot ent
 ### Current Goods Adoption (`SellProductCurrentGoods` custom recognizer)
 
 - Recognizes the currently selected goods icon in the outpost selling screen via IconRecognition `single_roi`, with candidates limited to the outpost's sellable items; the Win32 and ADB Pipelines pass `[1177,450,54,54]` and `[1151,393,66,66]` through `roi`, so Go hardcodes no platform coordinates.
-- Adoption checks first: not tried, not out of stock, not excluded by reserve rules; strict preferred-only mode also requires the item in the user's preferred list. Otherwise the flow falls back to the original "Switch Goods" path.
+- Rarity and price strategies reuse the normal selection rules. The current item is adopted only when it is exactly the next candidate after preferred slots, tried/out-of-stock state, and reserve rules are applied; otherwise the flow falls back to "Switch Goods" and scans the list.
+- The stock strategy depends on live storage quantities from the goods list, so it never recognizes or adopts the current item on the main screen. Every decision for the next item opens the list and scans stock again.
 - On hit, the `adopt` operation registers the recognized `itemId` as the outpost's current item with the same session effect as a switching `commit` (marks tried, updates the reserve-rule selection), so selling, reserve rules, and out-of-stock marking never distinguish where the goods came from.
-- Adoption semantics are "sell the current item first while it stays sellable": the main screen has no goods-grid stock observations, so no full strategy ordering runs here; once the item runs out of stock, SellLoop naturally moves on to the next one.
 
 ### Priority Selling (master switch, off by default, decoupled from region toggles)
 

--- a/docs/en_us/developers/tasks/sell-product-maintain.md
+++ b/docs/en_us/developers/tasks/sell-product-maintain.md
@@ -40,7 +40,7 @@ Per outpost (SellProduct{LocationId}Sell)
 
 SellProductSellLoop (unlimited rounds; vouchers checked first each round)
   ├─ [Anchor]ZeroMoneyHandler     vouchers exhausted → SellProductSellLoopEnd (post-sell)
-  ├─ [Anchor]CurrentGoodsReady    current goods match the static strategy → adopt → SellProductAtSell
+  ├─ [Anchor]CurrentGoodsReady    current goods match the current selection rules → adopt → SellProductAtSell
   └─ SellProductChangeGoods       click "Switch Goods" → ResetGoodsSelection → ChangeGoodsRelay
        ├─ [Anchor]SelectPriorityItem → SelectNewGoodConfirm → [Anchor]CommitPriorityItem
        │    → SellProductAtSell: re-check vouchers → out of stock → [Anchor]MarkOutOfStock
@@ -78,7 +78,7 @@ Task-level termination: if outpost management is locked, SceneManager cannot ent
 
 - Recognizes the currently selected goods icon in the outpost selling screen via IconRecognition `single_roi`, with candidates limited to the outpost's sellable items; the Win32 and ADB Pipelines pass `[1177,450,54,54]` and `[1151,393,66,66]` through `roi`, so Go hardcodes no platform coordinates.
 - Rarity and price strategies reuse the normal selection rules. The current item is adopted only when it is exactly the next candidate after preferred slots, tried/out-of-stock state, and reserve rules are applied; otherwise the flow falls back to "Switch Goods" and scans the list.
-- The stock strategy depends on live storage quantities from the goods list, so it never recognizes or adopts the current item on the main screen. Every decision for the next item opens the list and scans stock again.
+- Preferred slots take precedence over the stock strategy, so Stock may also adopt the first available preferred item after tried, out-of-stock, and reserve filters are applied. If the current item is not that preferred candidate, or no preferred item remains available, the goods list must be opened to read live storage quantities; an ordinary candidate is never adopted without that scan.
 - On hit, the `adopt` operation registers the recognized `itemId` as the outpost's current item with the same session effect as a switching `commit` (marks tried, updates the reserve-rule selection), so selling, reserve rules, and out-of-stock marking never distinguish where the goods came from.
 
 ### Priority Selling (master switch, off by default, decoupled from region toggles)

--- a/docs/en_us/developers/tasks/sell-product-maintain.md
+++ b/docs/en_us/developers/tasks/sell-product-maintain.md
@@ -40,6 +40,7 @@ Per outpost (SellProduct{LocationId}Sell)
 
 SellProductSellLoop (unlimited rounds; vouchers checked first each round)
   ├─ [Anchor]ZeroMoneyHandler     vouchers exhausted → SellProductSellLoopEnd (post-sell)
+  ├─ [Anchor]CurrentGoodsReady    current goods still sellable → adopt → SellProductAtSell
   └─ SellProductChangeGoods       click "Switch Goods" → ResetGoodsSelection → ChangeGoodsRelay
        ├─ [Anchor]SelectPriorityItem → SelectNewGoodConfirm → [Anchor]CommitPriorityItem
        │    → SellProductAtSell: re-check vouchers → out of stock → [Anchor]MarkOutOfStock
@@ -72,6 +73,13 @@ Task-level termination: if outpost management is locked, SceneManager cannot ent
 - Excluded upfront: zero stock, already tried, confirmed out of stock, never-sell, and reserve-satisfied items.
 - A selection is only "pending"; `commit` marks it tried only after the selling screen is recognized again — failed clicks or single-frame OCR flicker never skip a high-priority item.
 - When every candidate is unusable, two consecutive stable recognitions of the same set → `PriorityItemsExhausted`, closing the list and ending this outpost. Empty OCR results never count as "nothing left".
+
+### Current Goods Adoption (`SellProductCurrentGoods` custom recognizer)
+
+- Recognizes the currently selected goods icon in the outpost selling screen via IconRecognition `single_roi`, with candidates limited to the outpost's sellable items; the Win32 and ADB Pipelines pass `[1177,450,54,54]` and `[1151,393,66,66]` through `roi`, so Go hardcodes no platform coordinates.
+- Adoption checks first: not tried, not out of stock, not excluded by reserve rules; strict preferred-only mode also requires the item in the user's preferred list. Otherwise the flow falls back to the original "Switch Goods" path.
+- On hit, the `adopt` operation registers the recognized `itemId` as the outpost's current item with the same session effect as a switching `commit` (marks tried, updates the reserve-rule selection), so selling, reserve rules, and out-of-stock marking never distinguish where the goods came from.
+- Adoption semantics are "sell the current item first while it stays sellable": the main screen has no goods-grid stock observations, so no full strategy ordering runs here; once the item runs out of stock, SellLoop naturally moves on to the next one.
 
 ### Priority Selling (master switch, off by default, decoupled from region toggles)
 

--- a/docs/zh_cn/developers/tasks/sell-product-maintain.md
+++ b/docs/zh_cn/developers/tasks/sell-product-maintain.md
@@ -40,7 +40,7 @@ SellProductSchedule ──命中星期──> SellProductMain
 
 SellProductSellLoop（不限次数，每轮先查调度券）
   ├─ [Anchor]ZeroMoneyHandler     调度券不足 → SellProductSellLoopEnd（进售后）
-  ├─ [Anchor]CurrentGoodsReady    当前货品符合静态策略 → adopt 沿用 → SellProductAtSell
+  ├─ [Anchor]CurrentGoodsReady    当前货品符合当前选品规则 → adopt 沿用 → SellProductAtSell
   └─ SellProductChangeGoods       点「更换货品」→ ResetGoodsSelection → ChangeGoodsRelay
        ├─ [Anchor]SelectPriorityItem → SelectNewGoodConfirm → [Anchor]CommitPriorityItem
        │    → SellProductAtSell：再查调度券 → 缺货则 [Anchor]MarkOutOfStock 记缺货
@@ -77,7 +77,7 @@ SellProductSellLoop（不限次数，每轮先查调度券）
 
 - 据点主界面的货品槽位用 IconRecognition `single_roi` 识别当前选中的货品，候选只含本据点可售物品；Win32、ADB 两套 Pipeline 分别通过 `roi` 传入 `[1177,450,54,54]` 与 `[1151,393,66,66]`，Go 不硬编码平台坐标。
 - 稀有度和单价策略会复用正式选品规则，只有当前货品恰好是应用优先槽位、已尝试/缺货状态和保留规则后的下一候选时才沿用；否则落回「更换货品」流程扫描列表。
-- 库存策略依赖列表中的实时仓储数量，不识别或沿用主界面当前货品；每次选择下一种货品都打开列表重新扫描库存。
+- 优先槽位先于库存策略生效，因此库存策略也可沿用排除已尝试、缺货和保留规则后第一个可用的优先货品；当前货品不是该优先候选，或已无可用优先货品时，必须打开列表重新读取实时仓储数量，不能沿用普通候选。
 - 命中后由 `adopt` 操作把识别 detail 中的 `itemId` 登记为据点当前物品，状态效果与换货 `commit` 一致（记录已尝试、更新保留规则选中项），后续售卖、保留规则与缺货标记流程不区分货品来源。
 
 ### 优先售卖（默认关闭的总开关，与地区售卖开关解耦）

--- a/docs/zh_cn/developers/tasks/sell-product-maintain.md
+++ b/docs/zh_cn/developers/tasks/sell-product-maintain.md
@@ -40,6 +40,7 @@ SellProductSchedule ──命中星期──> SellProductMain
 
 SellProductSellLoop（不限次数，每轮先查调度券）
   ├─ [Anchor]ZeroMoneyHandler     调度券不足 → SellProductSellLoopEnd（进售后）
+  ├─ [Anchor]CurrentGoodsReady    当前选中货品仍可售卖 → adopt 沿用 → SellProductAtSell
   └─ SellProductChangeGoods       点「更换货品」→ ResetGoodsSelection → ChangeGoodsRelay
        ├─ [Anchor]SelectPriorityItem → SelectNewGoodConfirm → [Anchor]CommitPriorityItem
        │    → SellProductAtSell：再查调度券 → 缺货则 [Anchor]MarkOutOfStock 记缺货
@@ -71,6 +72,13 @@ SellProductSellLoop（不限次数，每轮先查调度券）
 - 先排除：零库存、已尝试、已缺货、永不售卖、已达保留量。
 - 选中只记为「待提交」，确认返回售卖界面后 `commit` 才标记已尝试——点击失败或单帧 OCR 波动不会跳过高优先级货品。
 - 候选全部不可用时，连续两次稳定识别到相同集合 → `PriorityItemsExhausted`，关闭列表结束本据点售卖。空 OCR 结果不算「无剩余货品」。
+
+### 当前货品沿用（`SellProductCurrentGoods` 自定义识别器）
+
+- 据点主界面的货品槽位用 IconRecognition `single_roi` 识别当前选中的货品，候选只含本据点可售物品；Win32、ADB 两套 Pipeline 分别通过 `roi` 传入 `[1177,450,54,54]` 与 `[1151,393,66,66]`，Go 不硬编码平台坐标。
+- 沿用前校验：未尝试、未缺货、未被保留规则排除；严格优先模式下还要求物品在用户优先列表内。不满足则落回「更换货品」原流程。
+- 命中后由 `adopt` 操作把识别 detail 中的 `itemId` 登记为据点当前物品，状态效果与换货 `commit` 一致（记录已尝试、更新保留规则选中项），后续售卖、保留规则与缺货标记流程不区分货品来源。
+- 沿用语义是「当前可售即先卖」：主界面没有货品网格的库存观测，不跑完整策略排序；缺货后回到 SellLoop 会自然切换到下一件。
 
 ### 优先售卖（默认关闭的总开关，与地区售卖开关解耦）
 

--- a/docs/zh_cn/developers/tasks/sell-product-maintain.md
+++ b/docs/zh_cn/developers/tasks/sell-product-maintain.md
@@ -40,7 +40,7 @@ SellProductSchedule ──命中星期──> SellProductMain
 
 SellProductSellLoop（不限次数，每轮先查调度券）
   ├─ [Anchor]ZeroMoneyHandler     调度券不足 → SellProductSellLoopEnd（进售后）
-  ├─ [Anchor]CurrentGoodsReady    当前选中货品仍可售卖 → adopt 沿用 → SellProductAtSell
+  ├─ [Anchor]CurrentGoodsReady    当前货品符合静态策略 → adopt 沿用 → SellProductAtSell
   └─ SellProductChangeGoods       点「更换货品」→ ResetGoodsSelection → ChangeGoodsRelay
        ├─ [Anchor]SelectPriorityItem → SelectNewGoodConfirm → [Anchor]CommitPriorityItem
        │    → SellProductAtSell：再查调度券 → 缺货则 [Anchor]MarkOutOfStock 记缺货
@@ -76,9 +76,9 @@ SellProductSellLoop（不限次数，每轮先查调度券）
 ### 当前货品沿用（`SellProductCurrentGoods` 自定义识别器）
 
 - 据点主界面的货品槽位用 IconRecognition `single_roi` 识别当前选中的货品，候选只含本据点可售物品；Win32、ADB 两套 Pipeline 分别通过 `roi` 传入 `[1177,450,54,54]` 与 `[1151,393,66,66]`，Go 不硬编码平台坐标。
-- 沿用前校验：未尝试、未缺货、未被保留规则排除；严格优先模式下还要求物品在用户优先列表内。不满足则落回「更换货品」原流程。
+- 稀有度和单价策略会复用正式选品规则，只有当前货品恰好是应用优先槽位、已尝试/缺货状态和保留规则后的下一候选时才沿用；否则落回「更换货品」流程扫描列表。
+- 库存策略依赖列表中的实时仓储数量，不识别或沿用主界面当前货品；每次选择下一种货品都打开列表重新扫描库存。
 - 命中后由 `adopt` 操作把识别 detail 中的 `itemId` 登记为据点当前物品，状态效果与换货 `commit` 一致（记录已尝试、更新保留规则选中项），后续售卖、保留规则与缺货标记流程不区分货品来源。
-- 沿用语义是「当前可售即先卖」：主界面没有货品网格的库存观测，不跑完整策略排序；缺货后回到 SellLoop 会自然切换到下一件。
 
 ### 优先售卖（默认关闭的总开关，与地区售卖开关解耦）
 

--- a/tools/pipeline-generate/SellProduct/data.test.mjs
+++ b/tools/pipeline-generate/SellProduct/data.test.mjs
@@ -613,6 +613,64 @@ test("SellProduct 各平台通过 Pipeline 配置货品名称、库存和点击�
     }
 });
 
+test("SellProduct 全部据点的当前货品 ROI 由各平台 Pipeline 提供", () => {
+    const platforms = [
+        {
+            name: "Win32",
+            resourceDir: "resource",
+            roi: [
+                1177,
+                450,
+                54,
+                54,
+            ],
+        },
+        {
+            name: "ADB",
+            resourceDir: "resource_adb",
+            roi: [
+                1151,
+                393,
+                66,
+                66,
+            ],
+        },
+    ];
+
+    for (const platform of platforms) {
+        for (const location of sellProductLocations) {
+            const pipeline = readPipeline(
+                new URL(
+                    `../../../assets/${platform.resourceDir}/pipeline/SellProduct/${location.RegionPrefix}/${location.LocationId}.json`,
+                    import.meta.url,
+                ),
+            );
+            const prefix = `SellProduct${location.LocationId}`;
+            const node = pipeline[`${prefix}CurrentGoodsReady`];
+
+            assert.ok(node, `${platform.name} ${location.LocationId} 缺少 CurrentGoodsReady 节点`);
+            assert.equal(node.custom_recognition_param.location, location.LocationId);
+            assert.deepEqual(node.custom_recognition_param.roi, platform.roi);
+            assert.ok(
+                node.custom_recognition_param.roi.every(Number.isInteger),
+                `${platform.name} ${location.LocationId} roi 应只包含整数`,
+            );
+            assert.equal(
+                node.custom_recognition_param.roi[2],
+                node.custom_recognition_param.roi[3],
+                `${platform.name} ${location.LocationId} roi 应为正方形`,
+            );
+
+            if (platform.name === "Win32") {
+                assert.equal(
+                    pipeline[`${prefix}Sell`].anchor.SellProductCurrentGoodsReady,
+                    `${prefix}CurrentGoodsReady`,
+                );
+            }
+        }
+    }
+});
+
 test("SellProduct 每轮选货及保留交易后优先检查调度券不足", () => {
     const pipeline = readPipeline(
         new URL("../../../assets/resource/pipeline/SellProduct/SellCore.json", import.meta.url),
@@ -620,6 +678,7 @@ test("SellProduct 每轮选货及保留交易后优先检查调度券不足", ()
 
     assert.deepEqual(pipeline.SellProductSellLoop.next, [
         "[Anchor]SellProductZeroMoneyHandler",
+        "[Anchor]SellProductCurrentGoodsReady",
         "SellProductChangeGoods",
     ]);
     assert.deepEqual(pipeline.SellProductAtSell.next.slice(0, 2), [

--- a/tools/pipeline-generate/SellProduct/pipeline-adb-data.mjs
+++ b/tools/pipeline-generate/SellProduct/pipeline-adb-data.mjs
@@ -1,5 +1,13 @@
 import {sellProductLocations} from "./model.mjs";
 
+// ADB 据点售卖主界面的当前货品槽位，以 1280x720 为基准。
+const CURRENT_GOODS_ROI_ADB = [
+    1151,
+    393,
+    66,
+    66,
+];
+
 // ADB BetterSliding 识别框，以 1280x720 为基准。
 const QUANTITY_BOX_ADB = [
     1065,
@@ -17,6 +25,7 @@ const MAX_QUANTITY_BOX_ADB = [
 export default sellProductLocations.map((location) => ({
     RegionPrefix: location.RegionPrefix,
     LocationId: location.LocationId,
+    CurrentGoodsROIAdb: CURRENT_GOODS_ROI_ADB,
     SliderQuantityBoxAdb: QUANTITY_BOX_ADB,
     AvailableQuantityBoxAdb: MAX_QUANTITY_BOX_ADB,
 }));

--- a/tools/pipeline-generate/SellProduct/pipeline-adb-template.jsonc
+++ b/tools/pipeline-generate/SellProduct/pipeline-adb-template.jsonc
@@ -1,4 +1,10 @@
 {
+    "SellProduct${LocationId}CurrentGoodsReady": {
+        "custom_recognition_param": {
+            "location": "${LocationId}",
+            "roi": "${CurrentGoodsROIAdb}"
+        }
+    },
     "SellProduct${LocationId}SelectPriorityItem": {
         "custom_recognition_param": {
             "location": "${LocationId}",

--- a/tools/pipeline-generate/SellProduct/pipeline-data.mjs
+++ b/tools/pipeline-generate/SellProduct/pipeline-data.mjs
@@ -9,6 +9,14 @@ const CURRENT_OPERATOR_ROI = [
     35,
 ];
 
+// Win32 据点售卖主界面的当前货品槽位，以 1280x720 为基准。
+const CURRENT_GOODS_ROI = [
+    1177,
+    450,
+    54,
+    54,
+];
+
 // Win32 BetterSliding 识别框，以 1280x720 为基准。
 const QUANTITY_BOX = [
     1107,
@@ -29,6 +37,7 @@ export default sellProductLocations.map((location) => ({
     LocationDesc: location.LocationDesc,
     TextExpected: location.TextExpected,
     CurrentOperatorROI: CURRENT_OPERATOR_ROI,
+    CurrentGoodsROI: CURRENT_GOODS_ROI,
     SliderQuantityBox: QUANTITY_BOX,
     AvailableQuantityBox: MAX_QUANTITY_BOX,
 }));

--- a/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
+++ b/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
@@ -25,6 +25,7 @@
         "pre_delay": 0,
         "anchor": {
             "SellProductZeroMoneyHandler": "SellProductZeroMoneyWithTip",
+            "SellProductCurrentGoodsReady": "SellProduct${LocationId}CurrentGoodsReady",
             "SellProductSelectPriorityItem": "SellProduct${LocationId}SelectPriorityItem",
             "SellProductPriorityItemsExhausted": "SellProduct${LocationId}PriorityItemsExhausted",
             "SellProductCommitPriorityItem": "SellProduct${LocationId}CommitPriorityItem",
@@ -1086,6 +1087,27 @@
         "rate_limit": 0
     },
     // ===== 动态优先级售卖循环 =====
+    "SellProduct${LocationId}CurrentGoodsReady": {
+        "desc": "${LocationDesc}当前选中货品仍可售卖，沿用并跳过更换货品",
+        "recognition": "Custom",
+        "custom_recognition": "SellProductCurrentGoods",
+        "custom_recognition_param": {
+            "location": "${LocationId}",
+            "roi": "${CurrentGoodsROI}"
+        },
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SellProductPrioritySession",
+        "custom_action_param": {
+            "operation": "adopt",
+            "location": "${LocationId}"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SellProductAtSell"
+        ]
+    },
     "SellProduct${LocationId}SelectPriorityItem": {
         "desc": "${LocationDesc}按当前策略选择下一个未尝试货品",
         "recognition": "Custom",

--- a/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
+++ b/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
@@ -1088,7 +1088,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProduct${LocationId}CurrentGoodsReady": {
-        "desc": "${LocationDesc}当前选中货品仍可售卖，沿用并跳过更换货品",
+        "desc": "${LocationDesc}当前选中货品符合静态选品策略，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
+++ b/tools/pipeline-generate/SellProduct/pipeline-template.jsonc
@@ -1088,7 +1088,7 @@
     },
     // ===== 动态优先级售卖循环 =====
     "SellProduct${LocationId}CurrentGoodsReady": {
-        "desc": "${LocationDesc}当前选中货品符合静态选品策略，沿用并跳过更换货品",
+        "desc": "${LocationDesc}当前选中货品符合当前选品规则，沿用并跳过更换货品",
         "recognition": "Custom",
         "custom_recognition": "SellProductCurrentGoods",
         "custom_recognition_param": {

--- a/tools/schema/components/sell_product.schema.json
+++ b/tools/schema/components/sell_product.schema.json
@@ -76,6 +76,29 @@
                 }
             ]
         },
+        "CurrentGoodsRecognitionParam": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "location",
+                "roi"
+            ],
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "pattern": "\\S"
+                },
+                "roi": {
+                    "description": "Current-goods slot ROI [x, y, width, height] supplied by the controller-specific Pipeline. Must be a positive square (width == height) because IconRecognition single_roi requires a square.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "minItems": 4,
+                    "maxItems": 4
+                }
+            }
+        },
         "PrioritySessionParam": {
             "oneOf": [
                 {
@@ -187,6 +210,7 @@
                     "properties": {
                         "operation": {
                             "enum": [
+                                "adopt",
                                 "commit",
                                 "out_of_stock"
                             ]

--- a/tools/schema/custom.recognition.schema.json
+++ b/tools/schema/custom.recognition.schema.json
@@ -38,6 +38,7 @@
                 "ScrollbarRecognition",
                 "ScrollbarCompleteRecognition",
                 "SellProductCurrentBestOperator",
+                "SellProductCurrentGoods",
                 "SellProductCurrentOperatorUncached",
                 "SellProductOperatorCacheReady",
                 "SellProductOperatorListBottom",
@@ -521,6 +522,20 @@
                 "required": [ "custom_recognition_param" ],
                 "properties": {
                     "custom_recognition_param": { "$ref": "./components/map_tracker.schema.json#/$defs/MapTrackerBigMapFindImageParam" }
+                }
+            }
+        },
+        {
+            "if": {
+                "type": "object",
+                "required": [ "custom_recognition" ],
+                "properties": { "custom_recognition": { "const": "SellProductCurrentGoods" } }
+            },
+            "then": {
+                "type": "object",
+                "required": [ "custom_recognition_param" ],
+                "properties": {
+                    "custom_recognition_param": { "$ref": "./components/sell_product.schema.json#/$defs/CurrentGoodsRecognitionParam" }
                 }
             }
         },


### PR DESCRIPTION
## 动机

据点会保留上次选中的售卖货品。原流程每轮进入据点都会打开「更换货品」重新选货，即使当前货品正好是本轮应选目标，也会产生不必要的界面操作。

当前货品不能只按「是否可售」判断是否沿用，还必须服从优先售卖、选品策略、已尝试/缺货状态和保留规则，避免绕过正式选品顺序。

## 行为变化

- 进入售卖循环后先识别当前货品；只有它恰好等于当前选品规则的下一候选时才沿用，否则回落到原有「更换货品」流程。
- 稀有度和单价策略复用正式选品排序，并在判断前应用优先槽位、已尝试、已缺货、永不售卖和保留量已满足等排除规则。
- 优先槽位先于库存策略生效，因此库存优先也可沿用第一可用优先货品；当前货品不是该优先候选或已无可用优先货品时，仍会打开列表重新读取实时库存，不会沿用库存未知的普通候选。
- 沿用效果与换货提交一致：登记当前货品、标记为已尝试并更新保留规则选中项。已尝试状态会阻止本次任务再次处理售卖后新生产出的同类货品。
- IconRecognition 的 `no_match` 视为正常回落；解析失败和结构化异常仍保留警告日志。
- 保留售卖后少量库存作为停止信号的既有规则：1～3 位白色库存会结束本轮，避免刚生产的少量同类货品被重复售卖。

## 实现

- 新增 `SellProductCurrentGoods` 自定义识别器，在据点主界面通过 IconRecognition `single_roi` 识别当前货品，候选限定为当前据点可售物品。
- 为 `SellProductPrioritySession` 新增 `adopt` 操作，从识别详情读取 `item_id`，同步更新 Attempted、Current 和保留规则状态。
- 在 `SellProductSellLoop.next` 的换货节点前加入 `[Anchor]SellProductCurrentGoodsReady`，接入四号谷地与武陵共 6 个据点。
- Win32 与 ADB Pipeline 分别通过必填 `roi` 参数传入 `[1177, 450, 54, 54]` 与 `[1151, 393, 66, 66]`，Go 不硬编码平台坐标。
- 同步 SellProduct 生成模板、PC/ADB 生成资源、JSON Schema、五语言运行提示及中英文维护文档。
- 补充识别结果解析、策略顺序、优先槽位、会话排除规则、库存策略边界和六据点双控制器 ROI 回归测试。
- 忽略本地 pnpm 内容缓存目录 `.pnpm-store/`。

## 验证

- SellProduct 生成器测试通过（43 / 43）
- `go test -count=1 ./sellproduct/...` 通过
- `go vet ./sellproduct/...` 通过
- `maa-tools check` 通过（Win32、ADB、CloudADB、PlayCover、Wlroots、MacOS 前台与后台）
- `maa-tools test` 通过（800 / 800）
- Markdownlint、Prettier、gofmt 与 `git diff --check` 通过
- 实机命中仍待验证；节点测试不会加载 go-service 自定义识别，但 IconRecognition `single_roi` 已有测试集覆盖
