### PR TITLE
fix(sentry): 默认分析最新 beta 版本

### DIFF
--- a/tools/sentry/auto_delivery_report.py
+++ b/tools/sentry/auto_delivery_report.py
@@ -1,8 +1,8 @@
 """根据 Sentry spans 生成自动送货任务分析报告。
 
-默认分析 beta 环境最近 24 小时的 DeliveryJobs 与 SeizeDeliveryJobs。报告分别展示
-导航阶段失败率、失败节点分布和路线内部错误率。路线内部错误可能已被上层重试恢复，
-因此不等同于整次自动送货任务失败。
+默认分析 beta 环境最新 MaaEnd beta release 最近 24 小时的 DeliveryJobs 与
+SeizeDeliveryJobs。报告分别展示导航阶段失败率、失败节点分布和路线内部错误率。
+路线内部错误可能已被上层重试恢复，因此不等同于整次自动送货任务失败。
 """
 
 from __future__ import annotations
@@ -22,6 +22,7 @@ try:
         DEFAULT_SENTRY_TIMEOUT_SECONDS,
         explore,
         format_rate,
+        resolve_latest_maaend_beta_release,
         resolve_sentry_command,
         show_progress,
         write_console_table,
@@ -31,6 +32,7 @@ except ImportError:
         DEFAULT_SENTRY_TIMEOUT_SECONDS,
         explore,
         format_rate,
+        resolve_latest_maaend_beta_release,
         resolve_sentry_command,
         show_progress,
         write_console_table,
@@ -357,11 +359,21 @@ def collect_report(
     quiet: bool,
 ) -> tuple[Report, set[str]]:
     route_definitions = load_route_definitions(catalog_path)
-    if release:
-        escaped_release = release.replace('"', '\\"')
-        scope_filter = f'release:"{escaped_release}"'
-    else:
-        scope_filter = f"environment:{environment}"
+    if release is None:
+        show_progress(
+            f"[0/3] 自动选择 {environment} 环境的最新 MaaEnd beta release",
+            quiet=quiet,
+        )
+        release = resolve_latest_maaend_beta_release(
+            sentry_command,
+            target=target,
+            environment=environment,
+            verbose=verbose,
+            timeout_seconds=timeout_seconds,
+        )
+        show_progress(f"使用 Sentry release：{release}", quiet=quiet)
+    escaped_release = release.replace('"', '\\"')
+    scope_filter = f'release:"{escaped_release}"'
     task_filter = f"task:[{','.join(tasks)}]"
     scope_filter = f"{scope_filter} {task_filter}"
 
