### PR TITLE
fix(EnvironmentMonitoring): 修正小壳兽拍摄路线

### DIFF
--- a/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
+++ b/assets/resource/pipeline/EnvironmentMonitoring/OutskirtsMonitoringTerminal/MiniShellbeast.json
@@ -226,7 +226,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToMiniShellbeast"
+            "MiniShellbeastInQuickTeleportMap"
         ]
     },
     "AlreadyTrackedMiniShellbeast": {
@@ -240,7 +240,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "GoToMiniShellbeast"
+            "MiniShellbeastOpenTrackedMissionMap"
         ]
     },
     "MiniShellbeastOpenTrackedMissionMap": {
@@ -350,10 +350,10 @@
         "custom_recognition_param": {
             "zone_id": "Wuling_Base",
             "target": [
-                523.06,
-                1739.74,
-                14.98,
-                14.38
+                0,
+                0,
+                1,
+                1
             ]
         },
         "pre_delay": 0,
@@ -370,7 +370,7 @@
         "custom_action": "SubTask",
         "custom_action_param": {
             "sub": [
-                "SceneEnterWorldWulingWulingCity4"
+                "SceneAnyEnterWorld"
             ]
         },
         "post_delay": 0,
@@ -387,19 +387,15 @@
         "custom_action_param": {
             "path": [
                 {
-                    "action": "ZONE",
-                    "zone_id": "Wuling_Base"
-                },
-                {
                     "action": "NAVMESH",
                     "target": [
-                        501.88,
-                        1748.21
+                        467.7,
+                        1751.95
                     ]
                 },
                 {
                     "action": "HEADING",
-                    "angle": 15
+                    "angle": 182
                 }
             ]
         },

--- a/tools/pipeline-generate/EnvironmentMonitoring/routes.json
+++ b/tools/pipeline-generate/EnvironmentMonitoring/routes.json
@@ -270,24 +270,13 @@
         "MissionId": "m1m56",
         "Name": "小壳兽",
         "Id": "MiniShellbeast",
-        "EnterMap": "SceneEnterWorldWulingWulingCity4",
-        "NavZoneId": "Wuling_Base",
-        "NavAssert": [
-            523.06,
-            1739.74,
-            14.98,
-            14.38
-        ],
+        "QuickTeleport": true,
         "NavPath": [
-            {
-                "action": "ZONE",
-                "zone_id": "Wuling_Base"
-            },
             {
                 "action": "NAVMESH",
                 "target": [
-                    501.88,
-                    1748.21
+                    467.7,
+                    1751.95
                 ]
             }
         ],
@@ -297,7 +286,7 @@
                 "壳"
             ]
         ],
-        "Heading": 15
+        "Heading": 182
     },
     {
         "MissionId": "m1m57",


### PR DESCRIPTION
## 问题

当前的拍摄位置，小壳兽有时可能不存在。

## 改动

- 将“小壳兽”改为从已追踪任务地图使用快捷传送，开始追踪与已追踪两种状态都会进入对应的任务地图传送流程，不再依赖固定的武陵城传送入口。
- 使用本次实测路线数据，将快捷传送后的 NAVMESH 目标更新为 `(467.7, 1751.95)`，并将最终朝向调整为 182°，使角色抵达有效拍摄位置后再进入拍照流程。
- 移除快捷传送路线不再需要的 `NavZoneId`、`NavAssert` 和前置 `ZONE`，由 MapNavigator 从当前落点自动确定起始区域。
- 在 `tools/pipeline-generate/EnvironmentMonitoring/routes.json` 维护源数据，并重新生成对应 Pipeline，确保配置源与运行资源一致。

本次修复直接调整传送入口、导航终点和拍摄朝向，没有增加硬延迟、盲目重试或额外相机扫描。

## 验证

- `pnpm generate:EnvironmentMonitoring`：生成 32 条路线、800 个任务节点，0 个诊断问题
- `node .agents/skills/environment-monitoring-add-route/check_missing.mjs`：所有观察点均已完整适配
- `pnpm format`
- `pnpm check`
- `pnpm test`：780 / 780 通过，包含 ADB 与 Win32 环境监测测试
- `git diff --check`

Fixes #5142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化“小壳兽”任务的追踪与已追踪流程，分别进入快捷传送地图。
  - 改进非起始位置下的任务接入方式，提升流程兼容性。
  - 优化自动寻路路线，取消不必要的区域切换，更新导航位置与朝向。
  - 提升前往目标地点时的导航准确性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->