### PR TITLE
fix(MapNavigator): 展开失败时跳过已走过的前缀再重试

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navi_controller.cpp
@@ -1,4 +1,6 @@
+#include <limits>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -124,8 +126,19 @@ bool NaviController::Navigate(const NaviParam& requested_param)
     LogInfo << "Initial Pos fixed:" << VAR(position_x) << VAR(position_y);
 
     std::vector<Waypoint> expanded_path;
+    size_t resume_index = 0;
     if (!ExpandNavmeshWaypoints(param, pos, is_stopping, expanded_path)) {
-        return false;
+        const std::optional<size_t> resume = ResolveRouteResumeIndex(param.path, pos);
+        if (!resume) {
+            return false;
+        }
+        NaviParam resumed_param = param;
+        resumed_param.path.assign(param.path.begin() + static_cast<std::ptrdiff_t>(*resume), param.path.end());
+        if (!ExpandNavmeshWaypoints(resumed_param, pos, is_stopping, expanded_path)) {
+            return false;
+        }
+        resume_index = *resume;
+        LogInfo << "Expanded the route again after skipping the traversed prefix." << VAR(resume_index);
     }
     if (expanded_path.empty()) {
         return true;
@@ -134,6 +147,13 @@ bool NaviController::Navigate(const NaviParam& requested_param)
     NaviParam expanded_param = param;
     expanded_param.path = std::move(expanded_path);
     expanded_param.authored_path = std::move(param.path);
+    if (resume_index > 0) {
+        for (Waypoint& waypoint : expanded_param.path) {
+            if (waypoint.authored_group_begin != std::numeric_limits<size_t>::max()) {
+                waypoint.authored_group_begin += resume_index;
+            }
+        }
+    }
 
     NavigationSession session(expanded_param.path, pos);
     session.UpdatePhase(NaviPhase::Bootstrap, "initial_fix");

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -387,6 +387,17 @@ semantic_nodes::Context BuildSemanticContext(
 
 } // namespace
 
+std::optional<size_t> ResolveRouteResumeIndex(const std::vector<Waypoint>& path, const NaviPosition& position)
+{
+    const std::optional<BootstrapContinueCandidate> candidate = ResolveBootstrapContinueCandidate(path, position);
+    if (!candidate || candidate->continue_index == 0 || candidate->continue_index >= path.size()) {
+        return std::nullopt;
+    }
+    LogInfo << "Route resume index resolved." << VAR(candidate->continue_index) << VAR(candidate->route_distance) << VAR(candidate->reason)
+            << VAR(position.x) << VAR(position.y) << VAR(position.zone_id);
+    return candidate->continue_index;
+}
+
 NavigationStateMachine::NavigationStateMachine(
     const NaviParam& param,
     ActionWrapper* action_wrapper,

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "async_prompt_action.h"
 #include "nav_run_controller.h"
@@ -24,6 +25,8 @@ class MotionController;
 class PositionProvider;
 class RoiTemplateScanner;
 struct RouteTrackingState;
+
+std::optional<size_t> ResolveRouteResumeIndex(const std::vector<Waypoint>& path, const NaviPosition& position);
 
 class NavigationStateMachine
 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 导航路径扩展失败时，系统会根据当前位置识别已完成的路径，并尝试从剩余路径继续导航。
  - 成功恢复导航后，路径中的航点分组信息会自动同步调整。

- **问题修复**
  - 改善了导航中断后的路线恢复能力；无法恢复时仍会正确返回失败状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->