### PR TITLE
fix(AutoDelivery): 查找交互按钮失败后再重试路线

### DIFF
--- a/agent/go-service/autodelivery/catalog.go
+++ b/agent/go-service/autodelivery/catalog.go
@@ -28,6 +28,7 @@ type destination struct {
 	DepotID          string
 	RouteNode        string
 	ZipRouteNode     string
+	RetryRouteNode   string
 	DestinationTexts []string
 	ObjectiveTexts   []string
 }
@@ -46,14 +47,15 @@ type generatedDepot struct {
 }
 
 type generatedDestination struct {
-	ID           string            `json:"id"`
-	Kind         string            `json:"kind"`
-	DepotID      string            `json:"depot_id"`
-	Name         map[string]string `json:"name"`
-	Mission      map[string]string `json:"mission"`
-	Area         map[string]string `json:"area"`
-	RouteNode    string            `json:"route_node"`
-	ZipRouteNode string            `json:"zip_route_node"`
+	ID             string            `json:"id"`
+	Kind           string            `json:"kind"`
+	DepotID        string            `json:"depot_id"`
+	Name           map[string]string `json:"name"`
+	Mission        map[string]string `json:"mission"`
+	Area           map[string]string `json:"area"`
+	RouteNode      string            `json:"route_node"`
+	ZipRouteNode   string            `json:"zip_route_node"`
+	RetryRouteNode string            `json:"retry_route_node"`
 }
 
 type depot struct {
@@ -195,6 +197,7 @@ func buildDestinations(generated generatedCatalog, depots map[string]depot) ([]a
 			DepotID:          source.DepotID,
 			RouteNode:        source.RouteNode,
 			ZipRouteNode:     source.ZipRouteNode,
+			RetryRouteNode:   source.RetryRouteNode,
 			DestinationTexts: destinationTexts,
 			ObjectiveTexts:   objectiveTexts,
 		})

