### PR TITLE
ci(essencefilter):增加基质筛选数据zmdmap更新

### DIFF
--- a/.github/workflows/sync-zmdmap.yml
+++ b/.github/workflows/sync-zmdmap.yml
@@ -138,6 +138,70 @@ jobs:
             **Version Information:**
             - Version: ${{ steps.version.outputs.version }}
 
+  sync-essence-filter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate MaaEndBot GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MAAEND_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MAAEND_BOT_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Sync EssenceFilter source data
+        id: sync
+        run: |
+          python3 -u tools/essence_filter/sync_zmdmap.py
+          if git diff --quiet -- \
+            assets/data/EssenceFilter/energy_point_gems.json \
+            assets/data/EssenceFilter/weapons_output.json; then
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate EssenceFilter data
+        if: steps.sync.outputs.updated == 'true'
+        run: |
+          python3 -u tools/essence_filter/extract_skill_pools.py
+          python3 -u tools/essence_filter/build_locations.py --time
+
+      - name: Create Pull Request
+        if: steps.sync.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          committer: "maaendbotapp[bot] <305547419+maaendbotapp[bot]@users.noreply.github.com>"
+          author: "maaendbotapp[bot] <305547419+maaendbotapp[bot]@users.noreply.github.com>"
+          add-paths: |
+            assets/data/EssenceFilter/energy_point_gems.json
+            assets/data/EssenceFilter/weapons_output.json
+            assets/data/EssenceFilter/skill_pools.json
+            assets/data/EssenceFilter/locations.json
+            assets/data/EssenceFilter/matcher_config.json
+          commit-message: "chore(essencefilter): sync zmdmap data"
+          branch: chore/sync-zmdmap-essence-filter-data
+          title: "chore(essencefilter): sync zmdmap data"
+          body: |
+            ## Summary
+
+            This PR synchronized the latest valid EssenceFilter data from zmdmap and regenerated dependent data files.
+
+            Please review the changes before merging it.
+
   sync-map:
     runs-on: ubuntu-latest
     steps:

--- a/tools/essence_filter/README.md
+++ b/tools/essence_filter/README.md
@@ -1,5 +1,20 @@
 # EssenceFilter 工具
 
+## sync_zmdmap.py
+
+从 zmdmap 当前版本下载 `energy_point_gems.json` 与 `weapons.json`，校验两份数据后分别写入
+`assets/data/EssenceFilter/energy_point_gems.json` 与 `weapons_output.json`。任一请求失败、返回非 JSON、空数据或结构无效时，整次同步不修改本地文件。
+
+```bash
+uv run tools/essence_filter/sync_zmdmap.py
+```
+
+仅验证指定版本且不写入文件：
+
+```bash
+uv run tools/essence_filter/sync_zmdmap.py --check-version 1.3.3
+```
+
 ## extract_skill_pools.py
 
 从 `weapons_output.json` 提取技能池（skill_pools），五语（cn/tc/en/jp/kr）直接取自同文件的 skills 数组，无需 i18n。

