### PR TITLE
fix:整送干员礼物次数限制太少了

### DIFF
--- a/assets/resource/pipeline/GiftOperator/GiftOperatorMain.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorMain.json
@@ -40,7 +40,7 @@
     },
     "GiftOperatorGoToDijiang": {
         "desc": "前往帝江号舰桥大世界",
-        "max_hit": 3,
+        "max_hit": 7,
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorMain.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorMain.json
@@ -40,7 +40,7 @@
     },
     "GiftOperatorGoToDijiang": {
         "desc": "前往帝江号舰桥大世界",
-        "max_hit": 7,
+        "max_hit": 5,
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,


### PR DESCRIPTION
## Sourcery 摘要

错误修复：
- 提高 GiftOperator pipeline 配置的使用上限。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

错误修复：
- 提高 GiftOperator pipeline 的干员送礼次数上限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 提高 GiftOperator pipeline 的干员送礼次数上限。

</details>

</details>