### PR TITLE
feat: 新增只收礼物独立任务，支持多选指定干员领取礼物

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -252,6 +252,7 @@
         "tasks/DijiangRewards.json",
         "tasks/VisitFriends.json",
         "tasks/GiftOperator.json",
+        "tasks/GiftOperatorReceive.json",
         "tasks/BatchAddFriends.json",
         // group: other_menu
         "tasks/PullCountCalculator.json",

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -196,7 +196,7 @@
     "option.SelectOperator.label": "Operator to gift",
     "option.SelectOperator.description": "Named operators are located by template matching. \"Any\" switches to trust sorting and picks three operators not yet at max trust, which tends to be more reliable.",
     "option.OnlyReceiveGift.label": "Only Receive Gifts",
-    "option.OnlyReceiveGift.description": "When enabled, only collect gifts from operators; no new dialogue or gift sending will be initiated.",
+    "option.OnlyReceiveGift.description": "When enabled, only collect gifts from operators; no new dialogue or gift sending will be initiated. Use \"Operator to gift\" to designate a recipient so only that operator's gifts are collected.",
     "option.AcceptAllGifts.label": "Accept all gifts",
     "option.AcceptAllGifts.description": "Only available when \"Only Receive Gifts\" is on. While enabled, the flow will not tap Leave mid-dialogue; you may exit a round only when the contact screen matches \"no selectable operator\", then the task entry restarts after leaving—useful for collecting gifts from multiple operators in turns.",
     "option.GiftCount.label": "Gift Count",
@@ -2214,5 +2214,7 @@
     "iconRecognition.name.item_domain_jinlong_coupon": "Wuling Stock Bill",
     "iconRecognition.name.item_domain_tundra_coupon": "Valley Stock Bill",
     "iconRecognition.name.item_spaceship_credit": "Credits",
-    "iconRecognition.name.item_originium_recharge": "Origeometry"
+    "iconRecognition.name.item_originium_recharge": "Origeometry",
+    "task.GiftOperatorReceive.label": "Only Receive Gifts",
+    "task.GiftOperatorReceive.description": "Only collect gifts from operators. You can check up to 5 specific operators; after collecting one, the task continues automatically and ends when all checked operators are collected or processed."
 }

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -192,7 +192,7 @@
     "option.SelectOperator.label": "プレゼントするオペレーター",
     "option.SelectOperator.description": "指名時はテンプレート一致で探します。「任意」は信頼度ソートに切り替え、信頼度未満のオペレーターを3名連続で選び、成功率を上げやすくします。",
     "option.OnlyReceiveGift.label": "プレゼント受け取りのみ",
-    "option.OnlyReceiveGift.description": "有効にすると、オペレーターからのプレゼントを受け取るだけで、新しい会話やプレゼントは行いません。",
+    "option.OnlyReceiveGift.description": "有効にすると、オペレーターからのプレゼントを受け取るだけで、新しい会話やプレゼントは行いません。「プレゼントするオペレーター」で受け取り対象を指定すると、そのオペレーターのプレゼントだけを受け取ります。",
     "option.AcceptAllGifts.label": "すべてのプレゼントを受け取る",
     "option.AcceptAllGifts.description": "「プレゼント受け取りのみ」がオンのときのみ利用できます。オンにすると会話の途中で「離脱」を押さず、連絡画面で「選択できるオペレーターがいない」と判定されたときだけ一度抜け、離脱後にタスク入口から再開して複数オペレーター分を順に受け取れます。",
     "option.GiftCount.label": "プレゼント数",
@@ -2214,5 +2214,7 @@
     "iconRecognition.name.item_domain_jinlong_coupon": "武陵取引券",
     "iconRecognition.name.item_domain_tundra_coupon": "谷地取引券",
     "iconRecognition.name.item_spaceship_credit": "FP",
-    "iconRecognition.name.item_originium_recharge": "展延源石"
+    "iconRecognition.name.item_originium_recharge": "展延源石",
+    "task.GiftOperatorReceive.label": "プレゼント受け取りのみ",
+    "task.GiftOperatorReceive.description": "オペレーターからのプレゼントのみ受け取ります。最大5名まで指定でき、受け取り後は自動的に次の指定オペレーターを探し、全員分を受け取るか処理し終えると終了します。"
 }

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -192,7 +192,7 @@
     "option.SelectOperator.label": "선물할 오퍼레이터",
     "option.SelectOperator.description": "지정 시 템플릿 매칭으로 찾습니다. \"임의\"는 신뢰도 정렬로 전환해 신뢰도가 아직 만렙이 아닌 오퍼레이터 3명을 연속 선택하며 성공률을 높이기 쉽습니다.",
     "option.OnlyReceiveGift.label": "선물 받기만",
-    "option.OnlyReceiveGift.description": "활성화 시 오퍼레이터의 선물만 받고, 새로운 대화나 선물은 시작하지 않습니다.",
+    "option.OnlyReceiveGift.description": "활성화 시 오퍼레이터의 선물만 받고, 새로운 대화나 선물은 시작하지 않습니다. \"선물할 오퍼레이터\"로 수령 대상을 지정하면 해당 오퍼레이터의 선물만 받습니다.",
     "option.AcceptAllGifts.label": "모든 선물 받기",
     "option.AcceptAllGifts.description": "\"선물 받기만\"이 켜져 있을 때만 사용할 수 있습니다. 켜면 대화 중 이탈 버튼을 누르지 않으며, 연락 화면에서 \"선택 가능한 오퍼레이터 없음\"으로 인식될 때만 한 라운드를 종료하고 이탈 후 작업 시작 지점부터 다시 진행하여 여러 오퍼레이터의 선물을 순차적으로 받을 수 있습니다.",
     "option.GiftCount.label": "선물 개수",
@@ -2214,5 +2214,7 @@
     "iconRecognition.name.item_domain_jinlong_coupon": "무릉 관리권",
     "iconRecognition.name.item_domain_tundra_coupon": "협곡 관리권",
     "iconRecognition.name.item_spaceship_credit": "크레딧",
-    "iconRecognition.name.item_originium_recharge": "파생 오리지늄"
+    "iconRecognition.name.item_originium_recharge": "파생 오리지늄",
+    "task.GiftOperatorReceive.label": "선물 받기만",
+    "task.GiftOperatorReceive.description": "오퍼레이터의 선물만 받습니다. 최대 5명까지 지정할 수 있으며, 받은 후 자동으로 다음 오퍼레이터를 찾고 모두 받거나 처리하면 종료됩니다."
 }

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -196,7 +196,7 @@
     "option.SelectOperator.label": "赠送干员",
     "option.SelectOperator.description": "指定干员时通过模板匹配寻人；「任意」会先切换为信赖排序并连选三名未满信赖干员，有利于提高选人成功率。",
     "option.OnlyReceiveGift.label": "只收礼物",
-    "option.OnlyReceiveGift.description": "开启后只领取干员赠送的礼物，不再发起新的对话和送礼。",
+    "option.OnlyReceiveGift.description": "开启后只领取干员赠送的礼物，不再发起新的对话和送礼；可在「赠送干员」中指定领取对象，只领取该干员的礼物。",
     "option.AcceptAllGifts.label": "接受全部礼物",
     "option.AcceptAllGifts.description": "仅在「只收礼物」开启时可用。开启后将不会在对话中途点击离开；只有在联络界面识别到「无可选干员」时可退出本轮并在离开后重新开始任务入口，用于轮流领取多名干员的礼物。",
     "option.GiftCount.label": "赠送数量",
@@ -2214,5 +2214,7 @@
     "iconRecognition.name.item_domain_jinlong_coupon": "武陵调度券",
     "iconRecognition.name.item_domain_tundra_coupon": "谷地调度券",
     "iconRecognition.name.item_spaceship_credit": "信用",
-    "iconRecognition.name.item_originium_recharge": "衍质源石"
+    "iconRecognition.name.item_originium_recharge": "衍质源石",
+    "task.GiftOperatorReceive.label": "只收礼物",
+    "task.GiftOperatorReceive.description": "只领取干员赠送的礼物；可勾选最多 5 名指定干员，领取后自动继续，领满或全部处理完结束。"
 }

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -196,7 +196,7 @@
     "option.SelectOperator.label": "贈送幹員",
     "option.SelectOperator.description": "指定幹員時透過模板比對尋人；「任意」會先切換為信賴排序並連選三名未滿信賴幹員，有利於提高選人成功率。",
     "option.OnlyReceiveGift.label": "只收禮物",
-    "option.OnlyReceiveGift.description": "開啟後只領取幹員贈送的禮物，不再發起新的對話和送禮。",
+    "option.OnlyReceiveGift.description": "開啟後只領取幹員贈送的禮物，不再發起新的對話和送禮；可在「贈送幹員」中指定領取對象，只領取該幹員的禮物。",
     "option.AcceptAllGifts.label": "接受全部禮物",
     "option.AcceptAllGifts.description": "僅在「只收禮物」開啟時可用。開啟後將不會在對話中途點選離開；只有在聯絡介面辨識到「無可選幹員」時可結束本輪並在離開後重新開始任務入口，用於輪流領取多名幹員的禮物。",
     "option.GiftCount.label": "贈送數量",
