### PR TITLE
fix:IMS文件损坏时候不会中断处理

### DIFF
--- a/agent/go-service/ims/add_item_data.go
+++ b/agent/go-service/ims/add_item_data.go
@@ -45,9 +45,9 @@ type addItemDataParam struct {
 // init / summary Focus is printed in either case.
 //
 // Finding no reward cards (IconRecognition no_match / grid_detection_failed)
-// is also success. A failed disk hydrate is treated like an uninitialized
-// cache: recognize and Focus, skip write, still return true. A3 must not
-// block the close-rewards next node.
+// is also success. Corrupt IMS.json is reset by ensureHydrated. Any remaining
+// hydrate error is treated like an uninitialized cache: recognize and Focus,
+// skip write, still return true. A3 must not block the close-rewards next node.
 //
 // Best practice: run as the action of a node that recognizes CloseRewardsButton,
 // then next to a Click node that closes the rewards UI.
@@ -78,8 +78,8 @@ func (a *AddItemData) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 
 	cacheReady := false
 	if err := ensureHydrated(); err != nil {
-		// A3 does not require a usable cache; a corrupt IMS.json must not
-		// block closing the rewards UI.
+		// Remaining hydrate errors (not corrupt-file, which ensureHydrated resets)
+		// must not block closing the rewards UI.
 		log.Warn().
 			Err(err).
 			Str("component", componentAddItemData).

--- a/agent/go-service/ims/storage.go
+++ b/agent/go-service/ims/storage.go
@@ -33,17 +33,21 @@ func defaultRecordPath() string {
 	return filepath.Join("debug", "record", recordFileName)
 }
 
+func emptyRecord() recordFile {
+	return recordFile{Items: map[string]int{}}
+}
+
 func loadRecord() (recordFile, error) {
 	path := recordPathFunc()
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return recordFile{Items: map[string]int{}}, nil
+			return emptyRecord(), nil
 		}
 		return recordFile{}, fmt.Errorf("read ims record: %w", err)
 	}
 	if len(raw) == 0 {
-		return recordFile{Items: map[string]int{}}, nil
+		return emptyRecord(), nil
 	}
 	var rec recordFile
 	if err := json.Unmarshal(raw, &rec); err != nil {
@@ -53,6 +57,22 @@ func loadRecord() (recordFile, error) {
 		rec.Items = map[string]int{}
 	}
 	return rec, nil
+}
+
+// resetCorruptRecord overwrites a damaged IMS.json with an empty valid snapshot.
+// Save failure is logged only: callers continue with empty in-memory cache.
+func resetCorruptRecord(cause error) {
+	path := recordPathFunc()
+	log.Warn().
+		Err(cause).
+		Str("path", path).
+		Msg("ims record corrupt, resetting file")
+	if err := saveRecord(emptyRecord()); err != nil {
+		log.Error().
+			Err(err).
+			Str("path", path).
+			Msg("failed to reset corrupt ims record, continuing with empty memory")
+	}
 }
 
 func saveRecord(rec recordFile) error {
@@ -95,6 +115,8 @@ func saveRecord(rec recordFile) error {
 
 // ensureHydrated loads debug/record/IMS.json into memory at most once per process
 // (until ClearCache). Hot-path reads stay in memory afterwards.
+// A missing or empty file is treated as an empty cache. A corrupt file is reset
+// to empty JSON so every IMS component can continue instead of failing the task.
 func ensureHydrated() error {
 	recordMu.Lock()
 	defer recordMu.Unlock()
@@ -104,7 +126,10 @@ func ensureHydrated() error {
 
 	rec, err := loadRecord()
 	if err != nil {
-		return err
+		resetCorruptRecord(err)
+		globalCache.clear()
+		hydrated = true
+		return nil
 	}
 	if !rec.UpdatedAt.IsZero() {
 		globalCache.markSynced(rec.UpdatedAt, rec.Items)

--- a/agent/go-service/ims/storage.go
+++ b/agent/go-service/ims/storage.go
@@ -13,6 +13,8 @@ import (
 
 const (
 	recordFileName = "IMS.json"
+	// Backup name is IMS.json.corrupt-<utc> beside the original file.
+	corruptRecordBackupTimeLayout = "20060102-150405.000"
 )
 
 // recordFile is the on-disk snapshot at debug/record/IMS.json.
@@ -59,20 +61,64 @@ func loadRecord() (recordFile, error) {
 	return rec, nil
 }
 
-// resetCorruptRecord overwrites a damaged IMS.json with an empty valid snapshot.
-// Save failure is logged only: callers continue with empty in-memory cache.
+// resetCorruptRecord moves a damaged IMS.json aside and writes an empty valid snapshot.
+// The original file is renamed, never deleted. Rename or save failure is logged only:
+// callers continue with empty in-memory cache and must not overwrite the old file.
 func resetCorruptRecord(cause error) {
 	path := recordPathFunc()
+	backup, err := renameCorruptRecord(path)
+	if err != nil {
+		log.Error().
+			Err(err).
+			AnErr("cause", cause).
+			Str("path", path).
+			Msg("failed to rename corrupt ims record, keeping original file, continuing with empty memory")
+		return
+	}
 	log.Warn().
 		Err(cause).
 		Str("path", path).
-		Msg("ims record corrupt, resetting file")
+		Str("backup", backup).
+		Msg("ims record corrupt, renamed old file and resetting")
 	if err := saveRecord(emptyRecord()); err != nil {
 		log.Error().
 			Err(err).
 			Str("path", path).
-			Msg("failed to reset corrupt ims record, continuing with empty memory")
+			Str("backup", backup).
+			Msg("failed to write empty ims record after rename, continuing with empty memory")
 	}
+}
+
+func renameCorruptRecord(path string) (backup string, err error) {
+	backup, err = nextCorruptBackupPath(path)
+	if err != nil {
+		return "", err
+	}
+	if err := os.Rename(path, backup); err != nil {
+		return "", fmt.Errorf("rename ims record to backup: %w", err)
+	}
+	return backup, nil
+}
+
+func nextCorruptBackupPath(path string) (string, error) {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	stamp := time.Now().UTC().Format(corruptRecordBackupTimeLayout)
+	candidate := filepath.Join(dir, base+".corrupt-"+stamp)
+	for i := 0; i < 100; i++ {
+		name := candidate
+		if i > 0 {
+			name = fmt.Sprintf("%s-%d", candidate, i)
+		}
+		_, err := os.Stat(name)
+		if os.IsNotExist(err) {
+			return name, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("stat ims corrupt backup: %w", err)
+		}
+	}
+	return "", fmt.Errorf("no free ims corrupt backup name under %s", dir)
 }
 
 func saveRecord(rec recordFile) error {
@@ -115,8 +161,8 @@ func saveRecord(rec recordFile) error {
 
 // ensureHydrated loads debug/record/IMS.json into memory at most once per process
 // (until ClearCache). Hot-path reads stay in memory afterwards.
-// A missing or empty file is treated as an empty cache. A corrupt file is reset
-// to empty JSON so every IMS component can continue instead of failing the task.
+// A missing or empty file is treated as an empty cache. A corrupt file is renamed
+// aside and replaced with empty JSON so every IMS component can continue.
 func ensureHydrated() error {
 	recordMu.Lock()
 	defer recordMu.Unlock()

--- a/agent/go-service/ims/storage_test.go
+++ b/agent/go-service/ims/storage_test.go
@@ -25,6 +25,24 @@ func withTempRecord(t *testing.T) string {
 	return path
 }
 
+func mustCorruptBackup(t *testing.T, recordPath string, want []byte) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(recordPath), "IMS.json.corrupt-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("corrupt backups=%v, want 1", matches)
+	}
+	got, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("backup %s bytes mismatch, len=%d want=%d", matches[0], len(got), len(want))
+	}
+}
+
 func TestEnsureHydratedResetsNULFile(t *testing.T) {
 	path := withTempRecord(t)
 	if err := os.WriteFile(path, make([]byte, 3354), 0o644); err != nil {
@@ -54,6 +72,7 @@ func TestEnsureHydratedResetsNULFile(t *testing.T) {
 	if err := json.Unmarshal(raw, &rec); err != nil {
 		t.Fatalf("reset file is not JSON: %v", err)
 	}
+	mustCorruptBackup(t, path, make([]byte, 3354))
 }
 
 func TestEnsureHydratedResetsInvalidJSON(t *testing.T) {
@@ -74,6 +93,7 @@ func TestEnsureHydratedResetsInvalidJSON(t *testing.T) {
 	if err := json.Unmarshal(raw, &rec); err != nil {
 		t.Fatalf("reset file is not JSON: %v", err)
 	}
+	mustCorruptBackup(t, path, []byte("{not-json"))
 }
 
 func TestEnsureHydratedKeepsValidRecord(t *testing.T) {
@@ -161,4 +181,5 @@ func TestIMSComponentsContinueAfterCorruptReset(t *testing.T) {
 	if rec.Items["item_diamond"] != 4 || rec.Items["item_originium_recharge"] != 8 {
 		t.Fatalf("rebuilt items=%v", rec.Items)
 	}
+	mustCorruptBackup(t, path, []byte("\x00\x00\x00"))
 }

--- a/agent/go-service/ims/storage_test.go
+++ b/agent/go-service/ims/storage_test.go
@@ -1,0 +1,164 @@
+package ims
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+)
+
+func withTempRecord(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "IMS.json")
+	oldPathFunc := recordPathFunc
+	recordPathFunc = func() string { return path }
+	t.Cleanup(func() {
+		recordPathFunc = oldPathFunc
+		ClearCache()
+	})
+	ClearCache()
+	return path
+}
+
+func TestEnsureHydratedResetsNULFile(t *testing.T) {
+	path := withTempRecord(t)
+	if err := os.WriteFile(path, make([]byte, 3354), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	simulateRestart()
+
+	if err := ensureHydrated(); err != nil {
+		t.Fatalf("ensureHydrated: %v", err)
+	}
+	hasData, _ := globalCache.snapshot()
+	if hasData {
+		t.Fatal("reset cache must not be marked ready")
+	}
+	if len(ItemsSnapshot()) != 0 {
+		t.Fatalf("reset cache items=%v", ItemsSnapshot())
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte{0}) {
+		t.Fatal("reset file still contains NUL")
+	}
+	var rec recordFile
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		t.Fatalf("reset file is not JSON: %v", err)
+	}
+}
+
+func TestEnsureHydratedResetsInvalidJSON(t *testing.T) {
+	path := withTempRecord(t)
+	if err := os.WriteFile(path, []byte("{not-json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	simulateRestart()
+
+	if err := ensureHydrated(); err != nil {
+		t.Fatalf("ensureHydrated: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rec recordFile
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		t.Fatalf("reset file is not JSON: %v", err)
+	}
+}
+
+func TestEnsureHydratedKeepsValidRecord(t *testing.T) {
+	path := withTempRecord(t)
+	at := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	if err := persistSynced(at, map[string]int{"item_diamond": 12}); err != nil {
+		t.Fatal(err)
+	}
+	simulateRestart()
+
+	if err := ensureHydrated(); err != nil {
+		t.Fatalf("ensureHydrated: %v", err)
+	}
+	if ItemsSnapshot()["item_diamond"] != 12 {
+		t.Fatalf("items=%v", ItemsSnapshot())
+	}
+	hasData, lastSync := globalCache.snapshot()
+	if !hasData || !lastSync.Equal(at) {
+		t.Fatalf("hasData=%v lastSync=%v", hasData, lastSync)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rec recordFile
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Items["item_diamond"] != 12 {
+		t.Fatalf("disk items=%v", rec.Items)
+	}
+}
+
+func TestIMSComponentsContinueAfterCorruptReset(t *testing.T) {
+	path := withTempRecord(t)
+	if err := os.WriteFile(path, []byte("\x00\x00\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	simulateRestart()
+
+	ready := &ItemDataReady{}
+	if _, ok := ready.Run(nil, &maa.CustomRecognitionArg{
+		CustomRecognitionParam: `{"refresh_days":7}`,
+		Roi:                    maa.Rect{0, 0, 1, 1},
+	}); ok {
+		t.Fatal("ItemDataReady should miss after reset (no_data)")
+	}
+
+	qty := &ItemQuantitySatisfied{}
+	if _, ok := qty.Run(nil, &maa.CustomRecognitionArg{
+		CustomRecognitionParam: `{"expression":"{item_diamond}>=0"}`,
+		Roi:                    maa.Rect{0, 0, 1, 1},
+	}); !ok {
+		t.Fatal("ItemQuantitySatisfied should run against empty reset cache")
+	}
+
+	upd := &UpdateItemQuantity{}
+	if !upd.Run(nil, &maa.CustomActionArg{
+		CustomActionParam: `{"item":"item_diamond","delta":4}`,
+	}) {
+		t.Fatal("UpdateItemQuantity should succeed after reset")
+	}
+	if got := globalCache.quantity("item_diamond"); got != 4 {
+		t.Fatalf("quantity=%d", got)
+	}
+
+	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	if err := persistSynced(at, map[string]int{"item_diamond": 4, "item_originium_recharge": 8}); err != nil {
+		t.Fatal(err)
+	}
+	hasData, _ := globalCache.snapshot()
+	if !hasData {
+		t.Fatal("A2 persist after reset should mark cache ready")
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rec recordFile
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		t.Fatalf("rebuilt file is not JSON: %v", err)
+	}
+	if rec.Items["item_diamond"] != 4 || rec.Items["item_originium_recharge"] != 8 {
+		t.Fatalf("rebuilt items=%v", rec.Items)
+	}
+}

--- a/agent/go-service/ims/update_item_quantity.go
+++ b/agent/go-service/ims/update_item_quantity.go
@@ -98,9 +98,11 @@ func persistItemsPreserveSync(items map[string]int, lastSync time.Time, hasData 
 	if !hasData || updatedAt.IsZero() {
 		rec, err := loadRecord()
 		if err != nil {
-			return err
-		}
-		if !rec.UpdatedAt.IsZero() {
+			log.Warn().
+				Err(err).
+				Str("component", componentUpdateItemQuantity).
+				Msg("ims record corrupt while preserving sync timestamp, ignoring old timestamp")
+		} else if !rec.UpdatedAt.IsZero() {
 			updatedAt = rec.UpdatedAt
 		}
 	}


### PR DESCRIPTION
close #5384 
A2在关闭通知时会静默处理任何错误
所有IMS组件在遇到文件损坏时会尝试重置文件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IMS 存储文件损坏或包含无效内容时会自动备份并重置为空记录，避免阻塞相关流程。
  * 损坏数据恢复后，系统可继续识别项目、更新缓存并重新保存有效数据。
  * 有效记录中的更新时间信息会继续保留。
  * 备份或重置过程中发生异常时，将保留原始文件并记录错误。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->