### PR TITLE
style: 任务设置选项默认收起

### DIFF
--- a/assets/tasks/setting/Keymap.json
+++ b/assets/tasks/setting/Keymap.json
@@ -4,6 +4,7 @@
             "name": "Keymap",
             "label": "$option.Keymap.label",
             "description": "$option.Keymap.description",
+            "default_expand": false,
             "option": [
                 "KeymapGeneral",
                 "KeymapFight"

--- a/assets/tasks/setting/Zipline.json
+++ b/assets/tasks/setting/Zipline.json
@@ -4,6 +4,7 @@
             "name": "Zipline",
             "label": "$option.Zipline.label",
             "description": "$option.Zipline.description",
+            "default_expand": false,
             "option": [
                 "ZiplineRouting"
             ]


### PR DESCRIPTION
<img width="1471" height="943" alt="image" src="https://github.com/user-attachments/assets/46099fae-9f13-41fe-8303-558c1586a466" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **界面优化**
  * “Keymap”和“Zipline”设置项现默认折叠显示，减少设置页面的初始展开内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->