### PR TITLE
fix: 全项目组件支持 JSONC 配置并强化icon-recognition发布检查

### DIFF
--- a/.agents/skills/meojson/SKILL.md
+++ b/.agents/skills/meojson/SKILL.md
@@ -29,7 +29,22 @@ auto opt = json::open("/path/to/file.json");
 
 // JSONC (with comments)
 auto opt = json::parsec(str);
+
+// JSONC file: check UTF-8 BOM and allow comments
+auto opt = json::open("/path/to/file.json", true, true);
 ```
+
+`json::open(path, check_bom, with_comments)` 的两个布尔参数分别控制 UTF-8 BOM 检查和注释解析；默认调用 `json::open(path)` 是严格 JSON，既不检查 BOM，也不接受注释。
+
+在 MaaEnd cpp-algo 中读取仓库维护、允许注释的 JSON/JSONC 文件时，优先复用公共能力：
+
+```cpp
+#include "Common/JsoncFile.h"
+
+auto opt = common::OpenJsoncFile(path);
+```
+
+运行时接口参数（如 `custom_recognition_param`）、识别结果 detail 和生成报告仍保持严格 JSON，除非对应契约明确允许 JSONC。不要为解决仓库配置文件的注释问题而放宽运行时输入边界。
 
 **cpp-algo 推荐模式** — 安全解析自定义识别参数：
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -244,6 +244,12 @@ jobs:
             agent/go-service/go.mod
             agent/go-service/go.sum
 
+      # Python 依赖下载: cli_support.py（dep_3rdparty/build_and_install 共用）顶层 import json5，
+      # 必须先于任何 import cli_support 的脚本装好（Setup WebView2 SDK 的 dep_3rdparty 即会触发）
+      - name: Install Python JSONC dependency
+        shell: bash
+        run: python -m pip install json5
+
       # 缓存策略: restore/save 分离。PR 只恢复 v2 缓存不写入, 非 PR 才 save, 全仓只维护一份 v2 快照。
       - name: Restore MaaDeps
         id: cache-maadeps
@@ -340,9 +346,8 @@ jobs:
             fi
           fi
 
-          # 合并各 resource 的 pipeline JSON 文件
+          # 合并各 resource 的 pipeline JSON 文件（json5 已在依赖下载区安装）
           echo "Merge pipeline JSON"
-          python -m pip install json5
           python tools/merge_pipeline.py install
 
           # 更新 interface.json（版本号 + 资源 hash）

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -368,7 +368,7 @@ jobs:
         run: ccache -sv || true
 
       - name: Run IconRecognition quick tests
-        if: matrix.os == 'win' && matrix.arch == 'x86_64' && needs.meta.outputs.icon_recognition_changed == 'true'
+        if: matrix.os == 'win' && matrix.arch == 'x86_64' && (needs.meta.outputs.is_release == 'true' || needs.meta.outputs.icon_recognition_changed == 'true')
         shell: powershell
         run: |
           $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,7 +57,13 @@
     ],
     "files.associations": {
         "**/assets/**/*.json": "jsonc",
-        "**/tests/**/*.json": "jsonc"
+        "**/tests/**/*.json": "jsonc",
+        "**/tools/locals/**/*.json": "jsonc",
+        "**/tools/icon_recognition/**/*.json": "jsonc",
+        "**/tools/pipeline-generate/**/*.json": "jsonc",
+        "**/tools/i18n/**/*.json": "jsonc",
+        "**/tools/essence_filter/**/*.json": "jsonc",
+        "**/tools/optimize_templates/**/*.json": "jsonc"
     },
     "[json][jsonc]": {
         "editor.formatOnSave": true,

--- a/agent/cpp-algo/source/Common/JsoncFile.h
+++ b/agent/cpp-algo/source/Common/JsoncFile.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+
+#include <meojson/json.hpp>
+
+namespace common
+{
+
+inline std::optional<json::value> OpenJsoncFile(const std::filesystem::path& path)
+{
+    // 仓库内 JSONC 允许注释，同时兼容可能带 UTF-8 BOM 的文件。
+    return json::open(path.string(), true, true);
+}
+
+} // namespace common

--- a/agent/cpp-algo/source/Common/JsoncFile.h
+++ b/agent/cpp-algo/source/Common/JsoncFile.h
@@ -11,7 +11,7 @@ namespace common
 inline std::optional<json::value> OpenJsoncFile(const std::filesystem::path& path)
 {
     // 仓库内 JSONC 允许注释，同时兼容可能带 UTF-8 BOM 的文件。
-    return json::open(path.string(), true, true);
+    return json::open(path, true, true);
 }
 
 } // namespace common

--- a/agent/cpp-algo/source/Common/notice.cpp
+++ b/agent/cpp-algo/source/Common/notice.cpp
@@ -3,8 +3,6 @@
 #include <cctype>
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
-#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -13,6 +11,7 @@
 #include <meojson/json.hpp>
 
 #include "../utils.h"
+#include "JsoncFile.h"
 
 namespace common::notice
 {
@@ -55,15 +54,8 @@ std::string ResolveLanguage()
 bool LoadInto(const std::filesystem::path& dir, const std::string& lang, std::unordered_map<std::string, std::string>& out)
 {
     const std::filesystem::path path = dir / (lang + ".json");
-    std::ifstream file(path);
-    if (!file.is_open()) {
-        LogWarn << "Notice locale file not found." << VAR(path);
-        return false;
-    }
-
-    std::ostringstream text;
-    text << file.rdbuf();
-    const auto parsed = json::parse(text.str());
+    // 仓库内 JSONC 允许注释、尾逗号与 BOM，用公共 OpenJsoncFile 读取。
+    const auto parsed = common::OpenJsoncFile(path);
     if (!parsed || !parsed->is_object()) {
         LogWarn << "Failed to parse notice locale file." << VAR(path);
         return false;

--- a/agent/cpp-algo/source/IconRecognition/detail/TemplateCatalog.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/TemplateCatalog.cpp
@@ -5,6 +5,7 @@
 
 #include <meojson/json.hpp>
 
+#include "Common/JsoncFile.h"
 #include "CompositeIcon.h"
 #include "DisabledIcon.h"
 
@@ -60,7 +61,7 @@ bool TemplateCatalog::InitializeUnlocked()
     region_unavailable_cache_.clear();
     region_unavailable_background_.release();
     region_unavailable_mark_.release();
-    const auto parsed = json::open((data_root_ / "recognition_items.json").string());
+    const auto parsed = common::OpenJsoncFile(data_root_ / "recognition_items.json");
     if (!parsed || !parsed->is_object()) {
         throw std::runtime_error("recognition_items.json must be an object");
     }

--- a/agent/cpp-algo/source/IconRecognition/test/CMakeLists.txt
+++ b/agent/cpp-algo/source/IconRecognition/test/CMakeLists.txt
@@ -1,5 +1,10 @@
 function(configure_icon_recognition_test target)
-    target_include_directories(${target} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/..")
+    target_include_directories(
+        ${target}
+        PRIVATE
+            "${CMAKE_CURRENT_LIST_DIR}/../.."
+            "${CMAKE_CURRENT_LIST_DIR}/.."
+    )
     if(MSVC)
         target_compile_options(${target} PRIVATE /utf-8 /W4 /WX /wd4251)
     else()

--- a/agent/cpp-algo/source/IconRecognition/test/manual_runner_config.cpp
+++ b/agent/cpp-algo/source/IconRecognition/test/manual_runner_config.cpp
@@ -10,6 +10,8 @@
 
 #include <meojson/json.hpp>
 
+#include "Common/JsoncFile.h"
+
 namespace iconrecognition::test
 {
 
@@ -137,7 +139,7 @@ CandidateFilter ReadImageCandidates(const std::filesystem::path& image_path)
     if (!std::filesystem::is_regular_file(config_path)) {
         return {};
     }
-    const auto parsed = json::open(config_path.string());
+    const auto parsed = common::OpenJsoncFile(config_path);
     if (!parsed || !parsed->is_object()) {
         throw std::runtime_error("image sidecar must be a JSON object: " + config_path.string());
     }
@@ -446,7 +448,7 @@ std::vector<ManualRunnerCase> DiscoverManualRunnerCases(
     if (!std::filesystem::is_directory(input_root)) {
         throw std::runtime_error("input directory does not exist: " + input_root.string());
     }
-    const auto parsed_rois = json::open(rois_path.string());
+    const auto parsed_rois = common::OpenJsoncFile(rois_path);
     if (!parsed_rois || !parsed_rois->is_object()) {
         throw std::runtime_error("unable to read rois.json: " + rois_path.string());
     }

--- a/agent/cpp-algo/source/IconRecognition/test/test_full_diff.cpp
+++ b/agent/cpp-algo/source/IconRecognition/test/test_full_diff.cpp
@@ -20,6 +20,7 @@
 #include <MaaUtils/NoWarningCV.hpp>
 #include <meojson/json.hpp>
 
+#include "Common/JsoncFile.h"
 #include "../IconRecognizer.h"
 #include "../detail/RecognitionDiagnostics.h"
 #include "../detail/TemplateCatalog.h"
@@ -57,7 +58,7 @@ struct RunnerCasePerformance
 
 json::value ReadJson(const std::filesystem::path& path)
 {
-    const auto parsed = json::open(path.string());
+    const auto parsed = common::OpenJsoncFile(path);
     if (!parsed) {
         throw std::runtime_error("unable to read JSON: " + path.string());
     }

--- a/agent/cpp-algo/source/MapLocator/YoloPredictor.cpp
+++ b/agent/cpp-algo/source/MapLocator/YoloPredictor.cpp
@@ -7,6 +7,7 @@
 #include <boost/regex.hpp>
 #include <meojson/json.hpp>
 
+#include "../Common/JsoncFile.h"
 #include "YoloPredictor.h"
 
 using Json = json::value;
@@ -32,7 +33,7 @@ YoloPredictor::YoloPredictor(const std::string& yoloModelPath, double confThresh
         fs::path jsonPath = modelPath;
         jsonPath.replace_extension(".json");
 
-        auto j_opt = json::open(jsonPath);
+        auto j_opt = common::OpenJsoncFile(jsonPath);
         if (j_opt) {
             Json j = *j_opt;
 
@@ -59,7 +60,7 @@ YoloPredictor::YoloPredictor(const std::string& yoloModelPath, double confThresh
 
         fs::path tileMappingPath = modelPath;
         tileMappingPath.replace_filename(MAA_NS::path("tile_mapping.json"));
-        auto tileMappingOpt = json::open(tileMappingPath);
+        auto tileMappingOpt = common::OpenJsoncFile(tileMappingPath);
         if (tileMappingOpt) {
             const Json& tileMapping = *tileMappingOpt;
             for (auto& [key, val] : tileMapping.as_object()) {

--- a/agent/cpp-algo/source/WorldMap/WorldMapSolver.cpp
+++ b/agent/cpp-algo/source/WorldMap/WorldMapSolver.cpp
@@ -2,8 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <fstream>
-#include <sstream>
 #include <vector>
 
 #include <MaaUtils/ImageIo.h>
@@ -11,6 +9,7 @@
 #include <MaaUtils/Platform.h>
 #include <meojson/json.hpp>
 
+#include "../Common/JsoncFile.h"
 #include "MapLocator/MatchStrategy.h"
 #include "MapNavigator/controller_type_utils.h"
 #include "utils.h"
@@ -327,15 +326,8 @@ void WorldMapSolver::LoadIconTable()
         return;
     }
 
-    std::ifstream stream(*file);
-    if (!stream.is_open()) {
-        LogError << "WorldMap: cannot open icon table" << VAR(MAA_NS::path_to_utf8_string(*file));
-        return;
-    }
-    std::ostringstream text;
-    text << stream.rdbuf();
-
-    const auto parsed = json::parse(text.str());
+    // 仓库内 JSONC 允许注释、尾逗号与 BOM，用公共 OpenJsoncFile 读取。
+    const auto parsed = common::OpenJsoncFile(*file);
     if (!parsed || !parsed->is_object()) {
         LogError << "WorldMap: icon table is not a JSON object" << VAR(MAA_NS::path_to_utf8_string(*file));
         return;

--- a/agent/go-service/essencefilter/matchapi/loader.go
+++ b/agent/go-service/essencefilter/matchapi/loader.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/jsonclean"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/resource"
 )
 
@@ -96,7 +97,7 @@ func loadMatcherConfig(dataDir string, locale string) (MatcherConfig, error) {
 		SuffixStopwordsMap map[string][]string
 	}
 
-	if err := json.Unmarshal(b, &withRaw); err != nil {
+	if err := json.Unmarshal(jsonclean.Clean(b), &withRaw); err != nil {
 		// matcher_config.json uses suffixStopwords as an object/map.
 		return MatcherConfig{}, err
 	}

--- a/agent/go-service/pkg/i18n/i18n.go
+++ b/agent/go-service/pkg/i18n/i18n.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"text/template"
 
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/jsonclean"
 	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/pienv"
 	"github.com/rs/zerolog/log"
 )
@@ -120,7 +121,7 @@ func loadMessages(dir, lang string) map[string]string {
 		}
 
 		var loaded map[string]string
-		if err := json.Unmarshal(data, &loaded); err != nil {
+		if err := json.Unmarshal(jsonclean.Clean(data), &loaded); err != nil {
 			log.Warn().Err(err).Str("lang", targetLang).Str("dir", dir).Msg("failed to parse i18n messages")
 			return false
 		}

--- a/agent/go-service/pkg/i18n/i18n_test.go
+++ b/agent/go-service/pkg/i18n/i18n_test.go
@@ -31,3 +31,17 @@ func TestSiblingLocaleDir(t *testing.T) {
 		t.Fatal("expected empty for missing sibling")
 	}
 }
+
+func TestLoadMessagesAcceptsJsonc(t *testing.T) {
+	root := t.TempDir()
+	// JSONC locale: line comment + trailing comma + BOM.
+	body := "\xEF\xBB\xBF{\n  // comment\n  \"a\": \"1\",\n}"
+	if err := os.WriteFile(filepath.Join(root, DefaultLang+".json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs := loadMessages(root, DefaultLang)
+	if got := msgs["a"]; got != "1" {
+		t.Fatalf("a=%q want %q", got, "1")
+	}
+}

--- a/agent/go-service/pkg/jsonclean/jsonclean.go
+++ b/agent/go-service/pkg/jsonclean/jsonclean.go
@@ -23,6 +23,9 @@ func Clean(raw []byte) []byte {
 	// State: 0 = normal, 1 = inside string, 2 = inside block comment.
 	state := 0
 	escaped := false
+	// 未闭合块注释的原始起点（raw 与 out 两个坐标），用于循环结束时回滚。
+	blockStartRaw := -1
+	blockStartOut := -1
 
 	i := 0
 	for i < len(raw) {
@@ -49,6 +52,8 @@ func Clean(raw []byte) []byte {
 					}
 					continue
 				case '*':
+					blockStartRaw = i
+					blockStartOut = len(out)
 					state = 2
 					i += 2
 					continue
@@ -85,6 +90,8 @@ func Clean(raw []byte) []byte {
 		case 2: // inside block comment
 			if c == '*' && i+1 < len(raw) && raw[i+1] == '/' {
 				state = 0
+				blockStartRaw = -1
+				blockStartOut = -1
 				i += 2
 				continue
 			}
@@ -93,6 +100,12 @@ func Clean(raw []byte) []byte {
 			}
 			i++
 		}
+	}
+
+	// 未闭合块注释：回滚已剥离的内容，原样保留 "/*" 及之后文本，
+	// 让后续严格 JSON 解析失败（避免格式错误被静默接受）。
+	if state == 2 && blockStartRaw >= 0 {
+		out = append(out[:blockStartOut], raw[blockStartRaw:]...)
 	}
 
 	// Tolerate a stray trailing comma at the very end of input (e.g. "[1,2,]").

--- a/agent/go-service/pkg/jsonclean/jsonclean.go
+++ b/agent/go-service/pkg/jsonclean/jsonclean.go
@@ -1,0 +1,111 @@
+// Package jsonclean sanitizes JSONC into strict JSON so it can be fed to a
+// plain JSON parser. It strips comments (// and /* */), trailing commas and
+// a leading UTF-8 BOM while keeping string literals intact and preserving
+// newlines so line numbers stay stable.
+package jsonclean
+
+import "bytes"
+
+// Clean removes JSONC-only constructs (comments, trailing commas) and a
+// leading UTF-8 BOM. The result is parseable by a strict JSON parser.
+//
+// The input must be valid UTF-8. Everything else is passed through
+// byte-for-byte so the result stays equivalent to the original JSON.
+func Clean(raw []byte) []byte {
+	// Drop BOM first.
+	raw = bytes.TrimPrefix(raw, []byte{0xEF, 0xBB, 0xBF})
+
+	if len(raw) == 0 {
+		return raw
+	}
+
+	out := make([]byte, 0, len(raw))
+	// State: 0 = normal, 1 = inside string, 2 = inside block comment.
+	state := 0
+	escaped := false
+
+	i := 0
+	for i < len(raw) {
+		c := raw[i]
+		switch state {
+		case 0: // normal
+			if c == '"' {
+				out = append(out, c)
+				state = 1
+				escaped = false
+				i++
+				continue
+			}
+			if c == '/' && i+1 < len(raw) {
+				switch raw[i+1] {
+				case '/':
+					// Line comment: skip to end of line, keep the newline.
+					for i < len(raw) && raw[i] != '\n' {
+						i++
+					}
+					if i < len(raw) && raw[i] == '\n' {
+						out = append(out, '\n')
+						i++
+					}
+					continue
+				case '*':
+					state = 2
+					i += 2
+					continue
+				}
+			}
+			if c == ',' {
+				// Decide whether this is a trailing comma by peeking at the next
+				// non-whitespace token. If it closes the current object/array,
+				// drop the comma.
+				j := i + 1
+				for j < len(raw) && isJSONSpace(raw[j]) {
+					j++
+				}
+				if j < len(raw) && (raw[j] == '}' || raw[j] == ']') {
+					i++
+					continue
+				}
+				out = append(out, c)
+				i++
+				continue
+			}
+			out = append(out, c)
+			i++
+		case 1: // inside string
+			out = append(out, c)
+			if escaped {
+				escaped = false
+			} else if c == '\\' {
+				escaped = true
+			} else if c == '"' {
+				state = 0
+			}
+			i++
+		case 2: // inside block comment
+			if c == '*' && i+1 < len(raw) && raw[i+1] == '/' {
+				state = 0
+				i += 2
+				continue
+			}
+			if c == '\n' {
+				out = append(out, '\n') // preserve line numbers
+			}
+			i++
+		}
+	}
+
+	// Tolerate a stray trailing comma at the very end of input (e.g. "[1,2,]").
+	if len(out) > 0 && out[len(out)-1] == ',' {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+func isJSONSpace(c byte) bool {
+	switch c {
+	case ' ', '\t', '\n', '\r':
+		return true
+	}
+	return false
+}

--- a/agent/go-service/pkg/jsonclean/jsonclean_test.go
+++ b/agent/go-service/pkg/jsonclean/jsonclean_test.go
@@ -2,6 +2,7 @@ package jsonclean
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -99,5 +100,30 @@ func TestCleanSlashNotComment(t *testing.T) {
 	cleaned := string(Clean([]byte(in)))
 	if cleaned != in {
 		t.Fatalf("cleaned=%q want %q", cleaned, in)
+	}
+}
+func TestCleanUnterminatedBlockCommentNotSwallowed(t *testing.T) {
+	in := `{"a": 1} /* unterminated`
+	cleaned := string(Clean([]byte(in)))
+	// 未闭合的 /* 不应被静默吞掉；要么原样保留触发后续解析失败，要么显式报错。
+	if !strings.Contains(cleaned, "/*") {
+		t.Fatalf("unterminated block comment was swallowed: cleaned=%q", cleaned)
+	}
+	// 且清理结果不应能通过严格 JSON 解析
+	var v any
+	if err := json.Unmarshal([]byte(cleaned), &v); err == nil {
+		t.Fatalf("unterminated block comment accepted as valid JSON: cleaned=%q", cleaned)
+	}
+}
+
+func TestCleanClosedBlockCommentStripped(t *testing.T) {
+	in := `{"a": 1} /* closed */`
+	cleaned := string(Clean([]byte(in)))
+	if strings.Contains(cleaned, "/*") || strings.Contains(cleaned, "closed") {
+		t.Fatalf("closed block comment not stripped: cleaned=%q", cleaned)
+	}
+	var v any
+	if err := json.Unmarshal([]byte(cleaned), &v); err != nil {
+		t.Fatalf("closed block comment broke parsing: %v; cleaned=%q", err, cleaned)
 	}
 }

--- a/agent/go-service/pkg/jsonclean/jsonclean_test.go
+++ b/agent/go-service/pkg/jsonclean/jsonclean_test.go
@@ -1,0 +1,103 @@
+package jsonclean
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// mustParse asserts the cleaned bytes parse under strict JSON and returns the
+// decoded value.
+func mustParse(t *testing.T, in string) any {
+	t.Helper()
+	cleaned := Clean([]byte(in))
+	var v any
+	if err := json.Unmarshal(cleaned, &v); err != nil {
+		t.Fatalf("json.Unmarshal(%q) failed: %v; cleaned=%q", in, err, string(cleaned))
+	}
+	return v
+}
+
+func TestCleanLineComment(t *testing.T) {
+	in := "{\n  // a comment\n  \"a\": 1,\n}"
+	v := mustParse(t, in)
+	if got := v.(map[string]any)["a"].(float64); got != 1 {
+		t.Fatalf("a=%v want 1", got)
+	}
+}
+
+func TestCleanBlockComment(t *testing.T) {
+	in := "/* header */\n{\n  /* multi\n     line */\n  \"a\": 1\n}"
+	v := mustParse(t, in)
+	if got := v.(map[string]any)["a"].(float64); got != 1 {
+		t.Fatalf("a=%v want 1", got)
+	}
+}
+
+func TestCleanCommentInsideString(t *testing.T) {
+	// // and /* inside a string literal must survive.
+	in := `{"a": "http://x/y", "b": "/* not a comment */", "c": "//"}`
+	v := mustParse(t, in)
+	m := v.(map[string]any)
+	if m["a"] != "http://x/y" {
+		t.Fatalf("a=%v", m["a"])
+	}
+	if m["b"] != "/* not a comment */" {
+		t.Fatalf("b=%v", m["b"])
+	}
+	if m["c"] != "//" {
+		t.Fatalf("c=%v", m["c"])
+	}
+}
+
+func TestCleanTrailingCommas(t *testing.T) {
+	in := `{
+  "a": 1,
+  "b": [1, 2,],
+}`
+	v := mustParse(t, in)
+	m := v.(map[string]any)
+	if m["a"].(float64) != 1 {
+		t.Fatal("a != 1")
+	}
+	arr := m["b"].([]any)
+	if len(arr) != 2 || arr[1].(float64) != 2 {
+		t.Fatalf("b=%v", arr)
+	}
+}
+
+func TestCleanBOM(t *testing.T) {
+	in := "\xEF\xBB\xBF{\"a\": 1}"
+	v := mustParse(t, in)
+	if got := v.(map[string]any)["a"].(float64); got != 1 {
+		t.Fatalf("a=%v want 1", got)
+	}
+}
+
+func TestCleanNewlinePreserved(t *testing.T) {
+	in := "{\n  // c\n  \"a\": 1\n}"
+	cleaned := string(Clean([]byte(in)))
+	// The comment line's leading whitespace stays; the newline that terminated
+	// the comment must be preserved so line numbers do not shift.
+	if cleaned != "{\n  \n  \"a\": 1\n}" {
+		t.Fatalf("cleaned=%q", cleaned)
+	}
+}
+
+func TestCleanEmptyAndPureComment(t *testing.T) {
+	if got := string(Clean([]byte(""))); got != "" {
+		t.Fatalf("empty=%q", got)
+	}
+	if got := string(Clean([]byte("// just a comment\n"))); got != "\n" {
+		t.Fatalf("pure=%q", got)
+	}
+}
+
+func TestCleanSlashNotComment(t *testing.T) {
+	// A lone '/' outside a string must not be treated as a comment start
+	// (Clean only strips // and /*, a bare slash passes through unchanged).
+	in := `{"/": 1}`
+	cleaned := string(Clean([]byte(in)))
+	if cleaned != in {
+		t.Fatalf("cleaned=%q want %q", cleaned, in)
+	}
+}

--- a/agent/go-service/pkg/resource/resource_reader.go
+++ b/agent/go-service/pkg/resource/resource_reader.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/jsonclean"
 	"github.com/rs/zerolog/log"
 )
 
@@ -35,7 +36,7 @@ func ReadJsonResource(relativePath string, out any) error {
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(content, out); err != nil {
+	if err := json.Unmarshal(jsonclean.Clean(content), out); err != nil {
 		log.Error().Err(err).Str("relativePath", relativePath).Int("contentLength", len(content)).Msg("Resource JSON cannot be parsed")
 		return err
 	}

--- a/agent/go-service/pkg/resource/resource_reader_test.go
+++ b/agent/go-service/pkg/resource/resource_reader_test.go
@@ -1,0 +1,45 @@
+package resource
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadJsonResourceAcceptsJsonc(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "test.json")
+	// JSONC: line comment + trailing comma.
+	data := `{
+	  // a comment
+	  "a": 1,
+	  "b": [1, 2,],
+	}`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out map[string]any
+	if err := ReadJsonResource(path, &out); err != nil {
+		t.Fatalf("ReadJsonResource: %v", err)
+	}
+	if out["a"].(float64) != 1 {
+		t.Fatalf("a=%v want 1", out["a"])
+	}
+}
+
+func TestReadJsonResourceAcceptsBOM(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "bom.json")
+	if err := os.WriteFile(path, []byte("\xEF\xBB\xBF{\"x\": 2}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out map[string]any
+	if err := ReadJsonResource(path, &out); err != nil {
+		t.Fatalf("ReadJsonResource BOM: %v", err)
+	}
+	if out["x"].(float64) != 2 {
+		t.Fatalf("x=%v want 2", out["x"])
+	}
+}

--- a/tools/cli_support.py
+++ b/tools/cli_support.py
@@ -1,4 +1,5 @@
 import json
+import json5
 import locale
 import os
 import platform
@@ -191,14 +192,14 @@ def init_localization(
     load_error_path: str | None = None
 
     try:
-        with open(locale_file, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        with open(locale_file, "r", encoding="utf-8-sig") as f:
+            data = json5.load(f)
         if isinstance(data, dict):
             lang_res = {str(k): str(v) for k, v in data.items()}
     except FileNotFoundError:
         load_error_path = str(locale_file)
         print(Console.err(f"[localization] locale file not found: {locale_file}"))
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, ValueError) as e:
         load_error_path = str(locale_file)
         print(Console.err(f"[localization] failed to decode locale json: {locale_file}: {e}"))
     except OSError as e:

--- a/tools/essence_filter/build_locations.py
+++ b/tools/essence_filter/build_locations.py
@@ -12,10 +12,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 import unicodedata
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
+
+import json5
 
 DEFAULT_ENERGY_POINTS = Path("assets/data/EssenceFilter/energy_point_gems.json")
 DEFAULT_SKILL_POOLS = Path("assets/data/EssenceFilter/skill_pools.json")
@@ -69,13 +72,16 @@ def _update_data_version(config_path: Path) -> None:
     """将 matcher_config 的 data_version 更新为当天日期（d/m/yyyy）。"""
     if not config_path.exists():
         return
-    with config_path.open("r", encoding="utf-8") as f:
-        data = json.load(f)
+    with config_path.open("r", encoding="utf-8-sig") as f:
+        data = json5.load(f)
     if not isinstance(data, dict):
         return
 
     now = datetime.now()
-    data["data_version"] = f"{now.day}/{now.month}/{now.year}"
+    new_version = f"{now.day}/{now.month}/{now.year}"
+    if data.get("data_version") == new_version:
+        return  # 无变化不重写，避免用 json.dump 抹掉手写注释
+    data["data_version"] = new_version
     with config_path.open("w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=4)
         f.write("\n")

--- a/tools/essence_filter/extract_skill_pools.py
+++ b/tools/essence_filter/extract_skill_pools.py
@@ -17,6 +17,8 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Set, Tuple
 
+import json5
+
 LANGS = ("CN", "TC", "EN", "JP", "KR")
 
 DEFAULT_MATCHER_CONFIG = Path("assets/data/EssenceFilter/matcher_config.json")
@@ -33,8 +35,8 @@ def load_suffix_stopwords(config_path: Path) -> Dict[str, List[str]]:
     }
     if not config_path.exists():
         return default
-    with config_path.open("r", encoding="utf-8") as f:
-        data = json.load(f)
+    with config_path.open("r", encoding="utf-8-sig") as f:
+        data = json5.load(f)
     stopwords = data.get("suffixStopwords")
     if isinstance(stopwords, dict):
         return {

--- a/tools/essence_filter/test_extract_skill_pools.py
+++ b/tools/essence_filter/test_extract_skill_pools.py
@@ -1,0 +1,42 @@
+"""Tests for tools/essence_filter/extract_skill_pools.py JSONC handling."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# 把 tools/ 插到 sys.path 最前，以便裸名 import extract_skill_pools。
+_TOOLS = Path(__file__).resolve().parent.parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+from extract_skill_pools import load_suffix_stopwords  # noqa: E402
+
+
+class LoadSuffixStopwordsTest(unittest.TestCase):
+    def test_jsonc_matcher_config(self):
+        # matcher_config 允许注释 + 尾逗号。
+        body = ('{\n  // 手写注释\n  "suffixStopwords": {\n    "CN": ["提升", "提高",],\n  },\n}')
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "matcher_config.json"
+            p.write_text(body, encoding="utf-8")
+            got = load_suffix_stopwords(p)
+        self.assertEqual(got["CN"], ["提升", "提高"])
+
+    def test_legacy_array(self):
+        body = '{"suffixStopwords": ["增强", "增幅"]}'
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "matcher_config.json"
+            p.write_text(body, encoding="utf-8")
+            got = load_suffix_stopwords(p)
+        self.assertEqual(got["CN"], ["增强", "增幅"])
+
+    def test_missing_file_returns_default(self):
+        got = load_suffix_stopwords(Path("does_not_exist.json"))
+        self.assertIn("CN", got)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/icon_recognition/fixed_items.py
+++ b/tools/icon_recognition/fixed_items.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
+
+import json5
 
 
 FIXED_ITEMS_PATH = Path(__file__).with_name("fixed_items.json")
 
 
 def load_fixed_items(path: str | Path = FIXED_ITEMS_PATH) -> dict[str, dict[str, Any]]:
-    source = json.loads(Path(path).read_text(encoding="utf-8"))
+    source = json5.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(source, dict):
         raise ValueError("fixed_items.json 顶层必须是对象")
     result: dict[str, dict[str, Any]] = {}

--- a/tools/icon_recognition/item_transfer/generate.py
+++ b/tools/icon_recognition/item_transfer/generate.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 
+import json5
+
 
 CATEGORY_TYPE_ORDER = (
     "Ore",
@@ -127,17 +129,18 @@ def update_item_transfer_task(
 
 
 def generate_item_transfer_task(catalog_path: Path, locale_path: Path, task_path: Path) -> int:
-    catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
-    zh_cn = json.loads(locale_path.read_text(encoding="utf-8"))
-    task = json.loads(task_path.read_text(encoding="utf-8"))
+    catalog = json5.loads(catalog_path.read_text(encoding="utf-8"))
+    zh_cn = json5.loads(locale_path.read_text(encoding="utf-8"))
+    task = json5.loads(task_path.read_text(encoding="utf-8"))
 
     forward_cases = build_transfer_cases(catalog, zh_cn, FORWARD_NODES)
     return_cases = build_transfer_cases(catalog, zh_cn, RETURN_NODES)
     updated = update_item_transfer_task(task, forward_cases, return_cases)
-    task_path.write_text(
-        json.dumps(updated, ensure_ascii=False, indent=4) + "\n",
-        encoding="utf-8",
-    )
+    if updated != task:
+        task_path.write_text(
+            json.dumps(updated, ensure_ascii=False, indent=4) + "\n",
+            encoding="utf-8",
+        )
     return len(forward_cases)
 
 

--- a/tools/icon_recognition/item_transfer/test_generate.py
+++ b/tools/icon_recognition/item_transfer/test_generate.py
@@ -103,7 +103,7 @@ class ItemTransferGeneratorTest(unittest.TestCase):
 
     def test_ctrl_click_custom_action_is_registered_as_common_component(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]
-        schema = json.loads(
+        schema = json5.loads(
             (repo_root / "tools/schema/custom.action.schema.json").read_text(
                 encoding="utf-8"
             )
@@ -278,15 +278,18 @@ class ItemTransferGeneratorTest(unittest.TestCase):
             locale_path = root / "zh_cn.json"
             task_path = root / "ItemTransfer.json"
             catalog_path.write_text(
-                json.dumps({"item_product": make_item("Product", -81, 1)}),
+                "// catalog JSONC\n"
+                + json.dumps({"item_product": make_item("Product", -81, 1)}),
                 encoding="utf-8",
             )
             locale_path.write_text(
-                json.dumps({"iconRecognition.name.item_product": "测试产物"}, ensure_ascii=False),
+                "// locale JSONC\n"
+                + json.dumps({"iconRecognition.name.item_product": "测试产物"}, ensure_ascii=False),
                 encoding="utf-8",
             )
             task_path.write_text(
-                json.dumps(
+                "// task JSONC\n"
+                + json.dumps(
                     {
                         "task": {"name": "ItemTransfer"},
                         "option": {
@@ -325,7 +328,7 @@ class ItemTransferGeneratorTest(unittest.TestCase):
 
             self.assertEqual(
                 json.loads(generated_task_path.read_text(encoding="utf-8")),
-                json.loads(tracked_task_path.read_text(encoding="utf-8")),
+                json5.loads(tracked_task_path.read_text(encoding="utf-8")),
             )
 
     def test_generated_resources_pass_maa_tools_check(self) -> None:

--- a/tools/icon_recognition/localization.py
+++ b/tools/icon_recognition/localization.py
@@ -8,6 +8,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+import json5
+
 from fixed_items import FIXED_NAME_KEYS
 from text import clean_text
 
@@ -80,7 +82,7 @@ def update_interface_locale(
     remove_stale: bool = True,
 ) -> None:
     target = Path(path)
-    interface = json.loads(target.read_text(encoding="utf-8"))
+    interface = json5.loads(target.read_text(encoding="utf-8"))
     if not isinstance(interface, dict):
         raise ValueError(f"locale must be an object: {target}")
 
@@ -113,12 +115,14 @@ def update_interface_locale(
         for item_key in item_keys:
             updated[item_key] = values[item_key]
 
+    if updated == interface:
+        return
     target.write_text(json.dumps(updated, ensure_ascii=False, indent=4) + "\n", encoding="utf-8")
 
 
 def load_json_object(path: str | Path) -> dict[str, Any]:
     source = Path(path)
-    payload = json.loads(source.read_text(encoding="utf-8-sig"))
+    payload = json5.loads(source.read_text(encoding="utf-8-sig"))
     if not isinstance(payload, dict):
         raise ValueError(f"JSON 顶层必须是对象: {source}")
     return payload

--- a/tools/icon_recognition/test_icon_recognition_tools.py
+++ b/tools/icon_recognition/test_icon_recognition_tools.py
@@ -20,6 +20,7 @@ from download import (
     prepare_item_map,
     prepare_weapon_map,
 )
+from fixed_items import load_fixed_items
 from localization import (
     FIXED_NAME_KEYS,
     LOCALE_MAP,
@@ -722,6 +723,76 @@ class IconRecognitionToolsTest(unittest.TestCase):
                 "iconRecognition.name.current": "Current",
             },
         )
+
+    def test_locale_update_accepts_jsonc_comments(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "locale.json"
+            path.write_text(
+                """{
+    // 语言文件允许保留业务说明注释。
+    "unrelated": "keep",
+    "iconRecognition.name.stale": "remove",
+}
+""",
+                encoding="utf-8",
+            )
+
+            update_interface_locale(
+                path,
+                {"iconRecognition.name.current": "Current"},
+            )
+
+            result = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            result,
+            {
+                "unrelated": "keep",
+                "iconRecognition.name.current": "Current",
+            },
+        )
+
+    def test_locale_update_preserves_jsonc_when_values_are_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "locale.json"
+            original = """{
+    // 语义未变化时保留注释和原始格式。
+    "iconRecognition.name.current": "Current",
+}
+"""
+            path.write_text(original, encoding="utf-8")
+
+            update_interface_locale(
+                path,
+                {"iconRecognition.name.current": "Current"},
+            )
+
+            result = path.read_text(encoding="utf-8")
+
+        self.assertEqual(result, original)
+
+    def test_fixed_items_accept_jsonc_comments(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "fixed_items.json"
+            path.write_text(
+                """{
+    // 上游表未收录的固定物品。
+    "item_test": {
+        "name": "测试物品",
+        "iconId": "item_test",
+        "i18nKey": "item_test_name",
+        "rarity": 3,
+        "storageKind": "Normal",
+        "categoryType": "Product",
+        "category": "产物",
+    },
+}
+""",
+                encoding="utf-8",
+            )
+
+            result = load_fixed_items(path)
+
+        self.assertEqual(result["item_test"]["iconId"], "item_test")
 
     def test_locale_update_keeps_item_keys_in_one_stable_group(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tools/locals/3rdparty_download/en_us.json
+++ b/tools/locals/3rdparty_download/en_us.json
@@ -1,4 +1,6 @@
 {
+    // JSONC: 允许注释与尾逗号（测试注释）
+
     "error_load_locale": "[ERROR] Failed to load locale file. Please ensure you have cloned the repository completely. File path: {path}",
     "description": "MaaEnd 3rdparty binary dependency downloader; installs everything under agent/cpp-algo/3rdparty/",
     "arg_webview2": "Download the WebView2 SDK (Windows only; no-op on other platforms)",

--- a/tools/locals/3rdparty_download/zh_cn.json
+++ b/tools/locals/3rdparty_download/zh_cn.json
@@ -1,4 +1,6 @@
 {
+    // JSONC: 允许注释与尾逗号（测试注释）
+
     "error_load_locale": "[ERROR] 加载语言文件失败，请完整地克隆仓库。文件路径: {path}",
     "description": "MaaEnd 3rdparty 二进制依赖下载工具，统一安装到 agent/cpp-algo/3rdparty/ 目录",
     "arg_webview2": "下载 WebView2 SDK（仅 Windows 上有效；其它平台为 no-op）",

--- a/tools/locals/build_and_install/en_us.json
+++ b/tools/locals/build_and_install/en_us.json
@@ -1,4 +1,6 @@
 {
+    // JSONC: 允许注释与尾逗号（测试注释）
+
     "error_load_locale": "[ERROR] Failed to load locale file. Please ensure you have cloned the repository completely. File path: {path}",
     "root_dir": "Project Root Directory",
     "install_dir": "Install Directory",

--- a/tools/locals/build_and_install/zh_cn.json
+++ b/tools/locals/build_and_install/zh_cn.json
@@ -1,4 +1,6 @@
 {
+    // JSONC: 允许注释与尾逗号（测试注释）
+
     "error_load_locale": "[ERROR] 加载语言文件失败，请完整地克隆仓库。文件路径: {path}",
     "root_dir": "项目根目录",
     "install_dir": "安装目录",

--- a/tools/locals/setup_workspace/en_us.json
+++ b/tools/locals/setup_workspace/en_us.json
@@ -1,4 +1,6 @@
 {
+    // JSONC: 允许注释与尾逗号（测试注释）
+
     "error_load_locale": "[ERROR] Failed to load locale file. Please ensure you have cloned the repository completely. File path: {path}",
     "inf_github_token_configured": "[INF] GitHub Token configured, will be used for API requests",
     "wrn_github_token_not_configured": "[WRN] GitHub Token not configured, using anonymous API requests (may be rate limited)",

--- a/tools/locals/setup_workspace/zh_cn.json
+++ b/tools/locals/setup_workspace/zh_cn.json
@@ -1,4 +1,6 @@
 {
+    // JSONC: 允许注释与尾逗号（测试注释）
+
     "error_load_locale": "[ERROR] 加载语言文件失败，请完整地克隆仓库。文件路径: {path}",
     "inf_github_token_configured": "[INF] 已配置 GitHub Token，将用于 API 请求",
     "wrn_github_token_not_configured": "[WRN] 未配置 GitHub Token，将使用匿名 API 请求（可能限流）",

--- a/tools/pipeline-generate/AutoDelivery/data.test.mjs
+++ b/tools/pipeline-generate/AutoDelivery/data.test.mjs
@@ -2,8 +2,7 @@ import assert from "node:assert/strict";
 import {existsSync, readdirSync, readFileSync} from "node:fs";
 import test from "node:test";
 
-import {parse as parseJsonc} from "jsonc-parser";
-
+import {parseJsonc, readJsonc} from "../jsonc.mjs";
 import routeRows, {buildRows} from "./routes-data.mjs";
 import {buildNavmeshPath, buildYawApproachTarget, depots, destinations, runtimeCatalog} from "./model.mjs";
 import {
@@ -612,9 +611,7 @@ test("AutoDelivery focus 文案统一使用完整 i18n 键", () => {
         "ja_jp",
         "ko_kr",
     ]) {
-        const locale = JSON.parse(
-            readFileSync(new URL(`../../../assets/locales/interface/${lang}.json`, import.meta.url), "utf8"),
-        );
+        const locale = readJsonc(new URL(`../../../assets/locales/interface/${lang}.json`, import.meta.url));
         const localeKeys = Object.keys(locale)
             .filter((key) => key.startsWith("task.AutoDelivery.focus."))
             .sort();
@@ -626,9 +623,7 @@ test("AutoDelivery focus 文案统一使用完整 i18n 键", () => {
             }
         }
 
-        const goServiceLocale = JSON.parse(
-            readFileSync(new URL(`../../../assets/locales/go-service/${lang}.json`, import.meta.url), "utf8"),
-        );
+        const goServiceLocale = readJsonc(new URL(`../../../assets/locales/go-service/${lang}.json`, import.meta.url));
         const goServiceLocaleKeys = Object.keys(goServiceLocale)
             .filter((key) => key.startsWith("autodelivery."))
             .sort();

--- a/tools/pipeline-generate/DeliveryJobs/data.test.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/data.test.mjs
@@ -4,8 +4,7 @@ import {join, relative} from "node:path";
 import test from "node:test";
 import {fileURLToPath} from "node:url";
 
-import {parse} from "jsonc-parser";
-
+import {parseJsonc, readJsonc} from "../jsonc.mjs";
 import {DELIVERY_JOB_FILL_ITEM_PRIORITY_COUNT, deliveryJobDepots, deliveryJobRegions} from "./model.mjs";
 
 const AUTO_DELIVERY_CONTROLLERS = [
@@ -20,13 +19,14 @@ const AUTO_DELIVERY_NAVIGATE_NODES = [
     "AutoDeliveryNavigateDestination",
 ];
 
-function readJsonc(path) {
-    return parse(readFileSync(path, "utf8"));
-}
-
 function readGeneratedPipeline(...segments) {
     return readJsonc(new URL(`../../../assets/resource/pipeline/${segments.join("/")}`, import.meta.url));
 }
+
+test("DeliveryJobs JSONC reader accepts comments and rejects malformed input", () => {
+    assert.deepEqual(parseJsonc('{\n  // comment\n  "value": 1,\n}', "inline fixture"), {value: 1});
+    assert.throws(() => parseJsonc('{"value": }', "invalid fixture"), /无法解析 JSONC invalid fixture/);
+});
 
 function readAdbPipeline(...segments) {
     return readJsonc(new URL(`../../../assets/resource_adb/pipeline/${segments.join("/")}`, import.meta.url));

--- a/tools/pipeline-generate/DeliveryJobs/data.test.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/data.test.mjs
@@ -25,6 +25,8 @@ function readGeneratedPipeline(...segments) {
 
 test("DeliveryJobs JSONC reader accepts comments and rejects malformed input", () => {
     assert.deepEqual(parseJsonc('{\n  // comment\n  "value": 1,\n}', "inline fixture"), {value: 1});
+    assert.deepEqual(parseJsonc('\uFEFF{"ok": true}', "BOM fixture"), {ok: true});
+    assert.throws(() => parseJsonc('{\uFEFF"ok": true}', "misplaced BOM fixture"), /InvalidSymbol at offset 1/);
     assert.throws(() => parseJsonc('{"value": }', "invalid fixture"), /无法解析 JSONC invalid fixture/);
 });
 

--- a/tools/pipeline-generate/DeliveryJobs/model.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/model.mjs
@@ -1,4 +1,4 @@
-import {readFileSync} from "node:fs";
+import {readJsonc} from "../jsonc.mjs";
 
 const INTERFACE_LOCALES = [
     "zh_cn",
@@ -8,9 +8,9 @@ const INTERFACE_LOCALES = [
     "ko_kr",
 ];
 
-const deliveryJobsData = JSON.parse(readFileSync(new URL("../data/delivery_jobs.json", import.meta.url), "utf8"));
-const iconRecognitionItems = JSON.parse(
-    readFileSync(new URL("../../../assets/data/IconRecognition/recognition_items.json", import.meta.url), "utf8"),
+const deliveryJobsData = readJsonc(new URL("../data/delivery_jobs.json", import.meta.url));
+const iconRecognitionItems = readJsonc(
+    new URL("../../../assets/data/IconRecognition/recognition_items.json", import.meta.url),
 );
 // 装箱物品选项的默认物品（砂叶粉末），各地区均需可装箱
 const DEFAULT_FILL_ITEM_ID = "item_plant_moss_powder_3";

--- a/tools/pipeline-generate/DeliveryJobs/sync-locales.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/sync-locales.mjs
@@ -2,6 +2,7 @@ import {readFileSync, writeFileSync} from "node:fs";
 import {dirname, resolve} from "node:path";
 import {fileURLToPath, pathToFileURL} from "node:url";
 
+import {parseJsonc} from "../jsonc.mjs";
 import {deliveryJobLocaleEntries} from "./model.mjs";
 
 const INTERFACE_LOCALES = [
@@ -96,7 +97,7 @@ export function syncDeliveryJobsLocaleCatalogs() {
     for (const fileLocale of INTERFACE_LOCALES) {
         const localePath = resolve(LOCALE_DIR, `${fileLocale}.json`);
         const originalText = readFileSync(localePath, "utf8");
-        const originalMessages = JSON.parse(originalText);
+        const originalMessages = parseJsonc(originalText, localePath);
         const regionResult = fillMissingLocaleEntries(
             originalMessages,
             deliveryJobLocaleEntries.regions,
@@ -122,8 +123,9 @@ export function syncDeliveryJobsLocaleCatalogs() {
         );
         validateLocaleCatalog(itemResult.messages, fileLocale);
 
-        const syncedText = `${JSON.stringify(itemResult.messages, null, 4)}\n`;
-        if (syncedText !== originalText.replace(/\r\n/g, "\n")) {
+        const changed = regionResult.filled + priorityCleanupResult.removed + priorityResult.filled + itemResult.filled;
+        if (changed > 0) {
+            const syncedText = `${JSON.stringify(itemResult.messages, null, 4)}\n`;
             writeFileSync(localePath, syncedText, "utf8");
             console.log(
                 `[DeliveryJobs] 已为 ${fileLocale}.json 补齐 ${regionResult.filled} 个地区/仓储节点键、补齐 ${priorityResult.filled} 个并清理 ${priorityCleanupResult.removed} 个装箱优先级键，以及补齐 ${itemResult.filled} 个物品键。`,

--- a/tools/pipeline-generate/DeliveryJobs/sync-locales.test.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/sync-locales.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import {readFileSync} from "node:fs";
 import test from "node:test";
 
+import {readJsonc} from "../jsonc.mjs";
 import {deliveryJobLocaleEntries} from "./model.mjs";
 import {fillMissingLocaleEntries, removeStaleLocaleEntries} from "./sync-locales.mjs";
 
@@ -97,9 +97,7 @@ test("DeliveryJobs generated locale entries exist in all interface locales", () 
         "ja_jp",
         "ko_kr",
     ]) {
-        const messages = JSON.parse(
-            readFileSync(new URL(`../../../assets/locales/interface/${fileLocale}.json`, import.meta.url), "utf8"),
-        );
+        const messages = readJsonc(new URL(`../../../assets/locales/interface/${fileLocale}.json`, import.meta.url));
         for (const key of expectedKeys) {
             assert.equal(typeof messages[key], "string", `${fileLocale} missing ${key}`);
             assert.notEqual(messages[key].trim(), "", `${fileLocale} has empty ${key}`);

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/common.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/common.mjs
@@ -1,6 +1,6 @@
-import {readFileSync} from "node:fs";
 import {dirname, resolve} from "node:path";
 import {fileURLToPath} from "node:url";
+import {readJsonc} from "../../jsonc.mjs";
 import {dataDir} from "../../utils/paths.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -18,7 +18,7 @@ export const LOCALES = [
 ];
 
 export function readJson(path) {
-    return JSON.parse(readFileSync(path, "utf8"));
+    return readJsonc(path);
 }
 
 export function readEnvironmentMonitoringData() {

--- a/tools/pipeline-generate/EnvironmentMonitoring/generator/sync-routes.mjs
+++ b/tools/pipeline-generate/EnvironmentMonitoring/generator/sync-routes.mjs
@@ -1,6 +1,7 @@
 import {existsSync, readFileSync, writeFileSync} from "node:fs";
 import {dirname, resolve} from "node:path";
 import {pathToFileURL} from "node:url";
+import {parseJsonc} from "../../jsonc.mjs";
 import {
     buildGeneratedIdIndex,
     collectMonitoringMissions,
@@ -60,7 +61,7 @@ function syncRouteLocaleCatalogs(missions, idByMissionId) {
     for (const fileLocale of INTERFACE_LOCALES) {
         const localePath = resolve(localeDir, `${fileLocale}.json`);
         const originalText = readFileSync(localePath, "utf8");
-        const messages = JSON.parse(originalText);
+        const messages = parseJsonc(originalText, localePath);
         const failureMessages = {};
         const sortedMissions = [...missions].sort((left, right) => {
             const leftId = idByMissionId.get(left.missionId);
@@ -93,8 +94,8 @@ function syncRouteLocaleCatalogs(missions, idByMissionId) {
             Object.assign(syncedMessages, failureMessages);
         }
         validateRouteLocaleCatalog(syncedMessages, failureMessages, missions.length, routeKeyPrefix, fileLocale);
-        const syncedText = `${JSON.stringify(syncedMessages, null, 4)}\n`;
-        if (syncedText !== originalText.replace(/\r\n/g, "\n")) {
+        if (JSON.stringify(syncedMessages) !== JSON.stringify(messages)) {
+            const syncedText = `${JSON.stringify(syncedMessages, null, 4)}\n`;
             writeFileSync(localePath, syncedText, "utf8");
             console.log(`[EnvironmentMonitoring] 已同步 ${fileLocale}.json 的路线失败提示。`);
         }
@@ -241,7 +242,7 @@ export function syncRouteConfig() {
     }
 
     const originalText = readFileSync(ROUTES_PATH, "utf8");
-    const routes = JSON.parse(originalText);
+    const routes = parseJsonc(originalText, ROUTES_PATH);
     const missions = collectMonitoringMissions(readJson(ENVIRONMENT_MONITORING_DATA_PATH));
     const idByMissionId = buildGeneratedIdIndex(missions);
     syncRouteLocaleCatalogs(missions, idByMissionId);

--- a/tools/pipeline-generate/SellProduct/data.test.mjs
+++ b/tools/pipeline-generate/SellProduct/data.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {readFileSync} from "node:fs";
 import test from "node:test";
 
+import {readJsonc} from "../jsonc.mjs";
 import {
     sellProductLocations,
     sellProductLocationsNewestFirst,
@@ -17,7 +18,7 @@ import {sellProductTaskRows} from "./task-data.mjs";
 const root = sellProductTaskRows[0];
 
 function readPipeline(url) {
-    return JSON.parse(readFileSync(url, "utf8").replace(/^\s*\/\/.*$/gm, ""));
+    return readJsonc(url);
 }
 
 test("SellProduct 保留按星期执行入口与任务选项", () => {

--- a/tools/pipeline-generate/SellProduct/sync-locales.mjs
+++ b/tools/pipeline-generate/SellProduct/sync-locales.mjs
@@ -2,6 +2,7 @@ import {readFileSync, writeFileSync} from "node:fs";
 import {dirname, resolve} from "node:path";
 import {fileURLToPath, pathToFileURL} from "node:url";
 
+import {parseJsonc, readJsonc} from "../jsonc.mjs";
 import {sellProductLocaleEntries, sellProductLocations} from "./model.mjs";
 import {sellProductItemLocaleEntries} from "./selection-data.mjs";
 
@@ -188,7 +189,7 @@ function validateLocaleCatalog(messages, fileLocale) {
 
 export function syncSellProductLocaleCatalogs() {
     // task-data.mjs 以中文名反查物品键，因此重复判定统一基于简中目录，保证五语言键集合一致。
-    const zhCNMessages = JSON.parse(readFileSync(resolve(LOCALE_DIR, "zh_cn.json"), "utf8"));
+    const zhCNMessages = readJsonc(resolve(LOCALE_DIR, "zh_cn.json"));
     const existingItemCNNames = new Set(
         Object.entries(zhCNMessages)
             .filter(([key]) => key.startsWith("item."))
@@ -204,7 +205,7 @@ export function syncSellProductLocaleCatalogs() {
     for (const fileLocale of INTERFACE_LOCALES) {
         const localePath = resolve(LOCALE_DIR, `${fileLocale}.json`);
         const originalText = readFileSync(localePath, "utf8");
-        const originalMessages = JSON.parse(originalText);
+        const originalMessages = parseJsonc(originalText, localePath);
         // 据点开关位于 SellProduct 固定设置之后、下一个任务之前。
         const stationResult = rebuildSettlementMessages(originalMessages, fileLocale, "task.VisitFriends.label");
 
@@ -223,10 +224,9 @@ export function syncSellProductLocaleCatalogs() {
         );
         validateLocaleCatalog(itemResult.messages, fileLocale);
 
-        // 与项目 JSON 约定保持一致：4 空格缩进、文件末尾一个换行。
-        // 比较时统一原文件的 CRLF，保证 Windows 下无内容变化时也不会反复重写。
-        const syncedText = `${JSON.stringify(itemResult.messages, null, 4)}\n`;
-        if (syncedText !== originalText.replace(/\r\n/g, "\n")) {
+        // 仅在解析后的内容或键顺序变化时写回，避免无变化运行删除 JSONC 注释。
+        if (JSON.stringify(itemResult.messages) !== JSON.stringify(originalMessages)) {
+            const syncedText = `${JSON.stringify(itemResult.messages, null, 4)}\n`;
             writeFileSync(localePath, syncedText, "utf8");
             console.log(
                 `[SellProduct] 已为 ${fileLocale}.json 按据点顺序重排，更新 ${stationResult.updated} 个据点名，清理 ${stationResult.removed} 个旧据点键，补齐 ${stationResult.inserted} 个据点键、${operatorResult.inserted} 个干员键和 ${itemResult.inserted} 个物品键。`,

--- a/tools/pipeline-generate/SellProduct/sync-locales.test.mjs
+++ b/tools/pipeline-generate/SellProduct/sync-locales.test.mjs
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
-import {readFileSync} from "node:fs";
 import test from "node:test";
 
+import {readJsonc} from "../jsonc.mjs";
 import {sellProductLocaleEntries, sellProductLocations} from "./model.mjs";
 import {insertMissingItemMessages, rebuildSettlementMessages} from "./sync-locales.mjs";
 
 function readPipeline(url) {
-    return JSON.parse(readFileSync(url, "utf8").replace(/^\s*\/\/.*$/gm, ""));
+    return readJsonc(url);
 }
 
 test("SellProduct locale settlement keys are rebuilt in game order", () => {
@@ -110,9 +110,7 @@ test("SellProduct UI focus messages use complete interface i18n keys", () => {
         "ja_jp",
         "ko_kr",
     ]) {
-        const locale = JSON.parse(
-            readFileSync(new URL(`../../../assets/locales/interface/${lang}.json`, import.meta.url), "utf8"),
-        );
+        const locale = readJsonc(new URL(`../../../assets/locales/interface/${lang}.json`, import.meta.url));
         for (const key of focusKeys) {
             assert.equal(typeof locale[key], "string", `${lang} missing ${key}`);
             assert.notEqual(locale[key].trim(), "", `${lang} has empty ${key}`);
@@ -129,7 +127,7 @@ test("SellProduct Go UI messages have matching keys in all locales", () => {
         "ko_kr",
     ].map((lang) => [
         lang,
-        JSON.parse(readFileSync(new URL(`../../../assets/locales/go-service/${lang}.json`, import.meta.url), "utf8")),
+        readJsonc(new URL(`../../../assets/locales/go-service/${lang}.json`, import.meta.url)),
     ]);
     const expectedKeys = Object.keys(localeEntries[0][1])
         .filter((key) => key.startsWith("sellproduct."))

--- a/tools/pipeline-generate/SellProduct/task-data.mjs
+++ b/tools/pipeline-generate/SellProduct/task-data.mjs
@@ -1,11 +1,10 @@
 // SellProduct Task 模板数据
 
-import {createRequire} from "node:module";
+import {readJsonc} from "../jsonc.mjs";
 import {sellProductLocations, toPascalCase} from "./model.mjs";
 import {sellProductSelectableItems, sellProductSelectionData} from "./selection-data.mjs";
 
-const require = createRequire(import.meta.url);
-const zhCNLocale = require("../../../assets/locales/interface/zh_cn.json");
+const zhCNLocale = readJsonc(new URL("../../../assets/locales/interface/zh_cn.json", import.meta.url));
 
 // 建立中文物品名到 interface locale key 的反查表。
 function buildItemLocaleKeyByCNName() {

--- a/tools/pipeline-generate/jsonc.mjs
+++ b/tools/pipeline-generate/jsonc.mjs
@@ -3,8 +3,10 @@ import {readFileSync} from "node:fs";
 import {parse, printParseErrorCode} from "jsonc-parser";
 
 export function parseJsonc(text, source = "input") {
+    // readFileSync 会保留 UTF-8 BOM，而 jsonc-parser 不接受前导 U+FEFF；仅移除文件开头的一个 BOM。
+    const content = text.startsWith("\uFEFF") ? text.slice(1) : text;
     const errors = [];
-    const value = parse(text, errors, {
+    const value = parse(content, errors, {
         allowTrailingComma: true,
         disallowComments: false,
     });

--- a/tools/pipeline-generate/jsonc.mjs
+++ b/tools/pipeline-generate/jsonc.mjs
@@ -1,0 +1,20 @@
+import {readFileSync} from "node:fs";
+
+import {parse, printParseErrorCode} from "jsonc-parser";
+
+export function parseJsonc(text, source = "input") {
+    const errors = [];
+    const value = parse(text, errors, {
+        allowTrailingComma: true,
+        disallowComments: false,
+    });
+    if (errors.length > 0) {
+        const detail = errors.map(({error, offset}) => `${printParseErrorCode(error)} at offset ${offset}`).join(", ");
+        throw new Error(`[pipeline-generate] 无法解析 JSONC ${source}: ${detail}`);
+    }
+    return value;
+}
+
+export function readJsonc(path) {
+    return parseJsonc(readFileSync(path, "utf8"), String(path));
+}


### PR DESCRIPTION
- 提取 Common/JsoncFile 公共读取能力，支持 UTF-8 BOM 与注释，并覆盖物品目录、ROI 和图片 sidecar 配置。

- 统一物品识别 Python 工具及 pipeline-generate 相关脚本的 JSONC 解析，补充 ItemTransfer、DeliveryJobs、AutoDelivery、EnvironmentMonitoring 与 SellProduct 回归。

- 在生成内容没有语义变化时保留语言文件的原始注释和格式，避免同步脚本无条件重写 JSONC。

- 正式 v* Release 构建忽略物品识别 paths filter，强制执行 IconRecognition quick 检查。

- 更新 meojson Skill，说明 json::open 的 BOM/注释参数、公共 JsoncFile 用法及严格 JSON 的运行时边界。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持读取包含注释、尾随逗号及 UTF-8 BOM 的 JSONC 配置文件。
  * 图标识别、资源生成、本地化、交付及地图相关流程现已兼容 JSONC 输入。
* **改进**
  * 内容未变化时避免重复写入，并尽可能保留原有注释与格式。
  * 改进跨平台构建缓存与构建流程，提升构建效率。
* **测试**
  * 新增 JSONC 解析、注释保留、BOM 处理及错误提示相关测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->