### PR TITLE
feat(setup): cpp-algo CI artifact digest 一致时跳过下载

### DIFF
--- a/tools/locals/setup_workspace/en_us.json
+++ b/tools/locals/setup_workspace/en_us.json
@@ -71,6 +71,8 @@
     "inf_cpp_algo_installed_skip": "[INF] cpp-algo already installed, skipping (use --update to update)",
     "err_cpp_algo_url_not_found": "[ERR] cpp-algo download URL not found",
     "inf_cpp_algo_latest_version": "[INF] cpp-algo is already up to date ({version}), skipping download",
+    "inf_cpp_algo_digest_match": "[INF] Remote cpp-algo artifact SHA256 matches the locally recorded value ({sha}), skipping download",
+    "wrn_cpp_algo_digest_unavailable": "[WRN] Could not retrieve the remote cpp-algo artifact checksum; falling back to the original logic",
     "inf_extract_install_cpp_algo": "[INF] Extracting and installing cpp-algo...",
     "err_cpp_algo_not_found": "[ERR] Could not find {name}",
     "err_cpp_algo_dmg_unsupported": "[ERR] This system cannot process dmg directly, please install cpp-algo manually from release package",

--- a/tools/locals/setup_workspace/zh_cn.json
+++ b/tools/locals/setup_workspace/zh_cn.json
@@ -71,6 +71,8 @@
     "inf_cpp_algo_installed_skip": "[INF] cpp-algo 已安装，跳过（如需更新，请使用 --update 参数）",
     "err_cpp_algo_url_not_found": "[ERR] 未找到 cpp-algo 下载链接",
     "inf_cpp_algo_latest_version": "[INF] cpp-algo 已是最新版本 ({version})，跳过下载",
+    "inf_cpp_algo_digest_match": "[INF] 远端 cpp-algo artifact 的 SHA256 与本地记录一致 ({sha})，跳过下载",
+    "wrn_cpp_algo_digest_unavailable": "[WRN] 无法获取远端 cpp-algo artifact 校验和，按原逻辑继续",
     "inf_extract_install_cpp_algo": "[INF] 解压并安装 cpp-algo...",
     "err_cpp_algo_not_found": "[ERR] 未能找到 {name}",
     "err_cpp_algo_dmg_unsupported": "[ERR] 当前系统不支持直接处理 dmg，请手动从发布包安装 cpp-algo",

--- a/tools/setup_workspace.py
+++ b/tools/setup_workspace.py
@@ -340,13 +340,21 @@ def _retry_on_permission(operation, *, error_key: str = "", **fmt_args) -> bool:
                 return False
 
 
-def _update_versions(install_root: Path, values: dict[str, str]) -> None:
-    """更新 version.json 中多个组件的版本号（单次读-改-写）"""
+def _update_versions(install_root: Path, values: dict[str, str | None]) -> None:
+    """更新 version.json 中多个组件的版本号（单次读-改-写）。
+
+    值为非空字符串时写入；值为 None 时删除对应键（用于清除过期记录，如
+    release 回退安装后移除旧的 CI artifact digest）。
+    """
     if not values:
         return
     version_file = install_root / VERSION_FILE_NAME
     versions = read_versions_file(version_file)
-    versions.update({k: v for k, v in values.items() if v})
+    for key, value in values.items():
+        if value is None:
+            versions.pop(key, None)
+        elif value:
+            versions[key] = value
     write_versions_file(version_file, versions)
 
 
@@ -356,6 +364,8 @@ def _update_component_version(
     version: str,
 ) -> None:
     """更新 version.json 中单个组件的版本号"""
+    if not version:
+        return
     _update_versions(install_root, {component_key: version})
 
 
