### PR TITLE
chore: 补充 DeliveryJobs 支持的 linux 控制器类型

### DIFF
--- a/assets/tasks/DeliveryJobs.json
+++ b/assets/tasks/DeliveryJobs.json
@@ -1653,6 +1653,8 @@
             "type": "switch",
             "controller": [
                 "Win32-Front",
+                "Linux-Gamescope",
+                "Linux-ScreenCast",
                 "Linux-Wlroots"
             ],
             "label": "$task.AutoDeliveryRiskAcknowledgement.label",
@@ -1681,6 +1683,8 @@
             "type": "switch",
             "controller": [
                 "Win32-Front",
+                "Linux-Gamescope",
+                "Linux-ScreenCast",
                 "Linux-Wlroots"
             ],
             "label": "$task.AutoDeliveryPreferZipline.label",

--- a/tools/pipeline-generate/DeliveryJobs/README.md
+++ b/tools/pipeline-generate/DeliveryJobs/README.md
@@ -47,7 +47,7 @@ pnpm fetch:zmdmap
 
 仓储坐标与全部送货终点均由 `delivery_destinations_data.py` 从游戏数据和 BaseNav 变换生成，普通点只需一个 `NAVMESH` 目标；断网格、分层或需要重新靠近取货点的路线才在 `tools/pipeline-generate/AutoDelivery/routes.json` 中保留覆盖。AutoDelivery 生成器将每条路线渲染为可独立试跑的 Pipeline 节点，并生成不含坐标的运行时匹配目录；Go Service 识别目标后动态选择对应节点。终点覆盖的 `path` 是包含最终航点的完整路线；仓储 `departure_path` 作为所有归属终点的公共离开路线前缀。`retry_path` 的用途、执行边界与维护要求见 AutoDelivery 文档，DeliveryJobs 不直接调用该内部路线。
 
-风险确认与滑索偏好仅对 `Win32-Front` / `Wlroots` 控制器开放；受项目接口能力限制，其他控制器仍可能显示“全自动送货”处理方式，但无法关闭默认安全守卫，选择后会直接停止任务。滑索偏好只允许 MapNavigator 在预计更快且满足供电、上下索条件时规划滑索，不保证每条路线都会使用。送货成功后返回 DeliveryJobs 仓储节点循环，送货失败则停止整个任务，避免继续装箱。该功能仍处于测试阶段，使用前必须确认风险提示。
+风险确认与滑索偏好仅对 `Win32-Front` / `Linux` 控制器开放；受项目接口能力限制，其他控制器仍可能显示“全自动送货”处理方式，但无法关闭默认安全守卫，选择后会直接停止任务。滑索偏好只允许 MapNavigator 在预计更快且满足供电、上下索条件时规划滑索，不保证每条路线都会使用。送货成功后返回 DeliveryJobs 仓储节点循环，送货失败则停止整个任务，避免继续装箱。该功能仍处于测试阶段，使用前必须确认风险提示。
 
 阈值输入虽然只允许数字，但 `pipeline_type` 必须保持为 `string`，因为它会被插入完整的 `ExpressionRecognition.expression` 字符串；设为 `int` 会尝试把整个表达式转换为整数，最终得到 `null`。
 

--- a/tools/pipeline-generate/DeliveryJobs/data.test.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/data.test.mjs
@@ -10,7 +10,9 @@ import {DELIVERY_JOB_FILL_ITEM_PRIORITY_COUNT, deliveryJobDepots, deliveryJobReg
 
 const AUTO_DELIVERY_CONTROLLERS = [
     "Win32-Front",
-    "Linux-Wlroots",
+    "Linux-Gamescope",
+    "Linux-ScreenCast",
+    "Linux-Wlroots"
 ];
 
 const AUTO_DELIVERY_NAVIGATE_NODES = [

--- a/tools/pipeline-generate/DeliveryJobs/task-template.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/task-template.mjs
@@ -23,7 +23,9 @@ const PACK_CARGO_EXPECTED = [
 
 const AUTO_DELIVERY_CONTROLLERS = [
     "Win32-Front",
-    "Linux-Wlroots",
+    "Linux-Gamescope",
+    "Linux-ScreenCast",
+    "Linux-Wlroots"
 ];
 
 const AUTO_DELIVERY_NAVIGATE_NODES = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 自动交付任务新增对 `Linux-Gamescope` 和 `Linux-ScreenCast` 控制器的支持。
  * 风险确认与滑索偏好现支持 Linux 控制器。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->