### PR TITLE
perf(AutoDelivery): 优化接单后的自动送货流程

### DIFF
--- a/assets/resource/pipeline/AutoDelivery/Common.json
+++ b/assets/resource/pipeline/AutoDelivery/Common.json
@@ -190,7 +190,16 @@
             "InMenuMission",
             "AutoDeliveryCheckDeliveryMissionSelected"
         ],
-        "box_index": 1
+        "box_index": 1,
+        "pre_wait_freezes": {
+            "time": 200,
+            "target": [
+                417,
+                51,
+                547,
+                279
+            ]
+        }
     },
     "AutoDeliveryInTaskDestinationMap": {
         "desc": "识别已打开的送货任务目标地图",
@@ -263,7 +272,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutoDeliveryCheckDeliveryMissionSelected"
+            "AutoDeliveryInDeliveryMissionDetail"
         ]
     },
     "AutoDeliverySelectDeliveryMissionFromList": {
@@ -283,7 +292,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutoDeliveryCheckDeliveryMissionSelected",
+            "AutoDeliveryInDeliveryMissionDetail",
             "AutoDeliverySelectDeliveryMission",
             "AutoDeliveryCheckDeliveryMissionListComplete",
             "[JumpBack]AutoDeliveryScrollMissionList"

--- a/assets/resource/pipeline/DeliveryJobs/Depot/ValleyIV/OriginLodespring.json
+++ b/assets/resource/pipeline/DeliveryJobs/Depot/ValleyIV/OriginLodespring.json
@@ -115,7 +115,7 @@
         ]
     },
     "DeliveryJobsAutoDeliveryOriginLodespring": {
-        "desc": "从矿脉源区当前任务详情开始全自动送货",
+        "desc": "为矿脉源区当前送货任务调用全自动送货",
         "pre_delay": 0,
         "anchor": {
             "AutoDeliveryAfterSubmitGoods": "DeliveryJobsValleyIVLoop"

--- a/assets/resource/pipeline/DeliveryJobs/Depot/ValleyIV/OriginiumSciencePark.json
+++ b/assets/resource/pipeline/DeliveryJobs/Depot/ValleyIV/OriginiumSciencePark.json
@@ -115,7 +115,7 @@
         ]
     },
     "DeliveryJobsAutoDeliveryOriginiumSciencePark": {
-        "desc": "从源石研究园当前任务详情开始全自动送货",
+        "desc": "为源石研究园当前送货任务调用全自动送货",
         "pre_delay": 0,
         "anchor": {
             "AutoDeliveryAfterSubmitGoods": "DeliveryJobsValleyIVLoop"

--- a/assets/resource/pipeline/DeliveryJobs/Depot/ValleyIV/PowerPlateau.json
+++ b/assets/resource/pipeline/DeliveryJobs/Depot/ValleyIV/PowerPlateau.json
@@ -115,7 +115,7 @@
         ]
     },
     "DeliveryJobsAutoDeliveryPowerPlateau": {
-        "desc": "从供能高地当前任务详情开始全自动送货",
+        "desc": "为供能高地当前送货任务调用全自动送货",
         "pre_delay": 0,
         "anchor": {
             "AutoDeliveryAfterSubmitGoods": "DeliveryJobsValleyIVLoop"

--- a/assets/resource/pipeline/DeliveryJobs/Depot/Wuling/TestArea.json
+++ b/assets/resource/pipeline/DeliveryJobs/Depot/Wuling/TestArea.json
@@ -115,7 +115,7 @@
         ]
     },
     "DeliveryJobsAutoDeliveryTestArea": {
-        "desc": "从试验园区当前任务详情开始全自动送货",
+        "desc": "为试验园区当前送货任务调用全自动送货",
         "pre_delay": 0,
         "anchor": {
             "AutoDeliveryAfterSubmitGoods": "DeliveryJobsWulingLoop"

--- a/assets/resource/pipeline/DeliveryJobs/Depot/Wuling/WulingCity.json
+++ b/assets/resource/pipeline/DeliveryJobs/Depot/Wuling/WulingCity.json
@@ -115,7 +115,7 @@
         ]
     },
     "DeliveryJobsAutoDeliveryWulingCity": {
-        "desc": "从武陵城区当前任务详情开始全自动送货",
+        "desc": "为武陵城区当前送货任务调用全自动送货",
         "pre_delay": 0,
         "anchor": {
             "AutoDeliveryAfterSubmitGoods": "DeliveryJobsWulingLoop"

--- a/assets/resource/pipeline/SeizeDeliveryJobs/AutoDeliveryAdapter.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/AutoDeliveryAdapter.json
@@ -12,50 +12,47 @@
         }
     },
     "SeizeDeliveryJobsTeleport": {
-        "desc": "打开当前任务详情；需要取货时仅快速传送到仓储节点附近",
+        "desc": "调用全自动送货；需要取货时仅快速传送到仓储节点附近",
         "recognition": "DirectHit",
         "pre_delay": 0,
         "action": "DoNothing",
         "anchor": {
-            "SeizeDeliveryJobsAfterEnterCurrentJobDetail": "AutoDelivery",
             "AutoDeliveryAfterRecognizeDestination": "SeizeDeliveryJobsDeliveryCannotTeleport",
             "AutoDeliveryAfterQuickTeleport": "SeizeDeliveryJobsSuccessTeleportDone"
         },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "SeizeDeliveryJobsEnterCurrentJobDetail"
+            "AutoDelivery"
         ]
     },
     "SeizeDeliveryJobsTeleportAndWalk": {
-        "desc": "打开当前任务详情，需要取货时快速传送后走到仓储节点",
+        "desc": "调用全自动送货，需要取货时快速传送后走到仓储节点",
         "recognition": "DirectHit",
         "pre_delay": 0,
         "action": "DoNothing",
         "anchor": {
-            "SeizeDeliveryJobsAfterEnterCurrentJobDetail": "AutoDelivery",
             "AutoDeliveryAfterRecognizeDestination": "SeizeDeliveryJobsDeliveryCannotTeleport",
             "AutoDeliveryAfterNavigateDepot": "SeizeDeliveryJobsSuccessWalkDone"
         },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "SeizeDeliveryJobsEnterCurrentJobDetail"
+            "AutoDelivery"
         ]
     },
     "SeizeDeliveryJobsFullDelivery": {
-        "desc": "打开当前任务详情，自动判断取货或送货并完成当前委托",
+        "desc": "调用全自动送货，自动判断取货或送货并完成当前委托",
         "recognition": "DirectHit",
         "pre_delay": 0,
         "action": "DoNothing",
         "anchor": {
-            "SeizeDeliveryJobsAfterEnterCurrentJobDetail": "AutoDelivery",
             "AutoDeliveryAfterSubmitGoods": "SeizeDeliveryJobsMain"
         },
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "SeizeDeliveryJobsEnterCurrentJobDetail"
+            "AutoDelivery"
         ]
     },
     "SeizeDeliveryJobsDeliveryCannotTeleport": {

--- a/assets/resource/pipeline/SeizeDeliveryJobs/AutoDeliveryAdapter.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/AutoDeliveryAdapter.json
@@ -33,7 +33,7 @@
         "action": "DoNothing",
         "anchor": {
             "AutoDeliveryAfterRecognizeDestination": "SeizeDeliveryJobsDeliveryCannotTeleport",
-            "AutoDeliveryAfterNavigateDepot": "SeizeDeliveryJobsSuccessWalkDone"
+            "AutoDeliveryAfterNavigateDepot": "SeizeDeliveryJobsRestoreTrackingAfterWalk"
         },
         "post_delay": 0,
         "rate_limit": 0,
@@ -64,6 +64,91 @@
         "rate_limit": 0,
         "focus": {
             "Node.Recognition.Succeeded": "$task.SeizeDeliveryJobs.focus.deliveryCannotTeleport"
+        }
+    },
+    "SeizeDeliveryJobsCheckDeliveryMissionTrackedAfterWalk": {
+        "desc": "确认到达仓储节点后送货任务已经处于追踪状态",
+        "recognition": "And",
+        "all_of": [
+            "AutoDeliveryInDeliveryMissionDetail",
+            "AutoDeliveryCheckCancelCurrentJobTrackingButton"
+        ],
+        "box_index": 1,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SeizeDeliveryJobsReturnWorldAfterTracking"
+        ]
+    },
+    "SeizeDeliveryJobsInDestinationMapAfterTracking": {
+        "desc": "确认到达仓储节点后重新追踪任务已打开目的地地图",
+        "recognition": "And",
+        "all_of": [
+            "AutoDeliveryInTaskDestinationMap"
+        ],
+        "box_index": 0,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SeizeDeliveryJobsReturnWorldAfterTracking"
+        ]
+    },
+    "SeizeDeliveryJobsRestoreTrackingAfterWalk": {
+        "desc": "到达仓储节点后重新进入送货任务详情并恢复追踪",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "AutoDeliveryEnsureDeliveryMissionSelected"
+            ],
+            "continue": false,
+            "strict": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SeizeDeliveryJobsCheckDeliveryMissionTrackedAfterWalk",
+            "SeizeDeliveryJobsStartTrackingAfterWalk"
+        ]
+    },
+    "SeizeDeliveryJobsReturnWorldAfterTracking": {
+        "desc": "确认送货任务已经追踪后返回仓储节点所在的大世界",
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "SceneAnyEnterWorld"
+            ],
+            "continue": false,
+            "strict": true
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "SeizeDeliveryJobsSuccessWalkDone"
+        ]
+    },
+    "SeizeDeliveryJobsStartTrackingAfterWalk": {
+        "desc": "到达仓储节点后点击开始追踪送货任务",
+        "recognition": "And",
+        "all_of": [
+            "AutoDeliveryInDeliveryMissionDetail",
+            "AutoDeliveryCheckStartTrackingButton"
+        ],
+        "box_index": 1,
+        "pre_delay": 0,
+        "action": "Click",
+        "post_delay": 0,
+        "rate_limit": 500,
+        "next": [
+            "SeizeDeliveryJobsInDestinationMapAfterTracking"
+        ],
+        "focus": {
+            "Node.Action.Starting": "$task.AutoDelivery.focus.start_tracking"
         }
     },
     "SeizeDeliveryJobsSuccessTeleportDone": {

--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsCommon.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsCommon.json
@@ -105,27 +105,7 @@
             "Node.Recognition.Succeeded": "已位于运送委托列表"
         }
     },
