### PR TITLE
fix(MapNavigator): 提前切换步行接近滑索

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -391,7 +391,7 @@ constexpr int32_t kSprintCancelReleaseMs = 60;
 // otherwise the mount prompt can appear on the first frame after walking is toggled and stop motion immediately.
 constexpr double kCollectWalkEnterBandWu = 3.0;
 constexpr double kCollectWalkExitBandWu = 4.5;
-constexpr double kZiplineWalkEnterBandWu = 6.0;
+constexpr double kZiplineWalkEnterBandWu = 5.0;
 constexpr double kZiplineWalkExitBandWu = 7.5;
 static_assert(kCollectWalkEnterBandWu < kCollectWalkExitBandWu, "collect walk enter band must be smaller than its exit band");
 static_assert(kZiplineWalkEnterBandWu < kZiplineWalkExitBandWu, "zipline walk enter band must be smaller than its exit band");

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -387,14 +387,20 @@ constexpr double kCollectSprintSuppressBandWu = 8.0;
 constexpr int32_t kSprintCancelReleaseMs = 60;
 
 // Walk near these points so the interact prompt stays up long enough to act on. Enter/exit differ for
-// hysteresis (each press flips game state); the enter band stays inside the sprint-suppress band.
+// hysteresis (each press flips game state). Ziplines need a longer walking approach than ordinary prompts,
+// otherwise the mount prompt can appear on the first frame after walking is toggled and stop motion immediately.
 constexpr double kCollectWalkEnterBandWu = 3.0;
 constexpr double kCollectWalkExitBandWu = 4.5;
-static_assert(kCollectWalkEnterBandWu < kCollectSprintSuppressBandWu, "walk band must sit inside the sprint-suppress band");
+constexpr double kZiplineWalkEnterBandWu = 6.0;
+constexpr double kZiplineWalkExitBandWu = 7.5;
+static_assert(kCollectWalkEnterBandWu < kCollectWalkExitBandWu, "collect walk enter band must be smaller than its exit band");
+static_assert(kZiplineWalkEnterBandWu < kZiplineWalkExitBandWu, "zipline walk enter band must be smaller than its exit band");
+static_assert(kZiplineWalkExitBandWu < kCollectSprintSuppressBandWu, "walk bands must sit inside the sprint-suppress band");
 
-// Acting on a prompt is gated on the same band that engages walking: the prompt icon fires for every interactable
-// on screen, so without this a route carrying one such point would stop at strangers all the way along.
-constexpr double kPromptTriggerBandWu = kCollectWalkEnterBandWu;
+// The prompt icon fires for every interactable on screen, so triggering stays in the tight band even when a
+// zipline starts walking earlier. Otherwise a route carrying one such point could stop at strangers along the way.
+constexpr double kPromptTriggerBandWu = 3.0;
+static_assert(kPromptTriggerBandWu < kZiplineWalkEnterBandWu, "zipline walking must start before prompt triggering");
 
 // Walking halves both speed and turn rate, so jogging-sized windows are doubled while engaged.
 constexpr int32_t kWalkModeSlowFactor = 2;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -2033,13 +2033,14 @@ bool NavigationStateMachine::TryZiplineMountPrompt(const Waypoint& waypoint, con
     return flagged && route.startup_motion_confirmed && route.waypoint_distance <= kPromptTriggerBandWu;
 }
 
-double NavigationStateMachine::NearestPromptDistanceSq() const
+NavigationStateMachine::PromptDistance NavigationStateMachine::NearestPromptDistance() const
 {
-    double nearest_sq = -1.0;
+    PromptDistance nearest;
     for (const AsyncPromptAction* prompt : { &collect_prompt_, &interact_prompt_ }) {
         const double distance_sq = prompt->NearestDistanceSq();
-        if (distance_sq >= 0.0 && (nearest_sq < 0.0 || distance_sq < nearest_sq)) {
-            nearest_sq = distance_sq;
+        if (distance_sq >= 0.0 && (nearest.distance_sq < 0.0 || distance_sq < nearest.distance_sq)) {
+            nearest.distance_sq = distance_sq;
+            nearest.is_zipline = false;
         }
     }
     // 上索点也算提示点: 同一个图标、同一件事 —— 够不够得着只看身位离架子多远。已经站上去了就不算,
@@ -2054,12 +2055,13 @@ double NavigationStateMachine::NearestPromptDistanceSq() const
             const double dx = waypoint.x - position_->x;
             const double dy = waypoint.y - position_->y;
             const double distance_sq = dx * dx + dy * dy;
-            if (nearest_sq < 0.0 || distance_sq < nearest_sq) {
-                nearest_sq = distance_sq;
+            if (nearest.distance_sq < 0.0 || distance_sq < nearest.distance_sq) {
+                nearest.distance_sq = distance_sq;
+                nearest.is_zipline = true;
             }
         }
     }
-    return nearest_sq;
+    return nearest;
 }
 
 void NavigationStateMachine::UpdatePromptSprintSuppression()
@@ -2068,7 +2070,7 @@ void NavigationStateMachine::UpdatePromptSprintSuppression()
         return;
     }
 
-    const double nearest_sq = NearestPromptDistanceSq();
+    const double nearest_sq = NearestPromptDistance().distance_sq;
     // 这条线上没有提示驱动的点时 nearest_sq < 0, 疾跑行为一点不碰
     const bool approaching_prompt = nearest_sq >= 0.0 && nearest_sq <= kCollectSprintSuppressBandWu * kCollectSprintSuppressBandWu;
     motion_controller_->SetSprintSuppressed(approaching_prompt);
