### PR TITLE
fix(icon-recognition): 修正库存转移网格定位偏移

### DIFF
--- a/agent/cpp-algo/source/IconRecognition/detail/GridAnchors.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/GridAnchors.cpp
@@ -297,7 +297,8 @@ std::optional<RegularAxisFit>
                 consistent,
                 maximum_count,
                 { static_cast<double>(profile.pitch_min), static_cast<double>(profile.pitch_max) },
-                profile.preferred_pitch);
+                profile.preferred_pitch,
+                profile.observed_pitch_tolerance);
             if (!fit) {
                 continue;
             }

--- a/agent/cpp-algo/source/IconRecognition/detail/GridDetector.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/GridDetector.cpp
@@ -1651,7 +1651,8 @@ GridLayout BuildTransferLayout(const cv::Mat& image, const cv::Rect& roi, const 
             observations,
             maximum_count,
             { static_cast<double>(profile.pitch_min), static_cast<double>(profile.pitch_max) },
-            profile.preferred_pitch);
+            profile.preferred_pitch,
+            profile.observed_pitch_tolerance);
     };
     const auto final_x_axis = fit_final_axis(local_x, std::max(1, static_cast<int>(local_x.size())));
     const auto final_y_axis = fit_final_axis(local_y, profile.maximum_rows);

--- a/agent/cpp-algo/source/IconRecognition/detail/GridProfiles.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/GridProfiles.cpp
@@ -178,6 +178,11 @@ double ForegroundTextureCoverage(const cv::Mat& crop, const TransferHypothesis& 
     return total_cells == 0 ? 0.0 : static_cast<double>(textured_cells) / total_cells;
 }
 
