### PR TITLE
fix(MapNavigator): 避免盲走兜底跳过作者路线

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -842,29 +842,24 @@ bool AppendNavmeshWaypoint(
             }
             return false;
         }
-        if (failure_is_terminal) {
-            LogWarn << "NAVMESH waypoint not directly reachable; attempting blind-target fallback." << VAR(state.navmesh_zone)
-                    << VAR(state.current_zone) << VAR(target.point.x) << VAR(target.point.y) << VAR(navmesh::ToString(route_result.status));
-        }
-        else {
-            LogDebug << "Global NAVMESH target not directly reachable; probing blind-target fallback." << VAR(state.navmesh_zone)
+        // 全局规划只有完整抵达终点才能跳过作者提示；盲走只是逐点执行时的局部兜底，
+        // 不能把“走到可走面边缘再直冲终点”冒充成完整路线。
+        if (!failure_is_terminal) {
+            LogDebug << "Global NAVMESH target not directly reachable; preserving authored hints." << VAR(state.navmesh_zone)
                      << VAR(state.current_zone) << VAR(target.point.x) << VAR(target.point.y)
                      << VAR(navmesh::ToString(route_result.status));
+            return false;
         }
+        LogWarn << "NAVMESH waypoint not directly reachable; attempting blind-target fallback." << VAR(state.navmesh_zone)
+                << VAR(state.current_zone) << VAR(target.point.x) << VAR(target.point.y) << VAR(navmesh::ToString(route_result.status));
         if (AppendBlindTargetFallback(param, navmesh, target.point, target.floor_y, should_stop, state, out_path)) {
             return true;
         }
         if (should_stop()) {
             return false;
         }
-        if (failure_is_terminal) {
-            LogError << "Failed to plan NAVMESH waypoint." << VAR(state.navmesh_zone) << VAR(state.current_zone) << VAR(target.point.x)
-                     << VAR(target.point.y) << VAR(navmesh::ToString(route_result.status));
-        }
-        else {
-            LogDebug << "Global NAVMESH target unavailable." << VAR(state.navmesh_zone) << VAR(state.current_zone) << VAR(target.point.x)
-                     << VAR(target.point.y) << VAR(navmesh::ToString(route_result.status));
-        }
+        LogError << "Failed to plan NAVMESH waypoint." << VAR(state.navmesh_zone) << VAR(state.current_zone) << VAR(target.point.x)
+                 << VAR(target.point.y) << VAR(navmesh::ToString(route_result.status));
         return false;
     }
 


### PR DESCRIPTION
## 问题

`AutoDeliveryRouteDepotDomain2Lv002Depot1WithZipline` 的完整步行规划与滑索桥接均失败后，全局规划仍接受了 blind-target fallback：先走到离终点约 27.64px 的可走面边缘，再盲走到终点。该不完整路线被视为全局规划成功，导致 4 个作者提示点全部被跳过，角色最终走入水中并触发 River-fall recovery。

## 修复

- 全局规划只有完整抵达终点时才允许跳过作者提示点
- 全局直达不可用时直接回退并逐点执行作者路线
- 保留 blind-target fallback 在单个作者 `NAVMESH` 节点上的既有兜底行为

## 验证

- `clang-format --dry-run --Werror agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp`
- cpp-algo RelWithDebInfo 完整构建通过
- `pnpm check`
- `pnpm test`：780/780，退出码 0，未生成 `tests/maatools/error_details.json`

本修复基于 2026-08-25 实机日志中的规划结果与落水恢复记录。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **问题修复**
  - 优化全局导航网格路径规划失败时的处理逻辑。
  - 对非终止性失败保留明确提示，避免执行不必要的盲目路径尝试。
  - 仅在终止性失败且目标未声明楼层时继续进行目标探测。
  - 调整相关日志级别，提升问题排查清晰度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->