### PR TITLE
ci: 校验 MaaUtils 版本一致性，不同步时自动开 PR 更新

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -37,6 +37,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      actions: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -107,12 +108,79 @@ jobs:
           excludes: ${{ (steps.set_tag.outputs.is_release == 'true' && steps.set_tag.outputs.is_prerelease == 'false') && 'prerelease, draft' || 'draft' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # 校验 MaaUtils submodule 是否落后/分叉于本次构建所用 maafw 版锁定的 commit，
+      # 不同步则联动触发 sync_maautils 工作流开修复 PR，并终止全部构建
+      # 注意：fork PR 无 bot App secrets，跳过 token 生成（联动触发会自动降级为 GITHUB_TOKEN）
+      - id: maautils-app-token
+        if: github.repository == 'MaaEnd/MaaEnd' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MAAEND_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MAAEND_BOT_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-actions: write
+
+      - id: maautils-sync-check
+        name: Check MaaUtils submodule matches MaaFramework release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_TOKEN: ${{ steps.maautils-app-token.outputs.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          # 版本号来自第三方 action 输出，必须经环境变量传递，禁止直接内插进脚本
+          MAAFW_VERSION: ${{ steps.maafw-latest-release.outputs.release }}
+          FAIL_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set +e
+          out=$(python3 tools/check_maautils_sync.py --maafw-ref "$MAAFW_VERSION")
+          rc=$?
+          set -e
+          echo "$out"
+          status=$(sed -n 's/^status=//p' <<<"$out")
+          expected=$(sed -n 's/^expected_sha=//p' <<<"$out")
+          current=$(sed -n 's/^current_sha=//p' <<<"$out")
+
+          # 写入 Run Summary，打开构建页即可看到判定结果，无需翻日志
+          {
+            echo "### MaaUtils Sync Check"
+            echo ""
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| MaaFramework | \`$MAAFW_VERSION\` |"
+            echo "| Upstream pinned MaaUtils | \`${expected:-n/a}\` |"
+            echo "| Local MaaUtils | \`${current:-n/a}\` |"
+            echo "| Verdict | \`$status\` (exit=$rc) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          case "$rc" in
+            0)
+              echo "MaaUtils gate passed: $status"
+              ;;
+            1|2)
+              echo "::error::MaaUtils submodule is '$status' relative to the pin of MaaFramework $MAAFW_VERSION; builds are blocked until it is synced."
+              if [ -n "$APP_TOKEN" ] || [ -n "$GITHUB_TOKEN" ]; then
+                export GH_TOKEN="${APP_TOKEN:-$GITHUB_TOKEN}"
+                gh workflow run sync_maautils.yml --repo "$GITHUB_REPOSITORY" --ref "$DEFAULT_BRANCH" \
+                  -f fail_run_url="$FAIL_RUN_URL" \
+                  || echo "::warning::Failed to dispatch sync_maautils workflow; it also runs on its daily schedule."
+              fi
+              exit 1
+              ;;
+            3)
+              echo "::error::Cannot resolve the MaaUtils pin of MaaFramework $MAAFW_VERSION (tag missing or upstream 'source/MaaUtils' path changed). Manual investigation required, see tools/check_maautils_sync.py"
+              exit 1
+              ;;
+            *)
+              echo "::warning::MaaUtils sync status is UNKNOWN due to transient network/API failures after retries; skipping the gate this run (daily scheduled check still applies)."
+              ;;
+          esac
+
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
       is_release: ${{ steps.set_tag.outputs.is_release }}
       is_prerelease: ${{ steps.set_tag.outputs.is_prerelease }}
       maafw_version: ${{ steps.maafw-latest-release.outputs.release }}
       mxu_version: ${{ steps.mxu-latest-release.outputs.release }}
+      maautils_expected_sha: ${{ steps.maautils-sync-check.outputs.expected_sha }}
       commit_sha: ${{ steps.commit.outputs.sha }}
       icon_recognition_changed: ${{ steps.icon-recognition-changes.outputs.icon_recognition }}
 
@@ -483,6 +551,7 @@ jobs:
             commit = "${{ needs.meta.outputs.commit_sha }}"
             maafw_version = "${{ needs.meta.outputs.maafw_version }}"
             mxu_version = "${{ needs.meta.outputs.mxu_version }}"
+            maautils_commit = "${{ needs.meta.outputs.maautils_expected_sha || 'unknown' }}"
             go_service = "unstripped binary with DWARF (Go emits no PDB); resolve with go tool addr2line"
           } | ConvertTo-Json
           Set-Content -Path "$symbols/symbols-manifest.json" -Value $manifest -Encoding utf8NoBOM

--- a/.github/workflows/sync_maautils.yml
+++ b/.github/workflows/sync_maautils.yml
@@ -1,0 +1,209 @@
+name: Sync MaaUtils Submodule
+
+# 校验 agent/cpp-algo/MaaUtils 是否落后于最新 MaaFramework 发布版锁定的 MaaUtils commit：
+# - behind / diverged -> 自动更新 submodule 并开 PR（CI 会在 PR 上验证编译）
+# - synced / ahead -> 无需处理；unknown -> 静默跳过等待下次巡检
+#
+# 触发方式：每日定时兜底 + install.yml 版本校验门禁失败时联动 + 手动 dispatch。
+
+on:
+  schedule:
+    - cron: "0 23 * * *" # UTC+8 07:00
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Only check and report, do not create/update PR
+        type: boolean
+        default: false
+      fail_run_url:
+        description: URL of the blocked install run (set automatically when dispatched by the install gate)
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# cron / install 联动 / 手动 dispatch 可能并发竞争固定的 bot/sync-maautils 分支，
+# 排队执行（不取消），后跑的会基于最新状态重新判定
+concurrency:
+  group: sync-maautils
+  cancel-in-progress: false
+
+jobs:
+  check-repository:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.repository }}" == "MaaEnd/MaaEnd" ]]; then
+            echo "Repository is MaaEnd/MaaEnd, proceeding with sync"
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "Repository is not MaaEnd/MaaEnd, skipping sync"
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
+
+  sync-maautils:
+    needs: check-repository
+    if: needs.check-repository.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      # checkout 用默认 GITHUB_TOKEN 即可；App token 延迟到确认要开 PR 时才生成，
+      # 避免 secrets 缺失/失效时连每日巡检和 dry-run 都跑不了
+      - name: Check Out Repository
+        uses: actions/checkout@v6
+
+      # 只初始化需要移动指针的 submodule，避免拉取体积较大的测试集等
+      - name: Init MaaUtils submodule
+        run: git submodule update --init agent/cpp-algo/MaaUtils
+
+      - name: Check MaaUtils sync status
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          out=$(python3 tools/check_maautils_sync.py --resolve-latest)
+          rc=$?
+          set -e
+          echo "$out"
+          status=$(sed -n 's/^status=//p' <<<"$out")
+          maafw_ref=$(sed -n 's/^maafw_ref=//p' <<<"$out")
+          expected_sha=$(sed -n 's/^expected_sha=//p' <<<"$out")
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "maafw_ref=$maafw_ref" >> "$GITHUB_OUTPUT"
+          echo "expected_sha=$expected_sha" >> "$GITHUB_OUTPUT"
+
+          # 写入 Run Summary，打开构建页即可看到巡检结论，无需翻日志
+          {
+            echo "### MaaUtils Sync Check"
+            echo ""
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| Latest MaaFramework | \`${maafw_ref:-n/a}\` |"
+            echo "| Upstream pinned MaaUtils | \`${expected_sha:-n/a}\` |"
+            echo "| Verdict | \`${status:-unknown}\` (exit=$rc) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          case "$rc" in
+            0)
+              echo "::notice::MaaUtils is up to date ('$status') against latest MaaFramework release."
+              exit 0
+              ;;
+            1|2)
+              echo "should_fix=true" >> "$GITHUB_OUTPUT"
+              ;;
+            3)
+              echo "::error::Upstream layout problem while resolving the latest MaaFramework release pin; manual investigation required."
+              exit 1
+              ;;
+            *)
+              echo "::notice::Transient network/API failure, status unknown; skipping this run (retry on next schedule or dispatch)."
+              exit 0
+              ;;
+          esac
+
+      # 只有真正要开 PR 时才需要写权限凭据
+      - name: Generate MaaEndBot GitHub App token
+        id: app-token
+        if: steps.check.outputs.should_fix == 'true' && inputs.dry_run != true
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MAAEND_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MAAEND_BOT_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Move MaaUtils submodule to expected commit
+        if: steps.check.outputs.should_fix == 'true'
+        env:
+          EXPECTED_SHA: ${{ steps.check.outputs.expected_sha }}
+        run: |
+          git -C agent/cpp-algo/MaaUtils fetch --no-tags origin "$EXPECTED_SHA"
+          git -C agent/cpp-algo/MaaUtils checkout --detach "$EXPECTED_SHA"
+          echo "Submodule now points at $(git -C agent/cpp-algo/MaaUtils rev-parse HEAD)"
+          git status --porcelain agent/cpp-algo/MaaUtils
+
+      - name: Prepare PR title and body
+        id: pr-texts
+        if: steps.check.outputs.should_fix == 'true'
+        env:
+          STATUS: ${{ steps.check.outputs.status }}
+          MAAFW_REF: ${{ steps.check.outputs.maafw_ref }}
+          EXPECTED_SHA: ${{ steps.check.outputs.expected_sha }}
+          TRIGGER: ${{ github.event_name }}
+          MAAFW_REPO: MaaXYZ/MaaFramework
+          FAIL_RUN_URL: ${{ inputs.fail_run_url }}
+        run: |
+          body_file=$(mktemp)
+          {
+            echo "Update \`agent/cpp-algo/MaaUtils\` to the commit pinned by [MaaFramework ${MAAFW_REF}](https://github.com/${MAAFW_REPO}/releases/tag/${MAAFW_REF})."
+            echo ""
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| Status | \`${STATUS}\` |"
+            echo "| Target MaaUtils commit | \`${EXPECTED_SHA}\` |"
+            echo "| Trigger | ${TRIGGER} |"
+            # 仅接受本仓库域名的链接，防止 dispatch 入参向 PR 正文注入任意内容
+            case "$FAIL_RUN_URL" in
+              https://github.com/*) echo "| Blocked install run | [view](${FAIL_RUN_URL}) |" ;;
+            esac
+          } > "$body_file"
+
+          {
+            echo ""
+            echo "Auto-generated by \`sync_maautils.yml\`; CI validates the build on this PR."
+            echo ""
+            echo "[skip changelog]"
+          } >> "$body_file"
+
+          {
+            echo "title=chore: update MaaUtils submodule to match MaaFramework ${MAAFW_REF}"
+            echo "labels<<LABELS_EOF"
+            echo "submodule"
+            echo "dependencies"
+            echo "LABELS_EOF"
+            echo "body<<BODY_EOF"
+            cat "$body_file"
+            echo "BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+          rm -f "$body_file"
+
+      - name: Create or update sync PR
+        if: steps.check.outputs.should_fix == 'true' && inputs.dry_run != true
+        id: create-pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          add-paths: agent/cpp-algo/MaaUtils
+          branch: bot/sync-maautils
+          title: ${{ steps.pr-texts.outputs.title }}
+          body: ${{ steps.pr-texts.outputs.body }}
+          labels: ${{ steps.pr-texts.outputs.labels }}
+          author: maaendbotapp[bot] <305547419+maaendbotapp[bot]@users.noreply.github.com>
+          committer: maaendbotapp[bot] <305547419+maaendbotapp[bot]@users.noreply.github.com>
+          commit-message: |-
+            ${{ steps.pr-texts.outputs.title }}
+
+            [skip changelog]
+
+      - name: Report sync PR
+        if: steps.create-pr.outputs.pull-request-url != ''
+        env:
+          STATUS: ${{ steps.check.outputs.status }}
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+        run: |
+          echo "::notice::Sync PR ($STATUS): $PR_URL"
+
+      - name: Report dry run result
+        if: steps.check.outputs.should_fix == 'true' && inputs.dry_run == true
+        env:
+          TITLE: ${{ steps.pr-texts.outputs.title }}
+          EXPECTED_SHA: ${{ steps.check.outputs.expected_sha }}
+          MAAFW_REF: ${{ steps.check.outputs.maafw_ref }}
+        run: |
+          echo "::notice::Dry run: would open/update PR '$TITLE' moving agent/cpp-algo/MaaUtils to $EXPECTED_SHA (MaaFramework $MAAFW_REF)"

--- a/tools/check_maautils_sync.py
+++ b/tools/check_maautils_sync.py
@@ -1,0 +1,312 @@
+"""
+检查 agent/cpp-algo/MaaUtils submodule 是否与 MaaFramework 发布版锁定的 commit 一致。
+
+cpp-algo 从源码编译 MaaUtils（agent/cpp-algo/MaaUtils），并链接 install 工作流下载的
+MaaFramework 预编译包。MaaFramework 自身通过其 source/MaaUtils submodule 锁定了一个
+精确的 MaaUtils commit，两边的 pin 一旦脱节就会导致构建失败。
+
+本脚本将本地 gitlink SHA 与指定 MaaFramework ref 锁定的 commit 比较，
+并通过 git 祖先关系归类：
+
+    synced    与上游锁定 commit 完全一致
+    ahead     是上游锁定 commit 的后代（有意的提前 bump，允许）
+    behind    是上游锁定 commit 的祖先 -> 需要更新
+    diverged  互不为祖先 -> 按 behind 同样处理（正常流程不会出现）
+    unknown   基础设施瞬时故障（网络/API），永不作为拦截构建的依据
+
+退出码：
+    0  synced / ahead
+    1  behind
+    2  diverged
+    3  上游布局异常（tag 不存在、submodule 路径改名等）-> 需人工介入
+    4  unknown（重试后仍失败）-> 调用方只告警不拦截
+
+所有网络与 git-fetch 操作均带指数退避重试；重试耗尽后归类为 unknown（退出码 4），
+仅 404 等确定性 API 错误映射为退出码 3。
+
+用法：
+    python tools/check_maautils_sync.py --maafw-ref v5.12.3
+    python tools/check_maautils_sync.py --resolve-latest
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+MAAFW_REPO = "MaaXYZ/MaaFramework"
+MAAFW_SUBMODULE_PATH = "source/MaaUtils"
+DEFAULT_API_BASE = "https://api.github.com"
+DEFAULT_MAAUTILS_URL = "https://github.com/MaaXYZ/MaaUtils.git"
+
+EXIT_OK = 0  # synced 或 ahead
+EXIT_BEHIND = 1
+EXIT_DIVERGED = 2
+EXIT_UPSTREAM_BROKEN = 3
+EXIT_UNKNOWN = 4
+
+
+class FatalUpstreamError(Exception):
+    """确定性的上游侧问题（404、响应结构不符合预期）。"""
+
+
+class InfrastructureError(Exception):
+    """重试后仍然存在的瞬态问题。"""
+
+
+def log(msg: str) -> None:
+    try:
+        sys.stdout.buffer.write((msg + "\n").encode("utf-8"))
+        sys.stdout.buffer.flush()
+    except OSError:
+        # 下游管道提前关闭导致 stdout 不可写；日志失败不能掩盖真实结论
+        pass
+
+
+def github_token() -> str:
+    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or ""
+
+
+def request_json(url: str, attempts: int, base_delay: float) -> "dict | list":
+    """从 GitHub API GET 一个 JSON 文档，带重试与指数退避。"""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "maaend-maautils-sync-check",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = github_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                raise FatalUpstreamError(f"404 Not Found: {url}") from None
+            retry_after = e.headers.get("Retry-After") if e.headers else None
+            rate_limited = e.code == 429 or (
+                e.code == 403 and e.headers and e.headers.get("x-ratelimit-remaining") == "0"
+            )
+            if rate_limited:
+                # 限流时优先遵循 Retry-After 头，等待时间不计入常规退避节奏
+                wait = float(retry_after) if retry_after else base_delay * (2 ** attempt)
+                log(f"[retry] rate limited (HTTP {e.code}), waiting {wait:.0f}s before attempt {attempt + 1}/{attempts}")
+                time.sleep(wait)
+                last_error = e
+                continue
+            if 500 <= e.code < 600:
+                last_error = e
+            else:
+                raise FatalUpstreamError(f"HTTP {e.code}: {url}") from None
+        except (urllib.error.URLError, TimeoutError, ConnectionError, json.JSONDecodeError, OSError) as e:
+            last_error = e
+
+        delay = base_delay * (2 ** (attempt - 1)) + random.uniform(0, 1)
+        log(f"[retry] attempt {attempt}/{attempts} failed: {last_error}; retrying in {delay:.1f}s")
+        time.sleep(delay)
+
+    raise InfrastructureError(f"GitHub API unreachable after {attempts} attempts: {url} ({last_error})")
+
+
+def resolve_latest_maafw(api_base: str, attempts: int, base_delay: float) -> str:
+    """取最新的非 draft release tag（语义与 install.yml 的版本解析器一致）。"""
+    data = request_json(f"{api_base}/repos/{MAAFW_REPO}/releases?per_page=30", attempts, base_delay)
+    for rel in data:
+        if not rel.get("draft") and rel.get("tag_name"):
+            return str(rel["tag_name"])
+    raise FatalUpstreamError(f"No non-draft release found for {MAAFW_REPO}")
+
+
+def get_expected_sha(api_base: str, maafw_ref: str, attempts: int, base_delay: float) -> str:
+    """获取指定 MaaFramework ref 锁定的 MaaUtils commit。"""
+    url = f"{api_base}/repos/{MAAFW_REPO}/contents/{MAAFW_SUBMODULE_PATH}?ref={urllib.parse.quote(maafw_ref)}"
+    try:
+        data = request_json(url, attempts, base_delay)
+    except FatalUpstreamError as e:
+        raise FatalUpstreamError(
+            f"{e}; check that MaaFramework ref '{maafw_ref}' exists and that its "
+            f"'{MAAFW_SUBMODULE_PATH}' submodule path has not been renamed"
+        ) from None
+    if data.get("type") != "submodule" or not data.get("sha"):
+        raise FatalUpstreamError(
+            f"Unexpected payload for '{MAAFW_SUBMODULE_PATH}' at '{maafw_ref}': type={data.get('type')!r}"
+        )
+    return str(data["sha"])
+
+
+def run_git(args: list[str], cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+def get_local_gitlink(submodule_path: str) -> str:
+    """读取 HEAD 中记录的 gitlink SHA，无需初始化 submodule。"""
+    proc = run_git(["ls-tree", "HEAD", "--", submodule_path])
+    if proc.returncode != 0:
+        raise InfrastructureError(f"git ls-tree failed: {proc.stderr.strip()}")
+    m = re.match(r"^[0-9]+ commit ([0-9a-f]{40})\b", proc.stdout.strip())
+    if not m:
+        raise FatalUpstreamError(f"'{submodule_path}' is not a gitlink in HEAD; is the path still correct?")
+    return m.group(1)
+
+
+def fetch_commits(maautils_url: str, shas: list[str], attempts: int, base_delay: float) -> None:
+    """把任意 commit 从 MaaUtils 远端拉取到本地对象库（GitHub 支持按可达 SHA fetch）。"""
+    last_error = ""
+    for attempt in range(1, attempts + 1):
+        proc = run_git(["fetch", "--no-tags", maautils_url, *shas])
+        if proc.returncode == 0:
+            return
+        last_error = proc.stderr.strip().splitlines()[-1] if proc.stderr.strip() else f"exit {proc.returncode}"
+        delay = base_delay * (2 ** (attempt - 1)) + random.uniform(0, 1)
+        log(f"[retry] git fetch attempt {attempt}/{attempts} failed: {last_error}; retrying in {delay:.1f}s")
+        time.sleep(delay)
+    raise InfrastructureError(f"git fetch failed after {attempts} attempts: {last_error}")
+
+
+def is_ancestor(a: str, b: str) -> bool:
+    """当且仅当 commit a 是 commit b 的祖先（或相等）时返回 True。"""
+    proc = run_git(["merge-base", "--is-ancestor", a, b])
+    if proc.returncode == 0:
+        return True
+    if proc.returncode == 1:
+        return False
+    raise InfrastructureError(f"git merge-base --is-ancestor failed: {proc.stderr.strip()}")
+
+
+def classify(local_sha: str, expected_sha: str) -> str:
+    if local_sha == expected_sha:
+        return "synced"
+    if is_ancestor(local_sha, expected_sha):
+        return "behind"
+    if is_ancestor(expected_sha, local_sha):
+        return "ahead"
+    return "diverged"
+
+
+def validate_sha(sha: str, label: str) -> str:
+    # SHA 会写入 GITHUB_OUTPUT 并作为 git 参数，必须确保是合法的 40 位十六进制，
+    # 防止异常/恶意响应通过换行符向输出文件注入伪造键值对
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise FatalUpstreamError(f"Illegal {label} (expect 40-hex): {sha[:80]!r}")
+    return sha
+
+
+def emit_outputs(mapping: dict[str, str]) -> None:
+    lines = [f"{key}={value}" for key, value in mapping.items()]
+    for line in lines:
+        log(line)
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+
+
+def _build_parser() -> _SafeArgumentParser:
+    parser = _SafeArgumentParser(description=__doc__.splitlines()[1])
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--maafw-ref", help="MaaFramework release tag to compare against")
+    group.add_argument("--resolve-latest", action="store_true", help="Resolve the latest MaaFramework release")
+    parser.add_argument("--github-api", default=DEFAULT_API_BASE, help="GitHub API base URL")
+    parser.add_argument("--maautils-url", default=DEFAULT_MAAUTILS_URL, help="MaaUtils git remote URL")
+    parser.add_argument("--submodule-path", default="agent/cpp-algo/MaaUtils", help="Local submodule path")
+    parser.add_argument("--local-sha", help="Override local gitlink SHA (for testing)")
+    parser.add_argument("--attempts", type=int, default=4, help="Retry attempts for network operations")
+    parser.add_argument("--base-delay", type=float, default=2.0, help="Base delay in seconds for exponential backoff")
+    return parser
+
+class _SafeArgumentParser(argparse.ArgumentParser):
+    """把用法错误转为异常而非直接退出。
+
+    argparse 默认在参数错误时以 exit 2 终止，会与 EXIT_DIVERGED 撞码，
+    导致调用方误判为"分叉"。这里改为抛异常，由入口统一归类为 unknown。
+    """
+
+    def error(self, message: str) -> None:
+        raise InfrastructureError(f"argument error: {message}")
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+
+    try:
+        maafw_ref = args.maafw_ref or resolve_latest_maafw(args.github_api, args.attempts, args.base_delay)
+        log(f"MaaFramework ref: {maafw_ref}")
+
+        expected_sha = validate_sha(
+            get_expected_sha(args.github_api, maafw_ref, args.attempts, args.base_delay), "upstream pin"
+        )
+        local_sha = validate_sha(args.local_sha or get_local_gitlink(args.submodule_path), "local gitlink")
+        log(f"Expected MaaUtils commit: {expected_sha}")
+        log(f"Current MaaUtils commit:  {local_sha}")
+
+        # fetch 失败时无法判断祖先关系；归为 unknown，保证调用方绝不因基础设施抖动误拦构建
+        try:
+            fetch_commits(args.maautils_url, [local_sha, expected_sha], args.attempts, args.base_delay)
+        except InfrastructureError as e:
+            log(f"[warn] cannot verify ancestry: {e}")
+            emit_outputs(
+                {
+                    "status": "unknown",
+                    "maafw_ref": maafw_ref,
+                    "expected_sha": expected_sha,
+                    "current_sha": local_sha,
+                }
+            )
+            return EXIT_UNKNOWN
+
+        status = classify(local_sha, expected_sha)
+
+        if status == "synced":
+            log(f"OK: MaaUtils pin matches the pin of MaaFramework {maafw_ref}")
+        elif status == "ahead":
+            log(f"OK: MaaUtils pin is ahead of the pin of MaaFramework {maafw_ref} (intentional forward bump)")
+        elif status == "behind":
+            log(f"OUT OF SYNC: MaaUtils pin is BEHIND the pin of MaaFramework {maafw_ref}; update required")
+        else:
+            log(f"OUT OF SYNC: MaaUtils pin DIVERGED from the pin of MaaFramework {maafw_ref}; human review required")
+
+        emit_outputs(
+            {
+                "status": status,
+                "maafw_ref": maafw_ref,
+                "expected_sha": expected_sha,
+                "current_sha": local_sha,
+            }
+        )
+        return {
+            "synced": EXIT_OK,
+            "ahead": EXIT_OK,
+            "behind": EXIT_BEHIND,
+            "diverged": EXIT_DIVERGED,
+        }[status]
+
+    except FatalUpstreamError as e:
+        log(f"[error] upstream layout problem: {e}")
+        emit_outputs({"status": "upstream-broken"})
+        return EXIT_UPSTREAM_BROKEN
+    except InfrastructureError as e:
+        log(f"[warn] transient infrastructure failure, status unknown: {e}")
+        emit_outputs({"status": "unknown"})
+        return EXIT_UNKNOWN
+
+
+if __name__ == "__main__":
+    try:
+        rc = main()
+    except Exception as e:  # noqa: BLE001 - 入口兜底：未捕获异常的默认退出码会撞 EXIT_BEHIND，必须归类为 unknown
+        log(f"[warn] unexpected internal error: {e!r}")
+        rc = EXIT_UNKNOWN
+    sys.exit(rc)


### PR DESCRIPTION
- install 构建前先校验 submodule 是否跟上最新 maafw，没跟上就拦下构建
- 新增每日巡检 workflow，落后时自动更新 submodule 并开同步 PR
- 判定逻辑在 tools/check_maautils_sync.py，两个 workflow 共用

## Sourcery 总结

确保 MaaUtils 与 MaaFramework 的发布版本保持一致，并通过定期同步拉取请求自动完成修复。

新功能：
- 添加针对 MaaFramework 发布版本固定提交的 MaaUtils 子模块自动同步检查。
- 创建定期运行和按需触发的工作流，在需要同步时更新子模块并创建或更新拉取请求。

错误修复：
- 当 MaaUtils 子模块落后于 MaaFramework 固定版本或与其发生分叉时，阻止构建继续进行。

增强功能：
- 集中处理同步状态检测，并支持带重试机制的以下状态：已同步、领先、落后、分叉、上游错误和临时失败。
- 在工作流摘要和发布符号清单中展示 MaaUtils 同步结果。

CI：
- 将同步检查门禁集成到安装工作流中，并在不匹配导致构建受阻时触发修复工作流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce MaaUtils consistency with MaaFramework releases and automate recovery through scheduled synchronization pull requests.

New Features:
- Add automated MaaUtils submodule synchronization checks against the MaaFramework release pin.
- Create a scheduled and on-demand workflow that updates the submodule and opens or updates a pull request when synchronization is required.

Bug Fixes:
- Prevent builds from proceeding when the MaaUtils submodule is behind or diverged from the MaaFramework pin.

Enhancements:
- Centralize sync status detection with retry-aware handling for synchronized, ahead, behind, diverged, upstream-error, and transient-failure states.
- Expose MaaUtils synchronization results in workflow summaries and release symbol manifests.

CI:
- Integrate the synchronization gate into the install workflow and trigger the repair workflow when a mismatch blocks a build.

</details>