### PR TITLE
fix: 缩小最终点击区域,防止点击到物品外

### DIFF
--- a/assets/resource/pipeline/AutoStockStaple/ValleyIV.json
+++ b/assets/resource/pipeline/AutoStockStaple/ValleyIV.json
@@ -66,9 +66,9 @@
             "type": "Click",
             "param": {
                 "target_offset": [
-                    -35,
+                    -45,
                     85,
-                    0,
+                    -30,
                     0
                 ]
             }

--- a/assets/resource/pipeline/AutoStockStaple/Wuling.json
+++ b/assets/resource/pipeline/AutoStockStaple/Wuling.json
@@ -63,9 +63,9 @@
             "type": "Click",
             "param": {
                 "target_offset": [
-                    -35,
+                    -45,
                     85,
-                    0,
+                    -30,
                     0
                 ]
             }


### PR DESCRIPTION
close #5367 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修正 Valley IV 场景中自动购买物品时的点击位置，提升交互准确性。
  - 修正 Wuling 场景中自动购买物品时的点击位置，减少点击偏移导致的操作失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->