### PR TITLE
fix(EssenceFilter): 遇到已上锁或已废弃基质时任务出错 (Go)

### DIFF
--- a/agent/go-service/essencefilter/README.md
+++ b/agent/go-service/essencefilter/README.md
@@ -14,12 +14,16 @@
 | Go `essencefilter` | OCR 归一化、技能匹配、Lock/Discard/Skip 决策、统计 |
 | Pipeline | 点击、滑动、等待和操作后确认 |
 
-Go 只通过 `ctx.OverrideNext` 选择 Pipeline 分支：
+Go 通过 `ctx.OverrideNext` 选择 Pipeline 分支：
 
-- 库存：`EssenceFilterLockItem` / `EssenceFilterDiscardItem` / `EssenceGridAdvance`；
-- 战后：`EssenceFilterAfterBattleLockItem` / `EssenceFilterAfterBattleDiscardItem` / `EssenceFilterAfterBattleCloseDetail`。
+- 库存锁定：`[EssenceFilterCheckLocked, EssenceFilterLockItem]`；
+- 库存废弃：`[EssenceFilterCheckDiscarded, EssenceFilterDiscardItem]`；
+- 库存跳过：`[EssenceGridAdvance]`；
+- 战后锁定：`[EssenceFilterAfterBattleCheckLocked, EssenceFilterAfterBattleLockItem]`；
+- 战后废弃：`[EssenceFilterAfterBattleCheckDiscarded, EssenceFilterAfterBattleDiscardItem]`；
+- 战后跳过：`[EssenceFilterAfterBattleCloseDetail]`。
 
-动作入口必须指向实际的 `LockItem` / `DiscardItem`，不能直接指向操作后的 `CheckLocked` / `CheckDiscarded`。
+锁定与废弃决策以 `[CheckLocked, LockItem]` 与 `[CheckDiscarded, DiscardItem]` 的顺序路由候选节点。已处于目标状态的基质由前置 `Check*` 节点直接命中并进入下一格；处于未锁定/未废弃状态的基质回落至 `*Item` 节点执行点击与确认。
 
 ## 文件与职责
 

--- a/agent/go-service/essencefilter/actions.go
+++ b/agent/go-service/essencefilter/actions.go
@@ -211,9 +211,17 @@ func (a *EssenceFilterSkillDecisionAction) Run(ctx *maa.Context, arg *maa.Custom
 		return false
 	}
 	return runUnifiedSkillDecision(ctx, arg, st, st.MatchEngine, ocr, decisionNextNodes{
-		Lock:    "EssenceFilterLockItem",
-		Discard: "EssenceFilterDiscardItem",
-		Skip:    "EssenceGridAdvance",
+		Lock: []maa.NextItem{
+			{Name: "EssenceFilterCheckLocked"},
+			{Name: "EssenceFilterLockItem"},
+		},
+		Discard: []maa.NextItem{
+			{Name: "EssenceFilterCheckDiscarded"},
+			{Name: "EssenceFilterDiscardItem"},
+		},
+		Skip: []maa.NextItem{
+			{Name: "EssenceGridAdvance"},
+		},
 	})
 }
 

--- a/agent/go-service/essencefilter/actionsAfterBattle.go
+++ b/agent/go-service/essencefilter/actionsAfterBattle.go
@@ -81,8 +81,16 @@ func (a *EssenceFilterAfterBattleSkillDecisionAction) Run(ctx *maa.Context, arg 
 		return false
 	}
 	return runUnifiedSkillDecision(ctx, arg, st, st.MatchEngine, ocr, decisionNextNodes{
-		Lock:    "EssenceFilterAfterBattleLockItem",
-		Discard: "EssenceFilterAfterBattleDiscardItem",
-		Skip:    "EssenceFilterAfterBattleCloseDetail",
+		Lock: []maa.NextItem{
+			{Name: "EssenceFilterAfterBattleCheckLocked"},
+			{Name: "EssenceFilterAfterBattleLockItem"},
+		},
+		Discard: []maa.NextItem{
+			{Name: "EssenceFilterAfterBattleCheckDiscarded"},
+			{Name: "EssenceFilterAfterBattleDiscardItem"},
+		},
+		Skip: []maa.NextItem{
+			{Name: "EssenceFilterAfterBattleCloseDetail"},
+		},
 	})
 }

--- a/agent/go-service/essencefilter/integration.go
+++ b/agent/go-service/essencefilter/integration.go
@@ -217,9 +217,9 @@ func reportFinishArtifacts(ctx *maa.Context, st *RunState) {
 }
 
 type decisionNextNodes struct {
-	Lock    string
-	Discard string
-	Skip    string
+	Lock    []maa.NextItem
+	Discard []maa.NextItem
+	Skip    []maa.NextItem
 }
 
 func runUnifiedSkillDecision(
@@ -263,7 +263,7 @@ func runUnifiedSkillDecision(
 				}
 			}
 		}
