### PR TITLE
fix(AutoDelivery): 修复 MapTracker 移除后生成失败

### DIFF
--- a/tools/pipeline-generate/AutoDelivery/data.test.mjs
+++ b/tools/pipeline-generate/AutoDelivery/data.test.mjs
@@ -252,6 +252,16 @@ test("AutoDelivery 资源回收站保留游戏内区域序号", () => {
     }
 });
 
+test("AutoDelivery 将 BaseNav 地区映射到 MapLocator 资源区", () => {
+    assert.deepEqual(
+        [...new Set(destinations.map((destination) => `${destination.map}:${destination.mapZone}`))].sort(),
+        [
+            "map01:ValleyIV",
+            "map02:Wuling",
+        ],
+    );
+});
+
 test("AutoDelivery 为同地图同区域的多个资源回收站生成地图图标候选", () => {
     const areaPipeline = JSON.parse(
         readFileSync(

--- a/tools/pipeline-generate/AutoDelivery/model.mjs
+++ b/tools/pipeline-generate/AutoDelivery/model.mjs
@@ -1,13 +1,9 @@
 import {readFileSync} from "node:fs";
 
+import {BASE_NAV_ZONE_IMAGE_PARTS} from "../../MapNavigator/web/static/js/model.js";
+
 const catalogSource = JSON.parse(readFileSync(new URL("../data/delivery_destinations.json", import.meta.url), "utf8"));
 const routeSource = JSON.parse(readFileSync(new URL("./routes.json", import.meta.url), "utf8"));
-const mapLocatorSource = JSON.parse(
-    readFileSync(
-        new URL("../../../assets/resource/image/MapLocator/maptracker_coordinate_transforms.json", import.meta.url),
-        "utf8",
-    ),
-);
 
 function assertArray(value, label) {
     if (!Array.isArray(value)) {
@@ -51,31 +47,15 @@ function buildAreaId(area, label) {
     return id;
 }
 
-const mapZones = new Map();
-
 function buildMapZone(map, label) {
-    const cached = mapZones.get(map);
-    if (cached) {
-        return cached;
+    const baseNavZone = assertNonEmptyString(catalogSource.maps?.[map]?.zone, `${label}.maps.${map}.zone`);
+    const [
+        resourceType,
+        zone,
+    ] = BASE_NAV_ZONE_IMAGE_PARTS[baseNavZone] ?? [];
+    if (resourceType !== "MapLocator" || !zone) {
+        throw new Error(`[AutoDelivery] ${label} 的 BaseNav 地区 ${baseNavZone} 无法对应 MapLocator 地区`);
     }
-
-    const mapPrefix = `${map}_`;
-    const zones = new Set();
-    for (const transform of assertArray(mapLocatorSource.transforms, "MapLocator.transforms")) {
-        if (typeof transform.map_name !== "string" || !transform.map_name.startsWith(mapPrefix)) {
-            continue;
-        }
-        const match = /^(.+)_Base$/.exec(transform.zone_id);
-        if (match) {
-            zones.add(match[1]);
-        }
-    }
-    if (zones.size !== 1) {
-        throw new Error(`[AutoDelivery] ${label} 的地图 ${map} 无法唯一对应 MapLocator 地区：${[...zones].join(", ")}`);
-    }
-
-    const [zone] = zones;
-    mapZones.set(map, zone);
     return zone;
 }
 


### PR DESCRIPTION
## 背景

`d382169f9` 移除 MapTracker 时删除了 `assets/resource/image/MapLocator/maptracker_coordinate_transforms.json`，但 AutoDelivery 生成器仍在加载该文件，导致 `pnpm generate:AutoDelivery` 以 `ENOENT` 失败。

## 改动

- 移除 AutoDelivery 对已删除 MapTracker 坐标变换文件的依赖。
- 从 `delivery_destinations.json` 读取 BaseNav zone，并复用 MapNavigator 已导出的 `BASE_NAV_ZONE_IMAGE_PARTS` 获取对应的 MapLocator 资源区，避免维护重复映射。
- 对缺失或无法映射的 BaseNav zone 保留显式错误，避免静默使用错误地图。
- 增加 `map01:ValleyIV`、`map02:Wuling` 映射回归测试。

## 验证

- `pnpm generate:AutoDelivery`：成功生成 56 个路线节点，0 个诊断问题
- `node --test tools/pipeline-generate/AutoDelivery/data.test.mjs`：11/11 通过
- `pnpm check`：通过
- `pnpm test`：780/780，通过且未产生 `tests/maatools/error_details.json`
- Prettier 检查与 `git diff --check`：通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化地图区域识别与映射，支持将 BaseNav 区域准确关联至 MapLocator 区域。
  - 对不支持的资源类型或缺失区域映射提供明确错误提示。
- **测试**
  - 新增验证，确保所有目的地组合仅映射至 ValleyIV 和 Wuling 两个地图区域。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->