### PR TITLE
fix(build): subprocess 统一 errors="replace", 兼容中文 Windows 的 GBK 工具输出 (…

### DIFF
--- a/tools/build_and_install.py
+++ b/tools/build_and_install.py
@@ -236,6 +236,7 @@ def build_go_agent(
         capture_output=True,
         text=True,
         encoding="utf-8",
+        errors="replace",
         env=env,
     )
     if tidy_result.stdout:
@@ -267,6 +268,7 @@ def build_go_agent(
         capture_output=True,
         text=True,
         encoding="utf-8",
+        errors="replace",
         env=env,
     )
     if vendor_result.stdout:
@@ -324,6 +326,7 @@ def build_go_agent(
         capture_output=True,
         text=True,
         encoding="utf-8",
+        errors="replace",
         env=env,
     )
     if result.stdout:
@@ -368,6 +371,7 @@ def setup_windows_msvc_env(arch: str = "x86_64") -> bool:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
         )
     except (OSError, subprocess.SubprocessError) as exc:
         print(f"  {Console.warn(t('warning'))} {t('vswhere_query_failed', error=exc)}")
@@ -698,6 +702,7 @@ def build_cpp_algo(
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
         )
 
         if result.stdout:
@@ -742,6 +747,7 @@ def build_cpp_algo(
         capture_output=True,
         text=True,
         encoding="utf-8",
+        errors="replace",
     )
     if result.stdout:
         print(result.stdout)
@@ -773,6 +779,7 @@ def build_cpp_algo(
         capture_output=True,
         text=True,
         encoding="utf-8",
+        errors="replace",
     )
     if result.stdout:
         print(result.stdout)


### PR DESCRIPTION
修复本地构建 UnicodeDecodeError)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改进 Go、CMake 构建及 Visual Studio 环境检测流程的文本输出处理。
  * 遇到无法解码的字符时将自动替换，避免构建或安装流程因编码问题中断。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->