### PR TITLE
refactor(Scene): 将权限等阶升级节点转为公开接口

### DIFF
--- a/assets/resource/pipeline/Interface/Scene.json
+++ b/assets/resource/pipeline/Interface/Scene.json
@@ -12,7 +12,7 @@
             "__ScenePrivateTrialOfSwordmancyEnterWorld",
             "__ScenePrivateAnyEnterWorldSuccess",
             "[JumpBack]__ScenePrivateLogin",
-            "[JumpBack]__ScenePrivateNoticeRewardsUpgrade",
+            "[JumpBack]SceneNoticeRewardsUpgrade",
             "[JumpBack]__ScenePrivateWorldSpaceExit",
             "[JumpBack]__ScenePrivateWorldStorySkip",
             "[JumpBack]__ScenePrivateLoggedOutConfirm",
@@ -141,7 +141,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "[JumpBack]__ScenePrivateNoticeRewardsUpgrade",
+            "[JumpBack]SceneNoticeRewardsUpgrade",
             "__ScenePrivateNextTrue"
         ]
     },
@@ -211,8 +211,25 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "[JumpBack]__ScenePrivateNoticeRewardsUpgrade",
+            "[JumpBack]SceneNoticeRewardsUpgrade",
             "[Anchor]SceneNoticeRewardsConfirmNextAnchor"
+        ]
+    },
+    "SceneNoticeRewardsUpgrade": {
+        "desc": "权限等阶升级界面，点击空白处关闭",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "__ScenePrivateNoticeRewardsUpgrade"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateNoticeRewardsUpgradeConfirm"
         ]
     },
     "SceneWaitLoadingExit": {

--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -843,6 +843,7 @@
         ],
         "action": "Click",
         "next": [
+            "[JumpBack]SceneNoticeRewardsUpgrade",
             "[JumpBack]SceneWaitBlackScreenLoadingExit",
             "ProtocolSpaceEnterSpaceSuccess",
             "ProtocolSpaceRewardClaimSuccessSanityLowDialog"

--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -35,6 +35,7 @@
         "post_delay": 1500, // 3D动画菜单会一直动无法用wait_freeze
         "rate_limit": 0,
         "next": [
+            "[JumpBack]SceneNoticeRewardsUpgrade",
             "__ScenePrivateAnyEnterWorldSuccess"
         ]
     },

--- a/docs/en_us/developers/scene-manager.md
+++ b/docs/en_us/developers/scene-manager.md
@@ -79,6 +79,7 @@ These node names **do not start with `__ScenePrivate`**.
 | Helper | `SceneDialogConfirm` | Click confirm button in dialogs. |
 | Helper | `SceneDialogCancel` | Click cancel button in dialogs. |
 | Helper | `SceneNoticeRewardsConfirm` | Click confirm button on rewards screens. |
+| Helper | `SceneNoticeRewardsUpgrade` | Close the Authority Level-up overlay by clicking the blank area. |
 | Helper | `SceneWaitLoadingExit` | Wait for loading screen to disappear. |
 
 ## Dijiang Depot Interfaces

--- a/docs/zh_cn/developers/scene-manager.md
+++ b/docs/zh_cn/developers/scene-manager.md
@@ -76,6 +76,7 @@ SceneManager 使用 MaaFramework 的 `[JumpBack]` 机制，将场景接口组织
 | 辅助 | `SceneDialogConfirm` | 点击对话框确认按钮 |
 | 辅助 | `SceneDialogCancel` | 点击对话框取消按钮 |
 | 辅助 | `SceneNoticeRewardsConfirm` | 点击奖励界面确认按钮 |
+| 辅助 | `SceneNoticeRewardsUpgrade` | 权限等阶升级界面，点击空白处关闭 |
 | 辅助 | `SceneWaitLoadingExit` | 等待加载界面消失 |
 
 ## 帝江号仓库接口


### PR DESCRIPTION
close #4348 

关闭升级界面的节点去掉__ScenePrivate

在万能跳转节点`__ScenePrivateMenuListEnterWorld`(从菜单总列表退出到大世界，避免电脑比较卡反复在菜单总列表和大世界之间切换)的next中添加JumpBack的权限等阶升级节点

在协议空间节点`ProtocolSpaceRewardClaimSuccessContinue`(协议空间奖励界面，继续下一轮)的next中添加JumpBack的权限等阶升级节点

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增权限等阶升级界面的处理流程，可识别升级提示并通过点击空白区域关闭。
  - 奖励领取、菜单退出及进入世界流程现可正确衔接升级提示界面。

- **文档**
  - 更新中英文开发者文档，补充该场景接口及使用说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->