-    // ===== 从运送委托列表进入当前送货任务详情 =====
-    "SeizeDeliveryJobsEnterCurrentJobDetail": {
-        "desc": "从任意位置进入当前送货任务的详情界面",
-        "pre_delay": 0,
-        "anchor": {
-            "SeizeDeliveryJobsAfterEnterWulingJobList": "__SeizeDeliveryJobsReadyToViewCurrentJob"
-        },
-        "post_delay": 0,
-        "next": [
-            "SeizeDeliveryJobsEnterWulingJobList"
-        ]
-    },
-    "__SeizeDeliveryJobsReadyToViewCurrentJob": {
-        "desc": "在运送委托列表，准备查看当前任务详情",
-        "pre_delay": 0,
-        "post_delay": 0,
-        "timeout": 5000, // 断言在较短时间内可找到当前任务详情（没找到就是没接任务）
-        "next": [
-            "__SeizeDeliveryJobsViewCurrentJob"
-        ]
-    },
+    // ===== 当前送货任务识别 =====
     "__SeizeDeliveryJobsRecoViewCurrentJob": {
         "desc": "寻找查看当前任务详情按钮（仅识别）",
         "recognition": "TemplateMatch",
@@ -137,37 +117,6 @@
         ],
         "template": "SeizeDeliveryJobs/DepotNodePage/JobViewButton.png",
         "order_by": "Score"
