### PR TITLE
fix(MapNavigator): 停稳后再点击登上滑索架

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
@@ -385,9 +385,6 @@ Result StartZiplineHop(
         if (ctx.maa_context == nullptr) {
             return AbandonZipline(ctx, "zipline_no_context", "no pipeline context to recognize the mount prompt");
         }
-        // 上索预筛可能在角色仍在走路时命中。与采集流程一致：先松开前进键，等待惯性消失，
-        // 再通过 OCR 获取已经稳定的可点击提示框。
-        utils::SleepFor(kStopWaitMs);
         if (!PressMountPrompt(ctx.maa_context)) {
             // 预筛叫停的这一次人还没走到, 认不出就是那个图标不属于滑索架: 当没发生, 接着走
             if (ctx.runtime_state->semantic.zipline_prompt_probe) {

--- a/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
@@ -385,6 +385,9 @@ Result StartZiplineHop(
         if (ctx.maa_context == nullptr) {
             return AbandonZipline(ctx, "zipline_no_context", "no pipeline context to recognize the mount prompt");
         }
+        // 上索预筛可能在角色仍在走路时命中。与采集流程一致：先松开前进键，等待惯性消失，
+        // 再通过 OCR 获取已经稳定的可点击提示框。
+        utils::SleepFor(kStopWaitMs);
         if (!PressMountPrompt(ctx.maa_context)) {
             // 预筛叫停的这一次人还没走到, 认不出就是那个图标不属于滑索架: 当没发生, 接着走
             if (ctx.runtime_state->semantic.zipline_prompt_probe) {

--- a/assets/resource/pipeline/MapNavigator/Zipline.json
+++ b/assets/resource/pipeline/MapNavigator/Zipline.json
@@ -3,12 +3,12 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            "MapNavigatorZiplineMount",
+            "MapNavigatorZiplineMountWaitFreezes",
             "MapNavigatorZiplineMountEnd"
         ]
     },
-    "MapNavigatorZiplineMount": {
-        "desc": "上索：认出架子的交互提示后按住 Alt 点击该提示",
+    "MapNavigatorZiplineMountWaitFreezes": {
+        "desc": "上索：识别滑索架交互提示，并等待提示区域稳定",
         "recognition": {
             "type": "OCR",
             "param": {
@@ -32,6 +32,18 @@
                 312
             ]
         },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "MapNavigatorZiplineMount"
+        ]
+    },
+    "MapNavigatorZiplineMount": {
+        "desc": "上索：重新识别滑索架交互提示后按住 Alt 点击该提示",
+        "recognition": "And",
+        "all_of": [
+            "MapNavigatorZiplineMountWaitFreezes"
+        ],
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "AutoAltClickAction",

--- a/assets/resource/pipeline/MapNavigator/Zipline.json
+++ b/assets/resource/pipeline/MapNavigator/Zipline.json
@@ -8,7 +8,7 @@
         ]
     },
     "MapNavigatorZiplineMount": {
-        "desc": "上索：认出架子的交互提示才按交互键",
+        "desc": "上索：认出架子的交互提示后按住 Alt 点击该提示",
         "recognition": {
             "type": "OCR",
             "param": {
@@ -24,8 +24,8 @@
             }
         },
         "pre_delay": 0,
-        "action": "ClickKey",
-        "key": 70, // F 交互；可通过全局设置 KeymapInteract 改绑
+        "action": "Custom",
+        "custom_action": "AutoAltClickAction",
         "post_delay": 0,
         "next": [
             "MapNavigatorZiplineMountEnd"

--- a/assets/resource/pipeline/MapNavigator/Zipline.json
+++ b/assets/resource/pipeline/MapNavigator/Zipline.json
@@ -23,6 +23,15 @@
                 ]
             }
         },
+        "pre_wait_freezes": {
+            "time": 300,
+            "target": [
+                755,
+                330,
+                297,
+                312
+            ]
+        },
         "pre_delay": 0,
         "action": "Custom",
         "custom_action": "AutoAltClickAction",

--- a/assets/resource_macos/pipeline/MacOSKeyMap.json
+++ b/assets/resource_macos/pipeline/MacOSKeyMap.json
@@ -178,14 +178,6 @@
             }
         }
     },
-    "MapNavigatorZiplineMount": {
-        "action": {
-            "type": "ClickKey",
-            "param": {
-                "key": 3
-            }
-        }
-    },
     "ProdManualOpenInMain": {
         "action": {
             "type": "KeyDown",

--- a/assets/tasks/setting/Keymap.json
+++ b/assets/tasks/setting/Keymap.json
@@ -58,9 +58,6 @@
                 },
                 "AutoPickInteractive": {
                     "key": "{KeymapInteract.primary}"
-                },
-                "MapNavigatorZiplineMount": {
-                    "key": "{KeymapInteract.primary}"
                 }
             }
         },


### PR DESCRIPTION
## 变更

- 修复滑索架旁存在采集物等其他交互目标时，通用交互键可能选错目标导致挂载失败的问题
- OCR 识别完整“登上滑索架”文本，并等待交互区域连续稳定 300 ms
- 画面稳定后重新 OCR 获取最新提示框，再使用 Alt+Click 精确点击
- 清理不再使用的滑索交互键配置与 macOS 派生键位资源

## 验证

- `git diff --check`

Closes #5329
Related #5331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 优化上索操作流程，能够更准确识别交互提示并执行对应操作。
  * 操作过程中增加短暂提示冻结，提升交互稳定性。

* **配置调整**
  * 移除已不再使用的上索快捷键映射及相关配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->