### PR TITLE
fix(MapNavigator): 闭环修正滑索瞄准

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -126,7 +126,7 @@ constexpr int32_t kHeadingVerifyMaxRetries = 3;
 constexpr int32_t kHeadingTurnStepIntervalMs = 100;     // step pacing floor; raised to the backend min send interval
 constexpr double kHeadingStableReadToleranceDeg = 15.0; // two fresh reads must agree this closely to count
 constexpr int32_t kHeadingStableReadIntervalMs = 120;
-constexpr int32_t kHeadingStableReadMaxFrames = 4;      // read budget; no stable pair -> accept open-loop
+constexpr int32_t kHeadingStableReadMaxFrames = 4;      // default HEADING read budget; the caller decides its fallback
 constexpr int32_t kSerialRouteRetryDelayMs = 180;
 constexpr double kBootstrapOwnershipProjectionCorridor = 3.0;
 constexpr double kBootstrapOwnershipProjectionFrontThreshold = 0.35;
@@ -270,7 +270,9 @@ constexpr int32_t kZiplineLaunchSettleMs = 400;
 // 瞄准精度只能在按左键之前保证: 按下去人就滑走了, 半空里没有跟随层能把方向修回来。走路那套
 // 40 度容差是靠跟随层善后才敢留的, 这里不能用
 constexpr double kZiplineAimToleranceDeg = 6.0;
-constexpr int32_t kZiplineAimMaxRetries = 3;
+// 上索后的稳定等待与全部水平修正共用这个截止时间。每次只发一个后端批次并等待真实反馈，
+// 避免大角度转向在上索动画尚未结束时一次性排入多条输入。
+constexpr int32_t kZiplineAimHeadingTimeoutMs = 6000;
 // 落差够大时镜头得抬到索的仰角上才起得了滑。小地图读不到俯仰, 所以每次从地面登上滑索架后
 // 先通过 Pipeline 把镜头拉到上限, 将该硬限位记作 +90 度, 再从这个固定基准开环调整。连续滑索
 // 没有上下索动作, 直接沿用上一跳记住的俯仰。游戏的俯仰范围不对称: 仰角最多 90 度, 俯角最多 60 度。

--- a/agent/cpp-algo/source/MapNavigator/semantic_helpers.h
+++ b/agent/cpp-algo/source/MapNavigator/semantic_helpers.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <chrono>
+
 #include "semantic_nodes.h"
 
 namespace mapnavigator
@@ -14,6 +16,8 @@ void SelectPhaseForCurrentWaypoint(const Context& ctx, const char* reason);
 bool TurnToHeadingOnce(const Context& ctx, double heading_delta);
 // 连着读到两帧一致的朝向才算数。读不出来返回 false，此时 out_heading 不可用。
 bool CaptureStableHeading(const Context& ctx, double* out_heading);
+// 连续读取到 deadline；用于必须等待真实反馈的闭环动作。超时前没有稳定朝向时返回 false。
+bool CaptureStableHeadingUntil(const Context& ctx, double* out_heading, std::chrono::steady_clock::time_point deadline);
 // 转向指令发不出去时返回 false。发得出去不代表转到位，转到位与否由 VerifyAndCorrectHeading 复核。
 bool CommitHeadingTurn(const Context& ctx, double heading_delta);
 // 复核转向结果并按需补一次。返回实际朝向；读不到稳定朝向时返回 fallback_heading。

--- a/agent/cpp-algo/source/MapNavigator/semantic_nodes.cpp
+++ b/agent/cpp-algo/source/MapNavigator/semantic_nodes.cpp
@@ -352,6 +352,28 @@ bool CaptureCleanFix(const Context& ctx, NaviPosition* out_pos)
     return false;
 }
 
+template <typename CanCaptureFrame>
+bool CaptureStableHeadingImpl(const Context& ctx, double* out_heading, const CanCaptureFrame& can_capture_frame)
+{
+    std::optional<double> previous;
+    for (int frame = 0; can_capture_frame(frame); ++frame) {
+        if (frame > 0) {
+            utils::SleepFor(kHeadingStableReadIntervalMs);
+        }
+        if (!ctx.position_provider->Capture(ctx.position, false, ctx.session->current_zone_id())
+            || ctx.position_provider->LastCaptureWasHeld()) {
+            continue;
+        }
+        const double current = NaviMath::NormalizeAngle(ctx.position->angle);
+        if (previous && std::abs(NaviMath::NormalizeAngle(current - *previous)) <= kHeadingStableReadToleranceDeg) {
+            *out_heading = current;
+            return true;
+        }
+        previous = current;
+    }
+    return false;
+}
+
 } // namespace
 
 bool TurnToHeadingOnce(const Context& ctx, double heading_delta)