@@ -2214,5 +2214,7 @@
     "iconRecognition.name.item_domain_jinlong_coupon": "武陵調度券",
     "iconRecognition.name.item_domain_tundra_coupon": "谷地調度券",
     "iconRecognition.name.item_spaceship_credit": "信用",
-    "iconRecognition.name.item_originium_recharge": "衍質源石"
+    "iconRecognition.name.item_originium_recharge": "衍質源石",
+    "task.GiftOperatorReceive.label": "只收禮物",
+    "task.GiftOperatorReceive.description": "只領取幹員贈送的禮物；可勾選最多 5 名指定幹員，領取後自動繼續，領滿或全部處理完結束。"
 }

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorContact.json
@@ -33,8 +33,105 @@
             "GiftOperatorSelectOp1",
             "GiftOperatorSelectSpecifiedOp",
             "GiftOperatorSelectGiftOp",
+            "GiftOperatorSelectSpecifiedGiftOp_Akekuri",
+            "GiftOperatorSelectSpecifiedGiftOp_Alesh",
+            "GiftOperatorSelectSpecifiedGiftOp_Antal",
+            "GiftOperatorSelectSpecifiedGiftOp_Arclight",
+            "GiftOperatorSelectSpecifiedGiftOp_Ardelia",
+            "GiftOperatorSelectSpecifiedGiftOp_Avywenna",
+            "GiftOperatorSelectSpecifiedGiftOp_Camille",
+            "GiftOperatorSelectSpecifiedGiftOp_Catcher",
+            "GiftOperatorSelectSpecifiedGiftOp_ChenQianyu",
+            "GiftOperatorSelectSpecifiedGiftOp_DaPan",
+            "GiftOperatorSelectSpecifiedGiftOp_Ember",
+            "GiftOperatorSelectSpecifiedGiftOp_Estella",
+            "GiftOperatorSelectSpecifiedGiftOp_Fluorite",
+            "GiftOperatorSelectSpecifiedGiftOp_Gilberta",
+            "GiftOperatorSelectSpecifiedGiftOp_Jue",
+            "GiftOperatorSelectSpecifiedGiftOp_Laevatain",
+            "GiftOperatorSelectSpecifiedGiftOp_LastRite",
+            "GiftOperatorSelectSpecifiedGiftOp_Lifeng",
+            "GiftOperatorSelectSpecifiedGiftOp_Liino",
+            "GiftOperatorSelectSpecifiedGiftOp_MiFu",
+            "GiftOperatorSelectSpecifiedGiftOp_Perlica",
+            "GiftOperatorSelectSpecifiedGiftOp_Pogranichnik",
+            "GiftOperatorSelectSpecifiedGiftOp_Rossi",
+            "GiftOperatorSelectSpecifiedGiftOp_Snowshine",
+            "GiftOperatorSelectSpecifiedGiftOp_Tangtang",
+            "GiftOperatorSelectSpecifiedGiftOp_Wulfgard",
+            "GiftOperatorSelectSpecifiedGiftOp_Xaihi",
+            "GiftOperatorSelectSpecifiedGiftOp_Yvonne",
+            "GiftOperatorSelectSpecifiedGiftOp_ZhuangFangyi",
             "[JumpBack]GiftOperatorSwipe", //滑动两次后会关闭
+            "GiftOperatorNoGiftOperatorSpecified", //只收礼物：连续3次无任何礼物图标则结束
             "GiftOperatorNoOperatorCanSelect" //落入无可选干员界面
+        ]
+    },
+    "GiftOperatorNoGiftOperatorSpecified": {
+        "desc": "只收礼物+指定干员：联络界面找不到带礼物的指定干员，刷新地图（谷地→帝江）后重新扫描，直到领取完每天的礼物量（领满由 Remain0/PostStop 停止）",
+        "enabled": false,
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    0,
+                    0,
+                    310,
+                    187
+                ],
+                "expected": [
+                    "干员联络",
+                    "幹員聯絡",
+                    "Operator Contact",
+                    "オペレーターの呼び出し"
+                ]
+            }
+        },
+        "next": [
+            "GiftOperatorRefreshMap"
+        ]
+    },
+    "GiftOperatorRefreshMap": {
+        "desc": "只收礼物+指定干员：刷新地图，先进入谷地大世界触发加载",
+        "next": [
+            "GiftOperatorRefreshMapInValley",
+            "[JumpBack]SceneEnterWorldValleyIVTheHub"
+        ]
+    },
+    "GiftOperatorRefreshMapInValley": {
+        "desc": "只收礼物+指定干员：已进入谷地大世界，准备重新进入帝江号舰桥",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "InWorld"
+                ]
+            }
+        },
+        "next": [
+            "GiftOperatorRefreshMapInDijiang",
+            "[JumpBack]GiftOperatorGoToDijiang"
+        ]
+    },
+    "GiftOperatorRefreshMapInDijiang": {
+        "desc": "只收礼物+指定干员：刷新完成，已回到帝江号舰桥，重新扫描联络界面",
+        "recognition": {
+            "type": "Custom",
+            "param": {
+                "custom_recognition": "MapLocateAssertLocation",
+                "custom_recognition_param": {
+                    "zone_id": "OMVBase01",
+                    "target": [
+                        155.86,
+                        186.98,
+                        10.14,
+                        9.06
+                    ]
+                }
+            }
+        },
+        "next": [
+            "GiftOperatorMainLoop"
         ]
     },
     "GiftOperatorNoOperatorCanSelect": {
@@ -160,6 +257,2026 @@
             "GiftOperatorSelect_ZhuangFangyi"
         ]
     },