@@ -507,12 +519,12 @@ def create_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--release",
-        help="精确的 Sentry release 名称；指定后覆盖默认 environment 筛选",
+        help="精确的 Sentry release 名称；未指定时自动选择最新 MaaEnd beta release",
     )
     parser.add_argument(
         "--environment",
         default="beta",
-        help="未指定 --release 时使用的 Sentry environment（默认：beta）",
+        help="自动选择 release 时使用的 Sentry environment（默认：beta）",
     )
     parser.add_argument("--target", default="maaend/rust", help="<org>/<project>")
     parser.add_argument(

--- a/tools/sentry/environment_monitoring_report.py
+++ b/tools/sentry/environment_monitoring_report.py
@@ -1,9 +1,9 @@
 """根据 Sentry spans 生成环境监测任务失败情况报告。
 
-执行次数按包含 ``GoTo*Move`` span 的唯一 trace 统计。传送失败取自路线专属的
-``QuickTeleport`` span，移动失败取自失败的移动 span；扫描失败归属于同一 trace
-中时间最近的前置 ``GoTo*Move`` span。同一观察点、同一 trace 中的同类重复 span
-只计数一次，总失败按三类失败 trace 的并集统计。
+默认分析 beta 环境最新 MaaEnd beta release。执行次数按包含 ``GoTo*Move`` span 的
+唯一 trace 统计。传送失败取自路线专属的 ``QuickTeleport`` span，移动失败取自失败的
+移动 span；扫描失败归属于同一 trace 中时间最近的前置 ``GoTo*Move`` span。同一
+观察点、同一 trace 中的同类重复 span 只计数一次，总失败按三类失败 trace 的并集统计。
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ try:
         DEFAULT_SENTRY_TIMEOUT_SECONDS,
         explore,
         format_rate,
+        resolve_latest_maaend_beta_release,
         resolve_sentry_command,
         show_progress,
         write_console_table,
@@ -34,6 +35,7 @@ except ImportError:
         DEFAULT_SENTRY_TIMEOUT_SECONDS,
         explore,
         format_rate,
+        resolve_latest_maaend_beta_release,
         resolve_sentry_command,
         show_progress,
         write_console_table,
@@ -282,11 +284,21 @@ def collect_report(
     verbose: bool,
     quiet: bool,
 ) -> tuple[list[ReportRow], int]:
-    if release:
-        escaped_release = release.replace('"', '\\"')
-        scope_filter = f'release:"{escaped_release}"'
-    else:
-        scope_filter = f"environment:{environment}"
+    if release is None:
+        show_progress(
+            f"[0/5] 自动选择 {environment} 环境的最新 MaaEnd beta release",
+            quiet=quiet,
+        )
+        release = resolve_latest_maaend_beta_release(
+            sentry_command,
+            target=target,
+            environment=environment,
+            verbose=verbose,
+            timeout_seconds=timeout_seconds,
+        )
+        show_progress(f"使用 Sentry release：{release}", quiet=quiet)
+    escaped_release = release.replace('"', '\\"')
+    scope_filter = f'release:"{escaped_release}"'
 
     move_filter = f"{scope_filter} span.description:GoTo*Move"
     teleport_failure_filter = (
@@ -473,12 +485,12 @@ def create_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--release",
-        help="精确的 Sentry release 名称；指定后覆盖默认 channel 筛选",
+        help="精确的 Sentry release 名称；未指定时自动选择最新 MaaEnd beta release",
     )
     parser.add_argument(
         "--environment",
         default="beta",
-        help="未指定 --release 时使用的 Sentry environment（默认：beta）",
+        help="自动选择 release 时使用的 Sentry environment（默认：beta）",
     )
     parser.add_argument("--target", default="maaend/rust", help="<org>/<project>")
     parser.add_argument(

--- a/tools/sentry/report_common.py
+++ b/tools/sentry/report_common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -13,6 +14,10 @@ from typing import Any, Sequence, TextIO
 
 EXPLORE_LIMIT = 1_000
 DEFAULT_SENTRY_TIMEOUT_SECONDS = 120.0
+DEFAULT_RELEASE_DISCOVERY_PERIOD = "90d"
+MAAEND_BETA_RELEASE_PATTERN = re.compile(
+    r"(?:^|\+)MaaEnd@v(\d+)\.(\d+)\.(\d+)-beta\.(\d+)$"
+)
 
 
 def resolve_sentry_command() -> str:
@@ -133,6 +138,52 @@ def explore(
             raise RuntimeError(f"sentry explore 返回了重复分页游标：{next_cursor}")
         seen_cursors.add(next_cursor)
         cursor = next_cursor
+
+
+def select_latest_maaend_beta_release(rows: Sequence[dict[str, Any]]) -> str:
+    """从 release 聚合结果中选择最新且样本最多的 MaaEnd beta release。"""
+    candidates: list[tuple[tuple[int, int, int, int], int, str]] = []
+    for row in rows:
+        release = row.get("release")
+        trace_count = row.get("count_unique(trace)")
+        if not isinstance(release, str) or not isinstance(trace_count, int):
+            continue
+
+        match = MAAEND_BETA_RELEASE_PATTERN.search(release)
+        if match is None:
+            continue
+        version = tuple(int(part) for part in match.groups())
+        candidates.append((version, trace_count, release))
+
+    if not candidates:
+        raise RuntimeError(
+            "Sentry 中找不到格式为 MaaEnd@vX.Y.Z-beta.N 的 beta release，"
+            "请通过 --release 显式指定。"
+        )
+    return max(candidates)[2]
+
+
+def resolve_latest_maaend_beta_release(
+    sentry_command: str,
+    *,
+    target: str,
+    environment: str,
+    verbose: bool = False,
+    timeout_seconds: float = DEFAULT_SENTRY_TIMEOUT_SECONDS,
+) -> str:
+    """查询 Sentry，并解析指定环境中最新的 MaaEnd beta release。"""
+    escaped_environment = environment.replace('"', '\\"')
+    rows = explore(
+        sentry_command,
+        target=target,
+        period=DEFAULT_RELEASE_DISCOVERY_PERIOD,
+        fields=("release", "count_unique(trace)"),
+        query=f'environment:"{escaped_environment}"',
+        sort="-count_unique(trace)",
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+    return select_latest_maaend_beta_release(rows)
 
 
 def format_rate(rate: float | None) -> str:


### PR DESCRIPTION
## 变更内容

- 未指定 `--release` 时，从 Sentry 的 beta 环境聚合近 90 天 release，自动解析最新的 MaaEnd beta 版本
- 严格匹配 `MaaEnd@vX.Y.Z-beta.N`，排除 RC、正式版、CI/dev 等干扰项；同一 MaaEnd 版本存在多个 MXU 组合时，选择唯一 trace 数最多的主流 release
- 自动送货与环境监测报告共用同一选择逻辑，并保留显式 `--release` 覆盖能力
- 在查询进度中输出最终使用的完整 Sentry release，便于复核统计口径

## 验证

- `uv run python -m py_compile tools/sentry/report_common.py tools/sentry/auto_delivery_report.py tools/sentry/environment_monitoring_report.py`
- 实时 Sentry 解析选中 `MXU@2.5.0-beta.1+MaaEnd@v2.26.0-beta.7`，未选中仅有少量样本的 `MXU@2.4.4+MaaEnd@v2.26.0-beta.7`
- `uv run python tools/sentry/auto_delivery_report.py --period 1h --format json --verbose`
- `uv run python tools/sentry/environment_monitoring_report.py --period 1h --format json --verbose`
- `pnpm check`
- `pnpm test`（780/780，未生成 `tests/maatools/error_details.json`）
- `git diff --check origin/v2...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Sentry 报告现在可自动识别指定环境中最新的 MaaEnd Beta 版本，并将其作为查询范围。
  * 默认查询最近 90 天的数据，并根据版本号和样本量选择版本。
  * 支持通过 `--release` 手动指定版本，保留现有的自定义查询方式。

* **错误提示**
  * 找不到可用版本时，将提示手动指定 `--release`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->