### PR TITLE
fix(MapNavigator): 转向批次按请求角度分配以提高灵活性

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/motion_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/motion_controller.cpp
@@ -121,10 +121,13 @@ TurnCommandResult MotionController::ApplySteering(double yaw_delta_deg, int64_t 
         action_wrapper_->SetMovementStateSync(false, false, false, false, 0);
     }
 
-    // Spend a long tick on several batches rather than one, so the turn achieved per metre walked holds up as
-    // the loop slows down. The transport's own minimum spacing still bounds how many actually fit.
+    // Spend the batches on the angle the command asks for rather than on how long the tick was: metering a big
+    // about-face one batch per tick stretched it over ~1.7s, and the character walks the whole time, so the turn
+    // swept a 3.5m arc into whatever stood beside it. The ceiling still caps every tick, which is what keeps each
+    // one an observation point -- a 185 turn goes out as 90 + 90 + 5, never all at once.
     const double batch_cap = steering_profile_.max_batch_delta_deg;
-    int64_t batches = std::clamp<int64_t>(tick_gap_ms / kSteeringRateReferenceMs, 1, kSteeringMaxBatchesPerTick);
+    int64_t batches =
+        std::clamp<int64_t>(static_cast<int64_t>(std::ceil(std::abs(yaw_delta_deg) / batch_cap)), 1, kSteeringMaxBatchesPerTick);
     if (steering_profile_.min_send_interval_ms > 0) {
         batches = std::max<int64_t>(1, std::min(batches, tick_gap_ms / steering_profile_.min_send_interval_ms));
     }

--- a/agent/cpp-algo/source/MapNavigator/motion_controller.h
+++ b/agent/cpp-algo/source/MapNavigator/motion_controller.h
@@ -26,6 +26,8 @@ public:
 
     bool IsMoving() const;
     bool IsMovingForward() const;
+    // The transport's per-drag cap, which is the angle the pending-turn floor is sized to cover.
+    double SteeringBatchCapDeg() const { return steering_profile_.max_batch_delta_deg; }
 
 private:
     bool ActionProducesTranslation(LocalDriverAction action) const;

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -111,13 +111,16 @@ constexpr int32_t kForwardHoldFutileReassertsBeforeRecovery = 2;
 // with the loop instead of silently discarding the rate.
 constexpr uint64_t kSteeringRateMaxGapTicks = 4;
 constexpr int32_t kSteeringRateReferenceMs = 100;
-// How long a sent turn may still be owed before it is written off. Measured on device the game yaws at about
-// 100 deg/s, so a capped command needs some 300ms to land; past double that the drag was swallowed, and holding
-// the debt any longer would suppress steering against a turn that is never arriving.
+// How long a sent turn may still be owed before it is written off, past which the drag was swallowed and holding
+// the debt would suppress steering against a turn never arriving. Covers the worst observed capture-to-fix lag
+// plus the time one per-drag-capped command takes to sweep; a tick that spends several batches sweeps further,
+// so the caller adds time for the part beyond the first. Yaw rate measured on device from single-command turns.
 constexpr int64_t kSteeringPendingLifetimeMs = 600;
-// Turn batches one tick may spend. The backend's per-batch cap is a per-drag reliability limit, not a budget
-// for the whole tick: a slow loop gets fewer, longer ticks, so one batch each would shrink the turn achieved
-// per metre walked just as the lag makes more of it necessary. Bounded so a misread heading cannot spin far.
+constexpr double kYawRateDegPerSec = 320.0;
+// Turn batches one tick may spend, and so the ceiling on how far one tick turns. Spending them on the angle the
+// command asks for rather than on how long the tick was lets a reversal finish in three ticks instead of seven,
+// while the ceiling keeps every tick an observation point: a heading read wrong on one frame costs at most this
+// much before the next fix corrects it.
 constexpr int32_t kSteeringMaxBatchesPerTick = 3;
 constexpr double kSteeringHeadingChangeEpsilonDeg = 0.05;
 constexpr int32_t kPostHeadingForwardPulseMs = 270;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -1711,9 +1711,16 @@ bool NavigationStateMachine::TickNavigate()
     // still in flight instead of commanding the same error again. Only motion toward the debt pays it down, and
     // an unpaid debt expires, so a swallowed drag can never leave steering suppressed against a turn never coming.
     // Walking turns at about half rate: a jogging-sized lifetime expires mid-turn and the loop re-commands it.
-    const int64_t pending_lifetime_ms =
-        walk_mode_.engaged() ? kSteeringPendingLifetimeMs * kWalkModeSlowFactor : kSteeringPendingLifetimeMs;
     SteeringRateState& steering_rate = runtime_state_.steering_rate;
+    // The floor covers one batch; a tick that spends several sweeps further and takes correspondingly longer to
+    // land, so add time for the part beyond the first batch. A debt written off mid-sweep makes the loop command
+    // the remainder a second time, which overshoots by whatever was still in flight and then hunts back.
+    const double extra_sweep_deg =
+        std::max(0.0, std::abs(steering_rate.cmd_delta_deg) - motion_controller_->SteeringBatchCapDeg());
+    const int64_t base_pending_lifetime_ms =
+        kSteeringPendingLifetimeMs + static_cast<int64_t>(extra_sweep_deg / kYawRateDegPerSec * 1000.0);
+    const int64_t pending_lifetime_ms =
+        walk_mode_.engaged() ? base_pending_lifetime_ms * kWalkModeSlowFactor : base_pending_lifetime_ms;
     if (steering_rate.pending_turn_deg != 0.0) {
         const int64_t pending_age_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - steering_rate.cmd_at).count();
         if (pending_age_ms >= pending_lifetime_ms) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化大角度转向处理：转向动作将根据角度大小拆分为多个批次，并限制每批转向幅度。
  - 改进未完成转向的处理时长，使其随剩余转向角度动态调整。
  - 在行走模式下继续应用相应的减速效果，提升转向过程的平滑性与可控性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->