### PR TITLE
docs(protocol): update UID hash algorithm in autostockpile daily storage

### DIFF
--- a/docs/en_us/protocol/autostockpile-daily-storage/protocol.md
+++ b/docs/en_us/protocol/autostockpile-daily-storage/protocol.md
@@ -47,7 +47,7 @@ A corresponding JSON Schema file is provided for third-party tools to validate t
 - `weekday: int` — Weekday of the server date, `1`=Monday through `7`=Sunday.
 - `utc_time: string` — UTC time when the record was written, RFC 3339 format (e.g., `2026-05-04T12:00:00Z`).
 - `region: string` — Region identifier. Current possible values: `Wuling`, `ValleyIV` (Valley IV).
-- `uid: string` — Player identifier. Derived from the in-game UID digits via SHA256 salted hash, taking the first 16 hex characters. Irreversible. Falls back to `"unknown"` when no valid UID is available.
+- `uid: string` — Player identifier. Acquired by `CaptureUid`: the in-game UID digits are hashed via SHA256 with a user-locally-generated random salt, taking the first 16 hex characters. Irreversible. Falls back to `"unknown"` when no valid UID is available.
 - `goods: array` — Array of goods recognized in this round; see below for elements.
 
 ### `goods[]` Fields
@@ -99,16 +99,16 @@ Readers can safely read `ElasticGoodsPrices.json` at any time and will never see
 
 ## UID Hash Algorithm
 
-For third parties needing to verify or compare UIDs, the algorithm is:
+UID acquisition is handled by `CaptureUid`: AutoStockpile invokes this custom action at the `AutoStockpileGetUid` node, reads the UID via screenshot OCR, and caches the raw digits; the hash result is used when writing records (see the [CaptureUid reference](../../developers/components/capture-uid.md)). For third parties needing to verify or compare UIDs, the algorithm is:
 
-1. Extract all consecutive digit segments from the in-game UID OCR result
-2. Concatenate all digit segments into a single string (e.g., `"123456789"`)
-3. Compute `SHA256(digit_string + "AutoStockpile")`
+1. `CaptureUid` captures a stable screen and runs OCR, extracting all consecutive digit segments from the result and concatenating them into a single string (e.g., `"123456789"`); the digit count is validated to be 8–12 before caching
+2. Read the user-locally-generated random salt: on first use, a 16-byte random salt (32 hex characters) is generated and written to `debug/record/random_salt.txt`, then reused; no fixed salt is used
+3. Compute `SHA256(digit_string + salt)`
 4. Take the first 16 characters of the hex digest as the final UID
 
-When no valid digits can be extracted, the UID is `"unknown"`.
+When no valid digits can be extracted (OCR failure or digit count outside the 8–12 range), the UID is `"unknown"`.
 
-> This hash is an **irreversible salted digest** — the original in-game UID cannot be reversed from the UID in the file.
+> This hash is an **irreversible salted digest** — the original in-game UID cannot be reversed from the UID in the file. The salt is generated locally per installation: it is stable across sessions within the same installation (usable to correlate the same player), but differs between installations, so the same player's hash cannot be compared across installations.
 
 ---
 

--- a/docs/zh_cn/protocol/autostockpile-daily-storage/protocol.md
+++ b/docs/zh_cn/protocol/autostockpile-daily-storage/protocol.md
@@ -47,7 +47,7 @@
 - `weekday: int`：服务器日对应的星期，`1`=周一 ~ `7`=周日。
 - `utc_time: string`：记录写入时的 UTC 时间，RFC 3339 格式（如 `2026-05-04T12:00:00Z`）。
 - `region: string`：地区标识。当前可能值：`Wuling`（武陵）、`ValleyIV`（四号谷地）。
-- `uid: string`：玩家标识。由游戏内 UID 数字部分经 SHA256 加盐哈希后取前 16 位十六进制。不可逆。无有效 UID 时回退为 `"unknown"`。
+- `uid: string`：玩家标识。由 `CaptureUid` 负责获取：对游戏内 UID 数字经 SHA256 加盐哈希后取前 16 位十六进制，盐为用户本地生成的随机盐。不可逆。无有效 UID 时回退为 `"unknown"`。
 - `goods: array`：本轮识别到的商品数组，元素见下。
 
 ### `goods[]` 字段
@@ -99,16 +99,16 @@ debug/record/ElasticGoodsPrices.json
 
 ## UID 哈希算法
 
-第三方如需验证或比对 UID，算法如下：
+UID 的获取由 `CaptureUid` 承担：AutoStockpile 在 `AutoStockpileGetUid` 节点调用该自定义动作，截屏 OCR 读取 UID 并缓存原始数字，记录写入时取哈希结果（详见 [CaptureUid 参考文档](../../developers/components/capture-uid.md)）。第三方如需验证或比对 UID，算法如下：
 
-1. 从游戏内 UID 的 OCR 结果中提取所有连续数字片段
-2. 将所有数字片段拼接为一个字符串（如 `"123456789"`）
-3. 计算 `SHA256(数字字符串 + "AutoStockpile")`
+1. `CaptureUid` 在稳定界面截屏 OCR，从结果中提取所有连续数字片段并拼接为一个字符串（如 `"123456789"`），校验位数 8–12 后缓存
+2. 读取用户本地生成的随机盐：首次使用时生成 16 字节随机盐（32 位十六进制）并写入 `debug/record/random_salt.txt`，之后复用；不再使用固定盐值
+3. 计算 `SHA256(数字字符串 + 盐)`
 4. 取十六进制摘要的前 16 个字符作为最终 UID
 
-无法提取有效数字时，UID 为 `"unknown"`。
+无法提取有效数字（OCR 失败或位数不在 8–12 范围）时，UID 为 `"unknown"`。
 
-> 该哈希为**不可逆加盐摘要**，无法从文件中的 UID 反推游戏内原始 UID。
+> 该哈希为**不可逆加盐摘要**，无法从文件中的 UID 反推游戏内原始 UID。盐由用户本地生成：同一安装内跨会话稳定（可用于关联同一玩家），不同安装之间盐不同，同一玩家的哈希值不可跨安装比对。
 
 ---
 


### PR DESCRIPTION
UID 获取职能由 CaptureUid 承担，盐值由固定 AutoStockpile 改为用户本地 生成的随机盐（debug/record/random_salt.txt），同步更新中英文协议文档。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新自动库存每日存储协议中的 UID 生成规则。
  * UID 现通过 OCR 读取并缓存，经过本地随机盐加密哈希处理。
  * 新增 UID 位数校验、无效输入回退及随机盐持久化说明。
  * 明确不同安装环境之间的 UID 不可直接比较。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->