### PR TITLE
fix(essencefilter): 修复基质网格首帧列识别

### DIFF
--- a/agent/cpp-algo/source/RecoGrid/GridDetector.cpp
+++ b/agent/cpp-algo/source/RecoGrid/GridDetector.cpp
@@ -133,7 +133,7 @@ std::vector<Segment> MergeCloseSegments(const std::vector<Segment>& segments, in
 std::vector<Segment> DetectColsFromDarkSeparators(const cv::Mat& binary, const GridDetectOptions& options)
 {
     std::vector<Segment> cols;
-    if (binary.empty() || options.lockedColWidth <= 0) {
+    if (binary.empty()) {
         return cols;
     }
 
@@ -162,7 +162,7 @@ std::vector<Segment> DetectColsFromDarkSeparators(const cv::Mat& binary, const G
     const int minLength = static_cast<int>(std::round(static_cast<double>(options.lockedColWidth) * options.minKeptSegmentRatio));
     const int maxLength =
         static_cast<int>(std::round(static_cast<double>(options.lockedColWidth) * (1.0 + options.lockedSegmentTolerance)));
-    if (minLength <= 0 || maxLength < minLength) {
+    if (options.lockedColWidth > 0 && (minLength <= 0 || maxLength < minLength)) {
         return cols;
     }
 
@@ -171,7 +171,7 @@ std::vector<Segment> DetectColsFromDarkSeparators(const cv::Mat& binary, const G
         const Segment& right = separators[i + 1];
         const Segment col { left.end, right.start };
         const int length = SegmentLength(col);
-        if (length >= minLength && length <= maxLength) {
+        if (options.lockedColWidth <= 0 || (length >= minLength && length <= maxLength)) {
             cols.push_back(col);
         }
     }
@@ -362,7 +362,7 @@ GridResult DetectGrid(const cv::Mat& image, const GridDetectOptions& options)
         options.lockedSegmentTolerance,
         result.minColWidth);
     std::vector<Segment> darkColSegments = DetectColsFromDarkSeparators(result.binary, options);
-    if (!darkColSegments.empty() && options.lockedColWidth > 0 && darkColSegments.size() >= brightColSegments.size()) {
+    if (!darkColSegments.empty()) {
         colSegments = darkColSegments;
     }
     else {


### PR DESCRIPTION
## 改动

- 允许 RecoGrid 在首帧直接使用暗色分隔线识别列
- 暗色列结果非空时优先使用，亮度投影仅作为兜底
- 已锁定列宽时继续保留原有宽度过滤

Issue #5208 的日志中，首帧被误识别为 `5×16`，滑动后变为 `5×2` 并连续触发 `shape_rejected`。本改动避免首帧由卡片内部亮度变化产生半宽伪列。

Fixes #5208

## 验证

- 回放 Issue 游戏截图与两张 `EssenceGridSwipeNext` on_error 图：均为 `5×9`、`col_width=99`
- `cpp-algo` RelWithDebInfo 构建通过
- `git diff --check` 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化暗分隔线列检测逻辑，无需启用锁定列宽即可运行。
  * 检测到暗分隔线列段时将优先采用，提升不同配置下的网格识别兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->