### PR TITLE
fix(MapNavigator): 稳定后复核上索提示

### DIFF
--- a/assets/resource/pipeline/MapNavigator/Zipline.json
+++ b/assets/resource/pipeline/MapNavigator/Zipline.json
@@ -4,7 +4,7 @@
         "post_delay": 0,
         "next": [
             "MapNavigatorZiplineMountWaitFreezes",
-            "MapNavigatorZiplineMountEnd"
+            "MapNavigatorZiplineMountRetryWaitFreezes"
         ]
     },
     "MapNavigatorZiplineMountWaitFreezes": {
@@ -36,6 +36,25 @@
         "post_delay": 0,
         "next": [
             "MapNavigatorZiplineMount"
+        ]
+    },
+    "MapNavigatorZiplineMountRetryWaitFreezes": {
+        "desc": "上索：首次 OCR 未命中时等待提示区域稳定，随后复核一次",
+        "recognition": "DirectHit",
+        "pre_wait_freezes": {
+            "time": 300,
+            "target": [
+                755,
+                330,
+                297,
+                312
+            ]
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "MapNavigatorZiplineMount",
+            "MapNavigatorZiplineMountEnd"
         ]
     },
     "MapNavigatorZiplineMount": {


### PR DESCRIPTION
## 变更

- 首次 OCR 未识别到“登上滑索架”时，不再立即退出上索子任务
- 等待交互提示区域连续稳定 300 ms 后，再复核一次完整文本
- 仅在复核命中后沿用现有 `Alt+Click` 操作；复核仍失败则交回现有重新站位 / 弃索逻辑，不增加循环或重复点击

## 原因

#5331 的武陵样本中，首次 OCR 只得到覆盖整个 ROI 的低分“`一`”（0.3327），约 160 ms 后同一位置已能以 0.9999 识别“长距滑索架”，说明提示动画期间存在瞬时 OCR 假阴性。现有稳定等待仅在首次 OCR 已命中后执行，无法覆盖这个入口漏识别。

## 验证

- `pnpm exec prettier --check assets/resource/pipeline/MapNavigator/Zipline.json`
- `$env:PYTHONUTF8='1'; uv run tools/validate_schema.py --resource-dirs assets/resource/pipeline/MapNavigator --interface-files assets/interface.json`
- `git diff --check`

未运行全量 `pnpm check` / `pnpm test`，本次未修改测试文件。

Related #5331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化滑索上索流程：首次识别失败后会等待提示区域稳定，并进行二次确认。
  * 二次确认成功时可继续上索操作，确认失败时结束流程，提升操作稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->