### PR TITLE
ci: 新增闲置 issue 自动关闭，成员 issue 自动打 MaaEnd Team 标签

### DIFF
--- a/.github/workflows/issue-auto-label.yml
+++ b/.github/workflows/issue-auto-label.yml
@@ -1,15 +1,44 @@
-name: task issue auto label
+name: issue auto label
 
 on:
   issues:
     types: [opened]
 
 jobs:
-  auto-label-task:
+  auto-label:
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
+      - name: Label team member issues
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const association = issue.author_association;
+
+            console.log(
+              `Issue #${issue.number} author_association: ${association}`
+            );
+
+            if (association === 'OWNER' || association === 'MEMBER') {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['MaaEnd Team'],
+              });
+
+              console.log(
+                `Added MaaEnd Team label to issue #${issue.number} (author: ${association})`
+              );
+            } else {
+              console.log(
+                `Skipping MaaEnd Team label for issue #${issue.number} (author: ${association})`
+              );
+            }
+
       - name: Match task labels by issue content
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,39 @@
+name: Issue Staleness Management
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Runs daily at UTC 00:00
+  workflow_dispatch: # Allows manual triggering
+
+env: # config
+  daysBeforeStale: 90 # Number of days of inactivity before marking as stale
+  daysBeforeClose: 7 # Number of days to wait after marking as stale before closing
+
+jobs:
+  stale:
+    name: Handle Stale Issues
+    if: github.repository_owner == 'MaaEnd'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write # Workaround for https://github.com/actions/stale/issues/1090
+      issues: write
+      pull-requests: none # Completely disable stalling for PRs
+      contents: none
+    steps:
+      - name: Handle stale issues
+        uses: actions/stale@v11
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: ${{ env.daysBeforeStale }}
+          days-before-close: ${{ env.daysBeforeClose }}
+          stale-issue-label: "stale"
+          stale-issue-message: |
+            This issue has been inactive for a prolonged period and will be closed automatically in ${{ env.daysBeforeClose }} days.
+            该问题已长时间处于闲置状态，${{ env.daysBeforeClose }} 天后将自动关闭。
+          exempt-issue-labels: "keep-open, MaaEnd Team, enhancement"
+          days-before-pr-stale: -1 # Completely disable stalling for PRs
+          days-before-pr-close: -1 # Completely disable closing for PRs
+
+          # Temporary to reduce the huge issues number
+          operations-per-run: 100
+          debug-only: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ jobs:
           stale-issue-message: |
             This issue has been inactive for a prolonged period and will be closed automatically in ${{ env.daysBeforeClose }} days.
             该问题已长时间处于闲置状态，${{ env.daysBeforeClose }} 天后将自动关闭。
-          exempt-issue-labels: "keep-open, MaaEnd Team, enhancement"
+          exempt-issue-labels: "keep-open, MaaEnd Team, enhancement, status: WIP"
           days-before-pr-stale: -1 # Completely disable stalling for PRs
           days-before-pr-close: -1 # Completely disable closing for PRs
 


### PR DESCRIPTION
- .github/workflows/stale.yml: 90 天无活动标记 stale，再 7 天自动关闭；keep-open / MaaEnd Team / enhancement 豁免，PR 完全豁免

- 重命名 task-issue-auto-label.yml 为 issue-auto-label.yml，新增成员(OWNER/MEMBER)自动打 MaaEnd Team 标签步骤

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 自动识别仓库团队成员创建的 Issue，并添加团队标签。
  * 新增闲置 Issue 管理：闲置 90 天后标记为过期，额外 7 天后自动关闭。
  * 支持每日定时或手动执行闲置 Issue 检查。

* **改进**
  * 持续根据 Issue 内容自动添加任务相关标签。
  * Pull Request 不参与闲置标记和自动关闭。
  * 支持排除指定标签（包括 `status: WIP`），每次最多处理 100 个项目。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->