+    "GiftOperatorSpecifiedGiftIcon": {
+        "desc": "只收礼物+指定干员：礼物图标定位，作为头像二次匹配的锚点",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    546,
+                    181,
+                    550,
+                    309
+                ],
+                "template": [
+                    "GiftOperator/Gift.png",
+                    "GiftOperator/Gift_2.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Akekuri": {
+        "desc": "只收礼物+指定干员：礼物行旁的Akekuri头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Akekuri.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Akekuri": {
+        "desc": "只收礼物+指定干员：点击带礼物的Akekuri行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Akekuri"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Akekuri"
+        ]
+    },
+    "GiftOperatorNamePatch_Akekuri": {
+        "desc": "只收礼物+指定干员：设置Akekuri的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "秋栗",
+                    "秋栗",
+                    "Akekuri",
+                    "アケクリ",
+                    "아케쿠리"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 秋栗 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Alesh": {
+        "desc": "只收礼物+指定干员：礼物行旁的Alesh头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Alesh.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Alesh": {
+        "desc": "只收礼物+指定干员：点击带礼物的Alesh行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Alesh"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Alesh"
+        ]
+    },
+    "GiftOperatorNamePatch_Alesh": {
+        "desc": "只收礼物+指定干员：设置Alesh的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "阿列什",
+                    "阿列什",
+                    "Alesh",
+                    "アレッシュ",
+                    "알레쉬"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 阿列什 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Antal": {
+        "desc": "只收礼物+指定干员：礼物行旁的Antal头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Antal.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Antal": {
+        "desc": "只收礼物+指定干员：点击带礼物的Antal行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Antal"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Antal"
+        ]
+    },
+    "GiftOperatorNamePatch_Antal": {
+        "desc": "只收礼物+指定干员：设置Antal的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "安塔尔",
+                    "安塔爾",
+                    "Antal",
+                    "アンタル",
+                    "안탈"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 安塔尔 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Arclight": {
+        "desc": "只收礼物+指定干员：礼物行旁的Arclight头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Arclight.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Arclight": {
+        "desc": "只收礼物+指定干员：点击带礼物的Arclight行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Arclight"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Arclight"
+        ]
+    },
+    "GiftOperatorNamePatch_Arclight": {
+        "desc": "只收礼物+指定干员：设置Arclight的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "弧光",
+                    "弧光",
+                    "Arclight",
+                    "アークライト",
+                    "아크라이트"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 弧光 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Ardelia": {
+        "desc": "只收礼物+指定干员：礼物行旁的Ardelia头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Ardelia.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Ardelia": {
+        "desc": "只收礼物+指定干员：点击带礼物的Ardelia行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Ardelia"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Ardelia"
+        ]
+    },
+    "GiftOperatorNamePatch_Ardelia": {
+        "desc": "只收礼物+指定干员：设置Ardelia的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "艾尔黛拉",
+                    "艾爾黛拉",
+                    "Ardelia",
+                    "アルデリア",
+                    "아델리아"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 艾尔黛拉 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Avywenna": {
+        "desc": "只收礼物+指定干员：礼物行旁的Avywenna头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Avywenna.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Avywenna": {
+        "desc": "只收礼物+指定干员：点击带礼物的Avywenna行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Avywenna"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Avywenna"
+        ]
+    },
+    "GiftOperatorNamePatch_Avywenna": {
+        "desc": "只收礼物+指定干员：设置Avywenna的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "艾维文娜",
+                    "艾維文娜",
+                    "Avywenna",
+                    "アイビーエナ",
+                    "아비웨나"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 艾维文娜 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Camille": {
+        "desc": "只收礼物+指定干员：礼物行旁的Camille头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Camille.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Camille": {
+        "desc": "只收礼物+指定干员：点击带礼物的Camille行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Camille"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Camille"
+        ]
+    },
+    "GiftOperatorNamePatch_Camille": {
+        "desc": "只收礼物+指定干员：设置Camille的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "卡缪",
+                    "卡繆",
+                    "Camille",
+                    "カミーユ",
+                    "카뮤"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 卡缪 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Catcher": {
+        "desc": "只收礼物+指定干员：礼物行旁的Catcher头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Catcher.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Catcher": {
+        "desc": "只收礼物+指定干员：点击带礼物的Catcher行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Catcher"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Catcher"
+        ]
+    },
+    "GiftOperatorNamePatch_Catcher": {
+        "desc": "只收礼物+指定干员：设置Catcher的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "卡契尔",
+                    "卡契爾",
+                    "Catcher",
+                    "キャッチャー",
+                    "카치르"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 卡契尔 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_ChenQianyu": {
+        "desc": "只收礼物+指定干员：礼物行旁的ChenQianyu头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/ChenQianyu.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_ChenQianyu": {
+        "desc": "只收礼物+指定干员：点击带礼物的ChenQianyu行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_ChenQianyu"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_ChenQianyu"
+        ]
+    },
+    "GiftOperatorNamePatch_ChenQianyu": {
+        "desc": "只收礼物+指定干员：设置ChenQianyu的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "陈千语",
+                    "陳千語",
+                    "Chen Qianyu",
+                    "チェン・センユー",
+                    "진천우"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 陈千语 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_DaPan": {
+        "desc": "只收礼物+指定干员：礼物行旁的DaPan头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/DaPan.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_DaPan": {
+        "desc": "只收礼物+指定干员：点击带礼物的DaPan行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_DaPan"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_DaPan"
+        ]
+    },
+    "GiftOperatorNamePatch_DaPan": {
+        "desc": "只收礼物+指定干员：设置DaPan的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "大潘",
+                    "大潘",
+                    "Da Pan",
+                    "ダパン",
+                    "판"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 大潘 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Ember": {
+        "desc": "只收礼物+指定干员：礼物行旁的Ember头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Ember.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Ember": {
+        "desc": "只收礼物+指定干员：点击带礼物的Ember行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Ember"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Ember"
+        ]
+    },
+    "GiftOperatorNamePatch_Ember": {
+        "desc": "只收礼物+指定干员：设置Ember的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "余烬",
+                    "餘燼",
+                    "Ember",
+                    "エンバー",
+                    "엠버"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 余烬 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Estella": {
+        "desc": "只收礼物+指定干员：礼物行旁的Estella头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Estella.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Estella": {
+        "desc": "只收礼物+指定干员：点击带礼物的Estella行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Estella"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Estella"
+        ]
+    },
+    "GiftOperatorNamePatch_Estella": {
+        "desc": "只收礼物+指定干员：设置Estella的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "埃特拉",
+                    "埃特拉",
+                    "Estella",
+                    "エステーラ",
+                    "에스텔라"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 埃特拉 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Fluorite": {
+        "desc": "只收礼物+指定干员：礼物行旁的Fluorite头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Fluorite.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Fluorite": {
+        "desc": "只收礼物+指定干员：点击带礼物的Fluorite行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Fluorite"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Fluorite"
+        ]
+    },
+    "GiftOperatorNamePatch_Fluorite": {
+        "desc": "只收礼物+指定干员：设置Fluorite的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "萤石",
+                    "螢石",
+                    "Fluorite",
+                    "フローライト",
+                    "플루라이트"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 萤石 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Gilberta": {
+        "desc": "只收礼物+指定干员：礼物行旁的Gilberta头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Gilberta.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Gilberta": {
+        "desc": "只收礼物+指定干员：点击带礼物的Gilberta行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Gilberta"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Gilberta"
+        ]
+    },
+    "GiftOperatorNamePatch_Gilberta": {
+        "desc": "只收礼物+指定干员：设置Gilberta的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "洁尔佩塔",
+                    "潔爾佩塔",
+                    "Gilberta",
+                    "ギルベルタ",
+                    "질베르타"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 洁尔佩塔 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Jue": {
+        "desc": "只收礼物+指定干员：礼物行旁的Jue头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Arcane.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Jue": {
+        "desc": "只收礼物+指定干员：点击带礼物的Jue行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Jue"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Jue"
+        ]
+    },
+    "GiftOperatorNamePatch_Jue": {
+        "desc": "只收礼物+指定干员：设置Jue的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "诀",
+                    "訣",
+                    "Arcane",
+                    "オクギ",
+                    "결"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 诀 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Laevatain": {
+        "desc": "只收礼物+指定干员：礼物行旁的Laevatain头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Laevatain.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Laevatain": {
+        "desc": "只收礼物+指定干员：点击带礼物的Laevatain行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Laevatain"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Laevatain"
+        ]
+    },
+    "GiftOperatorNamePatch_Laevatain": {
+        "desc": "只收礼物+指定干员：设置Laevatain的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "莱万汀",
+                    "萊萬汀",
+                    "Laevatain",
+                    "レーヴァテイン",
+                    "레바테인"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 莱万汀 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_LastRite": {
+        "desc": "只收礼物+指定干员：礼物行旁的LastRite头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/LastRite.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_LastRite": {
+        "desc": "只收礼物+指定干员：点击带礼物的LastRite行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_LastRite"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_LastRite"
+        ]
+    },
+    "GiftOperatorNamePatch_LastRite": {
+        "desc": "只收礼物+指定干员：设置LastRite的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "别礼",
+                    "別禮",
+                    "Last Rite",
+                    "ラストライト",
+                    "라스트 라이트"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 别礼 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Lifeng": {
+        "desc": "只收礼物+指定干员：礼物行旁的Lifeng头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Lifeng.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Lifeng": {
+        "desc": "只收礼物+指定干员：点击带礼物的Lifeng行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Lifeng"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Lifeng"
+        ]
+    },
+    "GiftOperatorNamePatch_Lifeng": {
+        "desc": "只收礼物+指定干员：设置Lifeng的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "黎风",
+                    "黎風",
+                    "Lifeng",
+                    "リーフォン",
+                    "여풍"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 黎风 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Liino": {
+        "desc": "只收礼物+指定干员：礼物行旁的Liino头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Liino.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Liino": {
+        "desc": "只收礼物+指定干员：点击带礼物的Liino行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Liino"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Liino"
+        ]
+    },
+    "GiftOperatorNamePatch_Liino": {
+        "desc": "只收礼物+指定干员：设置Liino的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "梨诺",
+                    "梨諾",
+                    "Liino",
+                    "リーノ",
+                    "리노"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 梨诺 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_MiFu": {
+        "desc": "只收礼物+指定干员：礼物行旁的MiFu头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/MiFu.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_MiFu": {
+        "desc": "只收礼物+指定干员：点击带礼物的MiFu行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_MiFu"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_MiFu"
+        ]
+    },
+    "GiftOperatorNamePatch_MiFu": {
+        "desc": "只收礼物+指定干员：设置MiFu的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "弭弗",
+                    "弭弗",
+                    "Mi Fu",
+                    "ミ・フ",
+                    "미푸"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 弭弗 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Perlica": {
+        "desc": "只收礼物+指定干员：礼物行旁的Perlica头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Perlica.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Perlica": {
+        "desc": "只收礼物+指定干员：点击带礼物的Perlica行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Perlica"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Perlica"
+        ]
+    },
+    "GiftOperatorNamePatch_Perlica": {
+        "desc": "只收礼物+指定干员：设置Perlica的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "佩丽卡",
+                    "佩麗卡",
+                    "Perlica",
+                    "ペリカ",
+                    "펠리카"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 佩丽卡 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Pogranichnik": {
+        "desc": "只收礼物+指定干员：礼物行旁的Pogranichnik头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Pogranichnik.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Pogranichnik": {
+        "desc": "只收礼物+指定干员：点击带礼物的Pogranichnik行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Pogranichnik"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Pogranichnik"
+        ]
+    },
+    "GiftOperatorNamePatch_Pogranichnik": {
+        "desc": "只收礼物+指定干员：设置Pogranichnik的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "骏卫",
+                    "駿衛",
+                    "Pogranichnik",
+                    "ポグラニチニク",
+                    "포그라니치니크"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 骏卫 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Rossi": {
+        "desc": "只收礼物+指定干员：礼物行旁的Rossi头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Rossi.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Rossi": {
+        "desc": "只收礼物+指定干员：点击带礼物的Rossi行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Rossi"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Rossi"
+        ]
+    },
+    "GiftOperatorNamePatch_Rossi": {
+        "desc": "只收礼物+指定干员：设置Rossi的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "洛茜",
+                    "洛西",
+                    "Rossi",
+                    "ロッシ",
+                    "로시"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 洛茜 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Snowshine": {
+        "desc": "只收礼物+指定干员：礼物行旁的Snowshine头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Snowshine.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Snowshine": {
+        "desc": "只收礼物+指定干员：点击带礼物的Snowshine行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Snowshine"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Snowshine"
+        ]
+    },
+    "GiftOperatorNamePatch_Snowshine": {
+        "desc": "只收礼物+指定干员：设置Snowshine的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "昼雪",
+                    "晝雪",
+                    "Snowshine",
+                    "スノーシャイン",
+                    "스노우샤인"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 昼雪 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Tangtang": {
+        "desc": "只收礼物+指定干员：礼物行旁的Tangtang头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Tangtang.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Tangtang": {
+        "desc": "只收礼物+指定干员：点击带礼物的Tangtang行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Tangtang"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Tangtang"
+        ]
+    },
+    "GiftOperatorNamePatch_Tangtang": {
+        "desc": "只收礼物+指定干员：设置Tangtang的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "汤汤",
+                    "湯湯",
+                    "Tangtang",
+                    "タンタン",
+                    "탕탕"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 汤汤 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Wulfgard": {
+        "desc": "只收礼物+指定干员：礼物行旁的Wulfgard头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Wulfgard.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Wulfgard": {
+        "desc": "只收礼物+指定干员：点击带礼物的Wulfgard行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Wulfgard"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Wulfgard"
+        ]
+    },
+    "GiftOperatorNamePatch_Wulfgard": {
+        "desc": "只收礼物+指定干员：设置Wulfgard的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "狼卫",
+                    "狼衛",
+                    "Wulfgard",
+                    "ウルフガード",
+                    "울프가드"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 狼卫 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Xaihi": {
+        "desc": "只收礼物+指定干员：礼物行旁的Xaihi头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Xaihi.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Xaihi": {
+        "desc": "只收礼物+指定干员：点击带礼物的Xaihi行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Xaihi"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Xaihi"
+        ]
+    },
+    "GiftOperatorNamePatch_Xaihi": {
+        "desc": "只收礼物+指定干员：设置Xaihi的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "赛希",
+                    "賽希",
+                    "Xaihi",
+                    "ザイヒ",
+                    "자이히"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 赛希 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_Yvonne": {
+        "desc": "只收礼物+指定干员：礼物行旁的Yvonne头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/Yvonne.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_Yvonne": {
+        "desc": "只收礼物+指定干员：点击带礼物的Yvonne行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_Yvonne"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_Yvonne"
+        ]
+    },
+    "GiftOperatorNamePatch_Yvonne": {
+        "desc": "只收礼物+指定干员：设置Yvonne的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "伊冯",
+                    "伊馮",
+                    "Yvonne",
+                    "イヴォンヌ",
+                    "이본"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 伊冯 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
+    "GiftOperatorSpecifiedGiftAvatar_ZhuangFangyi": {
+        "desc": "只收礼物+指定干员：礼物行旁的ZhuangFangyi头像",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": "GiftOperatorSpecifiedGiftIcon",
+                "roi_offset": [
+                    -48,
+                    -36,
+                    165,
+                    128
+                ],
+                "template": [
+                    "GiftOperator/Operators/ZhuangFangyi.png"
+                ],
+                "green_mask": true
+            }
+        }
+    },
+    "GiftOperatorSelectSpecifiedGiftOp_ZhuangFangyi": {
+        "desc": "只收礼物+指定干员：点击带礼物的ZhuangFangyi行（max_hit=1，已领取后不再触发）",
+        "enabled": false,
+        "max_hit": 1,
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "GiftOperatorSpecifiedGiftIcon",
+                    "GiftOperatorSpecifiedGiftAvatar_ZhuangFangyi"
+                ],
+                "box_index": 1
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "GiftOperatorNamePatch_ZhuangFangyi"
+        ]
+    },
+    "GiftOperatorNamePatch_ZhuangFangyi": {
+        "desc": "只收礼物+指定干员：设置ZhuangFangyi的对话阶段名称白名单",
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "PipelineOverrideAction",
+                "custom_action_param": {
+                    "patch": {
+                        "GiftOperatorName": {
+                            "expected": [
+                    "庄方宜",
+                    "莊方宜",
+                    "Zhuang Fangyi",
+                    "ゾアン・ファンイ",
+                    "장방이"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+                "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 庄方宜 的礼物"
+        },
+"next": [
+            "GiftOperatorSelectSpecifiedOpSuccess"
+        ]
+    },
     "GiftOperatorSelectSpecifiedOp": {
         "desc": "选择指定干员",
         "enabled": false,
@@ -194,7 +2311,7 @@
         ]
     },
     "GiftOperatorSelectSpecifiedOpSuccess": {
-        "desc": "选择指定干员成功",
+        "desc": "选择指定干员成功（校验失败时刷新地图恢复，避免误点无安排卡片卡死）",
         "recognition": {
             "type": "And",
             "param": {
@@ -205,6 +2322,9 @@
                 ]
             }
         },
+        "on_error": [
+            "GiftOperatorRefreshMap"
+        ],
         "next": [
             "GiftOperatorConfirmSelect"
         ]
@@ -753,5 +2873,79 @@
                 "key": 83
             }
         }