--- a/agent/go-service/autodelivery/resolve_destination.go
+++ b/agent/go-service/autodelivery/resolve_destination.go
@@ -8,6 +8,7 @@ import (
 const (
 	resolveDestinationActionName = "AutoDeliveryResolveDestinationAction"
 	navigateDestinationNode      = "AutoDeliveryNavigateDestination"
+	retryNavigateDestinationNode = "AutoDeliveryRetryNavigateDestination"
 	areaOCRNode                  = "AutoDeliveryAreaOCR"
 	destinationOCRNode           = "AutoDeliveryDestinationOCR"
 )
@@ -87,17 +88,31 @@ func (a *AutoDeliveryResolveDestinationAction) Run(ctx *maa.Context, arg *maa.Cu
 		Str("area", dest.AreaID).
 		Bool("zip", options.Zip).
 		Str("routeNode", selectRouteNode(dest.RouteNode, dest.ZipRouteNode, options.Zip)).
+		Str("retryRouteNode", dest.RetryRouteNode).
 		Msg("resolved delivery job destination")
 	return true
 }
 
 func buildDestinationNavigationOverride(dest destination, zip bool) map[string]any {
-	return map[string]any{
+	override := map[string]any{
 		navigateDestinationNode: map[string]any{
 			"custom_action": "SubTask",
 			"custom_action_param": map[string]any{
 				"sub": []string{selectRouteNode(dest.RouteNode, dest.ZipRouteNode, zip)},
 			},
 		},
+		retryNavigateDestinationNode: map[string]any{
+			"enabled": false,
+		},
 	}
+	if dest.RetryRouteNode != "" {
+		override[retryNavigateDestinationNode] = map[string]any{
+			"enabled":       true,
+			"custom_action": "SubTask",
+			"custom_action_param": map[string]any{
+				"sub": []string{dest.RetryRouteNode},
+			},
+		}
+	}
+	return override
 }

--- a/agent/go-service/autodelivery/resolve_destination_test.go
+++ b/agent/go-service/autodelivery/resolve_destination_test.go
@@ -11,7 +11,7 @@ import (
 func TestBuildDeliveryNavigationOverrideSelectsGeneratedSubTask(t *testing.T) {
 	t.Parallel()
 
-	destination := destination{RouteNode: "normal", ZipRouteNode: "zip"}
+	destination := destination{RouteNode: "normal", ZipRouteNode: "zip", RetryRouteNode: "retry"}
 	override := buildDestinationNavigationOverride(destination, true)
 	node := override[navigateDestinationNode].(map[string]any)
 	if node["custom_action"] != "SubTask" {
@@ -19,6 +19,24 @@ func TestBuildDeliveryNavigationOverrideSelectsGeneratedSubTask(t *testing.T) {
 	}
 	if got := navigationParam(t, override, navigateDestinationNode)["sub"]; !reflect.DeepEqual(got, []string{"zip"}) {
 		t.Fatalf("destination dispatcher sub = %#v", got)
+	}
+	retryNode := override[retryNavigateDestinationNode].(map[string]any)
+	if retryNode["enabled"] != true || retryNode["custom_action"] != "SubTask" {
+		t.Fatalf("unexpected destination retry dispatcher: %#v", retryNode)
+	}
+	if got := navigationParam(t, override, retryNavigateDestinationNode)["sub"]; !reflect.DeepEqual(got, []string{"retry"}) {
+		t.Fatalf("destination retry dispatcher sub = %#v", got)
+	}
+}
+
+func TestBuildDeliveryNavigationOverrideDisablesMissingRetryRoute(t *testing.T) {
+	t.Parallel()
+
+	destination := destination{RouteNode: "normal", ZipRouteNode: "zip"}
+	override := buildDestinationNavigationOverride(destination, false)
+	retryNode := override[retryNavigateDestinationNode].(map[string]any)
+	if retryNode["enabled"] != false {
+		t.Fatalf("unexpected destination retry dispatcher: %#v", retryNode)
 	}
 }
 

--- a/assets/resource/pipeline/AutoDelivery/Delivery.json
+++ b/assets/resource/pipeline/AutoDelivery/Delivery.json
@@ -91,7 +91,8 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutoDeliverySubmitGoodsWaitFreezes"
+            "AutoDeliverySubmitGoodsWaitFreezes",
+            "AutoDeliverySearchSubmitGoodsButton"
         ],
         "focus": {
             "Node.Action.Starting": "正在前往当前送货目标",
@@ -102,6 +103,38 @@
                 "trace": true
             }
         }
+    },
+    "AutoDeliverySearchSubmitGoodsButton": {
+        "desc": "到达送货目标后未找到交货按钮时，环绕微调站位并持续查找按钮",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "CharacterSearchAction",
+        "custom_action_param": {
+            "wait_nodes": [
+                "AutoDeliverySubmitGoodsWaitFreezes"
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoDeliverySubmitGoodsWaitFreezes"
+        ],
+        "on_error": [
+            "AutoDeliveryRetryNavigateDestination"
+        ]
+    },
+    "AutoDeliveryRetryNavigateDestination": {
+        "desc": "动态调用送货目标配置的一次性站位修正路线；无重试路线时不启用",
+        "enabled": false,
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "FalseAction",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoDeliverySubmitGoodsWaitFreezes"
+        ]
     },
     "AutoDeliverySubmitGoodsWaitFreezes": {
         "desc": "在送货目标附近识别交互按钮，并等待交互按钮稳定",

--- a/assets/resource/pipeline/AutoDelivery/Pickup.json
+++ b/assets/resource/pipeline/AutoDelivery/Pickup.json
@@ -245,12 +245,32 @@
         }
     },
     "AutoDeliveryFetchGoods": {
-        "desc": "识别并接取货物；按钮未出现时允许执行一次仓储私有重试路线",
+        "desc": "识别并接取货物；按钮未出现时先环绕搜索，再允许执行一次仓储私有重试路线",
         "pre_delay": 0,
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
             "AutoDeliveryFetchGoodsButtonWaitFreezes",
+            "AutoDeliverySearchFetchGoodsButton"
+        ]
+    },
+    "AutoDeliverySearchFetchGoodsButton": {
+        "desc": "仓储节点到达后未找到接取货物按钮时，环绕微调站位并持续查找按钮",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "CharacterSearchAction",
+        "custom_action_param": {
+            "wait_nodes": [
+                "AutoDeliveryFetchGoodsButtonWaitFreezes"
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoDeliveryFetchGoodsButtonWaitFreezes"
+        ],
+        "on_error": [
             "AutoDeliveryRetryNavigateDepot"
         ]
     },

--- a/tools/pipeline-generate/AutoDelivery/README.md
+++ b/tools/pipeline-generate/AutoDelivery/README.md
@@ -13,6 +13,6 @@ pnpm generate:AutoDelivery
 
 完整送货业务调用方仍只进入 `AutoDelivery`。生成的 `AutoDeliveryRoute...` 节点是公开的单路线测试入口，可在节点测试工具中单独运行；正常流程由 Go Service 识别当前仓储/终点后，通过固定 `SubTask` 分发节点动态调用。
 
-运行生成命令时，`sync-routes.mjs` 会按 `source_id` 刷新仓储的 `name` 以及终点的 `name` / `depot_id`，为游戏数据中的新增项补充 metadata-only 条目，并保留已有的 `description` / `path` / `retry_path` / `departure_path` 人工字段。
+运行生成命令时，`sync-routes.mjs` 会按 `source_id` 刷新仓储的 `name` 以及终点的 `name` / `depot_id`，为游戏数据中的新增项补充 metadata-only 条目，并保留已有的人工字段。仓储和终点都支持 `description` / `path` / `retry_path`；`departure_path` 仅用于仓储，并会拼接到该仓储所有终点主路线之前。
 
 修改 `routes.json` 时只使用 MapNavigator 工具实测得到的路径。普通可达目标仅保留同步出的元数据，由生成器使用游戏数据坐标生成单个 `NAVMESH` 点；跨层、断网格、交互或需要站位修正的路线才填写对应的路径覆盖。不要为了补齐字段而复制默认坐标。

--- a/tools/pipeline-generate/AutoDelivery/data.test.mjs
+++ b/tools/pipeline-generate/AutoDelivery/data.test.mjs
@@ -44,7 +44,19 @@ test("AutoDelivery 路线同步刷新元数据并保留人工覆盖字段", () =
                     ],
                 },
             ],
