### PR TITLE
feat(AutoDelivery): 按设备朝向生成正面接近路线

### DIFF
--- a/assets/data/AutoDelivery/catalog.json
+++ b/assets/data/AutoDelivery/catalog.json
@@ -11,7 +11,8 @@
             },
             "map": "map01",
             "route_node": "AutoDeliveryRouteDepotDomain1Lv005Depot1",
-            "zip_route_node": "AutoDeliveryRouteDepotDomain1Lv005Depot1WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDepotDomain1Lv005Depot1WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDepotRetryDomain1Lv005Depot1"
         },
         {
             "id": "domain_1_lv006_depot_1",
@@ -24,7 +25,8 @@
             },
             "map": "map01",
             "route_node": "AutoDeliveryRouteDepotDomain1Lv006Depot1",
-            "zip_route_node": "AutoDeliveryRouteDepotDomain1Lv006Depot1WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDepotDomain1Lv006Depot1WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDepotRetryDomain1Lv006Depot1"
         },
         {
             "id": "domain_1_lv007_depot_1",
@@ -37,7 +39,8 @@
             },
             "map": "map01",
             "route_node": "AutoDeliveryRouteDepotDomain1Lv007Depot1",
-            "zip_route_node": "AutoDeliveryRouteDepotDomain1Lv007Depot1WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDepotDomain1Lv007Depot1WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDepotRetryDomain1Lv007Depot1"
         },
         {
             "id": "domain_2_lv002_depot_1",
@@ -95,7 +98,8 @@
                 "ko_kr": "오리지늄 연구 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00501",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00501WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00501WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00501"
         },
         {
             "id": "deliver_target_map01_lv005_02",
@@ -123,7 +127,8 @@
                 "ko_kr": "오리지늄 연구 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00502",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00502WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00502WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00502"
         },
         {
             "id": "deliver_target_map01_lv005_03",
@@ -151,7 +156,8 @@
                 "ko_kr": "오리지늄 연구 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00503",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00503WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00503WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00503"
         },
         {
             "id": "deliver_target_map01_lv005_recycle_02",
@@ -180,7 +186,8 @@
                 "ko_kr": "오리지늄 연구 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv005Recycle02",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv005Recycle02WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv005Recycle02WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv005Recycle02"
         },
         {
             "id": "deliver_target_map01_lv005_recycle_03",
@@ -209,7 +216,8 @@
                 "ko_kr": "오리지늄 연구 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv005Recycle03",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv005Recycle03WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv005Recycle03WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv005Recycle03"
         },
         {
             "id": "deliver_target_map01_lv006_01",
@@ -237,7 +245,8 @@
                 "ko_kr": "광맥 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00601",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00601WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00601WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00601"
         },
         {
             "id": "deliver_target_map01_lv006_02",
@@ -265,7 +274,8 @@
                 "ko_kr": "광맥 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00602",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00602WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00602WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00602"
         },
         {
             "id": "deliver_target_map01_lv006_03",
@@ -293,7 +303,8 @@
                 "ko_kr": "광맥 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00603",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00603WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00603WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00603"
         },
         {
             "id": "deliver_target_map01_lv006_recycle_01",
@@ -322,7 +333,8 @@
                 "ko_kr": "광맥 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv006Recycle01",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv006Recycle01WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv006Recycle01WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv006Recycle01"
         },
         {
             "id": "deliver_target_map01_lv006_recycle_03",
@@ -351,7 +363,8 @@
                 "ko_kr": "광맥 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv006Recycle03",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv006Recycle03WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv006Recycle03WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv006Recycle03"
         },
         {
             "id": "deliver_target_map01_lv007_01",
@@ -379,7 +392,8 @@
                 "ko_kr": "에너지 공급 고지"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00701",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00701WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00701WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00701"
         },
         {
             "id": "deliver_target_map01_lv007_02",
@@ -407,7 +421,8 @@
                 "ko_kr": "에너지 공급 고지"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00702",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00702WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00702WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00702"
         },
         {
             "id": "deliver_target_map01_lv007_03",
@@ -435,7 +450,8 @@
                 "ko_kr": "에너지 공급 고지"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00703",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00703WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00703WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00703"
         },
         {
             "id": "deliver_target_map01_lv007_recycle_02",
@@ -464,7 +480,8 @@
                 "ko_kr": "에너지 공급 고지"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv007Recycle02",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv007Recycle02WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv007Recycle02WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv007Recycle02"
         },
         {
             "id": "deliver_target_map01_lv007_recycle_03",
@@ -493,7 +510,8 @@
                 "ko_kr": "에너지 공급 고지"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv007Recycle03",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv007Recycle03WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap01Lv007Recycle03WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv007Recycle03"
         },
         {
             "id": "deliver_target_map02_lv002_01",
@@ -521,7 +539,8 @@
                 "ko_kr": "무릉성"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00201",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00201WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00201WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00201"
         },
         {
             "id": "deliver_target_map02_lv002_02",
@@ -549,7 +568,8 @@
                 "ko_kr": "무릉성"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00202",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00202WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00202WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00202"
         },
         {
             "id": "deliver_target_map02_lv002_03",
@@ -577,7 +597,8 @@
                 "ko_kr": "무릉성"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00203",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00203WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00203WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00203"
         },
         {
             "id": "deliver_target_map02_lv002_recycle_01",
@@ -606,7 +627,8 @@
                 "ko_kr": "무릉성"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv002Recycle01",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv002Recycle01WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv002Recycle01WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv002Recycle01"
         },
         {
             "id": "deliver_target_map02_lv005_01",
@@ -634,7 +656,8 @@
                 "ko_kr": "실험 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00501",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00501WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00501WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00501"
         },
         {
             "id": "deliver_target_map02_lv005_02",
@@ -662,7 +685,8 @@
                 "ko_kr": "실험 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00502",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00502WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00502WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00502"
         },
         {
             "id": "deliver_target_map02_lv005_03",
@@ -690,7 +714,8 @@
                 "ko_kr": "실험 구역"
             },
             "route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00503",
-            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00503WithZipline"
+            "zip_route_node": "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00503WithZipline",
+            "retry_route_node": "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00503"
         }
     ]
 }

--- a/assets/resource/pipeline/AutoDelivery/Routes/OriginLodespring.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/OriginLodespring.json
@@ -10,6 +10,14 @@
                 {
                     "action": "NAVMESH",
                     "target": [
+                        909.468,
+                        264.338
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
                         912.255,
                         263.96
                     ]
@@ -39,12 +47,56 @@
                 {
                     "action": "NAVMESH",
                     "target": [
+                        909.468,
+                        264.338
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
                         912.255,
                         263.96
                     ]
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDepotRetryDomain1Lv006Depot1": {
+        "desc": "AutoDelivery 仓储站位修正路线：矿脉源区仓储节点（domain_1_lv006_depot_1）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        909.468,
+                        264.338
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        912.255,
+                        263.96
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -261,6 +313,42 @@
             }
         }
     },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00601": {
+        "desc": "AutoDelivery 终点站位修正路线：马泰奥（deliver_target_map01_lv006_01）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1132.593,
+                        468.409
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1132.593,
+                        471.222
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
     "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00602": {
         "desc": "AutoDelivery 终点路线：从矿脉源区仓储节点前往陆言（deliver_target_map01_lv006_02）",
         "recognition": "DirectHit",
@@ -453,6 +541,42 @@
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00602": {
+        "desc": "AutoDelivery 终点站位修正路线：陆言（deliver_target_map01_lv006_02）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1194.33,
+                        435.978
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1192.373,
+                        433.958
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -669,6 +793,42 @@
             }
         }
     },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00603": {
+        "desc": "AutoDelivery 终点站位修正路线：莫莉（deliver_target_map01_lv006_03）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1172.064,
+                        440.658
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1172.391,
+                        443.451
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
     "AutoDeliveryRouteDestinationDeliverTargetMap01Lv006Recycle01": {
         "desc": "AutoDelivery 终点路线：从矿脉源区仓储节点前往“不是废品佬”（deliver_target_map01_lv006_recycle_01）",
         "recognition": "DirectHit",
@@ -750,6 +910,14 @@
                     1025.89,
                     360.55
                 ],
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1049.837,
+                        431.627
+                    ],
+                    "required": true
+                },
                 {
                     "action": "NAVMESH",
                     "target": [
@@ -855,12 +1023,56 @@
                 {
                     "action": "NAVMESH",
                     "target": [
+                        1049.837,
+                        431.627
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
                         1048.016,
                         429.484
                     ]
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv006Recycle01": {
+        "desc": "AutoDelivery 终点站位修正路线：“不是废品佬”（deliver_target_map01_lv006_recycle_01）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1049.837,
+                        431.627
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1048.016,
+                        429.484
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -954,6 +1166,14 @@
                     1025.89,
                     360.55
                 ],
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1081.62,
+                        505.065
+                    ],
+                    "required": true
+                },
                 {
                     "action": "NAVMESH",
                     "target": [
@@ -1059,12 +1279,56 @@
                 {
                     "action": "NAVMESH",
                     "target": [
+                        1081.62,
+                        505.065
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
                         1078.905,
                         504.33
                     ]
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv006Recycle03": {
+        "desc": "AutoDelivery 终点站位修正路线：采购-矿区医疗站模组（deliver_target_map01_lv006_recycle_03）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1081.62,
+                        505.065
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1078.905,
+                        504.33
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/AutoDelivery/Routes/OriginLodespring.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/OriginLodespring.json
@@ -10,8 +10,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        909.468,
-                        264.338
+                        906.681,
+                        264.716
                     ],
                     "required": true
                 },
@@ -47,8 +47,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        909.468,
-                        264.338
+                        906.681,
+                        264.716
                     ],
                     "required": true
                 },
@@ -84,8 +84,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        909.468,
-                        264.338
+                        906.681,
+                        264.716
                     ],
                     "required": true
                 },
@@ -325,7 +325,7 @@
                     "action": "NAVMESH",
                     "target": [
                         1132.593,
-                        468.409
+                        465.597
                     ],
                     "required": true
                 },
@@ -564,8 +564,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1194.33,
-                        435.978
+                        1196.287,
+                        437.998
                     ],
                     "required": true
                 },
@@ -804,8 +804,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1172.064,
-                        440.658
+                        1171.738,
+                        437.864
                     ],
                     "required": true
                 },
@@ -913,8 +913,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1049.837,
-                        431.627
+                        1044.373,
+                        425.198
                     ],
                     "required": true
                 },
@@ -1023,8 +1023,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1049.837,
-                        431.627
+                        1044.373,
+                        425.198
                     ],
                     "required": true
                 },
@@ -1060,8 +1060,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1049.837,
-                        431.627
+                        1044.373,
+                        425.198
                     ],
                     "required": true
                 },
@@ -1169,8 +1169,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1081.62,
-                        505.065
+                        1073.476,
+                        502.859
                     ],
                     "required": true
                 },
@@ -1279,8 +1279,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1081.62,
-                        505.065
+                        1073.476,
+                        502.859
                     ],
                     "required": true
                 },
@@ -1316,8 +1316,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1081.62,
-                        505.065
+                        1073.476,
+                        502.859
                     ],
                     "required": true
                 },

--- a/assets/resource/pipeline/AutoDelivery/Routes/OriginiumSciencePark.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/OriginiumSciencePark.json
@@ -11,7 +11,7 @@
                     "action": "NAVMESH",
                     "target": [
                         1043.463,
-                        801.908
+                        799.095
                     ],
                     "required": true
                 },
@@ -48,7 +48,7 @@
                     "action": "NAVMESH",
                     "target": [
                         1043.463,
-                        801.908
+                        799.095
                     ],
                     "required": true
                 },
@@ -85,7 +85,7 @@
                     "action": "NAVMESH",
                     "target": [
                         1043.463,
-                        801.908
+                        799.095
                     ],
                     "required": true
                 },
@@ -178,8 +178,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1131.502,
-                        902.975
+                        1130.172,
+                        905.454
                     ],
                     "required": true
                 },
@@ -306,8 +306,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1162.513,
-                        828.793
+                        1163.183,
+                        831.525
                     ],
                     "required": true
                 },
@@ -400,8 +400,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        970.334,
-                        826.211
+                        972.459,
+                        828.054
                     ],
                     "required": true
                 },
@@ -436,7 +436,7 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        902.486,
+                        910.924,
                         764.145
                     ],
                     "required": true
@@ -473,7 +473,7 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        902.486,
+                        910.924,
                         764.145
                     ],
                     "required": true
@@ -510,7 +510,7 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        902.486,
+                        910.924,
                         764.145
                     ],
                     "required": true
@@ -546,8 +546,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1185.447,
-                        819.105
+                        1179.481,
+                        813.139
                     ],
                     "required": true
                 },
@@ -583,8 +583,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1185.447,
-                        819.105
+                        1179.481,
+                        813.139
                     ],
                     "required": true
                 },
@@ -620,8 +620,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1185.447,
-                        819.105
+                        1179.481,
+                        813.139
                     ],
                     "required": true
                 },

--- a/assets/resource/pipeline/AutoDelivery/Routes/OriginiumSciencePark.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/OriginiumSciencePark.json
@@ -11,6 +11,14 @@
                     "action": "NAVMESH",
                     "target": [
                         1043.463,
+                        801.908
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1043.463,
                         804.72
                     ]
                 }
@@ -40,11 +48,55 @@
                     "action": "NAVMESH",
                     "target": [
                         1043.463,
+                        801.908
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1043.463,
                         804.72
                     ]
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDepotRetryDomain1Lv005Depot1": {
+        "desc": "AutoDelivery 仓储站位修正路线：源石研究园仓储节点（domain_1_lv005_depot_1）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1043.463,
+                        801.908
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1043.463,
+                        804.72
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -103,6 +155,42 @@
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00501": {
+        "desc": "AutoDelivery 终点站位修正路线：英格（deliver_target_map01_lv005_01）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1131.502,
+                        902.975
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1132.831,
+                        900.497
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -207,6 +295,42 @@
             }
         }
     },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00502": {
+        "desc": "AutoDelivery 终点站位修正路线：基特（deliver_target_map01_lv005_02）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1162.513,
+                        828.793
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1161.842,
+                        826.062
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
     "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00503": {
         "desc": "AutoDelivery 终点路线：从源石研究园仓储节点前往嘉娜（deliver_target_map01_lv005_03）",
         "recognition": "DirectHit",
@@ -265,6 +389,42 @@
             }
         }
     },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00503": {
