### PR TITLE
feat(setup): 支持从 GitHub CLI 获取令牌

### DIFF
--- a/tools/locals/setup_workspace/en_us.json
+++ b/tools/locals/setup_workspace/en_us.json
@@ -2,7 +2,7 @@
     "error_load_locale": "[ERROR] Failed to load locale file. Please ensure you have cloned the repository completely. File path: {path}",
     "inf_github_token_configured": "[INF] GitHub Token configured, will be used for API requests",
     "wrn_github_token_not_configured": "[WRN] GitHub Token not configured, using anonymous API requests (may be rate limited)",
-    "inf_github_token_hint": "[INF] If you encounter API rate limits, please set GITHUB_TOKEN/GH_TOKEN environment variable",
+    "inf_github_token_hint": "[INF] If you encounter API rate limits, set GITHUB_TOKEN/GH_TOKEN or run gh auth login",
     "cmd_prefix": "[CMD]",
     "inf_command_success": "[INF] Command executed successfully: {cmd}",
     "err_command_failed": "[ERR] Command execution failed: {cmd}\n  Error: {error}",

--- a/tools/locals/setup_workspace/zh_cn.json
+++ b/tools/locals/setup_workspace/zh_cn.json
@@ -2,7 +2,7 @@
     "error_load_locale": "[ERROR] 加载语言文件失败，请完整地克隆仓库。文件路径: {path}",
     "inf_github_token_configured": "[INF] 已配置 GitHub Token，将用于 API 请求",
     "wrn_github_token_not_configured": "[WRN] 未配置 GitHub Token，将使用匿名 API 请求（可能限流）",
-    "inf_github_token_hint": "[INF] 如遇 API 速率限制，请设置环境变量 GITHUB_TOKEN/GH_TOKEN",
+    "inf_github_token_hint": "[INF] 如遇 API 速率限制，请设置环境变量 GITHUB_TOKEN/GH_TOKEN，或运行 gh auth login",
     "cmd_prefix": "[CMD]",
     "inf_command_success": "[INF] 命令执行成功: {cmd}",
     "err_command_failed": "[ERR] 命令执行失败: {cmd}\n  错误: {error}",

--- a/tools/setup_workspace.py
+++ b/tools/setup_workspace.py
@@ -11,6 +11,7 @@ import time
 import traceback
 import urllib.error
 import urllib.request
+from functools import cache
 from pathlib import Path
 from urllib.parse import quote, urlencode, urlparse
 
@@ -115,9 +116,37 @@ CACHE_DIR: Path = PROJECT_BASE / ".cache"
 VERSION_FILE_NAME: str = "version.json"
 
 
+@cache
+def get_github_token() -> str:
+    """Return a GitHub token from the environment or GitHub CLI."""
+    for variable in ("GITHUB_TOKEN", "GH_TOKEN"):
+        token = os.environ.get(variable, "").strip()
+        if token:
+            return token
+
+    gh_path = shutil.which("gh")
+    if not gh_path:
+        return ""
+
+    try:
+        result = subprocess.run(
+            [gh_path, "auth", "token"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
 def configure_token() -> None:
     """配置 GitHub Token，输出检测结果"""
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    token = get_github_token()
     if token:
         print(Console.ok(t("inf_github_token_configured")))
     else:
@@ -223,7 +252,7 @@ def get_latest_release_url(
     https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases
     """
     api_url = f"https://api.github.com/repos/{repo}/releases"
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    token = get_github_token()
 
     try:
         print(Console.info(t("inf_get_latest_release", repo=repo)))
@@ -899,8 +928,7 @@ def copy_cpp_algo_binary(src_path: Path, install_root: Path) -> None:
 
 def _github_auth_headers() -> dict[str, str] | None:
     """Return GitHub API auth headers, or None if no token is configured."""
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or ""
-    token = token.strip()
+    token = get_github_token()
     if not token:
         return None
     return {


### PR DESCRIPTION
## 改动内容

- 统一 GitHub Token 获取逻辑，依次尝试 `GITHUB_TOKEN`、`GH_TOKEN` 和本地 `gh auth token`
- 缓存获取结果，避免重复调用 GitHub CLI
- 在 `gh` 未安装、未登录、执行失败或超时时安全回退到匿名请求
- 更新中英文提示，引导用户通过环境变量或 `gh auth login` 配置凭据

## 验证

- [x] `uv run python -m py_compile tools/setup_workspace.py`
- [x] `pnpm exec prettier --check tools/locals/setup_workspace/zh_cn.json tools/locals/setup_workspace/en_us.json`
- [x] `pnpm check`
- [x] `uv run tools/setup_workspace.py --help`
- [x] 模拟验证环境变量优先级、空白值回退、CLI 结果缓存及失败/超时回退
- [x] 使用本机已登录的 `gh 2.98.0` 验证能够获取可用凭据

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 工作区设置现在支持自动识别多种 GitHub 认证方式，包括环境变量和 GitHub CLI 登录凭据。
  * GitHub 令牌会被缓存，减少重复认证请求并提升设置流程稳定性。
* **错误修复**
  * GitHub 认证失败或请求超时时，设置流程可更平稳地继续处理。
* **文案更新**
  * 更新中英文提示，说明可通过 `gh auth login` 配置 GitHub 认证，并补充令牌速率限制相关信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->