@@ -2078,7 +2080,7 @@ void NavigationStateMachine::UpdatePromptSprintSuppression()
 // stood on, released everywhere else (travel legs, recovery, turn-in-place nodes, before motion is confirmed).
 void NavigationStateMachine::UpdateWalkMode(NaviPhase phase)
 {
-    double nearest_sq = NearestPromptDistanceSq();
+    PromptDistance nearest = NearestPromptDistance();
     const bool recovering = runtime_state_.recovery.active || runtime_state_.cross_tier_escape.active;
     const bool has_waypoint = session_->HasCurrentWaypoint();
     const ActionType action = has_waypoint ? session_->CurrentWaypoint().action : ActionType::HEADING;
@@ -2091,24 +2093,28 @@ void NavigationStateMachine::UpdateWalkMode(NaviPhase phase)
         const double dx = goal.x - position_->x;
         const double dy = goal.y - position_->y;
         const double distance_sq = dx * dx + dy * dy;
-        if (nearest_sq < 0.0 || distance_sq < nearest_sq) {
-            nearest_sq = distance_sq;
+        if (nearest.distance_sq < 0.0 || distance_sq < nearest.distance_sq) {
+            nearest.distance_sq = distance_sq;
+            nearest.is_zipline = goal.action == ActionType::ZIPLINE;
         }
         settling_approach = true;
     }
-    if (phase != NaviPhase::Navigate || nearest_sq < 0.0 || recovering || !(plain_approach || settling_approach)
+    if (phase != NaviPhase::Navigate || nearest.distance_sq < 0.0 || recovering || !(plain_approach || settling_approach)
         || !runtime_state_.route.startup_motion_confirmed) {
         walk_mode_.Request(false);
         return;
     }
 
     const bool was_engaged = walk_mode_.engaged();
-    const double band = was_engaged ? kCollectWalkExitBandWu : kCollectWalkEnterBandWu;
-    walk_mode_.Request(nearest_sq <= band * band);
+    const double enter_band = nearest.is_zipline ? kZiplineWalkEnterBandWu : kCollectWalkEnterBandWu;
+    const double exit_band = nearest.is_zipline ? kZiplineWalkExitBandWu : kCollectWalkExitBandWu;
+    const double band = was_engaged ? exit_band : enter_band;
+    walk_mode_.Request(nearest.distance_sq <= band * band);
     const bool walking = walk_mode_.engaged();
     if (walking != was_engaged) {
-        const double nearest_stop_point = std::sqrt(nearest_sq);
-        LogInfo << "Walk mode boundary crossed." << VAR(walking) << VAR(nearest_stop_point) << VAR(position_->x) << VAR(position_->y);
+        const double nearest_stop_point = std::sqrt(nearest.distance_sq);
+        LogInfo << "Walk mode boundary crossed." << VAR(walking) << VAR(nearest.is_zipline) << VAR(nearest_stop_point) << VAR(position_->x)
+                << VAR(position_->y);
     }
 }
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -46,6 +46,12 @@ public:
     ~NavigationStateMachine();
 
 private:
+    struct PromptDistance
+    {
+        double distance_sq = -1.0;
+        bool is_zipline = false;
+    };
+
     bool Bootstrap();
     bool TickNavigate();
     bool TickPhase(NaviPhase phase);
@@ -92,8 +98,8 @@ private:
     // 架子的交互提示出现就算够得着了。预筛看错时返回 false, 这一拍照常往前走
     bool TryZiplineMountPrompt(const Waypoint& waypoint, const RouteTrackingState& route);
     void UpdatePromptSprintSuppression();
-    // Squared distance to the nearest prompt-driven point; -1 when the route has none or the agent is unlocalized.
-    double NearestPromptDistanceSq() const;
+    // Distance and kind of the nearest prompt-driven point; distance_sq is -1 when the route has none.
+    PromptDistance NearestPromptDistance() const;
     void UpdateWalkMode(NaviPhase phase);
 
     const NaviParam& param_;


### PR DESCRIPTION
## 问题

接近滑索时，步行切换与滑索提示触发共用 3 米边界。日志中角色在约 2.97 米才切换步行，下一帧提示即触发并停止前进，没有形成有效的步行接近阶段，容易错过上索位置。

## 修复

- 为滑索单独设置 5.0 米步行进入距离和 7.5 米退出迟滞距离
- 保持普通采集/交互的 3.0/4.5 米步行边界不变
- 将提示触发距离固定在 3.0 米，避免扩大误触范围
- 在最近提示点信息中保留是否为滑索，并在步行边界日志中输出该状态

## 验证

- `cpp-algo` RelWithDebInfo 编译链接通过
- `git diff --check` 通过
- 未运行仓库级 `pnpm check` / `pnpm test`：本次仅修改 C++ MapNavigator 运行时，未修改测试集

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 滑索导航提示现支持独立的步行进入与退出距离范围。
  * 导航提示计算现包含未完成的滑索航点。
* **改进**
  * 优化滑索提示附近的步行模式与冲刺抑制逻辑，减少模式切换抖动。
  * 普通收集点继续使用原有距离范围，提示触发距离采用独立阈值，提升导航提示的准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