-    },
-    "__SeizeDeliveryJobsViewCurrentJob": {
-        "desc": "在运送委托列表，点击查看当前任务详情",
-        "recognition": "TemplateMatch",
-        "roi": [
-            1170,
-            160,
-            100,
-            210
-        ], // 由于 And 模式不能正确处理 target_offset，此处直接拷贝原始识别参数
-        "template": "SeizeDeliveryJobs/DepotNodePage/JobViewButton.png",
-        // "recognition": "And",
-        // "all_of": [
-        //     "__SeizeDeliveryJobsRecoViewCurrentJob"
-        // ],
-        "order_by": "Score",
-        "action": "Click",
-        "target_offset": [
-            -50,
-            0,
-            0,
-            -10
-        ], // 点击识别位置稍左位置，并压缩点击高度，防止点到按钮外面
-        "post_wait_freezes": 500, // 等待任务详情界面弹出
-        "rate_limit": 500, // 加速等待任务详情界面弹出
-        "next": [
-            "[Anchor]SeizeDeliveryJobsAfterEnterCurrentJobDetail"
-        ],
-        "focus": {
-            "Node.Action.Starting": "打开当前任务详情"
-        }
     },
     // ===== 抢单核心识别（go 链式调用 + 价格下限过滤）=====
     "__SeizeDeliveryJobsRecoWulingToken": {

--- a/assets/tasks/DeliveryJobs.json
+++ b/assets/tasks/DeliveryJobs.json
@@ -111,7 +111,7 @@
                                 "DeliveryJobsRedistributionBidAction": "DeliveryJobsRedistributionBidNextStep",
                                 "DeliveryJobsOngoingDeliveryAction": "DeliveryJobsOpenOngoingAutoDeliveryOriginiumSciencePark",
                                 "DeliveryJobsAfterAcceptJob": "DeliveryJobsDeliverQuickly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryOriginiumSciencePark"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryOriginiumSciencePark"
                             }
                         }
                     }
