### PR TITLE
fix(MapNavigator): 网格边界边只用来算余量，不再拿它禁步

### DIFF
--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -573,65 +573,6 @@ WallCsr BuildWallIndex(const std::vector<WorldPoint>& p0, const std::vector<Worl
     return csr;
 }
 
-std::unordered_set<int64_t> BannedSteps(
-    const Mask& free,
-    const WallCsr& csr,
-    const std::vector<WorldPoint>& p0,
-    const std::vector<WorldPoint>& p1,
-    double ox,
-    double oy)
-{
-    std::unordered_set<int64_t> out;
-    if (p0.empty()) {
-        return out;
-    }
-    const int64_t nx = free.nx, ny = free.ny;
-    const int64_t NC = nx * ny;
-    for (int64_t c = 0; c < NC; ++c) {
-        if (csr.start[static_cast<size_t>(c + 1)] == csr.start[static_cast<size_t>(c)] || !free.v[static_cast<size_t>(c)]) {
-            continue;
-        }
-        const double cx = (static_cast<double>(c % nx) + 0.5) * kCS + ox;
-        const double cy = (static_cast<double>(c / nx) + 0.5) * kCS + oy;
-        for (const auto& d : kNb8) {
-            const int64_t ax = c % nx + d.dx, ay = c / nx + d.dy;
-            if (ax < 0 || ax >= nx || ay < 0 || ay >= ny) {
-                continue;
-            }
-            const int64_t b = ay * nx + ax;
-            if (!free.v[static_cast<size_t>(b)]) {
-                continue;
-            }
-            const double qx = cx + static_cast<double>(d.dx) * kCS;
-            const double qy = cy + static_cast<double>(d.dy) * kCS;
-            bool hit = false;
-            for (const int64_t cell : { c, b }) {
-                for (int64_t s = csr.start[static_cast<size_t>(cell)]; !hit && s < csr.start[static_cast<size_t>(cell + 1)]; ++s) {
-                    const int64_t w = csr.wid[static_cast<size_t>(s)];
-                    const double rx = qx - cx, ry = qy - cy;
-                    const double sx = p1[w].x - p0[w].x, sy = p1[w].y - p0[w].y;
-                    const double ux = p0[w].x - cx, uy = p0[w].y - cy;
-                    const double den = rx * sy - ry * sx;
-                    if (!(std::abs(den) > 1e-12)) {
-                        continue;
-                    }
-                    const double t = (ux * sy - uy * sx) / den;
-                    const double ww = (ux * ry - uy * rx) / den;
-                    hit = t > 1e-9 && t < 1 - 1e-9 && ww > -1e-9 && ww < 1 + 1e-9;
-                }
-                if (hit) {
-                    break;
-                }
-            }
-            if (hit) {
-                out.insert(c * NC + b);
-                out.insert(b * NC + c);
-            }
-        }
-    }
-    return out;
-}
-
 StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, const Mask& lay, double ox, double oy)
 {
     StepBarrier out;

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -35,9 +35,7 @@ inline constexpr double kCornerStep = 0.5;         // 拐点外挪步长 px
 inline constexpr int64_t kCornerDirs = 32;         // 拐点外挪候选方向数
 inline constexpr int64_t kCornerRounds = 3;        // 拐点外挪迭代轮数
 inline constexpr double kCostTol = 1e-9;           // 代价判据相对容差, 容纳共线子路径的浮点求和差
-inline constexpr double kMcHBand = 8.0;            // 层高度带(墙筛/盖章)px
-inline constexpr double kHBand = 6.0;              // 真墙探针高度带 px
-inline constexpr double kEpsProbe = 0.75;          // 真墙探针距离 px
+inline constexpr double kMcHBand = 8.0;            // 层高度带(边界边筛/盖章)px
 inline constexpr double kSnapRadius = 8.0;         // 起终点吸附半径 px
 inline constexpr double kDeckBand = 2.0;           // 声明面高度匹配容差 px, 需远小于相邻面间距
 inline constexpr double kMargin = 25.0;            // 窗口外扩 px
@@ -147,14 +145,6 @@ std::vector<uint8_t> WallsAtLayer(
     double oy);
 
 WallCsr BuildWallIndex(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny);
-
-std::unordered_set<int64_t> BannedSteps(
-    const Mask& free,
-    const WallCsr& csr,
-    const std::vector<WorldPoint>& p0,
-    const std::vector<WorldPoint>& p1,
-    double ox,
-    double oy);
 
 struct StepBarrier
 {

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdio>
 #include <limits>
 #include <optional>
 
@@ -47,7 +46,6 @@ struct RouteDiag
 {
     std::string err;
     std::vector<std::string> warn;
-    std::vector<WorldPoint> xwall;
     std::vector<double> clearance;
     std::vector<double> height; // 逐点所在面的高度; 层预言机走不通时清空
     std::vector<size_t> waypoints;
@@ -470,10 +468,10 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     for (size_t i = 0; i < walk.v.size(); ++i) {
         walk.v[i] = static_cast<uint8_t>(info.core.v[i] != 0 && info.lay.v[i] != 0);
     }
-    const auto bn = BannedSteps(info.lay, info.wcsr, info.wP0, info.wP1, x0, y0);
-    std::unordered_set<int64_t> blocked_steps = bn;
-    blocked_steps.insert(info.sev.steps.begin(), info.sev.steps.end());
-    // 掩膜距离场对跨越约束的墙无感, 取真墙距离的下确界补上
+    // 边界边只用来算余量, 不用来禁步: 补洞封缝那一步已经判定这些细缝可以跨,
+    // 回头再拿同一批边禁掉跨缝的一步, 等于在每道接缝上凭空立一堵墙
+    std::unordered_set<int64_t> blocked_steps(info.sev.steps.begin(), info.sev.steps.end());
+    // 掩膜距离场对跨越边界边无感, 取到边界的距离的下确界补上
     Mask wfree(nx, ny, 0);
     for (size_t i = 0; i < wfree.v.size(); ++i) {
         wfree.v[i] = info.wcsr.start[i + 1] > info.wcsr.start[i] ? 0 : 1;
@@ -604,11 +602,9 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         return std::nullopt;
     }
 
-    // 禁步面是硬的,墙边只罚分:窄处绕不开时宁可贴着走也不判不连通
-    const double BIGP = static_cast<double>(nx * ny) * kCS * (1.0 + kLam);
     const std::unordered_set<int64_t>* faces = &info.sev.steps;
-    const std::unordered_set<int64_t>* soft = &bn;
-    const double* soft_penalty = &BIGP;
+    const std::unordered_set<int64_t>* soft = nullptr;
+    const double* soft_penalty = nullptr;
     Mask on3 = cw3;
     // 可走集已经限死在终点那张面所属的类里, 起点这侧只剩层内挑高度
     const auto search = [&](const std::vector<uint8_t>& use,
@@ -728,19 +724,12 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     for (size_t k = 1; k < q->size(); ++k) {
         const int64_t ca = (*q)[k - 1].y * nx + (*q)[k - 1].x;
         const int64_t cb = (*q)[k].y * nx + (*q)[k].x;
-        if (!blocked_steps.contains(ca * NC + cb)) {
-            continue;
-        }
-        bad.push_back(k);
-        if (bn.contains(ca * NC + cb)) {
-            dg.xwall.push_back({ x0 + (static_cast<double>((*q)[k].x) + 0.5) * kCS, y0 + (static_cast<double>((*q)[k].y) + 0.5) * kCS });
+        if (blocked_steps.contains(ca * NC + cb)) {
+            bad.push_back(k);
         }
     }
-    if (!dg.xwall.empty()) {
-        dg.warn.push_back("不可避穿墙 " + std::to_string(dg.xwall.size()) + " 步");
-    }
-    if (bad.size() > dg.xwall.size()) {
-        dg.warn.push_back("不可避立面 " + std::to_string(bad.size() - dg.xwall.size()) + " 步");
+    if (!bad.empty()) {
+        dg.warn.push_back("不可避立面 " + std::to_string(bad.size()) + " 步");
     }
     dg.crossed_barrier = !bad.empty();
 
@@ -1205,7 +1194,6 @@ RecastPlanResult RecastNavEngine::planLocked(
                         }
                         res.warnings = dg.warn;
                         res.clearance = dg.clearance;
-                        res.wall_cross = dg.xwall;
                         res.snap_start = dg.snap_start;
                         res.snap_goal = dg.snap_goal;
                         res.waypoints = std::move(dg.waypoints);

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -24,8 +24,7 @@ struct RecastPlanResult
     std::vector<double> clearance; // 逐点通道半宽 px
     double length = 0.0;
     std::vector<std::string> warnings;
-    std::vector<WorldPoint> wall_cross; // 不可避穿墙步的格心
-    double snap_start = 0.0;            // 起/终点到可走格锚点距离 px
+    double snap_start = 0.0; // 起/终点到可走格锚点距离 px
     double snap_goal = 0.0;
     // 贪心拉直后的驱动航点下标(points 的下标,不含起点,末位恒为 points.size()-1)。
     // 空 = 该腿没有层预言机,拉直交给调用方。

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
+#include <cstdlib>
 #include <deque>
 #include <numeric>
 #include <utility>
@@ -497,43 +499,6 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
             + " bridge " + std::to_string(n_bridge) + " srcadj " + std::to_string(n_srcadj);
 }
 
-std::vector<int32_t> ZoneClean::batchLocate(const std::vector<WorldPoint>& pts, const std::vector<double>& hints) const
-{
-    std::vector<int32_t> out(pts.size(), -1);
-    for (size_t p = 0; p < pts.size(); ++p) {
-        const int64_t gx = static_cast<int64_t>(std::floor(pts[p].x / PolyMesh::kGridCell));
-        const int64_t gy = static_cast<int64_t>(std::floor(pts[p].y / PolyMesh::kGridCell));
-        const auto [glo, ghi] = std::equal_range(mesh.gkeys.begin(), mesh.gkeys.end(), gx * PolyMesh::kGridStride + gy);
-        double best = 0.0;
-        int32_t bt = -1;
-        for (auto it = glo; it != ghi; ++it) {
-            const int32_t t = mesh.gtris[static_cast<size_t>(it - mesh.gkeys.begin())];
-            const auto& tri = mesh.T[static_cast<size_t>(t)];
-            const WorldPoint& A = mesh.V[tri[0]];
-            const WorldPoint& B = mesh.V[tri[1]];
-            const WorldPoint& C = mesh.V[tri[2]];
-            const double den = (B.y - C.y) * (A.x - C.x) + (C.x - B.x) * (A.y - C.y);
-            if (std::fabs(den) < 1e-12) {
-                continue;
-            }
-            const double wa = ((B.y - C.y) * (pts[p].x - C.x) + (C.x - B.x) * (pts[p].y - C.y)) / den;
-            const double wb = ((C.y - A.y) * (pts[p].x - C.x) + (A.x - C.x) * (pts[p].y - C.y)) / den;
-            const double wc = 1.0 - wa - wb;
-            if (!(wa >= -1e-9 && wb >= -1e-9 && wc >= -1e-9)) {
-                continue;
-            }
-            const double h = wa * mesh.H[tri[0]] + wb * mesh.H[tri[1]] + wc * mesh.H[tri[2]];
-            const double score = std::fabs(h - hints[p]);
-            if (bt < 0 || score < best) {
-                best = score;
-                bt = t;
-            }
-        }
-        out[p] = bt;
-    }
-    return out;
-}
-
 std::optional<ZoneClean::SnapHit> ZoneClean::snap(const WorldPoint& p, double radius, std::optional<double> floor_y) const
 {
     const double r = std::max(0.0, radius);
@@ -572,8 +537,9 @@ std::optional<ZoneClean::SnapHit> ZoneClean::snap(const WorldPoint& p, double ra
     return std::nullopt;
 }
 
+// 收齐网格的边界边。这份数据只说哪里能走, 不带墙面/断崖之类的信息,
+// 再去分辨某条边是墙还是接缝等于凭空造数据, 所以这里只收边、不分类
 WallOracle::WallOracle(const ZoneClean& zc)
-    : zc_(zc)
 {
     const auto& mesh = zc.mesh;
     for (size_t i = 0; i < mesh.T.size(); ++i) {
@@ -589,92 +555,14 @@ WallOracle::WallOracle(const ZoneClean& zc)
             P1.push_back(p1);
             H0.push_back(mesh.H[a]);
             H1.push_back(mesh.H[b]);
-            M_.push_back({ (p0.x + p1.x) / 2.0, (p0.y + p1.y) / 2.0 });
-            const double dx = p1.x - p0.x;
-            const double dy = p1.y - p0.y;
-            const double ln = std::max(std::hypot(dx, dy), 1e-12);
-            NOBS_.push_back({ dy / ln, -dx / ln });
             HH.push_back((mesh.H[a] + mesh.H[b]) / 2.0);
             lo_.push_back({ std::min(p0.x, p1.x), std::min(p0.y, p1.y) });
             hi_.push_back({ std::max(p0.x, p1.x), std::max(p0.y, p1.y) });
         }
     }
-    cls_.assign(P0.size(), -1);
-    const auto cellKey = [](int64_t cx, int64_t cy) {
-        return (cx + (int64_t(1) << 30)) * (int64_t(1) << 31) + (cy + (int64_t(1) << 30));
-    };
-    for (const HopPt& hp : zc.hops) {
-        const double hz = triHeight(mesh, hp.to_tri);
-        for (const WorldPoint* pt : { &hp.exit_pt, &hp.entry_pt }) {
-            const int64_t cx = static_cast<int64_t>(std::floor(pt->x / kHopCell));
-            const int64_t cy = static_cast<int64_t>(std::floor(pt->y / kHopCell));
-            hop_grid_[cellKey(cx, cy)].push_back({ pt->x, pt->y, hz });
-        }
-    }
 }
 
-bool WallOracle::hopNear(int64_t ei, double tol) const
-{
-    const WorldPoint p0 = P0[static_cast<size_t>(ei)];
-    const WorldPoint p1 = P1[static_cast<size_t>(ei)];
-    const double hh = HH[static_cast<size_t>(ei)];
-    const double dx = p1.x - p0.x;
-    const double dy = p1.y - p0.y;
-    const double l2 = std::max(dx * dx + dy * dy, 1e-18);
-    const int64_t cx0 = static_cast<int64_t>(std::floor((std::min(p0.x, p1.x) - tol) / kHopCell));
-    const int64_t cx1 = static_cast<int64_t>(std::floor((std::max(p0.x, p1.x) + tol) / kHopCell));
-    const int64_t cy0 = static_cast<int64_t>(std::floor((std::min(p0.y, p1.y) - tol) / kHopCell));
-    const int64_t cy1 = static_cast<int64_t>(std::floor((std::max(p0.y, p1.y) + tol) / kHopCell));
-    for (int64_t cx = cx0; cx <= cx1; ++cx) {
-        for (int64_t cy = cy0; cy <= cy1; ++cy) {
-            const auto it = hop_grid_.find((cx + (int64_t(1) << 30)) * (int64_t(1) << 31) + (cy + (int64_t(1) << 30)));
-            if (it == hop_grid_.end()) {
-                continue;
-            }
-            for (const auto& h : it->second) {
-                if (std::fabs(h[2] - hh) > kMcHBand) {
-                    continue;
-                }
-                const double t = std::min(1.0, std::max(0.0, ((h[0] - p0.x) * dx + (h[1] - p0.y) * dy) / l2));
-                if (std::hypot(p0.x + dx * t - h[0], p0.y + dy * t - h[1]) <= tol) {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
-void WallOracle::classify(const std::vector<int64_t>& idx)
-{
-    std::vector<int64_t> todo;
-    for (const int64_t i : idx) {
-        if (cls_[static_cast<size_t>(i)] < 0) {
-            todo.push_back(i);
-        }
-    }
-    if (todo.empty()) {
-        return;
-    }
-    std::vector<WorldPoint> P;
-    std::vector<double> hh;
-    for (const int64_t i : todo) {
-        P.push_back({ M_[static_cast<size_t>(i)].x + NOBS_[static_cast<size_t>(i)].x * kEpsProbe,
-                      M_[static_cast<size_t>(i)].y + NOBS_[static_cast<size_t>(i)].y * kEpsProbe });
-        hh.push_back(HH[static_cast<size_t>(i)]);
-    }
-    const auto tri = zc_.batchLocate(P, hh);
-    for (size_t j = 0; j < todo.size(); ++j) {
-        const bool free = tri[j] >= 0 && std::fabs(triHeight(zc_.mesh, tri[j]) - hh[j]) <= kHBand;
-        bool wall = !free;
-        if (wall && hopNear(todo[j])) {
-            wall = false;
-        }
-        cls_[static_cast<size_t>(todo[j])] = wall ? 1 : 0;
-    }
-}
-
-std::vector<int64_t> WallOracle::wallsInBbox(double x0, double y0, double x1, double y1)
+std::vector<int64_t> WallOracle::wallsInBbox(double x0, double y0, double x1, double y1) const
 {
     std::vector<int64_t> idx;
     for (int64_t i = 0; i < static_cast<int64_t>(P0.size()); ++i) {
@@ -683,14 +571,7 @@ std::vector<int64_t> WallOracle::wallsInBbox(double x0, double y0, double x1, do
             idx.push_back(i);
         }
     }
-    classify(idx);
-    std::vector<int64_t> out;
-    for (const int64_t i : idx) {
-        if (cls_[static_cast<size_t>(i)] == 1) {
-            out.push_back(i);
-        }
-    }
-    return out;
+    return idx;
 }
 
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.h
@@ -66,8 +66,6 @@ public:
 
     std::optional<SnapHit> snap(const WorldPoint& p, double radius, std::optional<double> floor_y) const;
 
-    std::vector<int32_t> batchLocate(const std::vector<WorldPoint>& pts, const std::vector<double>& hints) const;
-
     std::string name;
     uint16_t zone_id = 0;
     int64_t lo = 0;
@@ -82,12 +80,13 @@ private:
     std::string error_;
 };
 
+// 网格的边界边索引: 可走面到此为止, 边的另一侧是什么一概不问
 class WallOracle
 {
 public:
     explicit WallOracle(const ZoneClean& zc);
 
-    std::vector<int64_t> wallsInBbox(double x0, double y0, double x1, double y1);
+    std::vector<int64_t> wallsInBbox(double x0, double y0, double x1, double y1) const;
 
     std::vector<WorldPoint> P0;
     std::vector<WorldPoint> P1;
@@ -96,17 +95,8 @@ public:
     std::vector<double> HH;
 
 private:
-    bool hopNear(int64_t ei, double tol = 1.5) const;
-    void classify(const std::vector<int64_t>& idx);
-
-    const ZoneClean& zc_;
-    std::vector<WorldPoint> M_;
-    std::vector<WorldPoint> NOBS_;
     std::vector<WorldPoint> lo_;
     std::vector<WorldPoint> hi_;
-    std::vector<int8_t> cls_;
-    static constexpr double kHopCell = 4.0;
-    std::unordered_map<int64_t, std::vector<std::array<double, 3>>> hop_grid_;
 };
 
 }


### PR DESCRIPTION
## Summary by Sourcery

允许在保持基于边界的净空（clearance）计算的同时，跨越有效的网格接缝进行导航。

Bug 修复：
- 防止网格边界边缘错误地阻挡可穿越的跨网格接缝步进。

增强内容：
- 通过仅将网格边界用于净空计算，并移除墙体与接缝的分类及相关诊断，简化边界边缘的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow navigation to cross valid mesh seams while retaining boundary-based clearance calculations.

Bug Fixes:
- Prevent grid boundary edges from incorrectly blocking traversable steps across mesh seams.

Enhancements:
- Simplify boundary-edge handling by using mesh boundaries for clearance calculations only and removing wall-versus-seam classification and related diagnostics.

</details>