### PR TITLE
fix(item-transfer): 修复物品网格、滚动边界与切换重试

### DIFF
--- a/agent/cpp-algo/source/IconRecognition/detail/GridDetector.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/GridDetector.cpp
@@ -96,6 +96,8 @@ constexpr double kMinimumTrustedStructureWithoutLegacySupport = 0.10;
 constexpr double kLegacyStructureWeight = 0.65;
 // legacy 候选中已对齐 rarity 色带比例的权重；调高更看重颜色锚点。
 constexpr double kLegacyRarityWeight = 0.35;
+// transfer 的弱 rarity 拟合必须包含彩色证据才可接管结构相位；灰色背景不能单独改写网格。
+constexpr int kMinimumReliableRarityCells = 1;
 // 补行所需的最低结构支持相对已有行均值比例；调高减少补行，调低可能扩展到空白行。
 constexpr double kRowCompletionSupportRatio = 0.04;
 // 仅一个直接观测时最多允许补出的行数；调大可覆盖更多行，也会放大单点误差。
@@ -1531,7 +1533,12 @@ GridLayout BuildTransferLayout(const cv::Mat& image, const cv::Rect& roi, const 
     std::vector<int> local_x = x_fit->starts;
     std::vector<int> local_y;
     const auto rarity_fit = FitRarityGrid(image(roi), local_x, hint.y_starts, profile);
-    if (rarity_fit) {
+    const bool reliable_rarity_fit =
+        rarity_fit.has_value()
+        && (!transfer
+            || rarity_fit->supporting_strong_cells >= kMinimumReliableRarityCells
+            || rarity_fit->supporting_chromatic_cells >= kMinimumReliableRarityCells);
+    if (reliable_rarity_fit) {
         local_x = rarity_fit->x_starts;
         const int count = std::min(profile.maximum_rows, std::max(static_cast<int>(hint.y_starts.size()), rarity_fit->supporting_rows));
         for (int row = 0; row < count; ++row) {
@@ -1623,7 +1630,7 @@ GridLayout BuildTransferLayout(const cv::Mat& image, const cv::Rect& roi, const 
                 break;
             }
             const bool stable_rarity_lattice =
-                (rarity_fit && rarity_fit->supporting_rows >= static_cast<int>(kStableRarityMinimumRows))
+                (reliable_rarity_fit && rarity_fit->supporting_rows >= static_cast<int>(kStableRarityMinimumRows))
                 || (trusted_selected && trusted_fit->y_axis.direct_indices.size() >= kStableRarityMinimumRows);
             if (!stable_rarity_lattice && (minimum_support <= 0.0 || row_support(following) < minimum_support)) {
                 break;
@@ -1632,7 +1639,7 @@ GridLayout BuildTransferLayout(const cv::Mat& image, const cv::Rect& roi, const 
         }
     }
     // 右侧七列始终检查分类工具栏遮挡；左侧四列的末行空行启发式只用于缺少 rarity 证据的旧结构路径。
-    if (!transfer && (column_count == 7 || (!rarity_fit && !trusted_selected))) {
+    if (!transfer && (column_count == 7 || (!reliable_rarity_fit && !trusted_selected))) {
         local_y = DropPortRows(image, roi, local_x, local_y, column_count, profile.cell_size);
     }
 

--- a/agent/cpp-algo/source/IconRecognition/detail/GridProfiles.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/GridProfiles.cpp
@@ -491,17 +491,24 @@ std::optional<TransferHypothesis> select_grid_hypothesis(const cv::Mat& crop, bo
         }
     }
     if (hypotheses.empty()) {
-        hypotheses = sparse_candidates;
+        for (auto candidate : sparse_candidates) {
+            candidate.foreground_texture_coverage = ForegroundTextureCoverage(crop, candidate);
+            if (candidate.foreground_texture_coverage > 0.0) {
+                hypotheses.push_back(std::move(candidate));
+            }
+        }
     }
     if (hypotheses.empty()) {
         return std::nullopt;
     }
-    const bool has_texture_evidence = std::ranges::any_of(hypotheses, [](const TransferHypothesis& hypothesis) {
-        return hypothesis.foreground_texture_coverage > 0.0;
+    const bool has_reliable_texture_evidence = std::ranges::any_of(hypotheses, [](const TransferHypothesis& hypothesis) {
+        return hypothesis.foreground_texture_coverage >= kMinimumSparseTransferTextureCoverage;
     });
-    if (require_texture && has_texture_evidence) {
-        std::erase_if(hypotheses, [](const TransferHypothesis& hypothesis) {
-            return hypothesis.foreground_texture_coverage < kMinimumSparseTransferTextureCoverage;
+    if (require_texture) {
+        std::erase_if(hypotheses, [has_reliable_texture_evidence](const TransferHypothesis& hypothesis) {
+            return has_reliable_texture_evidence
+                       ? hypothesis.foreground_texture_coverage < kMinimumSparseTransferTextureCoverage
+                       : hypothesis.foreground_texture_coverage <= 0.0;
         });
     }
     if (hypotheses.empty()) {

--- a/agent/cpp-algo/source/IconRecognition/detail/GridProfiles.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/GridProfiles.cpp
@@ -13,6 +13,7 @@
 
 #include "GridFeatures.h"
 #include "GridGeometry.h"
+#include "ForegroundTexture.h"
 
 namespace iconrecognition::detail
 {
@@ -47,6 +48,10 @@ constexpr int kLocalPeakNeighborhoodSize = 5;
 constexpr float kLocalPeakEqualityTolerance = 1e-7F;
 // 传输网格候选至少覆盖的槽位比例；调高减少破碎误检，调低可召回遮挡较多的网格。
 constexpr double kTransferHypothesisMinimumOccupancy = 0.42;
+// 稀疏单行候选中非空物品格的最低纹理覆盖率；调高抑制背景伪网格，调低可召回暗淡物品。
+constexpr double kMinimumSparseTransferTextureCoverage = 0.50;
+// 已有多行候选达到该覆盖率时，优先保留多行结构，避免单行局部纹理截断正常背包。
+constexpr double kMinimumStructuredTransferTextureCoverage = 0.60;
 // 宽 ROI 中单侧候选的最大宽度比例；调大可能把左右两侧合并，调小可能截断真实面板。
 constexpr double kTransferLocalizedMaximumWidthRatio = 0.70;
 // 独立局部候选相对最强候选的最低分数；调高只保留强面板，调低可保留弱面板但增加冲突。
@@ -155,7 +160,23 @@ struct TransferHypothesis
     int rows = 0;
     std::vector<int> x_starts;
     std::vector<int> y_starts;
+    double foreground_texture_coverage = 0.0;
 };
+
+double ForegroundTextureCoverage(const cv::Mat& crop, const TransferHypothesis& hypothesis)
+{
+    int textured_cells = 0;
+    int total_cells = 0;
+    for (int y : hypothesis.y_starts) {
+        for (int x : hypothesis.x_starts) {
+            ++total_cells;
+            if (!IsLowTexture(crop, cv::Rect(x, y, kBaseTransferProfile.cell_size, kBaseTransferProfile.cell_size), GridType::Transfer)) {
+                ++textured_cells;
+            }
+        }
+    }
+    return total_cells == 0 ? 0.0 : static_cast<double>(textured_cells) / total_cells;
+}
 
 std::vector<Peak> local_peaks(const cv::Mat& score, int maximum)
 {
@@ -434,7 +455,7 @@ std::vector<cv::Rect> discover_transfer_regions(const cv::Mat& crop)
     return { cv::Rect(0, 0, left_x2, crop.rows), cv::Rect(right_x1, 0, crop.cols - right_x1, crop.rows) };
 }
 
-std::optional<TransferHypothesis> select_grid_hypothesis(const cv::Mat& crop)
+std::optional<TransferHypothesis> select_grid_hypothesis(const cv::Mat& crop, bool require_texture)
 {
     const int maximum_columns = std::max(1, (crop.cols - kBaseTransferProfile.cell_size) / kBaseTransferProfile.pitch_min + 1);
     const int maximum_rows = std::max(1, (crop.rows - kBaseTransferProfile.cell_size) / kBaseTransferProfile.pitch_min + 1);
@@ -451,15 +472,63 @@ std::optional<TransferHypothesis> select_grid_hypothesis(const cv::Mat& crop)
         return filtered;
     };
     auto hypotheses = candidates(3);
+    for (auto& hypothesis : hypotheses) {
+        hypothesis.foreground_texture_coverage = ForegroundTextureCoverage(crop, hypothesis);
+    }
+    const bool has_reliable_multirow = std::ranges::any_of(hypotheses, [](const auto& hypothesis) {
+        return hypothesis.rows >= 2 && hypothesis.foreground_texture_coverage >= kMinimumStructuredTransferTextureCoverage;
+    });
+    const auto sparse_candidates = candidates(1);
+    if (!has_reliable_multirow) {
+        for (auto candidate : sparse_candidates) {
+            if (candidate.rows != 1 || candidate.columns < 3) {
+                continue;
+            }
+            candidate.foreground_texture_coverage = ForegroundTextureCoverage(crop, candidate);
+            if (candidate.foreground_texture_coverage >= kMinimumSparseTransferTextureCoverage) {
+                hypotheses.push_back(std::move(candidate));
+            }
+        }
+    }
     if (hypotheses.empty()) {
-        hypotheses = candidates(1);
+        hypotheses = sparse_candidates;
     }
     if (hypotheses.empty()) {
         return std::nullopt;
     }
-    const auto rank = [](const TransferHypothesis& item) {
-        return std::tuple {
-            item.columns, -item.rect.x, item.columns == 7 ? 0 : item.rows, item.occupancy, item.score, item.rows, -item.rect.y,
+    const bool has_texture_evidence = std::ranges::any_of(hypotheses, [](const TransferHypothesis& hypothesis) {
+        return hypothesis.foreground_texture_coverage > 0.0;
+    });
+    if (require_texture && has_texture_evidence) {
+        std::erase_if(hypotheses, [](const TransferHypothesis& hypothesis) {
+            return hypothesis.foreground_texture_coverage < kMinimumSparseTransferTextureCoverage;
+        });
+    }
+    if (hypotheses.empty()) {
+        return std::nullopt;
+    }
+    const auto rank = [require_texture](const TransferHypothesis& item) {
+        if (require_texture) {
+            return std::tuple<double, double, double, double, double, double, double, double> {
+                static_cast<double>(item.columns),
+                item.foreground_texture_coverage,
+                static_cast<double>(item.columns == 7 ? 0 : item.rows),
+                static_cast<double>(-item.rect.x),
+                item.occupancy,
+                item.score,
+                static_cast<double>(item.rows),
+                static_cast<double>(-item.rect.y),
+            };
+        }
+        return std::tuple<double, double, double, double, double, double, double, double> {
+            static_cast<double>(item.columns),
+            static_cast<double>(-item.rect.x),
+            static_cast<double>(item.columns == 7 ? 0 : item.rows),
+            item.occupancy,
+            item.score,
+            static_cast<double>(item.rows),
+            static_cast<double>(-item.rect.y),
+            0.0,
         };
     };
     return *std::ranges::max_element(hypotheses, {}, rank);
@@ -474,6 +543,7 @@ TransferGridHint to_hint(const TransferHypothesis& hypothesis, const cv::Rect& r
         .occupancy = hypothesis.occupancy,
         .x_starts = hypothesis.x_starts,
         .y_starts = hypothesis.y_starts,
+        .foreground_texture_coverage = hypothesis.foreground_texture_coverage,
     };
     for (int& value : hint.x_starts) {
         value += offset_x;
@@ -680,17 +750,25 @@ std::vector<TransferGridHint> DiscoverTransferGridHints(const cv::Mat& crop, boo
         return combined;
     }
     const auto regions = discover_transfer_regions(crop);
-    const auto broad =
+    auto broad =
         phase_hypotheses(crop, kTransferDiscoveryPitchRange, kTransferDiscoveryMinimumColumns, kTransferDiscoveryMinimumRows);
+    for (auto& hypothesis : broad) {
+        hypothesis.foreground_texture_coverage = ForegroundTextureCoverage(crop, hypothesis);
+    }
+    const bool broad_has_texture_evidence = std::ranges::any_of(broad, [](const TransferHypothesis& hypothesis) {
+        return hypothesis.foreground_texture_coverage > 0.0;
+    });
     std::vector<TransferGridHint> hints;
     for (const auto& raw_region : regions) {
         const cv::Rect region(raw_region.x, 0, raw_region.width, crop.rows);
         std::vector<TransferGridHint> candidates;
-        if (const auto local = select_grid_hypothesis(crop(region))) {
+        if (const auto local = select_grid_hypothesis(crop(region), structural_rank)) {
             candidates.push_back(to_hint(*local, region, region.x));
         }
         for (const auto& hypothesis : broad) {
-            if (hypothesis.rect.x >= region.x && hypothesis.rect.x + hypothesis.rect.width <= region.x + region.width) {
+            if ((!structural_rank || !broad_has_texture_evidence
+                 || hypothesis.foreground_texture_coverage >= kMinimumSparseTransferTextureCoverage)
+                && hypothesis.rect.x >= region.x && hypothesis.rect.x + hypothesis.rect.width <= region.x + region.width) {
                 candidates.push_back(to_hint(hypothesis, region, 0));
             }
         }
@@ -705,8 +783,9 @@ std::vector<TransferGridHint> DiscoverTransferGridHints(const cv::Mat& crop, boo
             }
             const double pitch = spacings.empty() ? kBaseTransferProfile.preferred_pitch : Median(spacings);
             if (structural_rank) {
-                return std::tuple<double, double, double, double, double, double, double> {
+                return std::tuple<double, double, double, double, double, double, double, double> {
                     static_cast<double>(columns),
+                    hint.foreground_texture_coverage,
                     static_cast<double>(columns == 7 ? 0 : hint.y_starts.size()),
                     hint.occupancy,
                     hint.score,
@@ -715,12 +794,13 @@ std::vector<TransferGridHint> DiscoverTransferGridHints(const cv::Mat& crop, boo
                     static_cast<double>(hint.y_starts.size()),
                 };
             }
-            return std::tuple<double, double, double, double, double, double, double> {
+            return std::tuple<double, double, double, double, double, double, double, double> {
                 static_cast<double>(columns),
                 static_cast<double>(-(hint.rect.x - hint.region.x)),
                 static_cast<double>(columns == 7 ? 0 : hint.y_starts.size()),
                 hint.occupancy,
                 hint.score,
+                -std::abs(pitch - kBaseTransferProfile.preferred_pitch),
                 static_cast<double>(hint.y_starts.size()),
                 static_cast<double>(-hint.rect.y),
             };

--- a/agent/cpp-algo/source/IconRecognition/detail/GridProfiles.h
+++ b/agent/cpp-algo/source/IconRecognition/detail/GridProfiles.h
@@ -77,6 +77,8 @@ struct TransferGridHint
     double occupancy = 0.0;
     std::vector<int> x_starts;
     std::vector<int> y_starts;
+    // 稀疏单行候选中具有前景纹理的格子比例，用于与多行背景伪网格消歧。
+    double foreground_texture_coverage = 0.0;
 };
 
 GridProfile ProfileFor(GridType type);

--- a/agent/cpp-algo/source/IconRecognition/test/test_small_algorithms.cpp
+++ b/agent/cpp-algo/source/IconRecognition/test/test_small_algorithms.cpp
@@ -627,6 +627,87 @@ void TestTransferRegionPartitionKeepsUndetectedOuterColumns()
     Check(regions[0].width >= detected_left.x + 4 * 69, "left transfer search region must retain room for a weak outer column");
 }
 
+void TestTransferGridDetectsSparseVisiblePhase()
+{
+    constexpr int kCellSize = 64;
+    constexpr int kPitch = 69;
+    constexpr int kColumns = 4;
+    constexpr int kVisiblePhaseX = 7;
+    constexpr int kBackgroundPhaseX = 36;
+    constexpr int kPhaseY = 15;
+    constexpr int kTargetColumn = 1;
+    const cv::Rect target_box(kVisiblePhaseX + kTargetColumn * kPitch, kPhaseY, kCellSize, kCellSize);
+    cv::Mat image(291, 330, CV_8UC3, cv::Scalar(24, 24, 24));
+
+    const auto draw_cell = [&](int x, int y, const cv::Scalar& border) {
+        image.colRange(x, x + 2).rowRange(y, y + kCellSize + 1).setTo(border);
+        image.colRange(x + kCellSize, x + kCellSize + 2).rowRange(y, y + kCellSize + 1).setTo(border);
+        image.rowRange(y, y + 2).colRange(x, x + kCellSize + 1).setTo(border);
+        image.rowRange(y + kCellSize, y + kCellSize + 2).colRange(x, x + kCellSize + 1).setTo(border);
+    };
+    // 模拟物品行下方的重复背景纹理，使结构检测稳定落在错误的半格相位。
+    for (int row = 0; row < 4; ++row) {
+        for (int column = 0; column < kColumns; ++column) {
+            draw_cell(kBackgroundPhaseX + column * kPitch, kPhaseY + row * kPitch, cv::Scalar(130, 130, 130));
+        }
+    }
+    // 可见物品行包含高纹理内容，避免测试只依赖单个模板图标。
+    for (int column = 0; column < kColumns; ++column) {
+        const int x = kVisiblePhaseX + column * kPitch;
+        draw_cell(x, kPhaseY, cv::Scalar(90, 90, 90));
+        for (int y = kPhaseY + 6; y < kPhaseY + kCellSize - 8; ++y) {
+            for (int local_x = 6; local_x < kCellSize - 6; ++local_x) {
+                const unsigned char value = static_cast<unsigned char>(40 + ((local_x * 7 + y * 11 + column * 13) % 180));
+                image.at<cv::Vec3b>(y, x + local_x) = cv::Vec3b(value, value, value);
+            }
+        }
+    }
+
+    const auto grid = iconrecognition::detail::DetectGrid(image, iconrecognition::GridType::Transfer, cv::Rect(0, 0, image.cols, image.rows), 1.0);
+    const auto target_cell = std::ranges::find_if(grid.cells, [&](const auto& cell) {
+        return std::abs(cell.cell_box.x - target_box.x) <= 1 && std::abs(cell.cell_box.y - target_box.y) <= 2;
+    });
+    std::string grid_summary = "sparse transfer grid must preserve the visible item phase";
+    if (!grid.grids.empty() && grid.grids.front().selection_diagnostics) {
+        const auto& layout = grid.grids.front();
+        const auto& diagnostics = *layout.selection_diagnostics;
+        grid_summary += "; origin=" + std::to_string(static_cast<int>(diagnostics.origin.x)) + ","
+                        + std::to_string(static_cast<int>(diagnostics.origin.y)) + "; pitch="
+                        + std::to_string(static_cast<int>(diagnostics.pitch.x)) + ","
+                        + std::to_string(static_cast<int>(diagnostics.pitch.y));
+        if (!layout.cells.empty()) {
+            grid_summary += "; first=" + std::to_string(layout.cells.front().cell_box.x) + ","
+                            + std::to_string(layout.cells.front().cell_box.y);
+        }
+    }
+    Check(target_cell != grid.cells.end(), grid_summary);
+
+    iconrecognition::detail::TemplateCatalog catalog("assets/data/IconRecognition", "assets/resource/image/IconRecognition");
+    Check(catalog.initialize(), "transfer recovery fixture catalog must initialize");
+    const auto& templates = catalog.load(kCellSize);
+    const auto target = std::ranges::find_if(templates, [](const auto& templ) { return templ.record.item_id == "item_iron_ore"; });
+    Check(target != templates.end(), "sparse transfer fixture must contain item_iron_ore");
+    target->image.copyTo(image(target_box));
+
+    iconrecognition::IconRecognizer recognizer("assets/data/IconRecognition");
+    Check(recognizer.initialize(), "sparse transfer recognizer must initialize");
+    iconrecognition::RecognitionRequest request;
+    request.grid_type = iconrecognition::GridType::Transfer;
+    request.roi = cv::Rect(0, 0, image.cols, image.rows);
+    request.candidates.item_ids = { "item_iron_ore" };
+    request.candidates.item_filters = { "Normal:Ore" };
+    request.candidates.item_recheck_filters = { "Normal:Ore" };
+    request.grid_scale_hint = 1.0;
+    request.deduplicate = true;
+    const auto result = recognizer.recognize(image, request);
+
+    Check(result.matched && result.matches.size() == 1, "sparse transfer target must be found from the detected grid");
+    Check(result.matches.front().item.item_id == "item_iron_ore", "sparse transfer detection must preserve the target id");
+    Check(
+        std::abs(result.matches.front().cell_box.x - target_box.x) <= 1 && std::abs(result.matches.front().cell_box.y - target_box.y) <= 2,
+        "transfer recognition must keep the target at its detected cell position");
+}
+
 void TestPortStoragerWideRoiUsesStablePanelPartitions()
 {
     const auto win32 = iconrecognition::detail::PartitionPortStoragerRegions(cv::Size(880, 350));
@@ -1245,6 +1326,7 @@ int main()
         TestRewardsAdbGridUsesSixColumnSharedOrigin();
         TestRewardsGridRenumbersColumnsAfterRoiFiltering();
         TestTransferRegionPartitionKeepsUndetectedOuterColumns();
+        TestTransferGridDetectsSparseVisiblePhase();
         TestPortStoragerWideRoiUsesStablePanelPartitions();
         TestCreditTradeGridUsesDimCardStructures();
         TestCreditTradeGridUsesSixColumnsWhenRoiCannotContainSeven();

--- a/agent/go-service/common/listcomplete/scrollbar_recognition.go
+++ b/agent/go-service/common/listcomplete/scrollbar_recognition.go
@@ -30,8 +30,9 @@ const (
 	// 调小可识别更短的滑块，也会增加孤立高亮噪声造成的误检。
 	scrollbarMinLength = 5
 
-	attachScrollbarTop    = "scrollbar_top"
-	attachScrollbarBottom = "scrollbar_bottom"
+	attachScrollbarTop     = "scrollbar_top"
+	attachScrollbarBottom  = "scrollbar_bottom"
+	attachScrollbarMissing = "scrollbar_missing"
 )
 
 // ScrollbarRecognition 识别滚动条白色滑块，并返回其绝对位置和相对 ROI 的边界信息。
@@ -135,11 +136,34 @@ func (r *ScrollbarCompleteRecognition) Run(
 		image.Rect(roi[0], roi[1], roi[0]+roi[2], roi[1]+roi[3]),
 	)
 	if !found {
-		log.Warn().
+		complete, err := observeMissingScrollbar(ctx, currentNode)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("component", scrollbarCompleteComponentName).
+				Str("node", currentNode).
+				Msg("failed to record missing scrollbar observation")
+			return nil, false
+		}
+		if !complete {
+			log.Info().
+				Str("component", scrollbarCompleteComponentName).
+				Str("node", currentNode).
+				Msg("scrollbar missing observation recorded, confirming once")
+			return nil, false
+		}
+
+		log.Info().
 			Str("component", scrollbarCompleteComponentName).
 			Str("node", currentNode).
-			Msg("valid scrollbar segment not found")
-		return nil, false
+			Msg("scrollbar missing in consecutive observations, list is not scrollable")
+		return &maa.CustomRecognitionResult{
+			Box: roi,
+			Detail: marshalDetail(map[string]any{
+				"scrollbar_found": false,
+				"complete":        true,
+			}),
+		}, true
 	}
 
 	previous, ready, err := loadScrollbarPosition(ctx, currentNode)
@@ -321,6 +345,77 @@ func loadScrollbarPosition(store nodeStore, nodeName string) (scrollbarSegment, 
 	return segment, true, nil
 }
 
+func observeMissingScrollbar(store nodeStore, nodeName string) (bool, error) {
+	missing, err := loadMissingScrollbar(store, nodeName)
+	if err != nil {
+		return false, err
+	}
+	if missing {
+		return true, nil
+	}
+	if err := saveMissingScrollbar(store, nodeName, true); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func loadMissingScrollbar(store nodeStore, nodeName string) (bool, error) {
+	raw, err := store.GetNodeJSON(nodeName)
+	if err != nil {
+		return false, err
+	}
+	var wrapper struct {
+		Attach map[string]json.RawMessage `json:"attach"`
+	}
+	if err := json.Unmarshal([]byte(raw), &wrapper); err != nil {
+		return false, err
+	}
+	readyRaw, ok := wrapper.Attach[attachReady]
+	if !ok {
+		return false, nil
+	}
+	var ready bool
+	if err := json.Unmarshal(readyRaw, &ready); err != nil {
+		return false, fmt.Errorf("attach.%s must be bool: %w", attachReady, err)
+	}
+	if !ready {
+		return false, nil
+	}
+	missingRaw, ok := wrapper.Attach[attachScrollbarMissing]
+	if !ok {
+		return false, nil
+	}
+	var missing bool
+	if err := json.Unmarshal(missingRaw, &missing); err != nil {
+		return false, fmt.Errorf("attach.%s must be bool: %w", attachScrollbarMissing, err)
+	}
+	return missing, nil
+}
+
+func saveMissingScrollbar(store nodeStore, nodeName string, missing bool) error {
+	raw, err := store.GetNodeJSON(nodeName)
+	if err != nil {
+		return err
+	}
+	var wrapper struct {
+		Attach map[string]any `json:"attach"`
+	}
+	if err := json.Unmarshal([]byte(raw), &wrapper); err != nil {
+		return err
+	}
+	if wrapper.Attach == nil {
+		wrapper.Attach = make(map[string]any)
+	}
+	wrapper.Attach[attachReady] = true
+	wrapper.Attach[attachScrollbarMissing] = missing
+
+	return store.OverridePipeline(map[string]any{
+		nodeName: map[string]any{
+			"attach": wrapper.Attach,
+		},
+	})
+}
+
 func unmarshalAttachInt(attach map[string]json.RawMessage, key string, target *int) error {
 	raw, ok := attach[key]
 	if !ok {
@@ -349,6 +444,7 @@ func saveScrollbarPosition(store nodeStore, nodeName string, segment scrollbarSe
 	wrapper.Attach[attachReady] = true
 	wrapper.Attach[attachScrollbarTop] = segment.Top
 	wrapper.Attach[attachScrollbarBottom] = segment.Bottom
+	wrapper.Attach[attachScrollbarMissing] = false
 
 	return store.OverridePipeline(map[string]any{
 		nodeName: map[string]any{

--- a/agent/go-service/common/listcomplete/scrollbar_recognition.go
+++ b/agent/go-service/common/listcomplete/scrollbar_recognition.go
@@ -166,25 +166,17 @@ func (r *ScrollbarCompleteRecognition) Run(
 		}, true
 	}
 
-	previous, ready, err := loadScrollbarPosition(ctx, currentNode)
+	previous, ready, complete, err := observeScrollbar(ctx, currentNode, segment, params.PositionTolerance)
 	if err != nil {
 		log.Error().
 			Err(err).
 			Str("component", scrollbarCompleteComponentName).
 			Str("node", currentNode).
-			Msg("failed to load scrollbar position")
+			Msg("failed to record valid scrollbar observation")
 		return nil, false
 	}
 
-	if !ready || !scrollbarSegmentsMatch(previous, segment, params.PositionTolerance) {
-		if err := saveScrollbarPosition(ctx, currentNode, segment); err != nil {
-			log.Error().
-				Err(err).
-				Str("component", scrollbarCompleteComponentName).
-				Str("node", currentNode).
-				Msg("failed to save scrollbar position")
-			return nil, false
-		}
+	if !complete {
 		log.Info().
 			Str("component", scrollbarCompleteComponentName).
 			Str("node", currentNode).
@@ -357,6 +349,24 @@ func observeMissingScrollbar(store nodeStore, nodeName string) (bool, error) {
 		return false, err
 	}
 	return false, nil
+}
+
+// observeScrollbar 先按旧位置判断列表是否停止移动，再保存当前有效位置并清除缺失确认状态。
+func observeScrollbar(
+	store nodeStore,
+	nodeName string,
+	segment scrollbarSegment,
+	positionTolerance int,
+) (previous scrollbarSegment, ready bool, complete bool, err error) {
+	previous, ready, err = loadScrollbarPosition(store, nodeName)
+	if err != nil {
+		return scrollbarSegment{}, false, false, err
+	}
+	complete = ready && scrollbarSegmentsMatch(previous, segment, positionTolerance)
+	if err = saveScrollbarPosition(store, nodeName, segment); err != nil {
+		return previous, ready, false, err
+	}
+	return previous, ready, complete, nil
 }
 
 func loadMissingScrollbar(store nodeStore, nodeName string) (bool, error) {

--- a/agent/go-service/common/listcomplete/scrollbar_recognition_test.go
+++ b/agent/go-service/common/listcomplete/scrollbar_recognition_test.go
@@ -199,6 +199,46 @@ func TestMissingScrollbarCompletesAfterConsecutiveConfirmation(t *testing.T) {
 	}
 }
 
+func TestUnchangedScrollbarObservationResetsMissingConfirmation(t *testing.T) {
+	t.Parallel()
+
+	const node = "ScrollbarBoundary"
+	store := newFakeNodeStore()
+	segment := scrollbarSegment{Top: 8, Bottom: 30}
+
+	_, ready, complete, err := observeScrollbar(store, node, segment, defaultPositionTolerance)
+	if err != nil {
+		t.Fatalf("first valid scrollbar observation: %v", err)
+	}
+	if ready || complete {
+		t.Fatal("first valid scrollbar observation must record the position without completing")
+	}
+
+	complete, err = observeMissingScrollbar(store, node)
+	if err != nil {
+		t.Fatalf("missing observation after valid scrollbar: %v", err)
+	}
+	if complete {
+		t.Fatal("first missing observation must request confirmation")
+	}
+
+	_, ready, complete, err = observeScrollbar(store, node, segment, defaultPositionTolerance)
+	if err != nil {
+		t.Fatalf("unchanged valid scrollbar observation: %v", err)
+	}
+	if !ready || !complete {
+		t.Fatal("unchanged valid scrollbar observation must report the list complete")
+	}
+
+	complete, err = observeMissingScrollbar(store, node)
+	if err != nil {
+		t.Fatalf("missing observation after unchanged valid scrollbar: %v", err)
+	}
+	if complete {
+		t.Fatal("unchanged valid scrollbar observation must reset missing confirmation state")
+	}
+}
+
 func paintWhiteRows(img *image.RGBA, top, bottom int) {
 	paintWhiteRowsAtX(img, 2, top, bottom)
 }

--- a/agent/go-service/common/listcomplete/scrollbar_recognition_test.go
+++ b/agent/go-service/common/listcomplete/scrollbar_recognition_test.go
@@ -154,6 +154,51 @@ func TestScrollbarPositionRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMissingScrollbarCompletesAfterConsecutiveConfirmation(t *testing.T) {
+	t.Parallel()
+
+	const node = "ScrollbarBoundary"
+	store := newFakeNodeStore()
+
+	complete, err := observeMissingScrollbar(store, node)
+	if err != nil {
+		t.Fatalf("first missing observation: %v", err)
+	}
+	if complete {
+		t.Fatal("first missing observation must request one confirmation scroll")
+	}
+
+	complete, err = observeMissingScrollbar(store, node)
+	if err != nil {
+		t.Fatalf("second missing observation: %v", err)
+	}
+	if !complete {
+		t.Fatal("second consecutive missing observation must treat the list as not scrollable")
+	}
+
+	if err := saveReady(store, node, false); err != nil {
+		t.Fatalf("reset scan state: %v", err)
+	}
+	complete, err = observeMissingScrollbar(store, node)
+	if err != nil {
+		t.Fatalf("first missing observation after scan reset: %v", err)
+	}
+	if complete {
+		t.Fatal("attach.ready=false must start a fresh missing confirmation cycle")
+	}
+
+	if err := saveScrollbarPosition(store, node, scrollbarSegment{Top: 8, Bottom: 30}); err != nil {
+		t.Fatalf("save valid scrollbar position: %v", err)
+	}
+	complete, err = observeMissingScrollbar(store, node)
+	if err != nil {
+		t.Fatalf("missing observation after valid scrollbar: %v", err)
+	}
+	if complete {
+		t.Fatal("a valid scrollbar observation must reset missing confirmation state")
+	}
+}
+
 func paintWhiteRows(img *image.RGBA, top, bottom int) {
 	paintWhiteRowsAtX(img, 2, top, bottom)
 }

--- a/assets/resource/pipeline/ItemTransfer.json
+++ b/assets/resource/pipeline/ItemTransfer.json
@@ -648,13 +648,33 @@
             }
         },
         "next": [
+            "ItemTransferResetRepoScrollHitCount"
+        ]
+    },
+    "ItemTransferResetRepoScrollHitCount": {
+        "desc": "每次完整扫描仓库前清理上下滚动节点的命中计数",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "ClearHitCount",
+                "custom_action_param": {
+                    "nodes": [
+                        "ItemTransferScrollUpwardRepo",
+                        "ItemTransferScrollDownwardRepo"
+                    ],
+                    "strict": true
+                }
+            }
+        },
+        "next": [
             "ItemTransferRepoScrollToTop"
         ]
     },
     "ItemTransferRepoScrollToTop": {
         "next": [
             "ItemTransferRepoTopReached",
-            "[JumpBack]ItemTransferScrollUpwardRepo"
+            "[JumpBack]ItemTransferScrollUpwardRepo",
+            "ItemTransferStop"
         ]
     },
     "ItemTransferRepoTopReached": {
@@ -684,7 +704,8 @@
             "[JumpBack][Anchor]MouseMoveResetAnchor",
             "[Anchor]ItemTransferCurrentRepoFind",
             "ItemTransferRepoBottomReached",
-            "[JumpBack]ItemTransferScrollDownwardRepo"
+            "[JumpBack]ItemTransferScrollDownwardRepo",
+            "ItemTransferStop"
         ]
     },
     "ItemTransferRepoBottomReached": {
@@ -707,6 +728,7 @@
         }
     },
     "ItemTransferScrollDownwardRepo": {
+        "max_hit": 20,
         "action": "Scroll",
         "target": [
             640,
@@ -729,6 +751,7 @@
     },
     "ItemTransferScrollUpwardRepo": {
         "desc": "完整扫描前向上滚动一页",
+        "max_hit": 20,
         "action": "Scroll",
         "target": [
             640,
@@ -1040,13 +1063,33 @@
             }
         },
         "next": [
+            "ItemTransferResetBagScrollHitCount"
+        ]
+    },
+    "ItemTransferResetBagScrollHitCount": {
+        "desc": "每次完整扫描背包前清理上下滚动节点的命中计数",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "ClearHitCount",
+                "custom_action_param": {
+                    "nodes": [
+                        "ItemTransferScrollUpwardBag",
+                        "ItemTransferScrollDownwardBag"
+                    ],
+                    "strict": true
+                }
+            }
+        },
+        "next": [
             "ItemTransferBagScrollToTop"
         ]
     },
     "ItemTransferBagScrollToTop": {
         "next": [
             "ItemTransferBagTopReached",
-            "[JumpBack]ItemTransferScrollUpwardBag"
+            "[JumpBack]ItemTransferScrollUpwardBag",
+            "ItemTransferStop"
         ]
     },
     "ItemTransferBagTopReached": {
@@ -1076,7 +1119,8 @@
             "[JumpBack][Anchor]MouseMoveResetAnchor",
             "[Anchor]ItemTransferCurrentBagFind",
             "ItemTransferBagBottomReached",
-            "[JumpBack]ItemTransferScrollDownwardBag"
+            "[JumpBack]ItemTransferScrollDownwardBag",
+            "ItemTransferStop"
         ]
     },
     "ItemTransferBagBottomReached": {
@@ -1099,6 +1143,7 @@
         }
     },
     "ItemTransferScrollDownwardBag": {
+        "max_hit": 20,
         "action": "Scroll",
         "target": [
             837,
@@ -1121,6 +1166,7 @@
     },
     "ItemTransferScrollUpwardBag": {
         "desc": "完整扫描前向上滚动一页",
+        "max_hit": 20,
         "action": "Scroll",
         "target": [
             837,

--- a/assets/resource/pipeline/ItemTransfer.json
+++ b/assets/resource/pipeline/ItemTransfer.json
@@ -179,6 +179,25 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "ItemTransferResetRepoSwitchHitCount"
+        ]
+    },
+    "ItemTransferResetRepoSwitchHitCount": {
+        "desc": "每轮转移开始前清理仓库切换节点的命中计数",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "ClearHitCount",
+                "custom_action_param": {
+                    "nodes": [
+                        "ItemTransferSwitchRepoToOrigin",
+                        "ItemTransferSwitchRepoToDestination",
+                        "ItemTransferSwitchRepoToOriginReturn"
+                    ]
+                }
+            }
+        },
+        "next": [
             "ItemTransferSwitchRepoToOrigin"
         ]
     },
@@ -218,6 +237,7 @@
         ]
     },
     "ItemTransferSwitchRepoToOrigin": {
+        "max_hit": 3,
         "recognition": "And",
         "all_of": [
             "ItemTransferRepoSwitchButton"
@@ -326,6 +346,19 @@
         ]
     },
     "ItemTransferOriginDispatch": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "ClearHitCount",
+                "custom_action_param": {
+                    "nodes": [
+                        "ItemTransferSwitchRepoToOrigin",
+                        "ItemTransferSwitchRepoToDestination",
+                        "ItemTransferSwitchRepoToOriginReturn"
+                    ]
+                }
+            }
+        },
         "anchor": {
             "ItemTransferForwardGateNext": "ItemTransferRepoToBag",
             "ItemTransferReturnGateNext": "ItemTransferTravelToDestinationForReturn"
@@ -337,6 +370,19 @@
         ]
     },
     "ItemTransferDestinationDispatch": {
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "ClearHitCount",
+                "custom_action_param": {
+                    "nodes": [
+                        "ItemTransferSwitchRepoToOrigin",
+                        "ItemTransferSwitchRepoToDestination",
+                        "ItemTransferSwitchRepoToOriginReturn"
+                    ]
+                }
+            }
+        },
         "anchor": {
             "ItemTransferReturnGateNext": "ItemTransferReturnRepoToBag",
             "ItemTransferForwardGateNext": "ItemTransferTravelToOriginForForward"
@@ -788,6 +834,7 @@
         ]
     },
     "ItemTransferSwitchRepoToDestination": {
+        "max_hit": 3,
         "recognition": "And",
         "all_of": [
             "ItemTransferRepoSwitchButton"
@@ -1357,6 +1404,7 @@
         ]
     },
     "ItemTransferSwitchRepoToOriginReturn": {
+        "max_hit": 3,
         "recognition": "And",
         "all_of": [
             "ItemTransferRepoSwitchButton"

--- a/docs/en_us/developers/custom.md
+++ b/docs/en_us/developers/custom.md
@@ -433,7 +433,7 @@ Both scrollbar recognizers share the same detector: search each ROI row for a pi
 
 `ScrollbarCompleteRecognition` lives in the same package as `ScrollbarRecognition` and reuses the same internal thumb detector. It stores and compares consecutive positions on top of that basic result, making it suitable for top/bottom detection when list content or backgrounds change and a full-region template comparison is not stable.
 
-**Hit semantics: `true` = the scrollbar did not move, so the list is at the top or bottom; `false` = completion cannot be determined yet (keep scrolling).**
+**Hit semantics: `true` = the scrollbar did not move, or no scrollbar was detected twice consecutively, so the list is at the top, bottom, or is not scrollable; `false` = completion cannot be determined yet (keep scrolling).**
 
 Parameters:
 
@@ -445,7 +445,7 @@ Behavior:
 1. Use the same internal detector as `ScrollbarRecognition` to obtain `[top, bottom]`.
 2. On the first recognition or after the thumb moves, write the boundaries to `attach.scrollbar_top` / `attach.scrollbar_bottom` on the current node, set `attach.ready` to `true`, and return **no match**.
 3. On later recognitions, return a **match** only when both boundaries are within `position_tolerance`; otherwise update the stored position and return **no match**.
-4. If no valid continuous white segment is found, return **no match** and preserve the previous valid position so a temporary missing highlight does not corrupt state.
+4. The first missing valid white segment records `attach.scrollbar_missing = true` and returns **no match**, allowing the Pipeline to perform one confirmation scroll. If the next observation is also missing, return a **match** and treat the list as not scrollable. Detecting a valid thumb later clears the missing state.
 
 The Pipeline layout is the same as for `ListCompleteRecognition`: put this recognition before the scroll node; a hit takes the "boundary reached" branch, while a miss falls through to scrolling. The scroll node must set `post_wait_freezes` so the next recognition runs only after the frame is still.
 
@@ -477,7 +477,7 @@ The Pipeline layout is the same as for `ListCompleteRecognition`: put this recog
 Notes:
 
 - The ROI should cover only the scrollbar track. White text or icons in the list may otherwise form a longer continuous segment.
-- The first call only records a position and cannot determine completion. Before a fresh list scan, reset `attach.ready` on the current node to `false` through `PipelineOverride`.
+- The first call only records a thumb position or missing observation and cannot determine completion. Before a fresh list scan, reset `attach.ready` on the current node to `false` through `PipelineOverride`; this also starts a new missing-confirmation cycle.
 - The component does not distinguish "top" from "bottom"; that meaning comes from the Pipeline's current scroll direction.
 - The component only detects the list boundary. Scrolling and subsequent business flow still belong in Pipeline.
 

--- a/docs/zh_cn/developers/custom.md
+++ b/docs/zh_cn/developers/custom.md
@@ -435,7 +435,7 @@ Pipeline 组织：把本识别放在滑动节点**之前**；命中走「到底�
 
 `ScrollbarCompleteRecognition` 与 `ScrollbarRecognition` 位于同一个包，并复用相同的内部滑块检测函数。它在基础检测结果之上保存和比较连续两次位置，适合列表内容或背景会变化、无法稳定做整块模板比较的到顶/到底判断。
 
-**命中语义：`true` = 滚动条未移动，列表已到顶或到底；`false` = 尚不能判定完成（应继续滚动）。**
+**命中语义：`true` = 滚动条未移动，或连续两次未检测到滚动条，列表已到顶、到底或不可滚动；`false` = 尚不能判定完成（应继续滚动）。**
 
 参数：
 
@@ -447,7 +447,7 @@ Pipeline 组织：把本识别放在滑动节点**之前**；命中走「到底�
 1. 使用与 `ScrollbarRecognition` 相同的内部算法获取 `[top, bottom]`。
 2. 首次识别或滑块位置变化时，将边界写入当前节点的 `attach.scrollbar_top` / `attach.scrollbar_bottom`，把 `attach.ready` 置 `true`，返回**未命中**。
 3. 后续识别中，上、下边界都在 `position_tolerance` 内时返回**命中**；任一边界超出容差则更新位置并返回**未命中**。
-4. 未找到有效连续白条时返回**未命中**，并保留上一次有效位置，避免高亮短暂消失污染状态。
+4. 首次未找到有效连续白条时记录 `attach.scrollbar_missing = true` 并返回**未命中**，让 Pipeline 做一次确认滚动；连续第二次仍未找到时返回**命中**，将列表视为不可滚动。之后重新检测到有效滑块会清除缺失状态。
 
 Pipeline 布局与 `ListCompleteRecognition` 相同：将本识别放在滚动节点之前；命中走“已到边界”分支，未命中落到滚动节点。滚动节点必须配置 `post_wait_freezes`，保证下一次识别发生在画面静止后。
 
@@ -479,7 +479,7 @@ Pipeline 布局与 `ListCompleteRecognition` 相同：将本识别放在滚动�
 注意事项：
 
 - ROI 应只覆盖滚动条轨道，避免列表中的白色文字或图标形成更长的连续段。
-- 首次调用只记录位置，不能判定完成。每次开始新的列表扫描前，应通过 `PipelineOverride` 将当前节点的 `attach.ready` 重置为 `false`。
+- 首次调用只记录滑块位置或缺失观察，不能判定完成。每次开始新的列表扫描前，应通过 `PipelineOverride` 将当前节点的 `attach.ready` 重置为 `false`；该重置也会开启新的缺失确认周期。
 - 组件不区分“到顶”和“到底”；方向语义由 Pipeline 当前采用的滚动方向决定。
 - 组件只负责判断列表边界，滚动和后续业务流程仍由 Pipeline 组织。
 


### PR DESCRIPTION
问题：

- Issue #5141 中仓库当前页可见蓝铁矿，但 transfer 网格被背景结构偏移，导致当前页识别失败并错误进入滚动扫描。

- Issue #5150 日志复现了同类边界问题：目标物品前 6 次识别成功并完成转移，随后因无滚动条检测不到顶部边界而反复上滑。

- 无滚动条列表在边界识别持续失败时会反复滚动；仓库切换按钮点击未生效时也缺少失败上限。

改动：

- 在 transfer 网格候选阶段比较多行与单行前景纹理，过滤低纹理背景伪网格，避免依赖逐格匹配失败后的补救。

- 限制弱灰色 rarity 证据的相位接管范围，保持 port_storager 的既有识别行为。

- 滚动条连续两次缺失时判定列表不可滚动，首次缺失仍保留一次确认滚动。

- 为三个仓库切换节点设置 3 次命中上限，并在每轮转移及正反向调度入口清理命中计数，使限制按单次转移流程生效。

- 增加稀疏网格、滚动条状态机和切换重试相关回归测试，并同步中英文自定义识别文档。

验证：

- Issue 图片识别通过；Win32 transfer 112/112、Win32 port_storager 10/10、ADB transfer 21/21、ADB port_storager 8/8。

- IconRecognition 小测试、Go common/listcomplete 测试、pnpm check 通过。

Close #5141
Close #5150

## Sourcery 总结

修复转移识别和列表导航边界处理问题，使物品转移在稀疏网格、缺少滚动条以及仓库切换重试场景下更加可靠。

Bug 修复：
- 改进转移网格检测，使稀疏的可见物品行能够被正确识别，而不会被背景结构挤开。
- 通过确认连续两次观察到缺少滚动条，防止不可滚动列表反复滚动。
- 限制仓库切换重试次数，并为每个转移流程重置重试状态，避免无限制地尝试切换。

增强功能：
- 优化转移识别的置信度处理，避免不可靠的灰色稀有度证据覆盖可靠的网格结构。
- 增加针对稀疏转移网格、滚动条边界状态以及缺少滚动条确认的回归测试覆盖。
- 更新英文和中文自定义识别文档中关于不可滚动列表处理的内容。

文档：
- 在英文和中文文档中记录连续检测到缺少滚动条是自定义列表识别完成的条件。

测试：
- 增加涵盖稀疏转移网格识别和连续确认缺少滚动条的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix transfer recognition and list-navigation boundary handling to make item transfers reliable across sparse grids, missing scrollbars, and warehouse-switch retries.

Bug Fixes:
- Improve transfer-grid detection so sparse visible item rows are recognized instead of being displaced by background structures.
- Prevent non-scrollable lists from repeatedly scrolling by confirming two consecutive missing-scrollbar observations.
- Limit warehouse-switch retries and reset retry state for each transfer flow to avoid unbounded switching attempts.

Enhancements:
- Refine transfer recognition confidence handling so weak gray rarity evidence cannot override reliable grid structure.
- Add regression coverage for sparse transfer grids, scrollbar boundary state, and missing-scrollbar confirmation.
- Update English and Chinese custom-recognition documentation for non-scrollable list handling.

Documentation:
- Document consecutive missing-scrollbar detection as a completion condition for custom list recognition in English and Chinese.

Tests:
- Add regression tests covering sparse transfer-grid recognition and consecutive scrollbar-missing confirmation.

</details>

## Sourcery 总结

改进稀疏网格、不可滚动列表和仓库切换重试的物品转移识别与列表导航边界处理。

Bug 修复：
- 防止转移网格识别在稀疏的可见物品行之上选择低纹理背景结构。
- 在一次确认尝试后，将连续未检测到滚动条视为不可滚动列表。
- 限制仓库切换重试次数，并为每个物品转移流程重置重试状态，以防止重复切换。

增强功能：
- 优化转移识别的置信度处理，确保不可靠的灰色稀有度证据无法覆盖可靠的网格结构。

文档：
- 使用英文和中文记录：连续未检测到滚动条可作为自定义列表识别的完成条件。

测试：
- 添加针对稀疏转移网格识别和连续未检测到滚动条确认的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

确保在网格稀疏、缺少滚动条以及仓库切换重试的情况下，物品转移识别和列表导航更加可靠。

Bug 修复：
- 改进转移网格检测，保留稀疏的可见物品行，避免选择低纹理的背景结构。
- 连续两次观察不到滚动条后完成处理，防止对不可滚动列表重复滚动。
- 限制仓库切换重试次数，并为每个物品转移流程重置重试状态，防止无限制地尝试切换。

增强功能：
- 优化转移识别的置信度处理，避免不可靠的灰色稀有度证据覆盖可靠的网格结构。

文档：
- 用英文和中文记录：连续检测不到滚动条是自定义列表识别的完成条件。

测试：
- 增加对稀疏转移网格识别和连续检测不到滚动条确认的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

改进稀疏网格、不可滚动列表和仓库切换重试场景下的物品转移识别与导航边界处理。

错误修复：
- 通过过滤低纹理背景结构，纠正稀疏可见物品行的转移网格选择，并防止不可靠的灰色稀有度证据覆盖可靠的网格结构。
- 将连续两次未检测到滚动条视为完成条件，避免不可滚动列表重复滚动。
- 限制仓库切换重试次数，并为每个物品转移工作流重置重试计数器，防止无限制地尝试切换。

文档：
- 在英文和中文文档中，将连续未检测到滚动条记录为自定义列表识别的完成条件。

测试：
- 增加对稀疏转移网格识别和连续未检测到滚动条确认逻辑的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

提升稀疏网格、不可滚动列表和仓库切换重试场景下的物品转移识别与导航可靠性。

Bug 修复：
- 通过过滤低纹理背景候选项，并要求可靠的稀有度证据后再调整网格对齐方式，修正稀疏可见物品行的转移网格选择。
- 连续两次未检测到滚动条后，将列表视为不可滚动，避免重复滚动到边界。
- 限制仓库切换重试次数，并为每个物品转移工作流重置重试状态，防止无限次切换尝试。

文档：
- 使用英文和中文记录：连续未检测到滚动条是自定义列表识别完成的条件。

测试：
- 增加对稀疏转移网格识别和滚动条缺失确认行为的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve item-transfer recognition and navigation reliability across sparse grids, non-scrollable lists, and warehouse-switch retry scenarios.

Bug Fixes:
- Correct transfer-grid selection for sparse visible item rows by filtering low-texture background candidates and requiring reliable rarity evidence before changing grid alignment.
- Treat lists as non-scrollable after two consecutive missing-scrollbar observations, preventing repeated boundary scrolling.
- Bound warehouse-switch retries and reset retry state for each item-transfer workflow to prevent unbounded switching attempts.

Documentation:
- Document consecutive missing-scrollbar detection as a completion condition for custom list recognition in English and Chinese.

Tests:
- Add regression coverage for sparse transfer-grid recognition and scrollbar-missing confirmation behavior.

</details>

</details>

</details>

</details>