@@ -282,7 +282,7 @@
                         "DeliveryJobsOriginiumScienceParkQuoteAtLeastMinimum": {
                             "anchor": {
                                 "DeliveryJobsQuoteAction": "DeliveryJobsQuoteAcceptJobOnly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryOriginiumSciencePark"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryOriginiumSciencePark"
                             }
                         }
                     }
@@ -338,7 +338,7 @@
                         "DeliveryJobsOriginiumScienceParkQuoteBelowMinimum": {
                             "anchor": {
                                 "DeliveryJobsQuoteAction": "DeliveryJobsQuoteAcceptJobOnly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryOriginiumSciencePark"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryOriginiumSciencePark"
                             }
                         }
                     }
@@ -424,7 +424,7 @@
                                 "DeliveryJobsRedistributionBidAction": "DeliveryJobsRedistributionBidNextStep",
                                 "DeliveryJobsOngoingDeliveryAction": "DeliveryJobsOpenOngoingAutoDeliveryOriginLodespring",
                                 "DeliveryJobsAfterAcceptJob": "DeliveryJobsDeliverQuickly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryOriginLodespring"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryOriginLodespring"
                             }
                         }
                     }
@@ -595,7 +595,7 @@
                         "DeliveryJobsOriginLodespringQuoteAtLeastMinimum": {
                             "anchor": {
                                 "DeliveryJobsQuoteAction": "DeliveryJobsQuoteAcceptJobOnly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryOriginLodespring"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryOriginLodespring"
                             }
                         }
                     }
@@ -651,7 +651,7 @@
                         "DeliveryJobsOriginLodespringQuoteBelowMinimum": {
                             "anchor": {
                                 "DeliveryJobsQuoteAction": "DeliveryJobsQuoteAcceptJobOnly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryOriginLodespring"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryOriginLodespring"
                             }
                         }
                     }
@@ -737,7 +737,7 @@
                                 "DeliveryJobsRedistributionBidAction": "DeliveryJobsRedistributionBidNextStep",
                                 "DeliveryJobsOngoingDeliveryAction": "DeliveryJobsOpenOngoingAutoDeliveryPowerPlateau",
                                 "DeliveryJobsAfterAcceptJob": "DeliveryJobsDeliverQuickly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryPowerPlateau"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryPowerPlateau"
                             }
                         }
                     }
@@ -908,7 +908,7 @@
                         "DeliveryJobsPowerPlateauQuoteAtLeastMinimum": {
                             "anchor": {
                                 "DeliveryJobsQuoteAction": "DeliveryJobsQuoteAcceptJobOnly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryPowerPlateau"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryPowerPlateau"
                             }
                         }
                     }
@@ -964,7 +964,7 @@
                         "DeliveryJobsPowerPlateauQuoteBelowMinimum": {
                             "anchor": {
                                 "DeliveryJobsQuoteAction": "DeliveryJobsQuoteAcceptJobOnly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryPowerPlateau"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryPowerPlateau"
                             }
                         }
                     }
@@ -1077,7 +1077,7 @@
                                 "DeliveryJobsRedistributionBidAction": "DeliveryJobsRedistributionBidNextStep",
                                 "DeliveryJobsOngoingDeliveryAction": "DeliveryJobsOpenOngoingAutoDeliveryWulingCity",
                                 "DeliveryJobsAfterAcceptJob": "DeliveryJobsDeliverQuickly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryWulingCity"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryWulingCity"
                             }
                         }
                     }