+        "desc": "AutoDelivery 终点站位修正路线：嘉娜（deliver_target_map01_lv005_03）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        970.334,
+                        826.211
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        968.209,
+                        824.369
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
     "AutoDeliveryRouteDestinationDeliverTargetMap01Lv005Recycle02": {
         "desc": "AutoDelivery 终点路线：从源石研究园仓储节点前往学术复读羽兽（deliver_target_map01_lv005_recycle_02）",
         "recognition": "DirectHit",
@@ -273,6 +433,14 @@
         "custom_action": "MapNavigateAction",
         "custom_action_param": {
             "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        902.486,
+                        764.145
+                    ],
+                    "required": true
+                },
                 {
                     "action": "NAVMESH",
                     "target": [
@@ -305,12 +473,56 @@
                 {
                     "action": "NAVMESH",
                     "target": [
+                        902.486,
+                        764.145
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
                         905.299,
                         764.145
                     ]
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv005Recycle02": {
+        "desc": "AutoDelivery 终点站位修正路线：学术复读羽兽（deliver_target_map01_lv005_recycle_02）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        902.486,
+                        764.145
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        905.299,
+                        764.145
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -331,6 +543,14 @@
         "custom_action": "MapNavigateAction",
         "custom_action_param": {
             "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1185.447,
+                        819.105
+                    ],
+                    "required": true
+                },
                 {
                     "action": "NAVMESH",
                     "target": [
@@ -363,12 +583,56 @@
                 {
                     "action": "NAVMESH",
                     "target": [
+                        1185.447,
+                        819.105
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
                         1183.458,
                         817.116
                     ]
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv005Recycle03": {
+        "desc": "AutoDelivery 终点站位修正路线：采购-醇化合物工厂模组（deliver_target_map01_lv005_recycle_03）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1185.447,
+                        819.105
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1183.458,
+                        817.116
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/AutoDelivery/Routes/PowerPlateau.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/PowerPlateau.json
@@ -116,8 +116,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        635.955,
-                        233.104
+                        635.915,
+                        235.916
                     ],
                     "required": true
                 },
@@ -210,8 +210,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        619.505,
-                        130.084
+                        622.317,
+                        130.043
                     ],
                     "required": true
                 },
@@ -304,8 +304,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        527.85,
-                        244.378
+                        527.863,
+                        247.191
                     ],
                     "required": true
                 },
@@ -398,8 +398,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        680.436,
-                        393.398
+                        679.687,
+                        396.109
                     ],
                     "required": true
                 },
@@ -435,7 +435,7 @@
                     "action": "NAVMESH",
                     "target": [
                         502.664,
-                        254.714
+                        246.277
                     ],
                     "required": true
                 },
@@ -472,7 +472,7 @@
                     "action": "NAVMESH",
                     "target": [
                         502.664,
-                        254.714
+                        246.277
                     ],
                     "required": true
                 },
@@ -509,7 +509,7 @@
                     "action": "NAVMESH",
                     "target": [
                         502.664,
-                        254.714
+                        246.277
                     ],
                     "required": true
                 },
@@ -545,7 +545,7 @@
                     "action": "NAVMESH",
                     "target": [
                         615.071,
-                        394.353
+                        402.791
                     ],
                     "required": true
                 },
@@ -582,7 +582,7 @@
                     "action": "NAVMESH",
                     "target": [
                         615.071,
-                        394.353
+                        402.791
                     ],
                     "required": true
                 },
@@ -619,7 +619,7 @@
                     "action": "NAVMESH",
                     "target": [
                         615.071,
-                        394.353
+                        402.791
                     ],
                     "required": true
                 },

--- a/assets/resource/pipeline/AutoDelivery/Routes/PowerPlateau.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/PowerPlateau.json
@@ -105,6 +105,42 @@
             }
         }
     },
+    "AutoDeliveryRouteDepotRetryDomain1Lv007Depot1": {
+        "desc": "AutoDelivery 仓储站位修正路线：供能高地仓储节点（domain_1_lv007_depot_1）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        635.955,
+                        233.104
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        635.995,
+                        230.292
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
     "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00701": {
         "desc": "AutoDelivery 终点路线：从供能高地仓储节点前往库济米尼奇娜（deliver_target_map01_lv007_01）",
         "recognition": "DirectHit",
@@ -151,6 +187,42 @@
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00701": {
+        "desc": "AutoDelivery 终点站位修正路线：库济米尼奇娜（deliver_target_map01_lv007_01）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        619.505,
+                        130.084
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        616.693,
+                        130.125
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -221,6 +293,42 @@
             }
         }
     },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00702": {
+        "desc": "AutoDelivery 终点站位修正路线：里斯卡（deliver_target_map01_lv007_02）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        527.85,
+                        244.378
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        527.836,
+                        241.566
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
     "AutoDeliveryRouteDestinationDeliverTargetMap01Lv00703": {
         "desc": "AutoDelivery 终点路线：从供能高地仓储节点前往戈里昂（deliver_target_map01_lv007_03）",
         "recognition": "DirectHit",
@@ -279,6 +387,42 @@
             }
         }
     },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv00703": {
+        "desc": "AutoDelivery 终点站位修正路线：戈里昂（deliver_target_map01_lv007_03）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        680.436,
+                        393.398
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        681.185,
+                        390.687
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
     "AutoDeliveryRouteDestinationDeliverTargetMap01Lv007Recycle02": {
         "desc": "AutoDelivery 终点路线：从供能高地仓储节点前往无畏的工团成员（deliver_target_map01_lv007_recycle_02）",
         "recognition": "DirectHit",
@@ -287,6 +431,14 @@
         "custom_action": "MapNavigateAction",
         "custom_action_param": {
             "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        502.664,
+                        254.714
+                    ],
+                    "required": true
+                },
                 {
                     "action": "NAVMESH",
                     "target": [
@@ -320,11 +472,55 @@
                     "action": "NAVMESH",
                     "target": [
                         502.664,
+                        254.714
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        502.664,
                         251.902
                     ]
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv007Recycle02": {
+        "desc": "AutoDelivery 终点站位修正路线：无畏的工团成员（deliver_target_map01_lv007_recycle_02）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        502.664,
+                        254.714
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        502.664,
+                        251.902
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -345,6 +541,14 @@
         "custom_action": "MapNavigateAction",
         "custom_action_param": {
             "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        615.071,
+                        394.353
+                    ],
+                    "required": true
+                },
                 {
                     "action": "NAVMESH",
                     "target": [
@@ -378,11 +582,55 @@
                     "action": "NAVMESH",
                     "target": [
                         615.071,
+                        394.353
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        615.071,
                         397.166
                     ]
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap01Lv007Recycle03": {
+        "desc": "AutoDelivery 终点站位修正路线：采购-超域试验场物资模组（deliver_target_map01_lv007_recycle_03）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        615.071,
+                        394.353
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        615.071,
+                        397.166
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/AutoDelivery/Routes/TestArea.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/TestArea.json
@@ -247,8 +247,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1380.787,
-                        1634.291
+                        1377.809,
+                        1634.659
                     ],
                     "required": true
                 },
@@ -389,8 +389,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1081.694,
-                        1457.8
+                        1080.082,
+                        1460.329
                     ],
                     "required": true
                 },
@@ -607,8 +607,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1366.956,
-                        1533.22
+                        1364.039,
+                        1532.519
                     ],
                     "required": true
                 },

--- a/assets/resource/pipeline/AutoDelivery/Routes/TestArea.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/TestArea.json
@@ -236,6 +236,42 @@
             }
         }
     },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00501": {
+        "desc": "AutoDelivery 终点站位修正路线：赵昭（deliver_target_map02_lv005_01）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1380.787,
+                        1634.291
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1383.764,
+                        1633.923
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
     "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00502": {
         "desc": "AutoDelivery 终点路线：从试验园区仓储节点前往裴令容（deliver_target_map02_lv005_02）",
         "recognition": "DirectHit",
@@ -330,6 +366,42 @@
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00502": {
+        "desc": "AutoDelivery 终点站位修正路线：裴令容（deliver_target_map02_lv005_02）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1081.694,
+                        1457.8
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1083.307,
+                        1455.27
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -512,6 +584,42 @@
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00503": {
+        "desc": "AutoDelivery 终点站位修正路线：阿禾（deliver_target_map02_lv005_03）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1366.956,
+                        1533.22
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        1369.873,
+                        1533.922
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/AutoDelivery/Routes/TestArea.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/TestArea.json
@@ -88,21 +88,20 @@
         "custom_action_param": {
             "path": [
                 {
-                    "action": "ZONE",
-                    "zone_id": "Wuling_Base"
+                    "action": "NAVMESH",
+                    "target": [
+                        1252.425,
+                        1746.923
+                    ],
+                    "required": true
                 },
                 {
                     "action": "NAVMESH",
                     "target": [
-                        1252.58,
-                        1739.8
+                        1252.425,
+                        1752.923
                     ]
-                },
-                [
-                    1252.63,
-                    1751.03,
-                    true
-                ]
+                }
             ]
         },
         "post_delay": 0,

--- a/assets/resource/pipeline/AutoDelivery/Routes/WulingCity.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/WulingCity.json
@@ -287,8 +287,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        541.013,
-                        1250.596
+                        543.995,
+                        1250.922
                     ],
                     "required": true
                 },
@@ -455,8 +455,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        464.919,
-                        1712.725
+                        467.918,
+                        1712.648
                     ],
                     "required": true
                 },
@@ -601,8 +601,8 @@
                 {
                     "action": "NAVMESH",
                     "target": [
-                        894.718,
-                        1411.423
+                        894.822,
+                        1414.421
                     ],
                     "required": true
                 },
@@ -756,7 +756,7 @@
                     "action": "NAVMESH",
                     "target": [
                         513.135,
-                        1647.773
+                        1656.773
                     ],
                     "required": true
                 },

--- a/assets/resource/pipeline/AutoDelivery/Routes/WulingCity.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/WulingCity.json
@@ -276,6 +276,42 @@
             }
         }
     },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00201": {
+        "desc": "AutoDelivery 终点站位修正路线：苏白易（deliver_target_map02_lv002_01）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        541.013,
+                        1250.596
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        538.031,
+                        1250.27
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
     "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00202": {
         "desc": "AutoDelivery 终点路线：从武陵城区仓储节点前往普里莫·林德（deliver_target_map02_lv002_02）",
         "recognition": "DirectHit",
@@ -408,6 +444,42 @@
             }
         }
     },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00202": {
+        "desc": "AutoDelivery 终点站位修正路线：普里莫·林德（deliver_target_map02_lv002_02）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        464.919,
+                        1712.725
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        461.92,
+                        1712.802
+                    ]
+                }
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
     "AutoDeliveryRouteDestinationDeliverTargetMap02Lv00203": {
         "desc": "AutoDelivery 终点路线：从武陵城区仓储节点前往于施（deliver_target_map02_lv002_03）",
         "recognition": "DirectHit",
@@ -506,6 +578,42 @@
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv00203": {
+        "desc": "AutoDelivery 终点站位修正路线：于施（deliver_target_map02_lv002_03）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        894.718,
+                        1411.423
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        894.615,
+                        1408.425
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -624,6 +732,42 @@
                 }
             ],
             "zip": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "AutoDeliveryRouteDestinationRetryDeliverTargetMap02Lv002Recycle01": {
+        "desc": "AutoDelivery 终点站位修正路线：火锅探店达人（deliver_target_map02_lv002_recycle_01）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "MapNavigateAction",
+        "custom_action_param": {
+            "path": [
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        513.135,
+                        1647.773
+                    ],
+                    "required": true
+                },
+                {
+                    "action": "NAVMESH",
+                    "target": [
+                        513.135,
+                        1650.773
+                    ]
+                }
+            ]
         },
         "post_delay": 0,
         "rate_limit": 0,

--- a/assets/resource/pipeline/AutoDelivery/Routes/WulingCity.json
+++ b/assets/resource/pipeline/AutoDelivery/Routes/WulingCity.json
@@ -110,21 +110,20 @@
         "custom_action_param": {
             "path": [
                 {
-                    "action": "ZONE",
-                    "zone_id": "Wuling_Base"
+                    "action": "NAVMESH",
+                    "target": [
+                        956.407,
+                        1831.725
+                    ],
+                    "required": true
                 },
                 {
                     "action": "NAVMESH",
                     "target": [
-                        964.99,
-                        1829.41
+                        950.498,
+                        1832.767
                     ]
-                },
-                [
-                    952.2,
-                    1832.68,
-                    true
-                ]
+                }
             ]
         },
         "post_delay": 0,

--- a/docs/zh_cn/developers/components/auto-delivery.md
+++ b/docs/zh_cn/developers/components/auto-delivery.md
@@ -103,7 +103,7 @@ AutoDelivery 是任务无关的自动送货组件。调用方打开正确的当�
 | `assets/resource/pipeline/AutoDelivery/Delivery.json` | 取消追踪、终点导航和提交货物 |
 | `agent/go-service/autodelivery/` | OCR 匹配、运行时目录校验和生成路线节点分发 |
 
-普通仓储和资源回收站由 `tools/pipeline-generate/data/scripts/delivery_destinations_data.py` 提供游戏数据坐标与 yaw。路线生成器先在目标 yaw 正方向 4 米处生成一个 `required: true` 的 `NAVMESH` 必经点，再前往原始坐标，从而保证从交互正面接近；普通收货 NPC 仍只生成原始坐标的单个 `NAVMESH` 目标。只有断网格、分层或需要特殊站位时，才在 `routes.json` 中维护覆盖。
+普通仓储和资源回收站由 `tools/pipeline-generate/data/scripts/delivery_destinations_data.py` 提供游戏数据坐标与 yaw。路线生成器先在目标 yaw 正方向 8 米处生成一个 `required: true` 的 `NAVMESH` 必经点，再前往原始坐标，从而保证从交互正面接近；普通收货 NPC 仍只生成原始坐标的单个 `NAVMESH` 目标。只有断网格、分层或需要特殊站位时，才在 `routes.json` 中维护覆盖。
 
 运行 `pnpm generate:AutoDelivery` 后，每条主路线会生成普通与允许滑索两个 `AutoDeliveryRoute...` 节点。所有仓储和送货目标还会用同一条两点接近路线生成一个不启用滑索的 retry 节点；显式 `retry_path` 可以覆盖该路线。固定的 `AutoDeliveryNavigateDepot`、`AutoDeliveryRetryNavigateDepot`、`AutoDeliveryNavigateDestination` 和 `AutoDeliveryRetryNavigateDestination` 是 `SubTask` 分发器：Go Service 只根据 OCR 结果选择生成节点名，不再把坐标或完整 `path` 注入 Pipeline。生成节点是公开的单路线测试入口，`desc` 会注明路线对应的仓储节点；它们不替代完整送货业务的唯一入口 `AutoDelivery`。
 
