### PR TITLE
feat(SceneLogin): 服务器维护期间自动重试登录并更新测试集子模块

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneLogin.json
+++ b/assets/resource/pipeline/SceneManager/SceneLogin.json
@@ -104,7 +104,8 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "__ScenePrivateLoginMaintenanceRetry"
+            "__ScenePrivateLoginMaintenanceRetry",
+            "__ScenePrivateLoginMaintenanceTitleDisappeared"
         ]
     },
     "__ScenePrivateLoginMaintenanceText": {
@@ -165,9 +166,12 @@
         },
         "post_delay": 0,
         "rate_limit": 0,
+        // 点确认/进入后会重新校验资源，网络波动时经常超过默认 20s timeout。
+        // 登录页还在就继续按 10s 间隔轮询，登录页消失则走 TitleDisappeared。
         "next": [
             "__ScenePrivateLoginMaintenance",
-            "__ScenePrivateLoginMaintenanceTitleDisappeared"
+            "__ScenePrivateLoginMaintenanceTitleDisappeared",
+            "__ScenePrivateLoginMaintenanceRetry"
         ]
     },
     "__ScenePrivateLoginMaintenanceTitleDisappeared": {

--- a/assets/resource/pipeline/SceneManager/SceneLogin.json
+++ b/assets/resource/pipeline/SceneManager/SceneLogin.json
@@ -17,6 +17,7 @@
             }
         },
         "next": [
+            "__ScenePrivateLoginMaintenance",
             "[JumpBack]__ScenePrivateCloseErrorDialog",
             "[JumpBack]__ScenePrivateCloseLoginAnnouncement",
             "__ScenePrivateLoginContinue",
@@ -48,6 +49,7 @@
             "type": "Click"
         },
         "next": [
+            "__ScenePrivateLoginMaintenance",
             "[JumpBack]__ScenePrivateCloseErrorDialog",
             "__ScenePrivateLoginContinueDisappeared",
             "__ScenePrivateLoginContinue"
@@ -81,6 +83,109 @@
             "[JumpBack]__ScenePrivateLoginCompanionGiftConfirm",
             "__ScenePrivateLoginSuccess",
             "[JumpBack]__ScenePrivateLoginCloseDialog"
+        ]
+    },
+    "__ScenePrivateLoginMaintenance": {
+        "desc": "服务器维护中，点击确认后定时重试进入游戏",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "__ScenePrivateLoginMaintenanceText",
+                    "__ScenePrivateCloseErrorDialog"
+                ],
+                "box_index": 1
+            }
+        },
+        "pre_delay": 0,
+        "action": {
+            "type": "Click"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateLoginMaintenanceRetry"
+        ]
+    },
+    "__ScenePrivateLoginMaintenanceText": {
+        "desc": "识别服务器维护提示",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    450,
+                    300,
+                    380,
+                    100
+                ],
+                "expected": [
+                    // "服务器正在维护中，本次维护预计将于2026/09/02 12:00 (UTC+8)结束。详情请关注官方公告。"
+                    // "伺服器正在維護中，本次維護預計將於2026/09/02 12:00 (UTC+8)結束。詳情請關注官方公告。"
+                    // "Server is under maintenance, which is expected to end at 2026-09-02 12:00 (UTC+8). Refer to official announcements for details."
+                    // "サーバーは現在メンテナンス中です。終了予定時刻：2026/09/02 12:00 (UTC+8)。詳細は公式のお知らせをご確認ください。"
+                    // "서버가 점검 중입니다. 이번 점검은 2026. 09. 02 12:00 (UTC+8)에 종료될 예정입니다. 자세한 내용은 공식 공지를 확인해 주세요."
+                    // 维护时间动态变化且长文本会被 OCR 分行，使用各语言首句稳定部分匹配
+                    // @i18n-skip
+                    "服务器正在维护中",
+                    "伺服器正在維護中",
+                    "(?i)Server\\s*is\\s*under\\s*maintenance",
+                    "サーバーは現在メンテナンス中です",
+                    "서버가\\s*점검\\s*중입니다",
+                    // 当前 OCR 模型不支持韩文，韩文维护弹窗使用动态日期时间格式兜底
+                    "\\d{4}\\s*\\.\\s*\\d{2}\\s*\\.\\s*\\d{2}\\s*\\d{1,2}:\\d{2}"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
+    "__ScenePrivateLoginMaintenanceRetry": {
+        "desc": "服务器维护中，等待后重新点击进入游戏",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "__ScenePrivateLogin"
+                ]
+            }
+        },
+        // 这是维护轮询间隔，不用于等待界面动画或掩盖识别问题
+        "pre_delay": 10000,
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    1095,
+                    350,
+                    185,
+                    55
+                ]
+            }
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateLoginMaintenance",
+            "__ScenePrivateLoginMaintenanceTitleDisappeared"
+        ]
+    },
+    "__ScenePrivateLoginMaintenanceTitleDisappeared": {
+        "desc": "服务器维护重试后，等待登录界面消失",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "__ScenePrivateLogin"
+                ]
+            }
+        },
+        "inverse": true,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "__ScenePrivateLoginContinueDisappeared"
         ]
     },
     "__ScenePrivateCloseErrorDialog": {

--- a/tests/SceneManager/test_login_maintenance.json
+++ b/tests/SceneManager/test_login_maintenance.json
@@ -1,0 +1,54 @@
+{
+    "configs": {
+        "name": "登录界面服务器维护识别",
+        "resource": "官服",
+        "controller": "Win32"
+    },
+    "cases": [
+        {
+            "name": "简体中文",
+            "image": "登录界面_服务器维护_简体中文.png",
+            "hits": [
+                "__ScenePrivateLoginMaintenanceText",
+                "__ScenePrivateLoginMaintenance",
+                "__ScenePrivateLoginMaintenanceRetry"
+            ]
+        },
+        {
+            "name": "繁体中文",
+            "image": "登录界面_服务器维护_繁体中文.png",
+            "hits": [
+                "__ScenePrivateLoginMaintenanceText",
+                "__ScenePrivateLoginMaintenance",
+                "__ScenePrivateLoginMaintenanceRetry"
+            ]
+        },
+        {
+            "name": "英文",
+            "image": "登录界面_服务器维护_英文.png",
+            "hits": [
+                "__ScenePrivateLoginMaintenanceText",
+                "__ScenePrivateLoginMaintenance",
+                "__ScenePrivateLoginMaintenanceRetry"
+            ]
+        },
+        {
+            "name": "日文",
+            "image": "登录界面_服务器维护_日文.png",
+            "hits": [
+                "__ScenePrivateLoginMaintenanceText",
+                "__ScenePrivateLoginMaintenance",
+                "__ScenePrivateLoginMaintenanceRetry"
+            ]
+        },
+        {
+            "name": "韩文",
+            "image": "登录界面_服务器维护_韩文.png",
+            "hits": [
+                "__ScenePrivateLoginMaintenanceText",
+                "__ScenePrivateLoginMaintenance",
+                "__ScenePrivateLoginMaintenanceRetry"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## 变更内容

- 在登录界面优先识别服务器维护弹窗，避免被通用错误弹窗流程直接结束
- 支持简体中文、繁体中文、英文、日文和韩文维护提示
- 点击维护弹窗确认后，每隔 10 秒重新发起一次登录请求
- 服务器开放后自动衔接现有登录流程进入游戏

## 实现说明

维护弹窗使用维护文本与确认按钮组合识别。10 秒等待为明确的维护轮询间隔，不用于等待界面动画或掩盖识别失败。

## 测试

- pnpm check 通过
- pnpm test：1279 / 1279 通过
- 新增五种语言的 Win32 官服维护弹窗识别用例

## 关联

- 测试集：MaaEnd/MaaEndTestset#8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 登录过程中新增服务器维护状态识别与处理。
  - 支持确认维护提示，并每 10 秒自动重试。
  - 维护结束后自动等待登录界面关闭，并继续原有登录流程。

- **测试**
  - 新增覆盖简体中文、繁体中文、英文、日文和韩文的维护场景测试。
  - 覆盖维护提示、维护状态及重试按钮的识别。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->