-            destinations: [],
+            destinations: [
+                {
+                    source_id: "destination-1",
+                    name: "旧终点名",
+                    depot_id: "old-depot",
+                    retry_path: [
+                        [
+                            3,
+                            4,
+                        ],
+                    ],
+                },
+            ],
         },
     );
 
@@ -70,6 +82,12 @@ test("AutoDelivery 路线同步刷新元数据并保留人工覆盖字段", () =
             source_id: "destination-1",
             name: "终点一",
             depot_id: "depot-1",
+            retry_path: [
+                [
+                    3,
+                    4,
+                ],
+            ],
         },
     ]);
 });
@@ -110,7 +128,10 @@ test("AutoDelivery routes.json 同步完整检索元数据并仅为必要项保�
 });
 
 test("AutoDelivery 路线为每个仓储和终点生成可独立执行的普通/滑索节点", () => {
-    const retryCount = depots.filter((item) => item.retryRouteNode).length;
+    const retryCount = [
+        ...depots,
+        ...destinations,
+    ].filter((item) => item.retryRouteNode).length;
     assert.equal(routeRows.length, depots.length * 2 + destinations.length * 2 + retryCount);
     assert.equal(new Set(routeRows.map((item) => item.Node)).size, routeRows.length);
     for (const row of routeRows) {

--- a/tools/pipeline-generate/AutoDelivery/model.mjs
+++ b/tools/pipeline-generate/AutoDelivery/model.mjs
@@ -129,8 +129,10 @@ export const destinations = assertArray(catalogSource.destinations, "delivery_de
                 ...depot.departurePath,
                 ...ownPath,
             ],
+            retryPath: override?.retry_path ?? [],
             routeNode: buildRouteNode("Destination", id),
             zipRouteNode: buildRouteNode("Destination", id, true),
+            retryRouteNode: override?.retry_path?.length ? buildRouteNode("DestinationRetry", id) : "",
         };
     })
     .sort((left, right) => left.id.localeCompare(right.id));
@@ -165,6 +167,7 @@ export const runtimeCatalog = {
         area: item.area,
         route_node: item.routeNode,
         zip_route_node: item.zipRouteNode,
+        ...(item.retryRouteNode ? {retry_route_node: item.retryRouteNode} : {}),
     })),
 };
 

--- a/tools/pipeline-generate/AutoDelivery/routes-data.mjs
+++ b/tools/pipeline-generate/AutoDelivery/routes-data.mjs
@@ -34,13 +34,22 @@ export default [
               ]
             : []),
     ]),
