### PR TITLE
fix:修复无法领取暂存区奖励时卡死

### DIFF
--- a/assets/resource/pipeline/DailyRewards/Emails.json
+++ b/assets/resource/pipeline/DailyRewards/Emails.json
@@ -199,6 +199,7 @@
             "param": {}
         },
         "next": [
+            "DailyEmailReceiveTSACannotClaim",
             "DailyEmailReceiveTSA"
         ],
         "focus": {
@@ -260,9 +261,41 @@
             "DailyEmailConfirmEmail"
         ]
     },
-    "DailyEmailReceiveTSA": {
+    "DailyEmailReceiveTSACannotClaim": {
+        "desc": "暂存区无法领取（灰色按钮）",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "DailyEmailReceiveTSAGrayButton",
+                    "DailyEmailReceiveTSACannotClaimText"
+                ],
+                "box_index": 1
+            }
+        },
+        "focus": {
+            "Node.Recognition.Succeeded": "无法领取"
+        }
+    },
+    "DailyEmailReceiveTSACannotClaimText": {
+        "desc": "暂存区无法领取时的按钮文本",
         "recognition": {
             "type": "OCR",
+            "param": {
+                "roi": "DailyEmailReceiveTSAGrayButton",
+                "expected": [
+                    "全部领取",
+                    "全部領取",
+                    "(?i)Claim\\s*All",
+                    "一括受取"
+                ]
+            }
+        }
+    },
+    "DailyEmailReceiveTSAGrayButton": {
+        "desc": "暂存区无法领取时的灰色按钮",
+        "recognition": {
+            "type": "ColorMatch",
             "param": {
                 "roi": [
                     497,
@@ -270,12 +303,30 @@
                     342,
                     128
                 ],
-                "expected": [
-                    "全部领取",
-                    "全部領取",
-                    "(?i)Claim\\s*All",
-                    "一括受取"
-                ]
+                "lower": [
+                    97,
+                    97,
+                    97
+                ],
+                "upper": [
+                    123,
+                    123,
+                    123
+                ],
+                "connected": true,
+                "count": 1000
+            }
+        }
+    },
+    "DailyEmailReceiveTSA": {
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "YellowConfirmButtonType1",
+                    "DailyEmailReceiveTSAText"
+                ],
+                "box_index": 1
             }
         },
         "pre_wait_freezes": 200,
@@ -286,6 +337,27 @@
         "next": [
             "DailyEmailConfirmTSA"
         ]
+    },
+    "DailyEmailReceiveTSAText": {
+        "desc": "暂存区全部领取按钮文本",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": "YellowConfirmButtonType1",
+                "roi_offset": [
+                    -106,
+                    -2,
+                    75,
+                    3
+                ],
+                "expected": [
+                    "全部领取",
+                    "全部領取",
+                    "(?i)Claim\\s*All",
+                    "一括受取"
+                ]
+            }
+        }
     },
     "DailyEmailFinish": {}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增邮件暂存区“无法领取”状态识别。
  * 增加灰色按钮、不可领取文本和可领取文本识别。
  * 可领取按钮现同时校验按钮颜色与显示文本，提升识别准确性。

* **问题修复**
  * 优化暂存区入口流程，正确处理暂时无法领取的邮件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->