### PR TITLE
fix(MapLocator): 小地图箭头被遮挡时拒绝该帧

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -807,6 +807,10 @@ private:
     std::uint64_t frameId = 0;
     std::uint64_t activeFrameId = 0;
 
+    // 小地图被遮挡的起始时刻，未遮挡时为默认值；超时放行后置位以免重复打日志
+    TimePoint occludedSince {};
+    bool occlusionTimedOut = false;
+
     std::vector<MapPosition> coldStartBuffer;
     std::optional<MapPosition> stablePosition;
 
@@ -1801,6 +1805,27 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
         return *resolvedAngle;
     };
 
+    // 角色箭头画在小地图最上层，正常一定看得见；看不见只能是有东西整个盖住了小地图。
+    // 这种帧的匹配分数面已被遮挡重塑，最高峰可能落在别处，所以整帧作废让上层原地等它散开
+    // （拿不到位置时导航本来就会停步重试），超时后改为放行，避免长期遮挡处彻底卡死。
+    if (resolveAngle() < 0.0) {
+        if (occludedSince == TimePoint {}) {
+            occludedSince = now;
+            occlusionTimedOut = false;
+            LogWarn << "Minimap occluded: character arrow not visible; holding until it clears.";
+        }
+        if (now - occludedSince < std::chrono::milliseconds(kOcclusionRejectTimeoutMs)) {
+            return LocateResult { .status = LocateStatus::ScreenBlocked, .debugMessage = "Minimap occluded: arrow not visible." };
+        }
+        if (!occlusionTimedOut) {
+            occlusionTimedOut = true;
+            LogWarn << "Minimap occlusion outlasted the reject timeout; locating on occluded frames again.";
+        }
+    }
+    else {
+        occludedSince = {};
+    }
+
     std::optional<YoloCoarseResult> angleGuardCoarse;
     FrameTemplateFeatureCache featureCache;
     std::optional<AsyncYoloHandle> sameFrameYolo;
@@ -2058,6 +2083,7 @@ void MapLocator::Impl::resetTrackingState()
         motionTracker->clearVelocity();
     }
     currentZoneId = "";
+    occludedSince = {};
     coldStartBuffer.clear();
     stablePosition.reset();
     arbiterRejectedPrimary.reset();

--- a/agent/cpp-algo/source/MapLocator/MapTypes.h
+++ b/agent/cpp-algo/source/MapLocator/MapTypes.h
@@ -158,6 +158,10 @@ constexpr double kHighConfidenceOverride = 0.85;  // 压倒分：远跳但此分
 constexpr const char* kColdStartCollectingMessage = "Cold-start collecting.";
 constexpr double kSeamFallbackMinPeakScore = 0.0;
 
+// 小地图被遮挡时最长拒绝多久，超时放行以免长期被遮挡的点位彻底卡死。
+// 实测遮挡自行消散耗时 2.8~4.2s，取 5s 留余量；上界是导航起步等待定位的 10s 预算。
+constexpr int kOcclusionRejectTimeoutMs = 5000;
+
 // tracking 匹配低于此分时通知上层考虑改走全局搜索
 constexpr double kFastTrackingPassScore = 0.75;
 constexpr double kStableDeadband = 0.15;


### PR DESCRIPTION
- close #4987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化小地图被遮挡时的定位处理：遮挡期间暂缓定位，持续超过 5 秒后自动恢复定位。
  * 小地图恢复可见后，系统会自动清除遮挡状态，提升后续定位准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->