### PR TITLE
fix(essencefilter): 修复未来可期基质误锁

### DIFF
--- a/agent/go-service/essencefilter/matchapi/engine.go
+++ b/agent/go-service/essencefilter/matchapi/engine.go
@@ -125,7 +125,7 @@ func (e *Engine) MatchOCR(ocr OCRInput, opts EssenceFilterOptions) (*MatchResult
 	// 1) Exact matching on (slot1,slot2,slot3) skill IDs.
 	ocrSkills := [3]string{ocr.Skills[0], ocr.Skills[1], ocr.Skills[2]}
 	ocrLevels := [3]int{ocr.Levels[0], ocr.Levels[1], ocr.Levels[2]}
-	ocrSkills, ocrLevels = e.reorderByPoolAssignmentIfPossible(ocrSkills, ocrLevels)
+	ocrSkills, ocrLevels, hasDistinctSkillPools := e.reorderByPoolAssignmentIfPossible(ocrSkills, ocrLevels)
 
 	// If no rarity is selected, exact matching must be disabled.
 	var exact *SkillCombinationMatch
@@ -149,7 +149,7 @@ func (e *Engine) MatchOCR(ocr OCRInput, opts EssenceFilterOptions) (*MatchResult
 	// 2) Extension rules: evaluate both first, then OR lock decision.
 	futureMatched := false
 	futureMinTotal := 0
-	if opts.KeepFuturePromising && opts.FuturePromisingMinTotal > 0 {
+	if opts.KeepFuturePromising && opts.FuturePromisingMinTotal > 0 && hasDistinctSkillPools {
 		if e.matchFuturePromising(ocrSkills, ocrLevels, opts.FuturePromisingMinTotal) {
 			futureMatched = true
 			futureMinTotal = opts.FuturePromisingMinTotal
@@ -254,11 +254,12 @@ func (e *Engine) MatchOCR(ocr OCRInput, opts EssenceFilterOptions) (*MatchResult
 }
 
 // reorderByPoolAssignmentIfPossible reorders OCR skills/levels into slot1/2/3 order
-// by inferring which slot-pool each OCR skill belongs to.
+// by inferring which slot-pool each OCR skill belongs to. The third return reports
+// whether the skills map uniquely to all three pools.
 //
 // If the inference is not unique (e.g. ambiguous match or duplicate slot assignment),
 // it falls back to the original input order.
-func (e *Engine) reorderByPoolAssignmentIfPossible(inSkills [3]string, inLevels [3]int) ([3]string, [3]int) {
+func (e *Engine) reorderByPoolAssignmentIfPossible(inSkills [3]string, inLevels [3]int) ([3]string, [3]int, bool) {
 	// Default: keep input order.
 	outSkills := inSkills
 	outLevels := inLevels
@@ -271,18 +272,18 @@ func (e *Engine) reorderByPoolAssignmentIfPossible(inSkills [3]string, inLevels 
 	for i := 0; i < 3; i++ {
 		slot, ok := e.assignSlotForOCRText(inSkills[i])
 		if !ok {
-			return outSkills, outLevels
+			return outSkills, outLevels, false
 		}
 		if used[slot] {
 			// Duplicate pool assignment (e.g. 2x slot1 + 1x slot2) => keep default order.
-			return outSkills, outLevels
+			return outSkills, outLevels, false
 		}
 		used[slot] = true
 		assignedSlots[i] = slot
 	}
 
 	if !used[1] || !used[2] || !used[3] {
-		return outSkills, outLevels
+		return outSkills, outLevels, false
 	}
 
 	// Build ordered arrays: [slot1, slot2, slot3].
@@ -294,7 +295,7 @@ func (e *Engine) reorderByPoolAssignmentIfPossible(inSkills [3]string, inLevels 
 		skillsOrdered[orderedIdx] = inSkills[i]
 		levelsOrdered[orderedIdx] = inLevels[i]
 	}
-	return skillsOrdered, levelsOrdered
+	return skillsOrdered, levelsOrdered, true
 }
 
 // assignSlotForOCRText returns which slot pool the given OCR skill text belongs to.


### PR DESCRIPTION
## 问题

“未来可期”规则此前只检查三个词条非空且等级总和达到阈值，没有确认三个词条分别来自能力值、属性和技能池，导致同一词条池的组合也会被误锁。

## 修改

- 复用现有词条池归属结果，记录三个词条是否唯一覆盖三个池
- 仅在池归属完整时执行“未来可期”匹配
- 保持精准武器匹配与“实用基质”规则行为不变

## 验证

- `go test ./essencefilter/... -count=1`
- `pnpm check`
- `pnpm test`（780/780）

Closes #4966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 优化 OCR 技能排序逻辑，仅在技能与技能池能够唯一匹配时应用“未来可期”规则。
  * 当技能无法识别、重复分配或缺少对应技能池时，保持原有顺序并停用该规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->