-		ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: next.Lock}})
+		ctx.OverrideNext(arg.CurrentTaskName, next.Lock)
 
 	case matchapi.MatchFuturePromising, matchapi.MatchSlot3Level3Practical:
 		var reason string
@@ -300,19 +300,19 @@ func runUnifiedSkillDecision(
 				}
 			}
 			reportExtRule(ctx, reason, true)
-			ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: next.Lock}})
+			ctx.OverrideNext(arg.CurrentTaskName, next.Lock)
 		} else {
 			reportExtRule(ctx, reason, false)
-			ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: next.Skip}})
+			ctx.OverrideNext(arg.CurrentTaskName, next.Skip)
 		}
 
 	case matchapi.MatchNone:
 		if matchResult.ShouldDiscard {
 			reportNoMatch(ctx, true)
-			ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: next.Discard}})
+			ctx.OverrideNext(arg.CurrentTaskName, next.Discard)
 		} else {
 			reportNoMatch(ctx, false)
-			ctx.OverrideNext(arg.CurrentTaskName, []maa.NextItem{{Name: next.Skip}})
+			ctx.OverrideNext(arg.CurrentTaskName, next.Skip)
 		}
 	}
 

--- a/docs/en_us/developers/components/recogrid-engine.md
+++ b/docs/en_us/developers/components/recogrid-engine.md
@@ -147,9 +147,12 @@ EssenceGrid processes only tracker `new_cells`:
 After Pipeline clicks a cell, Pipeline OCR nodes read three skills and levels.
 Go normalizes the OCR result, performs matching, and chooses the next branch candidates:
 
-- target matched: routes to `[CheckLocked, LockItem]`;
-- unmatched with discard enabled: routes to `[CheckDiscarded, DiscardItem]`;
-- other cases: routes to `[EssenceGridAdvance]` (or `[EssenceFilterAfterBattleCloseDetail]`).
+- inventory lock: `[EssenceFilterCheckLocked, EssenceFilterLockItem]`;
+- inventory discard: `[EssenceFilterCheckDiscarded, EssenceFilterDiscardItem]`;
+- inventory skip: `[EssenceGridAdvance]`;
+- after-battle lock: `[EssenceFilterAfterBattleCheckLocked, EssenceFilterAfterBattleLockItem]`;
+- after-battle discard: `[EssenceFilterAfterBattleCheckDiscarded, EssenceFilterAfterBattleDiscardItem]`;
+- after-battle skip: `[EssenceFilterAfterBattleCloseDetail]`.
 
 Lock and discard decisions route with `Check*` preceding `*Item`. For essences already in the target state, the check node matches immediately and advances to the next item. For items requiring action, execution falls through to the action node to perform clicking and subsequent verification.
 

--- a/docs/en_us/developers/components/recogrid-engine.md
+++ b/docs/en_us/developers/components/recogrid-engine.md
@@ -145,12 +145,13 @@ EssenceGrid processes only tracker `new_cells`:
 ## Go and Pipeline
 
 After Pipeline clicks a cell, Pipeline OCR nodes read three skills and levels.
-Go normalizes the OCR result, performs matching, and chooses one actual action
-entry: `LockItem`, `DiscardItem`, or the skip route.
+Go normalizes the OCR result, performs matching, and chooses the next branch candidates:
 
-Pipeline owns button recognition, clicking, and `CheckLocked` /
-`CheckDiscarded` verification. Go must not route directly to a post-action
-check node, because doing so skips the operation.
+- target matched: routes to `[CheckLocked, LockItem]`;
+- unmatched with discard enabled: routes to `[CheckDiscarded, DiscardItem]`;
+- other cases: routes to `[EssenceGridAdvance]` (or `[EssenceFilterAfterBattleCloseDetail]`).
+
+Lock and discard decisions route with `Check*` preceding `*Item`. For essences already in the target state, the check node matches immediately and advances to the next item. For items requiring action, execution falls through to the action node to perform clicking and subsequent verification.
 
 ## Controller overrides
 

--- a/docs/zh_cn/developers/components/recogrid-engine.md
+++ b/docs/zh_cn/developers/components/recogrid-engine.md
@@ -146,13 +146,13 @@ EssenceGrid 只处理 Tracker 的 `new_cells`：
 
 ## Go 与 Pipeline
 
-Pipeline 点击格子后，三个技能和等级由 OCR 节点读取。Go 的 `runUnifiedSkillDecision` 只决定分支：
+Pipeline 点击格子后，三个技能和等级由 OCR 节点读取。Go 的 `runUnifiedSkillDecision` 决定分支候选：
 
-- 命中目标：进入 `LockItem`；
-- 未命中且开启废弃：进入 `DiscardItem`；
+- 命中目标：进入 `[CheckLocked, LockItem]` 候选列表；
+- 未命中且开启废弃：进入 `[CheckDiscarded, DiscardItem]` 候选列表；
 - 其他情况：回到 `EssenceGridAdvance`。
 