+int formal_axis_capacity(int length)
+{
+    return std::max(1, (length - kBaseTransferProfile.cell_size) / kBaseTransferProfile.pitch_min + 1);
+}
+
 std::vector<Peak> local_peaks(const cv::Mat& score, int maximum)
 {
     if (score.empty()) {
@@ -457,8 +462,8 @@ std::vector<cv::Rect> discover_transfer_regions(const cv::Mat& crop)
 
 std::optional<TransferHypothesis> select_grid_hypothesis(const cv::Mat& crop, bool require_texture)
 {
-    const int maximum_columns = std::max(1, (crop.cols - kBaseTransferProfile.cell_size) / kBaseTransferProfile.pitch_min + 1);
-    const int maximum_rows = std::max(1, (crop.rows - kBaseTransferProfile.cell_size) / kBaseTransferProfile.pitch_min + 1);
+    const int maximum_columns = formal_axis_capacity(crop.cols);
+    const int maximum_rows = formal_axis_capacity(crop.rows);
     const auto candidates = [&](int minimum) {
         std::vector<TransferHypothesis> filtered;
         for (const auto& item :
@@ -765,13 +770,18 @@ std::vector<TransferGridHint> DiscoverTransferGridHints(const cv::Mat& crop, boo
     std::vector<TransferGridHint> hints;
     for (const auto& raw_region : regions) {
         const cv::Rect region(raw_region.x, 0, raw_region.width, crop.rows);
+        const int maximum_columns = formal_axis_capacity(region.width);
+        const int maximum_rows = formal_axis_capacity(region.height);
         std::vector<TransferGridHint> candidates;
         if (const auto local = select_grid_hypothesis(crop(region), structural_rank)) {
             candidates.push_back(to_hint(*local, region, region.x));
         }
         for (const auto& hypothesis : broad) {
+            // broad 的宽 pitch 范围只负责召回；候选数量仍须能按正式 pitch 落入当前单侧区域。
             if ((!structural_rank || !broad_has_texture_evidence
-                 || hypothesis.foreground_texture_coverage >= kMinimumSparseTransferTextureCoverage)
+                  || hypothesis.foreground_texture_coverage >= kMinimumSparseTransferTextureCoverage)
+                && hypothesis.columns <= std::min(kTransferMaximumColumns, maximum_columns)
+                && hypothesis.rows <= std::min(kBaseTransferProfile.maximum_rows, maximum_rows)
                 && hypothesis.rect.x >= region.x && hypothesis.rect.x + hypothesis.rect.width <= region.x + region.width) {
                 candidates.push_back(to_hint(hypothesis, region, 0));
             }

--- a/agent/cpp-algo/source/IconRecognition/detail/RegularLattice.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/RegularLattice.cpp
@@ -59,7 +59,8 @@ std::optional<RegularAxisFit> FitCandidate(
     double coarse_pitch,
     int maximum_count,
     std::pair<double, double> pitch_range,
-    double preferred_pitch)
+    double preferred_pitch,
+    double observed_pitch_tolerance)
 {
     std::vector<int> indices;
     indices.reserve(observations.size());
@@ -103,10 +104,13 @@ std::optional<RegularAxisFit> FitCandidate(
     if (denominator <= std::numeric_limits<double>::epsilon()) {
         return std::nullopt;
     }
-    const double pitch = numerator / denominator;
-    if (pitch < pitch_range.first || pitch > pitch_range.second) {
+    const double observed_pitch = numerator / denominator;
+    if (observed_pitch < pitch_range.first - observed_pitch_tolerance
+        || observed_pitch > pitch_range.second + observed_pitch_tolerance) {
         return std::nullopt;
     }
+    // 观测间距允许像素量化误差，但输出轴必须保持在正式 pitch 范围内。
+    const double pitch = std::clamp(observed_pitch, pitch_range.first, pitch_range.second);
     const double origin = mean_position - mean_index * pitch;
 
     double weighted_residual = 0.0;
@@ -165,7 +169,8 @@ std::optional<RegularAxisFit> FitRegularAxis(
     const std::vector<LatticeObservation>& source,
     int maximum_count,
     std::pair<double, double> pitch_range,
-    double preferred_pitch)
+    double preferred_pitch,
+    double observed_pitch_tolerance)
 {
     const auto observations = NormalizeObservations(source);
     if (observations.empty() || maximum_count <= 0 || pitch_range.first <= 0.0 || pitch_range.second < pitch_range.first) {
@@ -195,7 +200,8 @@ std::optional<RegularAxisFit> FitRegularAxis(
     };
     for (double pitch = pitch_range.first; pitch <= pitch_range.second + kPitchLoopEpsilon; pitch += kPitchStep) {
         for (const auto& seed : observations) {
-            const auto candidate = FitCandidate(observations, seed.position, pitch, maximum_count, pitch_range, preferred_pitch);
+            const auto candidate =
+                FitCandidate(observations, seed.position, pitch, maximum_count, pitch_range, preferred_pitch, observed_pitch_tolerance);
             if (!candidate) {
                 continue;
             }

--- a/agent/cpp-algo/source/IconRecognition/detail/RegularLattice.h
+++ b/agent/cpp-algo/source/IconRecognition/detail/RegularLattice.h
@@ -38,7 +38,8 @@ std::optional<RegularAxisFit> FitRegularAxis(
     const std::vector<LatticeObservation>& observations,
     int maximum_count,
     std::pair<double, double> pitch_range,
-    double preferred_pitch);
+    double preferred_pitch,
+    double observed_pitch_tolerance = 0.0);
 std::vector<int> ProjectRegularAxis(const RegularAxisFit& fit);
 
 } // namespace iconrecognition::detail

--- a/agent/cpp-algo/source/IconRecognition/detail/TrustedRarity.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/TrustedRarity.cpp
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <numeric>
+#include <optional>
 #include <tuple>
 
 #include "RarityClassifier.h"
@@ -72,18 +74,35 @@ cv::Vec3d MeanLab(const cv::Mat& lab, const cv::Rect& box, const cv::Mat& mask =
     return { mean[0], mean[1], mean[2] };
 }
 
+struct HorizontalRun
+{
+    int x = 0;
+    int width = 0;
+};
+
+std::optional<HorizontalRun> LongestHorizontalRun(const cv::Mat& mask, int y, int x_begin, int x_end)
+{
+    std::optional<HorizontalRun> best;
+    int run_begin = x_begin;
+    for (int x = x_begin; x <= x_end; ++x) {
+        const bool covered = x < x_end && mask.at<unsigned char>(y, x) != 0;
+        if (covered) {
+            continue;
+        }
+        if (x > run_begin && (!best || x - run_begin > best->width)) {
+            best = HorizontalRun { .x = run_begin, .width = x - run_begin };
+        }
+        run_begin = x + 1;
+    }
+    return best;
+}
+
 double LongestRunRatio(const cv::Mat& mask, const cv::Rect& box)
 {
     int longest = 0;
     for (int y = box.y; y < box.y + box.height; ++y) {
-        int current = 0;
-        for (int x = box.x; x < box.x + box.width; ++x) {
-            if (mask.at<unsigned char>(y, x) != 0) {
-                longest = std::max(longest, ++current);
-            }
-            else {
-                current = 0;
-            }
+        if (const auto run = LongestHorizontalRun(mask, y, box.x, box.x + box.width)) {
+            longest = std::max(longest, run->width);
         }
     }
     return static_cast<double>(longest) / box.width;
@@ -138,53 +157,91 @@ std::vector<TrustedRarityStrip> DetectTrustedRarityStrips(const cv::Mat& image, 
         cv::Mat centroids;
         const int components = cv::connectedComponentsWithStats(connected, labels, stats, centroids, 8, CV_32S);
         for (int component = 1; component < components; ++component) {
-            const cv::Rect box(
+            const cv::Rect component_box(
                 stats.at<int>(component, cv::CC_STAT_LEFT),
                 stats.at<int>(component, cv::CC_STAT_TOP),
                 stats.at<int>(component, cv::CC_STAT_WIDTH),
                 stats.at<int>(component, cv::CC_STAT_HEIGHT));
-            if (box.width < minimum_width || box.width > maximum_width || box.height < kMinimumThickness
-                || box.height > kMaximumThickness) {
+            // 组件可能被同色数字向上或向下粘连，先只按宽度排除不可能的短横线；
+            // 高度和上限在提取水平核心后再判断，避免杂点把真实色带提前过滤掉。
+            if (component_box.width < minimum_width) {
                 continue;
             }
-            const double coverage = static_cast<double>(cv::countNonZero(mask(box))) / box.area();
-            const double continuity = LongestRunRatio(mask, box);
-            const auto backgrounds = BackgroundBoxes(box, lab.size());
-            if (backgrounds.empty()) {
-                continue;
+
+            // 数字等同色杂点可能与色带连成一个组件；只保留达到单格宽度的水平核心行，
+            // 再用核心行重建色带框，避免杂点扩大高度并稀释颜色覆盖率。
+            struct CoreRun
+            {
+                int y = 0;
+                HorizontalRun run;
+            };
+            std::vector<CoreRun> core_runs;
+            for (int y = component_box.y; y < component_box.y + component_box.height; ++y) {
+                if (const auto run = LongestHorizontalRun(mask, y, component_box.x, component_box.x + component_box.width)) {
+                    if (run->width >= minimum_width) {
+                        core_runs.push_back({ y, *run });
+                    }
+                }
             }
-            const cv::Vec3d strip_mean = MeanLab(lab, box, mask);
-            std::vector<double> deltas;
-            for (const cv::Rect& background : backgrounds) {
-                deltas.push_back(cv::norm(strip_mean - MeanLab(lab, background)));
+            for (std::size_t begin = 0; begin < core_runs.size();) {
+                std::size_t end = begin + 1;
+                const int first_y = core_runs[begin].y;
+                while (end < core_runs.size() && core_runs[end].y == core_runs[end - 1].y + 1) {
+                    ++end;
+                }
+                const int top = first_y;
+                const int bottom = core_runs[end - 1].y + 1;
+                int left = std::numeric_limits<int>::max();
+                int right = std::numeric_limits<int>::min();
+                for (std::size_t index = begin; index < end; ++index) {
+                    left = std::min(left, core_runs[index].run.x);
+                    right = std::max(right, core_runs[index].run.x + core_runs[index].run.width);
+                }
+                const cv::Rect box(left, top, right - left, bottom - top);
+                if (box.width > maximum_width || box.height < kMinimumThickness || box.height > kMaximumThickness) {
+                    begin = end;
+                    continue;
+                }
+                const double coverage = static_cast<double>(cv::countNonZero(mask(box))) / box.area();
+                const double continuity = LongestRunRatio(mask, box);
+                const auto backgrounds = BackgroundBoxes(box, lab.size());
+                if (backgrounds.empty()) {
+                    begin = end;
+                    continue;
+                }
+                const cv::Vec3d strip_mean = MeanLab(lab, box, mask);
+                std::vector<double> deltas;
+                for (const cv::Rect& background : backgrounds) {
+                    deltas.push_back(cv::norm(strip_mean - MeanLab(lab, background)));
+                }
+                const double background_delta = std::accumulate(deltas.begin(), deltas.end(), 0.0) / static_cast<double>(deltas.size());
+                const double edge_response = *std::ranges::min_element(deltas);
+                const bool trusted = coverage >= kMinimumCoverage && continuity >= kMinimumContinuity
+                                     && background_delta >= kMinimumBackgroundDelta && edge_response >= kMinimumEdgeResponse;
+                if (trusted) {
+                    double confidence =
+                        kCoverageConfidenceWeight * coverage + kContinuityConfidenceWeight * continuity
+                        + kBackgroundConfidenceWeight * Clamp01(background_delta / kBackgroundDeltaScale)
+                        + kEdgeConfidenceWeight * Clamp01(edge_response / kEdgeResponseScale)
+                        + kThicknessConfidenceWeight * Clamp01(1.0 - std::abs(box.height - kExpectedThickness) / kThicknessDeviationScale);
+                    if (backgrounds.size() == 1) {
+                        confidence *= kSingleBackgroundPenalty;
+                    }
+                    candidates.push_back(TrustedRarityStrip {
+                        .box = box,
+                        .rarity = static_cast<int>(prototype_index + 1),
+                        .color_coverage = coverage,
+                        .continuity = continuity,
+                        .background_delta = background_delta,
+                        .edge_response = edge_response,
+                        .thickness = box.height,
+                        .confidence = confidence,
+                        .trusted = true,
+                        .can_seed_lattice = prototype_index != 0,
+                    });
+                }
+                begin = end;
             }
-            const double background_delta = std::accumulate(deltas.begin(), deltas.end(), 0.0) / static_cast<double>(deltas.size());
-            const double edge_response = *std::ranges::min_element(deltas);
-            const bool trusted = coverage >= kMinimumCoverage && continuity >= kMinimumContinuity
-                                 && background_delta >= kMinimumBackgroundDelta && edge_response >= kMinimumEdgeResponse;
-            if (!trusted) {
-                continue;
-            }
-            double confidence =
-                kCoverageConfidenceWeight * coverage + kContinuityConfidenceWeight * continuity
-                + kBackgroundConfidenceWeight * Clamp01(background_delta / kBackgroundDeltaScale)
-                + kEdgeConfidenceWeight * Clamp01(edge_response / kEdgeResponseScale)
-                + kThicknessConfidenceWeight * Clamp01(1.0 - std::abs(box.height - kExpectedThickness) / kThicknessDeviationScale);
-            if (backgrounds.size() == 1) {
-                confidence *= kSingleBackgroundPenalty;
-            }
-            candidates.push_back(TrustedRarityStrip {
-                .box = box,
-                .rarity = static_cast<int>(prototype_index + 1),
-                .color_coverage = coverage,
-                .continuity = continuity,
-                .background_delta = background_delta,
-                .edge_response = edge_response,
-                .thickness = box.height,
-                .confidence = confidence,
-                .trusted = true,
-                .can_seed_lattice = prototype_index != 0,
-            });
         }
     }
 

--- a/agent/cpp-algo/source/IconRecognition/docs/testing.md
+++ b/agent/cpp-algo/source/IconRecognition/docs/testing.md
@@ -2,6 +2,7 @@
 
 公开测试入口位于 `agent/cpp-algo/source/IconRecognition/test/`。CMake、C++ 测试、`run-tests.ps1`、`dataset-manifest.psd1` 和 `run-tests.local.example.psd1` 随 Git 提交；以下内容只用于本机测试并被忽略：
 
+- `input/<网格类型>/*.png`：叠加到所选 Win32/ADB 数据集的临时人工测试截图；
 - `input/expected.csv`：显式传入 `-UseLocalExpected` 时使用的候选校验基线；
 - `output/`：标注图、detail JSON 和报告；
 - `build/`：CMake 构建目录；
@@ -12,11 +13,20 @@
 - `win32`：读取子模块 `tests/MaaEndTestset/Win32/Official_CN/IconRecognition`；
 - `adb`：读取子模块 `tests/MaaEndTestset/ADB/Official_CN/IconRecognition`。
 
-每套目录分别维护截图、`rois.json` 和 `expected.csv`。`manual` 必须显式指定 `-Dataset win32` 或 `-Dataset adb`，两套资源不会混入同一次运行。`quick` 是干净 checkout 可运行的仓库门禁：它先校验 `dataset-manifest.psd1`，再分别运行两套数据集的典型图片，不叠加本地 fixture。数据集资源或典型图片缺失会直接失败。
+每套目录分别维护截图、`rois.json` 和 `expected.csv`。`manual` 必须显式指定 `-Dataset win32` 或 `-Dataset adb`，两套正式资源不会混入同一次运行；`test/input/` 中的临时图片只在 `manual` 中叠加，并使用所选数据集的 ROI 与控制器基准。`quick` 是干净 checkout 可运行的仓库门禁：它先校验 `dataset-manifest.psd1`，再分别运行两套数据集的典型图片，不叠加本地 fixture。数据集资源或典型图片缺失会直接失败。
 
 ## 准备图片
 
-1. 把 1280x720 测试截图放入对应数据集的 IconRecognition 网格目录：
+临时人工测试时，把 1280x720 截图放入本地忽略目录：
+
+```text
+agent/cpp-algo/source/IconRecognition/test/input/
+└── transfer/sample.png
+```
+
+然后通过 `-Dataset win32` 或 `-Dataset adb` 选择与截图匹配的 ROI 和控制器基准，并通过 `-GridType` 指定本地图片所属的网格类型。显式 `-Image sample.png` 命中本地图时，本地图优先于数据集中的同名图片，且默认不校验正式 `expected.csv`。
+
+需要纳入正式回归时，再把截图放入对应数据集的 IconRecognition 网格目录：
 
 ```text
 tests/MaaEndTestset/<Win32|ADB>/Official_CN/IconRecognition/
@@ -67,6 +77,7 @@ tests/MaaEndTestset/<Win32|ADB>/Official_CN/IconRecognition/
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset win32 -All
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset adb -All
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset adb -GridType transfer
+./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset win32 -GridType transfer -Image sample.png -Side full
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset adb -GridType transfer -Image sample.png -Side all
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset win32 -GridType transfer -Side all -Jobs 16
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset adb -Image sample.png
@@ -74,7 +85,7 @@ tests/MaaEndTestset/<Win32|ADB>/Official_CN/IconRecognition/
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset win32 -All -RecognizeRegionUnavailable
 ```
 
-Win32 与 ADB manual 默认读取各自子模块中的 `expected.csv`，并始终显式传入各自的 `rois.json`。只有显式传入 `-UseLocalExpected` 时，才改用 `test/input/expected.csv`；本地 CSV 不与 tracked CSV 叠加，也不会被复制进图片输入树。可从所选数据集的当前基线和一次人工运行报告生成候选文件：
+Win32 与 ADB manual 始终显式传入各自的 `rois.json`。正式数据集图片默认读取对应子模块中的 `expected.csv`；显式 `-Image` 命中 `test/input/` 本地图片时默认仅作人工审核，不传 expected。只有显式传入 `-UseLocalExpected` 时，才使用 `test/input/expected.csv`；本地 CSV 不与 tracked CSV 叠加，也不会被复制进图片输入树。可从所选数据集的当前基线和一次人工运行报告生成候选文件：
 
 ```powershell
 python tools/icon_recognition/expected.py `
@@ -153,7 +164,7 @@ python tools/icon_recognition/expected.py `
 
 ## 图像回归门槛
 
-截图回归通过 `manual` runner 执行。runner 只扫描所选数据集中的 `<网格类型>/` 图片，文件名只是输入标识，不参与生产判断，也不对应隐藏的 C++ 固定断言。需要复核某个算法场景时，应在报告或 PR 说明中记录数据集、图片相对路径、ROI、预期现象和实际结果；quick 只保留上面列出的少量典型样本，不要把本地任意图片编号写入测试代码。
+截图回归通过 `manual` runner 执行。runner 扫描所选数据集与本地 `input/` 合并后的 `<网格类型>/` 图片；本地图片不会进入 `quick`。文件名只是输入标识，不参与生产判断，也不对应隐藏的 C++ 固定断言。需要复核某个算法场景时，应在报告或 PR 说明中记录数据集、图片相对路径、ROI、预期现象和实际结果；quick 只保留上面列出的少量典型样本，不要把本地任意图片编号写入测试代码。
 
 回归审核至少覆盖：
 

--- a/agent/cpp-algo/source/IconRecognition/docs/testing.md
+++ b/agent/cpp-algo/source/IconRecognition/docs/testing.md
@@ -80,7 +80,7 @@ tests/MaaEndTestset/<Win32|ADB>/Official_CN/IconRecognition/
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset win32 -GridType transfer -Image sample.png -Side full
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset adb -GridType transfer -Image sample.png -Side all
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset win32 -GridType transfer -Side all -Jobs 16
-./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset adb -Image sample.png
+./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset adb -GridType transfer -Image sample.png
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset adb -GridType rewards -UseLocalExpected
 ./agent/cpp-algo/source/IconRecognition/test/run-tests.ps1 -Task manual -Dataset win32 -All -RecognizeRegionUnavailable
 ```

--- a/agent/cpp-algo/source/IconRecognition/test/run-tests.ps1
+++ b/agent/cpp-algo/source/IconRecognition/test/run-tests.ps1
@@ -29,6 +29,7 @@ $buildRoot = Join-Path $cppAlgoRoot "build"
 $testBuildRoot = Join-Path $buildRoot "source/IconRecognition/test"
 $mergedInputRoot = Join-Path $testBuildRoot "merged-input"
 $datasetManifestPath = Join-Path $testRoot "dataset-manifest.psd1"
+$localInputRoot = Join-Path $testRoot "input"
 $localExpectedPath = Join-Path $testRoot "input/expected.csv"
 $gridTypes = @(
     "trade",
@@ -61,8 +62,18 @@ function Show-Usage {
   trade, transfer, port_storager, valuables, shipment, credit_trade, rewards, single_roi
 
 Side 仅用于 transfer 和 port_storager；默认使用 full。
+显式选择 test/input 中的本地图片时必须同时指定 GridType。
 Jobs 的命令行参数优先于本机配置；未配置时使用 1。
 "@
+}
+
+function Exit-NativeCommandFailure {
+    param(
+        [Parameter(Mandatory)] [string]$Message,
+        [Parameter(Mandatory)] [int]$ExitCode
+    )
+    [Console]::Error.WriteLine("$Message，退出码: $ExitCode")
+    exit $ExitCode
 }
 
 if ($Help -or $PSBoundParameters.Count -eq 0) {
@@ -122,8 +133,9 @@ if ($VsDevShellPath) {
 function Invoke-CMake {
     param([string[]]$Arguments)
     & $CMakePath @Arguments
-    if ($LASTEXITCODE -ne 0) {
-        throw "CMake 执行失败，退出码: $LASTEXITCODE"
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        Exit-NativeCommandFailure -Message "CMake 执行失败" -ExitCode $exitCode
     }
 }
 
@@ -147,11 +159,14 @@ function Build-Targets {
 function Copy-InputTree {
     param(
         [Parameter(Mandatory)] [string]$SourceRoot,
-        [Parameter(Mandatory)] [string]$DestinationRoot
+        [Parameter(Mandatory)] [string]$DestinationRoot,
+        [switch]$PreferLocalConflicts,
+        [switch]$MarkAsLocal
     )
     if (-not (Test-Path -LiteralPath $SourceRoot -PathType Container)) {
         return
     }
+    $overwritten = [System.Collections.Generic.List[string]]::new()
     foreach ($file in Get-ChildItem -LiteralPath $SourceRoot -Recurse -File) {
         $relative = $file.FullName.Substring($SourceRoot.Length).TrimStart('\', '/')
         # expected.csv 是独立校验基线，只能通过显式 --expected 参数选择，不能混入图片输入树。
@@ -161,7 +176,39 @@ function Copy-InputTree {
         $destination = Join-Path $DestinationRoot $relative
         $destinationDirectory = Split-Path -Parent $destination
         New-Item -ItemType Directory -Path $destinationDirectory -Force | Out-Null
+        if ($MarkAsLocal) {
+            $base = [System.IO.Path]::GetFileNameWithoutExtension($destination)
+            $extension = [System.IO.Path]::GetExtension($destination)
+            $directory = Split-Path -Parent $destination
+            $suffix = 1
+            do {
+                $candidate = Join-Path $directory "$base.local$suffix$extension"
+                $suffix++
+            } while (Test-Path -LiteralPath $candidate -PathType Leaf)
+            $destination = $candidate
+        }
+        elseif (Test-Path -LiteralPath $destination -PathType Leaf) {
+            if ($PreferLocalConflicts) {
+                $overwritten.Add($relative)
+            }
+            else {
+                $base = [System.IO.Path]::GetFileNameWithoutExtension($destination)
+                $extension = [System.IO.Path]::GetExtension($destination)
+                $directory = Split-Path -Parent $destination
+                $suffix = 1
+                do {
+                    $candidate = Join-Path $directory "$base.local$suffix$extension"
+                    $suffix++
+                } while (Test-Path -LiteralPath $candidate -PathType Leaf)
+                $destination = $candidate
+            }
+        }
         Copy-Item -LiteralPath $file.FullName -Destination $destination -Force
+    }
+    if ($overwritten.Count -gt 0) {
+        $examples = @($overwritten | Select-Object -First 5) -join ", "
+        $suffix = if ($overwritten.Count -gt 5) { " 等" } else { "" }
+        Write-Warning "本地测试素材覆盖了 $($overwritten.Count) 个数据集同名文件: $examples$suffix"
     }
 }
 
@@ -193,6 +240,46 @@ function Prepare-DatasetInput {
     New-Item -ItemType Directory -Path $mergedInputRoot -Force | Out-Null
     Copy-InputTree -SourceRoot $paths.Root -DestinationRoot $mergedInputRoot
     return $paths
+}
+
+function Copy-LocalInputTrees {
+    param([switch]$PreferLocalConflicts)
+    foreach ($gridType in $gridTypes) {
+        Copy-InputTree `
+            -SourceRoot (Join-Path $localInputRoot $gridType) `
+            -DestinationRoot (Join-Path $mergedInputRoot $gridType) `
+            -PreferLocalConflicts:$PreferLocalConflicts `
+            -MarkAsLocal:$(-not $PreferLocalConflicts)
+    }
+}
+
+function Prepare-ManualInput {
+    param(
+        [Parameter(Mandatory)] [ValidateSet("win32", "adb")] [string]$Name,
+        [switch]$PreferLocalConflicts
+    )
+    $paths = Prepare-DatasetInput -Name $Name
+    Copy-LocalInputTrees -PreferLocalConflicts:$PreferLocalConflicts
+    return $paths
+}
+
+function Test-LocalImageSelection {
+    param(
+        [Parameter(Mandatory)] [string]$ImageName,
+        [string]$SelectedGridType
+    )
+    $selectedGridTypes = if ($SelectedGridType) { @($SelectedGridType) } else { $gridTypes }
+    foreach ($gridType in $selectedGridTypes) {
+        $localGridRoot = Join-Path $localInputRoot $gridType
+        if (-not (Test-Path -LiteralPath $localGridRoot -PathType Container)) {
+            continue
+        }
+        $match = Get-ChildItem -LiteralPath $localGridRoot -Recurse -File | Where-Object { $_.Name -eq $ImageName } | Select-Object -First 1
+        if ($null -ne $match) {
+            return $true
+        }
+    }
+    return $false
 }
 
 function Prepare-QuickDatasetInput {
@@ -252,8 +339,9 @@ function Invoke-QuickDataset {
         --recognize-region-unavailable `
         --expected $DatasetPaths.ExpectedPath `
         --rois $DatasetPaths.RoisPath
-    if ($LASTEXITCODE -ne 0) {
-        throw "quick 数据集回归失败: $($DatasetPaths.Name)，退出码: $LASTEXITCODE"
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        Exit-NativeCommandFailure -Message "quick 数据集回归失败: $($DatasetPaths.Name)" -ExitCode $exitCode
     }
 }
 
@@ -301,8 +389,9 @@ switch ($Task) {
             "icon-recognition-expected-tests"
         )) {
             & (Find-TestExecutable -Name $name)
-            if ($LASTEXITCODE -ne 0) {
-                throw "$name 执行失败，退出码: $LASTEXITCODE"
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -ne 0) {
+                Exit-NativeCommandFailure -Message "$name 执行失败" -ExitCode $exitCode
             }
         }
         foreach ($datasetName in @("win32", "adb")) {
@@ -322,7 +411,15 @@ switch ($Task) {
             Show-Usage
             throw "manual 任务必须指定 -All、-GridType 或 -Image。"
         }
-        $datasetPaths = Prepare-DatasetInput -Name $Dataset
+        $usesLocalImage = $PSBoundParameters.ContainsKey("Image") -and `
+            (Test-LocalImageSelection -ImageName $Image -SelectedGridType $GridType)
+        if ($usesLocalImage -and -not $GridType) {
+            throw "显式选择 test/input 中的本地图片时必须同时指定 -GridType。"
+        }
+        $datasetPaths = Prepare-ManualInput -Name $Dataset -PreferLocalConflicts:($usesLocalImage -or $UseLocalExpected)
+        if ($usesLocalImage) {
+            Write-Warning "显式 -Image 命中本地 input 素材，本次优先使用本地同名图片: $Image"
+        }
         Build-Targets -Targets @("icon-recognition-manual-runner")
         Set-TestRuntimePath
         $arguments = @()
@@ -350,17 +447,23 @@ switch ($Task) {
         }
         $arguments += @("--rois", $datasetPaths.RoisPath)
         if ($Side -eq "full") {
-            $arguments += @(
-                "--expected",
-                (Resolve-ExpectedResultsPath -DatasetPaths $datasetPaths -UseLocal:$UseLocalExpected)
-            )
+            if ($UseLocalExpected -or -not $usesLocalImage) {
+                $arguments += @(
+                    "--expected",
+                    (Resolve-ExpectedResultsPath -DatasetPaths $datasetPaths -UseLocal:$UseLocalExpected)
+                )
+            }
+            else {
+                Write-Warning "显式本地图片未启用 expected 校验，本次仅作人工审核: $Image"
+            }
         }
-        elseif ($Side -ne "full") {
+        else {
             Write-Warning "expected.csv 仅维护 full 基线，显式分侧运行仅作人工审计: $Side"
         }
         & (Find-TestExecutable -Name "icon-recognition-manual-runner") @arguments
-        if ($LASTEXITCODE -ne 0) {
-            throw "icon-recognition-manual-runner 执行失败，退出码: $LASTEXITCODE"
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            Exit-NativeCommandFailure -Message "icon-recognition-manual-runner 执行失败" -ExitCode $exitCode
         }
     }
 }

--- a/agent/cpp-algo/source/IconRecognition/test/run-tests.ps1
+++ b/agent/cpp-algo/source/IconRecognition/test/run-tests.ps1
@@ -168,6 +168,13 @@ function Copy-InputTree {
     }
     $overwritten = [System.Collections.Generic.List[string]]::new()
     foreach ($file in Get-ChildItem -LiteralPath $SourceRoot -Recurse -File) {
+        # MarkAsLocal 下由 PNG 统一复制同 stem JSON，确保两者始终使用相同的 .localN。
+        if ($MarkAsLocal -and $file.Extension -ieq ".json") {
+            $sourceImage = [System.IO.Path]::ChangeExtension($file.FullName, ".png")
+            if (Test-Path -LiteralPath $sourceImage -PathType Leaf) {
+                continue
+            }
+        }
         $relative = $file.FullName.Substring($SourceRoot.Length).TrimStart('\', '/')
         # expected.csv 是独立校验基线，只能通过显式 --expected 参数选择，不能混入图片输入树。
         if ($relative -eq "expected.csv") {
@@ -180,11 +187,22 @@ function Copy-InputTree {
             $base = [System.IO.Path]::GetFileNameWithoutExtension($destination)
             $extension = [System.IO.Path]::GetExtension($destination)
             $directory = Split-Path -Parent $destination
+            $sourceSidecar = if ($file.Extension -ieq ".png") {
+                [System.IO.Path]::ChangeExtension($file.FullName, ".json")
+            }
+            else {
+                $null
+            }
+            $hasSourceSidecar = $null -ne $sourceSidecar -and (Test-Path -LiteralPath $sourceSidecar -PathType Leaf)
             $suffix = 1
             do {
                 $candidate = Join-Path $directory "$base.local$suffix$extension"
+                $candidateSidecar = [System.IO.Path]::ChangeExtension($candidate, ".json")
                 $suffix++
-            } while (Test-Path -LiteralPath $candidate -PathType Leaf)
+            } while (
+                (Test-Path -LiteralPath $candidate -PathType Leaf) -or
+                ($hasSourceSidecar -and (Test-Path -LiteralPath $candidateSidecar -PathType Leaf))
+            )
             $destination = $candidate
         }
         elseif (Test-Path -LiteralPath $destination -PathType Leaf) {
@@ -204,6 +222,9 @@ function Copy-InputTree {
             }
         }
         Copy-Item -LiteralPath $file.FullName -Destination $destination -Force
+        if ($MarkAsLocal -and $hasSourceSidecar) {
+            Copy-Item -LiteralPath $sourceSidecar -Destination $candidateSidecar -Force
+        }
     }
     if ($overwritten.Count -gt 0) {
         $examples = @($overwritten | Select-Object -First 5) -join ", "

--- a/agent/cpp-algo/source/IconRecognition/test/test_small_algorithms.cpp
+++ b/agent/cpp-algo/source/IconRecognition/test/test_small_algorithms.cpp
@@ -822,6 +822,55 @@ void TestTransferGridDetectsSparseVisiblePhase()
         "transfer recognition must keep the target at its detected cell position");
 }
 
+void TestTransferGridRejectsBroadOvercapacityPhase()
+{
+    constexpr int kCellSize = 64;
+    constexpr int kFormalPitch = 69;
+    constexpr int kFormalColumns = 5;
+    constexpr int kBroadPitch = 66;
+    constexpr int kBroadColumns = 6;
+    constexpr int kRows = 4;
+    constexpr int kFormalPhaseX = 33;
+    constexpr int kBroadPhaseX = 2;
+    constexpr int kPhaseY = 7;
+    cv::Mat image(291, 398, CV_8UC3, cv::Scalar(24, 24, 24));
+
+    const auto draw_cell = [&](int x, int y, const cv::Scalar& border) {
+        image.colRange(x, x + 2).rowRange(y, y + kCellSize + 1).setTo(border);
+        image.colRange(x + kCellSize, x + kCellSize + 2).rowRange(y, y + kCellSize + 1).setTo(border);
+        image.rowRange(y, y + 2).colRange(x, x + kCellSize + 1).setTo(border);
+        image.rowRange(y + kCellSize, y + kCellSize + 2).colRange(x, x + kCellSize + 1).setTo(border);
+    };
+    // 真实五列格子提供稳定结构和前景纹理；错相位格会跨过这些纹理，因此单看纹理覆盖仍无法消歧。
+    for (int row = 0; row < kRows; ++row) {
+        for (int column = 0; column < kFormalColumns; ++column) {
+            const int x = kFormalPhaseX + column * kFormalPitch;
+            const int y = kPhaseY + row * kFormalPitch;
+            draw_cell(x, y, cv::Scalar(90, 90, 90));
+            for (int local_y = 6; local_y < kCellSize - 8; ++local_y) {
+                for (int local_x = 6; local_x < kCellSize - 6; ++local_x) {
+                    const unsigned char value =
+                        static_cast<unsigned char>(40 + ((local_x * 7 + local_y * 11 + row * 17 + column * 13) % 180));
+                    image.at<cv::Vec3b>(y + local_y, x + local_x) = cv::Vec3b(value, value, value);
+                }
+            }
+        }
+    }
+    // 粗搜索允许 66px pitch；该错相位能在 398px ROI 内塞入六列，但无法形成正式 69px 晶格。
+    for (int row = 0; row < kRows; ++row) {
+        for (int column = 0; column < kBroadColumns; ++column) {
+            draw_cell(kBroadPhaseX + column * kBroadPitch, kPhaseY + row * kFormalPitch, cv::Scalar(160, 160, 160));
+        }
+    }
+
+    const auto hints = iconrecognition::detail::DiscoverTransferGridHints(image, true);
+    Check(hints.size() == 1, "single transfer panel must produce one grid hint");
+    Check(hints.front().x_starts.size() == kFormalColumns, "broad search must not add a column that cannot fit the formal pitch");
+    Check(
+        std::abs(hints.front().x_starts.front() - kFormalPhaseX) <= 1,
+        "transfer hint must preserve the five-column formal phase");
+}
+
 void TestPortStoragerWideRoiUsesStablePanelPartitions()
 {
     const auto win32 = iconrecognition::detail::PartitionPortStoragerRegions(cv::Size(880, 350));
@@ -1036,6 +1085,22 @@ void TestTrustedRarityRejectsSameColorBackground()
     Check(trusted[0].trusted && trusted[1].trusted, "real narrow bars must pass local contrast and shape constraints");
 }
 
+void TestTrustedRarityIgnoresConnectedSpecks()
+{
+    cv::Mat image(120, 140, CV_8UC3, cv::Scalar(35, 40, 46));
+    const cv::Scalar rarity = RarityBgr(5);
+    image(cv::Rect(20, 70, 64, 2)).setTo(rarity);
+    // 模拟数量文字等动态同色杂点：它们会与色带连成超过固定高度的组件，
+    // 但自身宽度不足一个色带，不能成为稀有度条的核心证据。
+    image(cv::Rect(20, 60, 20, 11)).setTo(rarity);
+    image(cv::Rect(20, 72, 8, 1)).setTo(rarity);
+
+    const auto strips = iconrecognition::detail::DetectTrustedRarityStrips(image, 64);
+    Check(strips.size() == 1, "connected narrow specks must not create extra rarity strips");
+    Check(strips.front().box == cv::Rect(20, 70, 64, 2), "trusted rarity must keep the full-width strip core");
+    Check(strips.front().color_coverage >= 0.95, "connected specks must not dilute strip color coverage");
+}
+
 void TestGrayRarityCannotSeedLattice()
 {
     cv::Mat image(100, 100, CV_8UC3, cv::Scalar(25, 30, 35));
@@ -1060,6 +1125,20 @@ void TestRegularLatticeUsesOneGlobalFloatingPitch()
             starts[index] == cvRound(fit->origin + static_cast<double>(index + fit->minimum_index) * fit->pitch),
             "every integer start must project directly from one global model");
     }
+}
+
+void TestRegularLatticeUsesObservedPitchTolerance()
+{
+    const std::vector<iconrecognition::detail::LatticeObservation> quantized {
+        { 618.0, 1.0, true }, { 687.0, 1.0, true }, { 755.0, 1.0, true }, { 824.0, 1.0, true }, { 893.0, 1.0, true },
+    };
+    Check(
+        !iconrecognition::detail::FitRegularAxis(quantized, 5, { 69.0, 69.0 }, 69.0),
+        "fixed pitch must reject quantized observations when no tolerance is supplied");
+    const auto fit = iconrecognition::detail::FitRegularAxis(quantized, 5, { 69.0, 69.0 }, 69.0, 1.0);
+    Check(fit.has_value(), "fixed pitch must accept one-pixel quantization with observed tolerance");
+    Check(std::abs(fit->pitch - 69.0) <= 1e-9, "observed tolerance must not change the formal output pitch");
+    Check(iconrecognition::detail::ProjectRegularAxis(*fit) == std::vector<int> { 617, 686, 755, 824, 893 }, "fixed pitch projection must remain regular");
 }
 
 void TestRegularLatticeRejectsAccumulatingResiduals()
@@ -1585,14 +1664,17 @@ int main()
         TestRewardsGridRenumbersColumnsAfterRoiFiltering();
         TestTransferRegionPartitionKeepsUndetectedOuterColumns();
         TestTransferGridDetectsSparseVisiblePhase();
+        TestTransferGridRejectsBroadOvercapacityPhase();
         TestPortStoragerWideRoiUsesStablePanelPartitions();
         TestCreditTradeGridUsesDimCardStructures();
         TestCreditTradeGridUsesSixColumnsWhenRoiCannotContainSeven();
         TestValuablesGridKeepsSixColumnsAtAdbDensity();
         TestRarityRowEvidenceKeepsAllSixChannels();
         TestTrustedRarityRejectsSameColorBackground();
+        TestTrustedRarityIgnoresConnectedSpecks();
         TestGrayRarityCannotSeedLattice();
         TestRegularLatticeUsesOneGlobalFloatingPitch();
+        TestRegularLatticeUsesObservedPitchTolerance();
         TestRegularLatticeRejectsAccumulatingResiduals();
         TestRarityBandsRecoverGridFromGlobalEvidence();
         TestRarityUsesBottomEdgeRows();


### PR DESCRIPTION
- 按正式网格间距限制 transfer 单侧候选容量，避免宽范围搜索将五列区域误判为六列
- 从粘连数字和同色杂点中提取固定宽度稀有度条核心，并让 1px 观测间距容差参与晶格拟合
- 补充候选容量、同色杂点和间距容差的小算法回归测试
- 恢复 test/input 本地截图叠加、同名图片优先和默认跳过正式 expected 校验的人工测试流程
- 透传 CMake 与测试程序原生退出码，并补充本地图片测试文档

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 提升规则网格识别对像素量化误差和观测间距偏差的适应能力。
  * 优化网格候选范围，避免生成超出有效容量的行列。
  * 改进稀有度色带检测，减少窄小杂点导致的误识别，并提升色带覆盖率判断准确性。

* **测试与文档**
  * 增强本地图片测试支持、错误反馈和退出状态处理。
  * 修正人工测试命令，并补充图片选择、网格类型及回归测试说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->