### PR TITLE
feat(AutoEssence): 为基质刷取增加按星期执行的周计划

### DIFF
--- a/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
+++ b/assets/resource/pipeline/AutoEssence/CommonNodes/AutoEssence.json
@@ -1,4 +1,42 @@
 {
+    "AutoEssenceSchedule": {
+        "desc": "基质刷取计划任务",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "AutoEssenceScheduleEnabled",
+            "AutoEssenceScheduleEnd"
+        ]
+    },
+    "AutoEssenceScheduleEnabled": {
+        "desc": "基质刷取计划任务命中",
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "ScheduleRecognition",
+                "custom_recognition_param": {}
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "AutoEssenceMain"
+        ],
+        "attach": {
+            "monday": false,
+            "tuesday": false,
+            "wednesday": false,
+            "thursday": false,
+            "friday": false,
+            "saturday": false,
+            "sunday": false
+        }
+    },
+    "AutoEssenceScheduleEnd": {
+        "desc": "基质刷取计划任务跳过",
+        "pre_delay": 0,
+        "post_delay": 0
+    },
     "AutoEssenceMain": {
         "desc": "自动基质刷取的主入口",
         "pre_delay": 0,

--- a/assets/tasks/AutoEssence.json
+++ b/assets/tasks/AutoEssence.json
@@ -3,7 +3,7 @@
         {
             "name": "AutoEssence",
             "label": "$task.AutoEssence.label",
-            "entry": "AutoEssenceMain",
+            "entry": "AutoEssenceSchedule",
             "description": "$task.AutoEssence.description",
             "controller": [
                 "ADB",
@@ -14,6 +14,7 @@
                 "Win32-Front"
             ],
             "option": [
+                "AutoEssenceSchedule",
                 "AutoEssenceChooseLocation",
                 "AutoEssenceObtainMode",
                 "AutoEssenceRepeatCount",
@@ -29,6 +30,98 @@
         }
     ],
     "option": {
+        "AutoEssenceSchedule": {
+            "type": "checkbox",
+            "label": "$option.TaskSchedule.label",
+            "default_case": [
+                "AutoEssenceScheduleMonday",
+                "AutoEssenceScheduleTuesday",
+                "AutoEssenceScheduleWednesday",
+                "AutoEssenceScheduleThursday",
+                "AutoEssenceScheduleFriday",
+                "AutoEssenceScheduleSaturday",
+                "AutoEssenceScheduleSunday"
+            ],
+            "cases": [
+                {
+                    "name": "AutoEssenceScheduleMonday",
+                    "label": "$option.TaskScheduleMonday.label",
+                    "pipeline_override": {
+                        "AutoEssenceScheduleEnabled": {
+                            "attach": {
+                                "monday": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "AutoEssenceScheduleTuesday",
+                    "label": "$option.TaskScheduleTuesday.label",
+                    "pipeline_override": {
+                        "AutoEssenceScheduleEnabled": {
+                            "attach": {
+                                "tuesday": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "AutoEssenceScheduleWednesday",
+                    "label": "$option.TaskScheduleWednesday.label",
+                    "pipeline_override": {
+                        "AutoEssenceScheduleEnabled": {
+                            "attach": {
+                                "wednesday": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "AutoEssenceScheduleThursday",
+                    "label": "$option.TaskScheduleThursday.label",
+                    "pipeline_override": {
+                        "AutoEssenceScheduleEnabled": {
+                            "attach": {
+                                "thursday": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "AutoEssenceScheduleFriday",
+                    "label": "$option.TaskScheduleFriday.label",
+                    "pipeline_override": {
+                        "AutoEssenceScheduleEnabled": {
+                            "attach": {
+                                "friday": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "AutoEssenceScheduleSaturday",
+                    "label": "$option.TaskScheduleSaturday.label",
+                    "pipeline_override": {
+                        "AutoEssenceScheduleEnabled": {
+                            "attach": {
+                                "saturday": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "AutoEssenceScheduleSunday",
+                    "label": "$option.TaskScheduleSunday.label",
+                    "pipeline_override": {
+                        "AutoEssenceScheduleEnabled": {
+                            "attach": {
+                                "sunday": true
+                            }
+                        }
+                    }
+                }
+            ]
+        },
         "AutoEssenceChooseLocation": {
             "type": "checkbox",
             "label": "$option.AutoEssenceChooseLocation.label",


### PR DESCRIPTION
close #5251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增基质刷取计划任务，可按星期一至星期日配置执行日期。
  * 任务会根据计划自动判断是否执行；未命中计划时将跳过本次任务。
  * 更新任务入口，默认通过计划流程启动基质刷取任务。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->