### PR TITLE
fix: 基质刷取首墩无法领取奖励

### DIFF
--- a/assets/resource/pipeline/AutoEssence/RegionNodes/WLMarkerStone.json
+++ b/assets/resource/pipeline/AutoEssence/RegionNodes/WLMarkerStone.json
@@ -108,6 +108,27 @@
                 }
             }
         },
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "MapNavigateAction",
+                "custom_action_param": {
+                    "path": [
+                        {
+                            "action": "ZONE",
+                            "zone_id": "Wuling_Base"
+                        },
+                        {
+                            "action": "NAVMESH",
+                            "target": [
+                                318.4,
+                                2328.6
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         "next": [
             "GotoTriggerPointMoveExact_WLMarkerStone"
         ],


### PR DESCRIPTION
close #5233 
close #5235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 在 Wuling_Base 区域新增导航动作，可自动前往指定的 WLMarkerStone 位置。
  * 保留原有识别与流程配置，后续节点行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->