### PR TITLE
fix(MapNavigator): 修复adb镜头转向常量

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -16,7 +16,7 @@ constexpr double kTurnDegreesPerCircle = 360.0;
 
 struct AdbTouchTurnProfile
 {
-    double default_units_per_degree = 3.5;
+    double default_units_per_degree = 5.0;
     int32_t swipe_duration_ms = 70;
     int32_t post_swipe_settle_ms = 0;
 };


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修正ADB镜头转向的默认灵敏度常量，提升转向角度计算的准确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修正ADB镜头转向的默认灵敏度常量，提升转向角度计算的准确性。

</details>