### PR TITLE
feat(WorldMap): MapFind 识别前自动把地图缩到最小

### DIFF
--- a/agent/cpp-algo/source/WorldMap/WorldMapFind.cpp
+++ b/agent/cpp-algo/source/WorldMap/WorldMapFind.cpp
@@ -84,6 +84,13 @@ constexpr int kPinStreak = 3;
 constexpr int kMaxNudges = 6;
 constexpr double kNudgeRatio = 0.35;
 
+// 缩放档位是视口求解的未知量，进来先压到最小钉死。按钮坐标各端不同，
+// 所以复用 pipeline 那个节点而不在这儿抄一份
+constexpr const char* kZoomOutNode = "__ScenePrivateMapZoomOut";
+constexpr int kZoomOutMaxRounds = 10;
+constexpr int kZoomOutConfirmMisses = 3;
+constexpr int kZoomOutMissGapMillis = 400;
+
 bool ParseParam(const char* raw, FindParam* out)
 {
     if (raw == nullptr || std::strlen(raw) == 0) {
@@ -165,6 +172,61 @@ bool CaptureScreen(MaaController* controller, ScopedImageBuffer* buffer, cv::Mat
 
     *out = to_mat(buffer->Get());
     return !out->empty();
+}
+
+enum class ZoomOutResult
+{
+    Pressed,       // 认到减号，按了一下
+    NotRecognized, // 没认到：可能已到底，也可能只是那一帧没画完
+    Undispatched,  // 子任务没发出去，再试也发不出去
+};
+
+// timeout 压成 0：否则入口认不中时框架会重扫满默认 20 秒。
+// 判不出来当作还能缩——误判成「已最小」会让视口求解必然失败，多按一次只是白按
+ZoomOutResult PressZoomOutOnce(MaaContext* context)
+{
+    const std::string overrides =
+        json::value(json::object { { kZoomOutNode, json::object { { "timeout", 0 } } } }).dumps();
+
+    const MaaTaskId task_id = MaaContextRunTask(context, kZoomOutNode, overrides.c_str());
+    if (task_id == MaaInvalidId) {
+        LogWarn << "WorldMap: zoom-out subtask failed to dispatch" << VAR(kZoomOutNode);
+        return ZoomOutResult::Undispatched;
+    }
+
+    MaaTasker* tasker = MaaContextGetTasker(context);
+    ScopedStringBuffer entry;
+    constexpr MaaSize kNodeCap = 8;
+    MaaNodeId nodes[kNodeCap] {};
+    MaaSize node_count = kNodeCap;
+    MaaStatus status = MaaStatus_Invalid;
+    if (tasker == nullptr || !MaaTaskerGetTaskDetail(tasker, task_id, entry.Get(), nodes, &node_count, &status)) {
+        LogWarn << "WorldMap: zoom-out status unavailable, keeping on zooming" << VAR(task_id);
+        return ZoomOutResult::Pressed;
+    }
+    return status == MaaStatus_Failed ? ZoomOutResult::NotRecognized : ZoomOutResult::Pressed;
+}
+
+// 认到就接着按，一路按到底。认不到不等于已经到底（那一帧可能只是动画没画完），
+// 所以隔开确认几次才收手
+void ZoomMapOut(MaaContext* context)
+{
+    int misses = 0;
+    for (int round = 0; round < kZoomOutMaxRounds; ++round) {
+        const ZoomOutResult result = PressZoomOutOnce(context);
+        if (result == ZoomOutResult::Undispatched) {
+            return;
+        }
+        if (result == ZoomOutResult::Pressed) {
+            misses = 0;
+            continue;
+        }
+        if (++misses >= kZoomOutConfirmMisses) {
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(kZoomOutMissGapMillis));
+    }
+    LogWarn << "WorldMap: zoom-out never settled" << VAR(kZoomOutMaxRounds);
 }
 
 double RandomIn(double lo, double hi)
@@ -280,7 +342,7 @@ MaaBool MAA_CALL MapFindRun(
     [[maybe_unused]] const char* node_name,
     [[maybe_unused]] const char* custom_recognition_name,
     const char* custom_recognition_param,
-    const MaaImageBuffer* image,
+    [[maybe_unused]] const MaaImageBuffer* image,
     [[maybe_unused]] const MaaRect* roi_param,
     [[maybe_unused]] void* trans_arg,
     MaaRect* out_box,
@@ -325,9 +387,11 @@ MaaBool MAA_CALL MapFindRun(
     LogInfo << "WorldMap: find" << VAR(param.zone) << VAR(target.x) << VAR(target.y) << VAR(param.icon) << VAR(param.state)
             << VAR(param.max_attempts);
 
-    // 框架给的这一帧白拿，先用它。之后每挪一次地图都得重截
+    ZoomMapOut(context);
+
+    // 缩放那几趟自己会截屏，框架给进来的那一帧已过期
     ScopedImageBuffer buffer;
-    cv::Mat screen = image != nullptr ? to_mat(image) : cv::Mat();
+    cv::Mat screen;
 
     int attempt = 0;
     int pans = 0;

--- a/docs/en_us/developers/components/world-map.md
+++ b/docs/en_us/developers/components/world-map.md
@@ -9,7 +9,7 @@ It shares its template matching core and its base map images with [MapLocator](.
 - [Wiring up teleport points](#wiring-up-teleport-points)
 - [How recognition works](#how-recognition-works)
 
-WorldMap is a recognition layer. It only resolves a coordinate into a screen position on an already open map. Opening the map, switching layers and setting the zoom are the job of [SceneManager](../scene-manager.md); the confirmation dialog afterwards is handled by the Pipeline.
+WorldMap is a recognition layer. It only resolves a coordinate into a screen position on an already open map. Opening the map and switching layers are the job of [SceneManager](../scene-manager.md); the confirmation dialog afterwards is handled by the Pipeline. The zoom it sets itself, see below.
 
 ---
 
@@ -17,7 +17,9 @@ WorldMap is a recognition layer. It only resolves a coordinate into a screen pos
 
 Find the given coordinate on the current map, and confirm the icon sitting there if an icon name was given.
 
-The node captures the screen itself, solves the viewport, and pans the map when needed, until the target is inside the usable area. **Once `icon` is given, no confirmation means no coordinate** — being able to compute a position does not mean anything is there. It would rather fail and let the caller retry or take another candidate than hand back a computed empty spot. Without an `icon` it just solves the coordinate and hands it back, making no such promise.
+The node zooms the map all the way out first, then captures the screen itself, solves the viewport, and pans the map when needed, until the target is inside the usable area. **Once `icon` is given, no confirmation means no coordinate** — being able to compute a position does not mean anything is there. It would rather fail and let the caller retry or take another candidate than hand back a computed empty spot. Without an `icon` it just solves the coordinate and hands it back, making no such promise.
+
+The zoom level is the unknown the viewport solve has to sweep its scale band for, so pinning it down is the first thing the node does: it keeps running the Pipeline's `__ScenePrivateMapZoomOut`, pressing again for as long as the minus button is recognised. Once the minus button has greyed out — nothing left to zoom — that node no longer recognises and not a single touch goes out. But **failing to recognise it is not proof of having bottomed out**: that one frame may just be mid-animation, and believing the map is at its minimum when it is not makes the viewport solve fail every time. So it takes several spaced-out confirmations before it stops, and anything it cannot judge counts as "still zoomable". Writing `__ScenePrivateMapZoomOut` into the Pipeline is therefore optional: with it the zoom is already done, without it the node does it. The button sits at different coordinates on each client, so it follows the resource layers; the node itself carries no coordinates.
 
 ### Node parameters
 
@@ -130,9 +132,9 @@ Two entries exist today:
 
 ## Wiring up teleport points
 
-Teleport nodes live in `assets/resource/pipeline/SceneManager/SceneTeleport<Zone>.json` and fill the `__ScenePrivateMapTeleportPickAnchor` slot; entry nodes live in `Interface/Scene<Zone>.json`, bind that slot and route through `__ScenePrivateMap<SubArea>EnterWorldAnchorWithPick`, which switches the map to its main layer, sets a non-extreme zoom, and uses `all_of` to confirm that this really is that sub-area's map screen.
+Teleport nodes live in `assets/resource/pipeline/SceneManager/SceneTeleport<Zone>.json` and fill the `__ScenePrivateMapTeleportPickAnchor` slot; entry nodes live in `Interface/Scene<Zone>.json`, bind that slot and route through `__ScenePrivateMap<SubArea>EnterWorldAnchorWithPick`, which switches the map to its main layer, uses `all_of` to confirm that this really is that sub-area's map screen, and gives the zoom a head start on the way.
 
-The zoom step cannot be skipped: pushed to either end of its range, the patch of screen fed to the viewport solver holds too little terrain to resolve a unique viewport.
+The `__ScenePrivateMapZoomOut` in the entry node is a head start, not a requirement: `MapFind` zooms out on its own. Copy an existing entry when wiring up a new point; leaving it out costs nothing in recognition.
 
 The sub-area check lives on `...EnterWorldAnchorWithPick`; the `MapFind` node no longer repeats it — the `recognition` slot went to `MapFind`, and solving the viewport is itself the stronger test of "are we on this map at all".
 

--- a/docs/zh_cn/developers/components/world-map.md
+++ b/docs/zh_cn/developers/components/world-map.md
@@ -9,7 +9,7 @@ WorldMap 是基于原生 C++ 实现的大地图坐标识别系统。节点只需
 - [传送点接线](#传送点接线)
 - [识别原理](#识别原理)
 
-WorldMap 属于识别层，只负责在已经打开的大地图上把坐标解成屏幕位置。打开地图、切图层、调缩放由 [SceneManager](../scene-manager.md) 的万能跳转负责，点完之后的确认弹窗也由 Pipeline 接管。
+WorldMap 属于识别层，只负责在已经打开的大地图上把坐标解成屏幕位置。打开地图、切图层由 [SceneManager](../scene-manager.md) 的万能跳转负责，点完之后的确认弹窗也由 Pipeline 接管；缩放是它自己调的，见下。
 
 ---
 
@@ -17,7 +17,9 @@ WorldMap 属于识别层，只负责在已经打开的大地图上把坐标解�
 
 在当前大地图画面上找到指定坐标，给了图标名的话再确认那里的图标。
 
-节点执行时会自行截图、求解视口、必要时拖动地图，直到目标进入可用区域为止。**给了 `icon` 时，确认不到图标就不给坐标**——算得出位置不等于那里有东西，宁可返回失败让上层重试或走别的候选，也不交一个算出来的空位置。不给 `icon` 时只把坐标解出来交回，不作这层担保。
+节点执行时会先把地图缩到最小，再自行截图、求解视口、必要时拖动地图，直到目标进入可用区域为止。**给了 `icon` 时，确认不到图标就不给坐标**——算得出位置不等于那里有东西，宁可返回失败让上层重试或走别的候选，也不交一个算出来的空位置。不给 `icon` 时只把坐标解出来交回，不作这层担保。
+
+缩放档位是视口求解要在尺度带里扫出来的那个未知量，所以节点进来第一件事就是把它钉死：反复跑 pipeline 的 `__ScenePrivateMapZoomOut`，认到减号就接着按，一路按到底。减号已经灰了（缩不动了）时那个节点认不中，一次触控都不会发出去。但**认不到不等于已经到底**——那一帧可能只是动画没画完，而「以为最小、其实没缩到」会让后面的视口求解必然失败，所以要隔开几帧连着确认几次才收手；判不出来的时候一律当作还能缩。因此 pipeline 里写不写 `__ScenePrivateMapZoomOut` 都行：写了是提前缩好，不写这里也会缩。按钮坐标各端不同，它跟着资源层走，节点自己不带坐标。
 
 ### 节点参数
 
@@ -130,9 +132,9 @@ WorldMap 属于识别层，只负责在已经打开的大地图上把坐标解�
 
 ## 传送点接线
 
-传送点节点写在 `assets/resource/pipeline/SceneManager/SceneTeleport<区域>.json`，填进 `__ScenePrivateMapTeleportPickAnchor` 槽位；入口节点写在 `Interface/Scene<区域>.json`，绑定该槽位并经由 `__ScenePrivateMap<子区域>EnterWorldAnchorWithPick` 进入——后者负责把地图切到主图层、调到非极端缩放，并用 `all_of` 确认当前确实在该子区域的地图界面。
+传送点节点写在 `assets/resource/pipeline/SceneManager/SceneTeleport<区域>.json`，填进 `__ScenePrivateMapTeleportPickAnchor` 槽位；入口节点写在 `Interface/Scene<区域>.json`，绑定该槽位并经由 `__ScenePrivateMap<子区域>EnterWorldAnchorWithPick` 进入——后者负责把地图切到主图层，并用 `all_of` 确认当前确实在该子区域的地图界面，顺带先往最小缩一把。
 
-缩放这一步不能省：缩放条推到两端时，参与视口求解的那块画面里地形太少，解不出唯一的视口。
+入口里那条 `__ScenePrivateMapZoomOut` 是提前量、不是必需品：`MapFind` 自己会缩。新接的点照着现有入口抄一份就行，漏了也不会因此认不出来。
 
 子区域的确认闸在 `...EnterWorldAnchorWithPick` 上，`MapFind` 节点自己不再重复一遍——`recognition` 槽位让给了 `MapFind`，而视口求解本身就是更强的「在不在这张图上」判据。
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 地图查找会自动将地图缩放至最远视野后再进行识别和视口定位。
  * 增加对地图缩小按钮的重复确认机制，无法判断状态时会继续尝试。

* **改进**
  * 地图缩放预处理步骤改为可选，遗漏时仍可正常完成地图识别。
  * 更新中英文开发文档，明确地图缩放与传送流程的职责。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->