@@ -1247,7 +1257,7 @@ def _find_cpp_algo_in_ci(
     branch = checkout_branch or MAIN_BRANCH
     print(Console.info(t("inf_ci_artifact_search_branch", name=artifact_name, branch=branch)))
 
-    def _search_runs(runs_url: str) -> tuple[str | None, str | None]:
+    def _search_runs(runs_url: str) -> tuple[str | None, str | None, str | None]:
         try:
             data = _github_api_get(runs_url, auth_headers)
         except urllib.error.HTTPError as e:
@@ -1548,8 +1558,11 @@ def install_cpp_algo(
             print(Console.ok(t("inf_cpp_algo_install_complete")))
             cleanup_cache_file(download_path)
             version_to_write = remote_version or local_version
+            # 走 Release 回退安装成功：清除 CI artifact digest 记录，避免旧 digest
+            # 在新一轮 CI 恢复后误判"一致"而跳过下载。
             if version_to_write:
                 _update_component_version(install_root, "cpp_algo", version_to_write)
+            _update_versions(install_root, {"cpp_algo_sha256": None})
             return True, version_to_write, True
         except Exception as e:
             traceback.print_exc()

--- a/tools/setup_workspace.py
+++ b/tools/setup_workspace.py
@@ -340,18 +340,23 @@ def _retry_on_permission(operation, *, error_key: str = "", **fmt_args) -> bool:
                 return False
 
 
+def _update_versions(install_root: Path, values: dict[str, str]) -> None:
+    """更新 version.json 中多个组件的版本号（单次读-改-写）"""
+    if not values:
+        return
+    version_file = install_root / VERSION_FILE_NAME
+    versions = read_versions_file(version_file)
+    versions.update({k: v for k, v in values.items() if v})
+    write_versions_file(version_file, versions)
+
+
 def _update_component_version(
     install_root: Path,
     component_key: str,
     version: str,
 ) -> None:
     """更新 version.json 中单个组件的版本号"""
-    if not version:
-        return
-    version_file = install_root / VERSION_FILE_NAME
-    versions = read_versions_file(version_file)
-    versions[component_key] = version
-    write_versions_file(version_file, versions)
+    _update_versions(install_root, {component_key: version})
 
 
 def parse_semver(version: str) -> tuple[list[int], list[str]]:
@@ -982,14 +987,35 @@ def _github_api_get(url: str, auth_headers: dict[str, str]) -> dict:
         return json.loads(res.read())
 
 
+def parse_artifact_digest(value: object) -> str | None:
+    """解析 GitHub artifact 的 digest 字段为 64 位小写 hex。
+
+    GitHub 在 artifact 上传时计算并暴露 sha256:<hex>（UI 与 REST API 同一来源）。
+    返回规范化后的 hex；无法解析（缺失 / 非字符串 / 前缀或长度不符）返回 None。
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text.lower().startswith('sha256:'):
+        text = text[len('sha256:'):]
+    text = text.strip().lower()
+    if len(text) != 64:
+        return None
+    try:
+        int(text, 16)
+    except ValueError:
+        return None
+    return text
+
+
 def _find_cpp_algo_artifact_in_runs(
     auth_headers: dict[str, str],
     runs: list[dict],
     artifact_name: str,
-) -> tuple[str | None, str | None]:
+) -> tuple[str | None, str | None, str | None]:
     """Iterate *runs* (most-recent-first), fetch their artifacts, and return
-    (download_url, head_sha) for the first run that has a matching non-expired
-    artifact. Returns (None, None) when no match is found.
+    (download_url, head_sha, digest) for the first run that has a matching
+    non-expired artifact. Returns (None, None, None) when no match is found.
     """
     for run in runs:
         run_id = run["id"]
@@ -1025,9 +1051,9 @@ def _find_cpp_algo_artifact_in_runs(
                     f"artifacts/{artifact_id}/zip"
                 )
                 print(Console.ok(t("inf_ci_artifact_found", sha=head_sha[:7])))
-                return download_url, head_sha
+                return download_url, head_sha, parse_artifact_digest(artifact.get("digest"))
 
-    return None, None
+    return None, None, None
 
 
 def _find_cpp_algo_in_ci(
@@ -1035,7 +1061,7 @@ def _find_cpp_algo_in_ci(
     pr_number: int | None = None,
     run_id: int | None = None,
     branch: str | None = None,
-) -> tuple[str | None, str | None]:
+) -> tuple[str | None, str | None, str | None]:
     """Find a cpp-algo CI artifact from a successful install.yml workflow run.
 
     - When *run_id* is specified, fetches that exact workflow run's artifacts.
@@ -1046,11 +1072,11 @@ def _find_cpp_algo_in_ci(
       the current HEAD (PR/workflow-dispatch builds), then the latest run for
       that branch.
 
-    Returns (download_url, version_sha) or (None, None).
+    Returns (download_url, version_sha, digest) or (None, None, None).
     """
     if auth_headers is None:
         print(Console.info(t("inf_ci_artifact_no_token")))
-        return None, None
+        return None, None, None
 
     artifact_name = f"cpp-algo-{OS_KEYWORD}-{ARCH_KEYWORD}"
 
@@ -1070,20 +1096,20 @@ def _find_cpp_algo_in_ci(
                                      run_id=run_id, status="404", conclusion="not found")))
             else:
                 print(Console.warn(t("wrn_ci_artifact_list_runs_failed", error=e)))
-            return None, None
+            return None, None, None
         except urllib.error.URLError as e:
             print(Console.warn(t("wrn_ci_artifact_network_error", error=e.reason)))
-            return None, None
+            return None, None, None
         except Exception as e:
             print(Console.warn(t("wrn_ci_artifact_list_runs_failed", error=e)))
-            return None, None
+            return None, None, None
 
         status = run_data.get("status", "?")
         conclusion = run_data.get("conclusion", "?")
         if status != "completed" or conclusion != "success":
             print(Console.warn(t("wrn_ci_artifact_run_not_successful",
                                  run_id=run_id, status=status, conclusion=conclusion)))
-            return None, None
+            return None, None, None
 
         head_sha = run_data.get("head_sha", "")
         artifacts_url = (
@@ -1097,13 +1123,13 @@ def _find_cpp_algo_in_ci(
                 print(Console.warn(t("wrn_ci_artifact_rate_limited", code=e.code)))
             else:
                 print(Console.warn(t("wrn_ci_artifact_list_artifacts_failed", error=e)))
-            return None, None
+            return None, None, None
         except urllib.error.URLError as e:
             print(Console.warn(t("wrn_ci_artifact_network_error", error=e.reason)))
-            return None, None
+            return None, None, None
         except Exception as e:
             print(Console.warn(t("wrn_ci_artifact_list_artifacts_failed", error=e)))
-            return None, None
+            return None, None, None
 
         for artifact in artifacts_data.get("artifacts", []):
             if artifact.get("name") == artifact_name and not artifact.get("expired", False):
@@ -1113,10 +1139,10 @@ def _find_cpp_algo_in_ci(
                     f"artifacts/{artifact_id}/zip"
                 )
                 print(Console.ok(t("inf_ci_artifact_found", sha=head_sha[:7])))
-                return download_url, head_sha
+                return download_url, head_sha, parse_artifact_digest(artifact.get("digest"))
 
         print(Console.info(t("inf_ci_artifact_not_found")))
-        return None, None
+        return None, None, None
 
     # --- pr_number branch: search runs by PR head SHA ---
     if pr_number is not None:
@@ -1132,13 +1158,13 @@ def _find_cpp_algo_in_ci(
                 print(Console.warn(t("wrn_ci_artifact_rate_limited", code=e.code)))
             else:
                 print(Console.warn(t("wrn_ci_artifact_list_runs_failed", error=e)))
-            return None, None
+            return None, None, None
         except urllib.error.URLError as e:
             print(Console.warn(t("wrn_ci_artifact_network_error", error=e.reason)))
-            return None, None
+            return None, None, None
         except Exception as e:
             print(Console.warn(t("wrn_ci_artifact_list_runs_failed", error=e)))
-            return None, None
+            return None, None, None
 
         pr_title = pr_data.get("title", "?")
         pr_author = pr_data.get("user", {}).get("login", "?")
@@ -1158,16 +1184,16 @@ def _find_cpp_algo_in_ci(
             except urllib.error.HTTPError as e:
                 if e.code in (403, 429):
                     print(Console.warn(t("wrn_ci_artifact_rate_limited", code=e.code)))
-                    return None, None
+                    return None, None, None
                 else:
                     print(Console.warn(t("wrn_ci_artifact_list_runs_failed", error=e)))
-                    return None, None
+                    return None, None, None
             except urllib.error.URLError as e:
                 print(Console.warn(t("wrn_ci_artifact_network_error", error=e.reason)))
-                return None, None
+                return None, None, None
             except Exception as e:
                 print(Console.warn(t("wrn_ci_artifact_list_runs_failed", error=e)))
-                return None, None
+                return None, None, None
 
             sha_runs = data.get("workflow_runs", [])
             if sha_runs:
@@ -1188,16 +1214,16 @@ def _find_cpp_algo_in_ci(
         except urllib.error.HTTPError as e:
             if e.code in (403, 429):
                 print(Console.warn(t("wrn_ci_artifact_rate_limited", code=e.code)))
-                return None, None
+                return None, None, None
             else:
                 print(Console.warn(t("wrn_ci_artifact_list_runs_failed", error=e)))
-                return None, None
+                return None, None, None
         except urllib.error.URLError as e:
             print(Console.warn(t("wrn_ci_artifact_network_error", error=e.reason)))
-            return None, None
+            return None, None, None
         except Exception as e:
             print(Console.warn(t("wrn_ci_artifact_list_runs_failed", error=e)))
-            return None, None
+            return None, None, None
 
         all_runs = data.get("workflow_runs", [])
         pr_runs = [
@@ -1213,7 +1239,7 @@ def _find_cpp_algo_in_ci(
                 return result
 
         print(Console.info(t("inf_ci_artifact_pr_no_runs", pr=pr_number)))
-        return None, None
+        return None, None, None
 
     # --- default branch: use the checkout's branch, with v2 kept as the
     # protected default when a detached checkout has no branch name. ---
@@ -1229,17 +1255,17 @@ def _find_cpp_algo_in_ci(
                 print(Console.warn(t("wrn_ci_artifact_rate_limited", code=e.code)))
             else:
                 print(Console.warn(t("wrn_ci_artifact_list_runs_failed", error=e)))
-            return None, None
+            return None, None, None
         except urllib.error.URLError as e:
             print(Console.warn(t("wrn_ci_artifact_network_error", error=e.reason)))
-            return None, None
+            return None, None, None
         except Exception as e:
             print(Console.warn(t("wrn_ci_artifact_list_runs_failed", error=e)))
-            return None, None
+            return None, None, None
 
         runs = data.get("workflow_runs", [])
         if not runs:
-            return None, None
+            return None, None, None
         result = _find_cpp_algo_artifact_in_runs(auth_headers, runs, artifact_name)
         return result
 
@@ -1280,7 +1306,7 @@ def _find_cpp_algo_in_ci(
 
     print(Console.info(t("inf_ci_artifact_no_runs", branch=branch)))
     print(Console.info(t("inf_ci_artifact_not_found")))
-    return None, None
+    return None, None, None
 
 
 def install_cpp_algo(
@@ -1305,7 +1331,7 @@ def install_cpp_algo(
     # Try to grab just the cpp-algo binary from a recent successful workflow run.
     # Default: latest v2 push. Optionally: from a specific PR or run ID.
     auth_headers = _github_auth_headers()
-    ci_url, ci_version = _find_cpp_algo_in_ci(
+    ci_url, ci_version, ci_digest = _find_cpp_algo_in_ci(
         auth_headers, pr_number=pr_number, run_id=run_id,
     )
 
@@ -1313,9 +1339,26 @@ def install_cpp_algo(
     # back to the current checkout's branch before trying a release.
     if ci_url is None and (pr_number is not None or run_id is not None):
         print(Console.warn(t("wrn_ci_artifact_pr_run_not_found_fallback")))
-        ci_url, ci_version = _find_cpp_algo_in_ci(auth_headers)
+        ci_url, ci_version, ci_digest = _find_cpp_algo_in_ci(auth_headers)
 
     if ci_url:
+        # Fast path: the remote artifact is byte-identical (same GitHub digest)
+        # to the one we last downloaded — no need to re-download.
+        local_versions = read_versions_file(install_root / VERSION_FILE_NAME)
+        local_digest = local_versions.get("cpp_algo_sha256")
+        if (
+            update_mode
+            and cpp_algo_installed
+            and ci_digest is not None
+            and local_digest
+            and ci_digest == local_digest
+        ):
+            print(Console.ok(t("inf_cpp_algo_digest_match", sha=ci_digest[:16])))
+            return True, local_version, False
+
+        if update_mode and cpp_algo_installed and ci_digest is None:
+            print(Console.warn(t("wrn_cpp_algo_digest_unavailable")))
+
         ci_should_skip = (
             update_mode
             and cpp_algo_installed
@@ -1388,8 +1431,10 @@ def install_cpp_algo(
                         print(Console.ok(t("inf_cpp_algo_install_complete")))
                         cleanup_cache_file(ci_download_path)
                         version_to_write = ci_version or local_version
-                        if version_to_write:
-                            _update_component_version(install_root, "cpp_algo", version_to_write)
+                        _update_versions(install_root, {
+                            "cpp_algo": version_to_write,
+                            "cpp_algo_sha256": ci_digest,
+                        })
                         return True, version_to_write, True
                 except PermissionError:
                     # User declined the retry prompt — release fallback would


### PR DESCRIPTION
下载 cpp-algo CI artifact 后把 GitHub digest 记录到 install/version.json 的 cpp_algo_sha256；运行时先比对远端 digest 与本地上次记录，一致则不再下载 zip。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 下载 `cpp-algo` CI 构件时新增远程 SHA256 摘要校验。
  * 本地摘要与远程摘要匹配时跳过重复下载，并提示用户。
  * 安装成功后保存版本和摘要信息，便于后续校验。

* **错误修复**
  * 无法获取远程摘要时显示警告，并继续使用原有下载流程。
  * 回退至正式版本安装后，自动清理过期的构件摘要记录。

* **本地化**
  * 新增上述提示和警告的中英文消息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->