-实际按钮识别、点击和 `CheckLocked` / `CheckDiscarded` 确认都属于 Pipeline。Go 不能直接跳到确认节点，否则会跳过动作。
+锁定与废弃决策优先通过 `CheckLocked` / `CheckDiscarded` 匹配目标状态。已处于目标状态时直接流转下一项；处于待操作状态时由 `LockItem` / `DiscardItem` 执行点击并由后续节点确认。
 
 ## 控制器差异
 

--- a/docs/zh_cn/developers/components/recogrid-engine.md
+++ b/docs/zh_cn/developers/components/recogrid-engine.md
@@ -148,11 +148,14 @@ EssenceGrid 只处理 Tracker 的 `new_cells`：
 
 Pipeline 点击格子后，三个技能和等级由 OCR 节点读取。Go 的 `runUnifiedSkillDecision` 决定分支候选：
 
-- 命中目标：进入 `[CheckLocked, LockItem]` 候选列表；
-- 未命中且开启废弃：进入 `[CheckDiscarded, DiscardItem]` 候选列表；
-- 其他情况：回到 `EssenceGridAdvance`。
+- 库存锁定：`[EssenceFilterCheckLocked, EssenceFilterLockItem]`；
+- 库存废弃：`[EssenceFilterCheckDiscarded, EssenceFilterDiscardItem]`；
+- 库存跳过：`[EssenceGridAdvance]`；
+- 战后锁定：`[EssenceFilterAfterBattleCheckLocked, EssenceFilterAfterBattleLockItem]`；
+- 战后废弃：`[EssenceFilterAfterBattleCheckDiscarded, EssenceFilterAfterBattleDiscardItem]`；
+- 战后跳过：`[EssenceFilterAfterBattleCloseDetail]`。
 
-锁定与废弃决策优先通过 `CheckLocked` / `CheckDiscarded` 匹配目标状态。已处于目标状态时直接流转下一项；处于待操作状态时由 `LockItem` / `DiscardItem` 执行点击并由后续节点确认。
+锁定与废弃决策优先通过 `CheckLocked` / `CheckDiscarded` 以及战后对应的 `EssenceFilterAfterBattleCheck*` 匹配目标状态。已处于目标状态时直接流转下一项；处于待操作状态时由 `LockItem` / `DiscardItem` 以及战后对应的 `EssenceFilterAfterBattle*Item` 执行点击并由后续节点确认。
 
 ## 控制器差异
 


### PR DESCRIPTION
由 6eb0d596f9c62966745c632f3f548ae0b0c123a0 引入
存在于 v2.26.0-beta.4 中

看了眼 Sourcery 提到的文档，感觉里面写的和我修的想法不一样
我是不是把本应在 Pipeline 里面的逻辑写到 Go 里面了🤔

如果要改回原来文档的思路的话应该大概是这样
已据此在 #5183 中使用 Pipeline 修复
挑一个合(

```json
"EssenceFilterLockItem": {
    "desc": "锁定流程入口",
    "recognition": "DirectHit",
    "action": "DoNothing",
    "next": [
        "EssenceFilterCheckLocked",
        "EssenceFilterClickLockItem"
    ]
},
"EssenceFilterClickLockItem": {
    "desc": "识别未上锁图标并点击",
    "recognition": {
        "type": "TemplateMatch",
        "param": {
            "roi": [1217, 180, 21, 21],
            "template": "EssenceFilter/LockButton.png",
            "threshold": 0.9
        }
    },
    "action": "Click",
    "post_delay": 300,
    "next": [
        "EssenceFilterCheckLocked",
        "EssenceFilterClickLockItem"
    ]
}
```

## Sourcery 总结

在 EssenceFilter 决策流程中安全处理已锁定和已丢弃的材料。

错误修复：
- 在尝试执行操作前检查材料的当前状态，避免因材料已锁定或已丢弃而导致 EssenceFilter 处理失败。

增强功能：
- 在库存和战斗后 EssenceFilter 流程中，为锁定、丢弃和跳过决策支持多步骤路由。

文档：
- 更新 EssenceFilter 集成文档，说明状态检查和多步骤决策路由。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle already-locked and discarded materials safely in EssenceFilter decision flows.

Bug Fixes:
- Prevent EssenceFilter processing from failing when materials are already locked or discarded by checking their current state before attempting actions.

Enhancements:
- Support multi-step routing for lock, discard, and skip decisions in both inventory and post-battle EssenceFilter flows.

Documentation:
- Update EssenceFilter integration documentation to describe state checks and multi-step decision routing.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 优化技能决策流程：锁定和丢弃操作会先检查目标状态，再执行相应处理。
  * 支持库存与战后场景的差异化处理，已满足目标状态时可直接进入后续流程。
  * 保持跳过操作的现有路径，并统一更新精准匹配、扩展规则及未匹配场景的处理流程。

* **文档**
  * 补充库存与战后场景下锁定、丢弃和跳过操作的流程说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->