-    ...destinations.flatMap((destination) =>
-        buildRows(
+    ...destinations.flatMap((destination) => [
+        ...buildRows(
             destination.id,
             `AutoDelivery 终点路线：从${destination.depotName}仓储节点前往${destination.name.zh_cn}`,
             destination.path,
             destination.routeNode,
             destination.zipRouteNode,
         ),
-    ),
+        ...(destination.retryRouteNode
+            ? [
+                  {
+                      Node: destination.retryRouteNode,
+                      Description: `AutoDelivery 终点站位修正路线：${destination.name.zh_cn}（${destination.id}）`,
+                      ActionParam: rawJson({path: destination.retryPath}),
+                  },
+              ]
+            : []),
+    ]),
 ];

--- a/tools/pipeline-generate/DeliveryJobs/data.test.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/data.test.mjs
@@ -992,6 +992,16 @@ test("AutoDelivery keeps its task-detail entry and default branch flow explicit"
     ]);
     assert.deepEqual(pickup.AutoDeliveryFetchGoods.next, [
         "AutoDeliveryFetchGoodsButtonWaitFreezes",
+        "AutoDeliverySearchFetchGoodsButton",
+    ]);
+    assert.equal(pickup.AutoDeliverySearchFetchGoodsButton.custom_action, "CharacterSearchAction");
+    assert.deepEqual(pickup.AutoDeliverySearchFetchGoodsButton.custom_action_param.wait_nodes, [
+        "AutoDeliveryFetchGoodsButtonWaitFreezes",
+    ]);
+    assert.deepEqual(pickup.AutoDeliverySearchFetchGoodsButton.next, [
+        "AutoDeliveryFetchGoodsButtonWaitFreezes",
+    ]);
+    assert.deepEqual(pickup.AutoDeliverySearchFetchGoodsButton.on_error, [
         "AutoDeliveryRetryNavigateDepot",
     ]);
     assert.equal(pickup.AutoDeliveryRetryNavigateDepot.enabled, false);
