### PR TITLE
fix(EnvironmentMonitoring): 修复拍照流程与多条观察点路线

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/HangingVines.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "HangingVinesInQuickTeleportMap"
+            "GoToHangingVines"
         ]
     },
     "AlreadyTrackedHangingVines": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "HangingVinesOpenTrackedMissionMap"
+            "GoToHangingVines"
         ]
     },
     "HangingVinesOpenTrackedMissionMap": {
@@ -340,10 +340,10 @@
         "custom_recognition_param": {
             "zone_id": "Wuling_Base",
             "target": [
-                0,
-                0,
-                1,
-                1
+                556.4,
+                2209.45,
+                82.62,
+                59.95
             ]
         },
         "pre_delay": 0,
@@ -360,7 +360,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneAnyEnterWorld"
+                "SceneEnterWorldWulingMarkerStone3"
             ]
         },
         "post_delay": 0,
@@ -379,14 +379,14 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        69.1,
-                        129.69
+                        79.73,
+                        198.88
                     ],
                     "target_tier": "Wuling_L4_330"
                 },
                 {
                     "action": "HEADING",
-                    "angle": 173
+                    "angle": 0
                 }
             ]
         },

--- a/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/MarkerStoneMonitoringTerminal/PeachTreeAtBabblesSHome.json
@@ -354,7 +354,7 @@
         ]
     },
     "GoToPeachTreeAtBabblesSHomeNotAtStartPos": {
-        "desc": "前往念念家的桃树传送点，传送后调整朝向并拍照",
+        "desc": "不在念念家的桃树任务开始位置附近，先传送再继续寻路",
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "SubTask",
@@ -370,15 +370,23 @@
         ]
     },
     "GoToPeachTreeAtBabblesSHomeMove": {
-        "desc": "在念念家的桃树传送点调整拍照朝向",
+        "desc": "自动寻路前往念念家的桃树",
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "MapNavigateAction",
         "custom_action_param": {
             "path": [
                 {
+                    "action": "NAVMESH",
+                    "target": [
+                        258.16,
+                        207.3
+                    ],
+                    "target_tier": "Wuling_L4_328"
+                },
+                {
                     "action": "HEADING",
-                    "angle": 66
+                    "angle": 92
                 }
             ]
         },

--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/EternalSunset.json
@@ -216,7 +216,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "EternalSunsetInQuickTeleportMap"
+            "GoToEternalSunset"
         ]
     },
     "AlreadyTrackedEternalSunset": {
@@ -230,7 +230,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "EternalSunsetOpenTrackedMissionMap"
+            "GoToEternalSunset"
         ]
     },
     "EternalSunsetOpenTrackedMissionMap": {
@@ -340,10 +340,10 @@
         "custom_recognition_param": {
             "zone_id": "Wuling_Base",
             "target": [
-                0,
-                0,
-                1,
-                1
+                783.72,
+                2303.61,
+                51.61,
+                43.01
             ]
         },
         "pre_delay": 0,
@@ -360,7 +360,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneAnyEnterWorld"
+                "SceneEnterWorldWulingJingyuValley2"
             ]
         },
         "post_delay": 0,