@@ -121,7 +121,7 @@ AutoDelivery 是任务无关的自动送货组件。调用方打开正确的当�
 
 ### `retry_path`
 
-`retry_path` 使用与 `MapNavigateAction.custom_action_param.path` 相同的格式。它从主路线结束后的实际站位开始执行，应包含独立运行所需的区域声明和路径点。所有仓储和送货目标未配置时都使用自动生成的“4 米必经接近点 → 原始终点”路线，无需手工复制坐标；这不改变 NPC 主路线仍为单个终点的规则。
+`retry_path` 使用与 `MapNavigateAction.custom_action_param.path` 相同的格式。它从主路线结束后的实际站位开始执行，应包含独立运行所需的区域声明和路径点。所有仓储和送货目标未配置时都使用自动生成的“8 米必经接近点 → 原始终点”路线，无需手工复制坐标；这不改变 NPC 主路线仍为单个终点的规则。
 
 只在已经确认自动两点修正不适用时配置 `retry_path`，例如断网格、分层或目标附近需要绕行。不要用它掩盖模板不稳定、页面未加载或主路线错误。
 

--- a/docs/zh_cn/developers/components/auto-delivery.md
+++ b/docs/zh_cn/developers/components/auto-delivery.md
@@ -95,7 +95,7 @@ AutoDelivery 是任务无关的自动送货组件。调用方打开正确的当�
 | 路径 | 内容 |
 | --- | --- |
 | `tools/pipeline-generate/data/delivery_destinations.json` | zmdmap 数据 CI 自动生成并发布的仓储、终点、五语言文本、坐标和归属关系 |
-| `tools/pipeline-generate/AutoDelivery/routes.json` | 特殊仓储路线、取货站位修正和终点完整路线 |
+| `tools/pipeline-generate/AutoDelivery/routes.json` | 自动路线无法适用时的仓储、终点和站位修正路线覆盖 |
 | `assets/resource/pipeline/AutoDelivery/Routes/{RouteFileId}.json` | 由上述数据按仓储节点分组生成、可独立试跑的仓储与终点寻路节点 |
 | `assets/data/AutoDelivery/catalog.json` | 运行时 OCR 匹配目录，仅保留文本、归属关系和生成节点名 |
 | `assets/resource/pipeline/AutoDelivery/Common.json` | 公共入口和任务详情识别 |
@@ -103,37 +103,38 @@ AutoDelivery 是任务无关的自动送货组件。调用方打开正确的当�
 | `assets/resource/pipeline/AutoDelivery/Delivery.json` | 取消追踪、终点导航和提交货物 |
 | `agent/go-service/autodelivery/` | OCR 匹配、运行时目录校验和生成路线节点分发 |
 
-普通仓储和终点由 `tools/pipeline-generate/data/scripts/delivery_destinations_data.py` 从游戏数据生成单个 `NAVMESH` 目标。只有断网格、分层、需要分段靠近或需要修正取货站位时，才在 `routes.json` 中维护覆盖。
+普通仓储和资源回收站由 `tools/pipeline-generate/data/scripts/delivery_destinations_data.py` 提供游戏数据坐标与 yaw。路线生成器先在目标 yaw 正方向 4 米处生成一个 `required: true` 的 `NAVMESH` 必经点，再前往原始坐标，从而保证从交互正面接近；普通收货 NPC 仍只生成原始坐标的单个 `NAVMESH` 目标。只有断网格、分层或需要特殊站位时，才在 `routes.json` 中维护覆盖。
 
-运行 `pnpm generate:AutoDelivery` 后，每条主路线会生成普通与允许滑索两个 `AutoDeliveryRoute...` 节点，`retry_path` 则生成一个不继承滑索选项的站位修正节点。固定的 `AutoDeliveryNavigateDepot`、`AutoDeliveryRetryNavigateDepot` 和 `AutoDeliveryNavigateDestination` 是 `SubTask` 分发器：Go Service 只根据 OCR 结果选择生成节点名，不再把坐标或完整 `path` 注入 Pipeline。生成节点是公开的单路线测试入口，`desc` 会注明路线对应的仓储节点；它们不替代完整送货业务的唯一入口 `AutoDelivery`。
+运行 `pnpm generate:AutoDelivery` 后，每条主路线会生成普通与允许滑索两个 `AutoDeliveryRoute...` 节点。所有仓储和送货目标还会用同一条两点接近路线生成一个不启用滑索的 retry 节点；显式 `retry_path` 可以覆盖该路线。固定的 `AutoDeliveryNavigateDepot`、`AutoDeliveryRetryNavigateDepot`、`AutoDeliveryNavigateDestination` 和 `AutoDeliveryRetryNavigateDestination` 是 `SubTask` 分发器：Go Service 只根据 OCR 结果选择生成节点名，不再把坐标或完整 `path` 注入 Pipeline。生成节点是公开的单路线测试入口，`desc` 会注明路线对应的仓储节点；它们不替代完整送货业务的唯一入口 `AutoDelivery`。
 
 覆盖文件只有顶层 `depots` 和 `destinations`：
 
 | 数组 | 字段 | 含义 |
 | --- | --- | --- |
 | `depots` | `path` | 从快速传送落点前往仓储的完整 MapNavigator 路线；未配置时使用自动生成的仓储坐标 |
-| `depots` | `retry_path` | 首次未识别到取货按钮时执行一次的局部站位修正路线 |
+| `depots` | `retry_path` | 覆盖首次未识别到取货按钮时执行的自动两点站位修正路线 |
 | `depots` | `departure_path` | 拼接到该仓储所属终点路线前的公共离场路线 |
 | `destinations` | `path` | 包含最终航点的完整终点路线；未配置时使用自动生成的终点坐标 |
+| `destinations` | `retry_path` | 覆盖首次未识别到提交按钮时执行的自动两点站位修正路线 |
 
 终点目录中的 `area` 取自 `LevelDescTable.showName`，对应任务详情页实际显示的关卡名称，而不是地区建设中的仓储节点名称。普通收货任务按 `buyerName` 匹配终点；`kind` 为 `recycle_bin` 的回收站任务不显示买家名，改为匹配完整 `mission`。同一区域存在多个相同回收站文案时保持歧义失败，不静默选择可能错误的终点。
 
 ### `retry_path`
 
-`retry_path` 使用与 `MapNavigateAction.custom_action_param.path` 相同的格式。它从仓储主路线结束后的实际站位开始执行，应包含独立运行所需的区域声明和路径点。
+`retry_path` 使用与 `MapNavigateAction.custom_action_param.path` 相同的格式。它从主路线结束后的实际站位开始执行，应包含独立运行所需的区域声明和路径点。所有仓储和送货目标未配置时都使用自动生成的“4 米必经接近点 → 原始终点”路线，无需手工复制坐标；这不改变 NPC 主路线仍为单个终点的规则。
 
-只在已经确认以下根因时配置 `retry_path`：仓储主路线可以正确到达，但 MapNavigator 的默认到达范围可能让角色停在取货交互范围外。不要用它掩盖模板不稳定、页面未加载或主路线错误。
+只在已经确认自动两点修正不适用时配置 `retry_path`，例如断网格、分层或目标附近需要绕行。不要用它掩盖模板不稳定、页面未加载或主路线错误。
 
 执行边界如下：
 
 ```text
-前往仓储
-  -> 首次识别到取货按钮：直接取货
-  -> 首次未识别到，且配置了 retry_path：修正站位一次 -> 再识别一次
-  -> 没有 retry_path，或修正后仍未识别到：结束任务
+前往仓储或终点
+  -> 首次识别到交互按钮：继续取货或提交
+  -> 首次未识别到，且目录中存在 retry 节点：修正站位一次 -> 再识别一次
+  -> 没有 retry 节点，或修正后仍未识别到：结束任务
 ```
 
-`retry_path` 不继承仓储主路线的 `zip`，也不暴露为执行入口、anchor 或循环重试节点。一次 AutoDelivery 取货流程最多执行一次站位修正。
+retry 节点不继承主路线的 `zip`，也不形成 anchor 或循环重试。一次取货或交付流程最多执行一次站位修正。
 
 ### 验证
 

--- a/tools/pipeline-generate/AutoDelivery/README.md
+++ b/tools/pipeline-generate/AutoDelivery/README.md
@@ -15,6 +15,6 @@ pnpm generate:AutoDelivery
 
 完整送货业务调用方仍只进入 `AutoDelivery`。生成的 `AutoDeliveryRoute...` 节点是公开的单路线测试入口，可在节点测试工具中单独运行；正常流程由 Go Service 识别当前仓储/终点后，通过固定 `SubTask` 分发节点动态调用。
 
-运行生成命令时，`sync-routes.mjs` 会按 `source_id` 刷新仓储的 `name` 以及终点的 `name` / `depot_id`，为游戏数据中的新增项补充 metadata-only 条目，并保留已有的人工字段。仓储和终点都支持 `description` / `path` / `retry_path`；`departure_path` 仅用于仓储，并会拼接到该仓储所有终点主路线之前。
+运行生成命令时，`sync-routes.mjs` 会按 `source_id` 刷新仓储的 `name` 以及终点的 `name` / `depot_id`，为游戏数据中的新增项补充 metadata-only 条目，并保留已有的人工字段。仓储和终点都支持 `description` / `path` / `retry_path`；`departure_path` 仅用于仓储，并会拼接到该仓储所有终点主路线之前。所有仓储和送货目标默认还会用自动两点接近路线生成 retry 节点，显式 `retry_path` 可覆盖其站位修正路径。
 
-修改 `routes.json` 时只使用 MapNavigator 工具实测得到的路径。普通可达目标仅保留同步出的元数据，由生成器使用游戏数据坐标生成单个 `NAVMESH` 点；跨层、断网格、交互或需要站位修正的路线才填写对应的路径覆盖。不要为了补齐字段而复制默认坐标。
+修改 `routes.json` 时只使用 MapNavigator 工具实测得到的路径。普通可达目标仅保留同步出的元数据：仓储节点和资源回收站会在终点的 yaw 正方向 4 米处生成一个 `required: true` 的 `NAVMESH` 必经点，再前往原始坐标，保证从交互正面接近；普通收货 NPC 仍只生成原始坐标的单个 `NAVMESH` 点。跨层、断网格、交互或需要站位修正的路线才填写对应的路径覆盖，人工 `path` 不会自动插入接近点。不要为了补齐字段而复制默认坐标。

--- a/tools/pipeline-generate/AutoDelivery/README.md
+++ b/tools/pipeline-generate/AutoDelivery/README.md
@@ -17,4 +17,4 @@ pnpm generate:AutoDelivery
 
 运行生成命令时，`sync-routes.mjs` 会按 `source_id` 刷新仓储的 `name` 以及终点的 `name` / `depot_id`，为游戏数据中的新增项补充 metadata-only 条目，并保留已有的人工字段。仓储和终点都支持 `description` / `path` / `retry_path`；`departure_path` 仅用于仓储，并会拼接到该仓储所有终点主路线之前。所有仓储和送货目标默认还会用自动两点接近路线生成 retry 节点，显式 `retry_path` 可覆盖其站位修正路径。
 
-修改 `routes.json` 时只使用 MapNavigator 工具实测得到的路径。普通可达目标仅保留同步出的元数据：仓储节点和资源回收站会在终点的 yaw 正方向 4 米处生成一个 `required: true` 的 `NAVMESH` 必经点，再前往原始坐标，保证从交互正面接近；普通收货 NPC 仍只生成原始坐标的单个 `NAVMESH` 点。跨层、断网格、交互或需要站位修正的路线才填写对应的路径覆盖，人工 `path` 不会自动插入接近点。不要为了补齐字段而复制默认坐标。
+修改 `routes.json` 时只使用 MapNavigator 工具实测得到的路径。普通可达目标仅保留同步出的元数据：仓储节点和资源回收站会在终点的 yaw 正方向 8 米处生成一个 `required: true` 的 `NAVMESH` 必经点，再前往原始坐标，保证从交互正面接近；普通收货 NPC 仍只生成原始坐标的单个 `NAVMESH` 点。跨层、断网格、交互或需要站位修正的路线才填写对应的路径覆盖，人工 `path` 不会自动插入接近点。不要为了补齐字段而复制默认坐标。

--- a/tools/pipeline-generate/AutoDelivery/data.test.mjs
+++ b/tools/pipeline-generate/AutoDelivery/data.test.mjs
@@ -5,7 +5,7 @@ import test from "node:test";
 import {parse as parseJsonc} from "jsonc-parser";
 
 import routeRows from "./routes-data.mjs";
