### PR TITLE
feat(MapNavigator): 支持滚轮切换导航运行记录

### DIFF
--- a/tools/MapNavigator/web/static/index.html
+++ b/tools/MapNavigator/web/static/index.html
@@ -136,7 +136,7 @@
           <label class="sidebar-label" for="log-run-filter">按时间、节点或文件筛选</label>
           <input id="log-run-filter" class="entry" type="search" placeholder="例如 11:42 或 AutoDelivery" disabled />
           <label class="sidebar-label" for="log-run-select">导航运行记录</label>
-          <select id="log-run-select" class="combo log-run-select" disabled>
+          <select id="log-run-select" class="combo log-run-select" title="悬停后可使用鼠标滚轮切换" disabled>
             <option value="">请先导入日志</option>
           </select>
 

--- a/tools/MapNavigator/web/static/js/main.js
+++ b/tools/MapNavigator/web/static/js/main.js
@@ -43,6 +43,7 @@ import {
 } from "./model.js";
 import {compactNumber, roundHalfEven} from "./rounding.js";
 import {initFeedback, setStatus} from "./ui/toast.js";
+import {nextWheelSelectIndex} from "./ui/select.js";
 import {ConnectionPanel} from "./ui/connection.js";
 import {RecordingController} from "./ui/recording.js";
 import {NavTestController} from "./ui/navtest.js";
@@ -750,6 +751,21 @@ class MapNavigatorApp {
         e.logFileInput.addEventListener("change", () => this._importLogFiles(e.logFileInput.files));
         e.logRunFilter.addEventListener("input", () => this._populateLogRunSelect());
         e.logRunSelect.addEventListener("change", () => this._onLogRunChanged());
+        e.logRunSelect.addEventListener(
+            "wheel",
+            (event) => {
+                const nextIndex = nextWheelSelectIndex(
+                    e.logRunSelect.selectedIndex,
+                    e.logRunSelect.options.length,
+                    event.deltaY,
+                );
+                if (nextIndex === e.logRunSelect.selectedIndex) return;
+                event.preventDefault();
+                e.logRunSelect.selectedIndex = nextIndex;
+                this._onLogRunChanged();
+            },
+            {passive: false},
+        );
         e.btnLogDistanceClear.addEventListener("click", () => {
             this._clearLogDistanceSelection();
             setStatus("已清除滑索架测距。", "#10b981");

--- a/tools/MapNavigator/web/static/js/ui/select.js
+++ b/tools/MapNavigator/web/static/js/ui/select.js
@@ -1,0 +1,13 @@
+/**
+ * Return the adjacent option selected by a vertical wheel gesture.
+ *
+ * @param {number} currentIndex
+ * @param {number} optionCount
+ * @param {number} deltaY
+ * @returns {number}
+ */
+export function nextWheelSelectIndex(currentIndex, optionCount, deltaY) {
+    if (currentIndex < 0 || optionCount <= 0 || !Number.isFinite(deltaY) || deltaY === 0) return currentIndex;
+    const step = deltaY > 0 ? 1 : -1;
+    return Math.min(optionCount - 1, Math.max(0, currentIndex + step));
+}

--- a/tools/MapNavigator/web/test_select.mjs
+++ b/tools/MapNavigator/web/test_select.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {nextWheelSelectIndex} from "./static/js/ui/select.js";
+
+test("steps a select in the vertical wheel direction", () => {
+    assert.equal(nextWheelSelectIndex(1, 4, 120), 2);
+    assert.equal(nextWheelSelectIndex(2, 4, -120), 1);
+});
+
+test("keeps a select within its option bounds", () => {
+    assert.equal(nextWheelSelectIndex(0, 4, -120), 0);
+    assert.equal(nextWheelSelectIndex(3, 4, 120), 3);
+});
+
+test("ignores wheel events without a usable vertical delta", () => {
+    assert.equal(nextWheelSelectIndex(1, 4, 0), 1);
+    assert.equal(nextWheelSelectIndex(1, 4, Number.NaN), 1);
+    assert.equal(nextWheelSelectIndex(-1, 0, 120), -1);
+});


### PR DESCRIPTION
## 改动内容

- 为日志分析页的“导航运行记录”选择框增加鼠标滚轮切换。
- 按当前筛选后的可见记录逐条移动，并在首尾保持边界；仅在实际切换时阻止页面滚动。
- 复用现有运行记录切换流程，继续同步底图、视图框选和滑索架测距状态。
- 增加滚轮方向、选择边界和无效滚动的单元测试，并补充悬停提示。

## 验证

- `node --test tools/MapNavigator/web/test_*.mjs`：23/23 通过
- `pnpm check`：通过
- `pnpm test`：780/780 通过，未生成 `tests/maatools/error_details.json`
- `git diff --check`：通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 日志运行记录下拉框支持使用鼠标滚轮快速切换记录。
  - 添加悬停提示，说明可通过滚轮切换日志运行记录。

- **测试**
  - 增加滚轮切换方向、选项边界及无效输入场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->