--- a/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/TakePhoto.json
@@ -283,7 +283,7 @@
         "rate_limit": 0,
         "next": [
             "EnvironmentMonitoringShutterButtonPhotographyTarget",
-            "[JumpBack]EnvironmentMonitoringCameraScan"
+            "EnvironmentMonitoringCameraScan"
         ]
     },
     "EnvironmentMonitoringCameraScan": {

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -119,7 +119,14 @@
         "MissionId": "m1m32",
         "Name": "“栖霞驻影”",
         "Id": "EternalSunset",
-        "QuickTeleport": true,
+        "EnterMap": "SceneEnterWorldWulingJingyuValley2",
+        "NavZoneId": "Wuling_Base",
+        "NavAssert": [
+            783.72,
+            2303.61,
+            51.61,
+            43.01
+        ],
         "NavPath": [
             {
                 "action": "NAVMESH",

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -369,18 +369,25 @@
         "MissionId": "m1m62",
         "Name": "垂藤",
         "Id": "HangingVines",
-        "QuickTeleport": true,
+        "EnterMap": "SceneEnterWorldWulingMarkerStone3",
+        "NavZoneId": "Wuling_Base",
+        "NavAssert": [
+            556.4,
+            2209.45,
+            82.62,
+            59.95
+        ],
         "NavPath": [
             {
                 "action": "NAVMESH",
                 "target": [
-                    69.1,
-                    129.69
+                    79.73,
+                    198.88
                 ],
                 "target_tier": "Wuling_L4_330"
             }
         ],
-        "Heading": 173
+        "Heading": 0
     },
     {
         "MissionId": "m1m63",

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -464,7 +464,17 @@
         "Name": "念念家的桃树",
         "Id": "PeachTreeAtBabblesSHome",
         "QuickTeleport": true,
-        "Heading": 66
+        "NavPath": [
+            {
+                "action": "NAVMESH",
+                "target": [
+                    258.16,
+                    207.3
+                ],
+                "target_tier": "Wuling_L4_328"
+            }
+        ],
+        "Heading": 92
     },
     {
         "MissionId": "m1m67",


### PR DESCRIPTION
## 问题

环境监测任务目前存在两类问题：

- 拍照流程在扫描节点成功找到目标后，仍可能回到调用方继续移动相机，最终导致已经拍照成功的任务报错。
- 部分观察点依赖快捷传送或传送后直接拍照，但不同账号的基地位置、门是否开启以及实际落点并不一致，导致误选传送点、寻路失败或拍不到目标。

## 改动

- 修正拍照扫描的控制流：将 `EnvironmentMonitoringCameraScan` 作为正常分支进入，而不是通过 `JumpBack` 调用。该节点本身已经维护后续状态，直接分支可以在识别到拍照目标后按自己的 `next` 完成拍照，避免返回后再次移动相机。
- 修复「念念家的桃树」：快捷传送后不再只调整朝向，而是先通过 NAVMESH 移动到实测拍照位置，再将朝向调整为 92°。这样不再假设传送落点天然满足拍照条件。
- 修复「垂藤」：不再依赖任务地图快捷传送，改为从 `SceneEnterWorldWulingMarkerStone3` 进入，并补充起点断言、通用 NAVMESH 路线和最终朝向。该路线不依赖用户已经打开任务附近的门，能覆盖不同账号的场景状态。
- 修复「栖霞驻影」：不再使用可能误选基地的快捷传送，改为从 `SceneEnterWorldWulingJingyuValley2` 进入并校验起点后寻路。这样即使基地位于地图左侧附近，也不会把基地当作任务传送点。
- 在 `tools/pipeline-generate/EnvironmentMonitoring/routes.json` 维护上述实测路线，并重新生成对应 Pipeline，确保配置源与运行资源一致。

这些修复没有增加硬延迟或盲目重试，而是通过明确的入口、位置断言、寻路和节点状态流消除不稳定前提。

## 验证

- `pnpm generate:EnvironmentMonitoring`：生成 32 条路线、800 个任务节点，0 个诊断问题
- `node .agents/skills/environment-monitoring-add-route/check_missing.mjs`：所有观察点均已完整适配
- `pnpm format`
- `pnpm check`
- `pnpm test`：780 / 780 通过，包含 ADB 与 Win32 环境监测测试
- `git diff --check`

## 致谢

特别感谢 [lintx](https://github.com/lintx) 提供相关任务的日志和录像，帮助定位并复现这些问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化多个任务的传送与自动寻路流程，确保从不同位置进入正确地图并抵达目标区域。
  - 更新导航路径、目标坐标及最终朝向，提升任务追踪和到达准确性。
  - 修复部分任务在快捷传送或已追踪任务地图之间切换不一致的问题。
  - 优化隐藏全部干员后重新扫描拍照目标的流程，提升后续识别稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->