### PR TITLE
fix(EssenceFilter): 遇到已上锁或已废弃基质时任务出错 (Pipeline)

### DIFF
--- a/assets/resource/pipeline/EssenceFilter/EssenceFilterAfterBattleLockDiscard.json
+++ b/assets/resource/pipeline/EssenceFilter/EssenceFilterAfterBattleLockDiscard.json
@@ -2,7 +2,10 @@
     "EssenceFilterAfterBattleLockItem": {
         "desc": "战后基质筛选锁定流程入口",
         "recognition": "DirectHit",
+        "pre_delay": 0,
         "action": "DoNothing",
+        "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "EssenceFilterAfterBattleCheckLocked",
             "EssenceFilterAfterBattleClickLockItem"
@@ -87,7 +90,10 @@
     "EssenceFilterAfterBattleDiscardItem": {
         "desc": "战后基质筛选废弃流程入口",
         "recognition": "DirectHit",
+        "pre_delay": 0,
         "action": "DoNothing",
+        "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "EssenceFilterAfterBattleCheckDiscarded",
             "EssenceFilterAfterBattleClickDiscardItem"

--- a/assets/resource/pipeline/EssenceFilter/EssenceFilterAfterBattleLockDiscard.json
+++ b/assets/resource/pipeline/EssenceFilter/EssenceFilterAfterBattleLockDiscard.json
@@ -1,5 +1,14 @@
 {
     "EssenceFilterAfterBattleLockItem": {
+        "desc": "战后基质筛选锁定流程入口",
+        "recognition": "DirectHit",
+        "action": "DoNothing",
+        "next": [
+            "EssenceFilterAfterBattleCheckLocked",
+            "EssenceFilterAfterBattleClickLockItem"
+        ]
+    },
+    "EssenceFilterAfterBattleClickLockItem": {
         "desc": "锁定Essence",
         "recognition": {
             "type": "TemplateMatch",
@@ -22,7 +31,7 @@
         "post_delay": 300,
         "next": [
             "EssenceFilterAfterBattleCheckLocked",
-            "EssenceFilterAfterBattleLockItem"
+            "EssenceFilterAfterBattleClickLockItem"
         ],
         "focus": {
             //"Node.Action.Succeeded": "已锁定基质"
@@ -50,7 +59,7 @@
             "EssenceFilterAfterBattleRowNextItem"
         ],
         "on_error": [
-            "EssenceFilterAfterBattleLockItem"
+            "EssenceFilterAfterBattleClickLockItem"
         ],
         "focus": {
             //"Node.Action.Succeeded": "已确认上锁"
@@ -76,6 +85,15 @@
         "post_delay": 0
     },
     "EssenceFilterAfterBattleDiscardItem": {
+        "desc": "战后基质筛选废弃流程入口",
+        "recognition": "DirectHit",
+        "action": "DoNothing",
+        "next": [
+            "EssenceFilterAfterBattleCheckDiscarded",
+            "EssenceFilterAfterBattleClickDiscardItem"
+        ]
+    },
+    "EssenceFilterAfterBattleClickDiscardItem": {
         "desc": "废弃 Essence",
         "recognition": {
             "type": "TemplateMatch",
@@ -99,7 +117,7 @@
         "post_delay": 0,
         "next": [
             "EssenceFilterAfterBattleCheckDiscarded",
-            "EssenceFilterAfterBattleDiscardItem"
+            "EssenceFilterAfterBattleClickDiscardItem"
         ],
         "focus": {
             //"Node.Action.Succeeded": "已废弃基质"
@@ -128,7 +146,7 @@
             "EssenceFilterAfterBattleRowNextItem"
         ],
         "on_error": [
-            "EssenceFilterAfterBattleDiscardItem"
+            "EssenceFilterAfterBattleClickDiscardItem"
         ],
         "focus": {
             //"Node.Action.Succeeded": "已确认废弃"

--- a/assets/resource/pipeline/EssenceFilter/LockDiscard.json
+++ b/assets/resource/pipeline/EssenceFilter/LockDiscard.json
@@ -1,5 +1,14 @@
 {
     "EssenceFilterLockItem": {
+        "desc": "基质筛选锁定流程入口",
+        "recognition": "DirectHit",
+        "action": "DoNothing",
+        "next": [
+            "EssenceFilterCheckLocked",
+            "EssenceFilterClickLockItem"
+        ]
+    },
+    "EssenceFilterClickLockItem": {
         "desc": "锁定Essence",
         "recognition": {
             "type": "TemplateMatch",
@@ -21,7 +30,7 @@
         "post_delay": 300,
         "next": [
             "EssenceFilterCheckLocked",
-            "EssenceFilterLockItem"
+            "EssenceFilterClickLockItem"
         ],
         "focus": {
             "Node.Action.Succeeded": "已锁定基质"
@@ -48,13 +57,22 @@
             "EssenceGridAdvance"
         ],
         "on_error": [
-            "EssenceFilterLockItem"
+            "EssenceFilterClickLockItem"
         ],
         "focus": {
             "Node.Action.Succeeded": "已确认上锁"
         }
     },
     "EssenceFilterDiscardItem": {
+        "desc": "基质筛选废弃流程入口",
+        "recognition": "DirectHit",
+        "action": "DoNothing",
+        "next": [
+            "EssenceFilterCheckDiscarded",
+            "EssenceFilterClickDiscardItem"
+        ]
+    },
+    "EssenceFilterClickDiscardItem": {
         "desc": "废弃 Essence",
         "recognition": {
             "type": "TemplateMatch",
@@ -76,7 +94,7 @@
         "post_delay": 300,
         "next": [
             "EssenceFilterCheckDiscarded",
-            "EssenceFilterDiscardItem"
+            "EssenceFilterClickDiscardItem"
         ],
         "focus": {
             "Node.Action.Succeeded": "已废弃基质"
@@ -103,7 +121,7 @@
             "EssenceGridAdvance"
         ],
         "on_error": [
-            "EssenceFilterDiscardItem"
+            "EssenceFilterClickDiscardItem"
         ],
         "focus": {
             "Node.Action.Succeeded": "已确认废弃"

--- a/assets/resource/pipeline/EssenceFilter/LockDiscard.json
+++ b/assets/resource/pipeline/EssenceFilter/LockDiscard.json
@@ -2,7 +2,10 @@
     "EssenceFilterLockItem": {
         "desc": "基质筛选锁定流程入口",
         "recognition": "DirectHit",
+        "pre_delay": 0,
         "action": "DoNothing",
+        "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "EssenceFilterCheckLocked",
             "EssenceFilterClickLockItem"
@@ -66,7 +69,10 @@
     "EssenceFilterDiscardItem": {
         "desc": "基质筛选废弃流程入口",
         "recognition": "DirectHit",
+        "pre_delay": 0,
         "action": "DoNothing",
+        "post_delay": 0,
+        "rate_limit": 0,
         "next": [
             "EssenceFilterCheckDiscarded",
             "EssenceFilterClickDiscardItem"

--- a/assets/resource_adb/pipeline/EssenceFilter/LockDiscard.json
+++ b/assets/resource_adb/pipeline/EssenceFilter/LockDiscard.json
@@ -1,5 +1,5 @@
 {
-    "EssenceFilterLockItem": {
+    "EssenceFilterClickLockItem": {
         "recognition": {
             "param": {
                 "roi": [
@@ -23,7 +23,7 @@
             }
         }
     },
-    "EssenceFilterDiscardItem": {
+    "EssenceFilterClickDiscardItem": {
         "recognition": {
             "param": {
                 "roi": [


### PR DESCRIPTION
#5181
Copilot 给出的两条 Review 我觉得是对的，所以改了，合之前记得看看

## Sourcery 摘要

错误修复：
- 防止 EssenceFilter 流水线任务在处理已锁定或已丢弃的 essence 时失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent EssenceFilter pipeline tasks from failing when processing locked or discarded essences.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新功能
* 优化精华筛选中的锁定与废弃操作流程，新增清晰的操作入口及确认步骤。
* 操作失败或确认异常时，可自动返回对应的点击操作，提升流程连续性与稳定性。
* 支持战斗后锁定与废弃操作使用一致的处理流程。

## 配置更新
* 统一锁定、废弃操作相关配置名称，确保识别结果与实际操作保持一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->