-import {depots, destinations, runtimeCatalog} from "./model.mjs";
+import {buildNavmeshPath, buildYawApproachTarget, depots, destinations, runtimeCatalog} from "./model.mjs";
 import {
     ambiguousRecycleBinGroups,
     ambiguousRecycleBins,
@@ -19,6 +19,152 @@ import {buildSyncedRouteConfig} from "./sync-routes.mjs";
 
 const catalogSource = JSON.parse(readFileSync(new URL("../data/delivery_destinations.json", import.meta.url), "utf8"));
 const routeSource = JSON.parse(readFileSync(new URL("./routes.json", import.meta.url), "utf8"));
+
+test("AutoDelivery 按 yaw 正方向生成 4 米接近点", () => {
+    const map = {sx: 0.75, sy: 0.75};
+    const source = {u: 100, v: 200};
+    const expectedByYaw = new Map([
+        [
+            0,
+            [
+                100,
+                197,
+            ],
+        ],
+        [
+            90,
+            [
+                103,
+                200,
+            ],
+        ],
+        [
+            180,
+            [
+                100,
+                203,
+            ],
+        ],
+        [
+            270,
+            [
+                97,
+                200,
+            ],
+        ],
+    ]);
+
+    for (const [
+        yaw,
+        expected,
+    ] of expectedByYaw) {
+        const target = buildYawApproachTarget({...source, yaw}, map, `测试朝向 ${yaw}`);
+        assert.deepEqual(target, expected);
+        assert.ok(Math.abs(Math.hypot((target[0] - source.u) / map.sx, (target[1] - source.v) / map.sy) - 4) < 1e-9);
+    }
+});
+
+test("AutoDelivery 仓储和资源回收站主路线从正面接近且所有目标自动生成重试路线", () => {
+    const depotOverrides = new Map(
+        routeSource.depots.map((item) => [
+            item.source_id,
+            item,
+        ]),
+    );
+    const destinationOverrides = new Map(
+        routeSource.destinations.map((item) => [
+            item.source_id,
+            item,
+        ]),
+    );
+    const sourceByDepotId = new Map(
+        catalogSource.depots.map((item) => [
+            item.id,
+            item,
+        ]),
+    );
+    const sourceByDestinationId = new Map(
+        catalogSource.destinations.map((item) => [
+            item.id,
+            item,
+        ]),
+    );
+
+    for (const depot of depots) {
+        const source = sourceByDepotId.get(depot.id);
+        const defaultPath = buildNavmeshPath(source, `仓储 ${depot.id}`, true);
+        const override = depotOverrides.get(depot.id);
+        if (override?.path?.length) {
+            assert.deepEqual(depot.path, override.path);
+        } else {
+            assert.deepEqual(depot.path, defaultPath);
+        }
+
+        const expectedRetryPath = override?.retry_path?.length ? override.retry_path : defaultPath;
+        assert.deepEqual(depot.retryPath, expectedRetryPath);
+        assert.match(depot.retryRouteNode, /^AutoDeliveryRouteDepotRetry/);
+        assert.equal(defaultPath.length, 2);
+        assert.equal(defaultPath[0].required, true);
+        assert.deepEqual(defaultPath[1].target, [
+            source.u,
+            source.v,
+        ]);
+        const map = catalogSource.maps[source.map];
+        assert.ok(
+            Math.abs(
+                Math.hypot(
+                    (defaultPath[0].target[0] - source.u) / map.sx,
+                    (defaultPath[0].target[1] - source.v) / map.sy,
+                ) - 4,
+            ) < 0.002,
+        );
+    }
+
+    for (const destination of destinations) {
+        const source = sourceByDestinationId.get(destination.id);
+        const override = destinationOverrides.get(destination.id);
+        const depot = depots.find((item) => item.id === destination.depotId);
+        const ownPath = destination.path.slice(depot.departurePath.length);
+        const withApproachPoint = source.kind === "recycle_bin";
+        const defaultPath = buildNavmeshPath(source, `终点 ${destination.id}`, withApproachPoint);
+        if (override?.path?.length) {
+            assert.deepEqual(ownPath, override.path);
+        } else {
+            assert.deepEqual(ownPath, defaultPath);
+        }
+
+        const defaultRetryPath = buildNavmeshPath(source, `终点重试 ${destination.id}`, true);
+        const expectedRetryPath = override?.retry_path?.length ? override.retry_path : defaultRetryPath;
+        assert.deepEqual(destination.retryPath, expectedRetryPath);
+        assert.match(destination.retryRouteNode, /^AutoDeliveryRouteDestinationRetry/);
+
+        if (!withApproachPoint) {
+            assert.equal(defaultPath.length, 1);
+        } else {
+            assert.equal(defaultPath.length, 2);
+            assert.equal(defaultPath[0].required, true);
+            const map = catalogSource.maps[source.map];
+            assert.ok(
+                Math.abs(
+                    Math.hypot(
+                        (defaultPath[0].target[0] - source.u) / map.sx,
+                        (defaultPath[0].target[1] - source.v) / map.sy,
+                    ) - 4,
+                ) < 0.002,
+            );
+        }
+        assert.deepEqual(defaultPath.at(-1).target, [
+            source.u,
+            source.v,
+        ]);
+    }
+});
+
+test("AutoDelivery 接近点拒绝无效朝向和地图比例", () => {
+    const source = {u: 100, v: 200, yaw: 0};
+    assert.throws(() => buildYawApproachTarget({...source, yaw: Number.NaN}, {sx: 1, sy: 1}, "无效朝向"), /yaw/);
+    assert.throws(() => buildYawApproachTarget(source, {sx: 0, sy: 1}, "无效比例"), /sx\/sy/);
+});
 
 test("AutoDelivery 路线同步刷新元数据并保留人工覆盖字段", () => {
     const synced = buildSyncedRouteConfig(
@@ -148,7 +294,7 @@ test("AutoDelivery 路线为每个仓储和终点生成可独立执行的普通/
     for (const row of routeRows) {
         assert.match(row.Node, /^AutoDeliveryRoute/);
         assert.ok(row.ActionParam.value.path.length > 0);
-        assert.match(row.Description, /仓储节点/);
+        assert.match(row.Description, /仓储节点|终点站位修正路线/);
     }
 });
 

--- a/tools/pipeline-generate/AutoDelivery/data.test.mjs
+++ b/tools/pipeline-generate/AutoDelivery/data.test.mjs
@@ -20,7 +20,7 @@ import {buildSyncedRouteConfig} from "./sync-routes.mjs";
 const catalogSource = JSON.parse(readFileSync(new URL("../data/delivery_destinations.json", import.meta.url), "utf8"));
 const routeSource = JSON.parse(readFileSync(new URL("./routes.json", import.meta.url), "utf8"));
 
-test("AutoDelivery 按 yaw 正方向生成 4 米接近点", () => {
+test("AutoDelivery 按 yaw 正方向生成 8 米接近点", () => {
     const map = {sx: 0.75, sy: 0.75};
     const source = {u: 100, v: 200};
     const expectedByYaw = new Map([
@@ -28,13 +28,13 @@ test("AutoDelivery 按 yaw 正方向生成 4 米接近点", () => {
             0,
             [
                 100,
-                197,
+                194,
             ],
         ],
         [
             90,
             [
-                103,
+                106,
                 200,
             ],
         ],
@@ -42,13 +42,13 @@ test("AutoDelivery 按 yaw 正方向生成 4 米接近点", () => {
             180,
             [
                 100,
-                203,
+                206,
             ],
         ],
         [
             270,
             [
-                97,
+                94,
                 200,
             ],
         ],
@@ -60,7 +60,7 @@ test("AutoDelivery 按 yaw 正方向生成 4 米接近点", () => {
     ] of expectedByYaw) {
         const target = buildYawApproachTarget({...source, yaw}, map, `测试朝向 ${yaw}`);
         assert.deepEqual(target, expected);
-        assert.ok(Math.abs(Math.hypot((target[0] - source.u) / map.sx, (target[1] - source.v) / map.sy) - 4) < 1e-9);
+        assert.ok(Math.abs(Math.hypot((target[0] - source.u) / map.sx, (target[1] - source.v) / map.sy) - 8) < 1e-9);
     }
 });
 
@@ -115,7 +115,7 @@ test("AutoDelivery 仓储和资源回收站主路线从正面接近且所有目�
                 Math.hypot(
                     (defaultPath[0].target[0] - source.u) / map.sx,
                     (defaultPath[0].target[1] - source.v) / map.sy,
-                ) - 4,
+                ) - 8,
             ) < 0.002,
         );
     }
@@ -149,7 +149,7 @@ test("AutoDelivery 仓储和资源回收站主路线从正面接近且所有目�
                     Math.hypot(
                         (defaultPath[0].target[0] - source.u) / map.sx,
                         (defaultPath[0].target[1] - source.v) / map.sy,
-                    ) - 4,
+                    ) - 8,
                 ) < 0.002,
             );
         }

--- a/tools/pipeline-generate/AutoDelivery/model.mjs
+++ b/tools/pipeline-generate/AutoDelivery/model.mjs
@@ -5,7 +5,7 @@ import {BASE_NAV_ZONE_IMAGE_PARTS} from "../../MapNavigator/web/static/js/model.
 const catalogSource = JSON.parse(readFileSync(new URL("../data/delivery_destinations.json", import.meta.url), "utf8"));
 const routeSource = JSON.parse(readFileSync(new URL("./routes.json", import.meta.url), "utf8"));
 
-const APPROACH_DISTANCE_METERS = 4;
+const APPROACH_DISTANCE_METERS = 8;
 const COORDINATE_PRECISION = 3;
 
 function assertArray(value, label) {

--- a/tools/pipeline-generate/AutoDelivery/model.mjs
+++ b/tools/pipeline-generate/AutoDelivery/model.mjs
@@ -5,6 +5,9 @@ import {BASE_NAV_ZONE_IMAGE_PARTS} from "../../MapNavigator/web/static/js/model.
 const catalogSource = JSON.parse(readFileSync(new URL("../data/delivery_destinations.json", import.meta.url), "utf8"));
 const routeSource = JSON.parse(readFileSync(new URL("./routes.json", import.meta.url), "utf8"));
 
+const APPROACH_DISTANCE_METERS = 4;
+const COORDINATE_PRECISION = 3;
+
 function assertArray(value, label) {
     if (!Array.isArray(value)) {
         throw new TypeError(`[AutoDelivery] ${label} 必须是数组`);
@@ -71,18 +74,57 @@ function buildRouteNode(kind, sourceId, zip = false) {
     return `AutoDeliveryRoute${kind}${buildNodeId(sourceId)}${zip ? "WithZipline" : ""}`;
 }
 
-function buildNavmeshPath(source, label) {
+function roundCoordinate(value) {
+    return Number(value.toFixed(COORDINATE_PRECISION));
+}
+
+export function buildYawApproachTarget(source, map, label) {
     if (!Number.isFinite(source.u) || !Number.isFinite(source.v) || source.u < 0 || source.v < 0) {
         throw new TypeError(`[AutoDelivery] ${label} 的 u/v 坐标无效`);
+    }
+
+    if (!Number.isFinite(source.yaw)) {
+        throw new TypeError(`[AutoDelivery] ${label} 的 yaw 朝向无效`);
+    }
+    if (!Number.isFinite(map?.sx) || map.sx <= 0 || !Number.isFinite(map?.sy) || map.sy <= 0) {
+        throw new TypeError(`[AutoDelivery] ${label} 的地图 sx/sy 比例无效`);
+    }
+
+    const radians = (source.yaw * Math.PI) / 180;
+    return [
+        roundCoordinate(source.u + APPROACH_DISTANCE_METERS * map.sx * Math.sin(radians)),
+        roundCoordinate(source.v - APPROACH_DISTANCE_METERS * map.sy * Math.cos(radians)),
+    ];
+}
+
+export function buildNavmeshPath(source, label, withApproachPoint = false) {
+    if (!Number.isFinite(source.u) || !Number.isFinite(source.v) || source.u < 0 || source.v < 0) {
+        throw new TypeError(`[AutoDelivery] ${label} 的 u/v 坐标无效`);
+    }
+
+    const destination = {
+        action: "NAVMESH",
+        target: [
+            source.u,
+            source.v,
+        ],
+    };
+    if (!withApproachPoint) {
+        return [destination];
+    }
+
+    const mapId = assertNonEmptyString(source.map, `${label}.map`);
+    const map = catalogSource.maps?.[mapId];
+    if (!map) {
+        throw new Error(`[AutoDelivery] ${label} 引用了未知地图 ${mapId}`);
     }
     return [
         {
             action: "NAVMESH",
-            target: [
-                source.u,
-                source.v,
-            ],
+            target: buildYawApproachTarget(source, map, label),
+            required: true,
         },
+        destination,
     ];
 }
 
@@ -109,7 +151,9 @@ const destinationOverrides = new Map(destinationOverrideItems);
 export const depots = assertArray(catalogSource.depots, "delivery_destinations.depots").map((source, index) => {
     const id = assertNonEmptyString(source.id, `depots[${index}].id`);
     const override = depotOverrides.get(id);
-    const path = override?.path?.length ? override.path : buildNavmeshPath(source, `仓储 ${id}`);
+    const defaultPath = buildNavmeshPath(source, `仓储 ${id}`, true);
+    const path = override?.path?.length ? override.path : defaultPath;
+    const retryPath = override?.retry_path?.length ? override.retry_path : defaultPath;
     return {
         id,
         name: assertNonEmptyString(source.name?.zh_cn, `depots[${index}].name.zh_cn`),
@@ -117,11 +161,11 @@ export const depots = assertArray(catalogSource.depots, "delivery_destinations.d
         routeFileId: buildRouteFileId(source.name, `depots[${index}]`),
         map: assertNonEmptyString(source.map, `depots[${index}].map`),
         path,
-        retryPath: override?.retry_path ?? [],
+        retryPath,
         departurePath: override?.departure_path ?? [],
         routeNode: buildRouteNode("Depot", id),
         zipRouteNode: buildRouteNode("Depot", id, true),
-        retryRouteNode: override?.retry_path?.length ? buildRouteNode("DepotRetry", id) : "",
+        retryRouteNode: buildRouteNode("DepotRetry", id),
     };
 });
 assertUnique(depots, (item) => item.id, "仓储 ID");
@@ -153,7 +197,11 @@ export const destinations = assertArray(catalogSource.destinations, "delivery_de
             throw new Error(`[AutoDelivery] 终点 ${id} 引用了未知仓储 ${source.depot_id}`);
         }
         const override = destinationOverrides.get(id);
-        const ownPath = override?.path?.length ? override.path : buildNavmeshPath(source, `终点 ${id}`);
+        const withApproachPoint = source.kind === "recycle_bin";
+        const defaultPath = buildNavmeshPath(source, `终点 ${id}`, withApproachPoint);
+        const ownPath = override?.path?.length ? override.path : defaultPath;
+        const defaultRetryPath = buildNavmeshPath(source, `终点重试 ${id}`, true);
+        const retryPath = override?.retry_path?.length ? override.retry_path : defaultRetryPath;
         return {
             id,
             kind: source.kind,
@@ -175,10 +223,10 @@ export const destinations = assertArray(catalogSource.destinations, "delivery_de
                 ...depot.departurePath,
                 ...ownPath,
             ],
-            retryPath: override?.retry_path ?? [],
+            retryPath,
             routeNode: buildRouteNode("Destination", id),
             zipRouteNode: buildRouteNode("Destination", id, true),
-            retryRouteNode: override?.retry_path?.length ? buildRouteNode("DestinationRetry", id) : "",
+            retryRouteNode: buildRouteNode("DestinationRetry", id),
         };
     })
     .sort((left, right) => left.id.localeCompare(right.id));

--- a/tools/pipeline-generate/AutoDelivery/routes.json
+++ b/tools/pipeline-generate/AutoDelivery/routes.json
@@ -473,24 +473,6 @@
                     ]
                 }
             ],
-            "retry_path": [
-                {
-                    "action": "ZONE",
-                    "zone_id": "Wuling_Base"
-                },
-                {
-                    "action": "NAVMESH",
-                    "target": [
-                        964.99,
-                        1829.41
-                    ]
-                },
-                [
-                    952.2,
-                    1832.68,
-                    true
-                ]
-            ],
             "departure_path": [
                 {
                     "action": "ZONE",
@@ -532,24 +514,6 @@
                         1751.03
                     ]
                 }
-            ],
-            "retry_path": [
-                {
-                    "action": "ZONE",
-                    "zone_id": "Wuling_Base"
-                },
-                {
-                    "action": "NAVMESH",
-                    "target": [
-                        1252.58,
-                        1739.8
-                    ]
-                },
-                [
-                    1252.63,
-                    1751.03,
-                    true
-                ]
             ],
             "departure_path": [
                 {

--- a/tools/pipeline-generate/README.md
+++ b/tools/pipeline-generate/README.md
@@ -10,8 +10,13 @@ MaaEnd 使用四份由 zmdmap 数据 CI 生成并发布的精简游戏数据：
 这些文件都是按任务需要裁剪出的游戏数据，不是完整的上游数据快照，也不包含数据生产端的版本或来源元数据。MaaEnd 通过 `data/version.txt` 单独记录当前数据版本，`fetch-data.mjs` 根据 zmdmap 版本接口下载四份文件；版本未变化且本地缓存完整时跳过下载，网络检查失败时保留当前缓存。
 
 ```text
-TableCfg → data/scripts/*.py（zmdmap 数据 CI）→ zmdmap 发布精简游戏数据
-         → fetch-data.mjs（MaaEnd）→ data/*.json → 各任务生成器
+BeyondTableCfg/TableCfg ─┐
+                        ├→ data/scripts/*.py（本地生成）→ data/*.json
+BeyondMemoryPack/JsonData┘
+
+BeyondTableCfg + BeyondMemoryPack → endfield-workflow（CI）→ zmdmap 发布精简游戏数据
+                                                        → fetch-data.mjs（MaaEnd）
+                                                        → data/*.json → 各任务生成器
 ```
 
 ```shell
@@ -31,16 +36,28 @@ pnpm generate:SellProduct
 
 ## 精简游戏数据生成脚本
 
-`data/scripts/` 中的四个 Python 入口供 zmdmap 数据 CI 使用，不是 MaaEnd 日常生成流程的一部分。它们彼此独立，只读取当前任务需要的 TableCfg、GameplayConfig 与 BaseNav，并输出对应的精简游戏数据：
+`data/scripts/` 中的四个 Python 入口用于从本地解包仓库生成精简游戏数据，与
+`endfield-workflow` 中的 CI 生成逻辑保持一致。默认目录按当前 MaaEnd 仓库的兄弟目录解析：
+
+- `../BeyondTableCfg/TableCfg`；
+- `../BeyondMemoryPack/JsonData`；
+- 送货点坐标另外读取 MaaEnd 当前 `assets/resource/model/map/navmesh/base.nav.gz`。
+
+因此三个仓库位于同一 `Endfield` 目录时，无需先复制文件到下载目录，也无需传入路径：
 
 ```shell
-uv run tools/pipeline-generate/data/scripts/delivery_jobs_data.py --table-cfg-dir C:\path\to\TableCfg
-uv run tools/pipeline-generate/data/scripts/delivery_destinations_data.py --table-cfg-dir C:\path\to\TableCfg
-uv run tools/pipeline-generate/data/scripts/environment_monitoring_data.py --table-cfg-dir C:\path\to\TableCfg
-uv run tools/pipeline-generate/data/scripts/sell_product_data.py --table-cfg-dir C:\path\to\TableCfg
+uv run tools/pipeline-generate/data/scripts/delivery_jobs_data.py
+uv run tools/pipeline-generate/data/scripts/delivery_destinations_data.py
+uv run tools/pipeline-generate/data/scripts/environment_monitoring_data.py
+uv run tools/pipeline-generate/data/scripts/sell_product_data.py
 ```
 
-未指定 `--table-cfg-dir` 时默认读取当前用户的 `Downloads/TableCfg`。生成结果与已有文件相同时跳过写入；`--force` 可强制重写。`data/scripts/tablecfg_utils.py` 只负责本地文件读取、五语言文本引用、结果比较和 JSON 写入，任务业务规则分别留在四个入口中。
+仓库不在默认相对位置时，可用 `--table-cfg-dir` 覆盖 TableCfg；送货点脚本还可用
+`--gameplay-config-dir`、`--level-data-dir` 和 `--nav` 分别覆盖 BeyondMemoryPack 与
+BaseNav 路径。四个入口都支持 `--output`，可将结果写入临时目录做本地/CI 等价校验。
+生成结果与已有文件相同时跳过写入；`--force` 可强制重写。
+`data/scripts/tablecfg_utils.py` 只负责本地仓库路径、五语言文本引用、结果比较和 JSON
+写入，任务业务规则分别留在四个入口中。
 
 ## 鸣谢
 

--- a/tools/pipeline-generate/data/delivery_destinations.json
+++ b/tools/pipeline-generate/data/delivery_destinations.json
@@ -5,7 +5,8 @@
         "area": "任务详情页显示的关卡名，取自 LevelDescTable.showName",
         "serial_id": "资源回收站在当前区域内显示的序号，取自 RecycleBinTable.serialId",
         "depot_id": "该终点所属仓储节点 ID；没有同层仓储节点时为空字符串",
-        "depots": "仓储节点坐标，按 DomainDepotTable.id 精确关联 LevelMapMark.markInstId"
+        "depots": "仓储节点坐标，按 DomainDepotTable.id 精确关联 LevelMapMark.markInstId；yaw 为朝向（绕 Y 轴欧拉角，度），取自 LevelData 交互实体 rotation.y，缺省为 0",
+        "destinations": "普通收货 NPC 的 yaw 取自 NpcProxyTable.rotation.y；资源回收站的 yaw 取自 LevelData 交互实体 rotation.y，缺省为 0"
     },
     "maps": {
         "map01": {
@@ -49,7 +50,8 @@
             },
             "map": "map01",
             "u": 1043.463,
-            "v": 804.72
+            "v": 804.72,
+            "yaw": 0.0
         },
         {
             "id": "domain_1_lv006_depot_1",
@@ -62,7 +64,8 @@
             },
             "map": "map01",
             "u": 912.255,
-            "v": 263.96
+            "v": 263.96,
+            "yaw": 262.276
         },
         {
             "id": "domain_1_lv007_depot_1",
@@ -75,7 +78,8 @@
             },
             "map": "map01",
             "u": 635.995,
-            "v": 230.292
+            "v": 230.292,
+            "yaw": 180.818
         },
         {
             "id": "domain_2_lv002_depot_1",
@@ -88,7 +92,8 @@
             },
             "map": "map02",
             "u": 950.498,
-            "v": 1832.767
+            "v": 1832.767,
+            "yaw": 80.0
         },
         {
             "id": "domain_2_lv005_depot_1",
@@ -101,7 +106,8 @@
             },
             "map": "map02",
             "u": 1252.425,
-            "v": 1752.923
+            "v": 1752.923,
+            "yaw": 0.0
         }
     ],
     "destinations": [
@@ -132,7 +138,8 @@
             "depot_id": "domain_1_lv005_depot_1",
             "map": "map01",
             "u": 1132.831,
-            "v": 900.497
+            "v": 900.497,
+            "yaw": 208.2103
         },
         {
             "id": "deliver_target_map01_lv005_02",
@@ -161,7 +168,8 @@
             "depot_id": "domain_1_lv005_depot_1",
             "map": "map01",
             "u": 1161.842,
-            "v": 826.062
+            "v": 826.062,
+            "yaw": 166.20575
         },
         {
             "id": "deliver_target_map01_lv005_03",
@@ -190,7 +198,8 @@
             "depot_id": "domain_1_lv005_depot_1",
             "map": "map01",
             "u": 968.209,
-            "v": 824.369
+            "v": 824.369,
+            "yaw": 130.92804
         },
         {
             "id": "deliver_target_map01_lv005_recycle_02",
@@ -220,7 +229,8 @@
             "depot_id": "domain_1_lv005_depot_1",
             "map": "map01",
             "u": 905.299,
-            "v": 764.145
+            "v": 764.145,
+            "yaw": 270.0
         },
         {
             "id": "deliver_target_map01_lv005_recycle_03",
@@ -250,7 +260,8 @@
             "depot_id": "domain_1_lv005_depot_1",
             "map": "map01",
             "u": 1183.458,
-            "v": 817.116
+            "v": 817.116,
+            "yaw": 135.0
         },
         {
             "id": "deliver_target_map01_lv006_01",
@@ -279,7 +290,8 @@
             "depot_id": "domain_1_lv006_depot_1",
             "map": "map01",
             "u": 1132.593,
-            "v": 471.222
+            "v": 471.222,
+            "yaw": 0.0
         },
         {
             "id": "deliver_target_map01_lv006_02",
@@ -308,7 +320,8 @@
             "depot_id": "domain_1_lv006_depot_1",
             "map": "map01",
             "u": 1192.373,
-            "v": 433.958
+            "v": 433.958,
+            "yaw": 135.913422
         },
         {
             "id": "deliver_target_map01_lv006_03",
@@ -337,7 +350,8 @@
             "depot_id": "domain_1_lv006_depot_1",
             "map": "map01",
             "u": 1172.391,
-            "v": 443.451
+            "v": 443.451,
+            "yaw": 353.3304
         },
         {
             "id": "deliver_target_map01_lv006_recycle_01",
@@ -367,7 +381,8 @@
             "depot_id": "domain_1_lv006_depot_1",
             "map": "map01",
             "u": 1048.016,
-            "v": 429.484
+            "v": 429.484,
+            "yaw": 139.641
         },
         {
             "id": "deliver_target_map01_lv006_recycle_03",
@@ -397,7 +412,8 @@
             "depot_id": "domain_1_lv006_depot_1",
             "map": "map01",
             "u": 1078.905,
-            "v": 504.33
+            "v": 504.33,
+            "yaw": 105.156
         },
         {
             "id": "deliver_target_map01_lv007_01",
@@ -426,7 +442,8 @@
             "depot_id": "domain_1_lv007_depot_1",
             "map": "map01",
             "u": 616.693,
-            "v": 130.125
+            "v": 130.125,
+            "yaw": 89.1596451
         },
         {
             "id": "deliver_target_map01_lv007_02",
@@ -455,7 +472,8 @@
             "depot_id": "domain_1_lv007_depot_1",
             "map": "map01",
             "u": 527.836,
-            "v": 241.566
+            "v": 241.566,
+            "yaw": 179.720016
         },
         {
             "id": "deliver_target_map01_lv007_03",
@@ -484,7 +502,8 @@
             "depot_id": "domain_1_lv007_depot_1",
             "map": "map01",
             "u": 681.185,
-            "v": 390.687
+            "v": 390.687,
+            "yaw": 195.447449
         },
         {
             "id": "deliver_target_map01_lv007_recycle_02",
@@ -514,7 +533,8 @@
             "depot_id": "domain_1_lv007_depot_1",
             "map": "map01",
             "u": 502.664,
-            "v": 251.902
+            "v": 251.902,
+            "yaw": 180.0
         },
         {
             "id": "deliver_target_map01_lv007_recycle_03",
@@ -544,7 +564,8 @@
             "depot_id": "domain_1_lv007_depot_1",
             "map": "map01",
             "u": 615.071,
-            "v": 397.166
+            "v": 397.166,
+            "yaw": 0.0
         },
         {
             "id": "deliver_target_map02_lv002_01",
@@ -573,7 +594,8 @@
             "depot_id": "domain_2_lv002_depot_1",
             "map": "map02",
             "u": 538.031,
-            "v": 1250.27
+            "v": 1250.27,
+            "yaw": 96.23967
         },
         {
             "id": "deliver_target_map02_lv002_02",
@@ -602,7 +624,8 @@
             "depot_id": "domain_2_lv002_depot_1",
             "map": "map02",
             "u": 461.92,
-            "v": 1712.802
+            "v": 1712.802,
+            "yaw": 88.53024
         },
         {
             "id": "deliver_target_map02_lv002_03",
@@ -631,7 +654,8 @@
             "depot_id": "domain_2_lv002_depot_1",
             "map": "map02",
             "u": 894.615,
-            "v": 1408.425
+            "v": 1408.425,
+            "yaw": 178.0259
         },
         {
             "id": "deliver_target_map02_lv002_recycle_01",
@@ -661,7 +685,8 @@
             "depot_id": "domain_2_lv002_depot_1",
             "map": "map02",
             "u": 513.135,
-            "v": 1650.773
+            "v": 1650.773,
+            "yaw": 0.0
         },
         {
             "id": "deliver_target_map02_lv005_01",
@@ -690,7 +715,8 @@
             "depot_id": "domain_2_lv005_depot_1",
             "map": "map02",
             "u": 1383.764,
-            "v": 1633.923
+            "v": 1633.923,
+            "yaw": 262.955322
         },
         {
             "id": "deliver_target_map02_lv005_02",
@@ -719,7 +745,8 @@
             "depot_id": "domain_2_lv005_depot_1",
             "map": "map02",
             "u": 1083.307,
-            "v": 1455.27
+            "v": 1455.27,
+            "yaw": 212.518326
         },
         {
             "id": "deliver_target_map02_lv005_03",
@@ -748,7 +775,8 @@
             "depot_id": "domain_2_lv005_depot_1",
             "map": "map02",
             "u": 1369.873,
-            "v": 1533.922
+            "v": 1533.922,
+            "yaw": 283.525238
         }
     ]
 }

--- a/tools/pipeline-generate/data/delivery_destinations.json
+++ b/tools/pipeline-generate/data/delivery_destinations.json
@@ -6,7 +6,7 @@
         "serial_id": "资源回收站在当前区域内显示的序号，取自 RecycleBinTable.serialId",
         "depot_id": "该终点所属仓储节点 ID；没有同层仓储节点时为空字符串",
         "depots": "仓储节点坐标，按 DomainDepotTable.id 精确关联 LevelMapMark.markInstId；yaw 为朝向（绕 Y 轴欧拉角，度），取自 LevelData 交互实体 rotation.y，缺省为 0",
-        "destinations": "普通收货 NPC 的 yaw 取自 NpcProxyTable.rotation.y；资源回收站的 yaw 取自 LevelData 交互实体 rotation.y，缺省为 0"
+        "destinations": "普通收货 NPC 的 yaw 取自 NpcProxyTable.rotation.y；资源回收站的 yaw 取自 LevelData 交互实体 rotation.y 并翻转 180 度，缺省为 0"
     },
     "maps": {
         "map01": {
@@ -230,7 +230,7 @@
             "map": "map01",
             "u": 905.299,
             "v": 764.145,
-            "yaw": 270.0
+            "yaw": 90.0
         },
         {
             "id": "deliver_target_map01_lv005_recycle_03",
@@ -261,7 +261,7 @@
             "map": "map01",
             "u": 1183.458,
             "v": 817.116,
-            "yaw": 135.0
+            "yaw": 315.0
         },
         {
             "id": "deliver_target_map01_lv006_01",
@@ -382,7 +382,7 @@
             "map": "map01",
             "u": 1048.016,
             "v": 429.484,
-            "yaw": 139.641
+            "yaw": 319.641
         },
         {
             "id": "deliver_target_map01_lv006_recycle_03",
@@ -413,7 +413,7 @@
             "map": "map01",
             "u": 1078.905,
             "v": 504.33,
-            "yaw": 105.156
+            "yaw": 285.156
         },
         {
             "id": "deliver_target_map01_lv007_01",
@@ -534,7 +534,7 @@
             "map": "map01",
             "u": 502.664,
             "v": 251.902,
-            "yaw": 180.0
+            "yaw": 0.0
         },
         {
             "id": "deliver_target_map01_lv007_recycle_03",
@@ -565,7 +565,7 @@
             "map": "map01",
             "u": 615.071,
             "v": 397.166,
-            "yaw": 0.0
+            "yaw": 180.0
         },
         {
             "id": "deliver_target_map02_lv002_01",
@@ -686,7 +686,7 @@
             "map": "map02",
             "u": 513.135,
             "v": 1650.773,
-            "yaw": 0.0
+            "yaw": 180.0
         },
         {
             "id": "deliver_target_map02_lv005_01",

--- a/tools/pipeline-generate/data/scripts/delivery_destinations_data.py
+++ b/tools/pipeline-generate/data/scripts/delivery_destinations_data.py
@@ -17,6 +17,8 @@ from typing import Any
 
 from tablecfg_utils import (
     DATA_DIR,
+    DEFAULT_JSON_DATA_DIR,
+    DEFAULT_TABLE_CFG_DIR,
     LOCALE_TABLES,
     TableCfgError,
     assert_list,
@@ -34,6 +36,8 @@ LABEL = "DeliveryDestinations"
 REPO_ROOT = DATA_DIR.parents[2]
 OUTPUT_PATH = DATA_DIR / "delivery_destinations.json"
 USER_AGENT = "MaaEnd-pipeline"
+DEFAULT_GAMEPLAY_CONFIG_DIR = DEFAULT_JSON_DATA_DIR / "GameplayConfig"
+DEFAULT_LEVEL_DATA_DIR = DEFAULT_JSON_DATA_DIR / "LevelData"
 
 TABLE_NAMES = (
     "DomainDepotTable.json",
@@ -68,6 +72,15 @@ NAV_GEO_TAG = b"BGEO"
 NAV_GEO_HEADER = 72
 
 RICH_TEXT_TAG = re.compile(r"<[^<>]*>")
+
+DEPOT_INTERACTIVE_ID = "int_system_domain_depot"
+DEPOT_SYSTEM_COMPONENT = "DomainDepotSystemComponent"
+RECYCLE_INTERACTIVE_ID = "int_doodad_core_recycle"
+RECYCLE_SYSTEM_COMPONENT = "RecycleBinSystemComponent"
+INTERACTIVE_COMPONENTS = {
+    DEPOT_INTERACTIVE_ID: DEPOT_SYSTEM_COMPONENT,
+    RECYCLE_INTERACTIVE_ID: RECYCLE_SYSTEM_COMPONENT,
+}
 
 ENTITY_TYPE_NPC_PROXY = 1
 ENTITY_TYPE_RECYCLE_BIN = 2
@@ -282,17 +295,27 @@ def locate_target(
     npc_positions: dict[str, Any],
     mark_index: dict[str, dict[str, Any]],
     label: str,
-) -> tuple[float, float]:
+) -> tuple[float, float, float]:
     if entity_type == ENTITY_TYPE_NPC_PROXY:
         npc = assert_record(
             npc_positions.get(entity_key), f"{label} 在 NpcProxyTable 中的 {entity_key}"
         )
-        return read_xz(npc.get("position"), f"NpcProxyTable[{entity_key}].position")
+        x, z = read_xz(npc.get("position"), f"NpcProxyTable[{entity_key}].position")
+        rotation = npc.get("rotation")
+        rotation_record = rotation if isinstance(rotation, dict) else {}
+        return (
+            x,
+            z,
+            read_yaw(
+                rotation_record.get("y"), f"NpcProxyTable[{entity_key}].rotation.y"
+            ),
+        )
 
     basic = mark_index.get(entity_key)
     if basic is None:
         raise TableCfgError(f"{label} 在 LevelMapMark 中没有 {entity_key}")
-    return read_xz(basic.get("pos"), f"LevelMapMark[{entity_key}].pos")
+    x, z = read_xz(basic.get("pos"), f"LevelMapMark[{entity_key}].pos")
+    return x, z, 0.0
 
 
 def strip_rich_text(names: dict[str, str], label: str) -> dict[str, str]:
@@ -303,6 +326,138 @@ def strip_rich_text(names: dict[str, str], label: str) -> dict[str, str]:
             raise TableCfgError(f"{label} 在 {locale} 中为空")
         stripped[locale] = value
     return stripped
+
+
+def extract_system_instance_id(entity: dict[str, Any], component: str) -> str | None:
+    component_properties = entity.get("componentProperties")
+    if not isinstance(component_properties, dict):
+        return None
+    properties = component_properties.get(component)
+    if not isinstance(properties, list):
+        return None
+    for property_value in properties:
+        if not isinstance(property_value, dict):
+            continue
+        if property_value.get("key") != "system_inst_key":
+            continue
+        value = property_value.get("value")
+        if not isinstance(value, dict):
+            return None
+        values = value.get("valueArray")
+        if (
+            not isinstance(values, list)
+            or not values
+            or not isinstance(values[0], dict)
+        ):
+            return None
+        instance_id = values[0].get("valueString")
+        return str(instance_id) if instance_id else None
+    return None
+
+
+def read_yaw(value: Any, label: str) -> float:
+    if value is None:
+        return 0.0
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise TableCfgError(f"{label} 不是数值")
+    return float(value)
+
+
+def build_required_pose_entities(
+    depot_table: dict[str, Any], deliver_target_table: dict[str, Any]
+) -> dict[str, set[tuple[str, str]]]:
+    required: dict[str, set[tuple[str, str]]] = {}
+    for depot_id, entry_value in sorted_entries(depot_table):
+        entry = assert_record(entry_value, f"仓储节点 {depot_id}")
+        level_id = entry.get("refLevelId")
+        if isinstance(level_id, str) and level_id:
+            required.setdefault(level_id, set()).add((DEPOT_INTERACTIVE_ID, depot_id))
+
+    for target_id, entry_value in sorted_entries(deliver_target_table):
+        entry = assert_record(entry_value, f"送货目的地 {target_id}")
+        if (
+            normalize_entity_type(entry.get("entityType"), f"送货目的地 {target_id}")
+            != ENTITY_TYPE_RECYCLE_BIN
+        ):
+            continue
+        level_id = entry.get("level")
+        entity_key = entry.get("targetId")
+        if (
+            isinstance(level_id, str)
+            and level_id
+            and isinstance(entity_key, str)
+            and entity_key
+        ):
+            required.setdefault(level_id, set()).add(
+                (RECYCLE_INTERACTIVE_ID, entity_key)
+            )
+    return required
+
+
+def load_entity_yaws(
+    level_data_dir: Path,
+    depot_table: dict[str, Any],
+    deliver_target_table: dict[str, Any],
+) -> dict[tuple[str, str], float]:
+    root = level_data_dir.expanduser().resolve()
+    if not root.is_dir():
+        raise TableCfgError(f"LevelData 目录不存在：{root}")
+
+    required_by_level = build_required_pose_entities(depot_table, deliver_target_table)
+    yaws: dict[tuple[str, str], float] = {}
+    for level_id, required in sorted(required_by_level.items()):
+        level_dir = root / level_id
+        if not level_dir.is_dir():
+            print(
+                f"[{LABEL}] 警告：LevelData 目录不存在，朝向按 0 处理：{level_dir}",
+                file=sys.stderr,
+            )
+            continue
+
+        pending = set(required)
+        for json_file in sorted(level_dir.glob("*.json")):
+            try:
+                data = assert_record(
+                    json.loads(json_file.read_text(encoding="utf-8-sig")),
+                    str(json_file),
+                )
+            except (OSError, ValueError) as error:
+                print(
+                    f"[{LABEL}] 警告：读取关卡文件失败，已跳过 {json_file}：{error}",
+                    file=sys.stderr,
+                )
+                continue
+
+            interactives = data.get("interactives", [])
+            if not isinstance(interactives, list):
+                continue
+            for entity_value in interactives:
+                if not isinstance(entity_value, dict):
+                    continue
+                interactive_id = entity_value.get("entityDataIdKey")
+                component = INTERACTIVE_COMPONENTS.get(interactive_id)
+                if component is None:
+                    continue
+                instance_id = extract_system_instance_id(entity_value, component)
+                pose_key = (str(interactive_id), instance_id or "")
+                if pose_key not in pending:
+                    continue
+                rotation = entity_value.get("rotation")
+                rotation_record = rotation if isinstance(rotation, dict) else {}
+                yaws[(level_id, instance_id or "")] = read_yaw(
+                    rotation_record.get("y"),
+                    f"{json_file} 中 {instance_id} 的 rotation.y",
+                )
+                pending.remove(pose_key)
+            if not pending:
+                break
+
+        for _interactive_id, instance_id in sorted(pending):
+            print(
+                f"[{LABEL}] 警告：{instance_id} 在 {level_id} 的 LevelData 中缺少朝向实体，yaw 按 0 处理",
+                file=sys.stderr,
+            )
+    return yaws
 
 
 def build_depots_by_level(
@@ -326,6 +481,7 @@ def build_depots(
     mark_index: dict[str, dict[str, Any]],
     zones: dict[str, dict[str, Any]],
     used_zones: dict[str, dict[str, Any]],
+    entity_yaws: dict[tuple[str, str], float],
 ) -> list[dict[str, Any]]:
     depots: list[dict[str, Any]] = []
     for depot_id, entry_value in sorted_entries(depot_table):
@@ -357,6 +513,7 @@ def build_depots(
                 "map": map_id,
                 "u": u,
                 "v": v,
+                "yaw": entity_yaws.get((level_id, depot_id), 0.0),
             }
         )
     if not depots:
@@ -368,6 +525,7 @@ def build_delivery_destinations_data(
     tables: dict[str, Any],
     gameplay_config: dict[str, Any],
     zones: dict[str, dict[str, Any]],
+    level_data_dir: Path,
 ) -> dict[str, Any]:
     deliver_target_table = assert_record(
         tables["DomainDepotDeliverTargetTable.json"], "DomainDepotDeliverTargetTable"
@@ -376,9 +534,7 @@ def build_delivery_destinations_data(
         tables["DomainDepotBuyerTable.json"], "DomainDepotBuyerTable"
     )
     depot_table = assert_record(tables["DomainDepotTable.json"], "DomainDepotTable")
-    recycle_bin_table = assert_record(
-        tables["RecycleBinTable.json"], "RecycleBinTable"
-    )
+    recycle_bin_table = assert_record(tables["RecycleBinTable.json"], "RecycleBinTable")
     level_desc_table = assert_record(tables["LevelDescTable.json"], "LevelDescTable")
     locale_tables = build_locale_tables(tables)
 
@@ -392,9 +548,17 @@ def build_delivery_destinations_data(
         assert_record(gameplay_config["LevelMapMark.json"], "LevelMapMark")
     )
     depot_by_level = build_depots_by_level(depot_table)
+    entity_yaws = load_entity_yaws(level_data_dir, depot_table, deliver_target_table)
 
     used_zones: dict[str, dict[str, Any]] = {}
-    depots = build_depots(depot_table, locale_tables, mark_index, zones, used_zones)
+    depots = build_depots(
+        depot_table,
+        locale_tables,
+        mark_index,
+        zones,
+        used_zones,
+        entity_yaws,
+    )
     destinations: list[dict[str, Any]] = []
     for target_id, entry_value in sorted_entries(deliver_target_table):
         entry = assert_record(entry_value, f"送货目的地 {target_id}")
@@ -410,7 +574,9 @@ def build_delivery_destinations_data(
             raise TableCfgError(f"{label} 缺少 targetId")
 
         entity_type = normalize_entity_type(entry.get("entityType"), label)
-        x, z = locate_target(entity_type, entity_key, npc_positions, mark_index, label)
+        x, z, yaw = locate_target(
+            entity_type, entity_key, npc_positions, mark_index, label
+        )
 
         serial_id: int | None = None
         if entity_type == ENTITY_TYPE_RECYCLE_BIN:
@@ -424,8 +590,11 @@ def build_delivery_destinations_data(
                 )
             value = recycle_bin.get("serialId")
             if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-                raise TableCfgError(f"资源回收站 {entity_key} 的 serialId {value!r} 无效")
+                raise TableCfgError(
+                    f"资源回收站 {entity_key} 的 serialId {value!r} 无效"
+                )
             serial_id = value
+            yaw = entity_yaws.get((level_id, entity_key), 0.0)
 
         zone = used_zones.get(map_id)
         if zone is None:
@@ -468,6 +637,7 @@ def build_delivery_destinations_data(
             "map": map_id,
             "u": u,
             "v": v,
+            "yaw": yaw,
         }
         destinations.append(destination)
 
@@ -499,7 +669,14 @@ def build_delivery_destinations_data(
             "area": "任务详情页显示的关卡名，取自 LevelDescTable.showName",
             "serial_id": "资源回收站在当前区域内显示的序号，取自 RecycleBinTable.serialId",
             "depot_id": "该终点所属仓储节点 ID；没有同层仓储节点时为空字符串",
-            "depots": "仓储节点坐标，按 DomainDepotTable.id 精确关联 LevelMapMark.markInstId",
+            "depots": (
+                "仓储节点坐标，按 DomainDepotTable.id 精确关联 LevelMapMark.markInstId；"
+                "yaw 为朝向（绕 Y 轴欧拉角，度），取自 LevelData 交互实体 rotation.y，缺省为 0"
+            ),
+            "destinations": (
+                "普通收货 NPC 的 yaw 取自 NpcProxyTable.rotation.y；"
+                "资源回收站的 yaw 取自 LevelData 交互实体 rotation.y，缺省为 0"
+            ),
         },
         "maps": maps,
         "coord": (
@@ -516,12 +693,29 @@ def build_delivery_destinations_data(
 
 
 def parse_arguments(args: Sequence[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="生成送货点数据")
-    parser.add_argument(
-        "--table-cfg-dir", type=Path, default=None, help="TableCfg 目录"
+    parser = argparse.ArgumentParser(
+        description="从 BeyondTableCfg、BeyondMemoryPack 和本地 BaseNav 生成送货点数据"
     )
     parser.add_argument(
-        "--gameplay-config-dir", type=Path, default=None, help="GameplayConfig 目录"
+        "--table-cfg-dir",
+        type=Path,
+        default=DEFAULT_TABLE_CFG_DIR,
+        help=f"BeyondTableCfg 的 TableCfg 目录（默认：{DEFAULT_TABLE_CFG_DIR}）",
+    )
+    parser.add_argument(
+        "--gameplay-config-dir",
+        type=Path,
+        default=DEFAULT_GAMEPLAY_CONFIG_DIR,
+        help=(
+            "BeyondMemoryPack 的 GameplayConfig 目录"
+            f"（默认：{DEFAULT_GAMEPLAY_CONFIG_DIR}）"
+        ),
+    )
+    parser.add_argument(
+        "--level-data-dir",
+        type=Path,
+        default=DEFAULT_LEVEL_DATA_DIR,
+        help=f"BeyondMemoryPack 的 LevelData 目录（默认：{DEFAULT_LEVEL_DATA_DIR}）",
     )
     parser.add_argument("--nav", default=None, help="nav 数据的本地路径或 URL")
     parser.add_argument("--output", type=Path, default=OUTPUT_PATH, help="输出文件")
@@ -547,7 +741,12 @@ def main(args: Sequence[str] | None = None) -> int:
             "--gameplay-config-dir",
         )
         zones = load_nav_zones(options.nav)
-        data = build_delivery_destinations_data(tables, gameplay_config, zones)
+        data = build_delivery_destinations_data(
+            tables,
+            gameplay_config,
+            zones,
+            options.level_data_dir,
+        )
         if should_skip(options.output, data, options.force):
             print(f"[{LABEL}] 生成结果未变化，跳过写入；可使用 --force 强制重写")
             return 0

--- a/tools/pipeline-generate/data/scripts/delivery_destinations_data.py
+++ b/tools/pipeline-generate/data/scripts/delivery_destinations_data.py
@@ -363,6 +363,11 @@ def read_yaw(value: Any, label: str) -> float:
     return float(value)
 
 
+def reverse_yaw(yaw: float) -> float:
+    """将交互实体朝向翻转为角色正面接近方向。"""
+    return round((yaw + 180.0) % 360.0, 9)
+
+
 def build_required_pose_entities(
     depot_table: dict[str, Any], deliver_target_table: dict[str, Any]
 ) -> dict[str, set[tuple[str, str]]]:
@@ -594,7 +599,8 @@ def build_delivery_destinations_data(
                     f"资源回收站 {entity_key} 的 serialId {value!r} 无效"
                 )
             serial_id = value
-            yaw = entity_yaws.get((level_id, entity_key), 0.0)
+            raw_yaw = entity_yaws.get((level_id, entity_key))
+            yaw = reverse_yaw(raw_yaw) if raw_yaw is not None else 0.0
 
         zone = used_zones.get(map_id)
         if zone is None:
@@ -675,7 +681,7 @@ def build_delivery_destinations_data(
             ),
             "destinations": (
                 "普通收货 NPC 的 yaw 取自 NpcProxyTable.rotation.y；"
-                "资源回收站的 yaw 取自 LevelData 交互实体 rotation.y，缺省为 0"
+                "资源回收站的 yaw 取自 LevelData 交互实体 rotation.y 并翻转 180 度，缺省为 0"
             ),
         },
         "maps": maps,

--- a/tools/pipeline-generate/data/scripts/delivery_jobs_data.py
+++ b/tools/pipeline-generate/data/scripts/delivery_jobs_data.py
@@ -12,9 +12,8 @@ from tablecfg_utils import (
     intersects,
     run_cli,
     sorted_entries,
-    unique_sorted_numbers,
+    unique_sorted_strings,
 )
-
 
 TABLE_NAMES = (
     "DomainDataTable.json",
@@ -48,7 +47,7 @@ def build_delivery_jobs_data(tables: dict[str, Any]) -> dict[str, Any]:
         deliverable_items.append(
             {
                 "id": item_id,
-                "deliver_item_types": unique_sorted_numbers(
+                "deliver_item_types": unique_sorted_strings(
                     deliver_item_type_list,
                     f"物品 {item_id} deliverItemTypeList",
                 ),
@@ -91,7 +90,7 @@ def build_delivery_jobs_data(tables: dict[str, Any]) -> dict[str, Any]:
         ):
             has_level = True
             level = assert_record(level_value, f"仓储节点 {depot_id} 等级")
-            deliver_item_types = unique_sorted_numbers(
+            deliver_item_types = unique_sorted_strings(
                 level.get("deliverItemTypeList"),
                 f"仓储节点 {depot_id} 等级 {level.get('level')} deliverItemTypeList",
             )
@@ -144,7 +143,7 @@ def build_delivery_jobs_data(tables: dict[str, Any]) -> dict[str, Any]:
 def main() -> int:
     return run_cli(
         label="DeliveryJobs",
-        description="从本地 TableCfg 生成转交委托数据",
+        description="从 BeyondTableCfg 仓库生成转交委托数据",
         table_names=TABLE_NAMES,
         output_path=OUTPUT_PATH,
         build_data=build_delivery_jobs_data,

--- a/tools/pipeline-generate/data/scripts/environment_monitoring_data.py
+++ b/tools/pipeline-generate/data/scripts/environment_monitoring_data.py
@@ -12,7 +12,6 @@ from tablecfg_utils import (
     sorted_entries,
 )
 
-
 TABLE_NAMES = (
     "KiteStationEntrustTasksTable.json",
     "KiteStationLevelTable.json",
@@ -84,7 +83,7 @@ def build_environment_monitoring_data(tables: dict[str, Any]) -> dict[str, Any]:
 def main() -> int:
     return run_cli(
         label="EnvironmentMonitoring",
-        description="从本地 TableCfg 生成环境监测数据",
+        description="从 BeyondTableCfg 仓库生成环境监测数据",
         table_names=TABLE_NAMES,
         output_path=OUTPUT_PATH,
         build_data=build_environment_monitoring_data,

--- a/tools/pipeline-generate/data/scripts/sell_product_data.py
+++ b/tools/pipeline-generate/data/scripts/sell_product_data.py
@@ -14,7 +14,6 @@ from tablecfg_utils import (
     sorted_entries,
 )
 
-
 TABLE_NAMES = (
     "SettlementBasicDataTable.json",
     "SettlementTagTable.json",
@@ -194,7 +193,7 @@ def build_sell_product_data(tables: dict[str, Any]) -> dict[str, Any]:
 def main() -> int:
     return run_cli(
         label="SellProduct",
-        description="从本地 TableCfg 生成售卖产品数据",
+        description="从 BeyondTableCfg 仓库生成售卖产品数据",
         table_names=TABLE_NAMES,
         output_path=OUTPUT_PATH,
         build_data=build_sell_product_data,

--- a/tools/pipeline-generate/data/scripts/tablecfg_utils.py
+++ b/tools/pipeline-generate/data/scripts/tablecfg_utils.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any
 
-
-DEFAULT_TABLE_CFG_DIR = Path.home() / "Downloads" / "TableCfg"
 DATA_DIR = Path(__file__).resolve().parent.parent
+MAAEND_REPO_DIR = DATA_DIR.parents[2]
+ENDFIELD_WORKSPACE_DIR = MAAEND_REPO_DIR.parent
+DEFAULT_TABLE_CFG_DIR = ENDFIELD_WORKSPACE_DIR / "BeyondTableCfg" / "TableCfg"
+DEFAULT_JSON_DATA_DIR = ENDFIELD_WORKSPACE_DIR / "BeyondMemoryPack" / "JsonData"
 
 LOCALE_TABLE_SUFFIXES = {
     "zh_cn": "CN",
@@ -42,14 +45,14 @@ def sorted_entries(record: dict[str, Any]) -> list[tuple[str, Any]]:
     return sorted(record.items(), key=lambda entry: entry[0])
 
 
-def unique_sorted_numbers(values: Any, label: str) -> list[int | float]:
-    numbers = assert_list(values, label)
+def unique_sorted_strings(values: Any, label: str) -> list[str]:
+    items = assert_list(values, label)
     if not all(
-        isinstance(value, (int, float)) and not isinstance(value, bool)
-        for value in numbers
+        isinstance(value, (str, int, float)) and not isinstance(value, bool)
+        for value in items
     ):
-        raise TableCfgError(f"{label} 包含非数值元素")
-    return sorted(set(numbers))
+        raise TableCfgError(f"{label} 包含无法转为字符串的元素")
+    return sorted({str(value) for value in items})
 
 
 def build_locale_tables(tables: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -87,20 +90,26 @@ def intersects(left: Sequence[Any], right: Sequence[Any]) -> bool:
     return any(value in right_values for value in left)
 
 
+def resolve_json_paths(
+    directory: Path, file_names: Sequence[str], label: str
+) -> dict[str, Path]:
+    resolved_directory = directory.expanduser().resolve()
+    if not resolved_directory.is_dir():
+        raise TableCfgError(f"{label} 目录不存在：{resolved_directory}")
+
+    paths: dict[str, Path] = {}
+    for file_name in file_names:
+        path = resolved_directory / file_name
+        if not path.is_file():
+            raise TableCfgError(f"缺少 {label} 文件：{path}")
+        paths[file_name] = path
+    return paths
+
+
 def resolve_table_paths(
     table_cfg_dir: Path, table_names: Sequence[str]
 ) -> dict[str, Path]:
-    directory = table_cfg_dir.expanduser().resolve()
-    if not directory.is_dir():
-        raise TableCfgError(f"TableCfg 目录不存在：{directory}")
-
-    paths: dict[str, Path] = {}
-    for table_name in table_names:
-        path = directory / table_name
-        if not path.is_file():
-            raise TableCfgError(f"缺少 TableCfg 文件：{path}")
-        paths[table_name] = path
-    return paths
+    return resolve_json_paths(table_cfg_dir, table_names, "TableCfg")
 
 
 def load_tables(table_paths: dict[str, Path]) -> dict[str, Any]:
@@ -134,7 +143,9 @@ def write_dataset(output_path: Path, data: dict[str, Any]) -> None:
 
 
 def parse_arguments(
-    description: str, args: Sequence[str] | None = None
+    description: str,
+    output_path: Path,
+    args: Sequence[str] | None = None,
 ) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
@@ -142,6 +153,12 @@ def parse_arguments(
         type=Path,
         default=DEFAULT_TABLE_CFG_DIR,
         help=f"TableCfg 目录（默认：{DEFAULT_TABLE_CFG_DIR}）",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=output_path,
+        help=f"输出文件（默认：{output_path}）",
     )
     parser.add_argument(
         "--force",
@@ -180,12 +197,12 @@ def run_cli(
     build_data: Callable[[dict[str, Any]], dict[str, Any]],
     args: Sequence[str] | None = None,
 ) -> int:
-    options = parse_arguments(description, args)
+    options = parse_arguments(description, output_path, args)
     try:
         sync_dataset(
             label=label,
             table_names=table_names,
-            output_path=output_path,
+            output_path=options.output,
             build_data=build_data,
             table_cfg_dir=options.table_cfg_dir,
             force=options.force,

--- a/tools/pipeline-generate/data/sell_product.json
+++ b/tools/pipeline-generate/data/sell_product.json
@@ -832,166 +832,6 @@
                 }
             ]
         },
-        "stm_tundra_2": {
-            "id": "stm_tundra_2",
-            "region_id": "domain_1",
-            "names": {
-                "zh_cn": "基建前站",
-                "zh_tw": "基建前站",
-                "en_us": "Infra-Station",
-                "ja_jp": "建設基地",
-                "ko_kr": "기초 건설 주둔지"
-            },
-            "prosperity_levels": [
-                {
-                    "level": 1,
-                    "trade_items": [
-                        {
-                            "item_id": "item_proc_battery_1",
-                            "unit_price": 16
-                        },
-                        {
-                            "item_id": "item_iron_cmpt",
-                            "unit_price": 1
-                        }
-                    ]
-                },
-                {
-                    "level": 2,
-                    "trade_items": [
-                        {
-                            "item_id": "item_proc_battery_2",
-                            "unit_price": 30
-                        },
-                        {
-                            "item_id": "item_bottled_rec_hp_2",
-                            "unit_price": 27
-                        },
-                        {
-                            "item_id": "item_proc_battery_1",
-                            "unit_price": 16
-                        },
-                        {
-                            "item_id": "item_iron_cmpt",
-                            "unit_price": 1
-                        }
-                    ]
-                },
-                {
-                    "level": 3,
-                    "trade_items": [
-                        {
-                            "item_id": "item_bottled_rec_hp_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_proc_battery_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_proc_battery_2",
-                            "unit_price": 30
-                        },
-                        {
-                            "item_id": "item_bottled_rec_hp_2",
-                            "unit_price": 27
-                        },
-                        {
-                            "item_id": "item_proc_battery_1",
-                            "unit_price": 16
-                        },
-                        {
-                            "item_id": "item_iron_cmpt",
-                            "unit_price": 1
-                        }
-                    ]
-                },
-                {
-                    "level": 4,
-                    "trade_items": [
-                        {
-                            "item_id": "item_bottled_food_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_bottled_rec_hp_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_proc_battery_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_proc_battery_2",
-                            "unit_price": 30
-                        },
-                        {
-                            "item_id": "item_bottled_food_2",
-                            "unit_price": 27
-                        },
-                        {
-                            "item_id": "item_bottled_rec_hp_2",
-                            "unit_price": 27
-                        },
-                        {
-                            "item_id": "item_proc_battery_1",
-                            "unit_price": 16
-                        },
-                        {
-                            "item_id": "item_bottled_food_1",
-                            "unit_price": 10
-                        },
-                        {
-                            "item_id": "item_iron_cmpt",
-                            "unit_price": 1
-                        }
-                    ]
-                }
-            ],
-            "features": [
-                {
-                    "bonus_types": [
-                        "expProfit"
-                    ],
-                    "operator_ids": [
-                        "chr_0002_endminm",
-                        "chr_0003_endminf",
-                        "chr_0004_pelica",
-                        "chr_0005_chen",
-                        "chr_0006_wolfgd",
-                        "chr_0017_yvonne",
-                        "chr_0019_karin",
-                        "chr_0020_meurs",
-                        "chr_0021_whiten",
-                        "chr_0022_bounda",
-                        "chr_0023_antal",
-                        "chr_0027_tangtang",
-                        "chr_0028_wulfa"
-                    ]
-                },
-                {
-                    "bonus_types": [
-                        "moneyProfit"
-                    ],
-                    "operator_ids": [
-                        "chr_0009_azrila",
-                        "chr_0011_seraph",
-                        "chr_0017_yvonne",
-                        "chr_0033_camille"
-                    ]
-                },
-                {
-                    "bonus_types": [
-                        "moneyProduceSpeed"
-                    ],
-                    "operator_ids": [
-                        "chr_0005_chen",
-                        "chr_0017_yvonne",
-                        "chr_0035_liino"
-                    ]
-                }
-            ]
-        },
         "stm_hongs_2": {
             "id": "stm_hongs_2",
             "region_id": "domain_2",
@@ -1198,171 +1038,6 @@
                         "chr_0019_karin",
                         "chr_0029_pograni",
                         "chr_0030_zhuangfy"
-                    ]
-                }
-            ]
-        },
-        "stm_tundra_3": {
-            "id": "stm_tundra_3",
-            "region_id": "domain_1",
-            "names": {
-                "zh_cn": "重建指挥部",
-                "zh_tw": "重建指揮部",
-                "en_us": "Reconstruction HQ",
-                "ja_jp": "再建管理本部",
-                "ko_kr": "재건 지휘부"
-            },
-            "prosperity_levels": [
-                {
-                    "level": 1,
-                    "trade_items": [
-                        {
-                            "item_id": "item_proc_battery_2",
-                            "unit_price": 30
-                        },
-                        {
-                            "item_id": "item_bottled_rec_hp_2",
-                            "unit_price": 27
-                        },
-                        {
-                            "item_id": "item_iron_enr_cmpt",
-                            "unit_price": 3
-                        }
-                    ]
-                },
-                {
-                    "level": 2,
-                    "trade_items": [
-                        {
-                            "item_id": "item_bottled_rec_hp_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_proc_battery_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_proc_battery_2",
-                            "unit_price": 30
-                        },
-                        {
-                            "item_id": "item_bottled_rec_hp_2",
-                            "unit_price": 27
-                        },
-                        {
-                            "item_id": "item_iron_enr_cmpt",
-                            "unit_price": 3
-                        }
-                    ]
-                },
-                {
-                    "level": 3,
-                    "trade_items": [
-                        {
-                            "item_id": "item_bottled_rec_hp_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_bottled_food_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_proc_battery_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_proc_battery_2",
-                            "unit_price": 30
-                        },
-                        {
-                            "item_id": "item_bottled_food_2",
-                            "unit_price": 27
-                        },
-                        {
-                            "item_id": "item_bottled_rec_hp_2",
-                            "unit_price": 27
-                        },
-                        {
-                            "item_id": "item_bottled_food_1",
-                            "unit_price": 10
-                        },
-                        {
-                            "item_id": "item_iron_enr_cmpt",
-                            "unit_price": 3
-                        }
-                    ]
-                },
-                {
-                    "level": 4,
-                    "trade_items": [
-                        {
-                            "item_id": "item_bottled_rec_hp_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_bottled_food_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_proc_battery_3",
-                            "unit_price": 70
-                        },
-                        {
-                            "item_id": "item_proc_battery_2",
-                            "unit_price": 30
-                        },
-                        {
-                            "item_id": "item_bottled_food_2",
-                            "unit_price": 27
-                        },
-                        {
-                            "item_id": "item_bottled_rec_hp_2",
-                            "unit_price": 27
-                        },
-                        {
-                            "item_id": "item_bottled_food_1",
-                            "unit_price": 10
-                        },
-                        {
-                            "item_id": "item_iron_enr_cmpt",
-                            "unit_price": 3
-                        }
-                    ]
-                }
-            ],
-            "features": [
-                {
-                    "bonus_types": [
-                        "expProfit"
-                    ],
-                    "operator_ids": [
-                        "chr_0013_aglina",
-                        "chr_0014_aurora",
-                        "chr_0016_laevat",
-                        "chr_0025_ardelia",
-                        "chr_0029_pograni"
-                    ]
-                },
-                {
-                    "bonus_types": [
-                        "moneyProfit"
-                    ],
-                    "operator_ids": [
-                        "chr_0005_chen",
-                        "chr_0013_aglina",
-                        "chr_0024_deepfin",
-                        "chr_0029_pograni",
-                        "chr_0030_zhuangfy"
-                    ]
-                },
-                {
-                    "bonus_types": [
-                        "moneyProduceSpeed"
-                    ],
-                    "operator_ids": [
-                        "chr_0004_pelica",
-                        "chr_0013_aglina",
-                        "chr_0016_laevat"
                     ]
                 }
             ]
@@ -1720,6 +1395,331 @@
                         "chr_0023_antal",
                         "chr_0028_wulfa",
                         "chr_0033_camille"
+                    ]
+                }
+            ]
+        },
+        "stm_tundra_2": {
+            "id": "stm_tundra_2",
+            "region_id": "domain_1",
+            "names": {
+                "zh_cn": "基建前站",
+                "zh_tw": "基建前站",
+                "en_us": "Infra-Station",
+                "ja_jp": "建設基地",
+                "ko_kr": "기초 건설 주둔지"
+            },
+            "prosperity_levels": [
+                {
+                    "level": 1,
+                    "trade_items": [
+                        {
+                            "item_id": "item_proc_battery_1",
+                            "unit_price": 16
+                        },
+                        {
+                            "item_id": "item_iron_cmpt",
+                            "unit_price": 1
+                        }
+                    ]
+                },
+                {
+                    "level": 2,
+                    "trade_items": [
+                        {
+                            "item_id": "item_proc_battery_2",
+                            "unit_price": 30
+                        },
+                        {
+                            "item_id": "item_bottled_rec_hp_2",
+                            "unit_price": 27
+                        },
+                        {
+                            "item_id": "item_proc_battery_1",
+                            "unit_price": 16
+                        },
+                        {
+                            "item_id": "item_iron_cmpt",
+                            "unit_price": 1
+                        }
+                    ]
+                },
+                {
+                    "level": 3,
+                    "trade_items": [
+                        {
+                            "item_id": "item_bottled_rec_hp_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_proc_battery_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_proc_battery_2",
+                            "unit_price": 30
+                        },
+                        {
+                            "item_id": "item_bottled_rec_hp_2",
+                            "unit_price": 27
+                        },
+                        {
+                            "item_id": "item_proc_battery_1",
+                            "unit_price": 16
+                        },
+                        {
+                            "item_id": "item_iron_cmpt",
+                            "unit_price": 1
+                        }
+                    ]
+                },
+                {
+                    "level": 4,
+                    "trade_items": [
+                        {
+                            "item_id": "item_bottled_food_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_bottled_rec_hp_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_proc_battery_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_proc_battery_2",
+                            "unit_price": 30
+                        },
+                        {
+                            "item_id": "item_bottled_food_2",
+                            "unit_price": 27
+                        },
+                        {
+                            "item_id": "item_bottled_rec_hp_2",
+                            "unit_price": 27
+                        },
+                        {
+                            "item_id": "item_proc_battery_1",
+                            "unit_price": 16
+                        },
+                        {
+                            "item_id": "item_bottled_food_1",
+                            "unit_price": 10
+                        },
+                        {
+                            "item_id": "item_iron_cmpt",
+                            "unit_price": 1
+                        }
+                    ]
+                }
+            ],
+            "features": [
+                {
+                    "bonus_types": [
+                        "expProfit"
+                    ],
+                    "operator_ids": [
+                        "chr_0002_endminm",
+                        "chr_0003_endminf",
+                        "chr_0004_pelica",
+                        "chr_0005_chen",
+                        "chr_0006_wolfgd",
+                        "chr_0017_yvonne",
+                        "chr_0019_karin",
+                        "chr_0020_meurs",
+                        "chr_0021_whiten",
+                        "chr_0022_bounda",
+                        "chr_0023_antal",
+                        "chr_0027_tangtang",
+                        "chr_0028_wulfa"
+                    ]
+                },
+                {
+                    "bonus_types": [
+                        "moneyProfit"
+                    ],
+                    "operator_ids": [
+                        "chr_0009_azrila",
+                        "chr_0011_seraph",
+                        "chr_0017_yvonne",
+                        "chr_0033_camille"
+                    ]
+                },
+                {
+                    "bonus_types": [
+                        "moneyProduceSpeed"
+                    ],
+                    "operator_ids": [
+                        "chr_0005_chen",
+                        "chr_0017_yvonne",
+                        "chr_0035_liino"
+                    ]
+                }
+            ]
+        },
+        "stm_tundra_3": {
+            "id": "stm_tundra_3",
+            "region_id": "domain_1",
+            "names": {
+                "zh_cn": "重建指挥部",
+                "zh_tw": "重建指揮部",
+                "en_us": "Reconstruction HQ",
+                "ja_jp": "再建管理本部",
+                "ko_kr": "재건 지휘부"
+            },
+            "prosperity_levels": [
+                {
+                    "level": 1,
+                    "trade_items": [
+                        {
+                            "item_id": "item_proc_battery_2",
+                            "unit_price": 30
+                        },
+                        {
+                            "item_id": "item_bottled_rec_hp_2",
+                            "unit_price": 27
+                        },
+                        {
+                            "item_id": "item_iron_enr_cmpt",
+                            "unit_price": 3
+                        }
+                    ]
+                },
+                {
+                    "level": 2,
+                    "trade_items": [
+                        {
+                            "item_id": "item_bottled_rec_hp_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_proc_battery_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_proc_battery_2",
+                            "unit_price": 30
+                        },
+                        {
+                            "item_id": "item_bottled_rec_hp_2",
+                            "unit_price": 27
+                        },
+                        {
+                            "item_id": "item_iron_enr_cmpt",
+                            "unit_price": 3
+                        }
+                    ]
+                },
+                {
+                    "level": 3,
+                    "trade_items": [
+                        {
+                            "item_id": "item_bottled_rec_hp_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_bottled_food_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_proc_battery_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_proc_battery_2",
+                            "unit_price": 30
+                        },
+                        {
+                            "item_id": "item_bottled_food_2",
+                            "unit_price": 27
+                        },
+                        {
+                            "item_id": "item_bottled_rec_hp_2",
+                            "unit_price": 27
+                        },
+                        {
+                            "item_id": "item_bottled_food_1",
+                            "unit_price": 10
+                        },
+                        {
+                            "item_id": "item_iron_enr_cmpt",
+                            "unit_price": 3
+                        }
+                    ]
+                },
+                {
+                    "level": 4,
+                    "trade_items": [
+                        {
+                            "item_id": "item_bottled_rec_hp_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_bottled_food_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_proc_battery_3",
+                            "unit_price": 70
+                        },
+                        {
+                            "item_id": "item_proc_battery_2",
+                            "unit_price": 30
+                        },
+                        {
+                            "item_id": "item_bottled_food_2",
+                            "unit_price": 27
+                        },
+                        {
+                            "item_id": "item_bottled_rec_hp_2",
+                            "unit_price": 27
+                        },
+                        {
+                            "item_id": "item_bottled_food_1",
+                            "unit_price": 10
+                        },
+                        {
+                            "item_id": "item_iron_enr_cmpt",
+                            "unit_price": 3
+                        }
+                    ]
+                }
+            ],
+            "features": [
+                {
+                    "bonus_types": [
+                        "expProfit"
+                    ],
+                    "operator_ids": [
+                        "chr_0013_aglina",
+                        "chr_0014_aurora",
+                        "chr_0016_laevat",
+                        "chr_0025_ardelia",
+                        "chr_0029_pograni"
+                    ]
+                },
+                {
+                    "bonus_types": [
+                        "moneyProfit"
+                    ],
+                    "operator_ids": [
+                        "chr_0005_chen",
+                        "chr_0013_aglina",
+                        "chr_0024_deepfin",
+                        "chr_0029_pograni",
+                        "chr_0030_zhuangfy"
+                    ]
+                },
+                {
+                    "bonus_types": [
+                        "moneyProduceSpeed"
+                    ],
+                    "operator_ids": [
+                        "chr_0004_pelica",
+                        "chr_0013_aglina",
+                        "chr_0016_laevat"
                     ]
                 }
             ]


### PR DESCRIPTION
## 用户侧变化

- AutoDelivery 前往仓储节点和资源回收站时，会先抵达设备正面 8 米处的必经点，再走向交互位置，减少从背面或侧面靠近导致的交互失败。
- 首次未找到取货或提交按钮时，所有仓储节点和送货目标都有一次自动站位修正：重新从正面接近目标后再识别按钮。
- 资源回收站的设备朝向已按实机方向校正；普通收货 NPC 的主路线仍直接前往原始终点，不增加绕行。
- 开启滑索规划时，设备正面的接近点仍为必经点，不会被全局路线优化跳过。

## 开发者说明

- 本地精简数据生成器默认直接读取同级 `BeyondTableCfg` 与 `BeyondMemoryPack`，不再依赖下载目录；四个数据入口统一支持 `--output`。
- `delivery_destinations.json` 统一提供仓储、NPC、资源回收站的 `yaw`，并保留回收站 `serial_id`。回收站 yaw 在生成时翻转 180 度，输出值即为路线可直接使用的正面方向。
- 默认仓储与回收站主路线为“8 米正面必经点 → 原始终点”；NPC 主路线保持单点。所有仓储和送货目标都会生成同样的两点 retry 路线。
- 显式 `path`、`retry_path` 和仓储 `departure_path` 继续保持最高优先级，现有人工特殊路线不会被自动插点改写。
- 运行时目录和五份区域路线已重新生成，当前包含 5 个仓储、22 个送货目标和 81 个路线节点；测试契约与维护文档已同步。

## 验证

- 已使用本地数据源重新生成精简数据与 AutoDelivery 派生资源。
- `git diff --check origin/v2...HEAD`
- 按要求未运行测试与 `pnpm check`。