+    },
+
+    "GiftOperatorRemainReport": {
+        "desc": "只收礼物：领取成功后报告剩余指定干员",
+        "recognition": "DirectHit",
+        "next": [
+            "GiftOperatorRemain4",
+            "GiftOperatorRemain3",
+            "GiftOperatorRemain2",
+            "GiftOperatorRemain1",
+            "GiftOperatorRemain0",
+            "GiftOperatorReceiveMain"
+        ]
+    },
+    "GiftOperatorRemain4": {
+        "desc": "已领取 1/5，剩余 4 名",
+        "recognition": "DirectHit",
+        "max_hit": 1,
+        "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 1/5 名，剩余指定干员 4 名"
+        },
+        "next": [
+            "GiftOperatorReceiveMain"
+        ]
+    },
+    "GiftOperatorRemain3": {
+        "desc": "已领取 2/5，剩余 3 名",
+        "recognition": "DirectHit",
+        "max_hit": 1,
+        "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 2/5 名，剩余指定干员 3 名"
+        },
+        "next": [
+            "GiftOperatorReceiveMain"
+        ]
+    },
+    "GiftOperatorRemain2": {
+        "desc": "已领取 3/5，剩余 2 名",
+        "recognition": "DirectHit",
+        "max_hit": 1,
+        "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 3/5 名，剩余指定干员 2 名"
+        },
+        "next": [
+            "GiftOperatorReceiveMain"
+        ]
+    },
+    "GiftOperatorRemain1": {
+        "desc": "已领取 4/5，剩余 1 名",
+        "recognition": "DirectHit",
+        "max_hit": 1,
+        "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 4/5 名，剩余指定干员 1 名"
+        },
+        "next": [
+            "GiftOperatorReceiveMain"
+        ]
+    },
+    "GiftOperatorRemain0": {
+        "desc": "全部领取完成，停止任务",
+        "recognition": "DirectHit",
+        "max_hit": 1,
+        "focus": {
+            "Node.Recognition.Succeeded": "🎁 已领取 5/5 名，全部指定干员礼物领取完成"
+        },
+        "next": [
+            "GiftOperatorPostStop"
+        ]
+    },
+    "GiftOperatorPostStop": {
+        "desc": "任务完成，主动停止",
+        "action": "Custom",
+        "custom_action": "PostStop",
+        "next": []
     }
 }

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json
@@ -470,6 +470,39 @@
             "GiftOperatorLeave"
         ]
     },
+    "GiftOperatorReceiveDialogLoop": {
+        "desc": "只收礼物循环专用：领取成功后跳过对话，直接回到免背包入口。不叫 GiftOperatorReceiveDialog，避免被干员选项 case 的 next 覆盖回 GiftOperatorMain（那会存放背包）",
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "roi": [
+                    603,
+                    646,
+                    75,
+                    74
+                ],
+                "template": [
+                    "RealTimeTask/AutoSkipNext2.png"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click"
+        },
+        "post_wait_freezes": {
+            "time": 1000,
+            "timeout": 2000,
+            "target": [
+                831,
+                403,
+                161,
+                176
+            ]
+        },
+        "next": [
+            "GiftOperatorRemainReport"
+        ]
+    },
     "GiftOperatorSkipDialog": {
         "desc": "跳过对话，然后判断三种分支。next 含自身以便未跳转时重试一次点击",
         "recognition": {

--- a/assets/resource/pipeline/GiftOperator/GiftOperatorMain.json
+++ b/assets/resource/pipeline/GiftOperator/GiftOperatorMain.json
@@ -17,6 +17,38 @@
             "[JumpBack]GiftOperatorGoToDijiang"
         ]
     },