@@ -1248,7 +1248,7 @@
                         "DeliveryJobsWulingCityQuoteAtLeastMinimum": {
                             "anchor": {
                                 "DeliveryJobsQuoteAction": "DeliveryJobsQuoteAcceptJobOnly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryWulingCity"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryWulingCity"
                             }
                         }
                     }
@@ -1304,7 +1304,7 @@
                         "DeliveryJobsWulingCityQuoteBelowMinimum": {
                             "anchor": {
                                 "DeliveryJobsQuoteAction": "DeliveryJobsQuoteAcceptJobOnly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryWulingCity"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryWulingCity"
                             }
                         }
                     }
@@ -1390,7 +1390,7 @@
                                 "DeliveryJobsRedistributionBidAction": "DeliveryJobsRedistributionBidNextStep",
                                 "DeliveryJobsOngoingDeliveryAction": "DeliveryJobsOpenOngoingAutoDeliveryTestArea",
                                 "DeliveryJobsAfterAcceptJob": "DeliveryJobsDeliverQuickly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryTestArea"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryTestArea"
                             }
                         }
                     }
@@ -1561,7 +1561,7 @@
                         "DeliveryJobsTestAreaQuoteAtLeastMinimum": {
                             "anchor": {
                                 "DeliveryJobsQuoteAction": "DeliveryJobsQuoteAcceptJobOnly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryTestArea"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryTestArea"
                             }
                         }
                     }
@@ -1617,7 +1617,7 @@
                         "DeliveryJobsTestAreaQuoteBelowMinimum": {
                             "anchor": {
                                 "DeliveryJobsQuoteAction": "DeliveryJobsQuoteAcceptJobOnly",
-                                "DeliveryJobsGoToDepot": "DeliveryJobsOpenOngoingAutoDeliveryTestArea"
+                                "DeliveryJobsGoToDepot": "DeliveryJobsAutoDeliveryTestArea"
                             }
                         }
                     }

--- a/tools/pipeline-generate/DeliveryJobs/data.test.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/data.test.mjs
@@ -440,7 +440,7 @@ test("DeliveryJobs exposes automatic delivery for supported depots with shared s
             DeliveryJobsRedistributionBidAction: "DeliveryJobsRedistributionBidNextStep",
             DeliveryJobsOngoingDeliveryAction: openOngoingAutoDelivery,
             DeliveryJobsAfterAcceptJob: "DeliveryJobsDeliverQuickly",
-            DeliveryJobsGoToDepot: openOngoingAutoDelivery,
+            DeliveryJobsGoToDepot: autoDelivery,
         });
         assert.equal(ordinaryAutoOverride.AutoDeliveryOpenCurrentJobDetail, undefined);
         assert.equal(ordinaryAutoOverride.AutoDeliveryPostDepartureEntry, undefined);
@@ -457,7 +457,7 @@ test("DeliveryJobs exposes automatic delivery for supported depots with shared s
                 [`DeliveryJobs${depot.Id}Quote${comparison}`]: {
                     anchor: {
                         DeliveryJobsQuoteAction: "DeliveryJobsQuoteAcceptJobOnly",
-                        DeliveryJobsGoToDepot: openOngoingAutoDelivery,
+                        DeliveryJobsGoToDepot: autoDelivery,
                     },
                 },
             });
@@ -595,7 +595,7 @@ test("DeliveryJobs quote branches share actions with branch-specific defaults", 
                     ? [
                           {
                               DeliveryJobsQuoteAction: "DeliveryJobsQuoteAcceptJobOnly",
-                              DeliveryJobsGoToDepot: `DeliveryJobsOpenOngoingAutoDelivery${depot.Id}`,
+                              DeliveryJobsGoToDepot: `DeliveryJobsAutoDelivery${depot.Id}`,
                           },
                       ]
                     : []),
