### PR TITLE
fix(VisitFriends): 优化云端拜访结束和跳过好友的识别

### DIFF
--- a/assets/resource_cloud_adb/pipeline/VisitFriends/Exectue.json
+++ b/assets/resource_cloud_adb/pipeline/VisitFriends/Exectue.json
@@ -1,0 +1,24 @@
+{
+    "VisitFriendsEnterFriendsListSuccess": {
+        "all_of": [
+            "InFriendsList",
+            "VisitFriendsRecognitionItemEnterButton"
+        ],
+        "box_index": 0
+    },
+    "VisitFriendsMenuScanDetailClose": {
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    560,
+                    455,
+                    80,
+                    70
+                ],
+                "template": "Common/Button/CancelButtonType2.png",
+                "threshold": 0.9
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 修改内容

* 调整 `VisitFriendsEnterFriendsListSuccess`，使用 `InFriendsList ∧ VisitFriendsRecognitionItemEnterButton` 判断好友列表及列表项已经加载，避免返回列表时依赖容易受截断和刷新影响的好友名称 OCR。该节点仅用于确认返回列表，不参与好友筛选及 `visited` 记录。
* 调整 `VisitFriendsMenuScanDetailClose`，直接在详情弹窗按钮区域匹配 `CancelButtonType2.png`，绕过云端颜色与默认 `GrayButtonBackground` 不一致的问题，同时避免修改通用灰色按钮节点而影响其他流程。

## 验证结果

使用云端完整成功日志验证：

* 共完成 8 次从好友飞船返回好友列表：

  * `InFriendsList` 得分为 `0.953250～0.954388`
  * `VisitFriendsRecognitionItemEnterButton` 最佳得分为 `0.992909～0.993081`
* `VisitFriendsMenuScanDetailClose` 成功识别并点击 5 次：

  * 正确匹配框固定为 `[580,474,32,32]`
  * 正确匹配得分为 `0.994884～0.995016`
  * 非目标候选最高得分为 `0.494033`
  * 使用 `0.9` 阈值可以稳定区分正确目标和非目标候选

修改后拜访好友流程能够正常返回列表、继续扫描，并最终完成整个任务。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增“访问好友”流程配置。
  - 支持识别好友列表页面进入成功状态。
  - 支持通过取消按钮识别并关闭好友菜单详情页面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->