+    "GiftOperatorReceiveMain": {
+        "desc": "只收礼物：任务入口（不存放背包），领取后经 ReceiveDialogLoop 回到此节点",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "GiftOperatorClearHitCount"
+            ]
+        },
+        "post_delay": 0,
+        "next": [
+            "GiftOperatorInDijiang0",
+            "[JumpBack]GiftOperatorGoToDijiang"
+        ]
+    },
+    "GiftOperatorMainLoop": {
+        "desc": "只收礼物+指定干员：循环入口（新一轮联络界面扫描），不再存放背包",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "GiftOperatorClearHitCountLoop"
+            ]
+        },
+        "post_delay": 0,
+        "next": [
+            "GiftOperatorInDijiang0",
+            "[JumpBack]GiftOperatorGoToDijiang"
+        ]
+    },
     "GiftOperatorInDijiang0": {
         "desc": "确认已在帝江号舰桥大世界",
         "recognition": {
@@ -118,7 +150,36 @@
                 "GiftOperatorTurnWest",
                 "GiftOperatorMoveLocation1Move",
                 "GiftOperatorGoAheadContact",
-                "GiftOperatorBack"
+                "GiftOperatorBack",
+                "GiftOperatorSwipe", //每轮联络界面扫描重置滑动次数
+                "GiftOperatorClickContact", //刷新循环每轮重置点击联络台计数
+                "GiftOperatorNoGiftOperatorSpecified" //任务开始（含领取后回 Main）重置本轮无可领计数
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "GiftOperatorClearHitCountLoop": {
+        "desc": "清空节点MaxHit（循环入口专用，不重置本轮无可领计数）",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "ClearHitCount",
+        "custom_action_param": {
+            "nodes": [
+                "GiftOperatorMoveResetBackward",
+                "GiftOperatorTurnEast",
+                "GiftOperatorMoveLocation3Move",
+                "GiftOperatorTurnSoutheast",
+                "GiftOperatorTurnNorthwest",
+                "GiftOperatorTurnNorthByWest",
+                "GiftOperatorMoveLocation2Move",
+                "GiftOperatorTurnWest",
+                "GiftOperatorMoveLocation1Move",
+                "GiftOperatorGoAheadContact",
+                "GiftOperatorBack",
+                "GiftOperatorSwipe", //每轮联络界面扫描重置滑动次数
+                "GiftOperatorClickContact", //刷新循环每轮重置点击联络台计数
+                "GiftOperatorGoToDijiang" //刷新地图（谷地→帝江）后重置传送次数
             ]
         },
         "post_delay": 0,

--- a/assets/tasks/GiftOperator.json
+++ b/assets/tasks/GiftOperator.json
@@ -24,7 +24,7 @@
     ],
     "option": {
         "SelectOperator": {
-            "type": "select",
+            "type": "checkbox",
             "label": "$option.SelectOperator.label",
             "default_case": "Any",
             "description": "$option.SelectOperator.description",
@@ -36,19 +36,103 @@
                         "GiftOperatorSelectSpecifiedOp": {
                             "enabled": false
                         },
-                        "GiftOperatorContacSortOrder": {
-                            "enabled": true
-                        },
-                        "GiftOperatorContacSortBy": {
-                            "enabled": true
-                        },
-                        "GiftOperatorSelectOp1": {
-                            "enabled": true
-                        },
                         "GiftOperatorName": {
                             "expected": [
                                 ".*"
                             ]
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorNoGiftOperatorSpecified": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Perlica": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Yvonne": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Ardelia": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Gilberta": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_ChenQianyu": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Wulfgard": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Antal": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Xaihi": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Lifeng": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Catcher": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Arclight": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Avywenna": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Laevatain": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Alesh": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Pogranichnik": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_LastRite": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Ember": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Snowshine": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_DaPan": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Fluorite": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Akekuri": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Estella": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Rossi": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Tangtang": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_ZhuangFangyi": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_MiFu": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Camille": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Jue": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Liino": {
+                            "enabled": false
                         }
                     }
                 },
@@ -66,18 +150,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Perlica.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "佩丽卡",
-                                "佩麗卡",
-                                "Perlica",
-                                "ペリカ",
-                                "펠리카"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Perlica": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -96,18 +181,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Yvonne.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "伊冯",
-                                "伊馮",
-                                "Yvonne",
-                                "イヴォンヌ",
-                                "이본"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Yvonne": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -126,18 +212,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Ardelia.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "艾尔黛拉",
-                                "艾爾黛拉",
-                                "Ardelia",
-                                "アルデリア",
-                                "아델리아"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Ardelia": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -156,18 +243,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Gilberta.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "洁尔佩塔",
-                                "潔爾佩塔",
-                                "Gilberta",
-                                "ギルベルタ",
-                                "질베르타"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Gilberta": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -186,18 +274,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/ChenQianyu.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "陈千语",
-                                "陳千語",
-                                "Chen Qianyu",
-                                "チェン・センユー",
-                                "진천우"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_ChenQianyu": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -216,18 +305,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Wulfgard.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "狼卫",
-                                "狼衛",
-                                "Wulfgard",
-                                "ウルフガード",
-                                "울프가드"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Wulfgard": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -246,18 +336,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Antal.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "安塔尔",
-                                "安塔爾",
-                                "Antal",
-                                "アンタル",
-                                "안탈"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Antal": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -276,18 +367,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Xaihi.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "赛希",
-                                "賽希",
-                                "Xaihi",
-                                "ザイヒ",
-                                "자이히"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Xaihi": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -306,18 +398,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Lifeng.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "黎风",
-                                "黎風",
-                                "Lifeng",
-                                "リーフォン",
-                                "여풍"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Lifeng": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -336,18 +429,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Catcher.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "卡契尔",
-                                "卡契爾",
-                                "Catcher",
-                                "キャッチャー",
-                                "카치르"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Catcher": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -366,18 +460,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Arclight.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "弧光",
-                                "弧光",
-                                "Arclight",
-                                "アークライト",
-                                "아크라이트"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Arclight": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -396,18 +491,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Avywenna.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "艾维文娜",
-                                "艾維文娜",
-                                "Avywenna",
-                                "アイビーエナ",
-                                "아비웨나"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Avywenna": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -426,18 +522,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Laevatain.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "莱万汀",
-                                "萊萬汀",
-                                "Laevatain",
-                                "レーヴァテイン",
-                                "레바테인"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Laevatain": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -456,18 +553,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Alesh.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "阿列什",
-                                "阿列什",
-                                "Alesh",
-                                "アレッシュ",
-                                "알레쉬"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Alesh": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -486,18 +584,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Pogranichnik.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "骏卫",
-                                "駿衛",
-                                "Pogranichnik",
-                                "ポグラニチニク",
-                                "포그라니치니크"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Pogranichnik": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -516,18 +615,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/LastRite.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "别礼",
-                                "別禮",
-                                "Last Rite",
-                                "ラストライト",
-                                "라스트 라이트"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_LastRite": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -546,18 +646,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Ember.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "余烬",
-                                "餘燼",
-                                "Ember",
-                                "エンバー",
-                                "엠버"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Ember": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -576,18 +677,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Snowshine.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "昼雪",
-                                "晝雪",
-                                "Snowshine",
-                                "スノーシャイン",
-                                "스노우샤인"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Snowshine": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -606,18 +708,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/DaPan.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "大潘",
-                                "大潘",
-                                "Da Pan",
-                                "ダパン",
-                                "판"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_DaPan": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -636,18 +739,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Fluorite.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "萤石",
-                                "螢石",
-                                "Fluorite",
-                                "フローライト",
-                                "플루라이트"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Fluorite": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -666,18 +770,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Akekuri.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "秋栗",
-                                "秋栗",
-                                "Akekuri",
-                                "アケクリ",
-                                "아케쿠리"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Akekuri": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -696,18 +801,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Estella.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "埃特拉",
-                                "埃特拉",
-                                "Estella",
-                                "エステーラ",
-                                "에스텔라"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Estella": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -726,18 +832,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Rossi.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "洛茜",
-                                "洛西",
-                                "Rossi",
-                                "ロッシ",
-                                "로시"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Rossi": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -756,18 +863,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Tangtang.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "汤汤",
-                                "湯湯",
-                                "Tangtang",
-                                "タンタン",
-                                "탕탕"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Tangtang": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -786,18 +894,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/ZhuangFangyi.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "庄方宜",
-                                "莊方宜",
-                                "Zhuang Fangyi",
-                                "ゾアン・ファンイ",
-                                "장방이"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_ZhuangFangyi": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -816,18 +925,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/MiFu.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "弭弗",
-                                "弭弗",
-                                "Mi Fu",
-                                "ミ・フ",
-                                "미푸"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_MiFu": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -846,18 +956,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Camille.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "卡缪",
-                                "卡繆",
-                                "Camille",
-                                "カミーユ",
-                                "카뮤"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Camille": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -876,18 +987,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Arcane.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "诀",
-                                "訣",
-                                "Arcane",
-                                "オクギ",
-                                "결"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Jue": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -906,18 +1018,19 @@
                             "enabled": false
                         },
                         "GiftOperatorSelectSpecifiedOp": {
-                            "enabled": true,
                             "template": [
                                 "GiftOperator/Operators/Liino.png"
                             ]
                         },
-                        "GiftOperatorName": {
-                            "expected": [
-                                "梨诺",
-                                "梨諾",
-                                "Liino",
-                                "リーノ",
-                                "리노"
+                        "GiftOperatorSelectGiftOp": {
+                            "enabled": false
+                        },
+                        "GiftOperatorSelectSpecifiedGiftOp_Liino": {
+                            "enabled": true
+                        },
+                        "GiftOperatorReceiveDialog": {
+                            "next": [
+                                "GiftOperatorMain"
                             ]
                         }
                     }
@@ -933,6 +1046,7 @@
                 {
                     "name": "Yes",
                     "option": [
+                        "SelectOperator",
                         "AcceptAllGifts"
                     ],
                     "pipeline_override": {
@@ -964,6 +1078,9 @@
                                 "GiftOperatorBranchReceive",
                                 "GiftOperatorLeave"
                             ]
+                        },
+                        "GiftOperatorNoGiftOperatorSpecified": {
+                            "enabled": true
                         }
                     }
                 },
@@ -973,7 +1090,20 @@
                         "SelectOperator",
                         "SendWrongGift"
                     ],