--- a/tools/essence_filter/sync_zmdmap.py
+++ b/tools/essence_filter/sync_zmdmap.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""从 zmdmap 同步基质筛选的两份源数据。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+VERSION_API = "https://api.zmdmap.com/api/v1/endfield/version"
+DATA_BASE_URL = "https://assets.zmdmap.com/data/entity"
+LANGS = ("CN", "TC", "EN", "JP", "KR")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = REPO_ROOT / "assets" / "data" / "EssenceFilter"
+TARGETS = {
+    "energy_point_gems.json": DATA_DIR / "energy_point_gems.json",
+    "weapons.json": DATA_DIR / "weapons_output.json",
+}
+
+
+def _url(url: str) -> str:
+    return f"{url}?{urlencode({'source': 'MaaEnd', 't': time.time_ns() // 1_000_000})}"
+
+
+def _download_json(url: str) -> Any | None:
+    try:
+        request = Request(_url(url), headers={"User-Agent": "MaaEnd/EssenceFilter"})
+        with urlopen(request, timeout=60) as response:
+            return json.loads(response.read())
+    except (OSError, ValueError) as error:
+        print(f"[EssenceFilter] 跳过无效数据 {url}: {error}")
+        return None
+
+
+def _latest_version() -> str | None:
+    payload = _download_json(VERSION_API)
+    try:
+        version = payload["data"]["list"][0]["version"]
+    except (KeyError, IndexError, TypeError):
+        print("[EssenceFilter] 跳过同步：版本接口没有有效版本")
+        return None
+    return version if isinstance(version, str) and version else None
+
+
+def _valid_energy_points(data: Any) -> bool:
+    return isinstance(data, list) and bool(data) and all(
+        isinstance(row, dict)
+        and isinstance(row.get("pointName"), str)
+        and isinstance(row.get("secAttrTermNames"), list)
+        and isinstance(row.get("skillTermNames"), list)
+        for row in data
+    )
+
+
+def _valid_weapons(data: Any) -> bool:
+    return isinstance(data, dict) and bool(data) and all(
+        isinstance(row, dict)
+        and isinstance(row.get("skills"), dict)
+        and all(isinstance(row["skills"].get(lang), list) for lang in LANGS)
+        for row in data.values()
+    )
+
+
+def _download_sources(version: str) -> dict[str, Any] | None:
+    validators = {
+        "energy_point_gems.json": _valid_energy_points,
+        "weapons.json": _valid_weapons,
+    }
+    result: dict[str, Any] = {}
+    for filename, validator in validators.items():
+        url = f"{DATA_BASE_URL}/{quote(version, safe='')}/{filename}"
+        data = _download_json(url)
+        if not validator(data):
+            print(f"[EssenceFilter] 跳过同步：{filename} 为空或结构无效")
+            return None
+        result[filename] = data
+    return result
+
+
+def _write_json(path: Path, data: Any) -> None:
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=4) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check-version",
+        help="只检查指定版本的两份远端数据，不写入本地文件",
+    )
+    args = parser.parse_args()
+
+    version = args.check_version or _latest_version()
+    if not version:
+        return 1 if args.check_version else 0
+
+    print(f"[EssenceFilter] 检查 zmdmap {version}")
+    sources = _download_sources(version)
+    if sources is None:
+        return 1 if args.check_version else 0
+    if args.check_version:
+        print(f"[EssenceFilter] zmdmap {version} 数据有效")
+        return 0
+
+    changed = [
+        filename
+        for filename, path in TARGETS.items()
+        if json.loads(path.read_text(encoding="utf-8")) != sources[filename]
+    ]
+    if not changed:
+        print("[EssenceFilter] 本地数据已是最新")
+        return 0
+
+    for filename in changed:
+        _write_json(TARGETS[filename], sources[filename])
+        print(f"[EssenceFilter] 已更新 {TARGETS[filename].relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Sourcery 摘要

自动执行经过验证的 zmdmap 同步，并重新生成 EssenceFilter 数据。

新功能：
- 添加自动同步 zmdmap 中最新有效 EssenceFilter 源数据的功能，并在检测到更新时创建拉取请求。

增强功能：
- 添加 zmdmap 同步工具，用于验证远程数据，并支持特定版本的检查，同时不会修改本地文件。

CI：
- 添加 GitHub Actions 作业，在源数据更新后重新生成依赖的 EssenceFilter 数据。

文档：
- 记录 zmdmap 同步工具的使用方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automate validated zmdmap synchronization and regeneration of EssenceFilter data.

New Features:
- Add automated synchronization of the latest valid EssenceFilter source data from zmdmap and open a pull request when updates are detected.

Enhancements:
- Add a zmdmap synchronization utility that validates remote data and supports version-specific checks without modifying local files.

CI:
- Add a GitHub Actions job to regenerate dependent EssenceFilter data after source updates.

Documentation:
- Document usage of the zmdmap synchronization tool.

</details>