@@ -853,19 +853,34 @@ test("DeliveryJobs and SeizeDeliveryJobs compose AutoDelivery through continuati
     const seize = readGeneratedPipeline("SeizeDeliveryJobs", "AutoDeliveryAdapter.json");
     assert.equal(seize.SeizeDeliveryJobsPostProcessingEntry.anchor, undefined);
     assert.deepEqual(seize.SeizeDeliveryJobsTeleport.anchor, {
-        SeizeDeliveryJobsAfterEnterCurrentJobDetail: "AutoDelivery",
         AutoDeliveryAfterRecognizeDestination: "SeizeDeliveryJobsDeliveryCannotTeleport",
         AutoDeliveryAfterQuickTeleport: "SeizeDeliveryJobsSuccessTeleportDone",
     });
+    assert.deepEqual(seize.SeizeDeliveryJobsTeleport.next, [
+        "AutoDelivery",
+    ]);
     assert.deepEqual(seize.SeizeDeliveryJobsTeleportAndWalk.anchor, {
-        SeizeDeliveryJobsAfterEnterCurrentJobDetail: "AutoDelivery",
         AutoDeliveryAfterRecognizeDestination: "SeizeDeliveryJobsDeliveryCannotTeleport",
         AutoDeliveryAfterNavigateDepot: "SeizeDeliveryJobsSuccessWalkDone",
     });
+    assert.deepEqual(seize.SeizeDeliveryJobsTeleportAndWalk.next, [
+        "AutoDelivery",
+    ]);
     assert.deepEqual(seize.SeizeDeliveryJobsFullDelivery.anchor, {
-        SeizeDeliveryJobsAfterEnterCurrentJobDetail: "AutoDelivery",
         AutoDeliveryAfterSubmitGoods: "SeizeDeliveryJobsMain",
     });
+    assert.deepEqual(seize.SeizeDeliveryJobsFullDelivery.next, [
+        "AutoDelivery",
+    ]);
+    const seizeCommon = readGeneratedPipeline("SeizeDeliveryJobs", "SeizeDeliveryJobsCommon.json");
+    assert.notEqual(seizeCommon.__SeizeDeliveryJobsRecoViewCurrentJob, undefined);
+    for (const node of [
+        "SeizeDeliveryJobsEnterCurrentJobDetail",
+        "__SeizeDeliveryJobsReadyToViewCurrentJob",
+        "__SeizeDeliveryJobsViewCurrentJob",
+    ]) {
+        assert.equal(seizeCommon[node], undefined);
+    }
     assert.equal(seize.SeizeDeliveryJobsOpenCurrentJobForDestination, undefined);
     assert.equal(
         seize.SeizeDeliveryJobsDeliveryCannotTeleport.focus["Node.Recognition.Succeeded"],

--- a/tools/pipeline-generate/DeliveryJobs/data.test.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/data.test.mjs
@@ -861,10 +861,53 @@ test("DeliveryJobs and SeizeDeliveryJobs compose AutoDelivery through continuati
     ]);
     assert.deepEqual(seize.SeizeDeliveryJobsTeleportAndWalk.anchor, {
         AutoDeliveryAfterRecognizeDestination: "SeizeDeliveryJobsDeliveryCannotTeleport",
-        AutoDeliveryAfterNavigateDepot: "SeizeDeliveryJobsSuccessWalkDone",
+        AutoDeliveryAfterNavigateDepot: "SeizeDeliveryJobsRestoreTrackingAfterWalk",
     });
     assert.deepEqual(seize.SeizeDeliveryJobsTeleportAndWalk.next, [
         "AutoDelivery",
+    ]);
+    assert.equal(seize.SeizeDeliveryJobsRestoreTrackingAfterWalk.custom_action, "SubTask");
+    assert.deepEqual(seize.SeizeDeliveryJobsRestoreTrackingAfterWalk.custom_action_param, {
+        sub: [
+            "AutoDeliveryEnsureDeliveryMissionSelected",
+        ],
+        continue: false,
+        strict: true,
+    });
+    assert.deepEqual(seize.SeizeDeliveryJobsRestoreTrackingAfterWalk.next, [
+        "SeizeDeliveryJobsCheckDeliveryMissionTrackedAfterWalk",
+        "SeizeDeliveryJobsStartTrackingAfterWalk",
+    ]);
+    assert.deepEqual(seize.SeizeDeliveryJobsCheckDeliveryMissionTrackedAfterWalk.all_of, [
+        "AutoDeliveryInDeliveryMissionDetail",
+        "AutoDeliveryCheckCancelCurrentJobTrackingButton",
+    ]);
+    assert.deepEqual(seize.SeizeDeliveryJobsCheckDeliveryMissionTrackedAfterWalk.next, [
+        "SeizeDeliveryJobsReturnWorldAfterTracking",
+    ]);
+    assert.deepEqual(seize.SeizeDeliveryJobsStartTrackingAfterWalk.all_of, [
+        "AutoDeliveryInDeliveryMissionDetail",
+        "AutoDeliveryCheckStartTrackingButton",
+    ]);
+    assert.equal(seize.SeizeDeliveryJobsStartTrackingAfterWalk.action, "Click");
+    assert.deepEqual(seize.SeizeDeliveryJobsStartTrackingAfterWalk.next, [
+        "SeizeDeliveryJobsInDestinationMapAfterTracking",
+    ]);
+    assert.deepEqual(seize.SeizeDeliveryJobsInDestinationMapAfterTracking.all_of, [
+        "AutoDeliveryInTaskDestinationMap",
+    ]);
+    assert.deepEqual(seize.SeizeDeliveryJobsInDestinationMapAfterTracking.next, [
+        "SeizeDeliveryJobsReturnWorldAfterTracking",
+    ]);
+    assert.deepEqual(seize.SeizeDeliveryJobsReturnWorldAfterTracking.custom_action_param, {
+        sub: [
+            "SceneAnyEnterWorld",
+        ],
+        continue: false,
+        strict: true,
+    });
+    assert.deepEqual(seize.SeizeDeliveryJobsReturnWorldAfterTracking.next, [
+        "SeizeDeliveryJobsSuccessWalkDone",
     ]);
     assert.deepEqual(seize.SeizeDeliveryJobsFullDelivery.anchor, {
         AutoDeliveryAfterSubmitGoods: "SeizeDeliveryJobsMain",

--- a/tools/pipeline-generate/DeliveryJobs/depot-template.jsonc
+++ b/tools/pipeline-generate/DeliveryJobs/depot-template.jsonc
@@ -115,7 +115,7 @@
         ]
     },
     "DeliveryJobsAutoDelivery${DepotId}": {
-        "desc": "从${DepotName}当前任务详情开始全自动送货",
+        "desc": "为${DepotName}当前送货任务调用全自动送货",
         "pre_delay": 0,
         "anchor": {
             "AutoDeliveryAfterSubmitGoods": "DeliveryJobs${RegionId}Loop"

--- a/tools/pipeline-generate/DeliveryJobs/task-template.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/task-template.mjs
@@ -189,6 +189,7 @@ function buildQuoteThresholdOption(depot) {
 
 function buildQuoteActionOption(depot, {comparison, label, description, defaultCase}) {
     const comparisonNode = `DeliveryJobs${depot.Id}Quote${comparison}`;
+    const autoDelivery = `DeliveryJobsAutoDelivery${depot.Id}`;
     return {
         type: "select",
         label,
@@ -215,7 +216,7 @@ function buildQuoteActionOption(depot, {comparison, label, description, defaultC
                               [comparisonNode]: {
                                   anchor: {
                                       DeliveryJobsQuoteAction: "DeliveryJobsQuoteAcceptJobOnly",
-                                      DeliveryJobsGoToDepot: `DeliveryJobsOpenOngoingAutoDelivery${depot.Id}`,
+                                      DeliveryJobsGoToDepot: autoDelivery,
                                   },
                               },
                           },
@@ -263,7 +264,7 @@ function buildAutoDeliveryOverride(depot, {bidAction}) {
         },
         [cargoNode]: {
             enabled: true,
-            anchor: buildCargoAnchor(depot, bidAction, openOngoingAutoDelivery, openOngoingAutoDelivery),
+            anchor: buildCargoAnchor(depot, bidAction, openOngoingAutoDelivery, autoDelivery),
         },
     };
 }


### PR DESCRIPTION
## 概要

- 抢委托、转交委托接取送货任务后直接调用 `AutoDelivery`，不再重复打开任务界面
- DeliveryJobs 接单及报价分支直接进入对应仓储节点的自动送货包装节点
- “走到仓储节点”模式抵达后重新选中并追踪送货任务，确认目的地地图打开后返回大世界
- 清理不再使用的抢单任务详情入口，并同步生成模板与契约测试

## 验证

- `node --test tools/pipeline-generate/DeliveryJobs/data.test.mjs`（25/25 通过）
- 目标文件 Prettier 检查通过
- `git diff --check` 通过
- 未运行全量 `pnpm check` / `pnpm test`（本次未修改 `tests/`）

## 依赖

- Stacked on #5360
- 基准分支：`feat/auto-delivery-adb`

fixed #5154