### PR TITLE
fix: 排轴执行时对动作 requisites 条件求值，开关型战技不再每轮重复触发

### DIFF
--- a/agent/go-service/autofight/autofight.go
+++ b/agent/go-service/autofight/autofight.go
@@ -721,6 +721,9 @@ func (a *AutoFightMainAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bo
 						}
 					}
 				}
+			} else if skippedName := timeline.TakeSkippedActionName(); skippedName != "" {
+				// 队首动作因 requisites 条件不满足被跳过（如开关型战技的姿态已生效）
+				maafocus.PrintThrottle(ctx, 3*time.Second, i18n.T("autofight.endaxis.requisite_unmet_skip", skippedName))
 			}
 		}
 

--- a/agent/go-service/autofight/endaxistimeline.go
+++ b/agent/go-service/autofight/endaxistimeline.go
@@ -27,6 +27,8 @@ const (
 )
 
 // EndAxisAction 是从时间轴中提取出的一个待派发的 ultimate/skill 动作。
+// requisites / statusEffects 为内部字段：requisites 用于在派发前判断条件是否满足，
+// statusEffects 用于在动作实际执行后更新干员状态模型（如开关型战技的姿态）。
 type EndAxisAction struct {
 	Type      string // "ultimate" | "skill"（battleSkill 收集时已规范化为 skill）
 	TrackIdx  int    // 0..3，对应 scenario.data.tracks 的下标
@@ -34,16 +36,71 @@ type EndAxisAction struct {
 	Duration  int    // 帧
 	Name      string
 	ID        string
+
+	requisites    []timelineRequisiteRaw
+	statusEffects []timelineStatusEffect
 }
 
 // 以下是仅用于反序列化 JSON 的精简结构，业务上只关心这几个字段，
 // 其余字段（damageTicks/equip/stats 等）均忽略。
 type timelineActionRaw struct {
-	Type      string `json:"type"`
-	StartTime int    `json:"startTime"`
-	Duration  int    `json:"duration"`
-	Name      string `json:"name"`
-	ID        string `json:"id"`
+	Type       string                 `json:"type"`
+	StartTime  int                    `json:"startTime"`
+	Duration   int                    `json:"duration"`
+	Name       string                 `json:"name"`
+	ID         string                 `json:"id"`
+	Requisites []timelineRequisiteRaw `json:"requisites"`
+	Hits       []timelineHitRaw       `json:"hits"`
+	Payload    *timelinePayloadRaw    `json:"payload"`
+}
+
+// timelineRequisiteRaw 是动作的释放条件（与 end-axis 数据语义一致）：
+// 条件不满足时该动作应被跳过。condition 为条件树，支持
+// operatorStatus / not / or / and 以及数组（全部满足）。
+type timelineRequisiteRaw struct {
+	ID         string          `json:"id"`
+	Condition  json.RawMessage `json:"condition"`
+	MessageKey string          `json:"messageKey"`
+	Params     json.RawMessage `json:"params"`
+}
+
+type timelinePayloadRaw struct {
+	Hits []timelineHitRaw `json:"hits"`
+}
+
+type timelineHitRaw struct {
+	Effects []json.RawMessage `json:"effects"`
+}
+
+// timelineConditionRaw 是 requisites 条件树节点的精简结构。
+// 无法在运行时求值的条件种类（skillCooldownReady / ultimateCooldownReady /
+// enemyStatus / enemyHp 等）一律视为满足，避免误跳过动作；
+// 只有 operatorStatus 类条件参与实际跳过判定。
+type timelineConditionRaw struct {
+	Kind       string             `json:"kind"`
+	Status     json.RawMessage    `json:"status"`
+	Stacks     *timelineStacksRaw `json:"stacks"`
+	Condition  json.RawMessage    `json:"condition"`
+	Conditions []json.RawMessage  `json:"conditions"`
+}
+
+type timelineStacksRaw struct {
+	Compare string `json:"compare"` // "exact" | "atLeast" | "atMost"
+	Count   int    `json:"count"`
+}
+
+// timelineStatusEffect 是动作对干员状态的一次修改，取自动作 hits 中的
+// status / consume 效果，仅在动作执行后用于更新状态模型。
+// status 效果按 duration 过期（如莉诺演唱姿态持续 60 秒，到期后游戏内
+// 姿态自动结束，requisites 会重新允许施法）；consume 效果提前清除状态。
+type timelineStatusEffect struct {
+	kind           string // "status" | "consume"
+	id             string // status 效果的 id
+	target         string // "self" | "team"
+	duration       int    // 帧；0 表示不自动过期（直到被 consume）
+	stacks         int
+	operatorStatus []string        // consume 效果要清除的状态 id 列表
+	condition      json.RawMessage // 可选的生效条件
 }
 
 type timelineTrackRaw struct {
@@ -98,6 +155,22 @@ type EndAxisTimeline struct {
 	pausedAt       time.Time     // 当前这一段暂停的起始真实时间，仅在 paused=true 时有意义
 	pausedDuration time.Duration // 截至上次 resume，已累计的暂停总时长
 	endFrame       int           // 当前 scenario 内所有 action 的最晚结束帧 max(startTime + duration)
+
+	// 干员状态模型：仅在 end-axis 数据中同时被 requisites 引用、又被某个动作
+	// 的效果置位/清除的状态才会被跟踪（见 trackedStatuses）。
+	// 状态跨 scenario 轮次持续存在（开关型战技的姿态不会因重新选择方案而消失），
+	// 因此 reset() 不清空该模型，只在 SetTimelineCode 更换数据码时重建。
+	statuses        map[int]map[string]*timelineStatusState // trackIdx -> statusID -> 状态
+	trackedStatuses map[string]struct{}                     // 需要跟踪的状态 id 集合
+	lastSkippedName string                                  // 最近一次因条件不满足被跳过的动作名（供上层提示）
+}
+
+// timelineStatusState 描述一个干员状态的运行时快照。
+// 状态按动作效果携带的 duration 过期（如莉诺演唱姿态持续 60 秒），
+// 到期后视为不存在，requisites 会重新允许施法；也可被 consume 提前清除。
+type timelineStatusState struct {
+	stacks int       // 层数；0 表示不存在
+	expiry time.Time // 过期时刻；零值表示不自动过期（直到被 consume）
 }
 
 // NewEndAxisTimeline 返回一个空的时间轴对象，使用前需先调用 SetTimelineCode。
@@ -117,6 +190,9 @@ func (t *EndAxisTimeline) SetTimelineCode(code string) bool {
 			Msg("failed to decode timeline share code")
 		t.root = nil
 		t.reset()
+		t.statuses = nil
+		t.trackedStatuses = nil
+		t.lastSkippedName = ""
 		return false
 	}
 
@@ -129,14 +205,21 @@ func (t *EndAxisTimeline) SetTimelineCode(code string) bool {
 			Msg("failed to parse timeline json")
 		t.root = nil
 		t.reset()
+		t.statuses = nil
+		t.trackedStatuses = nil
+		t.lastSkippedName = ""
 		return false
 	}
 
 	t.root = &root
 	t.reset()
+	t.statuses = nil
+	t.trackedStatuses = collectTrackedStatuses(&root)
+	t.lastSkippedName = ""
 	log.Info().
 		Str("component", "EndAxisTimeline").
 		Int("scenarioCount", len(root.ScenarioList)).
+		Int("trackedStatusCount", len(t.trackedStatuses)).
 		Msg("timeline share code loaded")
 	return true
 }
@@ -276,20 +359,56 @@ func (t *EndAxisTimeline) SelectScenario(ctx *maa.Context, characterCount int, c
 // FrontAction 返回当前帧应触发的队首 ultimate/skill 动作。
 // 命中时会自动暂停内部计时，直到 PopFrontAction 调用后再恢复。
 // 未到时间或队列为空时返回 nil, false。
+//
+// 队首动作已到触发帧但 requisites 条件不满足时（例如开关型战技的姿态已生效），
+// 该动作会被直接丢弃并继续检查下一个动作，与 end-axis 数据语义一致；
+// 被跳过的动作名可通过 TakeSkippedActionName 取回用于用户提示。
 func (t *EndAxisTimeline) FrontAction() *EndAxisAction {
 	if !t.started || len(t.queue) == 0 {
 		return nil
 	}
-	if t.queue[0].StartTime > t.currentFrame() {
-		return nil
-	}
+	frame := t.currentFrame()
+	for len(t.queue) > 0 {
+		head := &t.queue[0]
+		if head.StartTime > frame {
+			return nil
+		}
 
-	t.pause()
-	head := t.queue[0]
-	return &head
+		if unmet := t.firstUnmetRequisite(head); unmet != nil {
+			t.lastSkippedName = head.Name
+			if t.lastSkippedName == "" {
+				t.lastSkippedName = head.ID
+			}
+			log.Info().
+				Str("component", "EndAxisTimeline").
+				Str("step", "FrontAction").
+				Str("actionId", head.ID).
+				Str("actionName", head.Name).
+				Int("trackIdx", head.TrackIdx).
+				Str("requisiteId", unmet.ID).
+				Str("messageKey", unmet.MessageKey).
+				Msg("action skipped: requisite condition not met")
+			t.queue = t.queue[1:]
+			continue
+		}
+
+		t.pause()
+		h := *head
+		return &h
+	}
+	return nil
+}
+
+// TakeSkippedActionName 返回并清空最近一次因 requisites 条件不满足而被跳过的
+// 动作名；没有发生过跳过时返回空字符串。
+func (t *EndAxisTimeline) TakeSkippedActionName() string {
+	name := t.lastSkippedName
+	t.lastSkippedName = ""
+	return name
 }
 
 // PopFrontAction 删除当前队首动作并恢复计时。队列为空或时间轴未启动时为空操作。
+// 动作被派发后，其 hits 中的 status / consume 效果会同步更新干员状态模型。
 func (t *EndAxisTimeline) PopFrontAction() {
 	if !t.started || len(t.queue) == 0 {
 		return
@@ -297,6 +416,7 @@ func (t *EndAxisTimeline) PopFrontAction() {
 
 	popped := t.queue[0]
 	t.queue = t.queue[1:]
+	t.applyActionStatusChanges(&popped)
 	t.resume()
 
 	log.Debug().
@@ -327,6 +447,8 @@ func (t *EndAxisTimeline) ActionFinish() bool {
 }
 
 // reset 清空运行时状态，但不清空 root（已加载的 JSON）。
+// 干员状态模型（statuses / trackedStatuses）属于整场战斗的持续状态，
+// 不会被清空；更换数据码时由 SetTimelineCode 显式重建。
 func (t *EndAxisTimeline) reset() {
 	t.selectedID = ""
 	t.queue = nil
@@ -416,7 +538,8 @@ func computeTimelineEndFrame(sc *timelineScenarioRaw) int {
 func collectTimelineActions(sc *timelineScenarioRaw) []EndAxisAction {
 	var out []EndAxisAction
 	for trackIdx, track := range sc.Data.Tracks {
-		for _, a := range track.Actions {
+		for i := range track.Actions {
+			a := &track.Actions[i]
 			actionType := a.Type
 			switch actionType {
 			case "battleSkill":
@@ -426,12 +549,14 @@ func collectTimelineActions(sc *timelineScenarioRaw) []EndAxisAction {
 				continue
 			}
 			out = append(out, EndAxisAction{
-				Type:      actionType,
-				TrackIdx:  trackIdx,
-				StartTime: a.StartTime,
-				Duration:  a.Duration,
-				Name:      a.Name,
-				ID:        a.ID,
+				Type:          actionType,
+				TrackIdx:      trackIdx,
+				StartTime:     a.StartTime,
+				Duration:      a.Duration,
+				Name:          a.Name,
+				ID:            a.ID,
+				requisites:    a.Requisites,
+				statusEffects: collectActionStatusEffects(a),
 			})
 		}
 	}
@@ -442,4 +567,411 @@ func collectTimelineActions(sc *timelineScenarioRaw) []EndAxisAction {
 		return out[i].TrackIdx < out[j].TrackIdx
 	})
 	return out
+}
+
+// collectActionStatusEffects 提取动作 hits 中会改变干员状态的效果（status / consume），
+// 供动作执行后更新状态模型。优先读取顶层 hits（buildBaseAction 会把 payload.hits
+// 克隆到 hits），旧数据只有 payload.hits 时退回读取 payload。
+func collectActionStatusEffects(a *timelineActionRaw) []timelineStatusEffect {
+	var out []timelineStatusEffect
+	hits := a.Hits
+	if len(hits) == 0 && a.Payload != nil {
+		hits = a.Payload.Hits
+	}
+	for i := range hits {
+		collectRawStatusEffects(hits[i].Effects, &out)
+	}
+	return out
+}
+
+// collectRawStatusEffects 递归遍历 effects 数组，收集 status / consume 效果；
+// 嵌套结构（effect.hit.effects、effect.effects）会一并下钻。
+func collectRawStatusEffects(nodes []json.RawMessage, out *[]timelineStatusEffect) {
+	for _, raw := range nodes {
+		var eff timelineEffectRaw
+		if err := json.Unmarshal(raw, &eff); err != nil || eff.Kind == "" {
+			// 不是标准效果对象：尝试按通用对象下钻嵌套字段，保证对结构变化健壮。
+			var generic map[string]json.RawMessage
+			if json.Unmarshal(raw, &generic) == nil {
+				if nested, ok := generic["effects"]; ok {
+					var arr []json.RawMessage
+					if json.Unmarshal(nested, &arr) == nil {
+						collectRawStatusEffects(arr, out)
+					}
+				}
+				if nested, ok := generic["hit"]; ok {
+					var h timelineHitRaw
+					if json.Unmarshal(nested, &h) == nil {
+						collectRawStatusEffects(h.Effects, out)
+					}
+				}
+			}
+			continue
+		}
+
+		switch eff.Kind {
+		case "status":
+			if eff.ID == "" {
+				continue
+			}
+			*out = append(*out, timelineStatusEffect{
+				kind:      "status",
+				id:        eff.ID,
+				target:    eff.Target,
+				duration:  eff.Duration,
+				stacks:    eff.Stacks,
+				condition: eff.Condition,
+			})
+		case "consume":
+			ids := parseStatusList(eff.OperatorStatus)
+			if len(ids) == 0 {
+				continue
+			}
+			team := eff.ConsumeTarget == "team" || eff.ConsumeScope == "team"
+			target := "self"
+			if team {
+				target = "team"
+			}
+			*out = append(*out, timelineStatusEffect{
+				kind:           "consume",
+				target:         target,
+				operatorStatus: ids,
+				condition:      eff.Condition,
+			})
+		}
+
+		// 递归下钻嵌套效果（如 hit 内嵌 effects）。
+		if eff.Hit != nil {
+			var h timelineHitRaw
+			if json.Unmarshal(eff.Hit, &h) == nil {
+				collectRawStatusEffects(h.Effects, out)
+			}
+		}
+		collectRawStatusEffects(eff.Effects, out)
+	}
+}
+
+// timelineEffectRaw 是 collectRawStatusEffects 使用的效果精简结构。
+type timelineEffectRaw struct {
+	Kind           string            `json:"kind"`
+	ID             string            `json:"id"`
+	Target         string            `json:"target"`
+	Duration       int               `json:"duration"`
+	Stacks         int               `json:"stacks"`
+	OperatorStatus json.RawMessage   `json:"operatorStatus"`
+	ConsumeTarget  string            `json:"consumeTarget"`
+	ConsumeScope   string            `json:"consumeScope"`
+	Condition      json.RawMessage   `json:"condition"`
+	Hit            json.RawMessage   `json:"hit"`
+	Effects        []json.RawMessage `json:"effects"`
+}
+
+// collectTrackedStatuses 扫描全部 scenario 中所有动作的 requisites，收集被
+// operatorStatus 条件引用的状态 id；同时检查这些状态是否真的会被某个动作的
+// 效果置位/清除。只有"既被引用、又被动作效果管理"的状态才纳入跟踪：
+// 仅被引用但由被动/触发器（MaaEnd 运行时未建模）施加的状态视为不存在，
+// 以保证 not(or(...)) 这类开关型战技守卫在部分成员未被动作管理时仍能正确求值。
+func collectTrackedStatuses(root *timelineRootRaw) map[string]struct{} {
+	referenced := make(map[string]struct{})
+	managed := make(map[string]struct{})
+	var walkCondition func(raw json.RawMessage)
+	walkCondition = func(raw json.RawMessage) {
+		if len(raw) == 0 || string(raw) == "null" {
+			return
+		}
+		var arr []json.RawMessage
+		if json.Unmarshal(raw, &arr) == nil {
+			for _, sub := range arr {
+				walkCondition(sub)
+			}
+			return
+		}
+		var c timelineConditionRaw
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return
+		}
+		switch c.Kind {
+		case "operatorStatus":
+			for _, s := range parseStatusList(c.Status) {
+				referenced[s] = struct{}{}
+			}
+		case "not":
+			walkCondition(c.Condition)
+		case "or", "and":
+			for _, sub := range c.Conditions {
+				walkCondition(sub)
+			}
+		}
+	}
+
+	for i := range root.ScenarioList {
+		sc := &root.ScenarioList[i]
+		for ti := range sc.Data.Tracks {
+			track := &sc.Data.Tracks[ti]
+			for ai := range track.Actions {
+				a := &track.Actions[ai]
+				for ri := range a.Requisites {
+					walkCondition(a.Requisites[ri].Condition)
+				}
+				for _, eff := range collectActionStatusEffects(a) {
+					if eff.kind == "status" && eff.id != "" {
+						managed[eff.id] = struct{}{}
+					}
+					for _, id := range eff.operatorStatus {
+						managed[id] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+
+	tracked := make(map[string]struct{})
+	for id := range referenced {
+		if _, ok := managed[id]; ok {
+			tracked[id] = struct{}{}
+		}
+	}
+	return tracked
+}
+
+// firstUnmetRequisite 返回动作第一个不满足的 requisites；全部满足时返回 nil。
+func (t *EndAxisTimeline) firstUnmetRequisite(a *EndAxisAction) *timelineRequisiteRaw {
+	for i := range a.requisites {
+		req := &a.requisites[i]
+		if !t.conditionMet(req.Condition, a.TrackIdx) {
+			return req
+		}
+	}
+	return nil
+}
+
+// 条件求值采用三值逻辑：除"满足/不满足"外，无法在运行时求值的条件种类
+// （skillCooldownReady / ultimateCooldownReady / ultimateEnhancement /
+// enemyStatus / enemyHp 等）标记为"未知"。未知在 or/not/and 中按真值表传播，
+// 顶层未知一律视为满足（放行），避免误跳过动作；只有能确定性判定为
+// 不满足的 requisites 才会导致动作被跳过。
+const (
+	condUnknown     = -1
+	condUnsatisfied = 0
+	condSatisfied   = 1
+)
+
+// conditionMet 求值一个条件树，返回该条件是否满足。
+// 顶层未知（无法求值）视为满足。
+func (t *EndAxisTimeline) conditionMet(raw json.RawMessage, trackIdx int) bool {
+	return t.evalCondition(raw, trackIdx) != condUnsatisfied
+}
+
+// evalCondition 递归求值条件树，返回 condUnknown / condUnsatisfied / condSatisfied。
+func (t *EndAxisTimeline) evalCondition(raw json.RawMessage, trackIdx int) int {
+	if len(raw) == 0 || string(raw) == "null" {
+		return condSatisfied
+	}
+	var arr []json.RawMessage
+	if json.Unmarshal(raw, &arr) == nil {
+		// 数组条件：全部满足才满足；任一不满足则不满足；否则未知。
+		anyUnknown := false
+		for _, sub := range arr {
+			switch t.evalCondition(sub, trackIdx) {
+			case condUnsatisfied:
+				return condUnsatisfied
+			case condUnknown:
+				anyUnknown = true
+			}
+		}
+		if anyUnknown {
+			return condUnknown
+		}
+		return condSatisfied
+	}
+	var c timelineConditionRaw
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return condSatisfied
+	}
+	switch c.Kind {
+	case "operatorStatus":
+		for _, s := range parseStatusList(c.Status) {
+			if !t.isTracked(s) {
+				// 未被任何动作效果管理的状态视为不存在（如该状态只由
+				// 被动/触发器施加，MaaEnd 运行时未建模）。
+				continue
+			}
+			st := t.statusState(trackIdx, s)
+			if st == nil || st.stacks <= 0 || (!st.expiry.IsZero() && time.Now().After(st.expiry)) {
+				continue
+			}
+			if c.Stacks != nil && !stacksMet(st.stacks, c.Stacks) {
+				continue
+			}
+			return condSatisfied
+		}
+		return condUnsatisfied
+	case "not":
+		switch t.evalCondition(c.Condition, trackIdx) {
+		case condSatisfied:
+			return condUnsatisfied
+		case condUnsatisfied:
+			return condSatisfied
+		default:
+			return condUnknown
+		}
+	case "or":
+		anyUnknown := false
+		for _, sub := range c.Conditions {
+			switch t.evalCondition(sub, trackIdx) {
+			case condSatisfied:
+				return condSatisfied
+			case condUnknown:
+				anyUnknown = true
+			}
+		}
+		if anyUnknown {
+			return condUnknown
+		}
+		return condUnsatisfied
+	case "and":
+		anyUnknown := false
+		for _, sub := range c.Conditions {
+			switch t.evalCondition(sub, trackIdx) {
+			case condUnsatisfied:
+				return condUnsatisfied
+			case condUnknown:
+				anyUnknown = true
+			}
+		}
+		if anyUnknown {
+			return condUnknown
+		}
+		return condSatisfied
+	default:
+		// 无法在运行时求值的条件种类（cooldown / enemy 等），标记为未知。
+		return condUnknown
+	}
+}
+
+// applyActionStatusChanges 在动作实际执行后更新干员状态模型：
+// status 效果置位对应状态（按 duration 过期，可带层数），
+// consume 效果清除对应状态。
+func (t *EndAxisTimeline) applyActionStatusChanges(a *EndAxisAction) {
+	if len(a.statusEffects) == 0 {
+		return
+	}
+	for i := range a.statusEffects {
+		e := &a.statusEffects[i]
+		if !t.statusEffectConditionMet(e, a.TrackIdx) {
+			continue
+		}
+		for _, tr := range statusTargetTracks(e.target, a.TrackIdx) {
+			switch e.kind {
+			case "status":
+				t.setStatus(tr, e.id, e.duration, e.stacks)
+			case "consume":
+				for _, id := range e.operatorStatus {
+					t.clearStatus(tr, id)
+				}
+			}
+		}
+	}
+}
+
+func (t *EndAxisTimeline) statusEffectConditionMet(e *timelineStatusEffect, trackIdx int) bool {
+	if len(e.condition) == 0 || string(e.condition) == "null" {
+		return true
+	}
+	return t.conditionMet(e.condition, trackIdx)
+}
+
+// statusTargetTracks 解析效果的 target 语义："team" 作用于全部 4 条 track，
+// 其余（self 等）作用于动作自身的 track。
+func statusTargetTracks(target string, trackIdx int) []int {
+	if target == "team" {
+		return []int{0, 1, 2, 3}
+	}
+	return []int{trackIdx}
+}
+
+func (t *EndAxisTimeline) isTracked(id string) bool {
+	if t.trackedStatuses == nil {
+		return false
+	}
+	_, ok := t.trackedStatuses[id]
+	return ok
+}
+
+func (t *EndAxisTimeline) statusState(trackIdx int, id string) *timelineStatusState {
+	if t.statuses == nil {
+		return nil
+	}
+	return t.statuses[trackIdx][id]
+}
+
+func (t *EndAxisTimeline) setStatus(trackIdx int, id string, duration, stacks int) {
+	if !t.isTracked(id) {
+		return
+	}
+	if t.statuses == nil {
+		t.statuses = make(map[int]map[string]*timelineStatusState)
+	}
+	m := t.statuses[trackIdx]
+	if m == nil {
+		m = make(map[string]*timelineStatusState)
+		t.statuses[trackIdx] = m
+	}
+	st := m[id]
+	if st == nil {
+		st = &timelineStatusState{}
+		m[id] = st
+	}
+	if stacks > 0 {
+		st.stacks += stacks
+	} else if st.stacks < 1 {
+		st.stacks = 1
+	}
+	if duration > 0 {
+		st.expiry = time.Now().Add(time.Duration(duration) * time.Second / time.Duration(timelineFPS))
+	}
+}
+
+func (t *EndAxisTimeline) clearStatus(trackIdx int, id string) {
+	m := t.statuses[trackIdx]
+	if m == nil {
+		return
+	}
+	if st := m[id]; st != nil {
+		st.stacks = 0
+	}
+}
+
+func stacksMet(stacks int, c *timelineStacksRaw) bool {
+	switch c.Compare {
+	case "exact":
+		return stacks == c.Count
+	case "atMost":
+		return stacks <= c.Count
+	default: // "atLeast" 及缺省
+		return stacks >= c.Count
+	}
+}
+
+// parseStatusList 解析 operatorStatus 的 status 字段：字符串或字符串数组；
+// EffectStat 对象（如 {modifier: "atkPercent"}）无法在运行时求值，直接忽略。
+func parseStatusList(raw json.RawMessage) []string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return []string{s}
+	}
+	var arr []json.RawMessage
+	if json.Unmarshal(raw, &arr) == nil {
+		var out []string
+		for _, item := range arr {
+			if json.Unmarshal(item, &s) == nil {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
 }

--- a/agent/go-service/autofight/endaxistimeline_test.go
+++ b/agent/go-service/autofight/endaxistimeline_test.go
@@ -1,0 +1,464 @@
+package autofight
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// encodeTimelineCode 生成与 end-axis "复制数据码" 相同的分享字符串：gzip 压缩 + base64url。
+func encodeTimelineCode(t *testing.T, root map[string]any) string {
+	t.Helper()
+	raw, err := json.Marshal(root)
+	if err != nil {
+		t.Fatalf("marshal timeline: %v", err)
+	}
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf.Bytes())
+}
+
+func scenarioWithActions(actions []map[string]any) map[string]any {
+	return map[string]any{
+		"scenarioList": []any{
+			map[string]any{
+				"id":   "sc1",
+				"name": "方案",
+				"data": map[string]any{
+					"tracks": []any{
+						map[string]any{"id": "track_1", "actions": actions},
+					},
+				},
+			},
+		},
+	}
+}
+
+// liinoToggleScenario 构造与 issue #5126 一致的开关型战技场景：
+// battleSkill 位于每轮循环开头（startTime=0），带
+// "not(liino-vocalist-stance OR liino-cosmovoice-stance)" 条件，
+// 动作 hits 会在执行后置位 liino-vocalist-stance。
+func liinoToggleScenario() map[string]any {
+	return scenarioWithActions([]map[string]any{
+		{
+			"id":        "liino_battleSkill",
+			"type":      "battleSkill",
+			"startTime": 0,
+			"duration":  42,
+			"name":      "战技",
+			"requisites": []any{
+				map[string]any{
+					"id": "liino-battle-skill-no-stance",
+					"condition": map[string]any{
+						"kind": "not",
+						"condition": map[string]any{
+							"kind": "or",
+							"conditions": []any{
+								map[string]any{"kind": "operatorStatus", "status": "liino-vocalist-stance"},
+								map[string]any{"kind": "operatorStatus", "status": "liino-cosmovoice-stance"},
+							},
+						},
+					},
+					"messageKey": "actionItem.requisiteTitle.liinoUseStanceTermination",
+				},
+			},
+			"hits": []any{
+				map[string]any{
+					"effects": []any{
+						map[string]any{
+							"id":       "liino-vocalist-stance",
+							"kind":     "status",
+							"target":   "self",
+							"duration": 3600,
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func newLiinoTimeline(t *testing.T) *EndAxisTimeline {
+	t.Helper()
+	tl := NewEndAxisTimeline()
+	if !tl.SetTimelineCode(encodeTimelineCode(t, liinoToggleScenario())) {
+		t.Fatal("SetTimelineCode failed")
+	}
+	return tl
+}
+
+// 核心回归：开关型战技第 1 轮触发并置位姿态，第 2 轮因 requisites
+// 条件不满足被跳过（不再反复开/关姿态），与 end-axis 数据语义一致。
+func TestToggleSkillSkippedOnSecondRound(t *testing.T) {
+	tl := newLiinoTimeline(t)
+
+	if !tl.SelectScenario(nil, 1, []int{1}, nil, 1, false) {
+		t.Fatal("SelectScenario round 1 failed")
+	}
+
+	// 第 1 轮：姿态未生效，战技应派发并置位姿态。
+	a := tl.FrontAction()
+	if a == nil {
+		t.Fatal("round 1: expected battleSkill action")
+	}
+	if a.Type != "skill" || a.ID != "liino_battleSkill" {
+		t.Fatalf("round 1: unexpected action %+v", a)
+	}
+	tl.PopFrontAction()
+	if st := tl.statusState(0, "liino-vocalist-stance"); st == nil || st.stacks < 1 {
+		t.Fatal("round 1: stance should be active after cast")
+	}
+
+	// 第 2 轮：重新选择方案，姿态仍然生效，战技应被跳过且队列为空。
+	if !tl.SelectScenario(nil, 1, []int{1}, nil, 1, false) {
+		t.Fatal("SelectScenario round 2 failed")
+	}
+	if a := tl.FrontAction(); a != nil {
+		t.Fatalf("round 2: expected skill to be skipped, got %+v", a)
+	}
+	if name := tl.TakeSkippedActionName(); name != "战技" {
+		t.Fatalf("round 2: skipped name = %q, want 战技", name)
+	}
+	if tl.TakeSkippedActionName() != "" {
+		t.Fatal("skipped name should be cleared after read")
+	}
+	if len(tl.queue) != 0 {
+		t.Fatalf("round 2: queue should be empty after skip, got %d", len(tl.queue))
+	}
+
+	// 回归：姿态在持续时间内（60 秒）连续多轮都保持，不会在每轮循环开头
+	// 被反复触发导致姿态开/关振荡；到期后（>60 秒）才允许再次施法，由
+	// TestStatusExpiresAfterDuration 覆盖。
+	for round := 3; round <= 5; round++ {
+		if !tl.SelectScenario(nil, 1, []int{1}, nil, 1, false) {
+			t.Fatalf("SelectScenario round %d failed", round)
+		}
+		if a := tl.FrontAction(); a != nil {
+			t.Fatalf("round %d: expected skill to be skipped, got %+v", round, a)
+		}
+		if name := tl.TakeSkippedActionName(); name != "战技" {
+			t.Fatalf("round %d: skipped name = %q, want 战技", round, name)
+		}
+		if st := tl.statusState(0, "liino-vocalist-stance"); st == nil || st.stacks < 1 {
+			t.Fatalf("round %d: stance should still be active (persist until consumed)", round)
+		}
+	}
+}
+
+// 无 requisites 的动作保持原有行为：每轮都照常派发。
+func TestNoRequisitesActionAlwaysDispatched(t *testing.T) {
+	root := scenarioWithActions([]map[string]any{
+		{"id": "op1_skill", "type": "skill", "startTime": 0, "duration": 10, "name": "战技"},
+	})
+	tl := NewEndAxisTimeline()
+	if !tl.SetTimelineCode(encodeTimelineCode(t, root)) {
+		t.Fatal("SetTimelineCode failed")
+	}
+	if !tl.SelectScenario(nil, 1, []int{1}, nil, 1, false) {
+		t.Fatal("SelectScenario failed")
+	}
+	a := tl.FrontAction()
+	if a == nil || a.ID != "op1_skill" {
+		t.Fatalf("expected skill to be dispatched, got %+v", a)
+	}
+	tl.PopFrontAction()
+	if tl.TakeSkippedActionName() != "" {
+		t.Fatal("no requisites: nothing should be skipped")
+	}
+}
+
+// consume 效果会清除对应状态，供后续轮次重新满足条件。
+func TestConsumeEffectClearsStatus(t *testing.T) {
+	root := scenarioWithActions([]map[string]any{
+		{
+			"id":        "op1_battleSkill",
+			"type":      "battleSkill",
+			"startTime": 0,
+			"duration":  42,
+			"name":      "战技",
+			"requisites": []any{
+				map[string]any{
+					"id": "no-stance",
+					"condition": map[string]any{
+						"kind": "not",
+						"condition": map[string]any{
+							"kind": "or",
+							"conditions": []any{
+								map[string]any{"kind": "operatorStatus", "status": "op1-stance"},
+								map[string]any{"kind": "operatorStatus", "status": "op1-stance-2"},
+							},
+						},
+					},
+				},
+			},
+			"hits": []any{
+				map[string]any{
+					"effects": []any{
+						map[string]any{"id": "op1-stance", "kind": "status", "target": "self", "duration": 3600},
+					},
+				},
+			},
+		},
+		{
+			"id":        "op1_skill2",
+			"type":      "skill",
+			"startTime": 100,
+			"duration":  10,
+			"name":      "战技2",
+			"hits": []any{
+				map[string]any{
+					"effects": []any{
+						map[string]any{
+							"kind":           "consume",
+							"operatorStatus": []any{"op1-stance"},
+							"consumeTarget":  "team",
+						},
+					},
+				},
+			},
+		},
+	})
+	tl := NewEndAxisTimeline()
+	if !tl.SetTimelineCode(encodeTimelineCode(t, root)) {
+		t.Fatal("SetTimelineCode failed")
+	}
+	if !tl.SelectScenario(nil, 1, []int{1}, nil, 1, false) {
+		t.Fatal("SelectScenario failed")
+	}
+
+	a := tl.FrontAction()
+	if a == nil || a.ID != "op1_battleSkill" {
+		t.Fatalf("expected battleSkill first, got %+v", a)
+	}
+	tl.PopFrontAction()
+	if st := tl.statusState(0, "op1-stance"); st == nil || st.stacks < 1 {
+		t.Fatal("stance should be active after battleSkill")
+	}
+
+	a = tl.FrontAction()
+	if a == nil || a.ID != "op1_skill2" {
+		t.Fatalf("expected second skill, got %+v", a)
+	}
+	tl.PopFrontAction()
+	if st := tl.statusState(0, "op1-stance"); st == nil || st.stacks != 0 {
+		t.Fatal("stance should be consumed after second skill")
+	}
+}
+
+// 旧数据只有 payload.hits 时，状态效果仍应被解析并应用。
+func TestStatusEffectsParsedFromPayloadHits(t *testing.T) {
+	root := scenarioWithActions([]map[string]any{
+		{
+			"id":        "op1_battleSkill",
+			"type":      "battleSkill",
+			"startTime": 0,
+			"duration":  42,
+			"name":      "战技",
+			"requisites": []any{
+				map[string]any{
+					"id": "no-stance",
+					"condition": map[string]any{
+						"kind": "not",
+						"condition": map[string]any{
+							"kind": "or",
+							"conditions": []any{
+								map[string]any{"kind": "operatorStatus", "status": "op1-stance"},
+								map[string]any{"kind": "operatorStatus", "status": "op1-stance-2"},
+							},
+						},
+					},
+				},
+			},
+			// 只有 payload.hits，没有顶层 hits。
+			"payload": map[string]any{
+				"hits": []any{
+					map[string]any{
+						"effects": []any{
+							map[string]any{"id": "op1-stance", "kind": "status", "target": "self", "duration": 3600},
+						},
+					},
+				},
+			},
+		},
+	})
+	tl := NewEndAxisTimeline()
+	if !tl.SetTimelineCode(encodeTimelineCode(t, root)) {
+		t.Fatal("SetTimelineCode failed")
+	}
+	if !tl.SelectScenario(nil, 1, []int{1}, nil, 1, false) {
+		t.Fatal("SelectScenario failed")
+	}
+	a := tl.FrontAction()
+	if a == nil {
+		t.Fatal("expected battleSkill")
+	}
+	tl.PopFrontAction()
+	if st := tl.statusState(0, "op1-stance"); st == nil || st.stacks < 1 {
+		t.Fatal("stance should be active after cast (parsed from payload.hits)")
+	}
+}
+
+// 条件树三值求值：operatorStatus / not / or / and / 数组 / 未知种类。
+func TestConditionTreeEvaluation(t *testing.T) {
+	tl := &EndAxisTimeline{
+		trackedStatuses: map[string]struct{}{"stance-a": {}, "stance-b": {}},
+		statuses: map[int]map[string]*timelineStatusState{
+			0: {},
+		},
+	}
+
+	notStance := json.RawMessage(`{"kind":"not","condition":{"kind":"or","conditions":[{"kind":"operatorStatus","status":"stance-a"},{"kind":"operatorStatus","status":"stance-b"}]}}`)
+	if !tl.conditionMet(notStance, 0) {
+		t.Fatal("no stance active: not(or) should be satisfied")
+	}
+	tl.setStatus(0, "stance-a", 0, 0)
+	if tl.conditionMet(notStance, 0) {
+		t.Fatal("stance-a active: not(or) should be unsatisfied")
+	}
+
+	// or：任一满足即满足。
+	either := json.RawMessage(`{"kind":"or","conditions":[{"kind":"operatorStatus","status":"stance-a"},{"kind":"operatorStatus","status":"stance-b"}]}`)
+	if !tl.conditionMet(either, 0) {
+		t.Fatal("stance-a active: or should be satisfied")
+	}
+	tl.clearStatus(0, "stance-a")
+	if tl.conditionMet(either, 0) {
+		t.Fatal("no stance active: or should be unsatisfied")
+	}
+
+	// and / 数组：全部满足才满足。
+	andCond := json.RawMessage(`{"kind":"and","conditions":[{"kind":"operatorStatus","status":"stance-a"},{"kind":"operatorStatus","status":"stance-b"}]}`)
+	tl.setStatus(0, "stance-a", 0, 0)
+	if tl.conditionMet(andCond, 0) {
+		t.Fatal("stance-b absent: and should be unsatisfied")
+	}
+	tl.setStatus(0, "stance-b", 0, 0)
+	if !tl.conditionMet(andCond, 0) {
+		t.Fatal("both present: and should be satisfied")
+	}
+	arrCond := json.RawMessage(`[{"kind":"operatorStatus","status":"stance-a"},{"kind":"operatorStatus","status":"stance-b"}]`)
+	if !tl.conditionMet(arrCond, 0) {
+		t.Fatal("array condition with both present should be satisfied")
+	}
+}
+
+// 无法求值的条件种类（cooldown / enemy / enhancement 等）不应导致动作被误跳过，
+// 包括出现在 not 内部时（如 arcane 的 or(not(ultimateEnhancement), ...)）。
+func TestUnknownConditionKindsFailOpen(t *testing.T) {
+	tl := &EndAxisTimeline{
+		trackedStatuses: map[string]struct{}{"arcana-ready": {}},
+		statuses: map[int]map[string]*timelineStatusState{
+			0: {},
+		},
+	}
+
+	// 纯未知条件：放行。
+	if !tl.conditionMet(json.RawMessage(`{"kind":"skillCooldownReady","cooldownKey":"liino-battle-skill"}`), 0) {
+		t.Fatal("skillCooldownReady should not block")
+	}
+	if !tl.conditionMet(json.RawMessage(`{"kind":"ultimateCooldownReady"}`), 0) {
+		t.Fatal("ultimateCooldownReady should not block")
+	}
+
+	// 未知条件经 not 取反后仍为未知，顶层未知放行（对应 arcane 的
+	// or(not(ultimateEnhancement), operatorStatus arcana-ready)）。
+	arcaneLike := json.RawMessage(`{"kind":"or","conditions":[{"kind":"not","condition":{"kind":"ultimateEnhancement"}},{"kind":"operatorStatus","status":"arcana-ready"}]}`)
+	if !tl.conditionMet(arcaneLike, 0) {
+		t.Fatal("unknown-enhancement branch should not block the ultimate")
+	}
+
+	// 已知不满足的分支仍会阻断：or(false, not-unknown) 整体未知 → 放行；
+	// 但如果要求必须有 arcana-ready（单独条件），不满足时应跳过。
+	if tl.conditionMet(json.RawMessage(`{"kind":"operatorStatus","status":"arcana-ready"}`), 0) {
+		t.Fatal("arcana-ready absent: operatorStatus condition should be unsatisfied")
+	}
+}
+
+// 层数约束。
+func TestConditionStacks(t *testing.T) {
+	tl := &EndAxisTimeline{
+		trackedStatuses: map[string]struct{}{"stance-a": {}},
+		statuses: map[int]map[string]*timelineStatusState{
+			0: {"stance-a": {stacks: 2}},
+		},
+	}
+
+	atLeast2 := json.RawMessage(`{"kind":"operatorStatus","status":"stance-a","stacks":{"compare":"atLeast","count":2}}`)
+	if !tl.conditionMet(atLeast2, 0) {
+		t.Fatal("stacks=2 should satisfy atLeast 2")
+	}
+	exact3 := json.RawMessage(`{"kind":"operatorStatus","status":"stance-a","stacks":{"compare":"exact","count":3}}`)
+	if tl.conditionMet(exact3, 0) {
+		t.Fatal("stacks=2 should not satisfy exact 3")
+	}
+	atMost1 := json.RawMessage(`{"kind":"operatorStatus","status":"stance-a","stacks":{"compare":"atMost","count":1}}`)
+	if tl.conditionMet(atMost1, 0) {
+		t.Fatal("stacks=2 should not satisfy atMost 1")
+	}
+}
+
+// 状态按 duration 过期：到期后视为不存在，requisites 重新允许施法。
+// （莉诺演唱姿态持续 60 秒，到期后战技应可再次施放以重新开启姿态。）
+func TestStatusExpiresAfterDuration(t *testing.T) {
+	tl := &EndAxisTimeline{
+		trackedStatuses: map[string]struct{}{"stance-a": {}},
+		statuses: map[int]map[string]*timelineStatusState{
+			0: {},
+		},
+	}
+
+	// 置位时带 duration（帧）：3600 帧 = 60 秒。
+	tl.setStatus(0, "stance-a", 3600, 0)
+	cond := json.RawMessage(`{"kind":"operatorStatus","status":"stance-a"}`)
+	if !tl.conditionMet(cond, 0) {
+		t.Fatal("status should be active within its duration")
+	}
+
+	// 直接把过期时刻拨到过去，模拟 60 秒已过。
+	tl.statuses[0]["stance-a"].expiry = time.Now().Add(-time.Second)
+	if tl.conditionMet(cond, 0) {
+		t.Fatal("expired status should be treated as absent")
+	}
+
+	// 过期后重新置位会刷新过期时刻。
+	tl.setStatus(0, "stance-a", 3600, 0)
+	if !tl.conditionMet(cond, 0) {
+		t.Fatal("re-applied status should be active again")
+	}
+
+	// consume 可提前清除。
+	tl.clearStatus(0, "stance-a")
+	if tl.conditionMet(cond, 0) {
+		t.Fatal("consumed status should be absent")
+	}
+}
+
+// 仅被 requisites 引用、但没有任何动作效果管理的状态视为不存在，
+// 保证 not(or(...)) 守卫在部分成员未受动作管理时仍能正确求值。
+func TestUntrackedStatusTreatedAsAbsent(t *testing.T) {
+	tl := &EndAxisTimeline{
+		trackedStatuses: map[string]struct{}{"stance-a": {}},
+		statuses: map[int]map[string]*timelineStatusState{
+			0: {},
+		},
+	}
+
+	// stance-b 未被跟踪（没有动作管理它），视为不存在。
+	guard := json.RawMessage(`{"kind":"not","condition":{"kind":"or","conditions":[{"kind":"operatorStatus","status":"stance-a"},{"kind":"operatorStatus","status":"stance-b"}]}}`)
+	if !tl.conditionMet(guard, 0) {
+		t.Fatal("all members absent (including untracked): guard should be satisfied")
+	}
+	tl.setStatus(0, "stance-a", 0, 0)
+	if tl.conditionMet(guard, 0) {
+		t.Fatal("tracked member present: guard should be unsatisfied")
+	}
+}

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -76,6 +76,7 @@
     "autofight.endaxis.waiting_combo_cooldown": "Waiting for link skill cooldown",
     "autofight.endaxis.retry_timeline": "Trying a new timeline round",
     "autofight.endaxis.no_matching_scenario": "No timeline plan available for current ultimate state; add more plans",
+    "autofight.endaxis.requisite_unmet_skip": "Skipping timeline action \"%s\": skill usage condition not met",
     "pullcount.resource.originium": "Essence Originium converted to Oroberyl",
     "pullcount.resource.oroberyl": "Oroberyl",
     "pullcount.resource_read_success": "%s read successfully: %d",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -76,6 +76,7 @@
     "autofight.endaxis.waiting_combo_cooldown": "連携技のクールダウン完了を待機中",
     "autofight.endaxis.retry_timeline": "新しい軸取りラウンドを試みます",
     "autofight.endaxis.no_matching_scenario": "現在の終結技状態に使用可能な軸取りがありません。プランを追加してください",
+    "autofight.endaxis.requisite_unmet_skip": "軸取りアクション「%s」をスキップ：スキル使用条件を満たしていません",
     "pullcount.resource.originium": "衍質源石を嵌晶玉へ換算した値",
     "pullcount.resource.oroberyl": "嵌晶玉",
     "pullcount.resource_read_success": "%sの読み取り成功：%d",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -76,6 +76,7 @@
     "autofight.endaxis.waiting_combo_cooldown": "연계기 쿨다운 완료 대기 중",
     "autofight.endaxis.retry_timeline": "새 타임라인 회차를 시도합니다",
     "autofight.endaxis.no_matching_scenario": "현재 종결기 상태에 사용 가능한 타임라인 방안이 없습니다. 더 많은 방안을 추가하세요",
+    "autofight.endaxis.requisite_unmet_skip": "타임라인 동작 \"%s\" 건너뛰기: 스킬 사용 조건 미충족",
     "pullcount.resource.originium": "연질 원석의 오로베릴 환산값",
     "pullcount.resource.oroberyl": "오로베릴",
     "pullcount.resource_read_success": "%s 읽기 성공: %d",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -76,6 +76,7 @@
     "autofight.endaxis.waiting_combo_cooldown": "等待连携技冷却完成",
     "autofight.endaxis.retry_timeline": "尝试新一轮排轴",
     "autofight.endaxis.no_matching_scenario": "当前终结技状态没有可用排轴，需添加更多方案",
+    "autofight.endaxis.requisite_unmet_skip": "跳过排轴动作「%s」，技能使用条件不满足",
     "pullcount.resource.originium": "衍质源石换算嵌晶玉",
     "pullcount.resource.oroberyl": "嵌晶玉",
     "pullcount.resource_read_success": "%s读取成功：%d",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -76,6 +76,7 @@
     "autofight.endaxis.waiting_combo_cooldown": "等待連攜技冷卻完成",
     "autofight.endaxis.retry_timeline": "嘗試新一輪排軸",
     "autofight.endaxis.no_matching_scenario": "當前終結技狀態沒有可用排軸，需添加更多方案",
+    "autofight.endaxis.requisite_unmet_skip": "跳過排軸動作「%s」，技能使用條件不滿足",
     "pullcount.resource.originium": "衍質源石換算嵌晶玉",
     "pullcount.resource.oroberyl": "嵌晶玉",
     "pullcount.resource_read_success": "%s讀取成功：%d",


### PR DESCRIPTION
## 背景

Fixes #5126（修复 #5126）：使用 end-axis 排轴数据进行自动战斗时，开关型战技（如莉诺「演唱姿态」）在每轮循环开头被重复触发，姿态无法保持。排轴数据中该动作自带 requisites 条件「不处于演唱姿态或宇宙之音姿态时才可使用」，但运行时完全忽略该字段。

## 改动

**`agent/go-service/autofight/endaxistimeline.go`**

1. 解析动作 `requisites`（支持 `operatorStatus` / `not` / `or` / `and` / 数组及 `stacks` 约束），在派发前求值；**条件不满足的动作直接跳过**，不再无条件按帧触发。
2. 新增按 track 的**干员状态模型**：动作 `hits` 中的 `status` / `consume` 效果在动作执行后置位/清除状态；状态按效果 `duration` 过期（与游戏一致，如演唱姿态 60 秒），**跨轮次持续**（重新选择方案不清空），仅更换数据码时重建。
3. 条件求值采用**三值逻辑**：无法在运行时求值的条件种类（`skillCooldownReady` / `ultimateEnhancement` / `enemyStatus` 等）视为"未知"，顶层未知放行，避免误跳过动作（如 arcane 终极技的 `or(not(ultimateEnhancement), operatorStatus ...)`）；未被动作效果管理的状态视为不存在。
4. 跳过后通过 maafocus 输出限频提示，新增 i18n key `autofight.endaxis.requisite_unmet_skip`（覆盖 zh_cn / zh_tw / en_us / ja_jp / ko_kr）。

**`agent/go-service/autofight/autofight.go`**：收到跳过通知时打印提示。

**测试**：新增 `agent/go-service/autofight/endaxistimeline_test.go`（9 个用例），覆盖：

- 开关型战技第 1 轮派发、第 2~5 轮姿态持续期内跳过（核心回归）；
- 状态按 duration 过期 / consume 清除 / 重新置位刷新；
- 条件树求值（not/or/and/数组/stacks）、未知条件种类放行、未跟踪状态视为不存在。

## 验证

- `go build ./...`、`go vet ./autofight/...` 通过；
- `go test ./autofight/...` 9/9 通过；
- 用报告者的真实排轴数据码端到端回放：第 1 轮派发战技并置位姿态，第 2 轮正确跳过；
- 实机测试（Windows / v2.26.0-beta.3 + 自编译 agent）：姿态 60 秒内轮次跳过、到期后重新施放，与游戏行为一致。

## 已知边界

- 仅由被动/触发器施加、且排轴内无动作效果管理的状态视为"不存在"（MaaEnd 未建模被动触发器）；
- `skillCooldownReady` 等冷却类条件暂按"满足"处理（fail-open），不阻断原有行为；
- 姿态到期后重开时机取决于排轴自身循环节奏，代码不会在轮次之间额外插入施法。
