### PR TITLE
fix(sentry): 按发布流程选择有效版本

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -730,3 +730,45 @@ jobs:
         run: |
           gh workflow run --repo $GITHUB_REPOSITORY discord-release-notification.yml \
             -f release_tag="${{ needs.meta.outputs.tag }}"
+
+  sentry_release:
+    if: ${{ needs.meta.outputs.is_release == 'true' && github.repository_owner == 'MaaEnd' }}
+    needs: [meta, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve Sentry release
+        id: sentry_release
+        env:
+          MAAEND_VERSION: ${{ needs.meta.outputs.tag }}
+          MXU_VERSION: ${{ needs.meta.outputs.mxu_version }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$MAAEND_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid MaaEnd release version: $MAAEND_VERSION"
+            exit 1
+          fi
+          if [[ ! "$MXU_VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid MXU release version: $MXU_VERSION"
+            exit 1
+          fi
+
+          release="MXU@${MXU_VERSION#v}+MaaEnd@$MAAEND_VERSION"
+          echo "release=$release" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: maaend
+          SENTRY_PROJECT: rust
+        with:
+          environment: ${{ needs.meta.outputs.is_prerelease == 'true' && 'beta' || 'stable' }}
+          release: ${{ steps.sentry_release.outputs.release }}
+          set_commits: auto
+          ignore_missing: true
+          ignore_empty: true

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -746,17 +746,6 @@ jobs:
           MAAEND_VERSION: ${{ needs.meta.outputs.tag }}
           MXU_VERSION: ${{ needs.meta.outputs.mxu_version }}
         run: |
-          set -euo pipefail
-
-          if [[ ! "$MAAEND_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Invalid MaaEnd release version: $MAAEND_VERSION"
-            exit 1
-          fi
-          if [[ ! "$MXU_VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Invalid MXU release version: $MXU_VERSION"
-            exit 1
-          fi
-
           release="MXU@${MXU_VERSION#v}+MaaEnd@$MAAEND_VERSION"
           echo "release=$release" | tee -a "$GITHUB_OUTPUT"
 

--- a/tools/sentry/auto_delivery_report.py
+++ b/tools/sentry/auto_delivery_report.py
@@ -1,6 +1,6 @@
 """根据 Sentry spans 生成自动送货任务分析报告。
 
-默认分析 beta 环境最新 MaaEnd beta release 最近 24 小时的 DeliveryJobs 与
+默认分析 beta 环境最新 MaaEnd Beta / RC 版本最近 24 小时的 DeliveryJobs 与
 SeizeDeliveryJobs。报告分别展示导航阶段失败率、失败节点分布和路线内部错误率。
 路线内部错误可能已被上层重试恢复，因此不等同于整次自动送货任务失败。
 """
@@ -22,7 +22,8 @@ try:
         DEFAULT_SENTRY_TIMEOUT_SECONDS,
         explore,
         format_rate,
-        resolve_latest_maaend_beta_release,
+        normalize_sentry_environment,
+        resolve_latest_maaend_release,
         resolve_sentry_command,
         show_progress,
         write_console_table,
@@ -32,7 +33,8 @@ except ImportError:
         DEFAULT_SENTRY_TIMEOUT_SECONDS,
         explore,
         format_rate,
-        resolve_latest_maaend_beta_release,
+        normalize_sentry_environment,
+        resolve_latest_maaend_release,
         resolve_sentry_command,
         show_progress,
         write_console_table,
@@ -360,12 +362,14 @@ def collect_report(
     quiet: bool,
 ) -> tuple[Report, set[str]]:
     route_definitions = load_route_definitions(catalog_path)
+    release_was_selected = release is None
     if release is None:
+        environment = normalize_sentry_environment(environment)
         show_progress(
-            f"[0/3] 自动选择 {environment} 环境的最新 MaaEnd beta release",
+            f"[0/3] 自动选择 {environment} 环境的最新 MaaEnd release",
             quiet=quiet,
         )
-        release = resolve_latest_maaend_beta_release(
+        release = resolve_latest_maaend_release(
             sentry_command,
             target=target,
             environment=environment,
@@ -375,6 +379,9 @@ def collect_report(
         show_progress(f"使用 Sentry release：{release}", quiet=quiet)
     escaped_release = release.replace('"', '\\"')
     scope_filter = f'release:"{escaped_release}"'
+    if release_was_selected:
+        escaped_environment = environment.replace('"', '\\"')
+        scope_filter = f'{scope_filter} environment:"{escaped_environment}"'
     task_filter = f"task:[{','.join(tasks)}]"
     scope_filter = f"{scope_filter} {task_filter}"
 
@@ -520,12 +527,18 @@ def create_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--release",
-        help="精确的 Sentry release 名称；未指定时自动选择最新 MaaEnd beta release",
+        help=(
+            "精确的 Sentry release 名称；未指定时优先选择发布流程上报的版本，"
+            "否则按 environment 从用户样本回退"
+        ),
     )
     parser.add_argument(
         "--environment",
         default="beta",
-        help="自动选择 release 时使用的 Sentry environment（默认：beta）",
+        help=(
+            "自动选择 release 时使用；beta 选择 Beta / RC，"
+            "prod（等同 stable）/ production / stable 选择稳定版（默认：beta）"
+        ),
     )
     parser.add_argument("--target", default="maaend/rust", help="<org>/<project>")
     parser.add_argument(

--- a/tools/sentry/auto_delivery_report.py
+++ b/tools/sentry/auto_delivery_report.py
@@ -534,11 +534,9 @@ def create_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--environment",
+        choices=("stable", "beta"),
         default="beta",
-        help=(
-            "自动选择 release 时使用；beta 选择 Beta / RC，"
-            "prod（等同 stable）/ production / stable 选择稳定版（默认：beta）"
-        ),
+        help="自动选择 release 时使用；stable 选择正式版，beta 选择 Beta / RC（默认：beta）",
     )
     parser.add_argument("--target", default="maaend/rust", help="<org>/<project>")
     parser.add_argument(

--- a/tools/sentry/environment_monitoring_report.py
+++ b/tools/sentry/environment_monitoring_report.py
@@ -499,11 +499,9 @@ def create_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--environment",
+        choices=("stable", "beta"),
         default="beta",
-        help=(
-            "自动选择 release 时使用；beta 选择 Beta / RC，"
-            "prod（等同 stable）/ production / stable 选择稳定版（默认：beta）"
-        ),
+        help="自动选择 release 时使用；stable 选择正式版，beta 选择 Beta / RC（默认：beta）",
     )
     parser.add_argument("--target", default="maaend/rust", help="<org>/<project>")
     parser.add_argument(

--- a/tools/sentry/environment_monitoring_report.py
+++ b/tools/sentry/environment_monitoring_report.py
@@ -1,6 +1,6 @@
 """根据 Sentry spans 生成环境监测任务失败情况报告。
 
-默认分析 beta 环境最新 MaaEnd beta release。执行次数按包含 ``GoTo*Move`` span 的
+默认分析 beta 环境最新 MaaEnd Beta / RC 版本。执行次数按包含 ``GoTo*Move`` span 的
 唯一 trace 统计。传送失败取自路线专属的 ``QuickTeleport`` span，移动失败取自失败的
 移动 span；扫描失败归属于同一 trace 中时间最近的前置 ``GoTo*Move`` span。同一
 观察点、同一 trace 中的同类重复 span 只计数一次，总失败按三类失败 trace 的并集统计。
@@ -25,7 +25,8 @@ try:
         DEFAULT_SENTRY_TIMEOUT_SECONDS,
         explore,
         format_rate,
-        resolve_latest_maaend_beta_release,
+        normalize_sentry_environment,
+        resolve_latest_maaend_release,
         resolve_sentry_command,
         show_progress,
         write_console_table,
@@ -35,7 +36,8 @@ except ImportError:
         DEFAULT_SENTRY_TIMEOUT_SECONDS,
         explore,
         format_rate,
-        resolve_latest_maaend_beta_release,
+        normalize_sentry_environment,
+        resolve_latest_maaend_release,
         resolve_sentry_command,
         show_progress,
         write_console_table,
@@ -284,12 +286,14 @@ def collect_report(
     verbose: bool,
     quiet: bool,
 ) -> tuple[list[ReportRow], int]:
+    release_was_selected = release is None
     if release is None:
+        environment = normalize_sentry_environment(environment)
         show_progress(
-            f"[0/5] 自动选择 {environment} 环境的最新 MaaEnd beta release",
+            f"[0/5] 自动选择 {environment} 环境的最新 MaaEnd release",
             quiet=quiet,
         )
-        release = resolve_latest_maaend_beta_release(
+        release = resolve_latest_maaend_release(
             sentry_command,
             target=target,
             environment=environment,
@@ -299,6 +303,9 @@ def collect_report(
         show_progress(f"使用 Sentry release：{release}", quiet=quiet)
     escaped_release = release.replace('"', '\\"')
     scope_filter = f'release:"{escaped_release}"'
+    if release_was_selected:
+        escaped_environment = environment.replace('"', '\\"')
+        scope_filter = f'{scope_filter} environment:"{escaped_environment}"'
 
     move_filter = f"{scope_filter} span.description:GoTo*Move"
     teleport_failure_filter = (
@@ -485,12 +492,18 @@ def create_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--release",
-        help="精确的 Sentry release 名称；未指定时自动选择最新 MaaEnd beta release",
+        help=(
+            "精确的 Sentry release 名称；未指定时优先选择发布流程上报的版本，"
+            "否则按 environment 从用户样本回退"
+        ),
     )
     parser.add_argument(
         "--environment",
         default="beta",
-        help="自动选择 release 时使用的 Sentry environment（默认：beta）",
+        help=(
+            "自动选择 release 时使用；beta 选择 Beta / RC，"
+            "prod（等同 stable）/ production / stable 选择稳定版（默认：beta）"
+        ),
     )
     parser.add_argument("--target", default="maaend/rust", help="<org>/<project>")
     parser.add_argument(

--- a/tools/sentry/report_common.py
+++ b/tools/sentry/report_common.py
@@ -19,7 +19,7 @@ DEFAULT_SENTRY_TIMEOUT_SECONDS = 120.0
 DEFAULT_RELEASE_DISCOVERY_PERIOD = "90d"
 MIN_RELEASE_UNIQUE_USERS = 10
 SENTRY_RELEASE_API_LIMIT = 100
-PRODUCTION_ENVIRONMENTS = frozenset(("prod", "production", "stable"))
+SUPPORTED_SENTRY_ENVIRONMENTS = frozenset(("beta", "stable"))
 MAAEND_RELEASE_PATTERN = re.compile(
     r"(?:^|\+)MaaEnd@v(\d+)\.(\d+)\.(\d+)(?:-(beta|rc)\.(\d+))?$"
 )
@@ -28,13 +28,11 @@ MAAEND_RELEASE_PATTERN = re.compile(
 def normalize_sentry_environment(environment: str) -> str:
     """规范化报告支持的 Sentry environment 名称。"""
     normalized = environment.strip().lower()
-    if normalized == "prod":
-        return "stable"
-    if normalized == "beta" or normalized in PRODUCTION_ENVIRONMENTS:
+    if normalized in SUPPORTED_SENTRY_ENVIRONMENTS:
         return normalized
     raise ValueError(
         f"不支持的 Sentry environment：{environment!r}，"
-        "应为 beta、prod、production 或 stable。"
+        "应为 beta 或 stable。"
     )
 
 
@@ -180,13 +178,13 @@ def maaend_release_version_key(
 ) -> tuple[int, int, int, int, int] | None:
     """解析与 environment 发布通道相符的 MaaEnd 版本排序键。"""
     environment = normalize_sentry_environment(environment)
-    is_production = environment in PRODUCTION_ENVIRONMENTS
+    is_stable = environment == "stable"
     match = MAAEND_RELEASE_PATTERN.search(release)
     if match is None:
         return None
 
     major, minor, patch, prerelease, prerelease_number = match.groups()
-    if is_production:
+    if is_stable:
         if prerelease is not None:
             return None
         prerelease_rank = 2
@@ -267,7 +265,7 @@ def select_latest_maaend_release(
     if not candidates:
         expected = (
             "MaaEnd@vX.Y.Z"
-            if environment in PRODUCTION_ENVIRONMENTS
+            if environment == "stable"
             else "MaaEnd@vX.Y.Z-beta.N 或 MaaEnd@vX.Y.Z-rc.N"
         )
         raise RuntimeError(

--- a/tools/sentry/report_common.py
+++ b/tools/sentry/report_common.py
@@ -9,15 +9,33 @@ import shutil
 import subprocess
 import sys
 import unicodedata
+from datetime import datetime
 from typing import Any, Sequence, TextIO
+from urllib.parse import quote
 
 
 EXPLORE_LIMIT = 1_000
 DEFAULT_SENTRY_TIMEOUT_SECONDS = 120.0
 DEFAULT_RELEASE_DISCOVERY_PERIOD = "90d"
-MAAEND_BETA_RELEASE_PATTERN = re.compile(
-    r"(?:^|\+)MaaEnd@v(\d+)\.(\d+)\.(\d+)-beta\.(\d+)$"
+MIN_RELEASE_UNIQUE_USERS = 10
+SENTRY_RELEASE_API_LIMIT = 100
+PRODUCTION_ENVIRONMENTS = frozenset(("prod", "production", "stable"))
+MAAEND_RELEASE_PATTERN = re.compile(
+    r"(?:^|\+)MaaEnd@v(\d+)\.(\d+)\.(\d+)(?:-(beta|rc)\.(\d+))?$"
 )
+
+
+def normalize_sentry_environment(environment: str) -> str:
+    """规范化报告支持的 Sentry environment 名称。"""
+    normalized = environment.strip().lower()
+    if normalized == "prod":
+        return "stable"
+    if normalized == "beta" or normalized in PRODUCTION_ENVIRONMENTS:
+        return normalized
+    raise ValueError(
+        f"不支持的 Sentry environment：{environment!r}，"
+        "应为 beta、prod、production 或 stable。"
+    )
 
 
 def resolve_sentry_command() -> str:
@@ -36,13 +54,13 @@ def resolve_sentry_command() -> str:
     )
 
 
-def run_sentry_json(
+def run_sentry_json_value(
     sentry_command: str,
     arguments: Sequence[str],
     *,
     verbose: bool = False,
     timeout_seconds: float = DEFAULT_SENTRY_TIMEOUT_SECONDS,
-) -> dict[str, Any]:
+) -> Any:
     """执行 Sentry CLI 并解析其 JSON 输出。"""
     if verbose:
         print(f"+ sentry {' '.join(arguments)}", file=sys.stderr)
@@ -77,6 +95,23 @@ def run_sentry_json(
             f"stdout:\n{process.stdout}\n"
             f"stderr:\n{process.stderr}"
         ) from error
+    return result
+
+
+def run_sentry_json(
+    sentry_command: str,
+    arguments: Sequence[str],
+    *,
+    verbose: bool = False,
+    timeout_seconds: float = DEFAULT_SENTRY_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """执行 Sentry CLI，并要求其返回 JSON 对象。"""
+    result = run_sentry_json_value(
+        sentry_command,
+        arguments,
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
     if not isinstance(result, dict):
         raise RuntimeError("sentry CLI 返回了非对象 JSON。")
     return result
@@ -140,30 +175,139 @@ def explore(
         cursor = next_cursor
 
 
-def select_latest_maaend_beta_release(rows: Sequence[dict[str, Any]]) -> str:
-    """从 release 聚合结果中选择最新且样本最多的 MaaEnd beta release。"""
-    candidates: list[tuple[tuple[int, int, int, int], int, str]] = []
+def maaend_release_version_key(
+    release: str, *, environment: str
+) -> tuple[int, int, int, int, int] | None:
+    """解析与 environment 发布通道相符的 MaaEnd 版本排序键。"""
+    environment = normalize_sentry_environment(environment)
+    is_production = environment in PRODUCTION_ENVIRONMENTS
+    match = MAAEND_RELEASE_PATTERN.search(release)
+    if match is None:
+        return None
+
+    major, minor, patch, prerelease, prerelease_number = match.groups()
+    if is_production:
+        if prerelease is not None:
+            return None
+        prerelease_rank = 2
+        prerelease_number = "0"
+    else:
+        if prerelease is None or prerelease_number is None:
+            return None
+        prerelease_rank = {"beta": 0, "rc": 1}[prerelease]
+
+    return (
+        int(major),
+        int(minor),
+        int(patch),
+        prerelease_rank,
+        int(prerelease_number),
+    )
+
+
+def select_latest_reported_maaend_release(
+    rows: Sequence[dict[str, Any]], *, environment: str
+) -> str | None:
+    """选择发布流程已 finalize 并记录 deploy 的最新 MaaEnd release。"""
+    environment = normalize_sentry_environment(environment)
+    candidates: list[
+        tuple[tuple[int, int, int, int, int], datetime, str]
+    ] = []
+    for row in rows:
+        release = row.get("version")
+        released_at = row.get("dateReleased")
+        deploy_count = row.get("deployCount")
+        if (
+            not isinstance(release, str)
+            or not isinstance(released_at, str)
+            or not isinstance(deploy_count, int)
+            or deploy_count < 1
+        ):
+            continue
+
+        version = maaend_release_version_key(release, environment=environment)
+        if version is None:
+            continue
+        try:
+            release_time = datetime.fromisoformat(
+                released_at.replace("Z", "+00:00")
+            )
+        except ValueError:
+            continue
+        candidates.append((version, release_time, release))
+
+    return max(candidates)[2] if candidates else None
+
+
+def select_latest_maaend_release(
+    rows: Sequence[dict[str, Any]], *, environment: str
+) -> str:
+    """从 spans 中选择用户数达标的最新 MaaEnd release。"""
+    environment = normalize_sentry_environment(environment)
+    candidates: list[
+        tuple[tuple[int, int, int, int, int], int, int, str]
+    ] = []
     for row in rows:
         release = row.get("release")
+        user_count = row.get("count_unique(user)")
         trace_count = row.get("count_unique(trace)")
-        if not isinstance(release, str) or not isinstance(trace_count, int):
+        if (
+            not isinstance(release, str)
+            or not isinstance(user_count, int)
+            or not isinstance(trace_count, int)
+            or user_count < MIN_RELEASE_UNIQUE_USERS
+        ):
             continue
 
-        match = MAAEND_BETA_RELEASE_PATTERN.search(release)
-        if match is None:
+        version = maaend_release_version_key(release, environment=environment)
+        if version is None:
             continue
-        version = tuple(int(part) for part in match.groups())
-        candidates.append((version, trace_count, release))
+        candidates.append((version, user_count, trace_count, release))
 
     if not candidates:
+        expected = (
+            "MaaEnd@vX.Y.Z"
+            if environment in PRODUCTION_ENVIRONMENTS
+            else "MaaEnd@vX.Y.Z-beta.N 或 MaaEnd@vX.Y.Z-rc.N"
+        )
         raise RuntimeError(
-            "Sentry 中找不到格式为 MaaEnd@vX.Y.Z-beta.N 的 beta release，"
+            f"Sentry 的 {environment} 环境中找不到格式为 {expected}、"
+            f"且至少有 {MIN_RELEASE_UNIQUE_USERS} 位独立用户的 release，"
             "请通过 --release 显式指定。"
         )
-    return max(candidates)[2]
+    return max(candidates)[3]
 
 
-def resolve_latest_maaend_beta_release(
+def query_sentry_releases(
+    sentry_command: str,
+    *,
+    target: str,
+    verbose: bool = False,
+    timeout_seconds: float = DEFAULT_SENTRY_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    """查询项目最新一页的 Sentry release 元数据。"""
+    organization, separator, project = target.partition("/")
+    if not separator or not organization or not project or "/" in project:
+        raise ValueError(f"无效的 Sentry target：{target!r}，应为 <org>/<project>。")
+
+    endpoint = (
+        f"projects/{quote(organization, safe='')}/{quote(project, safe='')}/"
+        f"releases/?per_page={SENTRY_RELEASE_API_LIMIT}"
+    )
+    result = run_sentry_json_value(
+        sentry_command,
+        ("api", endpoint, "--json"),
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+    if not isinstance(result, list) or not all(
+        isinstance(row, dict) for row in result
+    ):
+        raise RuntimeError("Sentry release API 返回的 JSON 不是对象数组。")
+    return result
+
+
+def resolve_latest_maaend_release(
     sentry_command: str,
     *,
     target: str,
@@ -171,19 +315,33 @@ def resolve_latest_maaend_beta_release(
     verbose: bool = False,
     timeout_seconds: float = DEFAULT_SENTRY_TIMEOUT_SECONDS,
 ) -> str:
-    """查询 Sentry，并解析指定环境中最新的 MaaEnd beta release。"""
+    """优先使用发布流程上报的 release，旧版本回退到 spans 样本。"""
+    environment = normalize_sentry_environment(environment)
+    release_rows = query_sentry_releases(
+        sentry_command,
+        target=target,
+        verbose=verbose,
+        timeout_seconds=timeout_seconds,
+    )
+    reported_release = select_latest_reported_maaend_release(
+        release_rows,
+        environment=environment,
+    )
+    if reported_release is not None:
+        return reported_release
+
     escaped_environment = environment.replace('"', '\\"')
     rows = explore(
         sentry_command,
         target=target,
         period=DEFAULT_RELEASE_DISCOVERY_PERIOD,
-        fields=("release", "count_unique(trace)"),
+        fields=("release", "count_unique(user)", "count_unique(trace)"),
         query=f'environment:"{escaped_environment}"',
-        sort="-count_unique(trace)",
+        sort="-count_unique(user)",
         verbose=verbose,
         timeout_seconds=timeout_seconds,
     )
-    return select_latest_maaend_beta_release(rows)
+    return select_latest_maaend_release(rows, environment=environment)
 
 
 def format_rate(rate: float | None) -> str:


### PR DESCRIPTION
## 改动内容

- 在正式 GitHub Release 完成后向 Sentry 上报精确的 `MXU@<version>+MaaEnd@<tag>` release，并按预发布/正式版记录 `beta` 或 `stable` deploy
- 报告脚本优先选择 CI 已 finalize 且有 deploy 的 release；历史版本回退到近 90 天 spans，并过滤独立用户少于 10 的异常组合
- Beta 通道支持 Beta 与 RC 版本，稳定通道只接受正式版本，并按 MaaEnd SemVer 选择最新版本
- 报告入口仅允许 `stable` 与 `beta`：前者选择正式版，后者选择 Beta / RC
- 自动选择 release 时，后续报告查询同时限定 release 与 environment

## 验证

- `pnpm check`
- `pnpm test`：780/780，未生成 `tests/maatools/error_details.json`
- Python `py_compile` 与版本选择边界检查
- `--environment prod --period 1h` 实时报告查询，确认实际使用 `environment:"stable"`
- `.github/workflows/install.yml` Prettier 检查
- `git diff --check`

## 说明

现有 Sentry 历史 release 尚无 `dateReleased`/deploy 元数据，因此当前实时验证走的是用户样本回退路径；CI 优先路径需等待下一次 tag 发布后验证。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 正式发布时自动创建对应的 Sentry Release，并区分 Beta 与稳定版环境。
  * 支持按 Beta、RC 或稳定版环境自动选择最新 MaaEnd 版本。
* **改进**
  * Sentry 报告查询会根据发布环境筛选数据，提升版本匹配准确性。
  * 优先使用已完成发布且包含部署记录的版本信息，无匹配时自动回退至备用查询方式。
  * 更新命令行帮助，明确 Release 与环境的选择规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
