### PR TITLE
fix: 自动战斗退出误识别

### DIFF
--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -443,11 +443,16 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 		if time.Since(lastLevelShowCheck) >= 5*time.Second {
 			lastLevelShowCheck = time.Now()
 			if getCharactorLevelShow(ctx, img) {
-				log.Info().Str("component", "AutoFight").Msg("character level show detected, exiting fight")
-				maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
-				// saveExitImage(img, "character_level_show")
-				result = true
-				break
+				confirmImg, ok := captureAndUpdateScreenDetail(ctx)
+				// 双重检测，避免ocr误识别
+				if ok && getCharactorLevelShow(ctx, confirmImg) {
+					log.Info().Str("component", "AutoFight").Msg("character level show detected, exiting fight")
+					maafocus.Print(ctx, i18n.T("autofight.exit_fight"))
+					// saveExitImage(confirmImg, "character_level_show")
+					result = true
+					break
+				}
+				log.Info().Str("component", "AutoFight").Msg("character level show confirm failed, continue fight")
 			}
 		}
 		// CharacterLevel小概率识别不到，comboEmpty大概率不显示了依然命中，双重保险


### PR DESCRIPTION
close #5013

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- 在检测到角色级界面显示时，要求进行第二次截图确认后才允许自动战斗退出，从而减少由于 OCR 识别错误导致的误退出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Require a second screenshot confirmation before AutoFight exits on detected character-level displays, reducing false exits caused by OCR misrecognition.

</details>