@@ -1146,6 +1156,22 @@ test("AutoDelivery keeps its task-detail entry and default branch flow explicit"
     assert.equal(delivery.AutoDeliveryNavigateDestination.custom_action_param, undefined);
     assert.deepEqual(delivery.AutoDeliveryNavigateDestination.next, [
         "AutoDeliverySubmitGoodsWaitFreezes",
+        "AutoDeliverySearchSubmitGoodsButton",
+    ]);
+    assert.equal(delivery.AutoDeliverySearchSubmitGoodsButton.custom_action, "CharacterSearchAction");
+    assert.deepEqual(delivery.AutoDeliverySearchSubmitGoodsButton.custom_action_param.wait_nodes, [
+        "AutoDeliverySubmitGoodsWaitFreezes",
+    ]);
+    assert.deepEqual(delivery.AutoDeliverySearchSubmitGoodsButton.next, [
+        "AutoDeliverySubmitGoodsWaitFreezes",
+    ]);
+    assert.deepEqual(delivery.AutoDeliverySearchSubmitGoodsButton.on_error, [
+        "AutoDeliveryRetryNavigateDestination",
+    ]);
+    assert.equal(delivery.AutoDeliveryRetryNavigateDestination.enabled, false);
+    assert.equal(delivery.AutoDeliveryRetryNavigateDestination.custom_action, "FalseAction");
+    assert.deepEqual(delivery.AutoDeliveryRetryNavigateDestination.next, [
+        "AutoDeliverySubmitGoodsWaitFreezes",
     ]);
     assert.deepEqual(delivery.AutoDeliverySubmitGoodsWaitFreezes.pre_wait_freezes, {
         time: 300,
@@ -1178,8 +1204,28 @@ test("AutoDelivery keeps its task-detail entry and default branch flow explicit"
     assert.equal(JSON.stringify(pickup).includes('"anchor"'), false);
     assert.equal(JSON.stringify(delivery).includes('"anchor"'), false);
     assert.equal(JSON.stringify(common).includes('"on_error"'), false);
-    assert.equal(JSON.stringify(pickup).includes('"on_error"'), false);
-    assert.equal(JSON.stringify(delivery).includes('"on_error"'), false);
+    assert.deepEqual(
+        Object.entries(pickup)
+            .filter(
+                ([
+                    ,
+                    node,
+                ]) => node.on_error !== undefined,
+            )
+            .map(([nodeName]) => nodeName),
+        ["AutoDeliverySearchFetchGoodsButton"],
+    );
+    assert.deepEqual(
+        Object.entries(delivery)
+            .filter(
+                ([
+                    ,
+                    node,
+                ]) => node.on_error !== undefined,
+            )
+            .map(([nodeName]) => nodeName),
+        ["AutoDeliverySearchSubmitGoodsButton"],
+    );
     assert.equal(JSON.stringify(pickup).includes("MapLocateAssertLocation"), false);
 
     assert.equal(JSON.stringify(common).includes("SeizeDeliveryJobs"), false);

--- a/tools/schema/auto_delivery_routes.schema.json
+++ b/tools/schema/auto_delivery_routes.schema.json
@@ -80,6 +80,9 @@
                     },
                     "path": {
                         "$ref": "#/$defs/path"
+                    },
+                    "retry_path": {
+                        "$ref": "#/$defs/path"
                     }
                 }
             }

--- a/tools/sentry/auto_delivery_report.py
+++ b/tools/sentry/auto_delivery_report.py
@@ -76,6 +76,7 @@ FAILURE_LABELS = {
     "AutoDeliveryReturnWorldAndNavigateDepot": "返回大世界并准备仓储导航",
     "AutoDeliveryNavigateDepot": "前往仓储节点",
     "AutoDeliveryFetchGoods": "接取货物",
+    "AutoDeliverySearchFetchGoodsButton": "环绕查找接取货物按钮",
     "AutoDeliveryFetchGoodsButtonWaitFreezes": "识别接取货物按钮",
     "AutoDeliveryFetchGoodsButton": "点击接取货物",
     "AutoDeliveryFetchGoodsDone": "确认已携带货物",
@@ -95,6 +96,8 @@ FAILURE_LABELS = {
     "AutoDeliveryCurrentJobTrackingGone": "确认送货任务追踪标记已消失",
     "AutoDeliveryReturnWorldAndNavigateDestination": "返回大世界并准备终点导航",
     "AutoDeliveryNavigateDestination": "前往送货目标",
+    "AutoDeliverySearchSubmitGoodsButton": "环绕查找交货按钮",
+    "AutoDeliveryRetryNavigateDestination": "送货目标站位重试",
     "AutoDeliverySubmitGoodsWaitFreezes": "识别交货按钮",
     "AutoDeliverySubmitGoods": "提交货物",
     "AutoDeliveryIsInChatDialog": "识别送货对话",
@@ -232,6 +235,7 @@ def load_route_definitions(path: Path) -> dict[str, RouteDefinition]:
         node_names = (
             f"AutoDeliveryRouteDestination{node_id}",
             f"AutoDeliveryRouteDestination{node_id}WithZipline",
+            f"AutoDeliveryRouteDestinationRetry{node_id}",
         )
         definition = RouteDefinition(
             route_id=route_id,


### PR DESCRIPTION
## 改动

- 仓储节点和送货目标到达后未识别到交互按钮时，先调用 `CharacterSearchAction` 环绕微调并持续查找按钮。
- 仅在环绕搜索仍失败后进入对应的 retry route，重试路线结束后重新识别按钮。
- 为送货目标补齐 `retry_path` 的 Schema、路线生成、运行时目录和 Go Service 动态注入支持，生成节点命名为 `AutoDeliveryRouteDestinationRetry...`。
- 同步更新生成契约测试、Sentry 失败节点标签及路线聚合，避免目标重试节点被统计为未知路线。

## 原因

MapNavigator 成功抵达坐标不代表角色已经处于可显示交互按钮的准确站位或朝向。先进行有识别反馈的站位搜索，可以避免按钮暂未出现时直接执行较重的重试路线，同时保留搜索失败后的明确兜底。

具体终点仍需在 `tools/pipeline-generate/AutoDelivery/routes.json` 中填写实测 `retry_path` 才会启用对应重试节点；本次未添加未经实机测量的路线坐标。

## 验证

- `node --test tools/pipeline-generate/AutoDelivery/data.test.mjs tools/pipeline-generate/DeliveryJobs/data.test.mjs`：29/29 通过
- `go test ./autodelivery`：通过
- `pnpm format:check`：通过
- `pnpm check`：通过
- `pnpm test`：780/780 完成，未生成 `tests/maatools/error_details.json`
- `python -m py_compile tools/sentry/auto_delivery_report.py`：通过
- `git diff --check`：通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 自动取货和交货时新增环绕搜索按钮流程，提升按钮识别成功率。
  - 交货导航失败时支持配置专用重试路线，并自动返回交货等待流程。
  - 支持为目的地配置可选的重试路线。

- **改进**
  - 错误处理和导航状态标识更加清晰，便于识别各类自动投递失败节点。
  - 更新路线配置说明及相关校验，确保重试路线配置有效。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->