@@ -382,23 +404,16 @@ bool TurnToHeadingOnce(const Context& ctx, double heading_delta)
 
 bool CaptureStableHeading(const Context& ctx, double* out_heading)
 {
-    std::optional<double> previous;
-    for (int frame = 0; frame < kHeadingStableReadMaxFrames; ++frame) {
-        if (frame > 0) {
-            utils::SleepFor(kHeadingStableReadIntervalMs);
-        }
-        if (!ctx.position_provider->Capture(ctx.position, false, ctx.session->current_zone_id())
-            || ctx.position_provider->LastCaptureWasHeld()) {
-            continue;
-        }
-        const double current = NaviMath::NormalizeAngle(ctx.position->angle);
-        if (previous && std::abs(NaviMath::NormalizeAngle(current - *previous)) <= kHeadingStableReadToleranceDeg) {
-            *out_heading = current;
-            return true;
-        }
-        previous = current;
-    }
-    return false;
+    return CaptureStableHeadingImpl(ctx, out_heading, [](int frame) { return frame < kHeadingStableReadMaxFrames; });
+}
+
+bool CaptureStableHeadingUntil(const Context& ctx, double* out_heading, std::chrono::steady_clock::time_point deadline)
+{
+    const auto interval = std::chrono::milliseconds(kHeadingStableReadIntervalMs);
+    return CaptureStableHeadingImpl(ctx, out_heading, [&](int frame) {
+        const auto now = std::chrono::steady_clock::now();
+        return frame == 0 ? now < deadline : now + interval <= deadline;
+    });
 }
 
 void StopMotionAndCommitment(const Context& ctx)

--- a/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
@@ -219,32 +219,52 @@ bool ResetPitchToMaximum(const Context& ctx)
     return true;
 }
 