-                    "pipeline_override": {}
+                    "pipeline_override": {
+                        "GiftOperatorContacSortOrder": {
+                            "enabled": true
+                        },
+                        "GiftOperatorContacSortBy": {
+                            "enabled": true
+                        },
+                        "GiftOperatorSelectOp1": {
+                            "enabled": true
+                        },
+                        "GiftOperatorSelectSpecifiedOp": {
+                            "enabled": true
+                        }
+                    }
                 }
             ]
         },

--- a/assets/tasks/GiftOperatorReceive.json
+++ b/assets/tasks/GiftOperatorReceive.json
@@ -1,0 +1,64 @@
+{
+    "task": [
+        {
+            "name": "GiftOperatorReceive",
+            "label": "$task.GiftOperatorReceive.label",
+            "entry": "GiftOperatorReceiveMain",
+            "description": "$task.GiftOperatorReceive.description",
+            "option": [
+                "SelectOperator"
+            ],
+            "group": [
+                "dijiang_ship"
+            ],
+            "controller": [
+                "ADB",
+                "Linux-Gamescope",
+                "Linux-ScreenCast",
+                "Linux-Wlroots",
+                "PlayCover",
+                "Win32-Front"
+            ],
+            "pipeline_override": {
+                "GiftOperatorContacSortOrder": {
+                    "enabled": false
+                },
+                "GiftOperatorContacSortBy": {
+                    "enabled": false
+                },
+                "GiftOperatorSelectOp1": {
+                    "enabled": false
+                },
+                "GiftOperatorSelectGiftOp": {
+                    "enabled": true
+                },
+                "GiftOperatorSelectSpecifiedOp": {
+                    "enabled": false
+                },
+                "GiftOperatorName": {
+                    "expected": [
+                        ".*"
+                    ]
+                },
+                "GiftOperatorBranchReceive": {
+                    "next": [
+                        "GiftOperatorReceiveDialogLoop",
+                        "GiftOperatorBagFull"
+                    ]
+                },
+                "GiftOperatorSkipDialog": {
+                    "next": [
+                        "GiftOperatorBranchReceive",
+                        "GiftOperatorLeave"
+                    ]
+                },
+                "GiftOperatorNoGiftOperatorSpecified": {
+                    "enabled": true
+                },
+                "GiftOperatorSwipe": {
+                    "enabled": false
+                }
+            }
+        }
+    ]
+}

--- a/docs/en_us/developers/tasks/gift-operator-maintain.md
+++ b/docs/en_us/developers/tasks/gift-operator-maintain.md
@@ -1,7 +1,7 @@
 # Development Manual - Gift Operator Maintenance Documentation
 
 This document explains the file distribution and two execution routes of `GiftOperator`.  
-This documentation was last updated on June 28, 2026.
+This documentation was last updated on August 25, 2026.
 
 ## File Paths
 
@@ -29,7 +29,7 @@ When adding a new operator, at least the following 6 locations need to be update
 | --- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1 | `assets/resource/image/GiftOperator/Operators/<Name>.png` | Win32 operator avatar template; must be processed with `tools/gift_operator/fill_gift_operator_green_box.py` before storage |
 | 2 | `assets/resource_adb/image/GiftOperator/Operators/<Name>.png` | ADB operator avatar template; processed similarly |
-| 3 | `assets/tasks/GiftOperator.json` → `SelectOperator` | Add a case to provide selectable operators in the UI and supply operator information for the "Receive Only" route |
+| 3 | `assets/tasks/GiftOperator.json` → `SelectOperator` | Add a case to provide selectable operators in the UI; the case also supplies the avatar template override for both "specific operator giving" and the "Receive Only + specific operator" combined selection |
 | 4 | `assets/resource/pipeline/GiftOperator/Operator/Operator.json` | OCR recognition and whitelist for each operator in "Receive Only" mode |
 | 5 | `assets/resource/pipeline/GiftOperator/GiftOperatorContact.json` → `GiftOperatorSelectGiftOp.next` | Append `GiftOperatorSelect_<Name>` to the `next` array at the "Receive Only" operator selection node; otherwise, the operator node will not be triggered |
 | 6 | `assets/locales/interface/*.json` → `operator.<Name>` | Operator display name for each language |
@@ -53,15 +53,20 @@ Corresponds to the "Receive Only" option being disabled. Configurable gift recip
 
 ## Route 2: Receive Only
 
-Corresponds to the "Receive Only" option being enabled. No longer actively gives gifts, only receives gifts from operators.
+Corresponds to the "Receive Only" option being enabled. No longer actively gives gifts, only receives gifts from operators. The "Select Operator" option (**a checkbox, up to 5 operators**) still takes effect here and narrows down the recipients.
 
