### PR TITLE
chore: 隐藏全局滑索设置中的“始终启用”选项

### DIFF
--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -134,7 +134,7 @@
     "option.Zipline.label": "滑索",
     "option.Zipline.description": "控制寻路时要不要绕去坐滑索",
     "option.ZiplineRouting.label": "寻路时使用滑索",
-    "option.ZiplineRouting.description": "**未导入滑索坐标时本项不生效，寻路将全程步行。**\n请先在任务列表中执行「🛝导入/更新滑索坐标」，导入一次长期有效。\n跟随任务：仅在路线指定使用滑索时启用\n始终启用：尽可能使用滑索，未通过收益判定的滑索会自动跳过\n始终禁用：全程步行",
+    "option.ZiplineRouting.description": "**未导入滑索坐标时本项不生效，寻路将全程步行。**\n请先在任务列表中执行「🛝导入/更新滑索坐标」，导入一次长期有效。\n跟随任务：仅在路线指定使用滑索时启用\n始终禁用：全程步行", //弃用：始终启用：尽可能使用滑索，未通过收益判定的滑索会自动跳过
     "option.ZiplineRouting.cases.Auto.label": "跟随任务",
     "option.ZiplineRouting.cases.Always.label": "始终启用",
     "option.ZiplineRouting.cases.Never.label": "始终禁用",

--- a/assets/tasks/setting/Zipline.json
+++ b/assets/tasks/setting/Zipline.json
@@ -31,17 +31,18 @@
                         }
                     }
                 },
-                {
-                    "name": "Always",
-                    "label": "$option.ZiplineRouting.cases.Always.label",
-                    "pipeline_override": {
-                        "MapNavigatorZiplinePreference": {
-                            "attach": {
-                                "zipline": "always"
-                            }
-                        }
-                    }
-                },
+                // 隐藏“始终启用”。
+                // {
+                //     "name": "Always",
+                //     "label": "$option.ZiplineRouting.cases.Always.label",
+                //     "pipeline_override": {
+                //         "MapNavigatorZiplinePreference": {
+                //             "attach": {
+                //                 "zipline": "always"
+                //             }
+                //         }
+                //     }
+                // },
                 {
                     "name": "Never",
                     "label": "$option.ZiplineRouting.cases.Never.label",


### PR DESCRIPTION
fix #5296 
建议合并到正式版

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能调整**
  - 移除 Zipline 路由设置中的“始终启用”选项。
  - 保留“跟随任务”和“始终禁用”配置。
- **本地化**
  - 更新中文界面说明，标记“始终启用”选项已弃用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->