-// 站在架子上瞄准。水平方向闭环收进容差, 俯仰按算好的仰角开环发。转镜头不带前进脉冲: 架子上
-// 转镜头就能带动小地图朝向, 而站在架子上按前进是没验证过的输入。读不到稳定朝向就返回 false,
-// 宁可退索走路也不盲按左键——按下去就滑走了, 没有第二次机会。
+// 站在架子上瞄准。先等上索后的新定位稳定，再按后端单批上限逐步转镜头；每一步都等稳定反馈后
+// 重算剩余角度，避免拿上索前的旧朝向一次性排入整段转向。俯仰仍按算好的仰角开环发。
+// 站在架子上按前进是没验证过的输入，所以这里只转镜头；闭环超时就退索，不盲按左键起滑。
 bool AimAtLanding(const Context& ctx, const ZiplineTarget& landing, int attempt, bool reset_pitch)
 {
-    const double target_heading = NaviMath::CalcTargetRotation(ctx.position->x, ctx.position->y, landing.x, landing.y);
-    double achieved = NaviMath::NormalizeAngle(ctx.position->angle);
-    double residual = NaviMath::NormalizeAngle(target_heading - achieved);
-    for (int correction = 0; correction <= kZiplineAimMaxRetries; ++correction) {
-        if (!TurnToHeadingOnce(ctx, residual)) {
-            LogWarn << "Zipline aim: the view turn was rejected." << VAR(residual);
-            return false;
-        }
-        utils::SleepFor(kWaitAfterFirstTurnMs);
-        if (!CaptureStableHeading(ctx, &achieved)) {
-            LogWarn << "Zipline aim: no stable heading on the tower." << VAR(target_heading);
-            return false;
-        }
+    const auto started_at = std::chrono::steady_clock::now();
+    const auto deadline = started_at + std::chrono::milliseconds(kZiplineAimHeadingTimeoutMs);
+
+    double achieved = 0.0;
+    if (!CaptureStableHeadingUntil(ctx, &achieved, deadline)) {
+        LogWarn << "Zipline aim: no stable heading on the tower before the deadline." << VAR(attempt) << VAR(kZiplineAimHeadingTimeoutMs);
+        return false;
+    }
+
+    const SteeringTransportProfile profile = ctx.action_wrapper->SteeringProfile();
+    double target_heading = 0.0;
+    double residual = 0.0;
+    int turn_step = 0;
+    while (true) {
+        target_heading = NaviMath::CalcTargetRotation(ctx.position->x, ctx.position->y, landing.x, landing.y);
         residual = NaviMath::NormalizeAngle(target_heading - achieved);
         if (std::abs(residual) <= kZiplineAimToleranceDeg) {
             break;
         }
-    }
-    if (std::abs(residual) > kZiplineAimToleranceDeg) {
-        LogWarn << "Zipline aim: the heading never settled." << VAR(target_heading) << VAR(achieved) << VAR(residual);
-        return false;
+        if (std::chrono::steady_clock::now() >= deadline) {
+            LogWarn << "Zipline aim: heading correction timed out." << VAR(attempt) << VAR(turn_step) << VAR(target_heading)
+                    << VAR(achieved) << VAR(residual) << VAR(kZiplineAimHeadingTimeoutMs);
+            return false;
+        }
+
+        const double turn_delta = std::clamp(residual, -profile.max_batch_delta_deg, profile.max_batch_delta_deg);
+        LogInfo << "Zipline aim: issuing closed-loop turn step." << VAR(attempt) << VAR(turn_step) << VAR(target_heading) << VAR(achieved)
+                << VAR(residual) << VAR(turn_delta);
+        if (!TurnToHeadingOnce(ctx, turn_delta)) {
+            LogWarn << "Zipline aim: the view turn was rejected." << VAR(turn_step) << VAR(turn_delta);
+            return false;
+        }
+        ++turn_step;
+        utils::SleepFor(kWaitAfterFirstTurnMs);
+        if (!CaptureStableHeadingUntil(ctx, &achieved, deadline)) {
+            const int64_t elapsed_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started_at).count();
+            LogWarn << "Zipline aim: no stable feedback after the turn step." << VAR(attempt) << VAR(turn_step) << VAR(target_heading)
+                    << VAR(residual) << VAR(elapsed_ms);
+            return false;
+        }
     }
 
     if (reset_pitch && !ResetPitchToMaximum(ctx)) {
@@ -263,8 +283,8 @@ bool AimAtLanding(const Context& ctx, const ZiplineTarget& landing, int attempt,
         utils::SleepFor(kWaitAfterFirstTurnMs);
     }
 
-    LogInfo << "Zipline aim settled." << VAR(attempt) << VAR(target_heading) << VAR(achieved) << VAR(landing.elevation_deg)
-            << VAR(pitch_target);
+    LogInfo << "Zipline aim settled." << VAR(attempt) << VAR(turn_step) << VAR(target_heading) << VAR(achieved)
+            << VAR(landing.elevation_deg) << VAR(pitch_target);
     return true;
 }
 


### PR DESCRIPTION
## 变更内容

- 滑索瞄准前等待连续稳定且非 held 的定位，并按最新位置重新计算目标朝向
- 将水平转向限制为单个后端批次，每次输入后重新采样朝向并按剩余误差继续修正
- 使用统一的 6 秒截止时间约束初始稳定等待和全部水平修正，仅在进入 6 度容差后调整俯仰并起滑
- 首次瞄准、起滑失败重瞄和反向回索统一复用闭环逻辑

## 问题原因

原实现直接使用上索前缓存的朝向，大角度转向会一次拆分并连续发送多个输入；随后若稳定采样失败便直接退出，没有根据实际朝向反馈继续修正。

## 验证

- `cmake --build agent/cpp-algo/build --config RelWithDebInfo --target cpp-algo -j 1`
- `git diff --check`
- 按本次开发约定未运行 `pnpm check` 和 `pnpm test`

fixed #5273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化滑索着陆瞄准流程，采用最长 6 秒的统一超时机制。
  - 通过多步闭环修正提升航向与水平调整的稳定性，每步操作后获取最新反馈。
  - 当超时、转向被拒绝或反馈失败时，流程会及时返回失败状态。
  - 增加稳定航向采集能力，支持在指定时间截止前持续获取有效结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->