-1. Similarly, store the bag first, then navigate to the operator contact point.
-2. In the contact list, [identify operators with gift icons](#receive-mode-how-to-correctly-select-the-target-operator) (implementation in `GiftOperatorContact.json` and `Operator/Operator.json`), rather than selecting by trust order or specific operator.
-3. Confirm the call, enter dialogue, prioritize clicking "Accept Gift".
-4. After receiving:
-    - **Accept All Gifts** disabled → Skip dialogue, then leave, task ends.
-    - **Accept All Gifts** enabled → Return to the start of the task, continue finding the next operator with a gift; only leave when no selectable operators remain in the contact interface.
-5. If the bag is full, prompt and end the task.
+1. Do **not** stash the bag — navigate directly to the operator contact point.
+2. In the contact list, [identify operators with gift icons](#receive-mode-how-to-correctly-select-the-target-operator) (implementation in `GiftOperatorContact.json` and `Operator/Operator.json`), rather than selecting by trust order.
+3. Then select operators (must pass [Selection State Verification](#selection-state-verification) after clicking; implementation in `GiftOperatorContact.json`):
+    - **Any**: any operator with a gift icon.
+    - **Specific Operators (multi-select)**: use a "gift icon + operator avatar" combined judgment — first locate the row with a gift, then match the avatar template of a selected operator (each operator has its own combined node `GiftOperatorSelectSpecifiedGiftOp_<Name>`, `max_hit=1`), and verify the selection state before calling. **No list scrolling** (`GiftOperatorSwipe` is disabled in the Receive task): if the current screen has no gift row for the specific operator, it **directly refreshes the map** instead of scrolling down to search.
+4. Confirm the call, enter dialogue, click "Accept Gift".
+5. After receiving:
+    - Specific operators (multi-select) → **automatically return to the task entry and continue to the next un-collected selected operator**; each operator's combined node is exhausted after one hit (already collected → no longer participates).
+    - **Accept All Gifts** disabled and no specific operator selected → Skip dialogue, then leave, task ends.
+    - **Accept All Gifts** enabled → continue finding the next operator with a gift.
+6. End condition: when no selected operator with a gift can be collected this round, the task enters the **map-refresh loop** (Valley IV → Di Jiang, see below), capped at 3 refreshes per waiting period (`GiftOperatorNoGiftOperatorSpecified`, `max_hit=3`); if still nothing, it falls into "no selectable operator" and ends — i.e., all checked operators have been collected.
+7. If the bag is full, prompt and end the task.
 
 ## Special Handling
 
@@ -118,6 +123,34 @@ Avatar templates must be processed by `fill_gift_operator_green_box.py` (green b
 
 If no operator with a gift is found on the current screen, the list scrolls up to 2 times; if still not found, it falls into "no selectable operator", which can serve as a round-end condition when "Accept All Gifts" is enabled.
 
+#### Receive Only + Specific Operators (Multi-select)
+
+"Operator to gift" is a **checkbox** (up to 5 operators). When "Receive Only" is enabled and operators are checked, the target is narrowed to **those operators**. Instead of the "click the gift row first, then identify who it is" flow, it first confirms that "this row has a gift AND this row is one of the checked operators"; it clicks only when both conditions hold, to avoid selecting another operator's gift row (implementation in `GiftOperatorContact.json`):
+
+1. **Locate the gift icon**: use `Gift.png` template matching in the contact list area (`green_mask`).
+2. **Match a checked avatar**: use the gift icon hit position as an anchor and secondarily match the avatar of one checked operator in the adjacent area (`Operators/<Name>.png`).
+3. **Click and verify**: click that row only when both match, then go through the same [Selection State Verification](#selection-state-verification), confirm sequence number `1`, then call.
+
+Each checked operator has its own set of nodes (enabled by the corresponding `SelectOperator` case in `assets/tasks/GiftOperator.json`, no cross-case override conflicts):
+
+- `GiftOperatorSelectSpecifiedGiftOp_<Name>`: `And` (shared `GiftOperatorSpecifiedGiftIcon` + that operator's `GiftOperatorSpecifiedGiftAvatar_<Name>`), `max_hit=1` — **after one hit (calling that operator) it is exhausted and never selected again in later rounds, i.e. "already collected → no longer participates"**.
+- `GiftOperatorNamePatch_<Name>`: on hit, dynamically sets the dialogue-stage name OCR whitelist to that operator's name, avoiding whitelist overwrites in multi-select.
+- Unchecked operators' combined nodes stay `enabled=false` and do not participate.
+
+Collection flow: after each collected operator, the task automatically returns to the task entry (the standalone "Receive Only" task uses `GiftOperatorReceiveMain`, **never stashing the bag**). In the Receive task, `GiftOperatorSwipe` is disabled — **no list scrolling**: when the current screen has no gift row for a specific operator, it directly enters the map-refresh loop.
+
+Log progress reporting (standalone "Receive Only" task): check any operators (daily target is **5**), collected in parallel — whoever has a gift is collected first, **no forced order**. Each collection:
+- that operator's `GiftOperatorNamePatch_<Name>` node `focus` prints "🎁 已领取 <operator> 的礼物";
+- after success, `GiftOperatorReceiveDialogLoop` → `GiftOperatorRemainReport` remainder chain (`GiftOperatorRemain4/3/2/1/0`, each `max_hit=1`, counting down) prints "🎁 已领取 k/5 名，剩余指定干员 N 名".
+
+When all 5 are collected, `GiftOperatorRemain0` prints "已领取 5/5 名，全部完成" and calls `PostStop` to **actively stop the task**.
+
+Map-refresh loop: when no checked operator with a gift can be found this round, `GiftOperatorNoGiftOperatorSpecified` (enabled in the standalone "Receive Only" task and in "Receive Only + specific operators" mode, no hit limit) enters the refresh chain and **keeps refreshing until all of the daily gift quota is collected** (ended by `Remain0`/`PostStop`):
+
+1. `GiftOperatorRefreshMap` → if not in an open world, `[JumpBack]SceneEnterWorldValleyIVTheHub` **enters the Valley IV open world** to trigger a map load;
+2. `GiftOperatorRefreshMapInValley` (`And[InWorld]` confirms being in an open world) → `[JumpBack]GiftOperatorGoToDijiang` **re-enters the Di Jiang bridge**;
+3. `GiftOperatorRefreshMapInDijiang` (reuses the `MapLocateAssertLocation` bridge assertion) → `GiftOperatorMainLoop` (no bag re-stash, only scroll/counters reset) re-scans the contact screen.
+
 ### After Calling Operator: What to Do If Dialogue Button Not Found
 
 After call confirmation, the task first waits for the operator to appear and attempts to click the dialogue entry. If the interactive dialogue button is still not visible on screen, it won't wait indefinitely but enters **Position Correction Fallback**, logic in `GiftOperatorNavigation.json`.
@@ -142,4 +175,5 @@ Two other similar retries handle click offsets caused by the operator walking ov
 ### Differences in Default Mode Operator Selection (Compared to Receive)
 
 The "Any" route doesn't rely on avatars, but instead: switches to trust ascending order → from top to bottom, finds rows with **incomplete trust and not selected**, and clicks three consecutively.  
-The "Specific Operator" route is similar to receive mode's second step, directly matching in the list using the avatar template, but without needing to first find the gift icon.
+The "Specific Operator" route is similar to receive mode's second step, directly matching in the list using the avatar template, but without needing to first find the gift icon.  
+"Receive Only + Specific Operator" matches the avatar template like the default "Specific Operator" route, but additionally requires the row to also have a gift icon (combined node `GiftOperatorSelectSpecifiedGiftOp`), and the dialogue-stage name OCR whitelist is statically set by the option case.

--- a/docs/zh_cn/developers/tasks/gift-operator-maintain.md
+++ b/docs/zh_cn/developers/tasks/gift-operator-maintain.md
@@ -1,7 +1,7 @@
 # 开发手册 - 赠送干员礼物维护文档
 
 本文说明 `GiftOperator` 的文件分布与两条执行路线。  
-该文档更新于 2026 年 6 月 28 日。
+该文档更新于 2026 年 8 月 25 日。
 
 ## 文件路径
 
@@ -29,7 +29,7 @@
 | --- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | 1 | `assets/resource/image/GiftOperator/Operators/<Name>.png` | Win32 干员头像模板；入库前须用 `tools/gift_operator/fill_gift_operator_green_box.py` 处理 |
 | 2 | `assets/resource_adb/image/GiftOperator/Operators/<Name>.png` | ADB 干员头像模板；同上处理 |
-| 3 | `assets/tasks/GiftOperator.json` → `SelectOperator` | 新增 case，在 UI 提供可选干员，并为「只收礼物」路线提供干员信息 |
+| 3 | `assets/tasks/GiftOperator.json` → `SelectOperator` | 新增 case，在 UI 提供可选干员；case 内同时提供「送礼指定干员」与「只收礼物 + 指定干员」组合选人所需的头像模板覆盖 |
 | 4 | `assets/resource/pipeline/GiftOperator/Operator/Operator.json` | 「只收礼物」模式下各干员的 OCR 识别与白名单 |
 | 5 | `assets/resource/pipeline/GiftOperator/GiftOperatorContact.json` → `GiftOperatorSelectGiftOp.next` | 在「只收礼物」选人节点的 `next` 数组追加 `GiftOperatorSelect_<Name>`，否则该干员节点不会被触发 |
 | 6 | `assets/locales/interface/*.json` → `operator.<Name>` | 各语言干员显示名称 |
@@ -53,15 +53,20 @@
 
 ## 路线二：只收礼物
 
-对应选项「只收礼物」开启。不再主动送礼，只领取干员送来的礼物。
+对应选项「只收礼物」开启。不再主动送礼，只领取干员送来的礼物。此时「赠送干员」选项（**多选框**，可勾选最多 5 名干员）同样生效，用于限定领取对象。
 
-1. 同样先存放背包，再寻路至干员联络台。
-2. 在联络列表中[识别带礼物图标的干员](#收礼模式如何正确选中目标干员)（实现见 `GiftOperatorContact.json` 与 `Operator/Operator.json`），而非按信赖排序或指定干员选人。
-3. 确认呼唤，进入对话，优先点击「收下礼物」。
-4. 领取后：
-    - **接受全部礼物**关闭 → 跳过对话后离开，任务结束。
-    - **接受全部礼物**开启 → 回到任务开头，继续找下一名有礼物的干员；直到联络界面无可选干员才离开。
-5. 若背包已满，提示后结束任务。
+1. **不存放背包**，直接寻路至干员联络台。
+2. 在联络列表中[识别带礼物图标的干员](#收礼模式如何正确选中目标干员)（实现见 `GiftOperatorContact.json` 与 `Operator/Operator.json`），而非按信赖排序。
+3. 再选人（点击后须经[选中态校验](#选中态校验)确认，实现见 `GiftOperatorContact.json`）：
+    - **任意**：任意带礼物图标的干员。
+    - **指定干员（多选）**：以「礼物图标 + 干员头像」组合判断——先定位带礼物的行，再用头像模板匹配目标干员（每名干员一个独立组合节点 `GiftOperatorSelectSpecifiedGiftOp_<Name>`，`max_hit=1`），命中后同样校验选中态再呼唤。**不滑动列表**（`GiftOperatorSwipe` 在只收任务中禁用）：当前屏没有带礼物的指定干员时，**直接刷新地图**等待，不尝试下滑寻找。
+4. 确认呼唤，进入对话，点击「收下礼物」。
+5. 领取后：
+    - 指定干员（多选）→ **自动回到任务入口继续找下一名未领取的指定干员**；每个干员的组合节点命中一次即耗尽（已领取不再参与）。
+    - **接受全部礼物**关闭且未指定干员 → 跳过对话后离开，任务结束。
+    - **接受全部礼物**开启 → 继续找下一名有礼物的干员。
+6. 结束条件：本轮联络界面没有任何可领取的指定干员时，进入**刷新地图循环**——先经 `SceneEnterWorldValleyIVTheHub` 进入谷地大世界触发加载，再经 `GiftOperatorGoToDijiang` 重新进入帝江号舰桥，随后走 `GiftOperatorMainLoop`（不再存放背包）重新扫描联络界面，直到领到礼物为止；`GiftOperatorNoGiftOperatorSpecified`（`max_hit=3`）限制**单个等待期**最多刷新 3 次，仍无可领则落入「无可选干员」，任务结束（即领满已勾选干员）。
+7. 若背包已满，提示后结束任务。
 
 ## 特殊处理
 
@@ -118,6 +123,34 @@
 
 当前屏找不到带礼物的干员时，列表最多滑动 2 次；仍找不到则落入「无可选干员」，在开启「接受全部礼物」时可作为整轮结束条件。
 
+#### 只收礼物 + 指定干员（多选）
+
+「赠送干员」为**多选框**，最多可勾选 5 名干员。开启「只收礼物」并勾选干员后，收礼目标收窄为**这些干员**。此时不走「先点礼物行、再识别是谁」的流程，而是先确认「该行带礼物、且该行是某个勾选干员」，两条件同时满足才点击，避免误选其他干员的礼物行（实现见 `GiftOperatorContact.json`）：
+
+1. **定位礼物图标**：在联络列表区域用 `Gift.png` 模板匹配礼物图标（`green_mask`）。
+2. **匹配指定头像**：以礼物图标命中位置为锚点，在相邻区域二次匹配某勾选干员的头像（`Operators/<Name>.png`）。
+3. **点击并校验**：两项都命中才点击该行，随后同样走[选中态校验](#选中态校验)，确认序号 `1` 后再呼唤。
+
+每个勾选干员对应一组独立节点（`assets/tasks/GiftOperator.json` → `SelectOperator` 各 case 启用对应组，互不覆盖）：
+
+- `GiftOperatorSelectSpecifiedGiftOp_<Name>`：`And`（共享 `GiftOperatorSpecifiedGiftIcon` + 该干员的 `GiftOperatorSpecifiedGiftAvatar_<Name>`），`max_hit=1`——**命中一次（呼唤该干员）后即耗尽，后续轮次不再选择，即「已领取不参与」**。
+- `GiftOperatorNamePatch_<Name>`：命中后动态把对话阶段名称 OCR 白名单设为该干员名字，避免多选时白名单互相覆盖。
+- 未勾选的干员组合节点保持 `enabled=false`，不参与轮询。
+
+领取流程：每领完一名干员自动回到任务入口（独立「只收礼物」任务走 `GiftOperatorReceiveMain`，**全程不存放背包**）继续找下一名未领取干员。只收任务中 `GiftOperatorSwipe` 被禁用，**不滑动列表**：当前屏没有带礼物的指定干员时，直接进入刷新地图循环。
+
+日志进度报告（独立「只收礼物」任务）：勾选任意干员（每天目标 **5 名**），并行领取——谁有礼物先领谁，**不强制顺序**。每领一名：
+- 该干员的 `GiftOperatorNamePatch_<Name>` 节点 `focus` 输出「🎁 已领取 <干员名> 的礼物」；
+- 领取成功后 `GiftOperatorReceiveDialogLoop` → `GiftOperatorRemainReport` 剩余数链（`GiftOperatorRemain4/3/2/1/0`，各 `max_hit=1` 计数递减）输出「🎁 已领取 k/5 名，剩余指定干员 N 名」。
+
+领满 5 名时 `GiftOperatorRemain0` 输出「已领取 5/5 名，全部完成」并调用 `PostStop` **主动停止任务**。
+
+刷新地图循环：本轮联络界面找不到任何带礼物的勾选干员时，`GiftOperatorNoGiftOperatorSpecified`（在独立「只收礼物」任务及「只收礼物 + 指定干员」模式启用，无命中上限）进入刷新链，**无限刷新直到领满每天的礼物量**（领满由 `Remain0`/`PostStop` 结束）：
+
+1. `GiftOperatorRefreshMap` → 不在大世界时 `[JumpBack]SceneEnterWorldValleyIVTheHub` **进入谷地大世界**触发地图加载；
+2. `GiftOperatorRefreshMapInValley`（`And[InWorld]` 确认已在大世界）→ `[JumpBack]GiftOperatorGoToDijiang` **重新进入帝江号舰桥**；
+3. `GiftOperatorRefreshMapInDijiang`（复用 `MapLocateAssertLocation` 断言舰桥位置）→ `GiftOperatorMainLoop`（不再存放背包，仅重置滑动等计数）重新扫描联络界面。
+
 ### 召唤干员后：找不到对话按钮怎么办
 
 呼唤确认后，任务会先等干员出现并尝试点击对话入口。若此时画面上还看不到可交互的对话按钮，不会一直傻等，而是进入**站位修正兜底**，逻辑在 `GiftOperatorNavigation.json`。
@@ -142,4 +175,5 @@
 ### 默认模式选人的差异（对比收礼）
 
 「任意」路线不靠头像，而是：切信赖度升序 → 从上到下找**信赖未满且未被选中**的行，连点三名。  
-「指定干员」路线与收礼第二步类似，直接在列表里用头像模板匹配，但不需要先找礼物图标。
+「指定干员」路线与收礼第二步类似，直接在列表里用头像模板匹配，但不需要先找礼物图标。  
+「只收礼物 + 指定干员」与默认「指定干员」一样用头像模板匹配，但额外要求该行同时带礼物图标（组合节点 `GiftOperatorSelectSpecifiedGiftOp`），且对话阶段名称 OCR 白名单由选项 case 静态指定。


### PR DESCRIPTION
# 新增「只收礼物」独立任务：多选指定干员领取礼物

## 概述

在 `GiftOperator`（赠送干员礼物）基础上新增独立任务 **「只收礼物」**（`GiftOperatorReceive`），用于每天从勾选的指定干员处领取礼物：不送礼、不存背包、不滑动列表，领不满就刷新地图等待，领满 5 名自动结束。

## 功能点

### 1. 独立任务 `assets/tasks/GiftOperatorReceive.json`
- 入口 `GiftOperatorReceiveMain`（不存放背包），挂在 `dijiang_ship` 组
- 选项：`赠送干员`（多选框，最多 5 名）+ 原「只收礼物」开关逻辑内联到任务级 override

### 2. 多选指定干员（`SelectOperator` 改为 checkbox）
- 每个干员生成独立识别节点：
  - `GiftOperatorSelectSpecifiedGiftOp_<Name>`：`And`（礼物图标 + 该干员头像），`max_hit=1` —— 命中一次即视为已领取，后续轮次不再选择
  - `GiftOperatorNamePatch_<Name>`：动态设置对话阶段名称 OCR 白名单，避免多选时互相覆盖，并输出 focus 日志「已领取 <干员名> 的礼物」

### 3. 领取进度日志
- 领取成功后进入剩余数链（`GiftOperatorRemain4/3/2/1/0`，`max_hit` 计数递减），输出 focus「已领取 k/5 名，剩余指定干员 N 名」
- 领满 5 名 → `GiftOperatorRemain0` → `PostStop` 主动结束任务

### 4. 无礼物刷新循环
- `GiftOperatorNoGiftOperatorSpecified` → 刷新链（先进谷地大世界触发加载 → 重新进入帝江号舰桥）→ `GiftOperatorMainLoop`（不存背包）重新扫描联络界面，无限刷新直到领满
- 误点「无安排」卡片导致选中态校验失败时，`GiftOperatorSelectSpecifiedOpSuccess` 的 `on_error` 触发刷新恢复，不再卡死

### 5. 修复
- `GiftOperatorClickContact`、`GiftOperatorGoToDijiang` 等 max_hit 节点加入 `ClearHitCount` 重置清单，修复刷新循环中点击联络台计数耗尽导致的卡死

## 改动文件

| 文件 | 说明 |
| --- | --- |
| `assets/tasks/GiftOperatorReceive.json` | 新增：只收礼物独立任务 |
| `assets/tasks/GiftOperator.json` | `SelectOperator` 改 checkbox；干员 case 独立节点 + focus 覆盖 |
| `assets/resource/pipeline/GiftOperator/GiftOperatorContact.json` | 29 干员独立组合节点、NamePatch focus、剩余数链、on_error、NoGift 刷新 |
| `assets/resource/pipeline/GiftOperator/GiftOperatorMain.json` | `GiftOperatorReceiveMain` 入口、`ClearHitCount` 拆分与补充 |
| `assets/resource/pipeline/GiftOperator/GiftOperatorGiftFlow.json` | `ReceiveDialogLoop` 接剩余数链 |
| `assets/interface.json` | import 新任务 |
| `assets/locales/interface/*.json`（5 语言） | 新任务 label/description、OnlyReceiveGift 描述 |
| `docs/zh_cn\|en_us/developers/tasks/gift-operator-maintain.md` | 开发手册更新 |

## 测试

- 仅简中环境验证（其余语言为文案同步）
- 四种模式覆盖：只收+任意 / 只收+指定多选 / 送礼+任意 / 送礼+指定


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“仅收取干员礼物”任务。
  * 支持最多指定 5 名干员，并按顺序领取对应礼物。
  * 领取过程中显示剩余进度，完成后自动结束；必要时会刷新地图并重新查找。
  * 优化“仅收取礼物”选项，可指定礼物接收对象。

* **文档**
  * 更新相关任务说明及多语言界面文本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->