### PR TITLE
feat(MapNavigator): NavMesh 规划重构为单一可走判据的拓扑与几何两段搜索

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_controller.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_controller.h
@@ -29,8 +29,6 @@ struct NaviParam
     // 这条路线允许不允许借滑索。默认关：没有显式写 zip 的请求一律纯走路，既不去找最近的
     // 滑索也不做加速，规划结果与没有滑索这件事时逐位相同。
     bool zipline_enabled = false;
-    // 使用全候选动态规划 Slim，追求精确最短距离；默认使用生产用的稀疏近似。
-    bool exact_slim = false;
     // 展开前的原始作者路线。执行侧拿到的 path 是全局展开后的；滑索链半路失败时要靠它重新展开
     // 剩余路线，而不是沿着按链尾落点规划的旧展开走。
     std::vector<Waypoint> authored_path;

--- a/agent/cpp-algo/source/MapNavigator/navi_param_parser.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navi_param_parser.cpp
@@ -539,7 +539,6 @@ struct NaviParamInput
     double navmesh_snap_radius_ = 5.0;
     double snap_radius_ = 5.0;
     bool zip_ = false;
-    bool exact_slim_ = false;
     NaviActionListInput action_;
     NaviActionListInput actions_;
     double x_ = 0.0;
@@ -569,7 +568,6 @@ struct NaviParamInput
         MEO_OPT MEO_KEY("sprint_threshold") sprint_threshold_,
         MEO_OPT MEO_KEY("enable_local_driver") enable_local_driver_,
         MEO_OPT MEO_KEY("zip") zip_,
-        MEO_OPT MEO_KEY("exact_slim") exact_slim_,
         MEO_OPT MEO_KEY("enable_bootstrap_navmesh") enable_bootstrap_navmesh_,
         MEO_OPT MEO_KEY("navmesh_file") navmesh_file_,
         MEO_OPT MEO_KEY("nav_file") nav_file_,
@@ -653,7 +651,6 @@ NaviParam build_navi_param(const NaviParamInput& input)
     param.sprint_threshold = input.sprint_threshold_;
     param.enable_local_driver = input.enable_local_driver_;
     param.zipline_enabled = input.zip_;
-    param.exact_slim = input.exact_slim_;
     param.enable_bootstrap_navmesh = input.enable_bootstrap_navmesh_;
 
     if (input.has_navmesh_file_) {

--- a/agent/cpp-algo/source/MapNavigator/navmesh_diagnostics.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_diagnostics.h
@@ -15,14 +15,13 @@ struct NavmeshRouteDiagnostic
 {
     struct Timing
     {
-        double astar_ms = 0.0;
-        double rerouted_ms = 0.0;
-        double string_pull_ms = 0.0;
-        double assembled_ms = 0.0;
-        double loop_fixed_ms = 0.0;
-        double slim_ms = 0.0;
-        double widened_ms = 0.0;
-        double final_ms = 0.0;
+        double window_ms = 0.0;
+        double topology_ms = 0.0;
+        double geometry_ms = 0.0;
+        double pull_ms = 0.0;
+        double assemble_ms = 0.0;
+        double lift_ms = 0.0;
+        double total_ms = 0.0;
     } timing;
 
     navmesh::WorldPoint start;
@@ -32,14 +31,11 @@ struct NavmeshRouteDiagnostic
     int64_t nx = 0;
     int64_t ny = 0;
     double cell_size = 0.0;
-    std::vector<navmesh::WorldPoint> astar_cells;
-    std::vector<double> astar_heights;
-    std::vector<navmesh::WorldPoint> rerouted_points;
-    std::vector<navmesh::WorldPoint> string_pull_points;
+    std::vector<navmesh::WorldPoint> topology_cells;
+    std::vector<double> topology_heights;
+    std::vector<navmesh::WorldPoint> taut_points;
+    std::vector<navmesh::WorldPoint> pulled_points;
     std::vector<navmesh::WorldPoint> assembled_points;
-    std::vector<navmesh::WorldPoint> loop_fixed_points;
-    std::vector<navmesh::WorldPoint> slim_points;
-    std::vector<navmesh::WorldPoint> widened_points;
     std::vector<navmesh::WorldPoint> planned_points;
     std::vector<std::string> warnings;
 };

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -50,6 +50,7 @@ struct CachedNavmesh
         , planner(pack)
         , engine(pack, planner)
     {
+        pack.releaseLinks();
     }
 };
 

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -1505,6 +1505,22 @@ std::optional<NavmeshSnap> NavmeshSnapAt(
     return NavmeshSnap { .distance = entry->distance, .height = navmesh->planner.triangleHeight(entry->triangle) };
 }
 
+std::vector<std::vector<uint32_t>> NavmeshRegionsNear(
+    const NaviParam& param,
+    const std::string& locator_zone,
+    const std::vector<navmesh::WorldPoint>& points)
+{
+    const std::string navmesh_zone = InferBaseNavZone(locator_zone, param.map_name);
+    if (navmesh_zone.empty()) {
+        return std::vector<std::vector<uint32_t>>(points.size());
+    }
+    const auto navmesh = LoadCachedNavmesh(ResolveNavmeshFile(param.navmesh_file), navmesh_zone);
+    if (!navmesh) {
+        return std::vector<std::vector<uint32_t>>(points.size());
+    }
+    return navmesh->engine.regionsNear(navmesh_zone, points);
+}
+
 double NavmeshOffMeshFraction(
     const NaviParam& param,
     const std::string& locator_zone,

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -558,8 +558,7 @@ navmesh::BaseNavRouteResult PlanCorridorRoute(
         request.goal_deck_y,
         request.blocked_triangles,
         request.blocked_points,
-        should_stop,
-        request.exact_slim);
+        should_stop);
     result.gap_start = plan.debug.gap_start;
     result.gap_goal = plan.debug.gap_goal;
     result.gap_distance = plan.debug.gap_distance;
@@ -585,27 +584,23 @@ navmesh::BaseNavRouteResult PlanCorridorRoute(
     if (out_diagnostic != nullptr) {
         out_diagnostic->start = request.start;
         out_diagnostic->goal = request.goal;
-        out_diagnostic->timing.astar_ms = plan.debug.timing.astar_ms;
-        out_diagnostic->timing.rerouted_ms = plan.debug.timing.rerouted_ms;
-        out_diagnostic->timing.string_pull_ms = plan.debug.timing.string_pull_ms;
-        out_diagnostic->timing.assembled_ms = plan.debug.timing.assembled_ms;
-        out_diagnostic->timing.loop_fixed_ms = plan.debug.timing.loop_fixed_ms;
-        out_diagnostic->timing.slim_ms = plan.debug.timing.slim_ms;
-        out_diagnostic->timing.widened_ms = plan.debug.timing.widened_ms;
-        out_diagnostic->timing.final_ms = plan.debug.timing.final_ms;
+        out_diagnostic->timing.window_ms = plan.debug.timing.window_ms;
+        out_diagnostic->timing.topology_ms = plan.debug.timing.topology_ms;
+        out_diagnostic->timing.geometry_ms = plan.debug.timing.geometry_ms;
+        out_diagnostic->timing.pull_ms = plan.debug.timing.pull_ms;
+        out_diagnostic->timing.assemble_ms = plan.debug.timing.assemble_ms;
+        out_diagnostic->timing.lift_ms = plan.debug.timing.lift_ms;
+        out_diagnostic->timing.total_ms = plan.debug.timing.total_ms;
         out_diagnostic->x0 = plan.debug.x0;
         out_diagnostic->y0 = plan.debug.y0;
         out_diagnostic->nx = plan.debug.nx;
         out_diagnostic->ny = plan.debug.ny;
         out_diagnostic->cell_size = plan.debug.cell_size;
-        out_diagnostic->astar_cells = std::move(plan.debug.astar_cells);
-        out_diagnostic->astar_heights = std::move(plan.debug.astar_heights);
-        out_diagnostic->rerouted_points = std::move(plan.debug.rerouted_points);
-        out_diagnostic->string_pull_points = std::move(plan.debug.string_pull_points);
+        out_diagnostic->topology_cells = std::move(plan.debug.topology_cells);
+        out_diagnostic->topology_heights = std::move(plan.debug.topology_heights);
+        out_diagnostic->taut_points = std::move(plan.debug.taut_points);
+        out_diagnostic->pulled_points = std::move(plan.debug.pulled_points);
         out_diagnostic->assembled_points = std::move(plan.debug.assembled_points);
-        out_diagnostic->loop_fixed_points = std::move(plan.debug.loop_fixed_points);
-        out_diagnostic->slim_points = std::move(plan.debug.slim_points);
-        out_diagnostic->widened_points = std::move(plan.debug.widened_points);
         out_diagnostic->planned_points = std::move(plan.debug.planned_points);
         out_diagnostic->warnings = std::move(plan.debug.warnings);
     }
@@ -649,9 +644,7 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRouteImpl(
         blocked_points,
         navmesh::kBaseNavFloorYNone,
         goal_deck_y,
-        start_floor_y);
-    request.exact_slim = param.exact_slim;
-    const auto plan_started_at = std::chrono::steady_clock::now();
+        start_floor_y);    const auto plan_started_at = std::chrono::steady_clock::now();
     const auto route_result = PlanCorridorRoute(*navmesh, request, {}, out_diagnostic);
     const int64_t plan_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - plan_started_at).count();
@@ -750,7 +743,6 @@ bool AppendBlindTargetFallback(
             continue;
         }
         auto request = BuildRouteRequest(navmesh.pack, state.current_zone, state.navmesh_zone, start, entry->point, {}, {}, goal_floor_y);
-        request.exact_slim = param.exact_slim;
         NavmeshRouteDiagnostic diagnostic;
         const auto route = PlanCorridorRoute(navmesh, request, should_stop, out_diagnostics == nullptr ? nullptr : &diagnostic);
         if (!route.ok() || route.path.points.empty()) {
@@ -931,9 +923,7 @@ bool AppendNavmeshWaypoint(
         {},
         {},
         target.floor_y,
-        target.deck_y);
-    request.exact_slim = param.exact_slim;
-    const auto plan_started_at = std::chrono::steady_clock::now();
+        target.deck_y);    const auto plan_started_at = std::chrono::steady_clock::now();
     NavmeshRouteDiagnostic route_diagnostic;
     auto route_result = PlanCorridorRoute(navmesh, request, should_stop, out_diagnostics == nullptr ? nullptr : &route_diagnostic);
     bool start_recovered = false;

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -93,6 +93,14 @@ std::optional<NavmeshSnap> NavmeshSnapAt(
     const navmesh::WorldPoint& point,
     double radius,
     std::optional<double> floor_y = std::nullopt);
+// The bake-time connectivity classes each point sits in. A route is searched inside one class only, so
+// two points whose sets are disjoint cannot be connected by any plan — a cheap way to drop legs that are
+// bound to fail. An empty set means "no answer" (no baked grid, unknown zone, no voxel nearby), never
+// "not connected"; callers must read it as permission to try.
+std::vector<std::vector<uint32_t>> NavmeshRegionsNear(
+    const NaviParam& param,
+    const std::string& locator_zone,
+    const std::vector<navmesh::WorldPoint>& points);
 float NavmeshFloorYForZone(const NaviParam& param, const std::string& locator_zone);
 bool NavmeshZonesShareGeometry(const NaviParam& param, const std::string& zone_a, const std::string& zone_b);
 

--- a/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
@@ -93,6 +93,27 @@ double Distance(const navmesh::WorldPoint& a, const navmesh::WorldPoint& b)
     return std::hypot(b.x - a.x, b.y - a.y);
 }
 
+// 两点之间还有没有可能连通。类号集合都是有序的，扫一遍就够。任一边空着是「问不出来」
+// 而不是「不连通」，这种时候一律当作可能连通，让规划自己去判。
+bool MayConnect(const std::vector<uint32_t>& a, const std::vector<uint32_t>& b)
+{
+    if (a.empty() || b.empty()) {
+        return true;
+    }
+    for (size_t i = 0, j = 0; i < a.size() && j < b.size();) {
+        if (a[i] == b[j]) {
+            return true;
+        }
+        if (a[i] < b[j]) {
+            ++i;
+        }
+        else {
+            ++j;
+        }
+    }
+    return false;
+}
+
 // 一个供电结构的供电范围。规则按 templateId 查一次就够，别放进逐根架子的内层循环。
 struct SupplyPoint
 {
@@ -488,6 +509,39 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
         return no_zipline("not one zipline here can be walked up to", &g_zipline_not_chosen);
     }
 
+    // 脚下有面不等于走得到。一条路线只在单一连通类里搜，所以上索点得跟角色同类、下索点
+    // 得跟送货点同类；不同类的架子规划必败，却照样按直线距离排在前头，把预算烧个精光。
+    // 判据只排除已知必败的组合：类号问不出来时按可能连通处理，宁可白跑一条也不误杀。
+    std::vector<navmesh::WorldPoint> probes;
+    probes.reserve(nodes.size() + 2);
+    for (const zipline::ZiplineNode& node : nodes) {
+        probes.push_back(ToWorld(node));
+    }
+    probes.push_back(start);
+    probes.push_back(goal);
+    const std::vector<std::vector<uint32_t>> regions = NavmeshRegionsNear(param, locator_zone, probes);
+    std::vector<bool> can_board(nodes.size(), false);
+    std::vector<bool> can_land(nodes.size(), false);
+    size_t cut_off = 0;
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        if (!reachable[i]) {
+            continue;
+        }
+        can_board[i] = MayConnect(regions[i], regions[nodes.size()]);
+        can_land[i] = MayConnect(regions[i], regions[nodes.size() + 1]);
+        if (!can_board[i] && !can_land[i]) {
+            ++cut_off;
+        }
+    }
+    if (cut_off != 0) {
+        LogDebug << "ZiplineRoute: these ziplines share no walkable ground with either end" << VAR(cut_off) << VAR(nodes.size());
+    }
+    // 一头都接不上时后面配对必然是空的。链中间的架子仍然全留着，那些是从索上落下去的。
+    if (std::none_of(can_board.begin(), can_board.end(), [](bool v) { return v; })
+        || std::none_of(can_land.begin(), can_land.end(), [](bool v) { return v; })) {
+        return no_zipline("no zipline can be boarded from here, or none of them lands near the destination", &g_zipline_not_chosen);
+    }
+
     // 索长上限逐点查一次就够：配对是 O(n²) 的，放进内层循环等于把字符串查表也乘上 n²。
     // 查不到的类型上限为 0，下面直接跳过——没登记过物理属性的架子不参与配对。
     std::vector<double> span_limit(nodes.size());
@@ -547,13 +601,13 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
     std::vector<size_t> chain_prev;
     for (size_t i = 0; i < nodes.size(); ++i) {
         // 这根架子连白送一整段滑行都够不着收益门槛，从它起头的所有链就都不必算了。
-        if (!reachable[i] || links[i].empty() || lb_from_start[i] + cost.mount_penalty >= gain_threshold) {
+        if (!can_board[i] || links[i].empty() || lb_from_start[i] + cost.mount_penalty >= gain_threshold) {
             continue;
         }
 
         SolveZipChains(nodes, links, cost, i, &chain_cost, &chain_prev);
         for (size_t j = 0; j < nodes.size(); ++j) {
-            if (j == i || !reachable[j] || !std::isfinite(chain_cost[j])) {
+            if (j == i || !can_land[j] || !std::isfinite(chain_cost[j])) {
                 continue;
             }
             const double zip_cost = cost.mount_penalty - cost.transfer_penalty + chain_cost[j];

--- a/agent/cpp-algo/source/MapNavmesh/MapNavmeshQuery.cpp
+++ b/agent/cpp-algo/source/MapNavmesh/MapNavmeshQuery.cpp
@@ -125,6 +125,7 @@ QueryContext* AcquireContext(const std::string& configured_path, std::string& er
     context->pack = std::move(*loaded.pack);
     context->planner.emplace(context->pack);
     context->engine.emplace(context->pack, *context->planner);
+    context->pack.releaseLinks();
     QueryContext* raw = context.get();
     g_contexts.emplace(key, std::move(context));
     LogInfo << "navmesh loaded" << VAR(key);

--- a/agent/cpp-algo/source/MapNavmesh/MapNavmeshQuery.cpp
+++ b/agent/cpp-algo/source/MapNavmesh/MapNavmeshQuery.cpp
@@ -339,7 +339,7 @@ json::object BuildRoute(QueryContext& context, const QueryParam& param)
     const navmesh::WorldPoint start { .x = param.start[0], .y = param.start[1] };
     const navmesh::WorldPoint goal { .x = param.goal[0], .y = param.goal[1] };
     const float floor_y = FloorOrNone(param.floor_y);
-    const auto plan = context.engine->plan(zone->name, start, goal, floor_y, floor_y, FloorOrNone(param.goal_deck_y), {}, {}, {}, false);
+    const auto plan = context.engine->plan(zone->name, start, goal, floor_y, floor_y, FloorOrNone(param.goal_deck_y), {}, {}, {});
 
     if (!plan.ok) {
         // 失败时带上两端的离网探针，调用方才能标出是哪个点掉在网格外。
@@ -379,39 +379,28 @@ json::object BuildRoute(QueryContext& context, const QueryParam& param)
                          { "nx", plan.debug.nx },
                          { "ny", plan.debug.ny },
                          { "cell_size", plan.debug.cell_size } } },
-        { "astar_cells", json::array() },
-        { "rerouted_points", json::array() },
-        { "string_pull_points", json::array() },
+        { "topology_cells", json::array() },
+        { "topology_heights", json::array() },
+        { "taut_points", json::array() },
+        { "pulled_points", json::array() },
         { "assembled_points", json::array() },
-        { "loop_fixed_points", json::array() },
-        { "slim_points", json::array() },
-        { "widened_points", json::array() },
         { "planned_points", json::array() },
         { "warnings", json::array() },
     };
-    for (const auto& p : plan.debug.astar_cells) {
-        debug["astar_cells"].as_array().emplace_back(json::array { p.x, p.y });
+    for (const auto& p : plan.debug.topology_cells) {
+        debug["topology_cells"].as_array().emplace_back(json::array { p.x, p.y });
     }
-    for (const double height : plan.debug.astar_heights) {
-        debug["astar_heights"].as_array().emplace_back(height);
+    for (const double height : plan.debug.topology_heights) {
+        debug["topology_heights"].as_array().emplace_back(height);
     }
-    for (const auto& p : plan.debug.rerouted_points) {
-        debug["rerouted_points"].as_array().emplace_back(json::array { p.x, p.y });
+    for (const auto& p : plan.debug.taut_points) {
+        debug["taut_points"].as_array().emplace_back(json::array { p.x, p.y });
     }
-    for (const auto& p : plan.debug.string_pull_points) {
-        debug["string_pull_points"].as_array().emplace_back(json::array { p.x, p.y });
+    for (const auto& p : plan.debug.pulled_points) {
+        debug["pulled_points"].as_array().emplace_back(json::array { p.x, p.y });
     }
     for (const auto& p : plan.debug.assembled_points) {
         debug["assembled_points"].as_array().emplace_back(json::array { p.x, p.y });
-    }
-    for (const auto& p : plan.debug.loop_fixed_points) {
-        debug["loop_fixed_points"].as_array().emplace_back(json::array { p.x, p.y });
-    }
-    for (const auto& p : plan.debug.slim_points) {
-        debug["slim_points"].as_array().emplace_back(json::array { p.x, p.y });
-    }
-    for (const auto& p : plan.debug.widened_points) {
-        debug["widened_points"].as_array().emplace_back(json::array { p.x, p.y });
     }
     for (const auto& p : plan.debug.planned_points) {
         debug["planned_points"].as_array().emplace_back(json::array { p.x, p.y });
@@ -468,21 +457,21 @@ json::array PointsToJson(const std::vector<navmesh::WorldPoint>& points)
 
 json::array DiagnosticPointsToJson(
     const std::vector<navmesh::WorldPoint>& points,
-    const std::vector<navmesh::WorldPoint>& astar_cells,
-    const std::vector<double>& astar_heights)
+    const std::vector<navmesh::WorldPoint>& cells,
+    const std::vector<double>& heights)
 {
     json::array out;
     for (const navmesh::WorldPoint& point : points) {
         double height = 0.0;
         bool have_height = false;
-        const size_t count = std::min(astar_cells.size(), astar_heights.size());
+        const size_t count = std::min(cells.size(), heights.size());
         double best_distance = 0.0;
         for (size_t i = 0; i < count; ++i) {
-            const double distance = std::hypot(point.x - astar_cells[i].x, point.y - astar_cells[i].y);
+            const double distance = std::hypot(point.x - cells[i].x, point.y - cells[i].y);
             if (!have_height || distance < best_distance) {
                 have_height = true;
                 best_distance = distance;
-                height = astar_heights[i];
+                height = heights[i];
             }
         }
         if (have_height) {
@@ -514,23 +503,20 @@ json::object DiagnosticToJson(const mapnavigator::NavmeshRouteDiagnostic& diagno
         { "goal", json::array { diagnostic.goal.x, diagnostic.goal.y } },
         { "timing_ms",
           json::object {
-              { "astar", diagnostic.timing.astar_ms },
-              { "rerouted", diagnostic.timing.rerouted_ms },
-              { "string_pull", diagnostic.timing.string_pull_ms },
-              { "assembled", diagnostic.timing.assembled_ms },
-              { "loop_fixed", diagnostic.timing.loop_fixed_ms },
-              { "slim", diagnostic.timing.slim_ms },
-              { "widened", diagnostic.timing.widened_ms },
-              { "final", diagnostic.timing.final_ms },
+              { "window", diagnostic.timing.window_ms },
+              { "topology", diagnostic.timing.topology_ms },
+              { "geometry", diagnostic.timing.geometry_ms },
+              { "pull", diagnostic.timing.pull_ms },
+              { "assemble", diagnostic.timing.assemble_ms },
+              { "lift", diagnostic.timing.lift_ms },
+              { "total", diagnostic.timing.total_ms },
           } },
-        { "astar_cells", DiagnosticPointsToJson(diagnostic.astar_cells, diagnostic.astar_cells, diagnostic.astar_heights) },
-        { "rerouted_points", DiagnosticPointsToJson(diagnostic.rerouted_points, diagnostic.astar_cells, diagnostic.astar_heights) },
-        { "string_pull_points", DiagnosticPointsToJson(diagnostic.string_pull_points, diagnostic.astar_cells, diagnostic.astar_heights) },
-        { "assembled_points", DiagnosticPointsToJson(diagnostic.assembled_points, diagnostic.astar_cells, diagnostic.astar_heights) },
-        { "loop_fixed_points", DiagnosticPointsToJson(diagnostic.loop_fixed_points, diagnostic.astar_cells, diagnostic.astar_heights) },
-        { "slim_points", DiagnosticPointsToJson(diagnostic.slim_points, diagnostic.astar_cells, diagnostic.astar_heights) },
-        { "widened_points", DiagnosticPointsToJson(diagnostic.widened_points, diagnostic.astar_cells, diagnostic.astar_heights) },
-        { "planned_points", DiagnosticPointsToJson(diagnostic.planned_points, diagnostic.astar_cells, diagnostic.astar_heights) },
+        { "topology_cells", DiagnosticPointsToJson(diagnostic.topology_cells, diagnostic.topology_cells, diagnostic.topology_heights) },
+        { "taut_points", DiagnosticPointsToJson(diagnostic.taut_points, diagnostic.topology_cells, diagnostic.topology_heights) },
+        { "pulled_points", DiagnosticPointsToJson(diagnostic.pulled_points, diagnostic.topology_cells, diagnostic.topology_heights) },
+        { "assembled_points",
+          DiagnosticPointsToJson(diagnostic.assembled_points, diagnostic.topology_cells, diagnostic.topology_heights) },
+        { "planned_points", DiagnosticPointsToJson(diagnostic.planned_points, diagnostic.topology_cells, diagnostic.topology_heights) },
         { "warnings", std::move(warnings) },
     };
 }

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
@@ -18,6 +18,8 @@ BaseNavPack MakeBaseNavPack(
     std::vector<BaseNavVertex> vertices,
     std::vector<BaseNavTriangle> triangles,
     std::vector<BaseNavLink> links,
+    std::vector<BaseNavSurface> surfaces,
+    std::vector<BaseNavOffMeshLink> off_mesh_links,
     std::vector<BaseNavSection> sections)
 {
     BaseNavPack pack;
@@ -26,6 +28,8 @@ BaseNavPack MakeBaseNavPack(
     pack.vertices_ = std::move(vertices);
     pack.triangles_ = std::move(triangles);
     pack.links_ = std::move(links);
+    pack.surfaces_ = std::move(surfaces);
+    pack.off_mesh_links_ = std::move(off_mesh_links);
     pack.sections_ = std::move(sections);
     return pack;
 }
@@ -50,6 +54,16 @@ const std::vector<BaseNavTriangle>& BaseNavPack::triangles() const
 const std::vector<BaseNavLink>& BaseNavPack::links() const
 {
     return links_;
+}
+
+const std::vector<BaseNavSurface>& BaseNavPack::surfaces() const
+{
+    return surfaces_;
+}
+
+const std::vector<BaseNavOffMeshLink>& BaseNavPack::offMeshLinks() const
+{
+    return off_mesh_links_;
 }
 
 const BaseNavZone* BaseNavPack::findZone(uint16_t zone_id) const

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
@@ -144,6 +144,12 @@ const char* ToString(BaseNavLoadStatus status)
     return "unknown";
 }
 
+void BaseNavPack::releaseLinks()
+{
+    // swap 空容器才还得掉容量: `= {}` 会挑上 initializer_list 赋值, 只把 size 清零。
+    std::vector<BaseNavLink>().swap(links_);
+}
+
 const BaseNavSection* BaseNavPack::section(const char (&tag)[5]) const
 {
     for (const BaseNavSection& s : sections_) {

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.h
@@ -174,6 +174,10 @@ public:
     // v4 附加段的原始字节;认不出的 tag 直接留着不解析。没有该段返回 nullptr。
     const BaseNavSection* section(const char (&tag)[5]) const;
 
+    // 连接表只被 BaseNavPlanner 的 CSR 邻接读一遍,之后全仓无读者。持有方在 planner
+    // 建完后调这个把它还给系统 —— 单区 map02base 有 1050 万条,占 80MB。
+    void releaseLinks();
+
 private:
     friend BaseNavPack detail::MakeBaseNavPack(
         std::filesystem::path path,

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.h
@@ -85,8 +85,6 @@ struct BaseNavTriangle
     std::array<uint32_t, 3> vertices { 0, 0, 0 };
     std::array<int32_t, 3> neighbors { -1, -1, -1 };
     uint32_t component_id = 0;
-    float center_u = 0.0F;
-    float center_v = 0.0F;
 };
 
 struct BaseNavLink

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.h
@@ -84,7 +84,6 @@ struct BaseNavTriangle
 {
     std::array<uint32_t, 3> vertices { 0, 0, 0 };
     std::array<int32_t, 3> neighbors { -1, -1, -1 };
-    uint32_t component_id = 0;
 };
 
 struct BaseNavLink

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.h
@@ -95,6 +95,30 @@ struct BaseNavLink
     uint32_t target = 0;
 };
 
+struct BaseNavSurface
+{
+    uint8_t area = 0;
+    uint8_t poly_type = 0;
+    uint32_t flags = 0;
+};
+
+inline constexpr uint8_t kBaseNavOffMeshRegular = 0;
+inline constexpr uint8_t kBaseNavOffMeshExtended = 1;
+
+struct BaseNavOffMeshLink
+{
+    uint16_t zone_id = 0;
+    uint8_t kind = kBaseNavOffMeshRegular;
+    int32_t is_ext = 0;
+    int32_t bidirectional = 0;
+    int32_t area = 0;
+    uint16_t link_type = 0;
+    uint8_t direction = 0;
+    float radius = 0.0F;
+    float cost_modifier = 0.0F;
+    std::array<BaseNavVertex, 4> points;
+};
+
 // v4 起包尾可以挂若干独立数据段,靠头里的段目录定位。四段原有数据一个字节不动,
 // 认不出某个 tag 的读取器跳过它即可。
 struct BaseNavSection
@@ -115,6 +139,8 @@ BaseNavPack MakeBaseNavPack(
     std::vector<BaseNavVertex> vertices,
     std::vector<BaseNavTriangle> triangles,
     std::vector<BaseNavLink> links,
+    std::vector<BaseNavSurface> surfaces,
+    std::vector<BaseNavOffMeshLink> off_mesh_links,
     std::vector<BaseNavSection> sections);
 
 }
@@ -128,6 +154,8 @@ public:
     const std::vector<BaseNavVertex>& vertices() const;
     const std::vector<BaseNavTriangle>& triangles() const;
     const std::vector<BaseNavLink>& links() const;
+    const std::vector<BaseNavSurface>& surfaces() const;
+    const std::vector<BaseNavOffMeshLink>& offMeshLinks() const;
     const BaseNavZone* findZone(uint16_t zone_id) const;
     const BaseNavZone* findZoneByName(const std::string& name) const;
 
@@ -155,6 +183,8 @@ private:
         std::vector<BaseNavVertex> vertices,
         std::vector<BaseNavTriangle> triangles,
         std::vector<BaseNavLink> links,
+        std::vector<BaseNavSurface> surfaces,
+        std::vector<BaseNavOffMeshLink> off_mesh_links,
         std::vector<BaseNavSection> sections);
 
     std::filesystem::path path_;
@@ -162,6 +192,8 @@ private:
     std::vector<BaseNavVertex> vertices_;
     std::vector<BaseNavTriangle> triangles_;
     std::vector<BaseNavLink> links_;
+    std::vector<BaseNavSurface> surfaces_;
+    std::vector<BaseNavOffMeshLink> off_mesh_links_;
     std::vector<BaseNavSection> sections_;
 };
 

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -89,9 +89,15 @@ void BaseNavPlanner::buildIndex()
     }
     buildNaturalComponents();
 
+    // 计数趟与填充趟之间只做了前缀和与 resize, 谓词读的分区、自然连通分量、三角几何一份都没动,
+    // 第二趟必然复现第一趟的答案。判完存一位, 位图按每条边一比特, 换掉整串重算。
+    const auto& links = pack_.links();
+    std::vector<uint64_t> passed(links.size() / 64 + 1, 0);
     size_t valid_link_count = 0;
-    for (const BaseNavLink& link : pack_.links()) {
+    for (size_t index = 0; index < links.size(); ++index) {
+        const BaseNavLink& link = links[index];
         if (isTraversableLink(link.source, link.target)) {
+            passed[index >> 6] |= uint64_t { 1 } << (index & 63);
             ++adjacency_offsets_[link.source + 1];
             ++valid_link_count;
         }
@@ -102,8 +108,9 @@ void BaseNavPlanner::buildIndex()
 
     adjacency_links_.resize(valid_link_count);
     std::vector<uint32_t> next_offsets = adjacency_offsets_;
-    for (const BaseNavLink& link : pack_.links()) {
-        if (isTraversableLink(link.source, link.target)) {
+    for (size_t index = 0; index < links.size(); ++index) {
+        if (((passed[index >> 6] >> (index & 63)) & 1) != 0) {
+            const BaseNavLink& link = links[index];
             adjacency_links_[next_offsets[link.source]++] = link.target;
         }
     }

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -5,10 +5,12 @@
 #include <cstdint>
 #include <limits>
 #include <numeric>
+#include <thread>
 #include <tuple>
 
 #include "BaseNavGeometry.h"
 #include "BaseNavPlanner.h"
+#include "NavParallel.h"
 
 namespace navmesh
 {
@@ -74,19 +76,29 @@ BaseNavPlanner::BaseNavPlanner(const BaseNavPack& pack)
     , adjacency_offsets_(pack.triangles().size() + 1, 0)
     , triangle_heights_(pack.triangles().size(), 0.0)
 {
-    buildIndex();
-    buildSpatialIndex();
-    computeTriangleHeights();
-}
-
-void BaseNavPlanner::buildIndex()
-{
     for (const auto& zone : pack_.zones()) {
         const uint32_t end = zone.first_triangle + zone.triangle_count;
         for (uint32_t index = zone.first_triangle; index < end && index < triangle_zones_.size(); ++index) {
             triangle_zones_[index] = zone.zone_id;
         }
     }
+    // 三段各写各的成员(连通分量与邻接表 / 空间桶 / 三角高度), 读的只有 pack_ 与刚填好的分区表,
+    // 谁都看不见另外两段的产物, 于是并起来跑与顺着跑逐位相同。
+    if (NavWorkerCount(static_cast<int64_t>(pack_.triangles().size())) <= 1) {
+        buildIndex();
+        buildSpatialIndex();
+        computeTriangleHeights();
+        return;
+    }
+    std::thread bins([this] { buildSpatialIndex(); });
+    std::thread heights([this] { computeTriangleHeights(); });
+    buildIndex();
+    bins.join();
+    heights.join();
+}
+
+void BaseNavPlanner::buildIndex()
+{
     buildNaturalComponents();
 
     // 计数趟与填充趟之间只做了前缀和与 resize, 谓词读的分区、自然连通分量、三角几何一份都没动,

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -101,16 +101,34 @@ void BaseNavPlanner::buildIndex()
 {
     buildNaturalComponents();
 
-    // 计数趟与填充趟之间只做了前缀和与 resize, 谓词读的分区、自然连通分量、三角几何一份都没动,
-    // 第二趟必然复现第一趟的答案。判完存一位, 位图按每条边一比特, 换掉整串重算。
+    // 位图按每条边一比特存下通行判据, 换掉填充趟的整串重算: 两趟之间只做了前缀和与 resize,
+    // 谓词读的分区表、自然连通分量与三角几何一个字都没写, 第二趟必然复现第一趟的答案。
+    // 按字切块并行, 相邻块碰不到同一个 uint64_t, 于是位图与线程数无关。
     const auto& links = pack_.links();
-    std::vector<uint64_t> passed(links.size() / 64 + 1, 0);
+    const size_t word_count = links.size() / 64 + 1;
+    std::vector<uint64_t> passed(word_count, 0);
+    ParallelChunks(
+        static_cast<int64_t>(word_count),
+        NavWorkerCount(static_cast<int64_t>(links.size())),
+        [&](size_t, int64_t begin, int64_t end) {
+            for (int64_t word = begin; word < end; ++word) {
+                const size_t first = static_cast<size_t>(word) << 6;
+                const size_t last = std::min(first + 64, links.size());
+                uint64_t bits = 0;
+                for (size_t index = first; index < last; ++index) {
+                    const BaseNavLink& link = links[index];
+                    if (isTraversableLink(link.source, link.target)) {
+                        bits |= uint64_t { 1 } << (index & 63);
+                    }
+                }
+                passed[static_cast<size_t>(word)] = bits;
+            }
+        });
+
     size_t valid_link_count = 0;
     for (size_t index = 0; index < links.size(); ++index) {
-        const BaseNavLink& link = links[index];
-        if (isTraversableLink(link.source, link.target)) {
-            passed[index >> 6] |= uint64_t { 1 } << (index & 63);
-            ++adjacency_offsets_[link.source + 1];
+        if (((passed[index >> 6] >> (index & 63)) & 1) != 0) {
+            ++adjacency_offsets_[links[index].source + 1];
             ++valid_link_count;
         }
     }

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -379,10 +379,10 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
         return best_floor;
     }
 
-    // Floor-blind path: rank by (non-island first, then snap distance, then smallest index). With no island
-    // in play this is exactly the legacy order — containing surfaces (distance 0) win, ties by smallest index —
-    // so the golden-hash parity holds; it only diverges to skip a micro-component when a real surface competes.
-    std::optional<std::tuple<int, double, uint32_t>> best_key;
+    // Floor-blind path: rank by (non-island first, then snap distance, then highest surface, then smallest
+    // index). Containing surfaces (distance 0) still win; it only diverges to skip a micro-component when a
+    // real surface competes, and to pick the top layer when several floors stack on the same (u,v).
+    std::optional<std::tuple<int, double, double, uint32_t>> best_key;
     std::optional<BaseNavSnapResult> best;
     for (const uint32_t triangle_index : candidates) {
         if (triangle_zones_[triangle_index] != zone_id) {
@@ -405,7 +405,13 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
                 continue;
             }
         }
-        const std::tuple<int, double, uint32_t> key { is_small_island(triangle_index) ? 1 : 0, distance, triangle_index };
+        // 距离打平只会发生在同一 (u,v) 上摞着好几层地面时(都含点 ⇒ 都是 0)。此时按高度降序:
+        // 底图像素是俯视图上的一点,那点看得见的就是最上面那层。原来的「取最小三角号」在这里
+        // 是任意的 —— 重烘一次三角顺序一换,起点就可能吸到桥下/水下那层,与终点分属两个分量,
+        // A* 直接报不连通。非打平的候选不受影响,distance 仍排在高度前面。
+        const std::tuple<int, double, double, uint32_t> key {
+            is_small_island(triangle_index) ? 1 : 0, distance, -triangle_heights_[triangle_index], triangle_index
+        };
         if (!best_key || key < *best_key) {
             best_key = key;
             best = BaseNavSnapResult { .triangle = triangle_index, .point = snapped, .distance = distance };

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -90,8 +90,9 @@ BaseNavPlanner::BaseNavPlanner(const BaseNavPack& pack)
         computeTriangleHeights();
         return;
     }
-    std::thread bins([this] { buildSpatialIndex(); });
-    std::thread heights([this] { computeTriangleHeights(); });
+    // jthread: buildIndex 抛出时(分配失败是唯一的来路)这两个还在跑, 析构自己接回来。
+    std::jthread bins([this] { buildSpatialIndex(); });
+    std::jthread heights([this] { computeTriangleHeights(); });
     buildIndex();
     bins.join();
     heights.join();

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -43,7 +43,6 @@ struct BaseNavRouteRequest
     // Height of the overlapping deck the goal sits on. floor_y steers the snap; this steers which span the
     // search must stop on. Unset -> the search keeps its full span set.
     float goal_deck_y = kBaseNavFloorYNone;
-    bool exact_slim = false;
 };
 
 enum class BaseNavRouteStatus

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -43,6 +43,7 @@ constexpr size_t kGzipReadChunkSize = 4 << 20;
 constexpr char kGeometrySectionTag[5] = "BGEO";
 constexpr char kOffMeshSectionTag[5] = "BOML";
 constexpr char kSurfaceSectionTag[5] = "BSRF";
+constexpr char kGridSectionTag[5] = "BGRD";
 constexpr uint32_t kGeometrySectionVersion = 1;
 constexpr uint16_t kOffMeshSectionVersion = 1;
 constexpr uint16_t kOffMeshRecordSize = 80;
@@ -130,20 +131,20 @@ BaseNavLink ReadLinkRecord(const uint8_t*& cursor)
     return link;
 }
 
-bool ParseOffMeshSection(const BaseNavSection& section, std::vector<BaseNavOffMeshLink>* links)
+bool ParseOffMeshSection(const uint8_t* data, size_t size, std::vector<BaseNavOffMeshLink>* links)
 {
     links->clear();
-    if (section.bytes.size() < kOffMeshHeaderSize || std::memcmp(section.bytes.data(), kOffMeshSectionTag, 4) != 0) {
+    if (size < kOffMeshHeaderSize || std::memcmp(data, kOffMeshSectionTag, 4) != 0) {
         return false;
     }
-    const uint8_t* cursor = section.bytes.data() + 4;
+    const uint8_t* cursor = data + 4;
     const uint16_t version = ReadU16(cursor);
     const uint16_t record_size = ReadU16(cursor);
     const uint32_t count = ReadU32(cursor);
     (void)ReadU32(cursor);
     if (version != kOffMeshSectionVersion || record_size != kOffMeshRecordSize
-        || count != (section.bytes.size() - kOffMeshHeaderSize) / kOffMeshRecordSize
-        || section.bytes.size() != kOffMeshHeaderSize + static_cast<size_t>(count) * kOffMeshRecordSize) {
+        || count != (size - kOffMeshHeaderSize) / kOffMeshRecordSize
+        || size != kOffMeshHeaderSize + static_cast<size_t>(count) * kOffMeshRecordSize) {
         return false;
     }
     links->reserve(count);
@@ -168,23 +169,23 @@ bool ParseOffMeshSection(const BaseNavSection& section, std::vector<BaseNavOffMe
         (void)ReadU32(cursor);
         links->push_back(link);
     }
-    return cursor == section.bytes.data() + section.bytes.size();
+    return cursor == data + size;
 }
 
-bool ParseSurfaceSection(const BaseNavSection& section, std::vector<BaseNavSurface>* surfaces)
+bool ParseSurfaceSection(const uint8_t* data, size_t size, std::vector<BaseNavSurface>* surfaces)
 {
     surfaces->clear();
-    if (section.bytes.size() < kSurfaceHeaderSize || std::memcmp(section.bytes.data(), kSurfaceSectionTag, 4) != 0) {
+    if (size < kSurfaceHeaderSize || std::memcmp(data, kSurfaceSectionTag, 4) != 0) {
         return false;
     }
-    const uint8_t* cursor = section.bytes.data() + 4;
+    const uint8_t* cursor = data + 4;
     const uint16_t version = ReadU16(cursor);
     const uint16_t record_size = ReadU16(cursor);
     const uint32_t count = ReadU32(cursor);
     (void)ReadU32(cursor);
     if (version != kSurfaceSectionVersion || record_size != kSurfaceRecordSize
-        || count != (section.bytes.size() - kSurfaceHeaderSize) / kSurfaceRecordSize
-        || section.bytes.size() != kSurfaceHeaderSize + static_cast<size_t>(count) * kSurfaceRecordSize) {
+        || count != (size - kSurfaceHeaderSize) / kSurfaceRecordSize
+        || size != kSurfaceHeaderSize + static_cast<size_t>(count) * kSurfaceRecordSize) {
         return false;
     }
     surfaces->reserve(count);
@@ -196,7 +197,7 @@ bool ParseSurfaceSection(const BaseNavSection& section, std::vector<BaseNavSurfa
         surface.flags = ReadU32(cursor);
         surfaces->push_back(surface);
     }
-    return cursor == section.bytes.data() + section.bytes.size();
+    return cursor == data + size;
 }
 
 uint64_t Fnv64Update(uint64_t hash, const uint8_t* bytes, size_t size)
@@ -694,8 +695,12 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     }
 
     // 段目录先读:v5 起四块几何连同区表都在 BGEO 段里,头里那四个偏移作废。
+    // 只有 BGRD 的字节要活过本函数(规划时才按瓦解码),其余段就地解析,段条目留空壳 ——
+    // 下游只拿 section(tag) != nullptr 认包的世代。
     std::vector<BaseNavSection> sections;
+    std::vector<std::pair<const uint8_t*, size_t>> section_raw;
     sections.reserve(section_count);
+    section_raw.reserve(section_count);
     const uint8_t* dir_cursor = file_bytes.data() + section_dir_offset;
     for (uint32_t index = 0; index < section_count; ++index) {
         BaseNavSection sec;
@@ -707,7 +712,11 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
         if (!OffsetRangeValid(offset, size, file_size)) {
             return Fail(BaseNavLoadStatus::InvalidOffset, "nav section is outside file bounds");
         }
-        sec.bytes.assign(file_bytes.data() + offset, file_bytes.data() + offset + size);
+        const uint8_t* at = file_bytes.data() + offset;
+        section_raw.emplace_back(at, static_cast<size_t>(size));
+        if (std::memcmp(sec.tag.data(), kGridSectionTag, 4) == 0) {
+            sec.bytes.assign(at, at + size);
+        }
         sections.push_back(std::move(sec));
     }
 
@@ -719,13 +728,13 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     const uint8_t* triangle_bytes = nullptr;
     const uint8_t* link_bytes = nullptr;
     if (sectioned) {
-        const BaseNavSection* found = nullptr;
-        for (const BaseNavSection& sec : sections) {
-            if (std::memcmp(sec.tag.data(), kGeometrySectionTag, 4) == 0) {
-                found = &sec;
+        const std::pair<const uint8_t*, size_t>* found = nullptr;
+        for (size_t i = 0; i < sections.size(); ++i) {
+            if (std::memcmp(sections[i].tag.data(), kGeometrySectionTag, 4) == 0) {
+                found = &section_raw[i];
             }
         }
-        if (found == nullptr || !ParseGeometrySection(found->bytes.data(), found->bytes.size(), &geometry)) {
+        if (found == nullptr || !ParseGeometrySection(found->first, found->second, &geometry)) {
             return Fail(BaseNavLoadStatus::InvalidOffset, "nav geometry section is missing or malformed");
         }
         if (geometry.vertices.total != vertex_count || geometry.triangles.total != triangle_count || geometry.links.total != link_count) {
@@ -993,16 +1002,17 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     }
 
     std::vector<BaseNavOffMeshLink> off_mesh_links;
-    for (const BaseNavSection& section : sections) {
-        if (std::memcmp(section.tag.data(), kOffMeshSectionTag, 4) == 0
-            && !ParseOffMeshSection(section, &off_mesh_links)) {
+    for (size_t i = 0; i < sections.size(); ++i) {
+        if (std::memcmp(sections[i].tag.data(), kOffMeshSectionTag, 4) == 0
+            && !ParseOffMeshSection(section_raw[i].first, section_raw[i].second, &off_mesh_links)) {
             return Fail(BaseNavLoadStatus::InvalidSize, "nav off-mesh section is malformed");
         }
     }
     std::vector<BaseNavSurface> surfaces;
-    for (const BaseNavSection& section : sections) {
-        if (std::memcmp(section.tag.data(), kSurfaceSectionTag, 4) == 0) {
-            if (!ParseSurfaceSection(section, &surfaces) || surfaces.size() != triangle_count) {
+    for (size_t i = 0; i < sections.size(); ++i) {
+        if (std::memcmp(sections[i].tag.data(), kSurfaceSectionTag, 4) == 0) {
+            if (!ParseSurfaceSection(section_raw[i].first, section_raw[i].second, &surfaces)
+                || surfaces.size() != triangle_count) {
                 return Fail(BaseNavLoadStatus::InvalidSize, "nav surface section is malformed");
             }
         }

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -41,7 +41,15 @@ constexpr uint16_t kGeometrySectionSince = 5;
 constexpr size_t kGzipReadChunkSize = 4 << 20;
 // BGEO 段:四块几何按定长块存,块内自足解码,按区加载只解用得着的块。
 constexpr char kGeometrySectionTag[5] = "BGEO";
+constexpr char kOffMeshSectionTag[5] = "BOML";
+constexpr char kSurfaceSectionTag[5] = "BSRF";
 constexpr uint32_t kGeometrySectionVersion = 1;
+constexpr uint16_t kOffMeshSectionVersion = 1;
+constexpr uint16_t kOffMeshRecordSize = 80;
+constexpr size_t kOffMeshHeaderSize = 16;
+constexpr uint16_t kSurfaceSectionVersion = 1;
+constexpr uint16_t kSurfaceRecordSize = 8;
+constexpr size_t kSurfaceHeaderSize = 16;
 constexpr size_t kGeoHeaderSize = 72;
 constexpr size_t kGeoChunkEntrySize = 16;
 constexpr size_t kInflateChunkSize = 1U << 16U;
@@ -119,6 +127,75 @@ BaseNavLink ReadLinkRecord(const uint8_t*& cursor)
     link.source = ReadU32(cursor);
     link.target = ReadU32(cursor);
     return link;
+}
+
+bool ParseOffMeshSection(const BaseNavSection& section, std::vector<BaseNavOffMeshLink>* links)
+{
+    links->clear();
+    if (section.bytes.size() < kOffMeshHeaderSize || std::memcmp(section.bytes.data(), kOffMeshSectionTag, 4) != 0) {
+        return false;
+    }
+    const uint8_t* cursor = section.bytes.data() + 4;
+    const uint16_t version = ReadU16(cursor);
+    const uint16_t record_size = ReadU16(cursor);
+    const uint32_t count = ReadU32(cursor);
+    (void)ReadU32(cursor);
+    if (version != kOffMeshSectionVersion || record_size != kOffMeshRecordSize
+        || count != (section.bytes.size() - kOffMeshHeaderSize) / kOffMeshRecordSize
+        || section.bytes.size() != kOffMeshHeaderSize + static_cast<size_t>(count) * kOffMeshRecordSize) {
+        return false;
+    }
+    links->reserve(count);
+    for (uint32_t index = 0; index < count; ++index) {
+        BaseNavOffMeshLink link;
+        link.zone_id = ReadU16(cursor);
+        link.kind = *cursor++;
+        ++cursor;
+        link.is_ext = ReadI32(cursor);
+        link.bidirectional = ReadI32(cursor);
+        link.area = ReadI32(cursor);
+        link.link_type = ReadU16(cursor);
+        link.direction = *cursor++;
+        ++cursor;
+        link.radius = ReadF32(cursor);
+        link.cost_modifier = ReadF32(cursor);
+        for (BaseNavVertex& point : link.points) {
+            point.u = ReadF32(cursor);
+            point.v = ReadF32(cursor);
+            point.height = ReadF32(cursor);
+        }
+        (void)ReadU32(cursor);
+        links->push_back(link);
+    }
+    return cursor == section.bytes.data() + section.bytes.size();
+}
+
+bool ParseSurfaceSection(const BaseNavSection& section, std::vector<BaseNavSurface>* surfaces)
+{
+    surfaces->clear();
+    if (section.bytes.size() < kSurfaceHeaderSize || std::memcmp(section.bytes.data(), kSurfaceSectionTag, 4) != 0) {
+        return false;
+    }
+    const uint8_t* cursor = section.bytes.data() + 4;
+    const uint16_t version = ReadU16(cursor);
+    const uint16_t record_size = ReadU16(cursor);
+    const uint32_t count = ReadU32(cursor);
+    (void)ReadU32(cursor);
+    if (version != kSurfaceSectionVersion || record_size != kSurfaceRecordSize
+        || count != (section.bytes.size() - kSurfaceHeaderSize) / kSurfaceRecordSize
+        || section.bytes.size() != kSurfaceHeaderSize + static_cast<size_t>(count) * kSurfaceRecordSize) {
+        return false;
+    }
+    surfaces->reserve(count);
+    for (uint32_t index = 0; index < count; ++index) {
+        BaseNavSurface surface;
+        surface.area = *cursor++;
+        surface.poly_type = *cursor++;
+        (void)ReadU16(cursor);
+        surface.flags = ReadU32(cursor);
+        surfaces->push_back(surface);
+    }
+    return cursor == section.bytes.data() + section.bytes.size();
 }
 
 uint64_t Fnv64Update(uint64_t hash, const uint8_t* bytes, size_t size)
@@ -914,9 +991,48 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
         links.push_back(link);
     }
 
+    std::vector<BaseNavOffMeshLink> off_mesh_links;
+    for (const BaseNavSection& section : sections) {
+        if (std::memcmp(section.tag.data(), kOffMeshSectionTag, 4) == 0
+            && !ParseOffMeshSection(section, &off_mesh_links)) {
+            return Fail(BaseNavLoadStatus::InvalidSize, "nav off-mesh section is malformed");
+        }
+    }
+    std::vector<BaseNavSurface> surfaces;
+    for (const BaseNavSection& section : sections) {
+        if (std::memcmp(section.tag.data(), kSurfaceSectionTag, 4) == 0) {
+            if (!ParseSurfaceSection(section, &surfaces) || surfaces.size() != triangle_count) {
+                return Fail(BaseNavLoadStatus::InvalidSize, "nav surface section is malformed");
+            }
+        }
+    }
+    if (zone_scoped && !surfaces.empty()) {
+        std::vector<BaseNavSurface> scoped(
+            surfaces.begin() + selected_first_triangle,
+            surfaces.begin() + selected_triangle_end);
+        surfaces = std::move(scoped);
+    }
+    if (zone_scoped) {
+        std::erase_if(off_mesh_links, [&](const BaseNavOffMeshLink& link) { return link.zone_id != selected_zone->zone_id; });
+    }
+    for (const BaseNavOffMeshLink& link : off_mesh_links) {
+        const bool known_zone = std::any_of(
+            zones.begin(), zones.end(), [&](const BaseNavZone& zone) { return zone.zone_id == link.zone_id; });
+        if (!known_zone) {
+            return Fail(BaseNavLoadStatus::InvalidSize, "nav off-mesh link refers to an unknown zone");
+        }
+    }
+
     BaseNavLoadResult result;
-    result.pack =
-        detail::MakeBaseNavPack(path, std::move(zones), std::move(vertices), std::move(triangles), std::move(links), std::move(sections));
+    result.pack = detail::MakeBaseNavPack(
+        path,
+        std::move(zones),
+        std::move(vertices),
+        std::move(triangles),
+        std::move(links),
+        std::move(surfaces),
+        std::move(off_mesh_links),
+        std::move(sections));
     return result;
 }
 

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -18,6 +18,7 @@
 #include <MaaUtils/Logger.h>
 
 #include "BaseNavReader.h"
+#include "NavParallel.h"
 
 namespace navmesh
 {
@@ -364,24 +365,22 @@ bool ParseGeometrySection(const uint8_t* data, uint64_t size, GeometrySection* o
 }
 
 // 顶点是 12 字节记录做的字节平面:n × 12 的字节矩阵转置成 12 × n。
-bool DecodeVertexChunk(const uint8_t* data, size_t size, uint32_t count, std::vector<uint8_t>* out)
+bool DecodeVertexChunk(const uint8_t* data, size_t size, uint32_t count, uint8_t* out)
 {
     std::vector<std::vector<uint8_t>> stream;
     if (!SplitChunkStreams(data, size, 1, &stream) || stream[0].size() != static_cast<size_t>(count) * kVertexSize) {
         return false;
     }
-    const size_t at = out->size();
-    out->resize(at + stream[0].size());
     for (size_t i = 0; i < count; ++i) {
         for (size_t j = 0; j < kVertexSize; ++j) {
-            (*out)[at + i * kVertexSize + j] = stream[0][j * count + i];
+            out[i * kVertexSize + j] = stream[0][j * count + i];
         }
     }
     return true;
 }
 
 // 三角的重心不存,这里先留空,顶点到位后按 ((a+b)+c)/3.0f 重算。
-bool DecodeTriangleChunk(const uint8_t* data, size_t size, uint32_t count, uint32_t first, std::vector<uint8_t>* out)
+bool DecodeTriangleChunk(const uint8_t* data, size_t size, uint32_t count, uint32_t first, uint8_t* out)
 {
     std::vector<std::vector<uint8_t>> stream;
     if (!SplitChunkStreams(data, size, 7, &stream) || stream[3].size() != (static_cast<size_t>(count) * 3 + 7) / 8) {
@@ -395,8 +394,6 @@ bool DecodeTriangleChunk(const uint8_t* data, size_t size, uint32_t count, uint3
     const uint8_t* neighbor_cursor = stream[4].data();
     const uint8_t* const neighbor_end = neighbor_cursor + stream[4].size();
 
-    const size_t at = out->size();
-    out->resize(at + static_cast<size_t>(count) * kTriangleSize);
     int64_t running = 0;
     for (uint32_t t = 0; t < count; ++t) {
         uint64_t packed[3] = {};
@@ -407,7 +404,7 @@ bool DecodeTriangleChunk(const uint8_t* data, size_t size, uint32_t count, uint3
         }
         running += UnZigzag(packed[0]);
         const int64_t vertex[3] = { running, running + UnZigzag(packed[1]), running + UnZigzag(packed[2]) };
-        uint8_t* record = out->data() + at + static_cast<size_t>(t) * kTriangleSize;
+        uint8_t* record = out + static_cast<size_t>(t) * kTriangleSize;
         for (int i = 0; i < 3; ++i) {
             if (vertex[i] < 0 || vertex[i] > UINT32_MAX) {
                 return false;
@@ -452,7 +449,7 @@ bool DecodeTriangleChunk(const uint8_t* data, size_t size, uint32_t count, uint3
         }
         const uint32_t value = static_cast<uint32_t>(component);
         for (uint64_t i = 0; i < run; ++i) {
-            std::memcpy(out->data() + at + static_cast<size_t>(filled + i) * kTriangleSize + 24, &value, 4);
+            std::memcpy(out + static_cast<size_t>(filled + i) * kTriangleSize + 24, &value, 4);
         }
         filled += static_cast<uint32_t>(run);
     }
@@ -464,7 +461,7 @@ bool DecodeTriangleChunk(const uint8_t* data, size_t size, uint32_t count, uint3
     return neighbor_cursor == neighbor_end && value_cursor == value_end && length_cursor == length_end;
 }
 
-bool DecodeLinkChunk(const uint8_t* data, size_t size, uint32_t count, std::vector<uint8_t>* out)
+bool DecodeLinkChunk(const uint8_t* data, size_t size, uint32_t count, uint8_t* out)
 {
     std::vector<std::vector<uint8_t>> stream;
     if (!SplitChunkStreams(data, size, 2, &stream)) {
@@ -474,8 +471,6 @@ bool DecodeLinkChunk(const uint8_t* data, size_t size, uint32_t count, std::vect
     const uint8_t* const source_end = source_cursor + stream[0].size();
     const uint8_t* target_cursor = stream[1].data();
     const uint8_t* const target_end = target_cursor + stream[1].size();
-    const size_t at = out->size();
-    out->resize(at + static_cast<size_t>(count) * kLinkSize);
     int64_t source = 0;
     for (uint32_t i = 0; i < count; ++i) {
         uint64_t step = 0;
@@ -489,9 +484,40 @@ bool DecodeLinkChunk(const uint8_t* data, size_t size, uint32_t count, std::vect
             return false;
         }
         const uint32_t pair[2] = { static_cast<uint32_t>(source), static_cast<uint32_t>(target) };
-        std::memcpy(out->data() + at + static_cast<size_t>(i) * kLinkSize, pair, sizeof(pair));
+        std::memcpy(out + static_cast<size_t>(i) * kLinkSize, pair, sizeof(pair));
     }
     return source_cursor == source_end && target_cursor == target_end;
+}
+
+// 解第 [low, high] 块, 接在 out 尾上。块定长, 每块的输出长度只由自己的 span 定,
+// 所以先按总长开好再让各块写各自那段 —— 与一块块接着写逐字节相同, 于是能并起来解。
+bool DecodeChunkSpan(
+    const GeoChunkTable& table,
+    const uint8_t* base,
+    uint32_t low,
+    uint32_t high,
+    size_t record_size,
+    std::vector<uint8_t>* out,
+    const std::function<bool(const uint8_t*, size_t, uint32_t, uint32_t, uint8_t*)>& decode)
+{
+    const uint32_t base_record = table.first(low);
+    const size_t records = static_cast<size_t>(table.first(high)) + table.span(high) - base_record;
+    const size_t at = out->size();
+    out->resize(at + records * record_size);
+    const auto chunks = static_cast<int64_t>(high - low + 1);
+    std::vector<uint8_t> ok(static_cast<size_t>(chunks), 1);
+    ParallelChunks(chunks, NavWorkerCount(static_cast<int64_t>(records)), [&](size_t, int64_t b, int64_t e) {
+        for (int64_t c = b; c < e; ++c) {
+            const uint32_t i = low + static_cast<uint32_t>(c);
+            uint32_t size = 0;
+            const uint8_t* src = table.bytes(base, i, size);
+            uint8_t* dst = out->data() + at + (static_cast<size_t>(table.first(i)) - base_record) * record_size;
+            if (!decode(src, size, table.span(i), table.first(i), dst)) {
+                ok[static_cast<size_t>(c)] = 0;
+            }
+        }
+    });
+    return std::find(ok.begin(), ok.end(), 0) == ok.end();
 }
 
 // 解出覆盖 [from, to) 的整块,返回块首记录的全局下标。
@@ -500,8 +526,10 @@ bool DecodeChunkRange(
     const uint8_t* base,
     uint32_t from,
     uint32_t to,
+    size_t record_size,
+    std::vector<uint8_t>* out,
     uint32_t* out_first,
-    const std::function<bool(const uint8_t*, size_t, uint32_t, uint32_t)>& decode)
+    const std::function<bool(const uint8_t*, size_t, uint32_t, uint32_t, uint8_t*)>& decode)
 {
     if (from >= to) {
         *out_first = from;
@@ -513,14 +541,7 @@ bool DecodeChunkRange(
         return false;
     }
     *out_first = table.first(low);
-    for (uint32_t i = low; i <= high; ++i) {
-        uint32_t size = 0;
-        const uint8_t* at = table.bytes(base, i, size);
-        if (!decode(at, size, table.span(i), table.first(i))) {
-            return false;
-        }
-    }
-    return true;
+    return DecodeChunkSpan(table, base, low, high, record_size, out, decode);
 }
 
 BaseNavLoadResult Fail(BaseNavLoadStatus status, std::string message)
@@ -827,9 +848,11 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
                 geometry.base,
                 selected_first_triangle,
                 selected_triangle_end,
+                kTriangleSize,
+                &triangle_storage,
                 &triangle_base,
-                [&](const uint8_t* at, size_t size, uint32_t span, uint32_t first) {
-                    return DecodeTriangleChunk(at, size, span, first, &triangle_storage);
+                [](const uint8_t* at, size_t size, uint32_t span, uint32_t first, uint8_t* dst) {
+                    return DecodeTriangleChunk(at, size, span, first, dst);
                 })) {
             return Fail(BaseNavLoadStatus::InvalidSize, "nav triangle chunk is malformed");
         }
@@ -857,9 +880,11 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
                 geometry.base,
                 want_low,
                 want_high,
+                kVertexSize,
+                &vertex_storage,
                 &vertex_base,
-                [&](const uint8_t* at, size_t size, uint32_t span, uint32_t) {
-                    return DecodeVertexChunk(at, size, span, &vertex_storage);
+                [](const uint8_t* at, size_t size, uint32_t span, uint32_t, uint8_t* dst) {
+                    return DecodeVertexChunk(at, size, span, dst);
                 })) {
             return Fail(BaseNavLoadStatus::InvalidSize, "nav vertex chunk is malformed");
         }
@@ -882,10 +907,18 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
         const uint32_t link_chunks = geometry.links.count();
         const uint32_t low_chunk = zone_scoped ? GeoLinkChunkFor(geometry.links, selected_first_triangle) : 0;
         const uint32_t high_chunk = zone_scoped ? GeoLinkChunkFor(geometry.links, selected_triangle_end) : link_chunks;
-        for (uint32_t i = low_chunk; i < link_chunks && i <= high_chunk; ++i) {
-            uint32_t size = 0;
-            const uint8_t* at = geometry.links.bytes(geometry.base, i, size);
-            if (!DecodeLinkChunk(at, size, geometry.links.span(i), &link_storage)) {
+        if (low_chunk < link_chunks && low_chunk <= high_chunk) {
+            const uint32_t last_chunk = std::min(high_chunk, link_chunks - 1);
+            if (!DecodeChunkSpan(
+                    geometry.links,
+                    geometry.base,
+                    low_chunk,
+                    last_chunk,
+                    kLinkSize,
+                    &link_storage,
+                    [](const uint8_t* at, size_t size, uint32_t span, uint32_t, uint8_t* dst) {
+                        return DecodeLinkChunk(at, size, span, dst);
+                    })) {
                 return Fail(BaseNavLoadStatus::InvalidSize, "nav link chunk is malformed");
             }
         }

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -117,10 +117,9 @@ BaseNavTriangle ReadTriangleRecord(const uint8_t*& cursor)
     for (int32_t& value : triangle.neighbors) {
         value = ReadI32(cursor);
     }
-    triangle.component_id = ReadU32(cursor);
-    // 记录尾部两个 float 是重心, 全仓无读者, 跳过不落盘。哈希仍按整条记录算,
-    // 所以按区加载时补重心的那段不能省。
-    cursor += 8;
+    // 分量号与尾部两个 float 重心都全仓无读者, 跳过不落盘 —— 分量号由 planner 从
+    // neighbors 自己重算。哈希仍按整条记录算, 所以按区加载时补重心的那段不能省。
+    cursor += 12;
     return triangle;
 }
 

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -116,8 +116,9 @@ BaseNavTriangle ReadTriangleRecord(const uint8_t*& cursor)
         value = ReadI32(cursor);
     }
     triangle.component_id = ReadU32(cursor);
-    triangle.center_u = ReadF32(cursor);
-    triangle.center_v = ReadF32(cursor);
+    // 记录尾部两个 float 是重心, 全仓无读者, 跳过不落盘。哈希仍按整条记录算,
+    // 所以按区加载时补重心的那段不能省。
+    cursor += 8;
     return triangle;
 }
 

--- a/agent/cpp-algo/source/Navmesh/NavParallel.h
+++ b/agent/cpp-algo/source/Navmesh/NavParallel.h
@@ -10,7 +10,7 @@
 namespace navmesh
 {
 
-inline constexpr unsigned kNavWorkerLimit = 4;      // 再多就落到能效核上, 这几个环是访存绑死的, 量不出加速
+inline constexpr unsigned kNavWorkerLimit = 4;      // 这几个环是访存绑死的, 线程再多也量不出加速
 inline constexpr int64_t kNavSerialFloor = 1 << 16; // 元素数低于此值, 起线程比算还贵
 
 inline std::atomic<unsigned>& NavWorkerOverride()

--- a/agent/cpp-algo/source/Navmesh/NavParallel.h
+++ b/agent/cpp-algo/source/Navmesh/NavParallel.h
@@ -51,6 +51,8 @@ inline size_t NavWorkerCountForBlocks(int64_t n)
 }
 
 // fn(w, begin, end) 跑第 w 块 [begin, end)。调用线程自己领第 0 块, 因此只多起 workers-1 个。
+// 池子用 jthread: 调用线程这块抛出时(分配失败是唯一的来路), 析构自己把工人接回来。裸 thread
+// 在那条路上还是 joinable, 析构即 terminate, 连崩溃点都留不下。
 template <class F>
 void ParallelChunks(int64_t n, size_t workers, F&& fn)
 {
@@ -59,7 +61,7 @@ void ParallelChunks(int64_t n, size_t workers, F&& fn)
     }
     const size_t nw = std::max<size_t>(1, workers);
     const int64_t step = (n + static_cast<int64_t>(nw) - 1) / static_cast<int64_t>(nw);
-    std::vector<std::thread> pool;
+    std::vector<std::jthread> pool;
     pool.reserve(nw - 1);
     for (size_t w = 1; w < nw; ++w) {
         const int64_t b = std::min(n, step * static_cast<int64_t>(w));
@@ -70,7 +72,7 @@ void ParallelChunks(int64_t n, size_t workers, F&& fn)
         pool.emplace_back([&fn, w, b, e] { fn(w, b, e); });
     }
     fn(size_t { 0 }, int64_t { 0 }, std::min(n, step));
-    for (std::thread& th : pool) {
+    for (std::jthread& th : pool) {
         th.join();
     }
 }

--- a/agent/cpp-algo/source/Navmesh/NavParallel.h
+++ b/agent/cpp-algo/source/Navmesh/NavParallel.h
@@ -37,6 +37,19 @@ inline size_t NavWorkerCount(int64_t n)
     return static_cast<size_t>(avail);
 }
 
+// 一个元素就是一整块瓦这种循环, 元素数只有几百, 拿它比 kNavSerialFloor 会一路退回单线程。
+// 这里只按块数封顶。
+inline size_t NavWorkerCountForBlocks(int64_t n)
+{
+    const unsigned forced = NavWorkerOverride().load();
+    const unsigned avail =
+        forced != 0 ? forced : std::min(kNavWorkerLimit, std::max(1U, std::thread::hardware_concurrency()));
+    if (n <= 1 || avail <= 1) {
+        return 1;
+    }
+    return static_cast<size_t>(std::min<int64_t>(n, avail));
+}
+
 // fn(w, begin, end) 跑第 w 块 [begin, end)。调用线程自己领第 0 块, 因此只多起 workers-1 个。
 template <class F>
 void ParallelChunks(int64_t n, size_t workers, F&& fn)

--- a/agent/cpp-algo/source/Navmesh/NavParallel.h
+++ b/agent/cpp-algo/source/Navmesh/NavParallel.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+namespace navmesh::recast
+{
+
+inline constexpr unsigned kNavWorkerLimit = 4;      // 再多就落到能效核上, 这几个环是访存绑死的, 量不出加速
+inline constexpr int64_t kNavSerialFloor = 1 << 16; // 元素数低于此值, 起线程比算还贵
+
+inline std::atomic<unsigned>& NavWorkerOverride()
+{
+    static std::atomic<unsigned> value { 0 };
+    return value;
+}
+
+// 只改用几个线程, 不改算什么: 切块按下标静态划分, 每块写自己那段, 1 线程与 N 线程输出逐位相同。
+// 台架靠它把同一份代码跑成两种线程数来验这一点, 生产不调, 走硬件并发。
+inline void SetNavWorkerLimit(unsigned limit)
+{
+    NavWorkerOverride().store(limit);
+}
+
+inline size_t NavWorkerCount(int64_t n)
+{
+    const unsigned forced = NavWorkerOverride().load();
+    const unsigned avail =
+        forced != 0 ? forced : std::min(kNavWorkerLimit, std::max(1U, std::thread::hardware_concurrency()));
+    if (n < kNavSerialFloor || avail <= 1) {
+        return 1;
+    }
+    return static_cast<size_t>(avail);
+}
+
+// fn(w, begin, end) 跑第 w 块 [begin, end)。调用线程自己领第 0 块, 因此只多起 workers-1 个。
+template <class F>
+void ParallelChunks(int64_t n, size_t workers, F&& fn)
+{
+    if (n <= 0) {
+        return;
+    }
+    const size_t nw = std::max<size_t>(1, workers);
+    const int64_t step = (n + static_cast<int64_t>(nw) - 1) / static_cast<int64_t>(nw);
+    std::vector<std::thread> pool;
+    pool.reserve(nw - 1);
+    for (size_t w = 1; w < nw; ++w) {
+        const int64_t b = std::min(n, step * static_cast<int64_t>(w));
+        const int64_t e = std::min(n, b + step);
+        if (b >= e) {
+            break;
+        }
+        pool.emplace_back([&fn, w, b, e] { fn(w, b, e); });
+    }
+    fn(size_t { 0 }, int64_t { 0 }, std::min(n, step));
+    for (std::thread& th : pool) {
+        th.join();
+    }
+}
+
+// 过滤环的合流: 每块只往自己那个桶里推, 收工按块序接起来。桶序即下标序, 于是与线程数无关。
+template <class T>
+void ConcatBins(const std::vector<std::vector<T>>& bins, std::vector<T>& out)
+{
+    size_t total = out.size();
+    for (const std::vector<T>& bin : bins) {
+        total += bin.size();
+    }
+    out.reserve(total);
+    for (const std::vector<T>& bin : bins) {
+        out.insert(out.end(), bin.begin(), bin.end());
+    }
+}
+
+}

--- a/agent/cpp-algo/source/Navmesh/NavParallel.h
+++ b/agent/cpp-algo/source/Navmesh/NavParallel.h
@@ -7,7 +7,7 @@
 #include <thread>
 #include <vector>
 
-namespace navmesh::recast
+namespace navmesh
 {
 
 inline constexpr unsigned kNavWorkerLimit = 4;      // 再多就落到能效核上, 这几个环是访存绑死的, 量不出加速

--- a/agent/cpp-algo/source/Navmesh/RecastNavBake.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavBake.cpp
@@ -1,30 +1,52 @@
 #include "RecastNavBake.h"
 
+#include <algorithm>
 #include <utility>
 
 namespace navmesh::recast
 {
 
-BakedWalls BakeWalls(WallOracle& wo, double x0, double y0, int64_t nx, int64_t ny)
+// 收齐窗口内的边界边。这份数据只说哪里能走, 不带墙面/断崖之类的信息,
+// 再去分辨某条边是墙还是接缝等于凭空造数据, 所以这里只收边、不分类。
+// 三角的包围盒罩得住它自己的每条边, 于是分桶查出来的三角必是超集; 按三角号升序、
+// 边内序 k 升序枚举, 得到的就是全网格顺序扫描的同一子序列。
+BakedWalls BakeWalls(const ZoneClean& zc, double x0, double y0, int64_t nx, int64_t ny)
 {
     BakedWalls out;
-    const auto widx = wo.wallsInBbox(x0 - 4, y0 - 4, x0 + static_cast<double>(nx) * kCS + 4, y0 + static_cast<double>(ny) * kCS + 4);
-    out.p0.reserve(widx.size());
-    out.p1.reserve(widx.size());
-    out.h0.reserve(widx.size());
-    out.h1.reserve(widx.size());
-    out.hh.reserve(widx.size());
-    for (const int64_t i : widx) {
-        out.p0.push_back(wo.P0[static_cast<size_t>(i)]);
-        out.p1.push_back(wo.P1[static_cast<size_t>(i)]);
-        out.h0.push_back(wo.H0[static_cast<size_t>(i)]);
-        out.h1.push_back(wo.H1[static_cast<size_t>(i)]);
-        out.hh.push_back(wo.HH[static_cast<size_t>(i)]);
+    const double bx0 = x0 - 4;
+    const double by0 = y0 - 4;
+    const double bx1 = x0 + static_cast<double>(nx) * kCS + 4;
+    const double by1 = y0 + static_cast<double>(ny) * kCS + 4;
+    const PolyMesh& mesh = zc.mesh;
+    for (const int32_t t : mesh.trisInBox(bx0, by0, bx1, by1)) {
+        const auto i = static_cast<size_t>(t);
+        if (zc.walkable[i] == 0) {
+            // 掩码外的三角不出边。它与可走面之间那条缝已在 ZoneClean 里割断,
+            // 所以那条边会由可走面这一侧收成边界边 —— 水岸因此成墙,而不是消失。
+            continue;
+        }
+        for (int k = 0; k < 3; ++k) {
+            if (mesh.NB[i][k] >= 0) {
+                continue;
+            }
+            const int32_t a = mesh.T[i][k];
+            const int32_t b = mesh.T[i][(k + 1) % 3];
+            const WorldPoint p0 = mesh.V[a];
+            const WorldPoint p1 = mesh.V[b];
+            if (std::max(p0.x, p1.x) >= bx0 && std::min(p0.x, p1.x) <= bx1 && std::max(p0.y, p1.y) >= by0
+                && std::min(p0.y, p1.y) <= by1) {
+                out.p0.push_back(p0);
+                out.p1.push_back(p1);
+                out.h0.push_back(mesh.H[a]);
+                out.h1.push_back(mesh.H[b]);
+                out.hh.push_back((mesh.H[a] + mesh.H[b]) / 2.0);
+            }
+        }
     }
     return out;
 }
 
-BakedCells BakeCells(const ZoneClean& zc, WallOracle& wo, double x0, double y0, int64_t nx, int64_t ny)
+BakedCells BakeCells(const ZoneClean& zc, double x0, double y0, int64_t nx, int64_t ny)
 {
     BakedCells out;
     out.x0 = x0;
@@ -36,7 +58,7 @@ BakedCells BakeCells(const ZoneClean& zc, WallOracle& wo, double x0, double y0, 
     AppendSeamBridge(out.rcs, nx, ny);
     out.st = BuildSpans(out.rcs.cell, out.rcs.h);
 
-    BakedWalls walls = BakeWalls(wo, x0, y0, nx, ny);
+    BakedWalls walls = BakeWalls(zc, x0, y0, nx, ny);
     out.wallP0 = std::move(walls.p0);
     out.wallP1 = std::move(walls.p1);
     out.wallH0 = std::move(walls.h0);

--- a/agent/cpp-algo/source/Navmesh/RecastNavBake.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavBake.cpp
@@ -31,7 +31,8 @@ BakedCells BakeCells(const ZoneClean& zc, WallOracle& wo, double x0, double y0, 
     out.y0 = y0;
     out.nx = nx;
     out.ny = ny;
-    out.rcs = Rasterize(zc.mesh.V, zc.mesh.H, zc.mesh.T, x0, y0, nx, ny);
+    // 掩码随网格一起送进体素化 —— 烘焙期与运行期共用这一处判据,两边的可走面必然一致
+    out.rcs = Rasterize(zc.mesh.V, zc.mesh.H, zc.mesh.T, x0, y0, nx, ny, &zc.walkable);
     AppendSeamBridge(out.rcs, nx, ny);
     out.st = BuildSpans(out.rcs.cell, out.rcs.h);
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavBake.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavBake.h
@@ -20,7 +20,7 @@ struct BakedWalls
     std::vector<double> hh;
 };
 
-BakedWalls BakeWalls(WallOracle& wo, double x0, double y0, int64_t nx, int64_t ny);
+BakedWalls BakeWalls(const ZoneClean& zc, double x0, double y0, int64_t nx, int64_t ny);
 
 // 一块矩形范围内、只由区几何与墙决定的体素数据。起点、终点、封堵都不参与,
 // 所以同一矩形任何时候烤出来的都一样,可以离线算好存进包里。
@@ -41,6 +41,6 @@ struct BakedCells
 };
 
 // 矩形左下角 (x0,y0)、nx×ny 格。墙取窗口外扩 4px 内的,与盖章口径一致。
-BakedCells BakeCells(const ZoneClean& zc, WallOracle& wo, double x0, double y0, int64_t nx, int64_t ny);
+BakedCells BakeCells(const ZoneClean& zc, double x0, double y0, int64_t nx, int64_t ny);
 
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -1352,10 +1352,13 @@ std::vector<std::vector<WorldPoint>> TraceContours(const Mask& mask)
 {
     const int64_t ny = mask.ny, nx = mask.nx;
     const int64_t W = nx + 1;
-    const int64_t KK = W * (ny + 1);
-    std::unordered_map<int64_t, std::vector<int64_t>> nxt;
+    // 每个格角一字节: 低四位记这四个侧上有没有出边, 高四位记走过没有。给定角与侧, 出边的落点唯一
+    // (角号之差就是 kStep), 侧号本身即出边, 邻接表与走过集都不必再散列。
+    const int64_t kStep[4] = { W, -1, -W, 1 };
+    std::vector<uint8_t> bits(static_cast<size_t>(W * (ny + 1)), 0);
     std::vector<int64_t> order;
-    for (const auto& sd : kSides) {
+    for (int s = 0; s < 4; ++s) {
+        const int64_t* sd = kSides[s];
         const int64_t dx = sd[0], dy = sd[1];
         for (int64_t y = 0; y < ny; ++y) {
             for (int64_t x = 0; x < nx; ++x) {
@@ -1367,40 +1370,47 @@ std::vector<std::vector<WorldPoint>> TraceContours(const Mask& mask)
                     continue;
                 }
                 const int64_t u = (y + sd[3]) * W + (x + sd[2]);
-                const int64_t v = (y + sd[5]) * W + (x + sd[4]);
-                auto [it, fresh] = nxt.try_emplace(u);
-                if (fresh) {
+                uint8_t& b = bits[static_cast<size_t>(u)];
+                if ((b & 0x0FU) == 0) {
                     order.push_back(u);
                 }
-                it->second.push_back(v);
+                b |= static_cast<uint8_t>(1U << s);
             }
         }
     }
     std::vector<std::vector<WorldPoint>> loops;
-    std::unordered_set<int64_t> used;
     for (const int64_t u0 : order) {
-        for (const int64_t v0 : nxt[u0]) {
-            if (used.contains(u0 * KK + v0)) {
+        for (int s0 = 0; s0 < 4; ++s0) {
+            const uint8_t m0 = static_cast<uint8_t>(1U << s0);
+            const uint8_t b0 = bits[static_cast<size_t>(u0)];
+            if ((b0 & m0) == 0 || (b0 & static_cast<uint8_t>(m0 << 4)) != 0) {
                 continue;
             }
             std::vector<int64_t> loop;
-            int64_t u = u0, v = v0;
+            int64_t u = u0, v = u0 + kStep[s0];
+            int su = s0;
             while (true) {
-                used.insert(u * KK + v);
+                bits[static_cast<size_t>(u)] |= static_cast<uint8_t>(1U << (su + 4));
                 loop.push_back(u);
-                const auto it = nxt.find(v);
-                if (it == nxt.end() || it->second.empty()) {
+                const uint8_t out = static_cast<uint8_t>(bits[static_cast<size_t>(v)] & 0x0FU);
+                if (out == 0) {
                     break;
                 }
-                int64_t w = 0;
-                if (it->second.size() == 1) {
-                    w = it->second[0];
+                int sw = 0;
+                if ((out & static_cast<uint8_t>(out - 1)) == 0) {
+                    while ((out & static_cast<uint8_t>(1U << sw)) == 0) {
+                        ++sw;
+                    }
                 }
                 else {
                     // 岔口优先右转,与 A* 禁切角一致
                     const int64_t d0 = v % W - u % W, d1 = v / W - u / W;
                     int best = 10;
-                    for (const int64_t z : it->second) {
+                    for (int s = 0; s < 4; ++s) {
+                        if ((out & static_cast<uint8_t>(1U << s)) == 0) {
+                            continue;
+                        }
+                        const int64_t z = v + kStep[s];
                         const int64_t e0 = z % W - v % W, e1 = z / W - v / W;
                         int rank = 9;
                         if (e0 == d1 && e1 == -d0) {
@@ -1417,15 +1427,17 @@ std::vector<std::vector<WorldPoint>> TraceContours(const Mask& mask)
                         }
                         if (rank < best) {
                             best = rank;
-                            w = z;
+                            sw = s;
                         }
                     }
                 }
-                if (used.contains(v * KK + w)) {
+                if ((bits[static_cast<size_t>(v)] & static_cast<uint8_t>(1U << (sw + 4))) != 0) {
                     break;
                 }
+                const int64_t w = v + kStep[sw];
                 u = v;
                 v = w;
+                su = sw;
             }
             if (loop.size() >= 4) {
                 std::vector<WorldPoint> pts;

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -662,11 +662,9 @@ std::vector<uint8_t> WallsAtLayer(
     return keep;
 }
 
-WallCsr BuildWallIndex(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny)
+Mask WallHits(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny)
 {
-    WallCsr csr;
-    csr.start.assign(static_cast<size_t>(nx * ny + 1), 0);
-    std::vector<std::pair<int64_t, int64_t>> entries;
+    Mask hit(nx, ny, 0);
     for (size_t i = 0; i < p0.size(); ++i) {
         const double L = std::hypot(p1[i].x - p0[i].x, p1[i].y - p0[i].y);
         const int64_t steps = sampleSteps(L, 0.2);
@@ -677,20 +675,11 @@ WallCsr BuildWallIndex(const std::vector<WorldPoint>& p0, const std::vector<Worl
             const int64_t gx = static_cast<int64_t>(std::floor((sx - ox) / kCS));
             const int64_t gy = static_cast<int64_t>(std::floor((sy - oy) / kCS));
             if (gx >= 0 && gx < nx && gy >= 0 && gy < ny) {
-                entries.emplace_back(gy * nx + gx, static_cast<int64_t>(i));
+                hit.at(gy, gx) = 1;
             }
         }
     }
-    std::sort(entries.begin(), entries.end());
-    entries.erase(std::unique(entries.begin(), entries.end()), entries.end());
-    for (const auto& [cid, wid] : entries) {
-        ++csr.start[static_cast<size_t>(cid + 1)];
-        csr.wid.push_back(wid);
-    }
-    for (size_t i = 1; i < csr.start.size(); ++i) {
-        csr.start[i] += csr.start[i - 1];
-    }
-    return csr;
+    return hit;
 }
 
 std::vector<int64_t> Comps4(const Mask& mask)

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -1723,6 +1723,7 @@ void Blockers::buildIndex() const
         }
     }
     seen_.assign(a_.size(), 0);
+    bseen_.assign(bstart_.size() - 1, 0);
 }
 
 bool Blockers::blocked(const WorldPoint& p, const WorldPoint& q) const
@@ -1738,10 +1739,10 @@ bool Blockers::blocked(const WorldPoint& p, const WorldPoint& q) const
     }
     if (++epoch_ == 0) {
         std::fill(seen_.begin(), seen_.end(), 0);
+        std::fill(bseen_.begin(), bseen_.end(), 0);
         ++epoch_;
     }
     const int64_t ns = static_cast<int64_t>(std::hypot(rx, ry) / (kBkt * 0.5)) + 1;
-    cand_.clear();
     for (int64_t k = 0; k <= ns && bnx_ > 0; ++k) {
         const double t = static_cast<double>(k) / static_cast<double>(ns);
         const int64_t sx0 = static_cast<int64_t>((p.x + rx * t - bx0_) / kBkt);
@@ -1749,34 +1750,37 @@ bool Blockers::blocked(const WorldPoint& p, const WorldPoint& q) const
         for (int64_t gy = std::max<int64_t>(sy0 - 1, 0); gy <= std::min(sy0 + 1, bny_ - 1); ++gy) {
             for (int64_t gx = std::max<int64_t>(sx0 - 1, 0); gx <= std::min(sx0 + 1, bnx_ - 1); ++gx) {
                 const size_t bk = static_cast<size_t>(gy * bnx_ + gx);
+                // 取样间隔半桶而邻域取三乘三, 同一个桶要被相邻取样点各扫一遍; 桶也挂世代戳,
+                // 二次访问时桶里每段都已标过, 本来就一段都不产, 整桶跳过待测集不变。
+                if (bseen_[bk] == epoch_) {
+                    continue;
+                }
+                bseen_[bk] = epoch_;
                 for (int32_t e = bstart_[bk]; e < bstart_[bk + 1]; ++e) {
                     const int32_t id = bitem_[static_cast<size_t>(e)];
                     if (seen_[static_cast<size_t>(id)] == epoch_) {
                         continue;
                     }
                     seen_[static_cast<size_t>(id)] = epoch_;
-                    cand_.push_back(id);
+                    const size_t i = static_cast<size_t>(id);
+                    if (hi_[i].x < lox || lo_[i].x > hix || hi_[i].y < loy || lo_[i].y > hiy) {
+                        continue;
+                    }
+                    const double sx = b_[i].x - a_[i].x, sy = b_[i].y - a_[i].y;
+                    const double den = rx * sy - ry * sx;
+                    if (!(std::abs(den) > 1e-12)) {
+                        continue;
+                    }
+                    const double ux = a_[i].x - p.x, uy = a_[i].y - p.y;
+                    const double tt = (ux * sy - uy * sx) / den;
+                    const double w = (ux * ry - uy * rx) / den;
+                    // 挡线一侧取闭区间: 挡线段是格边, 精确 45° 的弦每次都正好交在端点上, 开区间会让它
+                    // 从每道轴对齐挡线的顶点缝里溜过去。弦一侧仍开区间, 端点搭在挡线上是贴墙走不算穿墙。
+                    if (tt > eps && tt < 1 - eps && w > -eps && w < 1 + eps) {
+                        return true;
+                    }
                 }
             }
-        }
-    }
-    for (const int32_t ii : cand_) {
-        const size_t i = static_cast<size_t>(ii);
-        if (hi_[i].x < lox || lo_[i].x > hix || hi_[i].y < loy || lo_[i].y > hiy) {
-            continue;
-        }
-        const double sx = b_[i].x - a_[i].x, sy = b_[i].y - a_[i].y;
-        const double den = rx * sy - ry * sx;
-        if (!(std::abs(den) > 1e-12)) {
-            continue;
-        }
-        const double ux = a_[i].x - p.x, uy = a_[i].y - p.y;
-        const double t = (ux * sy - uy * sx) / den;
-        const double w = (ux * ry - uy * rx) / den;
-        // 挡线一侧取闭区间: 挡线段是格边, 精确 45° 的弦每次都正好交在端点上, 开区间会让它
-        // 从每道轴对齐挡线的顶点缝里溜过去。弦一侧仍开区间, 端点搭在挡线上是贴墙走不算穿墙。
-        if (t > eps && t < 1 - eps && w > -eps && w < 1 + eps) {
-            return true;
         }
     }
     return offMask(p, q);

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -45,10 +45,7 @@ int64_t sampleSteps(double len, double sub)
 
 int64_t occFind(const SpanTable& st, int64_t cid)
 {
-    if (cid < 0 || cid >= static_cast<int64_t>(st.c2j.size())) {
-        return -1;
-    }
-    return st.c2j[static_cast<size_t>(cid)];
+    return st.j(cid);
 }
 
 // cid 沿 (dx,dy) 走 s 格处是否有落在 h±kStepUp 的 span。s 可为负,即朝反方向探。
@@ -63,8 +60,8 @@ bool levelAt(const SpanTable& st, int64_t nx, int64_t ny, int64_t cid, int64_t d
     if (j < 0) {
         return false;
     }
-    const int64_t b = st.cstart[static_cast<size_t>(j)];
-    const int64_t n = st.ccnt[static_cast<size_t>(j)];
+    const int64_t b = st.cstart(j);
+    const int64_t n = st.ccnt(j);
     for (int64_t k = 0; k < n; ++k) {
         if (std::fabs(static_cast<double>(st.sp_h[static_cast<size_t>(b + k)] - h)) <= kStepUp) {
             return true;
@@ -258,7 +255,7 @@ SpanTable BuildSpans(const std::vector<int64_t>& cell, const std::vector<float>&
             if (cnt) {
                 st.sp_h.push_back(static_cast<float>(acc / static_cast<double>(cnt)));
             }
-            st.sp_cell.push_back(c);
+            st.sp_cell.push_back(static_cast<int32_t>(c));
             acc = 0.0;
             cnt = 0;
             anchor = hv;
@@ -270,7 +267,7 @@ SpanTable BuildSpans(const std::vector<int64_t>& cell, const std::vector<float>&
     return PackSpans(std::move(st.sp_cell), std::move(st.sp_h));
 }
 
-SpanTable PackSpans(std::vector<int64_t> cell, std::vector<float> h, std::vector<uint8_t>* flags)
+SpanTable PackSpans(std::vector<int32_t> cell, std::vector<float> h, std::vector<uint8_t>* flags)
 {
     SpanTable st;
     const int64_t n_span = static_cast<int64_t>(cell.size());
@@ -280,9 +277,9 @@ SpanTable PackSpans(std::vector<int64_t> cell, std::vector<float> h, std::vector
     // 主键 cell 是格号, 计数排序按升序装桶且桶内保持原次序; 副键 h 在桶内插入排序, 严格大于
     // 才挪位同样保序。两步都稳定 ⇒ 与按 (cell, h) 稳定排序同序, 而一格的 span 只有几条。
     const int64_t nc = *std::max_element(cell.begin(), cell.end()) + 1;
-    std::vector<int64_t> ord(static_cast<size_t>(n_span));
+    std::vector<int32_t> ord(static_cast<size_t>(n_span));
     std::vector<int32_t> cstart(static_cast<size_t>(nc + 1), 0);
-    for (const int64_t c : cell) {
+    for (const int32_t c : cell) {
         ++cstart[static_cast<size_t>(c) + 1];
     }
     for (size_t k = 1; k < cstart.size(); ++k) {
@@ -291,13 +288,13 @@ SpanTable PackSpans(std::vector<int64_t> cell, std::vector<float> h, std::vector
     {
         std::vector<int32_t> fill(cstart.begin(), cstart.end() - 1);
         for (int64_t i = 0; i < n_span; ++i) {
-            ord[static_cast<size_t>(fill[static_cast<size_t>(cell[static_cast<size_t>(i)])]++)] = i;
+            ord[static_cast<size_t>(fill[static_cast<size_t>(cell[static_cast<size_t>(i)])]++)] = static_cast<int32_t>(i);
         }
     }
     for (int64_t c = 0; c < nc; ++c) {
         const int64_t b = cstart[static_cast<size_t>(c)], e = cstart[static_cast<size_t>(c) + 1];
         for (int64_t i = b + 1; i < e; ++i) {
-            const int64_t v = ord[static_cast<size_t>(i)];
+            const int32_t v = ord[static_cast<size_t>(i)];
             const float hv = h[static_cast<size_t>(v)];
             int64_t j = i;
             while (j > b && h[static_cast<size_t>(ord[static_cast<size_t>(j - 1)])] > hv) {
@@ -320,29 +317,29 @@ SpanTable PackSpans(std::vector<int64_t> cell, std::vector<float> h, std::vector
         }
         flags->swap(fo);
     }
+    // 先数一遍占用格再一次分配。边数边 push 会按二的幂扩容, 逐格数组在满窗口上要白占近一倍。
+    int64_t n_occ = 0;
     for (int64_t i = 0; i < n_span; ++i) {
-        if (i == 0 || st.sp_cell[i] != st.sp_cell[i - 1]) {
-            st.occ.push_back(st.sp_cell[i]);
-            st.cstart.push_back(i);
-            st.ccnt.push_back(0);
+        if (i == 0 || st.sp_cell[static_cast<size_t>(i)] != st.sp_cell[static_cast<size_t>(i - 1)]) {
+            ++n_occ;
         }
-        ++st.ccnt.back();
     }
-    st.K = *std::max_element(st.ccnt.begin(), st.ccnt.end());
-    st.c2j.assign(static_cast<size_t>(st.occ.back() + 1), -1);
-    for (size_t ci = 0; ci < st.occ.size(); ++ci) {
-        st.c2j[static_cast<size_t>(st.occ[ci])] = static_cast<int32_t>(ci);
+    st.cs.resize(static_cast<size_t>(n_occ) + 1);
+    st.cs[static_cast<size_t>(n_occ)] = static_cast<int32_t>(n_span);
+    for (int64_t i = 0, ci = 0; i < n_span; ++i) {
+        if (i == 0 || st.sp_cell[static_cast<size_t>(i)] != st.sp_cell[static_cast<size_t>(i - 1)]) {
+            st.cs[static_cast<size_t>(ci++)] = static_cast<int32_t>(i);
+        }
     }
-    const int64_t n_occ = static_cast<int64_t>(st.occ.size());
-    st.sp_ci.resize(static_cast<size_t>(n_span));
+    st.c2j.assign(static_cast<size_t>(st.sp_cell.back()) + 1, -1);
+    for (int64_t ci = 0; ci < n_occ; ++ci) {
+        st.c2j[static_cast<size_t>(st.occ(ci))] = static_cast<int32_t>(ci);
+    }
     st.face.assign(static_cast<size_t>(n_occ), 0);
-    for (int64_t ci = 0, si = 0; ci < n_occ; ++ci) {
-        for (int64_t r = 0; r < st.ccnt[ci]; ++r, ++si) {
-            st.sp_ci[si] = ci;
-        }
+    for (int64_t ci = 0; ci < n_occ; ++ci) {
         // 同一格的 span 已按高排好, 首末就是这一列的最低最高。
-        const int64_t b = st.cstart[static_cast<size_t>(ci)];
-        const int64_t c = st.ccnt[static_cast<size_t>(ci)];
+        const int64_t b = st.cstart(ci);
+        const int64_t c = st.ccnt(ci);
         const double lo = st.sp_h[static_cast<size_t>(b)];
         const double hi = st.sp_h[static_cast<size_t>(b + c - 1)];
         st.face[static_cast<size_t>(ci)] = static_cast<uint8_t>(c != 2 && hi - lo > kClimb);
@@ -358,8 +355,8 @@ void AppendSeamBridge(RasterCells& rc, int64_t nx, int64_t ny)
     }
     const SpanTable st = BuildSpans(rc.cell, rc.h);
     std::vector<uint8_t> O2(static_cast<size_t>(nx * ny), 0);
-    for (const int64_t c : st.occ) {
-        O2[static_cast<size_t>(c)] = 1;
+    for (int64_t ci = 0, cn = st.nOcc(); ci < cn; ++ci) {
+        O2[static_cast<size_t>(st.occ(ci))] = 1;
     }
     const auto occAt = [&](int64_t y, int64_t x) {
         return y >= 0 && y < ny && x >= 0 && x < nx && O2[static_cast<size_t>(y * nx + x)] != 0;
@@ -391,8 +388,8 @@ void AppendSeamBridge(RasterCells& rc, int64_t nx, int64_t ny)
                         const int64_t jb = occFind(st, cid - dr * (dy * nx + dx));
                         float best_dh = std::numeric_limits<float>::infinity();
                         float best_ha = 0.0f, best_hb = 0.0f;
-                        const int64_t ba = st.cstart[static_cast<size_t>(ja)], na = st.ccnt[static_cast<size_t>(ja)];
-                        const int64_t bb = st.cstart[static_cast<size_t>(jb)], nb = st.ccnt[static_cast<size_t>(jb)];
+                        const int64_t ba = st.cstart(ja), na = st.ccnt(ja);
+                        const int64_t bb = st.cstart(jb), nb = st.ccnt(jb);
                         for (int64_t p = 0; p < na; ++p) {
                             const float ha = st.sp_h[static_cast<size_t>(ba + p)];
                             for (int64_t q = 0; q < nb; ++q) {
@@ -426,7 +423,7 @@ std::vector<uint8_t> Flood(int64_t seed, const SpanTable& st, int64_t nx)
     while (!frontier.empty()) {
         std::vector<int64_t> next;
         for (const int64_t f : frontier) {
-            const int64_t cid = st.occ[st.sp_ci[f]];
+            const int64_t cid = st.sp_cell[f];
             const int64_t gx = cid % nx;
             for (const auto& d : dirs) {
                 const int64_t dx = d[0], dy = d[1];
@@ -437,7 +434,7 @@ std::vector<uint8_t> Flood(int64_t seed, const SpanTable& st, int64_t nx)
                 if (j < 0) {
                     continue;
                 }
-                const int64_t b = st.cstart[static_cast<size_t>(j)], n = st.ccnt[static_cast<size_t>(j)];
+                const int64_t b = st.cstart(j), n = st.ccnt(j);
                 for (int64_t slot = 0; slot < n; ++slot) {
                     const int64_t cand = b + slot;
                     if (!(std::fabs(st.sp_h[static_cast<size_t>(cand)] - st.sp_h[f]) <= 3.0f)) {
@@ -469,8 +466,8 @@ std::vector<int32_t> LabelRegions(const SpanTable& st, int64_t nx)
     };
     // Flood 的邻接是对称的,所以只朝 +x/+y 合并一遍就够
     const int64_t dirs[2][2] = { { 1, 0 }, { 0, 1 } };
-    for (int64_t ci = 0; ci < static_cast<int64_t>(st.occ.size()); ++ci) {
-        const int64_t cid = st.occ[static_cast<size_t>(ci)];
+    for (int64_t ci = 0, cn = st.nOcc(); ci < cn; ++ci) {
+        const int64_t cid = st.occ(ci);
         const int64_t gx = cid % nx;
         for (const auto& d : dirs) {
             if (d[0] != 0 && gx + d[0] >= nx) {
@@ -480,9 +477,9 @@ std::vector<int32_t> LabelRegions(const SpanTable& st, int64_t nx)
             if (j < 0) {
                 continue;
             }
-            const int64_t jb = st.cstart[static_cast<size_t>(j)], jn = st.ccnt[static_cast<size_t>(j)];
-            for (int64_t r = 0; r < st.ccnt[static_cast<size_t>(ci)]; ++r) {
-                const int64_t u = st.cstart[static_cast<size_t>(ci)] + r;
+            const int64_t jb = st.cstart(j), jn = st.ccnt(j);
+            for (int64_t r = 0; r < st.ccnt(ci); ++r) {
+                const int64_t u = st.cstart(ci) + r;
                 for (int64_t slot = 0; slot < jn; ++slot) {
                     const int64_t v = jb + slot;
                     if (!(std::fabs(st.sp_h[static_cast<size_t>(v)] - st.sp_h[static_cast<size_t>(u)]) <= 3.0f)) {
@@ -514,7 +511,7 @@ std::vector<uint8_t> SpanReach(int64_t seed, const SpanTable& st, const std::vec
     while (!frontier.empty()) {
         std::vector<int64_t> next;
         for (const int64_t f : frontier) {
-            const int64_t cid = st.occ[st.sp_ci[f]];
+            const int64_t cid = st.sp_cell[f];
             const int64_t gx = cid % nx, gy = cid / nx;
             for (const auto& d : kNb8) {
                 const int64_t ax = gx + d.dx, ay = gy + d.dy;
@@ -525,7 +522,7 @@ std::vector<uint8_t> SpanReach(int64_t seed, const SpanTable& st, const std::vec
                 if (j < 0) {
                     continue;
                 }
-                const int64_t b = st.cstart[static_cast<size_t>(j)], n = st.ccnt[static_cast<size_t>(j)];
+                const int64_t b = st.cstart(j), n = st.ccnt(j);
                 for (int64_t slot = 0; slot < n; ++slot) {
                     // 先问候选走没走过。垂直可达判据没有副作用, 挪到这一问之后逐位同答,
                     // 而广度优先里绝大多数邻接探到的是已访问的 span。
@@ -623,7 +620,7 @@ std::vector<uint8_t> StampWalls(
             if (j < 0) {
                 continue;
             }
-            const int64_t b = st.cstart[static_cast<size_t>(j)], n = st.ccnt[static_cast<size_t>(j)];
+            const int64_t b = st.cstart(j), n = st.ccnt(j);
             for (int64_t slot = 0; slot < n; ++slot) {
                 const int64_t sid = b + slot;
                 if (std::abs(static_cast<double>(st.sp_h[static_cast<size_t>(sid)]) - hh[i]) <= kMcHBand) {
@@ -694,133 +691,6 @@ WallCsr BuildWallIndex(const std::vector<WorldPoint>& p0, const std::vector<Worl
         csr.start[i] += csr.start[i - 1];
     }
     return csr;
-}
-
-StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, const Mask& lay, double ox, double oy)
-{
-    StepBarrier out;
-    const int64_t nx = lay.nx, ny = lay.ny, NC = nx * ny, K = st.K;
-    out.steps.resize(nx, ny);
-    if (K <= 0) {
-        return out;
-    }
-    constexpr float kInf = std::numeric_limits<float>::infinity();
-    std::vector<float> T(static_cast<size_t>(NC * K), kInf);
-    for (size_t j = 0; j < st.occ.size(); ++j) {
-        float* row = &T[static_cast<size_t>(st.occ[j] * K)];
-        int64_t n = 0;
-        const int64_t b = st.cstart[j], cn = st.ccnt[j];
-        for (int64_t k = 0; k < cn; ++k) {
-            const int64_t sid = b + k;
-            if (vis[static_cast<size_t>(sid)] != 0) {
-                row[n++] = st.sp_h[static_cast<size_t>(sid)];
-            }
-        }
-    }
-
-    std::vector<uint8_t> ghost(static_cast<size_t>(NC), 0);
-    bool any_ghost = false;
-    for (int64_t c = 0; c < NC; ++c) {
-        if (lay.v[static_cast<size_t>(c)] != 0 && !std::isfinite(T[static_cast<size_t>(c * K)])) {
-            ghost[static_cast<size_t>(c)] = 1;
-            any_ghost = true;
-        }
-    }
-    if (any_ghost) {
-        std::vector<float> g(static_cast<size_t>(NC));
-        for (int64_t c = 0; c < NC; ++c) {
-            g[static_cast<size_t>(c)] = T[static_cast<size_t>(c * K)];
-        }
-        const int64_t rounds = static_cast<int64_t>(std::ceil(std::sqrt(static_cast<double>(kHoleMaxCells)))) + 1;
-        for (int64_t it = 0; it < rounds; ++it) {
-            std::vector<float> nv = g;
-            for (int64_t y = 0; y < ny; ++y) {
-                for (int64_t x = 0; x < nx; ++x) {
-                    const size_t c = static_cast<size_t>(y * nx + x);
-                    if (ghost[c] == 0) {
-                        continue;
-                    }
-                    float m = g[c];
-                    if (x + 1 < nx) {
-                        m = std::min(m, g[c + 1]);
-                    }
-                    if (x > 0) {
-                        m = std::min(m, g[c - 1]);
-                    }
-                    if (y + 1 < ny) {
-                        m = std::min(m, g[c + static_cast<size_t>(nx)]);
-                    }
-                    if (y > 0) {
-                        m = std::min(m, g[c - static_cast<size_t>(nx)]);
-                    }
-                    nv[c] = m;
-                }
-            }
-            const bool same = nv == g;
-            g.swap(nv);
-            if (same) {
-                break;
-            }
-        }
-        for (int64_t c = 0; c < NC; ++c) {
-            if (ghost[static_cast<size_t>(c)] != 0) {
-                T[static_cast<size_t>(c * K)] = g[static_cast<size_t>(c)];
-            }
-        }
-    }
-    out.t0.resize(static_cast<size_t>(NC));
-    for (int64_t c = 0; c < NC; ++c) {
-        out.t0[static_cast<size_t>(c)] = T[static_cast<size_t>(c * K)];
-    }
-
-    static constexpr std::array<std::array<int64_t, 2>, 4> kDirs { { { 1, 0 }, { 0, 1 }, { 1, 1 }, { 1, -1 } } };
-    for (const auto& d : kDirs) {
-        const int64_t dx = d[0], dy = d[1];
-        for (int64_t c = 0; c < NC; ++c) {
-            if (lay.v[static_cast<size_t>(c)] == 0 || !std::isfinite(T[static_cast<size_t>(c * K)])) {
-                continue;
-            }
-            const int64_t ax = c % nx + dx, ay = c / nx + dy;
-            if (ax < 0 || ax >= nx || ay < 0 || ay >= ny) {
-                continue;
-            }
-            const int64_t b = ay * nx + ax;
-            if (!std::isfinite(T[static_cast<size_t>(b * K)])) {
-                continue;
-            }
-            float best = kInf;
-            int64_t bka = 0, bkb = 0;
-            for (int64_t ka = 0; ka < K; ++ka) {
-                for (int64_t kb = 0; kb < K; ++kb) {
-                    const float raw = std::fabs(T[static_cast<size_t>(c * K + ka)] - T[static_cast<size_t>(b * K + kb)]);
-                    const float dd = std::isfinite(raw) ? raw : kInf;
-                    if (dd < best) {
-                        best = dd;
-                        bka = ka;
-                        bkb = kb;
-                    }
-                }
-            }
-            if (!(static_cast<double>(best) > UpAllow(std::hypot(static_cast<double>(dx), static_cast<double>(dy))))) {
-                continue;
-            }
-            const bool up = T[static_cast<size_t>(b * K + bkb)] > T[static_cast<size_t>(c * K + bka)];
-            if (up) {
-                out.steps.set(c, b);
-            }
-            else {
-                out.steps.set(b, c);
-            }
-            if (dx != 0 && dy != 0) {
-                continue;
-            }
-            const double px = ox + static_cast<double>(c % nx + dx) * kCS;
-            const double py = oy + static_cast<double>(c / nx + dy) * kCS;
-            out.p0.push_back({ px, py });
-            out.p1.push_back({ px + static_cast<double>(dy) * kCS, py + static_cast<double>(dx) * kCS });
-        }
-    }
-    return out;
 }
 
 std::vector<int64_t> Comps4(const Mask& mask)
@@ -1072,7 +942,6 @@ bool Visibility::ok(const WorldPoint& p, const WorldPoint& q, float hp, float hq
 std::optional<std::vector<int64_t>> SpanAstar(
     const SpanTable& st,
     const std::vector<uint8_t>& ok,
-    const std::vector<int64_t>& cidx,
     const Mask& ok2,
     int64_t s,
     const std::vector<int64_t>& gset,
@@ -1087,7 +956,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
         return std::nullopt;
     }
     const int64_t nx = ok2.nx, ny = ok2.ny;
-    const int64_t gc = st.occ[st.sp_ci[static_cast<size_t>(gset.front())]];
+    const int64_t gc = st.sp_cell[static_cast<size_t>(gset.front())];
     const int64_t gxx = gc % nx, gyy = gc / nx;
     std::vector<double> dist(st.sp_h.size(), std::numeric_limits<double>::infinity());
     std::vector<int64_t> prev(st.sp_h.size(), -1);
@@ -1119,7 +988,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
             if (d.dx != 0 && d.dy != 0 && !(ok2.at(y, a) && ok2.at(b, x))) {
                 continue;
             }
-            const int64_t j = cidx[static_cast<size_t>(cw)];
+            const int64_t j = st.j(cw);
             if (j < 0) {
                 continue;
             }
@@ -1134,7 +1003,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
                 pen = *bnp;
             }
             const double stp = d.w * 0.5 * static_cast<double>(mult.v[static_cast<size_t>(cw)] + mult.v[static_cast<size_t>(cu)]);
-            const int64_t jb = st.cstart[static_cast<size_t>(j)], jn = st.ccnt[static_cast<size_t>(j)];
+            const int64_t jb = st.cstart(j), jn = st.ccnt(j);
             for (int64_t k = 0; k < jn; ++k) {
                 const int64_t w = jb + k;
                 if (ok[static_cast<size_t>(w)] == 0 || closed[static_cast<size_t>(w)] == 0) {
@@ -1159,7 +1028,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
         const auto [f, u] = pq.top();
         pq.pop();
         double d0 = dist[static_cast<size_t>(u)];
-        const int64_t cu = st.occ[st.sp_ci[static_cast<size_t>(u)]];
+        const int64_t cu = st.sp_cell[static_cast<size_t>(u)];
         const int64_t x = cu % nx, y = cu / nx;
         if (f > d0 + std::hypot(static_cast<double>(gxx - x), static_cast<double>(gyy - y)) + 1e-9) {
             continue;
@@ -1171,7 +1040,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
             const int64_t p = prev[static_cast<size_t>(u)];
             if (p >= 0
                 && !vis->ok(
-                    vis->at(st.occ[st.sp_ci[static_cast<size_t>(p)]]),
+                    vis->at(st.sp_cell[static_cast<size_t>(p)]),
                     vis->at(cu),
                     st.sp_h[static_cast<size_t>(p)],
                     st.sp_h[static_cast<size_t>(u)])) {
@@ -1198,7 +1067,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
             if (d.dx != 0 && d.dy != 0 && !(ok2.at(y, a) && ok2.at(b, x))) {
                 continue;
             }
-            const int64_t j = cidx[static_cast<size_t>(cv)];
+            const int64_t j = st.j(cv);
             if (j < 0) {
                 continue;
             }
@@ -1222,7 +1091,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
             if (vis != nullptr) {
                 const int64_t p = prev[static_cast<size_t>(u)];
                 if (p >= 0 && mult.v[static_cast<size_t>(cv)] <= 1.0F) {
-                    const int64_t cp = st.occ[st.sp_ci[static_cast<size_t>(p)]];
+                    const int64_t cp = st.sp_cell[static_cast<size_t>(p)];
                     if (mult.v[static_cast<size_t>(cp)] <= 1.0F) {
                         const double cd = dist[static_cast<size_t>(p)]
                             + std::hypot(static_cast<double>(a - cp % nx), static_cast<double>(b - cp / nx));
@@ -1233,7 +1102,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
                     }
                 }
             }
-            const int64_t sb = st.cstart[static_cast<size_t>(j)], sn = st.ccnt[static_cast<size_t>(j)];
+            const int64_t sb = st.cstart(j), sn = st.ccnt(j);
             for (int64_t k = 0; k < sn; ++k) {
                 const int64_t v = sb + k;
                 if (ok[static_cast<size_t>(v)] == 0) {
@@ -1270,8 +1139,8 @@ std::optional<std::vector<int64_t>> SpanAstar(
     const std::vector<int64_t> corn = out;
     out.assign(1, corn.front());
     for (size_t i = 1; i < corn.size(); ++i) {
-        const int64_t ca = st.occ[st.sp_ci[static_cast<size_t>(corn[i - 1])]];
-        const int64_t cb = st.occ[st.sp_ci[static_cast<size_t>(corn[i])]];
+        const int64_t ca = st.sp_cell[static_cast<size_t>(corn[i - 1])];
+        const int64_t cb = st.sp_cell[static_cast<size_t>(corn[i])];
         const int64_t axx = ca % nx, ayy = ca / nx, bxx = cb % nx, byy = cb / nx;
         const int64_t n = std::max<int64_t>(std::max(std::abs(bxx - axx), std::abs(byy - ayy)), 1);
         const float ha = st.sp_h[static_cast<size_t>(corn[i - 1])];
@@ -1280,17 +1149,17 @@ std::optional<std::vector<int64_t>> SpanAstar(
             const int64_t cx = axx + static_cast<int64_t>(std::nearbyint(static_cast<double>(bxx - axx) * static_cast<double>(k) / static_cast<double>(n)));
             const int64_t cy = ayy + static_cast<int64_t>(std::nearbyint(static_cast<double>(byy - ayy) * static_cast<double>(k) / static_cast<double>(n)));
             const int64_t cc = cy * nx + cx;
-            if (cc == st.occ[st.sp_ci[static_cast<size_t>(out.back())]]) {
+            if (cc == st.sp_cell[static_cast<size_t>(out.back())]) {
                 continue;
             }
-            const int64_t j = cidx[static_cast<size_t>(cc)];
+            const int64_t j = st.j(cc);
             if (j < 0) {
                 continue;
             }
             const float ht = ha + (hb - ha) * static_cast<float>(k) / static_cast<float>(n);
             int64_t bv = -1;
             float bdh = 0.0F;
-            const int64_t sb = st.cstart[static_cast<size_t>(j)], sn = st.ccnt[static_cast<size_t>(j)];
+            const int64_t sb = st.cstart(j), sn = st.ccnt(j);
             for (int64_t kk = 0; kk < sn; ++kk) {
                 const int64_t v = sb + kk;
                 if (ok[static_cast<size_t>(v)] == 0) {
@@ -1836,12 +1705,12 @@ std::optional<std::vector<float>> LayerOracle::walk(const std::vector<WorldPoint
     std::vector<float> nxt;
     CellPt pc = cells.empty() ? CellPt {} : cells[0];
     for (size_t i = 1; i < cells.size(); ++i) {
-        const int64_t j = (*cidx_)[static_cast<size_t>(cells[i].y * nx_ + cells[i].x)];
+        const int64_t j = st_->j(cells[i].y * nx_ + cells[i].x);
         if (j < 0) {
             continue;
         }
         nb.clear();
-        const int64_t sb = st_->cstart[static_cast<size_t>(j)], sn = st_->ccnt[static_cast<size_t>(j)];
+        const int64_t sb = st_->cstart(j), sn = st_->ccnt(j);
         for (int64_t k = 0; k < sn; ++k) {
             nb.push_back(st_->sp_h[static_cast<size_t>(sb + k)]);
         }

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -43,15 +43,99 @@ int64_t sampleSteps(double len, double sub)
     return std::max<int64_t>(static_cast<int64_t>(std::ceil(len / (kCS * sub))), 1) + 1;
 }
 
-int64_t occFind(const std::vector<int64_t>& occ, int64_t cid)
+int64_t occFind(const SpanTable& st, int64_t cid)
 {
-    auto it = std::lower_bound(occ.begin(), occ.end(), cid);
-    if (it == occ.end() || *it != cid) {
+    if (cid < 0 || cid >= static_cast<int64_t>(st.c2j.size())) {
         return -1;
     }
-    return it - occ.begin();
+    return st.c2j[static_cast<size_t>(cid)];
 }
 
+// cid 沿 (dx,dy) 走 s 格处是否有落在 h±kStepUp 的 span。s 可为负,即朝反方向探。
+bool levelAt(const SpanTable& st, int64_t nx, int64_t ny, int64_t cid, int64_t dx, int64_t dy, int64_t s, float h)
+{
+    const int64_t ax = cid % nx + dx * s;
+    const int64_t ay = cid / nx + dy * s;
+    if (ax < 0 || ax >= nx || ay < 0 || ay >= ny) {
+        return false;
+    }
+    const int64_t j = occFind(st, ay * nx + ax);
+    if (j < 0) {
+        return false;
+    }
+    const int64_t b = st.cstart[static_cast<size_t>(j)];
+    const int64_t n = st.ccnt[static_cast<size_t>(j)];
+    for (int64_t k = 0; k < n; ++k) {
+        if (std::fabs(static_cast<double>(st.sp_h[static_cast<size_t>(b + k)] - h)) <= kStepUp) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// cid 沿 (dx,dy) 走 s 格那一列是否是被栅格化的立面: 面摞起来够得上一堵墙, 且不止两张。
+// 恰好两张是地面上方顶着一层盖 —— 柱廊、桥下、挑檐都是这个形状, 中间隔的是层高不是墙。
+bool rasterFace(const SpanTable& st, int64_t nx, int64_t ny, int64_t cid, int64_t dx, int64_t dy, int64_t s)
+{
+    const int64_t ax = cid % nx + dx * s;
+    const int64_t ay = cid / nx + dy * s;
+    if (ax < 0 || ax >= nx || ay < 0 || ay >= ny) {
+        return false;
+    }
+    const int64_t j = occFind(st, ay * nx + ax);
+    return j >= 0 && st.face[static_cast<size_t>(j)] != 0;
+}
+
+}
+
+// 抬升超出可迈台阶高时的补充放行。往前几格就回到出发高度 = 落脚处只是路面上一处窄凸起;
+// 身后几格就有目标高度 = 出发处只是路面上一处浅坑。台阶与立面的落差会一直延续下去,
+// 前后都够不着,所以这里放行不了它们。
+bool RiseOk(const SpanTable& st, int64_t nx, int64_t ny, int64_t cid, int64_t dx, int64_t dy, float h0, float h1)
+{
+    const double dh = static_cast<double>(h1) - static_cast<double>(h0);
+    if (dh < -kClimb) {
+        return false;
+    }
+    // 坡度口径以内两条支路结论一样: 立面按坡度放行, 平地按 UpAllow 放行而 UpAllow 恒不小于
+    // 坡度口径。于是这一档不必去问是不是立面 —— 绝大多数边是平的, 省下的正是那两次叠层扫描。
+    // 格步至少一维非零 ⇒ 模长不小于 1 ⇒ 一格坡高是坡度口径的下界, 先用它筛掉平边。
+    if (dh <= kSlope * kCS) {
+        return true;
+    }
+    const double w = std::hypot(static_cast<double>(dx), static_cast<double>(dy));
+    if (dh <= kSlope * w * kCS) {
+        return true;
+    }
+    // 被栅格化的立面上只按坡度放行, 可迈台阶高与凸起/浅坑这些路面口径一概不给, 否则从旁边
+    // 迈上立面、顺着叠层逐格爬升、再迈回地面, 整堵墙就被爬上去了。坡度口径与不认台阶时是
+    // 同一个值, 所以这里放行的永远是原有的子集。
+    if (rasterFace(st, nx, ny, cid, dx, dy, 0) || rasterFace(st, nx, ny, cid, dx, dy, 1)) {
+        return false;
+    }
+    // 走到这里坡度口径已经不放行, UpAllow 取的那两项里就只剩可迈台阶高。
+    if (dh <= kStepUp) {
+        return true;
+    }
+    if (dh > kBumpUp) {
+        return false;
+    }
+    for (int64_t s = 2; s <= kBumpCells; ++s) {
+        // 往前几格回到出发高度而没有目标高度: 落脚处是路面上一处窄凸起。两个高度都在说明
+        // 那里是上下两层叠着, 立面被栅格化成一列叠层时正是如此, 于是不算凸起 —— 少了这一条,
+        // 台阶侧面与地面就被连起来, 直线会从楼梯旁边爬上去而不是从台阶口走上去。
+        if (levelAt(st, nx, ny, cid, dx, dy, s, h0) && !levelAt(st, nx, ny, cid, dx, dy, s, h1)) {
+            return true;
+        }
+    }
+    for (int64_t s = 1; s <= kDipCells; ++s) {
+        // 身后有目标高度而没有出发高度: 出发处是路面上一处浅坑。两个高度都在说明身后是上下
+        // 两层叠着, 一级级往上的台阶正是如此; 挡住这一类, 才不会顺着台阶把立面爬上去。
+        if (levelAt(st, nx, ny, cid, dx, dy, -s, h1) && !levelAt(st, nx, ny, cid, dx, dy, -s, h0)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 RasterCells Rasterize(
@@ -61,13 +145,17 @@ RasterCells Rasterize(
     double ox,
     double oy,
     int64_t nx,
-    int64_t ny)
+    int64_t ny,
+    const std::vector<uint8_t>* walkable)
 {
     RasterCells out;
     const double hcs = kCS * 0.5;
     std::vector<int64_t> kept;
     kept.reserve(T.size());
     for (int64_t ti = 0; ti < static_cast<int64_t>(T.size()); ++ti) {
+        if (walkable != nullptr && (*walkable)[static_cast<size_t>(ti)] == 0) {
+            continue; // 掩码外的三角不进体素:水面、禁区不再铺出可走格
+        }
         const WorldPoint& A = V[T[ti][0]];
         const WorldPoint& B = V[T[ti][1]];
         const WorldPoint& C = V[T[ti][2]];
@@ -189,11 +277,36 @@ SpanTable PackSpans(std::vector<int64_t> cell, std::vector<float> h, std::vector
     if (n_span == 0) {
         return st;
     }
+    // 主键 cell 是格号, 计数排序按升序装桶且桶内保持原次序; 副键 h 在桶内插入排序, 严格大于
+    // 才挪位同样保序。两步都稳定 ⇒ 与按 (cell, h) 稳定排序同序, 而一格的 span 只有几条。
+    const int64_t nc = *std::max_element(cell.begin(), cell.end()) + 1;
     std::vector<int64_t> ord(static_cast<size_t>(n_span));
-    std::iota(ord.begin(), ord.end(), 0);
-    std::stable_sort(ord.begin(), ord.end(), [&](int64_t a, int64_t b) {
-        return cell[a] < cell[b] || (cell[a] == cell[b] && h[a] < h[b]);
-    });
+    std::vector<int32_t> cstart(static_cast<size_t>(nc + 1), 0);
+    for (const int64_t c : cell) {
+        ++cstart[static_cast<size_t>(c) + 1];
+    }
+    for (size_t k = 1; k < cstart.size(); ++k) {
+        cstart[k] += cstart[k - 1];
+    }
+    {
+        std::vector<int32_t> fill(cstart.begin(), cstart.end() - 1);
+        for (int64_t i = 0; i < n_span; ++i) {
+            ord[static_cast<size_t>(fill[static_cast<size_t>(cell[static_cast<size_t>(i)])]++)] = i;
+        }
+    }
+    for (int64_t c = 0; c < nc; ++c) {
+        const int64_t b = cstart[static_cast<size_t>(c)], e = cstart[static_cast<size_t>(c) + 1];
+        for (int64_t i = b + 1; i < e; ++i) {
+            const int64_t v = ord[static_cast<size_t>(i)];
+            const float hv = h[static_cast<size_t>(v)];
+            int64_t j = i;
+            while (j > b && h[static_cast<size_t>(ord[static_cast<size_t>(j - 1)])] > hv) {
+                ord[static_cast<size_t>(j)] = ord[static_cast<size_t>(j - 1)];
+                --j;
+            }
+            ord[static_cast<size_t>(j)] = v;
+        }
+    }
     st.sp_cell.resize(static_cast<size_t>(n_span));
     st.sp_h.resize(static_cast<size_t>(n_span));
     for (int64_t i = 0; i < n_span; ++i) {
@@ -216,16 +329,23 @@ SpanTable PackSpans(std::vector<int64_t> cell, std::vector<float> h, std::vector
         ++st.ccnt.back();
     }
     st.K = *std::max_element(st.ccnt.begin(), st.ccnt.end());
+    st.c2j.assign(static_cast<size_t>(st.occ.back() + 1), -1);
+    for (size_t ci = 0; ci < st.occ.size(); ++ci) {
+        st.c2j[static_cast<size_t>(st.occ[ci])] = static_cast<int32_t>(ci);
+    }
     const int64_t n_occ = static_cast<int64_t>(st.occ.size());
-    st.HK.assign(static_cast<size_t>(n_occ * st.K), std::numeric_limits<float>::infinity());
-    st.IK.assign(static_cast<size_t>(n_occ * st.K), -1);
     st.sp_ci.resize(static_cast<size_t>(n_span));
+    st.face.assign(static_cast<size_t>(n_occ), 0);
     for (int64_t ci = 0, si = 0; ci < n_occ; ++ci) {
         for (int64_t r = 0; r < st.ccnt[ci]; ++r, ++si) {
-            st.HK[ci * st.K + r] = st.sp_h[si];
-            st.IK[ci * st.K + r] = si;
             st.sp_ci[si] = ci;
         }
+        // 同一格的 span 已按高排好, 首末就是这一列的最低最高。
+        const int64_t b = st.cstart[static_cast<size_t>(ci)];
+        const int64_t c = st.ccnt[static_cast<size_t>(ci)];
+        const double lo = st.sp_h[static_cast<size_t>(b)];
+        const double hi = st.sp_h[static_cast<size_t>(b + c - 1)];
+        st.face[static_cast<size_t>(ci)] = static_cast<uint8_t>(c != 2 && hi - lo > kClimb);
     }
     return st;
 }
@@ -237,7 +357,6 @@ void AppendSeamBridge(RasterCells& rc, int64_t nx, int64_t ny)
         return;
     }
     const SpanTable st = BuildSpans(rc.cell, rc.h);
-    const int64_t K = st.K;
     std::vector<uint8_t> O2(static_cast<size_t>(nx * ny), 0);
     for (const int64_t c : st.occ) {
         O2[static_cast<size_t>(c)] = 1;
@@ -268,17 +387,16 @@ void AppendSeamBridge(RasterCells& rc, int64_t nx, int64_t ny)
                             continue;
                         }
                         const int64_t cid = y * nx + x;
-                        const int64_t ja = occFind(st.occ, cid + dl * (dy * nx + dx));
-                        const int64_t jb = occFind(st.occ, cid - dr * (dy * nx + dx));
-                        // 空槽 inf-inf=nan 会毒化 argmin,两侧用相反哨兵
+                        const int64_t ja = occFind(st, cid + dl * (dy * nx + dx));
+                        const int64_t jb = occFind(st, cid - dr * (dy * nx + dx));
                         float best_dh = std::numeric_limits<float>::infinity();
                         float best_ha = 0.0f, best_hb = 0.0f;
-                        for (int64_t p = 0; p < K; ++p) {
-                            const float hka = st.HK[ja * K + p];
-                            const float ha = std::isfinite(hka) ? hka : 1e9f;
-                            for (int64_t q = 0; q < K; ++q) {
-                                const float hkb = st.HK[jb * K + q];
-                                const float hb = std::isfinite(hkb) ? hkb : -1e9f;
+                        const int64_t ba = st.cstart[static_cast<size_t>(ja)], na = st.ccnt[static_cast<size_t>(ja)];
+                        const int64_t bb = st.cstart[static_cast<size_t>(jb)], nb = st.ccnt[static_cast<size_t>(jb)];
+                        for (int64_t p = 0; p < na; ++p) {
+                            const float ha = st.sp_h[static_cast<size_t>(ba + p)];
+                            for (int64_t q = 0; q < nb; ++q) {
+                                const float hb = st.sp_h[static_cast<size_t>(bb + q)];
                                 const float dh = std::fabs(ha - hb);
                                 if (dh < best_dh) {
                                     best_dh = dh;
@@ -315,16 +433,17 @@ std::vector<uint8_t> Flood(int64_t seed, const SpanTable& st, int64_t nx)
                 if (dx != 0 && (gx + dx < 0 || gx + dx >= nx)) {
                     continue;
                 }
-                const int64_t j = occFind(st.occ, cid + dy * nx + dx);
+                const int64_t j = occFind(st, cid + dy * nx + dx);
                 if (j < 0) {
                     continue;
                 }
-                for (int64_t slot = 0; slot < st.K; ++slot) {
-                    if (!(std::fabs(st.HK[j * st.K + slot] - st.sp_h[f]) <= 3.0f)) {
+                const int64_t b = st.cstart[static_cast<size_t>(j)], n = st.ccnt[static_cast<size_t>(j)];
+                for (int64_t slot = 0; slot < n; ++slot) {
+                    const int64_t cand = b + slot;
+                    if (!(std::fabs(st.sp_h[static_cast<size_t>(cand)] - st.sp_h[f]) <= 3.0f)) {
                         continue;
                     }
-                    const int64_t cand = st.IK[j * st.K + slot];
-                    if (cand >= 0 && !vis[static_cast<size_t>(cand)]) {
+                    if (!vis[static_cast<size_t>(cand)]) {
                         vis[static_cast<size_t>(cand)] = 1;
                         next.push_back(cand);
                     }
@@ -357,18 +476,20 @@ std::vector<int32_t> LabelRegions(const SpanTable& st, int64_t nx)
             if (d[0] != 0 && gx + d[0] >= nx) {
                 continue;
             }
-            const int64_t j = occFind(st.occ, cid + d[1] * nx + d[0]);
+            const int64_t j = occFind(st, cid + d[1] * nx + d[0]);
             if (j < 0) {
                 continue;
             }
+            const int64_t jb = st.cstart[static_cast<size_t>(j)], jn = st.ccnt[static_cast<size_t>(j)];
             for (int64_t r = 0; r < st.ccnt[static_cast<size_t>(ci)]; ++r) {
                 const int64_t u = st.cstart[static_cast<size_t>(ci)] + r;
-                for (int64_t slot = 0; slot < st.K; ++slot) {
-                    if (!(std::fabs(st.HK[j * st.K + slot] - st.sp_h[static_cast<size_t>(u)]) <= 3.0f)) {
+                for (int64_t slot = 0; slot < jn; ++slot) {
+                    const int64_t v = jb + slot;
+                    if (!(std::fabs(st.sp_h[static_cast<size_t>(v)] - st.sp_h[static_cast<size_t>(u)]) <= 3.0f)) {
                         continue;
                     }
                     const int32_t a = find(static_cast<int32_t>(u));
-                    const int32_t b = find(static_cast<int32_t>(st.IK[j * st.K + slot]));
+                    const int32_t b = find(static_cast<int32_t>(v));
                     if (a != b) {
                         parent[static_cast<size_t>(a)] = b;
                     }
@@ -400,20 +521,23 @@ std::vector<uint8_t> SpanReach(int64_t seed, const SpanTable& st, const std::vec
                 if (ax < 0 || ax >= nx || ay < 0 || ay >= ny) {
                     continue;
                 }
-                const int64_t j = occFind(st.occ, ay * nx + ax);
+                const int64_t j = occFind(st, ay * nx + ax);
                 if (j < 0) {
                     continue;
                 }
-                for (int64_t slot = 0; slot < st.K; ++slot) {
-                    const float dh = st.HK[j * st.K + slot] - st.sp_h[f];
-                    if (!(static_cast<double>(dh) <= kUp * d.w) || !(dh >= -static_cast<float>(kClimb))) {
+                const int64_t b = st.cstart[static_cast<size_t>(j)], n = st.ccnt[static_cast<size_t>(j)];
+                for (int64_t slot = 0; slot < n; ++slot) {
+                    // 先问候选走没走过。垂直可达判据没有副作用, 挪到这一问之后逐位同答,
+                    // 而广度优先里绝大多数邻接探到的是已访问的 span。
+                    const int64_t cand = b + slot;
+                    if (ok[static_cast<size_t>(cand)] == 0 || vis[static_cast<size_t>(cand)]) {
                         continue;
                     }
-                    const int64_t cand = st.IK[j * st.K + slot];
-                    if (cand >= 0 && ok[static_cast<size_t>(cand)] != 0 && !vis[static_cast<size_t>(cand)]) {
-                        vis[static_cast<size_t>(cand)] = 1;
-                        next.push_back(cand);
+                    if (!RiseOk(st, nx, ny, cid, d.dx, d.dy, st.sp_h[f], st.sp_h[static_cast<size_t>(cand)])) {
+                        continue;
                     }
+                    vis[static_cast<size_t>(cand)] = 1;
+                    next.push_back(cand);
                 }
             }
         }
@@ -495,16 +619,15 @@ std::vector<uint8_t> StampWalls(
             if (gx < 0 || gx >= nx || gy < 0 || gy >= ny) {
                 continue;
             }
-            const int64_t j = occFind(st.occ, gy * nx + gx);
+            const int64_t j = occFind(st, gy * nx + gx);
             if (j < 0) {
                 continue;
             }
-            for (int64_t slot = 0; slot < st.K; ++slot) {
-                if (std::abs(static_cast<double>(st.HK[j * st.K + slot]) - hh[i]) <= kMcHBand) {
-                    const int64_t sid = st.IK[j * st.K + slot];
-                    if (sid >= 0) {
-                        blocked[static_cast<size_t>(sid)] = 1;
-                    }
+            const int64_t b = st.cstart[static_cast<size_t>(j)], n = st.ccnt[static_cast<size_t>(j)];
+            for (int64_t slot = 0; slot < n; ++slot) {
+                const int64_t sid = b + slot;
+                if (std::abs(static_cast<double>(st.sp_h[static_cast<size_t>(sid)]) - hh[i]) <= kMcHBand) {
+                    blocked[static_cast<size_t>(sid)] = 1;
                 }
             }
         }
@@ -577,6 +700,7 @@ StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, con
 {
     StepBarrier out;
     const int64_t nx = lay.nx, ny = lay.ny, NC = nx * ny, K = st.K;
+    out.steps.resize(nx, ny);
     if (K <= 0) {
         return out;
     }
@@ -585,9 +709,10 @@ StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, con
     for (size_t j = 0; j < st.occ.size(); ++j) {
         float* row = &T[static_cast<size_t>(st.occ[j] * K)];
         int64_t n = 0;
-        for (int64_t k = 0; k < K; ++k) {
-            const int64_t sid = st.IK[j * static_cast<size_t>(K) + static_cast<size_t>(k)];
-            if (sid >= 0 && vis[static_cast<size_t>(sid)] != 0) {
+        const int64_t b = st.cstart[j], cn = st.ccnt[j];
+        for (int64_t k = 0; k < cn; ++k) {
+            const int64_t sid = b + k;
+            if (vis[static_cast<size_t>(sid)] != 0) {
                 row[n++] = st.sp_h[static_cast<size_t>(sid)];
             }
         }
@@ -676,11 +801,16 @@ StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, con
                     }
                 }
             }
-            if (!(static_cast<double>(best) > kSlope * std::hypot(static_cast<double>(dx), static_cast<double>(dy)) * kCS)) {
+            if (!(static_cast<double>(best) > UpAllow(std::hypot(static_cast<double>(dx), static_cast<double>(dy))))) {
                 continue;
             }
             const bool up = T[static_cast<size_t>(b * K + bkb)] > T[static_cast<size_t>(c * K + bka)];
-            out.steps.insert(up ? c * NC + b : b * NC + c);
+            if (up) {
+                out.steps.set(c, b);
+            }
+            else {
+                out.steps.set(b, c);
+            }
             if (dx != 0 && dy != 0) {
                 continue;
             }
@@ -824,15 +954,14 @@ std::optional<std::vector<CellPt>> CostAstar(
     CellPt s,
     CellPt g,
     const Grid<float>& mult,
-    const std::unordered_set<int64_t>* banned,
+    const EdgeBits* banned,
     const double* bnp,
-    const std::unordered_set<int64_t>* forbidden)
+    const EdgeBits* forbidden)
 {
     const int64_t ny = mask.ny, nx = mask.nx;
     if (!mask.at(s.y, s.x) || !mask.at(g.y, g.x)) {
         return std::nullopt;
     }
-    const int64_t NC = nx * ny;
     Grid<double> dist(nx, ny, std::numeric_limits<double>::infinity());
     Grid<int64_t> prev(nx, ny, -1);
     dist.at(s.y, s.x) = 0.0;
@@ -858,12 +987,13 @@ std::optional<std::vector<CellPt>> CostAstar(
             if (d.dx != 0 && d.dy != 0 && !(mask.at(y, a) && mask.at(b, x))) {
                 continue;
             }
-            const int64_t eid = (y * nx + x) * NC + (b * nx + a);
-            if (forbidden != nullptr && forbidden->contains(eid)) {
+            const int64_t cu = y * nx + x;
+            const int64_t cv = b * nx + a;
+            if (forbidden != nullptr && forbidden->has(cu, cv)) {
                 continue;
             }
             double pen = 0.0;
-            if (banned != nullptr && banned->contains(eid)) {
+            if (banned != nullptr && banned->has(cu, cv)) {
                 if (bnp == nullptr) {
                     continue;
                 }
@@ -894,6 +1024,51 @@ std::optional<std::vector<CellPt>> CostAstar(
     return out;
 }
 
+bool Visibility::crossesStep(const WorldPoint& p, const WorldPoint& q) const
+{
+    const bool hs = steps_ != nullptr && !steps_->empty();
+    const bool hf = faces_ != nullptr && !faces_->empty();
+    if (!hs && !hf) {
+        return false;
+    }
+    // 取样与层走查同一套整数插值, 于是"弦经过哪些格"这件事在两处判据里是同一个答案
+    const int64_t ax = static_cast<int64_t>((p.x - x0_) / kCS);
+    const int64_t ay = static_cast<int64_t>((p.y - y0_) / kCS);
+    const int64_t bx = static_cast<int64_t>((q.x - x0_) / kCS);
+    const int64_t by = static_cast<int64_t>((q.y - y0_) / kCS);
+    const int64_t n = std::max<int64_t>(std::max(std::abs(bx - ax), std::abs(by - ay)), 1);
+    int64_t px = ax;
+    int64_t py = ay;
+    for (int64_t k = 1; k <= n; ++k) {
+        const int64_t cx = ax + static_cast<int64_t>(std::nearbyint(static_cast<double>(bx - ax) * static_cast<double>(k) / static_cast<double>(n)));
+        const int64_t cy = ay + static_cast<int64_t>(std::nearbyint(static_cast<double>(by - ay) * static_cast<double>(k) / static_cast<double>(n)));
+        if (cx == px && cy == py) {
+            continue;
+        }
+        if (px >= 0 && py >= 0 && px < nx_ && py < ny_ && cx >= 0 && cy >= 0 && cx < nx_ && cy < ny_) {
+            const int64_t ca = py * nx_ + px;
+            const int64_t cb = cy * nx_ + cx;
+            if ((hs && steps_->has(ca, cb)) || (hf && faces_->has(ca, cb))) {
+                return true;
+            }
+        }
+        px = cx;
+        py = cy;
+    }
+    return false;
+}
+
+bool Visibility::ok(const WorldPoint& p, const WorldPoint& q, float hp, float hq) const
+{
+    if (blk_ != nullptr && blk_->blocked(p, q)) {
+        return false;
+    }
+    if (crossesStep(p, q)) {
+        return false;
+    }
+    return lyo_ == nullptr || lyo_->ok(p, q, hp, hq);
+}
+
 std::optional<std::vector<int64_t>> SpanAstar(
     const SpanTable& st,
     const std::vector<uint8_t>& ok,
@@ -902,14 +1077,16 @@ std::optional<std::vector<int64_t>> SpanAstar(
     int64_t s,
     const std::vector<int64_t>& gset,
     const Grid<float>& mult,
-    const std::unordered_set<int64_t>* banned,
+    const EdgeBits* banned,
     const double* bnp,
-    const std::unordered_set<int64_t>* forbidden)
+    const EdgeBits* forbidden,
+    const Visibility* vis,
+    std::vector<int64_t>* corners)
 {
     if (s < 0 || ok[static_cast<size_t>(s)] == 0 || gset.empty()) {
         return std::nullopt;
     }
-    const int64_t nx = ok2.nx, ny = ok2.ny, NC = nx * ny, K = st.K;
+    const int64_t nx = ok2.nx, ny = ok2.ny;
     const int64_t gc = st.occ[st.sp_ci[static_cast<size_t>(gset.front())]];
     const int64_t gxx = gc % nx, gyy = gc / nx;
     std::vector<double> dist(st.sp_h.size(), std::numeric_limits<double>::infinity());
@@ -919,14 +1096,89 @@ std::optional<std::vector<int64_t>> SpanAstar(
     std::priority_queue<Node, std::vector<Node>, std::greater<Node>> pq;
     pq.emplace(0.0, s);
     int64_t hit = -1;
+    // Lazy Theta* 的 SetVertex: 祖父直连验不过时, 从已展开的邻格里挑最便宜的那个当父亲。
+    // 视线全失效则整条路逐格退化成 A*, 所以弦无权把一条走得通的腿变成走不通。
+    std::vector<uint8_t> closed;
+    if (vis != nullptr) {
+        closed.assign(st.sp_h.size(), 0);
+    }
+    const auto reparent = [&](int64_t u, int64_t cu) {
+        const int64_t x = cu % nx, y = cu / nx;
+        const float hu = st.sp_h[static_cast<size_t>(u)];
+        double bd = std::numeric_limits<double>::infinity();
+        int64_t bp = -1;
+        for (const auto& d : kNb8) {
+            const int64_t a = x + d.dx, b = y + d.dy;
+            if (a < 0 || a >= nx || b < 0 || b >= ny) {
+                continue;
+            }
+            const int64_t cw = b * nx + a;
+            if (ok2.v[static_cast<size_t>(cw)] == 0) {
+                continue;
+            }
+            if (d.dx != 0 && d.dy != 0 && !(ok2.at(y, a) && ok2.at(b, x))) {
+                continue;
+            }
+            const int64_t j = cidx[static_cast<size_t>(cw)];
+            if (j < 0) {
+                continue;
+            }
+            if (forbidden != nullptr && forbidden->has(cw, cu)) {
+                continue;
+            }
+            double pen = 0.0;
+            if (banned != nullptr && banned->has(cw, cu)) {
+                if (bnp == nullptr) {
+                    continue;
+                }
+                pen = *bnp;
+            }
+            const double stp = d.w * 0.5 * static_cast<double>(mult.v[static_cast<size_t>(cw)] + mult.v[static_cast<size_t>(cu)]);
+            const int64_t jb = st.cstart[static_cast<size_t>(j)], jn = st.ccnt[static_cast<size_t>(j)];
+            for (int64_t k = 0; k < jn; ++k) {
+                const int64_t w = jb + k;
+                if (ok[static_cast<size_t>(w)] == 0 || closed[static_cast<size_t>(w)] == 0) {
+                    continue;
+                }
+                if (!RiseOk(st, nx, ny, cw, -d.dx, -d.dy, st.sp_h[static_cast<size_t>(w)], hu)) {
+                    continue;
+                }
+                const double nd = dist[static_cast<size_t>(w)] + stp + pen;
+                if (nd < bd - 1e-12) {
+                    bd = nd;
+                    bp = w;
+                }
+            }
+        }
+        if (bp >= 0) {
+            dist[static_cast<size_t>(u)] = bd;
+            prev[static_cast<size_t>(u)] = bp;
+        }
+    };
     while (!pq.empty()) {
         const auto [f, u] = pq.top();
         pq.pop();
-        const double d0 = dist[static_cast<size_t>(u)];
+        double d0 = dist[static_cast<size_t>(u)];
         const int64_t cu = st.occ[st.sp_ci[static_cast<size_t>(u)]];
         const int64_t x = cu % nx, y = cu / nx;
         if (f > d0 + std::hypot(static_cast<double>(gxx - x), static_cast<double>(gyy - y)) + 1e-9) {
             continue;
+        }
+        if (vis != nullptr) {
+            if (closed[static_cast<size_t>(u)] != 0) {
+                continue;
+            }
+            const int64_t p = prev[static_cast<size_t>(u)];
+            if (p >= 0
+                && !vis->ok(
+                    vis->at(st.occ[st.sp_ci[static_cast<size_t>(p)]]),
+                    vis->at(cu),
+                    st.sp_h[static_cast<size_t>(p)],
+                    st.sp_h[static_cast<size_t>(u)])) {
+                reparent(u, cu);
+            }
+            closed[static_cast<size_t>(u)] = 1;
+            d0 = dist[static_cast<size_t>(u)];
         }
         if (std::find(gset.begin(), gset.end(), u) != gset.end()) {
             hit = u;
@@ -950,12 +1202,11 @@ std::optional<std::vector<int64_t>> SpanAstar(
             if (j < 0) {
                 continue;
             }
-            const int64_t eid = cu * NC + cv;
-            if (forbidden != nullptr && forbidden->contains(eid)) {
+            if (forbidden != nullptr && forbidden->has(cu, cv)) {
                 continue;
             }
             double pen = 0.0;
-            if (banned != nullptr && banned->contains(eid)) {
+            if (banned != nullptr && banned->has(cu, cv)) {
                 if (bnp == nullptr) {
                     continue;
                 }
@@ -963,19 +1214,39 @@ std::optional<std::vector<int64_t>> SpanAstar(
             }
             const float step = static_cast<float>(d.w * 0.5) * (m0 + mult.v[static_cast<size_t>(cv)]);
             const double nd = d0 + static_cast<double>(step) + pen;
-            for (int64_t k = 0; k < K; ++k) {
-                const int64_t v = st.IK[j * K + k];
-                if (v < 0 || ok[static_cast<size_t>(v)] == 0) {
+            // Theta* 松弛: 先按祖父直连计价, 视线留到弹出时验。弦按欧氏长度计价, 只有单价恒为一
+            // 的实心区里这笔账才精确; 中脊带单价随净空抬到七倍, 放弦进去等于免掉那笔税, 搜索会
+            // 转头挑窄道。两端都在实心区才许走弦, 整段是否落在实心区由弹出时的视线判据兜底。
+            int64_t np = u;
+            double ndp = nd;
+            if (vis != nullptr) {
+                const int64_t p = prev[static_cast<size_t>(u)];
+                if (p >= 0 && mult.v[static_cast<size_t>(cv)] <= 1.0F) {
+                    const int64_t cp = st.occ[st.sp_ci[static_cast<size_t>(p)]];
+                    if (mult.v[static_cast<size_t>(cp)] <= 1.0F) {
+                        const double cd = dist[static_cast<size_t>(p)]
+                            + std::hypot(static_cast<double>(a - cp % nx), static_cast<double>(b - cp / nx));
+                        if (cd < ndp - 1e-12) {
+                            np = p;
+                            ndp = cd;
+                        }
+                    }
+                }
+            }
+            const int64_t sb = st.cstart[static_cast<size_t>(j)], sn = st.ccnt[static_cast<size_t>(j)];
+            for (int64_t k = 0; k < sn; ++k) {
+                const int64_t v = sb + k;
+                if (ok[static_cast<size_t>(v)] == 0) {
                     continue;
                 }
-                const float dh = st.HK[j * K + k] - hu;
-                if (static_cast<double>(dh) > kUp * d.w || dh < -static_cast<float>(kClimb)) {
+                const float hv = st.sp_h[static_cast<size_t>(v)];
+                if (!RiseOk(st, nx, ny, cu, d.dx, d.dy, hu, hv)) {
                     continue;
                 }
-                if (nd < dist[static_cast<size_t>(v)] - 1e-12) {
-                    dist[static_cast<size_t>(v)] = nd;
-                    prev[static_cast<size_t>(v)] = u;
-                    pq.emplace(nd + std::hypot(static_cast<double>(gxx - a), static_cast<double>(gyy - b)), v);
+                if (ndp < dist[static_cast<size_t>(v)] - 1e-12) {
+                    dist[static_cast<size_t>(v)] = ndp;
+                    prev[static_cast<size_t>(v)] = np;
+                    pq.emplace(ndp + std::hypot(static_cast<double>(gxx - a), static_cast<double>(gyy - b)), v);
                 }
             }
         }
@@ -988,84 +1259,221 @@ std::optional<std::vector<int64_t>> SpanAstar(
         out.push_back(prev[static_cast<size_t>(out.back())]);
     }
     std::reverse(out.begin(), out.end());
+    if (corners != nullptr) {
+        *corners = out;
+    }
+    if (vis == nullptr) {
+        return out;
+    }
+    // 父链是拐点序列, 下游按逐格路径读, 因此把每条弦铺回格上再交出去。中间格的 span 按弦两端
+    // 线性插值取最近高度 —— 视线判据已经验过整条弦的高度链, 这里只是给链上的落点具名。
+    const std::vector<int64_t> corn = out;
+    out.assign(1, corn.front());
+    for (size_t i = 1; i < corn.size(); ++i) {
+        const int64_t ca = st.occ[st.sp_ci[static_cast<size_t>(corn[i - 1])]];
+        const int64_t cb = st.occ[st.sp_ci[static_cast<size_t>(corn[i])]];
+        const int64_t axx = ca % nx, ayy = ca / nx, bxx = cb % nx, byy = cb / nx;
+        const int64_t n = std::max<int64_t>(std::max(std::abs(bxx - axx), std::abs(byy - ayy)), 1);
+        const float ha = st.sp_h[static_cast<size_t>(corn[i - 1])];
+        const float hb = st.sp_h[static_cast<size_t>(corn[i])];
+        for (int64_t k = 1; k < n; ++k) {
+            const int64_t cx = axx + static_cast<int64_t>(std::nearbyint(static_cast<double>(bxx - axx) * static_cast<double>(k) / static_cast<double>(n)));
+            const int64_t cy = ayy + static_cast<int64_t>(std::nearbyint(static_cast<double>(byy - ayy) * static_cast<double>(k) / static_cast<double>(n)));
+            const int64_t cc = cy * nx + cx;
+            if (cc == st.occ[st.sp_ci[static_cast<size_t>(out.back())]]) {
+                continue;
+            }
+            const int64_t j = cidx[static_cast<size_t>(cc)];
+            if (j < 0) {
+                continue;
+            }
+            const float ht = ha + (hb - ha) * static_cast<float>(k) / static_cast<float>(n);
+            int64_t bv = -1;
+            float bdh = 0.0F;
+            const int64_t sb = st.cstart[static_cast<size_t>(j)], sn = st.ccnt[static_cast<size_t>(j)];
+            for (int64_t kk = 0; kk < sn; ++kk) {
+                const int64_t v = sb + kk;
+                if (ok[static_cast<size_t>(v)] == 0) {
+                    continue;
+                }
+                const float dh = std::fabs(st.sp_h[static_cast<size_t>(v)] - ht);
+                if (bv < 0 || dh < bdh) {
+                    bv = v;
+                    bdh = dh;
+                }
+            }
+            if (bv >= 0) {
+                out.push_back(bv);
+            }
+        }
+        if (out.back() != corn[i]) {
+            out.push_back(corn[i]);
+        }
+    }
     return out;
 }
 
 namespace
 {
 
-Grid<float> LocalMax(const Grid<float>& a, int64_t k)
+// 最近源点两遍扫描: 每格从已定好的邻格里接过离自己最近的那个源点。前一遍铺左上半个邻域,
+// 后一遍反向铺右下半个, 两遍合起来每格的八个方向都问过。没有源点的格留 -1。
+void NearestSource(
+    const std::vector<uint8_t>& src, int64_t nx, int64_t ny,
+    std::vector<int32_t>& fx, std::vector<int32_t>& fy)
 {
-    Grid<float> m = a;
-    for (int ax = 0; ax < 2; ++ax) {
-        Grid<float> acc = m;
-        for (int64_t y = 0; y < m.ny; ++y) {
-            for (int64_t x = 0; x < m.nx; ++x) {
-                float v = acc.at(y, x);
-                for (int64_t s = 1; s <= k; ++s) {
-                    for (int sgn = 0; sgn < 2; ++sgn) {
-                        const int64_t yy = ax == 0 ? y + (sgn == 0 ? -s : s) : y;
-                        const int64_t xx = ax == 1 ? x + (sgn == 0 ? -s : s) : x;
-                        if (yy >= 0 && yy < m.ny && xx >= 0 && xx < m.nx) {
-                            v = std::max(v, m.at(yy, xx));
-                        }
-                    }
-                }
-                acc.at(y, x) = v;
+    const int64_t n = nx * ny;
+    fx.assign(static_cast<size_t>(n), -1);
+    fy.assign(static_cast<size_t>(n), -1);
+    for (int64_t i = 0; i < n; ++i) {
+        if (src[static_cast<size_t>(i)] != 0) {
+            fx[static_cast<size_t>(i)] = static_cast<int32_t>(i % nx);
+            fy[static_cast<size_t>(i)] = static_cast<int32_t>(i / nx);
+        }
+    }
+    const auto take = [&](int64_t c, int64_t x, int64_t y, int64_t o) {
+        const int64_t ox = fx[static_cast<size_t>(o)];
+        if (ox < 0) {
+            return;
+        }
+        const int64_t oy = fy[static_cast<size_t>(o)];
+        const int64_t od = (ox - x) * (ox - x) + (oy - y) * (oy - y);
+        const int64_t cx = fx[static_cast<size_t>(c)];
+        if (cx >= 0) {
+            const int64_t cy = fy[static_cast<size_t>(c)];
+            if ((cx - x) * (cx - x) + (cy - y) * (cy - y) <= od) {
+                return;
             }
         }
-        m = std::move(acc);
-    }
-    return m;
-}
-
-}
-
-Grid<float> PrefField(const Grid<float>& dist, bool ridge)
-{
-    const Grid<float> locw = LocalMax(dist, static_cast<int64_t>(std::ceil(kR / kCS)));
-    const int64_t ny = dist.ny, nx = dist.nx;
-    Grid<float> pref(nx, ny, 0.0f);
-    for (size_t i = 0; i < pref.v.size(); ++i) {
-        pref.v[i] = std::max(std::min(1.75f, 0.6f * locw.v[i]), 0.25f);
-    }
-    if (!ridge) {
-        return pref;
-    }
-    const float ninf = -std::numeric_limits<float>::infinity();
-    const auto at = [&](int64_t y, int64_t x) {
-        return y >= 0 && y < ny && x >= 0 && x < nx ? dist.at(y, x) : ninf;
+        fx[static_cast<size_t>(c)] = static_cast<int32_t>(ox);
+        fy[static_cast<size_t>(c)] = static_cast<int32_t>(oy);
     };
-    const int64_t dirs[4][2] = { { 0, 1 }, { 1, 0 }, { 1, 1 }, { 1, -1 } }; // (dy,dx)
-    Grid<float> out = pref;
     for (int64_t y = 0; y < ny; ++y) {
         for (int64_t x = 0; x < nx; ++x) {
-            const float dv = dist.at(y, x);
-            bool rg = false;
-            for (const auto& d : dirs) {
-                const float a = at(y + d[0], x + d[1]);
-                const float b = at(y - d[0], x - d[1]);
-                if (dv >= std::max(a, b) && dv > std::min(a, b)) {
-                    rg = true;
-                    break;
+            const int64_t c = y * nx + x;
+            if (y > 0) {
+                take(c, x, y, c - nx);
+                if (x > 0) {
+                    take(c, x, y, c - nx - 1);
+                }
+                if (x + 1 < nx) {
+                    take(c, x, y, c - nx + 1);
                 }
             }
-            if (rg && dv >= 0.5f) {
-                out.at(y, x) = std::min(pref.at(y, x), dv);
+            if (x > 0) {
+                take(c, x, y, c - 1);
+            }
+        }
+        for (int64_t x = nx - 2; x >= 0; --x) {
+            take(y * nx + x, x, y, y * nx + x + 1);
+        }
+    }
+    for (int64_t y = ny - 1; y >= 0; --y) {
+        for (int64_t x = nx - 1; x >= 0; --x) {
+            const int64_t c = y * nx + x;
+            if (y + 1 < ny) {
+                take(c, x, y, c + nx);
+                if (x > 0) {
+                    take(c, x, y, c + nx - 1);
+                }
+                if (x + 1 < nx) {
+                    take(c, x, y, c + nx + 1);
+                }
+            }
+            if (x + 1 < nx) {
+                take(c, x, y, c + 1);
+            }
+        }
+        for (int64_t x = 1; x < nx; ++x) {
+            take(y * nx + x, x, y, y * nx + x - 1);
+        }
+    }
+}
+
+} // namespace
+
+// λ 中轴: 一格与某个邻格的最近障碍点相隔 λ 以上, 这一格就在中轴上。地形边界从来不是标准
+// 几何体, 按净空取局部最大会把每一道锯齿都读成中轴; 而毛刺两侧的最近障碍点本来就挨着,
+// 隔不开 λ, 两堵墙之间的格最近点则分列两侧, 至少隔着整个走廊宽。
+Mask MedialAxis(const Grid<float>& dist, double lam)
+{
+    const int64_t ny = dist.ny;
+    const int64_t nx = dist.nx;
+    const int64_t n = nx * ny;
+    std::vector<uint8_t> solid(static_cast<size_t>(n), 0);
+    for (int64_t i = 0; i < n; ++i) {
+        solid[static_cast<size_t>(i)] = static_cast<uint8_t>(dist.v[static_cast<size_t>(i)] <= 0.0F);
+    }
+    std::vector<int32_t> fx;
+    std::vector<int32_t> fy;
+    NearestSource(solid, nx, ny, fx, fy);
+    const double step = lam / kCS;
+    const int64_t thr = static_cast<int64_t>(std::ceil(step * step));
+    Mask out(nx, ny, 0);
+    for (int64_t y = 0; y < ny; ++y) {
+        for (int64_t x = 0; x < nx; ++x) {
+            const int64_t c = y * nx + x;
+            const int64_t cx = fx[static_cast<size_t>(c)];
+            if (dist.v[static_cast<size_t>(c)] <= 0.0F || cx < 0) {
+                continue;
+            }
+            const int64_t cy = fy[static_cast<size_t>(c)];
+            for (const auto& d : kNb8) {
+                const int64_t a = x + d.dx;
+                const int64_t b = y + d.dy;
+                if (a < 0 || a >= nx || b < 0 || b >= ny) {
+                    continue;
+                }
+                const int64_t o = b * nx + a;
+                const int64_t ox = fx[static_cast<size_t>(o)];
+                if (ox < 0) {
+                    continue;
+                }
+                const int64_t oy = fy[static_cast<size_t>(o)];
+                if ((ox - cx) * (ox - cx) + (oy - cy) * (oy - cy) >= thr) {
+                    out.at(y, x) = 1;
+                    break;
+                }
             }
         }
     }
     return out;
 }
 
-Grid<float> TargetField(const Grid<float>& dist)
+// 走廊半宽: 每格取最近那个种子格的净空, 也就是它所在这条走廊有多宽。弦的容许净空照它按比例
+// 定 —— 取全局常数两头都顾不上, 收紧会把窄段的弦整段否掉逐格走成锯齿, 放开则宽处一路贴角切。
+// band 是走廊本身: 种子每格张一个半径等于自身净空的球, 并起来即是。球与最近的障碍相切, 并集
+// 因此越不过任何一堵墙 —— 隔壁那条平行道进不来, 半宽也就不会认到墙那边的窄缝上去。
+Grid<float> CorridorWidth(const Grid<float>& dist, const Mask& seed, Mask* band)
 {
-    const Grid<float> locw = LocalMax(dist, static_cast<int64_t>(std::ceil(kR / kCS)));
-    Grid<float> tgt(dist.nx, dist.ny, 0.0f);
-    for (size_t i = 0; i < tgt.v.size(); ++i) {
-        tgt.v[i] = std::max(std::min(static_cast<float>(kGeoR), locw.v[i]), 0.25f);
+    const int64_t ny = dist.ny;
+    const int64_t nx = dist.nx;
+    std::vector<int32_t> fx;
+    std::vector<int32_t> fy;
+    NearestSource(seed.v, nx, ny, fx, fy);
+    Grid<float> out(nx, ny, 0.0F);
+    if (band != nullptr) {
+        *band = Mask(nx, ny, 0);
     }
-    return tgt;
+    for (int64_t y = 0; y < ny; ++y) {
+        for (int64_t x = 0; x < nx; ++x) {
+            const int64_t i = y * nx + x;
+            const int64_t ax = fx[static_cast<size_t>(i)];
+            if (ax < 0) {
+                continue;
+            }
+            const int64_t ay = fy[static_cast<size_t>(i)];
+            const float w = dist.v[static_cast<size_t>(ay * nx + ax)];
+            out.v[static_cast<size_t>(i)] = w;
+            if (band != nullptr) {
+                const double dx = static_cast<double>(ax - x) * kCS;
+                const double dy = static_cast<double>(ay - y) * kCS;
+                const bool in = dx * dx + dy * dy <= static_cast<double>(w) * static_cast<double>(w);
+                band->at(y, x) = static_cast<uint8_t>(in || seed.at(y, x) != 0);
+            }
+        }
+    }
+    return out;
 }
 
 namespace
@@ -1266,13 +1674,94 @@ Blockers::Blockers(
     }
 }
 
+void Blockers::buildIndex() const
+{
+    built_ = true;
+    if (a_.empty()) {
+        return;
+    }
+    double mnx = lo_[0].x, mny = lo_[0].y, mxx = hi_[0].x, mxy = hi_[0].y;
+    for (size_t i = 1; i < a_.size(); ++i) {
+        mnx = std::min(mnx, lo_[i].x);
+        mny = std::min(mny, lo_[i].y);
+        mxx = std::max(mxx, hi_[i].x);
+        mxy = std::max(mxy, hi_[i].y);
+    }
+    bx0_ = mnx - kBkt;
+    by0_ = mny - kBkt;
+    bnx_ = static_cast<int64_t>((mxx + kBkt - bx0_) / kBkt) + 1;
+    bny_ = static_cast<int64_t>((mxy + kBkt - by0_) / kBkt) + 1;
+    bstart_.assign(static_cast<size_t>(bnx_ * bny_ + 1), 0);
+    // 段按包围盒入桶, 盒放量 kBktPad 盖住相交判据留给两端的那点余量。挡线都是轮廓折线段,
+    // 盒里的桶数与段长同阶, 数一趟填一趟就够。
+    const auto span = [&](size_t i, int64_t* g) {
+        g[0] = static_cast<int64_t>((lo_[i].x - kBktPad - bx0_) / kBkt);
+        g[1] = static_cast<int64_t>((hi_[i].x + kBktPad - bx0_) / kBkt);
+        g[2] = static_cast<int64_t>((lo_[i].y - kBktPad - by0_) / kBkt);
+        g[3] = static_cast<int64_t>((hi_[i].y + kBktPad - by0_) / kBkt);
+    };
+    int64_t g[4];
+    for (size_t i = 0; i < a_.size(); ++i) {
+        span(i, g);
+        for (int64_t gy = g[2]; gy <= g[3]; ++gy) {
+            for (int64_t gx = g[0]; gx <= g[1]; ++gx) {
+                ++bstart_[static_cast<size_t>(gy * bnx_ + gx) + 1];
+            }
+        }
+    }
+    for (size_t k = 1; k < bstart_.size(); ++k) {
+        bstart_[k] += bstart_[k - 1];
+    }
+    bitem_.resize(static_cast<size_t>(bstart_.back()));
+    std::vector<int32_t> fill(bstart_.begin(), bstart_.end() - 1);
+    for (size_t i = 0; i < a_.size(); ++i) {
+        span(i, g);
+        for (int64_t gy = g[2]; gy <= g[3]; ++gy) {
+            for (int64_t gx = g[0]; gx <= g[1]; ++gx) {
+                bitem_[static_cast<size_t>(fill[static_cast<size_t>(gy * bnx_ + gx)]++)] = static_cast<int32_t>(i);
+            }
+        }
+    }
+    seen_.assign(a_.size(), 0);
+}
+
 bool Blockers::blocked(const WorldPoint& p, const WorldPoint& q) const
 {
     constexpr double eps = 1e-7;
     const double lox = std::min(p.x, q.x) - eps, hix = std::max(p.x, q.x) + eps;
     const double loy = std::min(p.y, q.y) - eps, hiy = std::max(p.y, q.y) + eps;
     const double rx = q.x - p.x, ry = q.y - p.y;
-    for (size_t i = 0; i < a_.size(); ++i) {
+    // 弦上取样间隔半个桶, 每点连同八邻一起取: 弦上任何一点离某个取样点不超过半个桶, 于是它
+    // 所在的桶必在某个取样点的三乘三邻域里, 待测集因此不漏。
+    if (!built_) {
+        buildIndex();
+    }
+    if (++epoch_ == 0) {
+        std::fill(seen_.begin(), seen_.end(), 0);
+        ++epoch_;
+    }
+    const int64_t ns = static_cast<int64_t>(std::hypot(rx, ry) / (kBkt * 0.5)) + 1;
+    cand_.clear();
+    for (int64_t k = 0; k <= ns && bnx_ > 0; ++k) {
+        const double t = static_cast<double>(k) / static_cast<double>(ns);
+        const int64_t sx0 = static_cast<int64_t>((p.x + rx * t - bx0_) / kBkt);
+        const int64_t sy0 = static_cast<int64_t>((p.y + ry * t - by0_) / kBkt);
+        for (int64_t gy = std::max<int64_t>(sy0 - 1, 0); gy <= std::min(sy0 + 1, bny_ - 1); ++gy) {
+            for (int64_t gx = std::max<int64_t>(sx0 - 1, 0); gx <= std::min(sx0 + 1, bnx_ - 1); ++gx) {
+                const size_t bk = static_cast<size_t>(gy * bnx_ + gx);
+                for (int32_t e = bstart_[bk]; e < bstart_[bk + 1]; ++e) {
+                    const int32_t id = bitem_[static_cast<size_t>(e)];
+                    if (seen_[static_cast<size_t>(id)] == epoch_) {
+                        continue;
+                    }
+                    seen_[static_cast<size_t>(id)] = epoch_;
+                    cand_.push_back(id);
+                }
+            }
+        }
+    }
+    for (const int32_t ii : cand_) {
+        const size_t i = static_cast<size_t>(ii);
         if (hi_[i].x < lox || lo_[i].x > hix || hi_[i].y < loy || lo_[i].y > hiy) {
             continue;
         }
@@ -1284,7 +1773,9 @@ bool Blockers::blocked(const WorldPoint& p, const WorldPoint& q) const
         const double ux = a_[i].x - p.x, uy = a_[i].y - p.y;
         const double t = (ux * sy - uy * sx) / den;
         const double w = (ux * ry - uy * rx) / den;
-        if (t > eps && t < 1 - eps && w > eps && w < 1 - eps) {
+        // 挡线一侧取闭区间: 挡线段是格边, 精确 45° 的弦每次都正好交在端点上, 开区间会让它
+        // 从每道轴对齐挡线的顶点缝里溜过去。弦一侧仍开区间, 端点搭在挡线上是贴墙走不算穿墙。
+        if (t > eps && t < 1 - eps && w > -eps && w < 1 + eps) {
             return true;
         }
     }
@@ -1309,39 +1800,6 @@ bool Blockers::offMask(const WorldPoint& p, const WorldPoint& q) const
         }
     }
     return false;
-}
-
-float ClearanceFloor::seg(const WorldPoint& p, const WorldPoint& q) const
-{
-    const double L = std::hypot(q.x - p.x, q.y - p.y);
-    const int64_t n = static_cast<int64_t>(L / (cs_ * 0.5)) + 2;
-    const double step = 1.0 / static_cast<double>(n - 1);
-    float m = std::numeric_limits<float>::infinity();
-    for (int64_t i = 0; i < n; ++i) {
-        const double t = i == n - 1 ? 1.0 : static_cast<double>(i) * step;
-        int64_t gx = static_cast<int64_t>((p.x + (q.x - p.x) * t - x0_) / cs_);
-        int64_t gy = static_cast<int64_t>((p.y + (q.y - p.y) * t - y0_) / cs_);
-        gx = std::max<int64_t>(0, std::min<int64_t>(cf_->nx - 1, gx));
-        gy = std::max<int64_t>(0, std::min<int64_t>(cf_->ny - 1, gy));
-        m = std::min(m, cf_->at(gy, gx));
-    }
-    return m;
-}
-
-double ClearanceFloor::cost(const WorldPoint& p, const WorldPoint& q) const
-{
-    const double L = std::hypot(q.x - p.x, q.y - p.y);
-    const int64_t n = std::max<int64_t>(static_cast<int64_t>(std::ceil(L / (cs_ * 0.5))), 1);
-    double acc = 0.0;
-    for (int64_t i = 0; i < n; ++i) {
-        const double t = (static_cast<double>(i) + 0.5) / static_cast<double>(n);
-        int64_t gx = static_cast<int64_t>((p.x + (q.x - p.x) * t - x0_) / cs_);
-        int64_t gy = static_cast<int64_t>((p.y + (q.y - p.y) * t - y0_) / cs_);
-        gx = std::max<int64_t>(0, std::min<int64_t>(mg_->nx - 1, gx));
-        gy = std::max<int64_t>(0, std::min<int64_t>(mg_->ny - 1, gy));
-        acc += static_cast<double>(mg_->at(gy, gx));
-    }
-    return L * (acc / static_cast<double>(n));
 }
 
 std::optional<std::vector<float>> LayerOracle::walk(const std::vector<WorldPoint>& pts, float h) const
@@ -1379,16 +1837,15 @@ std::optional<std::vector<float>> LayerOracle::walk(const std::vector<WorldPoint
             continue;
         }
         nb.clear();
-        for (int64_t k = 0; k < st_->K; ++k) {
-            if (st_->IK[j * st_->K + k] >= 0) {
-                nb.push_back(st_->HK[j * st_->K + k]);
-            }
+        const int64_t sb = st_->cstart[static_cast<size_t>(j)], sn = st_->ccnt[static_cast<size_t>(j)];
+        for (int64_t k = 0; k < sn; ++k) {
+            nb.push_back(st_->sp_h[static_cast<size_t>(sb + k)]);
         }
         if (nb.empty()) {
             continue;
         }
         nxt.clear();
-        const double up = kSlope * std::hypot(static_cast<double>(cells[i].x - pc.x), static_cast<double>(cells[i].y - pc.y)) * kCS + kQH;
+        const double up = UpAllow(std::hypot(static_cast<double>(cells[i].x - pc.x), static_cast<double>(cells[i].y - pc.y))) + kQH;
         for (const float t : nb) {
             for (const float c : cur) {
                 const float dh = t - c;
@@ -1419,338 +1876,43 @@ bool LayerOracle::ok(const WorldPoint& p, const WorldPoint& q, float h, float hq
 std::vector<WorldPoint> StringPull(
     const std::vector<WorldPoint>& pts,
     const Blockers& blk,
-    const ClearanceFloor* cfl,
     const LayerOracle* lyo,
-    const std::vector<float>* hs)
+    const std::vector<float>* hs,
+    const Visibility* vis)
 {
-    if (lyo != nullptr && (hs == nullptr || hs->empty())) {
-        return pts;
+    std::vector<WorldPoint> P = pts;
+    std::vector<size_t> idx(P.size());
+    for (size_t k = 0; k < idx.size(); ++k) {
+        idx[k] = k;
     }
-    return Slim(pts, blk, cfl, lyo, hs == nullptr ? 0.0F : hs->front(), false, kStringPullMaxMergeGap);
-}
-
-// 动态规划抽稀: 把输入路径点作为有向无环图的节点, 任意安全直连作为候选边。
-// 首要目标是最短总长度; 净空仅作为合并约束。等长时 Slim 可再选择更少的路径点。
-std::vector<WorldPoint> Slim(
-    const std::vector<WorldPoint>& pts,
-    const Blockers& blk,
-    const ClearanceFloor* cfl,
-    const LayerOracle* lyo,
-    float h,
-    bool prefer_fewer_points,
-    size_t max_merge_gap)
-{
-    if (pts.size() < 3) {
-        return pts;
-    }
-    const std::vector<WorldPoint>& P = pts;
-    std::vector<std::optional<std::vector<float>>> hv;
-    const auto chain = [&](size_t k) {
-        for (size_t i = k; i < P.size(); ++i) {
-            hv[i] = hv[i - 1].has_value() ? lyo->walk({ P[i - 1], P[i] }, *hv[i - 1]) : std::nullopt;
-        }
-    };
-    if (lyo != nullptr && !P.empty()) {
-        hv.assign(P.size(), std::nullopt);
-        hv[0] = std::vector<float> { h };
-        chain(1);
-    }
-    std::vector<double> original_clearance(P.size(), std::numeric_limits<double>::infinity());
-    if (cfl != nullptr) {
-        for (size_t i = 1; i < P.size(); ++i) {
-            original_clearance[i] = cfl->seg(P[i - 1], P[i]);
-        }
-    }
-
-    struct DpState
-    {
-        double length = std::numeric_limits<double>::infinity();
-        size_t segments = std::numeric_limits<size_t>::max();
-        size_t previous = std::numeric_limits<size_t>::max();
-    };
-
-    std::vector<DpState> dp(P.size());
-    dp[0] = { 0.0, 0, 0 };
-    const bool sparse_global = max_merge_gap == 0;
-    std::vector<std::vector<double>> clearance_rmq;
-    std::vector<size_t> clearance_log;
-    if (cfl != nullptr && sparse_global) {
-        clearance_log.resize(P.size() + 1, 0);
-        for (size_t i = 2; i <= P.size(); ++i) {
-            clearance_log[i] = clearance_log[i / 2] + 1;
-        }
-        clearance_rmq.push_back(original_clearance);
-        for (size_t level = 1; (size_t { 1 } << level) <= P.size(); ++level) {
-            const size_t span = size_t { 1 } << level;
-            const size_t half = span >> 1;
-            std::vector<double> row(P.size() - span + 1);
-            for (size_t i = 0; i + span <= P.size(); ++i) {
-                row[i] = std::min(clearance_rmq[level - 1][i], clearance_rmq[level - 1][i + half]);
-            }
-            clearance_rmq.push_back(std::move(row));
-        }
-    }
-    const auto swallowed_clearance = [&](size_t first_edge, size_t last_edge) {
-        if (cfl == nullptr) {
-            return std::numeric_limits<double>::infinity();
-        }
-        if (!sparse_global) {
-            double result = std::numeric_limits<double>::infinity();
-            for (size_t edge = first_edge; edge <= last_edge; ++edge) {
-                result = std::min(result, original_clearance[edge]);
-            }
-            return result;
-        }
-        const size_t length = last_edge - first_edge + 1;
-        const size_t level = clearance_log[length];
-        const size_t span = size_t { 1 } << level;
-        return std::min(clearance_rmq[level][first_edge], clearance_rmq[level][last_edge - span + 1]);
-    };
-    for (size_t j = 1; j < P.size(); ++j) {
-        std::vector<size_t> candidates;
-        if (max_merge_gap > 0) {
-            const size_t first = j > max_merge_gap ? j - max_merge_gap : 0;
-            candidates.reserve(j - first);
-            for (size_t i = j; i > first;) {
-                candidates.push_back(--i);
-            }
-        }
-        else {
-            candidates.reserve(kSlimLocalWindow + 1 + 8);
-            const size_t first = j > kSlimLocalWindow ? j - kSlimLocalWindow : 0;
-            for (size_t i = j; i > first;) {
-                candidates.push_back(--i);
-            }
-            for (size_t gap = kSlimLocalWindow; gap < j;) {
-                const size_t candidate = j - gap;
-                candidates.push_back(candidate);
-                if (candidate > 0) {
-                    candidates.push_back(candidate - 1);
-                }
-                const double local_clearance = swallowed_clearance(candidate + 1, j);
-                const double growth = cfl == nullptr || local_clearance >= 2.0 ? 1.5
-                                      : local_clearance >= 1.0                 ? 1.2
-                                      : local_clearance >= 0.5                 ? 1.1
-                                                                               : 1.05;
-                const size_t next_gap = static_cast<size_t>(std::ceil(static_cast<double>(gap) * growth));
-                if (next_gap <= gap) {
-                    break;
-                }
-                gap = next_gap;
-            }
-            candidates.push_back(0);
-            std::sort(candidates.begin(), candidates.end(), std::greater<>());
-            candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
-        }
-        for (const size_t i : candidates) {
-            if (dp[i].segments == std::numeric_limits<size_t>::max()) {
-                continue;
-            }
-            const bool adjacent = j == i + 1;
-            const double direct_clearance = cfl == nullptr ? std::numeric_limits<double>::infinity() : cfl->seg(P[i], P[j]);
-            const double previous_min = swallowed_clearance(i + 1, j);
-            const bool clearance_ok = cfl == nullptr || direct_clearance > kSlimClearanceBypass || direct_clearance >= previous_min;
-            // 原始相邻边是保底路径,即使当前抽稀判据无法复核它也不能丢掉;
-            // 只有跨越中间点的候选边才需要通过合并安全性检查。
-            if (!adjacent && (!clearance_ok || blk.blocked(P[i], P[j]))) {
-                continue;
-            }
-            if (!adjacent && lyo != nullptr) {
-                const auto nh = hv[i].has_value() ? lyo->walk({ P[i], P[j] }, *hv[i]) : std::nullopt;
-                if (!nh.has_value() || !hv[j].has_value() || !std::all_of(hv[j]->begin(), hv[j]->end(), [&](float v) {
-                        return std::find(nh->begin(), nh->end(), v) != nh->end();
-                    })) {
-                    continue;
-                }
-            }
-            const double length = dp[i].length + std::hypot(P[j].x - P[i].x, P[j].y - P[i].y);
-            const size_t segments = dp[i].segments + 1;
-            const double length_tol = kCostTol * std::max({ 1.0, length, dp[j].length });
-            const bool better = dp[j].segments == std::numeric_limits<size_t>::max() || length < dp[j].length - length_tol
-                                || (prefer_fewer_points && std::fabs(length - dp[j].length) <= length_tol && segments < dp[j].segments);
-            if (better) {
-                dp[j] = { length, segments, i };
-            }
-        }
-    }
-    if (dp.back().segments == std::numeric_limits<size_t>::max()) {
-        return pts;
-    }
-
-    std::vector<size_t> keep;
-    for (size_t i = P.size() - 1; i != std::numeric_limits<size_t>::max(); i = dp[i].previous) {
-        keep.push_back(i);
-        if (i == 0) {
-            break;
-        }
-    }
-    std::reverse(keep.begin(), keep.end());
-    std::vector<WorldPoint> out;
-    out.reserve(keep.size());
-    for (const size_t i : keep) {
-        out.push_back(P[i]);
-    }
-    return out;
-}
-
-namespace
-{
-
-double CellValue(const Grid<float>& F, double x0, double y0, double cs, const WorldPoint& p)
-{
-    const int64_t cy = std::min(std::max(static_cast<int64_t>((p.y - y0) / cs), int64_t { 0 }), F.ny - 1);
-    const int64_t cx = std::min(std::max(static_cast<int64_t>((p.x - x0) / cs), int64_t { 0 }), F.nx - 1);
-    return static_cast<double>(F.at(cy, cx));
-}
-
-double TurnCos(const WorldPoint& a, const WorldPoint& b, const WorldPoint& c)
-{
-    const double ux = b.x - a.x, uy = b.y - a.y;
-    const double vx = c.x - b.x, vy = c.y - b.y;
-    const double nu = std::hypot(ux, uy), nv = std::hypot(vx, vy);
-    if (nu < 1e-12 || nv < 1e-12) {
-        return -1.0;
-    }
-    return (ux * vx + uy * vy) / (nu * nv);
-}
-
-}
-
-// 拉直把拐点钉在轮廓角上, 过角即贴角切线, 实机绕不过去。沿转弯外侧扫方向把
-// 拐点外挪到留够过角余量; 只挪拐点不插点, 两段仍是直线, 直角不抹圆。
-// 判据取拐点自身净空: 用整弦会被两侧远处的窄段钉死, 角上的亏欠被掩盖。
-// 相邻段短于 kCornerSeg 的不算拐点, 亚像素锯齿挪动只会把线推向墙。
-// 候选按偏离转弯外侧的角度排序, 达标即停; 绝大多数方向被挡线否决, 少试方向
-// 会整体空转。两段弦净空各自允许半格退让, 挡线与层高各自否决。
-// 候选不得把转角掰得更尖: 外挪是给转弯让余量, 掰尖等于就地折返。
-std::vector<WorldPoint> WidenCorners(
-    const std::vector<WorldPoint>& pts,
-    const Blockers& blk,
-    const Grid<float>& dist,
-    double x0,
-    double y0,
-    double cs,
-    const ClearanceFloor* cfl,
-    const LayerOracle* lyo,
-    float h)
-{
-    std::vector<WorldPoint> Q = pts;
-    if (Q.size() < 3) {
-        return Q;
-    }
-    const double cosmin = std::cos(kCornerTurn * (std::numbers::pi / 180.0));
-    const int64_t nstep = std::max(int64_t { 1 }, static_cast<int64_t>(std::lround(kCornerMax / kCornerStep)));
-    std::vector<double> ang(static_cast<size_t>(kCornerDirs));
-    for (int64_t t = 0; t < kCornerDirs; ++t) {
-        ang[static_cast<size_t>(t)] = 2.0 * std::numbers::pi * static_cast<double>(t) / static_cast<double>(kCornerDirs);
-    }
-    for (int64_t r = 0; r < kCornerRounds; ++r) {
-        bool moved = false;
-        for (size_t k = 1; k + 1 < Q.size(); ++k) {
-            const WorldPoint &a = Q[k - 1], &b = Q[k], &c = Q[k + 1];
-            double ux = b.x - a.x, uy = b.y - a.y;
-            double vx = c.x - b.x, vy = c.y - b.y;
-            const double nu = std::hypot(ux, uy), nv = std::hypot(vx, vy);
-            if (nu < kCornerSeg || nv < kCornerSeg) {
-                continue;
-            }
-            ux /= nu;
-            uy /= nu;
-            vx /= nv;
-            vy /= nv;
-            if (ux * vx + uy * vy > cosmin) {
-                continue;
-            }
-            double best = CellValue(dist, x0, y0, cs, b);
-            if (best >= kCornerR) {
-                continue;
-            }
-            const double out = std::atan2(uy - vy, ux - vx);
-            const double fa = cfl != nullptr ? static_cast<double>(cfl->seg(a, b)) - kClrTol : -1.0;
-            const double fc = cfl != nullptr ? static_cast<double>(cfl->seg(b, c)) - kClrTol : -1.0;
-            const auto dev = [&](double t) {
-                return std::abs(std::remainder(t - out, 2.0 * std::numbers::pi));
-            };
-            std::vector<double> order = ang;
-            std::stable_sort(order.begin(), order.end(), [&](double p, double q) { return dev(p) < dev(q); });
-            const double turn = ux * vx + uy * vy;
-            bool have = false;
-            WorldPoint pick {};
-            for (const double t : order) {
-                const double dx = std::cos(t), dy = std::sin(t);
-                for (int64_t i = 1; i <= nstep; ++i) {
-                    const WorldPoint q { .x = b.x + dx * static_cast<double>(i) * kCornerStep,
-                                         .y = b.y + dy * static_cast<double>(i) * kCornerStep };
-                    if (blk.blocked(a, q) || blk.blocked(q, c)) {
+    for (int round = 0; round < 6; ++round) {
+        std::vector<WorldPoint> out { P[0] };
+        std::vector<size_t> oid { idx[0] };
+        size_t i = 0;
+        while (i < P.size() - 1) {
+            size_t j = P.size() - 1;
+            while (j > i + 1) {
+                if (vis != nullptr) {
+                    if (vis->ok(P[i], P[j], (*hs)[idx[i]], (*hs)[idx[j]])) {
                         break;
                     }
-                    if (TurnCos(a, q, c) < turn - 1e-9) {
-                        continue;
-                    }
-                    const double v = CellValue(dist, x0, y0, cs, q);
-                    if (v > best + 1e-9
-                        && (cfl == nullptr || (static_cast<double>(cfl->seg(a, q)) >= fa && static_cast<double>(cfl->seg(q, c)) >= fc))) {
-                        best = v;
-                        pick = q;
-                        have = true;
-                        if (best >= kCornerR) {
-                            break;
-                        }
-                    }
+                    --j;
+                    continue;
                 }
-                if (best >= kCornerR) {
+                if (!blk.blocked(P[i], P[j]) && (lyo == nullptr || lyo->ok(P[i], P[j], (*hs)[idx[i]], (*hs)[idx[j]]))) {
                     break;
                 }
+                --j;
             }
-            if (!have) {
-                continue;
-            }
-            if (lyo != nullptr) {
-                std::vector<WorldPoint> probe = Q;
-                probe[k] = pick;
-                if (!lyo->walk(probe, h).has_value()) {
-                    continue;
-                }
-            }
-            Q[k] = pick;
-            moved = true;
+            out.push_back(P[j]);
+            oid.push_back(idx[j]);
+            i = j;
         }
-        if (!moved) {
+        const bool changed = out.size() != P.size();
+        P = std::move(out);
+        idx = std::move(oid);
+        if (!changed) {
             break;
-        }
-    }
-    return Q;
-}
-
-std::vector<WorldPoint> DropLoops(const std::vector<WorldPoint>& pts)
-{
-    constexpr double eps = 1e-9;
-    std::vector<WorldPoint> P = pts;
-    bool changed = true;
-    while (changed && P.size() > 3) {
-        changed = false;
-        for (size_t i = 0; i + 1 < P.size() && !changed; ++i) {
-            for (size_t j = i + 2; j + 1 < P.size(); ++j) {
-                const WorldPoint &a = P[i], &b = P[i + 1], &c = P[j], &d = P[j + 1];
-                const double rx = b.x - a.x, ry = b.y - a.y;
-                const double sx = d.x - c.x, sy = d.y - c.y;
-                const double den = rx * sy - ry * sx;
-                if (std::abs(den) < eps) {
-                    continue;
-                }
-                const double t = ((c.x - a.x) * sy - (c.y - a.y) * sx) / den;
-                const double u = ((c.x - a.x) * ry - (c.y - a.y) * rx) / den;
-                if (!(eps < t && t < 1 - eps && eps < u && u < 1 - eps)) {
-                    continue;
-                }
-                const WorldPoint x { a.x + rx * t, a.y + ry * t };
-                std::vector<WorldPoint> np(P.begin(), P.begin() + static_cast<int64_t>(i) + 1);
-                np.push_back(x);
-                np.insert(np.end(), P.begin() + static_cast<int64_t>(j) + 1, P.end());
-                P = std::move(np);
-                changed = true;
-                break;
-            }
         }
     }
     return P;

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -948,7 +948,8 @@ std::optional<std::vector<int64_t>> SpanAstar(
     const int64_t gc = st.sp_cell[static_cast<size_t>(gset.front())];
     const int64_t gxx = gc % nx, gyy = gc / nx;
     std::vector<double> dist(st.sp_h.size(), std::numeric_limits<double>::infinity());
-    std::vector<int64_t> prev(st.sp_h.size(), -1);
+    // 存的是 span 下标, 一个区的 span 数远在 int32 之内, 窄一半省下的是每次规划的瞬时峰值。
+    std::vector<int32_t> prev(st.sp_h.size(), -1);
     dist[static_cast<size_t>(s)] = 0.0;
     using Node = std::tuple<double, int64_t>;
     std::priority_queue<Node, std::vector<Node>, std::greater<Node>> pq;
@@ -1010,7 +1011,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
         }
         if (bp >= 0) {
             dist[static_cast<size_t>(u)] = bd;
-            prev[static_cast<size_t>(u)] = bp;
+            prev[static_cast<size_t>(u)] = static_cast<int32_t>(bp);
         }
     };
     while (!pq.empty()) {
@@ -1103,7 +1104,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
                 }
                 if (ndp < dist[static_cast<size_t>(v)] - 1e-12) {
                     dist[static_cast<size_t>(v)] = ndp;
-                    prev[static_cast<size_t>(v)] = np;
+                    prev[static_cast<size_t>(v)] = static_cast<int32_t>(np);
                     pq.emplace(ndp + std::hypot(static_cast<double>(gxx - a), static_cast<double>(gyy - b)), v);
                 }
             }

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -1884,42 +1884,30 @@ std::vector<WorldPoint> StringPull(
     const std::vector<float>* hs,
     const Visibility* vis)
 {
-    std::vector<WorldPoint> P = pts;
-    std::vector<size_t> idx(P.size());
-    for (size_t k = 0; k < idx.size(); ++k) {
-        idx[k] = k;
-    }
-    for (int round = 0; round < 6; ++round) {
-        std::vector<WorldPoint> out { P[0] };
-        std::vector<size_t> oid { idx[0] };
-        size_t i = 0;
-        while (i < P.size() - 1) {
-            size_t j = P.size() - 1;
-            while (j > i + 1) {
-                if (vis != nullptr) {
-                    if (vis->ok(P[i], P[j], (*hs)[idx[i]], (*hs)[idx[j]])) {
-                        break;
-                    }
-                    --j;
-                    continue;
-                }
-                if (!blk.blocked(P[i], P[j]) && (lyo == nullptr || lyo->ok(P[i], P[j], (*hs)[idx[i]], (*hs)[idx[j]]))) {
+    // 一趟就到不动点。第二趟从锚点 c 出发时, 候选是链上 c 之后第二个起的点, 而链严格递增,
+    // 它们全落在第一趟从 c 往下扫时已经判死的那段下标里, 于是原地找回同一个 j, 输出与输入
+    // 相同。谓词只看两个端点(挡线索引的世代戳只管去重, 不进返回值), 故这个复现是必然的。
+    std::vector<WorldPoint> out { pts[0] };
+    size_t i = 0;
+    while (i < pts.size() - 1) {
+        size_t j = pts.size() - 1;
+        while (j > i + 1) {
+            if (vis != nullptr) {
+                if (vis->ok(pts[i], pts[j], (*hs)[i], (*hs)[j])) {
                     break;
                 }
                 --j;
+                continue;
             }
-            out.push_back(P[j]);
-            oid.push_back(idx[j]);
-            i = j;
+            if (!blk.blocked(pts[i], pts[j]) && (lyo == nullptr || lyo->ok(pts[i], pts[j], (*hs)[i], (*hs)[j]))) {
+                break;
+            }
+            --j;
         }
-        const bool changed = out.size() != P.size();
-        P = std::move(out);
-        idx = std::move(oid);
-        if (!changed) {
-            break;
-        }
+        out.push_back(pts[j]);
+        i = j;
     }
-    return P;
+    return out;
 }
 
 } // namespace navmesh::recast

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -812,7 +812,7 @@ std::optional<std::vector<CellPt>> CostAstar(
     const Mask& mask,
     CellPt s,
     CellPt g,
-    const Grid<float>& mult,
+    const PriceField& mult,
     const EdgeBits* banned,
     const double* bnp,
     const EdgeBits* forbidden)
@@ -934,7 +934,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
     const Mask& ok2,
     int64_t s,
     const std::vector<int64_t>& gset,
-    const Grid<float>& mult,
+    const PriceField& mult,
     const EdgeBits* banned,
     const double* bnp,
     const EdgeBits* forbidden,
@@ -991,7 +991,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
                 }
                 pen = *bnp;
             }
-            const double stp = d.w * 0.5 * static_cast<double>(mult.v[static_cast<size_t>(cw)] + mult.v[static_cast<size_t>(cu)]);
+            const double stp = d.w * 0.5 * static_cast<double>(mult.v(static_cast<size_t>(cw)) + mult.v(static_cast<size_t>(cu)));
             const int64_t jb = st.cstart(j), jn = st.ccnt(j);
             for (int64_t k = 0; k < jn; ++k) {
                 const int64_t w = jb + k;
@@ -1043,7 +1043,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
             break;
         }
         const float hu = st.sp_h[static_cast<size_t>(u)];
-        const float m0 = mult.v[static_cast<size_t>(cu)];
+        const float m0 = mult.v(static_cast<size_t>(cu));
         for (const auto& d : kNb8) {
             const int64_t a = x + d.dx, b = y + d.dy;
             if (a < 0 || a >= nx || b < 0 || b >= ny) {
@@ -1070,7 +1070,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
                 }
                 pen = *bnp;
             }
-            const float step = static_cast<float>(d.w * 0.5) * (m0 + mult.v[static_cast<size_t>(cv)]);
+            const float step = static_cast<float>(d.w * 0.5) * (m0 + mult.v(static_cast<size_t>(cv)));
             const double nd = d0 + static_cast<double>(step) + pen;
             // Theta* 松弛: 先按祖父直连计价, 视线留到弹出时验。弦按欧氏长度计价, 只有单价恒为一
             // 的实心区里这笔账才精确; 中脊带单价随净空抬到七倍, 放弦进去等于免掉那笔税, 搜索会
@@ -1079,9 +1079,9 @@ std::optional<std::vector<int64_t>> SpanAstar(
             double ndp = nd;
             if (vis != nullptr) {
                 const int64_t p = prev[static_cast<size_t>(u)];
-                if (p >= 0 && mult.v[static_cast<size_t>(cv)] <= 1.0F) {
+                if (p >= 0 && mult.v(static_cast<size_t>(cv)) <= 1.0F) {
                     const int64_t cp = st.sp_cell[static_cast<size_t>(p)];
-                    if (mult.v[static_cast<size_t>(cp)] <= 1.0F) {
+                    if (mult.v(static_cast<size_t>(cp)) <= 1.0F) {
                         const double cd = dist[static_cast<size_t>(p)]
                             + std::hypot(static_cast<double>(a - cp % nx), static_cast<double>(b - cp / nx));
                         if (cd < ndp - 1e-12) {

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -1508,12 +1508,10 @@ std::vector<WorldPoint> SimplifyLoop(const std::vector<WorldPoint>& P, double ma
     return out;
 }
 
-Blockers::Blockers(
+BlockerSegments::BlockerSegments(
     const std::vector<std::vector<WorldPoint>>& loops,
     const std::vector<WorldPoint>* extra_a,
-    const std::vector<WorldPoint>* extra_b,
-    std::optional<OnMask> on)
-    : on_(on)
+    const std::vector<WorldPoint>* extra_b)
 {
     for (const auto& P : loops) {
         for (size_t i = 0; i < P.size(); ++i) {
@@ -1525,26 +1523,21 @@ Blockers::Blockers(
         a_.insert(a_.end(), extra_a->begin(), extra_a->end());
         b_.insert(b_.end(), extra_b->begin(), extra_b->end());
     }
-    lo_.reserve(a_.size());
-    hi_.reserve(a_.size());
-    for (size_t i = 0; i < a_.size(); ++i) {
-        lo_.push_back({ std::min(a_[i].x, b_[i].x), std::min(a_[i].y, b_[i].y) });
-        hi_.push_back({ std::max(a_[i].x, b_[i].x), std::max(a_[i].y, b_[i].y) });
-    }
 }
 
-void Blockers::buildIndex() const
+void BlockerSegments::buildIndex() const
 {
     built_ = true;
     if (a_.empty()) {
         return;
     }
-    double mnx = lo_[0].x, mny = lo_[0].y, mxx = hi_[0].x, mxy = hi_[0].y;
+    double mnx = lo(0).x, mny = lo(0).y, mxx = hi(0).x, mxy = hi(0).y;
     for (size_t i = 1; i < a_.size(); ++i) {
-        mnx = std::min(mnx, lo_[i].x);
-        mny = std::min(mny, lo_[i].y);
-        mxx = std::max(mxx, hi_[i].x);
-        mxy = std::max(mxy, hi_[i].y);
+        const WorldPoint l = lo(i), h = hi(i);
+        mnx = std::min(mnx, l.x);
+        mny = std::min(mny, l.y);
+        mxx = std::max(mxx, h.x);
+        mxy = std::max(mxy, h.y);
     }
     bx0_ = mnx - kBkt;
     by0_ = mny - kBkt;
@@ -1554,10 +1547,11 @@ void Blockers::buildIndex() const
     // 段按包围盒入桶, 盒放量 kBktPad 盖住相交判据留给两端的那点余量。挡线都是轮廓折线段,
     // 盒里的桶数与段长同阶, 数一趟填一趟就够。
     const auto span = [&](size_t i, int64_t* g) {
-        g[0] = static_cast<int64_t>((lo_[i].x - kBktPad - bx0_) / kBkt);
-        g[1] = static_cast<int64_t>((hi_[i].x + kBktPad - bx0_) / kBkt);
-        g[2] = static_cast<int64_t>((lo_[i].y - kBktPad - by0_) / kBkt);
-        g[3] = static_cast<int64_t>((hi_[i].y + kBktPad - by0_) / kBkt);
+        const WorldPoint l = lo(i), h = hi(i);
+        g[0] = static_cast<int64_t>((l.x - kBktPad - bx0_) / kBkt);
+        g[1] = static_cast<int64_t>((h.x + kBktPad - bx0_) / kBkt);
+        g[2] = static_cast<int64_t>((l.y - kBktPad - by0_) / kBkt);
+        g[3] = static_cast<int64_t>((h.y + kBktPad - by0_) / kBkt);
     };
     int64_t g[4];
     for (size_t i = 0; i < a_.size(); ++i) {
@@ -1593,44 +1587,46 @@ bool Blockers::blocked(const WorldPoint& p, const WorldPoint& q) const
     const double rx = q.x - p.x, ry = q.y - p.y;
     // 弦上取样间隔半个桶, 每点连同八邻一起取: 弦上任何一点离某个取样点不超过半个桶, 于是它
     // 所在的桶必在某个取样点的三乘三邻域里, 待测集因此不漏。
-    if (!built_) {
-        buildIndex();
+    const BlockerSegments& sg = *segs_;
+    if (!sg.built_) {
+        sg.buildIndex();
     }
-    if (++epoch_ == 0) {
-        std::fill(seen_.begin(), seen_.end(), 0);
-        std::fill(bseen_.begin(), bseen_.end(), 0);
-        ++epoch_;
+    if (++sg.epoch_ == 0) {
+        std::fill(sg.seen_.begin(), sg.seen_.end(), 0);
+        std::fill(sg.bseen_.begin(), sg.bseen_.end(), 0);
+        ++sg.epoch_;
     }
     const int64_t ns = static_cast<int64_t>(std::hypot(rx, ry) / (kBkt * 0.5)) + 1;
-    for (int64_t k = 0; k <= ns && bnx_ > 0; ++k) {
+    for (int64_t k = 0; k <= ns && sg.bnx_ > 0; ++k) {
         const double t = static_cast<double>(k) / static_cast<double>(ns);
-        const int64_t sx0 = static_cast<int64_t>((p.x + rx * t - bx0_) / kBkt);
-        const int64_t sy0 = static_cast<int64_t>((p.y + ry * t - by0_) / kBkt);
-        for (int64_t gy = std::max<int64_t>(sy0 - 1, 0); gy <= std::min(sy0 + 1, bny_ - 1); ++gy) {
-            for (int64_t gx = std::max<int64_t>(sx0 - 1, 0); gx <= std::min(sx0 + 1, bnx_ - 1); ++gx) {
-                const size_t bk = static_cast<size_t>(gy * bnx_ + gx);
+        const int64_t sx0 = static_cast<int64_t>((p.x + rx * t - sg.bx0_) / kBkt);
+        const int64_t sy0 = static_cast<int64_t>((p.y + ry * t - sg.by0_) / kBkt);
+        for (int64_t gy = std::max<int64_t>(sy0 - 1, 0); gy <= std::min(sy0 + 1, sg.bny_ - 1); ++gy) {
+            for (int64_t gx = std::max<int64_t>(sx0 - 1, 0); gx <= std::min(sx0 + 1, sg.bnx_ - 1); ++gx) {
+                const size_t bk = static_cast<size_t>(gy * sg.bnx_ + gx);
                 // 取样间隔半桶而邻域取三乘三, 同一个桶要被相邻取样点各扫一遍; 桶也挂世代戳,
                 // 二次访问时桶里每段都已标过, 本来就一段都不产, 整桶跳过待测集不变。
-                if (bseen_[bk] == epoch_) {
+                if (sg.bseen_[bk] == sg.epoch_) {
                     continue;
                 }
-                bseen_[bk] = epoch_;
-                for (int32_t e = bstart_[bk]; e < bstart_[bk + 1]; ++e) {
-                    const int32_t id = bitem_[static_cast<size_t>(e)];
-                    if (seen_[static_cast<size_t>(id)] == epoch_) {
+                sg.bseen_[bk] = sg.epoch_;
+                for (int32_t e = sg.bstart_[bk]; e < sg.bstart_[bk + 1]; ++e) {
+                    const int32_t id = sg.bitem_[static_cast<size_t>(e)];
+                    if (sg.seen_[static_cast<size_t>(id)] == sg.epoch_) {
                         continue;
                     }
-                    seen_[static_cast<size_t>(id)] = epoch_;
+                    sg.seen_[static_cast<size_t>(id)] = sg.epoch_;
                     const size_t i = static_cast<size_t>(id);
-                    if (hi_[i].x < lox || lo_[i].x > hix || hi_[i].y < loy || lo_[i].y > hiy) {
+                    const WorldPoint sl = sg.lo(i), sh = sg.hi(i);
+                    if (sh.x < lox || sl.x > hix || sh.y < loy || sl.y > hiy) {
                         continue;
                     }
-                    const double sx = b_[i].x - a_[i].x, sy = b_[i].y - a_[i].y;
+                    const double sx = sg.b_[i].x - sg.a_[i].x, sy = sg.b_[i].y - sg.a_[i].y;
                     const double den = rx * sy - ry * sx;
                     if (!(std::abs(den) > 1e-12)) {
                         continue;
                     }
-                    const double ux = a_[i].x - p.x, uy = a_[i].y - p.y;
+                    const double ux = sg.a_[i].x - p.x, uy = sg.a_[i].y - p.y;
                     const double tt = (ux * sy - uy * sx) / den;
                     const double w = (ux * ry - uy * rx) / den;
                     // 挡线一侧取闭区间: 挡线段是格边, 精确 45° 的弦每次都正好交在端点上, 开区间会让它

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -137,12 +137,6 @@ struct SpanTable
 // 相邻格垂直可达判据: cid 格上高 h0 的 span 能否迈到 (dx,dy) 邻格上高 h1 的 span。
 bool RiseOk(const SpanTable& st, int64_t nx, int64_t ny, int64_t cid, int64_t dx, int64_t dy, float h0, float h1);
 
-struct WallCsr
-{
-    std::vector<int64_t> wid;
-    std::vector<int64_t> start;
-};
-
 // walkable 非空时按三角下标逐个过滤:标 0 的不体素化。掩码须与 T 同长同序;
 // 调用方自己压缩过的子集三角表留 nullptr。
 RasterCells Rasterize(
@@ -189,7 +183,8 @@ std::vector<uint8_t> WallsAtLayer(
     double ox,
     double oy);
 
-WallCsr BuildWallIndex(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny);
+// 逐格一位: 这一格里落过边界边的采样点。距离场对跨边界无感, 用它把边所在的格从自由集里扣掉。
+Mask WallHits(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny);
 
 // (dy+1)*3+(dx+1) → 位号 |(位存在终点格 ? 8 : 0), -1 表示这个位移不是八邻。
 // 表由 kGridStepDx/Dy 现推, 于是与包里 stepbits 的位序同一份定义。

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -105,22 +105,33 @@ struct RasterCells
     std::vector<uint8_t> ins;
 };
 
-// 同一格的 span 在 sp_h 里是连续一段: 下标 [cstart[j], cstart[j]+ccnt[j])。逐格取这一段,
-// 不必按全窗口最大叠层数 K 逐槽扫 —— K 取最大值, 而绝大多数格只有一张面。
+// 同一格的 span 在 sp_h 里是连续一段: 下标 [cstart(j), cstart(j)+ccnt(j))。逐格取这一段,
+// 不必按全窗口最大叠层数逐槽扫 —— 那个上限取全窗最大值, 而绝大多数格只有一张面。
 struct SpanTable
 {
-    std::vector<int64_t> sp_cell;
+    std::vector<int32_t> sp_cell;
     std::vector<float> sp_h;
-    std::vector<int64_t> occ;
-    std::vector<int64_t> cstart;
-    std::vector<int64_t> ccnt;
-    int64_t K = 0;
-    std::vector<int64_t> sp_ci;
+    // CSR 边界, 长度 = 占用格数 + 1, 末位是 span 总数。每格的起点、条数、所在格号都由它
+    // 与 sp_cell 现推, 各存一份逐格数组是同一份信息的三个副本。
+    std::vector<int32_t> cs;
     // 逐占用格一位: 这一列是不是被栅格化的立面。判据只看该格自己的叠层, 建表时算一次。
     std::vector<uint8_t> face;
-    // 格号 → occ 下标的直查表, 空格填 -1。邻格查询在 BFS 与垂直可达判据里是最内层的一步,
-    // 建表时摊掉一次, 就不必每次在 occ 上二分。长度只到最大占用格, 表外一律当空格。
+    // 格号 → 占用格下标的直查表, 空格填 -1。邻格查询在 BFS 与垂直可达判据里是最内层的一步,
+    // 建表时摊掉一次, 就不必每次二分。长度只到最大占用格, 表外一律当空格。
     std::vector<int32_t> c2j;
+
+    int64_t nOcc() const { return cs.empty() ? 0 : static_cast<int64_t>(cs.size()) - 1; }
+
+    int64_t cstart(int64_t ci) const { return cs[static_cast<size_t>(ci)]; }
+
+    int64_t ccnt(int64_t ci) const { return cs[static_cast<size_t>(ci) + 1] - cs[static_cast<size_t>(ci)]; }
+
+    int64_t occ(int64_t ci) const { return sp_cell[static_cast<size_t>(cs[static_cast<size_t>(ci)])]; }
+
+    int64_t j(int64_t cid) const
+    {
+        return cid >= 0 && cid < static_cast<int64_t>(c2j.size()) ? c2j[static_cast<size_t>(cid)] : -1;
+    }
 };
 
 // 相邻格垂直可达判据: cid 格上高 h0 的 span 能否迈到 (dx,dy) 邻格上高 h1 的 span。
@@ -148,7 +159,7 @@ void AppendSeamBridge(RasterCells& rc, int64_t nx, int64_t ny);
 
 SpanTable BuildSpans(const std::vector<int64_t>& cell, const std::vector<float>& h);
 
-SpanTable PackSpans(std::vector<int64_t> cell, std::vector<float> h, std::vector<uint8_t>* flags = nullptr);
+SpanTable PackSpans(std::vector<int32_t> cell, std::vector<float> h, std::vector<uint8_t>* flags = nullptr);
 
 std::vector<uint8_t> Flood(int64_t seed, const SpanTable& st, int64_t nx);
 
@@ -254,10 +265,7 @@ struct StepBarrier
     EdgeBits steps;
     std::vector<WorldPoint> p0;
     std::vector<WorldPoint> p1;
-    std::vector<float> t0;
 };
-
-StepBarrier StepBreaks(const SpanTable& st, const std::vector<uint8_t>& vis, const Mask& lay, double ox, double oy);
 
 std::vector<int64_t> Comps4(const Mask& mask);
 
@@ -282,7 +290,6 @@ class Visibility;
 std::optional<std::vector<int64_t>> SpanAstar(
     const SpanTable& st,
     const std::vector<uint8_t>& ok,
-    const std::vector<int64_t>& cidx,
     const Mask& ok2,
     int64_t s,
     const std::vector<int64_t>& gset,
@@ -353,9 +360,8 @@ private:
 class LayerOracle
 {
 public:
-    LayerOracle(const SpanTable* st, const std::vector<int64_t>* cidx, int64_t nx, int64_t ny, double x0, double y0)
+    LayerOracle(const SpanTable* st, int64_t nx, int64_t ny, double x0, double y0)
         : st_(st)
-        , cidx_(cidx)
         , nx_(nx)
         , ny_(ny)
         , x0_(x0)
@@ -372,7 +378,6 @@ public:
 
 private:
     const SpanTable* st_ = nullptr;
-    const std::vector<int64_t>* cidx_ = nullptr;
     int64_t nx_ = 0;
     int64_t ny_ = 0;
     double x0_ = 0.0;

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -268,11 +268,34 @@ Mask FillHoles(const Mask& mask, int64_t max_cells, const Mask* protect);
 
 Mask CloseCracks(const Mask& core, const Mask& lay, const Mask* protect);
 
+// 逐格单价: 净空夹进 [lo, hi] 后按亏欠比例上浮, 最宽处恒为一; dist 为空表示处处一价。
+// 它是净空场的逐元素函数, 每次取值现算 —— 单独铺一张全窗口的 float 表, 存的是同一份
+// 数据的第二个副本。
+struct PriceField
+{
+    const Grid<float>* dist = nullptr;
+    double lo = 0.0;
+    double hi = 0.0;
+
+    float v(size_t i) const
+    {
+        if (dist == nullptr) {
+            return 1.0F;
+        }
+        return static_cast<float>(hi / std::min(std::max(static_cast<double>(dist->v[i]), lo), hi));
+    }
+
+    float at(int64_t y, int64_t x) const
+    {
+        return dist == nullptr ? 1.0F : v(static_cast<size_t>(y * dist->nx + x));
+    }
+};
+
 std::optional<std::vector<CellPt>> CostAstar(
     const Mask& mask,
     CellPt s,
     CellPt g,
-    const Grid<float>& mult,
+    const PriceField& mult,
     const EdgeBits* banned,
     const double* bnp,
     const EdgeBits* forbidden = nullptr);
@@ -288,7 +311,7 @@ std::optional<std::vector<int64_t>> SpanAstar(
     const Mask& ok2,
     int64_t s,
     const std::vector<int64_t>& gset,
-    const Grid<float>& mult,
+    const PriceField& mult,
     const EdgeBits* banned,
     const double* bnp,
     const EdgeBits* forbidden = nullptr,

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -340,9 +340,10 @@ private:
     mutable int64_t bny_ = 0;
     mutable std::vector<int32_t> bstart_;
     mutable std::vector<int32_t> bitem_;
-    // 同一段会落进多个桶, 用一组世代戳去重, 逐腿不清零。
+    // 同一段会落进多个桶、同一个桶又会被相邻取样点重复扫到, 段与桶各挂一组世代戳去重,
+    // 逐腿不清零。相交测试就地做, 命中即返回: 返回值是候选集上的或, 短路不改变它。
     mutable std::vector<uint32_t> seen_;
-    mutable std::vector<int32_t> cand_;
+    mutable std::vector<uint32_t> bseen_;
     mutable uint32_t epoch_ = 0;
 };
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <optional>
@@ -7,43 +8,64 @@
 #include <vector>
 
 #include "NavmeshTypes.h"
+#include "RecastNavGridIO.h"
 
 namespace navmesh::recast
 {
 
-inline constexpr double kCS = 0.25;                 // 体素边长 px
-inline constexpr double kClimb = 3.0;               // 相邻格可连通最大高差 px
-inline constexpr double kSlope = 1.0;               // 可攀爬坡度上限 tanθ, 抬升超过水平位移的这个倍数即立面
-inline constexpr double kUp = kSlope * kCS;         // 正交相邻格允许的抬升 px, 斜向按实际水平位移等比放大
-inline constexpr double kMergeH = kUp;              // 同列 span 合并容差 px, 取 kUp 使同层内处处可一步跨到
-inline constexpr double kQH = 1.0;                  // 体素取样高差容差 px, 需装下斜面单格起伏与格心取样偏差
-inline constexpr double kEdtCap = 12.0;             // 距离场截断 px
-inline constexpr double kR = 1.75;                  // 期望余量上限 px
-inline constexpr double kGeoR = 3.5;                // 几何口径舒适余量上限 px
-inline constexpr double kRel = 0.6;                 // 期望余量 = min(R, REL×局部净空)
-inline constexpr double kLam = 4.0;                 // 按局部通道目标计亏欠的满亏欠一步加价倍数
-inline constexpr double kLamR = 28.0;               // 按固定余量目标 kR 计亏欠的满亏欠一步加价倍数
-inline constexpr double kRidgeFloor = 0.5;          // 脊线保底余量地板 px
-inline constexpr double kMaxErr = 0.5;              // 轮廓 DP 容差 px
-inline constexpr double kSlimClearanceBypass = 1.0; // 直连净空超过该值时跳过原净空比较 px
-inline constexpr double kClrTol = 0.125;            // 拉直允许的净空退让 px, 取半格即采样步长
-inline constexpr size_t kStringPullMaxMergeGap = 6; // StringPull 最多跨越的输入路径步数
-inline constexpr size_t kSlimLocalWindow = 4;       // Slim 局部完整搜索窗口
-inline constexpr double kCornerR = 1.75;            // 过角期望余量 px
-inline constexpr double kCornerTurn = 5.0;          // 需要留过角余量的最小转角 度
-inline constexpr double kCornerSeg = 2.0;           // 认定为拐点的最小相邻段长 px
-inline constexpr double kCornerMax = 4.0;           // 拐点外挪上限 px
-inline constexpr double kCornerStep = 0.5;          // 拐点外挪步长 px
-inline constexpr int64_t kCornerDirs = 32;          // 拐点外挪候选方向数
-inline constexpr int64_t kCornerRounds = 3;         // 拐点外挪迭代轮数
-inline constexpr double kCostTol = 1e-9;            // 代价判据相对容差, 容纳共线子路径的浮点求和差
-inline constexpr double kMcHBand = 8.0;             // 层高度带(边界边筛/盖章)px
-inline constexpr double kSnapRadius = 8.0;          // 起终点吸附半径 px
-inline constexpr double kDeckBand = 2.0;            // 声明面高度匹配容差 px, 需远小于相邻面间距
-inline constexpr double kMargin = 25.0;             // 窗口外扩 px
-inline constexpr double kBlockedPointRadius = 1.0;  // 封堵点盖章半径 px
-inline constexpr int64_t kHoleMaxCells = 32;        // 封闭小洞填充上限(格 = 2px²)
-inline constexpr int64_t kMaxCells = 30'000'000;
+inline constexpr double kCS = 0.25;                // 体素边长 px
+inline constexpr double kClimb = 3.0;              // 相邻格可连通最大高差 px
+inline constexpr double kSlope = 1.0;              // 可攀爬坡度上限 tanθ, 抬升超过水平位移的这个倍数即立面
+inline constexpr double kStepUp = 0.5;             // 可直接迈上的台阶高 px, 是角色属性所以不跟体素边长挂钩
+inline constexpr double kBumpUp = 1.25;            // 跨过路面窄凸起/浅坑允许的抬升 px, 仅在落差不延伸时生效
+inline constexpr int64_t kBumpCells = 3;           // 前探格数: 抬升在这么多格内回到出发高度即窄凸起
+inline constexpr int64_t kDipCells = 2;            // 后探格数: 目标高度在身后这么多格内出现即浅坑
+inline constexpr double kWallH = 1.25;             // 禁步边同时挡住拉直视线所需的落差 px, 取路面起伏上限
+inline constexpr double kMergeH = kSlope * kCS;    // 同列 span 合并容差 px, 取一格坡面起伏
+inline constexpr double kQH = 1.0;                 // 体素取样高差容差 px, 需装下斜面单格起伏与格心取样偏差
+inline constexpr double kEdtCap = 12.0;            // 距离场截断 px
+inline constexpr double kR = 1.75;                 // 期望余量上限 px
+inline constexpr double kMaxErr = 0.5;             // 轮廓 DP 容差 px
+inline constexpr double kMcHBand = 8.0;            // 层高度带(边界边筛/盖章)px
+inline constexpr double kBkt = 4.0;                // 挡线索引桶边长 px
+inline constexpr double kBktPad = 1e-6;            // 入桶时给挡线包围盒的放量 px, 需盖过相交判据放给挡线两端的余量
+inline constexpr double kSnapRadius = 8.0;         // 起终点吸附半径 px
+inline constexpr double kDeckBand = 2.0;           // 声明面高度匹配容差 px, 需远小于相邻面间距
+inline constexpr double kBlockedPointRadius = 1.0; // 封堵点盖章半径 px
+inline constexpr int64_t kHoleMaxCells = 32;       // 封闭小洞填充上限(格 = 2px²)
+// 单区格数上限。规划铺满整区, 这道闸只用来挡烘出来就不正常的区, 正常区离它很远。
+inline constexpr int64_t kMaxCells = 400'000'000;
+
+// VV(c) 的期望净空 c: 障碍按 c 膨胀后仍自由的地方走可见图, 膨胀后被吃掉的窄处走中脊。净空在
+// 拓扑层是掩膜而不是价格 —— 按每格加价的写法会把中途钻的一小段窄缝摊进整条路长里平均掉,
+// 那一小段再窄也只体现成一点点均价。取通行余量 kR: 这是烘焙腐蚀用的同一条角色半宽。
+inline constexpr double kClrPref = kR; // 期望净空 px
+// 中轴判据的毛刺尺度 px: 两侧最近障碍点隔不开这么远的起伏, 当边界噪声看待。上界由最窄那条
+// 可通行缝定死 —— 净空 w 的缝两壁只隔开约 2w, 比这还大就提不出中轴, 通道在那里断掉, 线只能
+// 绕整栋楼。两个格已经挡得住单格边界抖动, 再抬就开始吃掉实测里真走得通的窄走廊。
+inline constexpr double kClrLambda = 2.0 * kCS;
+// 定通道那一层单价按净空取值的区间, 单位 px。到 kClrPref 就封顶的话, 中轴上处处够宽单价一律
+// 为一, 平行分支里最短的那条必然中标, 而窄缝总比宽道短 —— 于是线钻缝; 上限抬到这里, 绕去宽道
+// 的那点长度才买得起。两端之比就是这层肯买的绕路倍数上限: 一条全程走窄处的腿, 会被长到这个
+// 倍数的宽路顶掉, 取 4 时实测那条 5.25 倍外环买不动。窄到下限以下不再细分, 那是几何层的事。
+inline constexpr double kClrWide = 4.0;
+inline constexpr double kClrNarrow = 1.0;
+// 弦的容许净空占所在走廊半宽的比例。弦贴着障碍角切过去时净空恰好等于这道阈值 —— 按走廊比例
+// 定, 宽走廊就把线推离墙, 窄缝里自动松到弦仍走得通; 换成常数则收紧走锯齿、放开贴角切。
+inline constexpr double kChordFrac = 0.8;
+// 中脊上的突变抬升每次记一笔, 单位是格步价。连续缓坡不计, 只有必须迈上去的那种算。
+inline constexpr double kStepTax = 6.0;
+// 终线取直的拐角余量 px: 挡线按 kClrPref 加这一笔算, 弦贴角切过去时的净空即是这个和。
+inline constexpr double kGeoMargin = 0.0;
+// 拐点朝净空更高一侧能挪的最大位移 px。上界给到半格宽以内, 越界那些拐角就不是余量问题了。
+inline constexpr double kLiftMax = 0.5;
+
+// 相邻格允许的抬升 px, w 是水平位移(格)。坡面按坡度上限放行, 台阶按可迈高度放行, 两者取大。
+// 只按坡度判会把可迈的台阶高绑死成体素边长, 于是路缘、地面微起伏这些连续地面全被切成立面。
+inline double UpAllow(double w)
+{
+    return std::max(kStepUp, kSlope * w * kCS);
+}
 
 template <typename T>
 struct Grid
@@ -83,7 +105,8 @@ struct RasterCells
     std::vector<uint8_t> ins;
 };
 
-// HK/IK 行主序 [n_occ][K],空槽 inf/-1
+// 同一格的 span 在 sp_h 里是连续一段: 下标 [cstart[j], cstart[j]+ccnt[j])。逐格取这一段,
+// 不必按全窗口最大叠层数 K 逐槽扫 —— K 取最大值, 而绝大多数格只有一张面。
 struct SpanTable
 {
     std::vector<int64_t> sp_cell;
@@ -92,10 +115,16 @@ struct SpanTable
     std::vector<int64_t> cstart;
     std::vector<int64_t> ccnt;
     int64_t K = 0;
-    std::vector<float> HK;
-    std::vector<int64_t> IK;
     std::vector<int64_t> sp_ci;
+    // 逐占用格一位: 这一列是不是被栅格化的立面。判据只看该格自己的叠层, 建表时算一次。
+    std::vector<uint8_t> face;
+    // 格号 → occ 下标的直查表, 空格填 -1。邻格查询在 BFS 与垂直可达判据里是最内层的一步,
+    // 建表时摊掉一次, 就不必每次在 occ 上二分。长度只到最大占用格, 表外一律当空格。
+    std::vector<int32_t> c2j;
 };
+
+// 相邻格垂直可达判据: cid 格上高 h0 的 span 能否迈到 (dx,dy) 邻格上高 h1 的 span。
+bool RiseOk(const SpanTable& st, int64_t nx, int64_t ny, int64_t cid, int64_t dx, int64_t dy, float h0, float h1);
 
 struct WallCsr
 {
@@ -103,6 +132,8 @@ struct WallCsr
     std::vector<int64_t> start;
 };
 
+// walkable 非空时按三角下标逐个过滤:标 0 的不体素化。掩码须与 T 同长同序;
+// 调用方自己压缩过的子集三角表留 nullptr。
 RasterCells Rasterize(
     const std::vector<WorldPoint>& V,
     const std::vector<double>& H,
@@ -110,7 +141,8 @@ RasterCells Rasterize(
     double ox,
     double oy,
     int64_t nx,
-    int64_t ny);
+    int64_t ny,
+    const std::vector<uint8_t>* walkable = nullptr);
 
 void AppendSeamBridge(RasterCells& rc, int64_t nx, int64_t ny);
 
@@ -148,9 +180,78 @@ std::vector<uint8_t> WallsAtLayer(
 
 WallCsr BuildWallIndex(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny);
 
+// (dy+1)*3+(dx+1) → 位号 |(位存在终点格 ? 8 : 0), -1 表示这个位移不是八邻。
+// 表由 kGridStepDx/Dy 现推, 于是与包里 stepbits 的位序同一份定义。
+inline constexpr std::array<int8_t, 9> MakeEdgeSlots()
+{
+    std::array<int8_t, 9> t {};
+    t.fill(-1);
+    for (int i = 0; i < 4; ++i) {
+        const int dx = static_cast<int>(kGridStepDx[i]);
+        const int dy = static_cast<int>(kGridStepDy[i]);
+        t[static_cast<size_t>((dy + 1) * 3 + dx + 1)] = static_cast<int8_t>(2 * i);
+        t[static_cast<size_t>((1 - dy) * 3 + 1 - dx)] = static_cast<int8_t>(2 * i + 1 + 8);
+    }
+    return t;
+}
+
+inline constexpr std::array<int8_t, 9> kEdgeSlot = MakeEdgeSlots();
+
+// 禁行边集。边只连八邻 ⇒ 一格一字节, 四个规范方向各占两位(正向、反向)即可存下全部边。
+// 非八邻的格对没有位可存, locate 一律返回 -1: 这既是越界保护, 也正是散列集查不到那个键
+// 时给的答案, 两种实现因此逐位同答。
+struct EdgeBits
+{
+    std::vector<uint8_t> v;
+    int64_t nx = 0;
+    int64_t ny = 0;
+    bool any = false;
+
+    void resize(int64_t w, int64_t h)
+    {
+        nx = w;
+        ny = h;
+        v.assign(static_cast<size_t>(w * h), 0);
+        any = false;
+    }
+
+    // 返回 (存位的格 << 3) | 位号
+    int64_t locate(int64_t a, int64_t b) const
+    {
+        const int64_t dx = b % nx - a % nx;
+        const int64_t dy = b / nx - a / nx;
+        if (dx < -1 || dx > 1 || dy < -1 || dy > 1) {
+            return -1;
+        }
+        const int8_t s = kEdgeSlot[static_cast<size_t>((dy + 1) * 3 + dx + 1)];
+        if (s < 0) {
+            return -1;
+        }
+        return (((s & 8) != 0 ? b : a) << 3) | (s & 7);
+    }
+
+    void set(int64_t a, int64_t b)
+    {
+        const int64_t loc = locate(a, b);
+        if (loc < 0) {
+            return;
+        }
+        v[static_cast<size_t>(loc >> 3)] |= static_cast<uint8_t>(1U << (loc & 7));
+        any = true;
+    }
+
+    bool has(int64_t a, int64_t b) const
+    {
+        const int64_t loc = locate(a, b);
+        return loc >= 0 && (v[static_cast<size_t>(loc >> 3)] & (1U << (loc & 7))) != 0;
+    }
+
+    bool empty() const { return !any; }
+};
+
 struct StepBarrier
 {
-    std::unordered_set<int64_t> steps;
+    EdgeBits steps;
     std::vector<WorldPoint> p0;
     std::vector<WorldPoint> p1;
     std::vector<float> t0;
@@ -169,10 +270,15 @@ std::optional<std::vector<CellPt>> CostAstar(
     CellPt s,
     CellPt g,
     const Grid<float>& mult,
-    const std::unordered_set<int64_t>* banned,
+    const EdgeBits* banned,
     const double* bnp,
-    const std::unordered_set<int64_t>* forbidden = nullptr);
+    const EdgeBits* forbidden = nullptr);
 
+class Visibility;
+
+// vis 非空则按 Lazy Theta* 展开: 松弛先把父指针接到祖父, 弹出时才验一次视线, 验不过退回格步。
+// 于是路径由父链上的直线段构成, 紧绷这件事在搜索里完成, 不再靠事后拉直。
+// 返回值恒为逐格路径, 拓扑判据按格读。corners 非空则另交出父链本身, 那才是几何要走的折线。
 std::optional<std::vector<int64_t>> SpanAstar(
     const SpanTable& st,
     const std::vector<uint8_t>& ok,
@@ -181,13 +287,15 @@ std::optional<std::vector<int64_t>> SpanAstar(
     int64_t s,
     const std::vector<int64_t>& gset,
     const Grid<float>& mult,
-    const std::unordered_set<int64_t>* banned,
+    const EdgeBits* banned,
     const double* bnp,
-    const std::unordered_set<int64_t>* forbidden = nullptr);
+    const EdgeBits* forbidden = nullptr,
+    const Visibility* vis = nullptr,
+    std::vector<int64_t>* corners = nullptr);
 
-Grid<float> PrefField(const Grid<float>& dist, bool ridge);
+Mask MedialAxis(const Grid<float>& dist, double lam);
 
-Grid<float> TargetField(const Grid<float>& dist);
+Grid<float> CorridorWidth(const Grid<float>& dist, const Mask& seed, Mask* band = nullptr);
 
 std::vector<std::vector<WorldPoint>> TraceContours(const Mask& mask);
 
@@ -215,37 +323,27 @@ public:
 
 private:
     bool offMask(const WorldPoint& p, const WorldPoint& q) const;
+    void buildIndex() const;
 
     std::vector<WorldPoint> a_;
     std::vector<WorldPoint> b_;
     std::vector<WorldPoint> lo_;
     std::vector<WorldPoint> hi_;
     std::optional<OnMask> on_;
-};
-
-// 沿弦按半格步长采样: seg 取 min(净空, 目标余量) 的下确界, cost 取代价泛函积分
-class ClearanceFloor
-{
-public:
-    ClearanceFloor(const Grid<float>* cf, const Grid<float>* mg, double x0, double y0, double cs)
-        : cf_(cf)
-        , mg_(mg)
-        , x0_(x0)
-        , y0_(y0)
-        , cs_(cs)
-    {
-    }
-
-    float seg(const WorldPoint& p, const WorldPoint& q) const;
-
-    double cost(const WorldPoint& p, const WorldPoint& q) const;
-
-private:
-    const Grid<float>* cf_ = nullptr;
-    const Grid<float>* mg_ = nullptr;
-    double x0_ = 0.0;
-    double y0_ = 0.0;
-    double cs_ = kCS;
+    // 挡线按均匀桶建 CSR 索引。弦与某段相交必然共有一点: 那点在段的包围盒里 ⇒ 段登记在它所在
+    // 的桶, 那点又在弦上 ⇒ 弦的取样覆盖到它所在的桶, 于是只测弦扫过的桶与全表扫描同答。
+    // 索引首次查询时才建: 一条腿里要造好几个 Blockers, 其中几个一次都不查。
+    mutable bool built_ = false;
+    mutable double bx0_ = 0.0;
+    mutable double by0_ = 0.0;
+    mutable int64_t bnx_ = 0;
+    mutable int64_t bny_ = 0;
+    mutable std::vector<int32_t> bstart_;
+    mutable std::vector<int32_t> bitem_;
+    // 同一段会落进多个桶, 用一组世代戳去重, 逐腿不清零。
+    mutable std::vector<uint32_t> seen_;
+    mutable std::vector<int32_t> cand_;
+    mutable uint32_t epoch_ = 0;
 };
 
 // 走查只用来跟住弦所在的层, 立面本身由挡线集与拓扑禁步管住, 故抬升按体素取样
@@ -280,33 +378,59 @@ private:
     double y0_ = 0.0;
 };
 
+// 搜索与终线共用的唯一视线判据。四件事一次答完: 通道掩膜、立面禁步、计税台阶、层走查。
+// 禁步与台阶按边集逐格查, 与拓扑层同一份口径; 弦跨过台阶就白拿了那笔税, 因此一律当挡, 台阶
+// 处自然退化成格步。墙不必单列: 弦被限在净空 ≥ c 的实心区内, 够不着墙。
+class Visibility
+{
+public:
+    Visibility(
+        const Blockers* blk,
+        const LayerOracle* lyo,
+        const EdgeBits* faces,
+        const EdgeBits* steps,
+        int64_t nx,
+        int64_t ny,
+        double x0,
+        double y0)
+        : blk_(blk)
+        , lyo_(lyo)
+        , faces_(faces)
+        , steps_(steps)
+        , nx_(nx)
+        , ny_(ny)
+        , x0_(x0)
+        , y0_(y0)
+    {
+    }
+
+    bool ok(const WorldPoint& p, const WorldPoint& q, float hp, float hq) const;
+
+    // 格心 + 半格 = 世界坐标, 与拉直取点同一口径
+    WorldPoint at(int64_t cell) const
+    {
+        return { x0_ + (static_cast<double>(cell % nx_) + 0.5) * kCS, y0_ + (static_cast<double>(cell / nx_) + 0.5) * kCS };
+    }
+
+private:
+    bool crossesStep(const WorldPoint& p, const WorldPoint& q) const;
+
+    const Blockers* blk_ = nullptr;
+    const LayerOracle* lyo_ = nullptr;
+    const EdgeBits* faces_ = nullptr;
+    const EdgeBits* steps_ = nullptr;
+    int64_t nx_ = 0;
+    int64_t ny_ = 0;
+    double x0_ = 0.0;
+    double y0_ = 0.0;
+};
+
+// vis 非空则整条弦只问它一句 —— 与搜索同一个判据, 拉直因此不会跨过搜索认为看不见的地方。
 std::vector<WorldPoint> StringPull(
     const std::vector<WorldPoint>& pts,
     const Blockers& blk,
-    const ClearanceFloor* cfl,
     const LayerOracle* lyo = nullptr,
-    const std::vector<float>* hs = nullptr);
-
-std::vector<WorldPoint> Slim(
-    const std::vector<WorldPoint>& pts,
-    const Blockers& blk,
-    const ClearanceFloor* cfl,
-    const LayerOracle* lyo = nullptr,
-    float h = 0.0F,
-    bool prefer_fewer_points = true,
-    size_t max_merge_gap = 0);
-
-std::vector<WorldPoint> WidenCorners(
-    const std::vector<WorldPoint>& pts,
-    const Blockers& blk,
-    const Grid<float>& dist,
-    double x0,
-    double y0,
-    double cs,
-    const ClearanceFloor* cfl,
-    const LayerOracle* lyo,
-    float h);
-
-std::vector<WorldPoint> DropLoops(const std::vector<WorldPoint>& pts);
+    const std::vector<float>* hs = nullptr,
+    const Visibility* vis = nullptr);
 
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -326,38 +326,30 @@ std::vector<std::vector<WorldPoint>> TraceContours(const Mask& mask);
 
 std::vector<WorldPoint> SimplifyLoop(const std::vector<WorldPoint>& P, double max_err);
 
-// on 掩膜密采样兜底:精确 45° 弦会从轮廓顶点缝溜走
-class Blockers
+// 挡线段表与它的桶索引。一条腿里几个视图的段几何逐字相同、只有 on 掩膜不同, 段表因此拆出来
+// 共享: 世代戳每次查询开头先自增再比较, 多个视图共用一套仍只在单次查询内去重。
+class BlockerSegments
 {
 public:
-    struct OnMask
-    {
-        const Mask* mask = nullptr;
-        double x0 = 0.0;
-        double y0 = 0.0;
-        double cs = kCS;
-    };
-
-    Blockers(
+    BlockerSegments() = default;
+    BlockerSegments(
         const std::vector<std::vector<WorldPoint>>& loops,
         const std::vector<WorldPoint>* extra_a,
-        const std::vector<WorldPoint>* extra_b,
-        std::optional<OnMask> on);
-
-    bool blocked(const WorldPoint& p, const WorldPoint& q) const;
+        const std::vector<WorldPoint>* extra_b);
 
 private:
-    bool offMask(const WorldPoint& p, const WorldPoint& q) const;
+    friend class Blockers;
+
     void buildIndex() const;
+    // 段包围盒是两端点的逐分量 min/max, 存成表只是把同一个数再摊一份内存。
+    WorldPoint lo(size_t i) const { return { std::min(a_[i].x, b_[i].x), std::min(a_[i].y, b_[i].y) }; }
+    WorldPoint hi(size_t i) const { return { std::max(a_[i].x, b_[i].x), std::max(a_[i].y, b_[i].y) }; }
 
     std::vector<WorldPoint> a_;
     std::vector<WorldPoint> b_;
-    std::vector<WorldPoint> lo_;
-    std::vector<WorldPoint> hi_;
-    std::optional<OnMask> on_;
     // 挡线按均匀桶建 CSR 索引。弦与某段相交必然共有一点: 那点在段的包围盒里 ⇒ 段登记在它所在
     // 的桶, 那点又在弦上 ⇒ 弦的取样覆盖到它所在的桶, 于是只测弦扫过的桶与全表扫描同答。
-    // 索引首次查询时才建: 一条腿里要造好几个 Blockers, 其中几个一次都不查。
+    // 索引首次查询时才建: 一条腿里要造好几个视图, 其中几个一次都不查。
     mutable bool built_ = false;
     mutable double bx0_ = 0.0;
     mutable double by0_ = 0.0;
@@ -370,6 +362,33 @@ private:
     mutable std::vector<uint32_t> seen_;
     mutable std::vector<uint32_t> bseen_;
     mutable uint32_t epoch_ = 0;
+};
+
+// on 掩膜密采样兜底:精确 45° 弦会从轮廓顶点缝溜走
+class Blockers
+{
+public:
+    struct OnMask
+    {
+        const Mask* mask = nullptr;
+        double x0 = 0.0;
+        double y0 = 0.0;
+        double cs = kCS;
+    };
+
+    Blockers(const BlockerSegments& segs, std::optional<OnMask> on)
+        : segs_(&segs)
+        , on_(on)
+    {
+    }
+
+    bool blocked(const WorldPoint& p, const WorldPoint& q) const;
+
+private:
+    bool offMask(const WorldPoint& p, const WorldPoint& q) const;
+
+    const BlockerSegments* segs_ = nullptr;
+    std::optional<OnMask> on_;
 };
 
 // 走查只用来跟住弦所在的层, 立面本身由挡线集与拓扑禁步管住, 故抬升按体素取样

--- a/agent/cpp-algo/source/Navmesh/RecastNavGridIO.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGridIO.cpp
@@ -177,7 +177,7 @@ bool DecodeGridTile(const uint8_t* data, size_t len, GridTile& out)
                 return false;
             }
             GridSpanRec r {};
-            r.cell = cell;
+            r.cell = static_cast<int32_t>(cell);
             r.rid = static_cast<uint32_t>(rid);
             r.clr = static_cast<uint16_t>(clr);
             r.flags = *col[3]++;
@@ -360,7 +360,7 @@ bool DecodeGridTileV3(const uint8_t* data, size_t len, int32_t nx, GridTile& out
     out.rec.assign(static_cast<size_t>(n), GridSpanRec {});
     for (size_t i = 0; i < static_cast<size_t>(ncell); ++i) {
         for (uint64_t j = 0; j < depth[i]; ++j) {
-            out.rec[base[i] + static_cast<size_t>(j)].cell = cell[i];
+            out.rec[base[i] + static_cast<size_t>(j)].cell = static_cast<int32_t>(cell[i]);
         }
     }
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavGridIO.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGridIO.cpp
@@ -197,6 +197,70 @@ bool DecodeGridTile(const uint8_t* data, size_t len, GridTile& out)
     return true;
 }
 
+// 头部与 DecodeGridTileV3 逐字段相同, 差别只在后面: 前两条流读掉长度就跳过, 第三条才解开。
+bool DecodeGridTileRegionsV3(const uint8_t* data, size_t len, std::vector<uint32_t>& out)
+{
+    out.clear();
+    if (data == nullptr) {
+        return false;
+    }
+    const uint8_t* p = data;
+    const uint8_t* const end = data + len;
+
+    uint64_t n = 0;
+    if (!GetVarint(p, end, n)) {
+        return false;
+    }
+    if (n == 0) {
+        return p == end;
+    }
+    if (static_cast<size_t>(end - p) < sizeof(float)) {
+        return false;
+    }
+    p += sizeof(float);
+
+    uint64_t regions = 0;
+    uint64_t ncell = 0;
+    uint64_t kmax = 0;
+    if (!GetVarint(p, end, regions) || !GetVarint(p, end, ncell) || !GetVarint(p, end, kmax)) {
+        return false;
+    }
+    if (ncell == 0 || ncell > n || kmax == 0 || kmax > n || regions == 0 || regions > n || n > UINT32_MAX) {
+        return false;
+    }
+    const size_t select_size = static_cast<size_t>(kmax) * kGridFieldCount;
+    if (static_cast<size_t>(end - p) < select_size) {
+        return false;
+    }
+    p += select_size;
+
+    std::vector<uint8_t> dict;
+    for (int i = 0; i < 3; ++i) {
+        uint64_t packed = 0;
+        if (!GetVarint(p, end, packed) || static_cast<uint64_t>(end - p) < packed) {
+            return false;
+        }
+        if (i == 2 && !Inflate(p, static_cast<size_t>(packed), dict)) {
+            return false;
+        }
+        p += packed;
+    }
+    if (regions > dict.size()) {
+        return false;
+    }
+    out.resize(static_cast<size_t>(regions));
+    const uint8_t* pd = dict.data();
+    const uint8_t* const pd_end = pd + dict.size();
+    for (uint32_t& id : out) {
+        uint64_t value = 0;
+        if (!GetVarint(pd, pd_end, value) || value > UINT32_MAX) {
+            return false;
+        }
+        id = static_cast<uint32_t>(value);
+    }
+    return pd == pd_end;
+}
+
 bool DecodeGridTileV3(const uint8_t* data, size_t len, int32_t nx, GridTile& out)
 {
     out = GridTile {};
@@ -521,6 +585,31 @@ bool GridPack::decodeTile(const GridTileRef& t, GridTile& out) const
         return false;
     }
     return DecodeGridTile(raw.data(), raw.size(), out) && out.rec.size() == t.records;
+}
+
+bool GridPack::tileRegions(const GridTileRef& t, std::vector<uint32_t>& out) const
+{
+    out.clear();
+    if (base_ == nullptr) {
+        return false;
+    }
+    if (t.records == 0) {
+        return true;
+    }
+    if (version_ == kGridSectionVersion) {
+        return DecodeGridTileRegionsV3(base_ + t.offset, t.len, out);
+    }
+    // v2 的载荷没有独立的字典流,只能整块解开再收。
+    GridTile tile;
+    if (!decodeTile(t, tile)) {
+        return false;
+    }
+    for (const GridSpanRec& r : tile.rec) {
+        out.push_back(r.rid);
+    }
+    std::sort(out.begin(), out.end());
+    out.erase(std::unique(out.begin(), out.end()), out.end());
+    return true;
 }
 
 std::vector<const GridTileRef*> GridTilesInRect(const GridZoneDir& zone, int64_t gx0, int64_t gy0, int64_t gx1, int64_t gy1)

--- a/agent/cpp-algo/source/Navmesh/RecastNavGridIO.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGridIO.h
@@ -59,6 +59,9 @@ bool DecodeGridTile(const uint8_t* data, size_t len, GridTile& out);
 // 解一块 v3 瓦。段里的原始字节直接进,内部逐流 inflate;差分要瓦宽 nx。
 bool DecodeGridTileV3(const uint8_t* data, size_t len, int32_t nx, GridTile& out);
 
+// 只取一块 v3 瓦的类号字典。前两条流带长度前缀,跳过就行,所以不必解开整块瓦。
+bool DecodeGridTileRegionsV3(const uint8_t* data, size_t len, std::vector<uint32_t>& out);
+
 // 段目录里的一块瓦。格号全是全局的(gx0 = llround(ox / kCS)),自有矩形
 // [px0,px1]×[py0,py1] 是瓦内格号闭区间,各瓦互不重叠且拼起来覆盖全区。
 struct GridTileRef
@@ -105,6 +108,9 @@ public:
     const GridZoneDir* findZone(const std::string& name) const;
     // 解一块瓦:按需 inflate 再解码,不缓存。空瓦返回空 GridTile。
     bool decodeTile(const GridTileRef& t, GridTile& out) const;
+    // 一块瓦里出现过的类号。只解类号字典那一条流,比整块解开便宜得多,
+    // 用来在解瓦之前就把不含目标类的瓦筛掉。
+    bool tileRegions(const GridTileRef& t, std::vector<uint32_t>& out) const;
 
 private:
     const uint8_t* base_ = nullptr;

--- a/agent/cpp-algo/source/Navmesh/RecastNavGridIO.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGridIO.h
@@ -16,7 +16,7 @@ inline constexpr char kGridSectionTag[5] = "BGRD";
 // 补出来的格没有实体 span 时挂一条 ghost 或 fill。
 struct GridSpanRec
 {
-    int64_t cell = 0;  // 瓦内格号 y * nx + x
+    int32_t cell = 0;  // 瓦内格号 y * nx + x
     uint32_t rid = 0;  // 全区类号
     float h = 0.0F;
     uint16_t clr = 0;  // 净空的平方格距,还原用 GridClearance

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -175,7 +175,7 @@ int64_t pickDeckRec(const GridWindow& gw, int64_t nx, int64_t ny, int64_t gcx, i
     return best;
 }
 
-// 点到最近核心格的格距 × kCS,与窗口里的 near() 同口径,只是在全区图上量。
+// 点到最近核心格的格距 × kCS,与窗口里的 nearestCell() 同口径,只是在全区图上量。
 // 搜索半径取判据的两倍,够不着的点只报这个下界,反正它已经在闸外了。
 double coreAnchorPx(const GridPack& gp, const GridZoneDir& gz, const WorldPoint& p)
 {
@@ -880,7 +880,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const CellPt sc { static_cast<int64_t>((s.x - x0) / kCS), static_cast<int64_t>((s.y - y0) / kCS) };
     const CellPt gc { static_cast<int64_t>((g.x - x0) / kCS), static_cast<int64_t>((g.y - y0) / kCS) };
 
-    const auto near = [&](const Mask& mask, const CellPt& p) -> std::pair<std::optional<CellPt>, double> {
+    const auto nearestCell = [&](const Mask& mask, const CellPt& p) -> std::pair<std::optional<CellPt>, double> {
         bool have = false;
         int64_t bd = 0;
         CellPt bc;
@@ -971,7 +971,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     // 高度差, 让吸附结果跟 atDeck 选的那张 span 一致。
     const auto nearGoal = [&](const std::vector<uint8_t>& use, const Mask& cells) -> std::pair<std::optional<CellPt>, double> {
         if (!goal_deck.has_value()) {
-            return near(cells, gc);
+            return nearestCell(cells, gc);
         }
         bool have = false;
         int64_t bd = 0;
@@ -1002,7 +1002,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         return { bc, std::sqrt(static_cast<double>(bd)) * kCS };
     };
 
-    const auto snap0 = near(cw3, sc);
+    const auto snap0 = nearestCell(cw3, sc);
     const auto snap1 = nearGoal(useW, cw3);
     if (!snap0.first.has_value()) {
         dg.err = "walk 掩膜为空";
@@ -1217,8 +1217,8 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         if (!resnap) {
             return std::nullopt;
         }
-        std::tie(as_, dsa) = near(wl, sc);
-        std::tie(ag_, dga) = near(wl, gc);
+        std::tie(as_, dsa) = nearestCell(wl, sc);
+        std::tie(ag_, dga) = nearestCell(wl, gc);
         if (!as_.has_value() || !ag_.has_value()) {
             return std::nullopt;
         }

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -845,11 +845,12 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             }
         }
     }
-    const Grid<float> wdist = Clearance(wfree);
-    Grid<float> dist(nx, ny, 0.0F);
-    for (size_t i = 0; i < dist.v.size(); ++i) {
-        dist.v[i] = std::min(info.dist.v[i], wdist.v[i]);
+    // 取小就地写回接缝净空那张表: 另开一张同尺寸的只是让两张 36MB 的图在整个 routeWindow 里同时活着。
+    Grid<float> wdist = Clearance(wfree);
+    for (size_t i = 0; i < wdist.v.size(); ++i) {
+        wdist.v[i] = std::min(info.dist.v[i], wdist.v[i]);
     }
+    const Grid<float> dist = std::move(wdist);
     // VV(c): 障碍按期望净空 c 膨胀后仍自由的格走可见图那一侧, 膨胀后被吃掉的窄处只留中脊,
     // 对应论文里 V∩M(c) 的那段 Voronoi 弧。净空在这一层是掩膜: 开阔地没有贴墙这个选项, 窄缝
     // 里没有偏一侧这个选项, 中途钻的一小段窄缝也就无法被整条路长平均掉。

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -1046,7 +1046,8 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         }
         std::vector<int32_t> cs(n, std::numeric_limits<int32_t>::max());
         std::vector<float> bw(n, -1.0F);
-        std::vector<int64_t> pv(n, -1);
+        // 父链存的是格号, 上界 kMaxCells 装得进 32 位; 比较里它会提回 64 位, 全序照旧。
+        std::vector<int32_t> pv(n, -1);
         std::priority_queue<std::tuple<int32_t, float, int64_t>> pq;
         cs[s0] = 0;
         bw[s0] = dist.v[s0];
@@ -1082,7 +1083,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
                     if (kc < cs[k] || (kc == cs[k] && (kb > bw[k] || (kb == bw[k] && c < pv[k])))) {
                         cs[k] = kc;
                         bw[k] = kb;
-                        pv[k] = c;
+                        pv[k] = static_cast<int32_t>(c);
                         pq.emplace(-kc, kb, -static_cast<int64_t>(k));
                     }
                 }
@@ -1339,14 +1340,14 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         const size_t n = static_cast<size_t>(nx * ny);
         constexpr int32_t kBig = std::numeric_limits<int32_t>::max() / 4;
         std::vector<int32_t> dc(n, kBig);
-        std::vector<int64_t> src(n, -1);
+        std::vector<int32_t> src(n, -1);
         std::vector<uint8_t> ina(n, 0);
         for (size_t i = 0; i < ra.size(); ++i) {
             const auto c = static_cast<size_t>(st3.sp_cell[i]);
             ina[c] = static_cast<uint8_t>(ina[c] | ra[i]);
             if (rb[i] != 0) {
                 dc[c] = 0;
-                src[c] = static_cast<int64_t>(c);
+                src[c] = static_cast<int32_t>(c);
             }
         }
         const auto relax = [&](size_t c, int64_t bx, int64_t by, int32_t w) {

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -1,8 +1,10 @@
 #include "RecastNavRoute.h"
 
+#include "NavParallel.h"
 #include "RecastNavBake.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <limits>
@@ -87,37 +89,68 @@ struct GridWindow
 
 bool loadGridWindow(const GridPack& gp, const GridZoneDir& gz, int64_t wgx0, int64_t wgy0, int64_t nx, int64_t ny, GridWindow& out)
 {
-    GridTile tile;
     const std::vector<const GridTileRef*> tiles = GridTilesInRect(gz, wgx0, wgy0, wgx0 + nx - 1, wgy0 + ny - 1);
-    // 先按瓦目录里的记录数开够。边 push 边按二的幂扩容, 满窗口上要白占近一倍,
-    // 而这份表是建窗最大的一块。窗外与非自有矩形的记录会被滤掉, 所以这是个上界。
+    // 先按瓦目录里的记录数开够。窗外与非自有矩形的记录会被滤掉, 所以这是个上界。
+    // 解瓦是纯读: 每块领一段瓦, 按同一个上界给它划一段互不相交的写区直写, 收工按块序压紧。
+    // 写区起点与压紧次序都只由瓦下标定, 于是 rec 的次序与线程数无关, 表也始终只有一份。
+    const auto nt = static_cast<int64_t>(tiles.size());
+    const size_t nw = NavWorkerCountForBlocks(nt);
     size_t cap = 0;
     for (const GridTileRef* t : tiles) {
         cap += t->records;
     }
-    out.rec.reserve(cap);
-    for (const GridTileRef* t : tiles) {
-        if (t->records == 0) {
-            continue;
+    out.rec.assign(cap, GridSpanRec {});
+    std::vector<size_t> beg(nw, 0);
+    std::vector<size_t> cnt(nw, 0);
+    std::atomic<bool> ok { true };
+    ParallelChunks(nt, nw, [&](size_t w, int64_t lo, int64_t hi) {
+        size_t at = 0;
+        for (int64_t i = 0; i < lo; ++i) {
+            at += tiles[static_cast<size_t>(i)]->records;
         }
-        if (!gp.decodeTile(*t, tile)) {
-            return false;
-        }
-        for (GridSpanRec& r : tile.rec) {
-            const int64_t ix = r.cell % t->nx;
-            const int64_t iy = r.cell / t->nx;
-            if (ix < t->px0 || ix > t->px1 || iy < t->py0 || iy > t->py1) {
+        beg[w] = at;
+        GridTile tile;
+        for (int64_t i = lo; i < hi; ++i) {
+            const GridTileRef* t = tiles[static_cast<size_t>(i)];
+            if (t->records == 0) {
                 continue;
             }
-            const int64_t wx = t->gx0 + ix - wgx0;
-            const int64_t wy = t->gy0 + iy - wgy0;
-            if (wx < 0 || wx >= nx || wy < 0 || wy >= ny) {
-                continue;
+            if (!gp.decodeTile(*t, tile)) {
+                ok.store(false);
+                return;
             }
-            r.cell = static_cast<int32_t>(wy * nx + wx);
-            out.rec.push_back(r);
+            for (GridSpanRec& r : tile.rec) {
+                const int64_t ix = r.cell % t->nx;
+                const int64_t iy = r.cell / t->nx;
+                if (ix < t->px0 || ix > t->px1 || iy < t->py0 || iy > t->py1) {
+                    continue;
+                }
+                const int64_t wx = t->gx0 + ix - wgx0;
+                const int64_t wy = t->gy0 + iy - wgy0;
+                if (wx < 0 || wx >= nx || wy < 0 || wy >= ny) {
+                    continue;
+                }
+                r.cell = static_cast<int32_t>(wy * nx + wx);
+                out.rec[at++] = r;
+            }
         }
+        cnt[w] = at - beg[w];
+    });
+    if (!ok.load()) {
+        out.rec.clear();
+        return false;
     }
+    size_t kept = cnt[0];
+    for (size_t w = 1; w < nw; ++w) {
+        if (cnt[w] != 0 && beg[w] != kept) {
+            std::move(
+                out.rec.begin() + static_cast<int64_t>(beg[w]),
+                out.rec.begin() + static_cast<int64_t>(beg[w] + cnt[w]),
+                out.rec.begin() + static_cast<int64_t>(kept));
+        }
+        kept += cnt[w];
+    }
+    out.rec.resize(kept);
     out.head.assign(static_cast<size_t>(nx * ny), -1);
     out.next.assign(out.rec.size(), -1);
     for (size_t i = out.rec.size(); i-- > 0;) {
@@ -297,33 +330,64 @@ ZoneBoundsPx regionBounds(const GridPack& gp, const GridZoneDir& gz, uint32_t re
     b.y0 = std::numeric_limits<int64_t>::max();
     b.x1 = std::numeric_limits<int64_t>::min();
     b.y1 = std::numeric_limits<int64_t>::min();
-    GridTile tile;
-    std::vector<uint32_t> rids;
-    for (const GridTileRef& t : gz.tiles) {
-        if (t.records == 0) {
-            continue;
+    // 先看每块瓦的类号字典。一个类只落在少数几块瓦里, 其余的整块跳过, 不用解开。
+    // 挑完再并行解剩下的, 静态分块才不会有人整块领到空活。
+    std::vector<const GridTileRef*> hits;
+    {
+        const auto ntl = static_cast<int64_t>(gz.tiles.size());
+        // 每块只写自己那几个下标位, 收工再按下标序把中标的挑出来。
+        std::vector<uint8_t> hit(static_cast<size_t>(ntl), 0);
+        ParallelChunks(ntl, NavWorkerCountForBlocks(ntl), [&](size_t, int64_t lo, int64_t hi) {
+            std::vector<uint32_t> rids;
+            for (int64_t i = lo; i < hi; ++i) {
+                const GridTileRef& t = gz.tiles[static_cast<size_t>(i)];
+                if (t.records == 0) {
+                    continue;
+                }
+                if (gp.tileRegions(t, rids) && std::find(rids.begin(), rids.end(), region) != rids.end()) {
+                    hit[static_cast<size_t>(i)] = 1;
+                }
+            }
+        });
+        for (int64_t i = 0; i < ntl; ++i) {
+            if (hit[static_cast<size_t>(i)] != 0) {
+                hits.push_back(&gz.tiles[static_cast<size_t>(i)]);
+            }
         }
-        // 先看这块瓦的类号字典。一个类只落在少数几块瓦里, 其余的整块跳过, 不用解开。
-        if (!gp.tileRegions(t, rids) || std::find(rids.begin(), rids.end(), region) == rids.end()) {
-            continue;
-        }
-        if (!gp.decodeTile(t, tile)) {
-            continue;
-        }
-        for (const GridSpanRec& r : tile.rec) {
-            if (r.rid != region) {
+    }
+    // 每块自己收一个包围盒, 收工再取并。取极值与次序无关, 于是与线程数无关。
+    const auto nh = static_cast<int64_t>(hits.size());
+    const size_t nw = NavWorkerCountForBlocks(nh);
+    std::vector<ZoneBoundsPx> part(nw, b);
+    ParallelChunks(nh, nw, [&](size_t w, int64_t lo, int64_t hi) {
+        ZoneBoundsPx& p = part[w];
+        GridTile tile;
+        for (int64_t i = lo; i < hi; ++i) {
+            const GridTileRef& t = *hits[static_cast<size_t>(i)];
+            if (!gp.decodeTile(t, tile)) {
                 continue;
             }
-            const int64_t ix = r.cell % t.nx;
-            const int64_t iy = r.cell / t.nx;
-            if (ix < t.px0 || ix > t.px1 || iy < t.py0 || iy > t.py1) {
-                continue;
+            for (const GridSpanRec& r : tile.rec) {
+                if (r.rid != region) {
+                    continue;
+                }
+                const int64_t ix = r.cell % t.nx;
+                const int64_t iy = r.cell / t.nx;
+                if (ix < t.px0 || ix > t.px1 || iy < t.py0 || iy > t.py1) {
+                    continue;
+                }
+                p.x0 = std::min<int64_t>(p.x0, t.gx0 + ix);
+                p.y0 = std::min<int64_t>(p.y0, t.gy0 + iy);
+                p.x1 = std::max<int64_t>(p.x1, t.gx0 + ix);
+                p.y1 = std::max<int64_t>(p.y1, t.gy0 + iy);
             }
-            b.x0 = std::min<int64_t>(b.x0, t.gx0 + ix);
-            b.y0 = std::min<int64_t>(b.y0, t.gy0 + iy);
-            b.x1 = std::max<int64_t>(b.x1, t.gx0 + ix);
-            b.y1 = std::max<int64_t>(b.y1, t.gy0 + iy);
         }
+    });
+    for (const ZoneBoundsPx& p : part) {
+        b.x0 = std::min(b.x0, p.x0);
+        b.y0 = std::min(b.y0, p.y0);
+        b.x1 = std::max(b.x1, p.x1);
+        b.y1 = std::max(b.y1, p.y1);
     }
     return b;
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -323,7 +323,6 @@ ZoneBoundsPx regionBounds(const GridPack& gp, const GridZoneDir& gz, uint32_t re
 }
 
 std::optional<WindowInfo> buildWindow(
-    WallOracle& wo,
     const GridPack& gp,
     const GridZoneDir& gz,
     const ZoneClean& zc,
@@ -403,7 +402,7 @@ std::optional<WindowInfo> buildWindow(
         info.vis3.push_back(static_cast<uint8_t>(r.rid == region));
     }
 
-    const BakedWalls walls = BakeWalls(wo, x0, y0, nx, ny);
+    const BakedWalls walls = BakeWalls(zc, x0, y0, nx, ny);
     const std::vector<uint8_t> keep = WallsAtLayer(walls.p0, walls.p1, walls.hh, info.lh, x0, y0);
     for (size_t i = 0; i < keep.size(); ++i) {
         if (keep[i] != 0) {
@@ -1783,9 +1782,6 @@ RecastNavEngine::ZoneEntry& RecastNavEngine::zoneEntry(const std::string& name)
     if (it == zones_.end()) {
         ZoneEntry e;
         e.zc = std::make_unique<ZoneClean>(pack_, planner_, name, walkable_flags_);
-        if (e.zc->valid()) {
-            e.wo = std::make_unique<WallOracle>(*e.zc);
-        }
         it = zones_.emplace(name, std::move(e)).first;
     }
     return it->second;
@@ -1904,7 +1900,6 @@ RecastPlanResult RecastNavEngine::planLocked(
         return res;
     }
     const ZoneClean& zc = *ze.zc;
-    WallOracle& wo = *ze.wo;
     std::vector<int32_t> blocked_local;
     for (const uint32_t t : blocked) {
         const int64_t local = static_cast<int64_t>(t) - zc.lo;
@@ -1998,7 +1993,7 @@ RecastPlanResult RecastNavEngine::planLocked(
     const double y1 = static_cast<double>(zb.y1 + 1 + kFieldHalo) * kCS;
 
     const double t_win0 = nowMs();
-    auto info = buildWindow(wo, grid_, *gz, zc, start, ss->point, goal, h0, region, x0, y0, x1, y1, blocked_local, blocked_points, err);
+    auto info = buildWindow(grid_, *gz, zc, start, ss->point, goal, h0, region, x0, y0, x1, y1, blocked_local, blocked_points, err);
     const double window_ms = nowMs() - t_win0;
     if (!info.has_value()) {
         res.error = err.empty() ? "路线失败" : err;

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -432,6 +432,9 @@ std::optional<WindowInfo> buildWindow(
     if (!pickRegion(pw, pw, s, s_snap, g, h0, std::nullopt, seed_region, cell0, err)) {
         return std::nullopt;
     }
+    // 逐格链表只服务于起点格查询, 到这里就没有读者了; 下面是顺着记录表走一遍。
+    gw.head = std::vector<int32_t>();
+    gw.next = std::vector<int32_t>();
 
     WindowInfo info;
     info.x0 = x0;
@@ -443,8 +446,13 @@ std::optional<WindowInfo> buildWindow(
     info.dist = Grid<float>(nx, ny, 0.0F);
     Grid<float> lh(nx, ny, std::numeric_limits<float>::quiet_NaN());
     std::vector<uint8_t> stepbits(static_cast<size_t>(nx * ny), 0);
+    // 记录数就是 span 表的上界。让它自己长的话, 扩容那一刻新旧两份缓冲同时活着,
+    // 而这一刻正是建窗内存最高的时候。
     std::vector<int32_t> sp_cell;
     std::vector<float> sp_h;
+    sp_cell.reserve(gw.rec.size());
+    sp_h.reserve(gw.rec.size());
+    info.vis3.reserve(gw.rec.size());
     // 表里留着别的类的 span:层判据要看整列,少一层就会从楼板底下穿过去
     for (const GridSpanRec& r : gw.rec) {
         const bool ghost = (r.flags & kGridFlagGhost) != 0;

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -82,14 +82,22 @@ double nowMs()
 struct GridWindow
 {
     std::vector<GridSpanRec> rec;
-    std::vector<int64_t> head; // 逐格: 记录链表头,无记录为 -1
-    std::vector<int64_t> next; // 逐记录: 同格的下一条
+    std::vector<int32_t> head; // 逐格: 记录链表头,无记录为 -1
+    std::vector<int32_t> next; // 逐记录: 同格的下一条
 };
 
 bool loadGridWindow(const GridPack& gp, const GridZoneDir& gz, int64_t wgx0, int64_t wgy0, int64_t nx, int64_t ny, GridWindow& out)
 {
     GridTile tile;
-    for (const GridTileRef* t : GridTilesInRect(gz, wgx0, wgy0, wgx0 + nx - 1, wgy0 + ny - 1)) {
+    const std::vector<const GridTileRef*> tiles = GridTilesInRect(gz, wgx0, wgy0, wgx0 + nx - 1, wgy0 + ny - 1);
+    // 先按瓦目录里的记录数开够。边 push 边按二的幂扩容, 满窗口上要白占近一倍,
+    // 而这份表是建窗最大的一块。窗外与非自有矩形的记录会被滤掉, 所以这是个上界。
+    size_t cap = 0;
+    for (const GridTileRef* t : tiles) {
+        cap += t->records;
+    }
+    out.rec.reserve(cap);
+    for (const GridTileRef* t : tiles) {
         if (t->records == 0) {
             continue;
         }
@@ -107,7 +115,7 @@ bool loadGridWindow(const GridPack& gp, const GridZoneDir& gz, int64_t wgx0, int
             if (wx < 0 || wx >= nx || wy < 0 || wy >= ny) {
                 continue;
             }
-            r.cell = wy * nx + wx;
+            r.cell = static_cast<int32_t>(wy * nx + wx);
             out.rec.push_back(r);
         }
     }
@@ -116,7 +124,7 @@ bool loadGridWindow(const GridPack& gp, const GridZoneDir& gz, int64_t wgx0, int
     for (size_t i = out.rec.size(); i-- > 0;) {
         const auto c = static_cast<size_t>(out.rec[i].cell);
         out.next[i] = out.head[c];
-        out.head[c] = static_cast<int64_t>(i);
+        out.head[c] = static_cast<int32_t>(i);
     }
     return true;
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -414,6 +414,21 @@ std::optional<WindowInfo> buildWindow(
     // 窗口原点是对齐过的,所以它落在全局格线上,窗口格与烘焙格一一对上
     const int64_t wgx0 = std::llround(x0 / kCS);
     const int64_t wgy0 = std::llround(y0 / kCS);
+
+    // 区网格只有取墙与盖封堵面两个读者, 两者都只认窗口矩形, 与格图无关。放在开图之前算,
+    // 它就能在建窗最吃内存的那一段开始前整个交还, 不必一直挂到用完。
+    BakedWalls walls = BakeWalls(zc, x0, y0, nx, ny);
+    RasterCells brc;
+    if (!blocked_local.empty()) {
+        std::vector<std::array<int32_t, 3>> bt;
+        bt.reserve(blocked_local.size());
+        for (const int32_t t : blocked_local) {
+            bt.push_back(zc.mesh.T[static_cast<size_t>(t)]);
+        }
+        brc = Rasterize(zc.mesh.V, zc.mesh.H, bt, x0, y0, nx, ny);
+    }
+    zc.release();
+
     GridPatch pw;
     pw.x0 = x0;
     pw.y0 = y0;
@@ -486,7 +501,6 @@ std::optional<WindowInfo> buildWindow(
     std::vector<WorldPoint> wP0;
     std::vector<WorldPoint> wP1;
     {
-        const BakedWalls walls = BakeWalls(zc, x0, y0, nx, ny);
         const std::vector<uint8_t> keep = WallsAtLayer(walls.p0, walls.p1, walls.hh, lh, x0, y0);
         for (size_t i = 0; i < keep.size(); ++i) {
             if (keep[i] != 0) {
@@ -495,29 +509,20 @@ std::optional<WindowInfo> buildWindow(
             }
         }
     }
+    walls = BakedWalls();
     info.whit = WallHits(wP0, wP1, x0, y0, nx, ny);
 
-    if (!blocked_local.empty()) {
-        std::vector<std::array<int32_t, 3>> bt;
-        bt.reserve(blocked_local.size());
-        for (const int32_t t : blocked_local) {
-            bt.push_back(zc.mesh.T[static_cast<size_t>(t)]);
-        }
-        const RasterCells brc = Rasterize(zc.mesh.V, zc.mesh.H, bt, x0, y0, nx, ny);
-        for (size_t ci = 0; ci < brc.cell.size(); ++ci) {
-            const auto cell = static_cast<size_t>(brc.cell[ci]);
-            const float lf = lh.v[cell];
-            // 层高带内才盖掉,免得误伤其他楼层的格
-            if (!std::isnan(lf) && std::fabs(brc.h[ci] - lf) <= static_cast<float>(kClimb)) {
-                info.core.v[cell] = 0;
-                info.lay.v[cell] = 0;
-            }
+    for (size_t ci = 0; ci < brc.cell.size(); ++ci) {
+        const auto cell = static_cast<size_t>(brc.cell[ci]);
+        const float lf = lh.v[cell];
+        // 层高带内才盖掉,免得误伤其他楼层的格
+        if (!std::isnan(lf) && std::fabs(brc.h[ci] - lf) <= static_cast<float>(kClimb)) {
+            info.core.v[cell] = 0;
+            info.lay.v[cell] = 0;
         }
     }
+    brc = RasterCells();
     lh = Grid<float>();
-    // 区网格的最后一个读者到此为止。往下是 span 表与各场, 建窗最吃内存的一段,
-    // 让它挂到那时就是白抬一份峰值。
-    zc.release();
 
     // 封堵点无自带高度;窗口层已按起点层高筛过,直接按平面距离盖格即可
     if (!blocked_points.empty()) {

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -1549,7 +1549,9 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         solidc.v[i] = static_cast<uint8_t>(static_cast<double>(dist.v[i]) >= need);
     }
     const Blockers::OnMask onv { &solidc, x0, y0, kCS };
-    const Blockers blk_vis({}, nullptr, nullptr, onv);
+    // 搜索期的视线只靠 on 掩膜兜底, 不带轮廓挡线。
+    const BlockerSegments no_segs;
+    const Blockers blk_vis(no_segs, onv);
     const Visibility vis(&blk_vis, &lyo, faces, bn, nx, ny, x0, y0);
     if (vv.has_value()) {
         // 几何这一次锁在走廊里。放开的话它按恒一的单价重解一遍, 又会挑回拓扑刚花钱绕开的那条
@@ -1630,7 +1632,9 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         }
     }
     const Blockers::OnMask onm { &tm, x0, y0, kCS };
-    const Blockers blk_gray(loops_core, &info.segA, &info.segB, onm);
+    // 灰、硬两个视图的挡线几何逐字相同, 段表与桶索引共享一份, 两遍构建省成一遍。
+    const BlockerSegments core_segs(loops_core, &info.segA, &info.segB);
+    const Blockers blk_gray(core_segs, onm);
     // 几何用的视线判据: 跨步禁行、立面、层判据与搜索那一个逐字相同, 只把自由区从计价用的实心区
     // 换成这条路自己的管道。实心区那道限制是为让弦的欧氏长度等于代价, 只约束搜索; 终线取直不计价,
     // 该由能不能走过去决定。管道只比路径宽一格, 拉直因此仍出不了这条通道。
@@ -1718,7 +1722,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     // 抬升放在取直之后: 放前面的话抬起来的拐点让两侧更容易连通, 取直一刀就把它跳过去了。
     // 判据换成硬墙那一套 —— 通道掩膜只比路径宽一格, 拿它判等于禁止拐点离开原路径。
     if (lyo_p != nullptr && out.size() >= 3) {
-        const Blockers blk_hard(loops_core, &info.segA, &info.segB, std::nullopt);
+        const Blockers blk_hard(core_segs, std::nullopt);
         const Visibility vis_hard(&blk_hard, &lyo, faces, bn, nx, ny, x0, y0);
         LiftCorners(out, dist, x0, y0, vis_hard, lyo, lyo_h, kLiftMax);
     }

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -59,7 +59,24 @@ struct RouteDiag
     bool hop_barrier = false; // 端点接线的那一跳跨了禁行边
     double snap_start = 0.0;
     double snap_goal = 0.0;
+
+    // 诊断埋点。只读各阶段的出口, 不参与任何判据, 摘掉它们路线逐点不变。
+    RecastPlanResult::Debug::Timing timing;
+    std::vector<WorldPoint> topology_cells;
+    std::vector<double> topology_heights;
+    std::vector<WorldPoint> taut_points;
+    std::vector<WorldPoint> pulled_points;
+    std::vector<WorldPoint> assembled_points;
+    std::optional<WorldPoint> gap_start;
+    std::optional<WorldPoint> gap_goal;
+    std::optional<double> gap_distance;
 };
+
+// 单调钟读数, 单位毫秒
+double nowMs()
+{
+    return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now().time_since_epoch()).count();
+}
 
 // 窗口里从预烘图解出来的记录。格号已换成窗口格号,窗外的与不属于本瓦自有矩形的
 // 都已剔除;一格只归一块瓦,所以同格的记录必然来自同一块瓦、按 (类号, 高) 排好。
@@ -787,6 +804,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const BaseNavPlanner& pl,
     uint16_t zid)
 {
+    const double t_topo0 = nowMs();
     const int64_t nx = info.nx;
     const int64_t ny = info.ny;
     const double x0 = info.x0;
@@ -1227,6 +1245,142 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         return t;
     };
 
+    // 一端的可达 span 集。展开判据与 SpanAstar 逐字相同: 格掩膜、对角切角、立面禁步、RiseOk。
+    // backward 那一路走的是 v→u 这个方向 —— 禁行边与抬升判据都是有向的, 拿正向去问会把单向的
+    // 台阶说成两边都能过。
+    const auto reachFrom = [&](const std::vector<int64_t>& seeds, const std::vector<uint8_t>& use, const Mask& ok2,
+                               bool backward) {
+        std::vector<uint8_t> seen(st3.sp_h.size(), 0);
+        std::vector<int64_t> frontier;
+        for (const int64_t v : seeds) {
+            if (v >= 0 && use[static_cast<size_t>(v)] != 0 && seen[static_cast<size_t>(v)] == 0) {
+                seen[static_cast<size_t>(v)] = 1;
+                frontier.push_back(v);
+            }
+        }
+        while (!frontier.empty()) {
+            std::vector<int64_t> next;
+            for (const int64_t u : frontier) {
+                const int64_t cu = st3.sp_cell[static_cast<size_t>(u)];
+                const int64_t ux = cu % nx;
+                const int64_t uy = cu / nx;
+                const float hu = st3.sp_h[static_cast<size_t>(u)];
+                for (int64_t dy = -1; dy <= 1; ++dy) {
+                    for (int64_t dx = -1; dx <= 1; ++dx) {
+                        const int64_t vx = ux + dx;
+                        const int64_t vy = uy + dy;
+                        if ((dx == 0 && dy == 0) || vx < 0 || vy < 0 || vx >= nx || vy >= ny) {
+                            continue;
+                        }
+                        const int64_t cv = vy * nx + vx;
+                        if (ok2.v[static_cast<size_t>(cv)] == 0) {
+                            continue;
+                        }
+                        if (dx != 0 && dy != 0 && !(ok2.at(uy, vx) && ok2.at(vy, ux))) {
+                            continue;
+                        }
+                        if (info.cidx[static_cast<size_t>(cv)] < 0) {
+                            continue;
+                        }
+                        if (faces->has(backward ? cv : cu, backward ? cu : cv)) {
+                            continue;
+                        }
+                        const int64_t j = info.cidx[static_cast<size_t>(cv)];
+                        const int64_t jb = st3.cstart[static_cast<size_t>(j)];
+                        for (int64_t k = 0, kn = st3.ccnt[static_cast<size_t>(j)]; k < kn; ++k) {
+                            const int64_t v = jb + k;
+                            if (use[static_cast<size_t>(v)] == 0 || seen[static_cast<size_t>(v)] != 0) {
+                                continue;
+                            }
+                            const float hv = st3.sp_h[static_cast<size_t>(v)];
+                            if (!(backward ? RiseOk(st3, nx, ny, cv, -dx, -dy, hv, hu)
+                                           : RiseOk(st3, nx, ny, cu, dx, dy, hu, hv))) {
+                                continue;
+                            }
+                            seen[static_cast<size_t>(v)] = 1;
+                            next.push_back(v);
+                        }
+                    }
+                }
+            }
+            frontier = std::move(next);
+        }
+        return seen;
+    };
+    // 断开时报缝: 两端各自泛洪, 取两片可达集之间最近的一对格。倒角距离场从终点侧铺开、起点侧
+    // 扫一遍取最小, 与逐对比较同解而只花一遍网格。判在最宽松的 core 上, 缝因此是真的缝。
+    const auto reportGap = [&] {
+        if (!as_.has_value() || !ag_.has_value()) {
+            return;
+        }
+        std::vector<uint8_t> useC;
+        Mask cc3;
+        mk(info.core, useC, cc3);
+        const int64_t sd = atSeedLayer(pick(*as_, useC));
+        const std::vector<int64_t> gs = goalsOf(pick(*ag_, useC));
+        if (sd < 0 || gs.empty()) {
+            return;
+        }
+        const std::vector<uint8_t> ra = reachFrom({ sd }, useC, cc3, false);
+        const std::vector<uint8_t> rb = reachFrom(gs, useC, cc3, true);
+        const size_t n = static_cast<size_t>(nx * ny);
+        constexpr int32_t kBig = std::numeric_limits<int32_t>::max() / 4;
+        std::vector<int32_t> dc(n, kBig);
+        std::vector<int64_t> src(n, -1);
+        std::vector<uint8_t> ina(n, 0);
+        for (size_t i = 0; i < ra.size(); ++i) {
+            const auto c = static_cast<size_t>(st3.sp_cell[i]);
+            ina[c] = static_cast<uint8_t>(ina[c] | ra[i]);
+            if (rb[i] != 0) {
+                dc[c] = 0;
+                src[c] = static_cast<int64_t>(c);
+            }
+        }
+        const auto relax = [&](size_t c, int64_t bx, int64_t by, int32_t w) {
+            if (bx < 0 || by < 0 || bx >= nx || by >= ny) {
+                return;
+            }
+            const auto b = static_cast<size_t>(by * nx + bx);
+            if (dc[b] < kBig && dc[b] + w < dc[c]) {
+                dc[c] = dc[b] + w;
+                src[c] = src[b];
+            }
+        };
+        for (int64_t y = 0; y < ny; ++y) {
+            for (int64_t x = 0; x < nx; ++x) {
+                const auto c = static_cast<size_t>(y * nx + x);
+                relax(c, x - 1, y - 1, 141);
+                relax(c, x, y - 1, 100);
+                relax(c, x + 1, y - 1, 141);
+                relax(c, x - 1, y, 100);
+            }
+        }
+        for (int64_t y = ny - 1; y >= 0; --y) {
+            for (int64_t x = nx - 1; x >= 0; --x) {
+                const auto c = static_cast<size_t>(y * nx + x);
+                relax(c, x + 1, y + 1, 141);
+                relax(c, x, y + 1, 100);
+                relax(c, x - 1, y + 1, 141);
+                relax(c, x + 1, y, 100);
+            }
+        }
+        int64_t best = -1;
+        for (size_t c = 0; c < n; ++c) {
+            if (ina[c] != 0 && src[c] >= 0 && (best < 0 || dc[c] < dc[static_cast<size_t>(best)])) {
+                best = static_cast<int64_t>(c);
+            }
+        }
+        if (best < 0) {
+            return;
+        }
+        const int64_t peer = src[static_cast<size_t>(best)];
+        const WorldPoint a { x0 + (static_cast<double>(best % nx) + 0.5) * kCS, y0 + (static_cast<double>(best / nx) + 0.5) * kCS };
+        const WorldPoint b { x0 + (static_cast<double>(peer % nx) + 0.5) * kCS, y0 + (static_cast<double>(peer / nx) + 0.5) * kCS };
+        dg.gap_start = a;
+        dg.gap_goal = b;
+        dg.gap_distance = std::hypot(a.x - b.x, a.y - b.y);
+    };
+
     // 硬约束基线: 原始硬图上的纯长度最短路。硬图可达它就一定存在, 于是舒适选路永远不会把一条
     // 走得通的腿判成不可达。它同时是端点的回缩通道 —— 起终点天然贴墙时, 搜索沿这条按亏欠计价
     // 的线走几格就自然汇入 VV 图, 端点附近不需要任何放宽半径。
@@ -1234,6 +1388,8 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const Grid<float> unit(nx, ny, 1.0F);
     const std::optional<Topo> base = solve(all, unit, nullptr, nullptr, true);
     if (!base.has_value()) {
+        reportGap();
+        dg.timing.topology_ms = nowMs() - t_topo0;
         if (goal_deck.has_value()) {
             const std::vector<int64_t> gv = pick(*ag_, useW);
             std::vector<float> hv;
@@ -1365,6 +1521,21 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         vv = solve(limw, multw, bn, bpw, false);
         dg.warn.emplace_back("通道未接通, 退到全图亏欠计价");
     }
+    {
+        const Topo& tp = vv.has_value() ? *vv : *base;
+        dg.topology_cells.reserve(tp.q.size());
+        for (const CellPt& c : tp.q) {
+            dg.topology_cells.push_back({ x0 + (static_cast<double>(c.x) + 0.5) * kCS, y0 + (static_cast<double>(c.y) + 0.5) * kCS });
+        }
+        if (tp.qs.has_value()) {
+            dg.topology_heights.reserve(tp.qs->size());
+            for (const int64_t v : *tp.qs) {
+                dg.topology_heights.push_back(static_cast<double>(st3.sp_h[static_cast<size_t>(v)]));
+            }
+        }
+    }
+    dg.timing.topology_ms = nowMs() - t_topo0;
+    const double t_geo0 = nowMs();
     // 通道定了才铺几何: 同一张中标掩膜上再解一次, 这次带视线判据, 出来的父链已经是紧绷折线。
     // 弦只许落在 cpref 的实心区内 —— 中脊是净空极大线, 对它取直等于把线拽向墙, 那一段照旧逐格走;
     // 实心区里单价恒为一, 弦的欧氏长度因此就是精确代价。拐角余量往上收窄这个自由集: 弦贴着障碍角
@@ -1403,6 +1574,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             vv = std::move(tt);
         }
     }
+    dg.timing.geometry_ms = nowMs() - t_geo0;
     const Topo& win = vv.has_value() ? *vv : *base;
     for (const std::string& w : win.warn) {
         dg.warn.push_back(w);
@@ -1493,12 +1665,17 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             gq.push_back({ c % nx, c / nx });
         }
     }
+    const double t_pull0 = nowMs();
     std::vector<WorldPoint> taut = cen(by_corn ? gq : *q);
+    dg.taut_points = taut;
     if (taut.size() >= 2) {
         taut = StringPull(taut, blk_gray, hs.empty() ? nullptr : &lyo, hs.empty() ? nullptr : &hs,
             by_corn ? &vis_geo : nullptr);
     }
+    dg.pulled_points = taut;
+    dg.timing.pull_ms = nowMs() - t_pull0;
 
+    const double t_asm0 = nowMs();
     std::vector<WorldPoint> line;
     line.push_back(s);
     line.insert(line.end(), taut.begin(), taut.end());
@@ -1540,6 +1717,10 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     else {
         out = ded;
     }
+    dg.assembled_points = out;
+    dg.timing.assemble_ms = nowMs() - t_asm0;
+
+    const double t_lift0 = nowMs();
     // 抬升放在取直之后: 放前面的话抬起来的拐点让两侧更容易连通, 取直一刀就把它跳过去了。
     // 判据换成硬墙那一套 —— 通道掩膜只比路径宽一格, 拿它判等于禁止拐点离开原路径。
     if (lyo_p != nullptr && out.size() >= 3) {
@@ -1547,6 +1728,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         const Visibility vis_hard(&blk_hard, &lyo, faces, bn, nx, ny, x0, y0);
         LiftCorners(out, dist, x0, y0, vis_hard, lyo, lyo_h, kLiftMax);
     }
+    dg.timing.lift_ms = nowMs() - t_lift0;
     dg.clearance.reserve(out.size());
     for (const auto& p : out) {
         const int64_t cx = std::min(std::max(static_cast<int64_t>(std::floor((p.x - info.x0) / kCS)), int64_t { 0 }), nx - 1);
@@ -1618,11 +1800,10 @@ RecastPlanResult RecastNavEngine::plan(
     float goal_deck_y,
     const std::vector<uint32_t>& blocked,
     const std::vector<WorldPoint>& blocked_points,
-    const std::function<bool()>& should_stop,
-    bool exact_slim)
+    const std::function<bool()>& should_stop)
 {
     const std::lock_guard<std::mutex> lock(mutex_);
-    return planLocked(zone_name, start, goal, start_floor_y, goal_floor_y, goal_deck_y, blocked, blocked_points, should_stop, exact_slim);
+    return planLocked(zone_name, start, goal, start_floor_y, goal_floor_y, goal_deck_y, blocked, blocked_points, should_stop);
 }
 
 void RecastNavEngine::warm(const std::string& zone_name)
@@ -1704,9 +1885,9 @@ RecastPlanResult RecastNavEngine::planLocked(
     float goal_deck_y,
     const std::vector<uint32_t>& blocked,
     const std::vector<WorldPoint>& blocked_points,
-    const std::function<bool()>& should_stop,
-    bool /*exact_slim*/)
+    const std::function<bool()>& should_stop)
 {
+    const double t_all0 = nowMs();
     RecastPlanResult res;
     if (!grid_.valid()) {
         res.error = grid_error_;
@@ -1816,15 +1997,38 @@ RecastPlanResult RecastNavEngine::planLocked(
     const double x1 = static_cast<double>(zb.x1 + 1 + kFieldHalo) * kCS;
     const double y1 = static_cast<double>(zb.y1 + 1 + kFieldHalo) * kCS;
 
+    const double t_win0 = nowMs();
     auto info = buildWindow(wo, grid_, *gz, zc, start, ss->point, goal, h0, region, x0, y0, x1, y1, blocked_local, blocked_points, err);
+    const double window_ms = nowMs() - t_win0;
     if (!info.has_value()) {
         res.error = err.empty() ? "路线失败" : err;
         return res;
     }
     RouteDiag dg;
     auto line = routeWindow(*info, start, goal, dg, gdk, planner_, zc.zone_id);
+    // 失败的腿才最需要诊断: 断开时的缝、窗口范围、各阶段耗时全在这里, 两条出口都得带上。
+    const auto dump = [&] {
+        res.debug.timing = dg.timing;
+        res.debug.timing.window_ms = window_ms;
+        res.debug.timing.total_ms = nowMs() - t_all0;
+        res.debug.x0 = x0;
+        res.debug.y0 = y0;
+        res.debug.nx = nx;
+        res.debug.ny = ny;
+        res.debug.cell_size = kCS;
+        res.debug.topology_cells = std::move(dg.topology_cells);
+        res.debug.topology_heights = std::move(dg.topology_heights);
+        res.debug.taut_points = std::move(dg.taut_points);
+        res.debug.pulled_points = std::move(dg.pulled_points);
+        res.debug.assembled_points = std::move(dg.assembled_points);
+        res.debug.gap_start = dg.gap_start;
+        res.debug.gap_goal = dg.gap_goal;
+        res.debug.gap_distance = dg.gap_distance;
+        res.debug.warnings = dg.warn;
+    };
     if (!line.has_value()) {
         res.error = dg.err.empty() ? "路线失败" : dg.err;
+        dump();
         return res;
     }
     if (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius || dg.hop_barrier) {
@@ -1839,6 +2043,7 @@ RecastPlanResult RecastNavEngine::planLocked(
             dg.snap_start,
             dg.snap_goal);
         res.error = buf;
+        dump();
         return res;
     }
     res.ok = true;
@@ -1851,13 +2056,8 @@ RecastPlanResult RecastNavEngine::planLocked(
     res.snap_start = dg.snap_start;
     res.snap_goal = dg.snap_goal;
     res.waypoints = std::move(dg.waypoints);
-    res.debug.x0 = x0;
-    res.debug.y0 = y0;
-    res.debug.nx = nx;
-    res.debug.ny = ny;
-    res.debug.cell_size = kCS;
+    dump();
     res.debug.planned_points = res.points;
-    res.debug.warnings = res.warnings;
     return res;
 }
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -44,7 +44,6 @@ struct WindowInfo
     double h0 = 0.0;
     SpanTable st3;
     std::vector<uint8_t> vis3;
-    std::vector<int64_t> cidx;
     std::vector<uint8_t> reach3;
 };
 
@@ -373,7 +372,7 @@ std::optional<WindowInfo> buildWindow(
     info.dist = Grid<float>(nx, ny, 0.0F);
     info.lh = Grid<float>(nx, ny, std::numeric_limits<float>::quiet_NaN());
     std::vector<uint8_t> stepbits(static_cast<size_t>(nx * ny), 0);
-    std::vector<int64_t> sp_cell;
+    std::vector<int32_t> sp_cell;
     std::vector<float> sp_h;
     // 表里留着别的类的 span:层判据要看整列,少一层就会从楼板底下穿过去
     for (const GridSpanRec& r : gw.rec) {
@@ -397,7 +396,7 @@ std::optional<WindowInfo> buildWindow(
         if (fill || (ghost && r.rid != region)) {
             continue;
         }
-        sp_cell.push_back(r.cell);
+        sp_cell.push_back(static_cast<int32_t>(r.cell));
         sp_h.push_back(r.h);
         info.vis3.push_back(static_cast<uint8_t>(r.rid == region));
     }
@@ -455,27 +454,23 @@ std::optional<WindowInfo> buildWindow(
     info.h0 = h0;
     info.sev.steps.resize(nx, ny);
     info.st3 = PackSpans(std::move(sp_cell), std::move(sp_h), &info.vis3);
-    info.cidx.assign(static_cast<size_t>(nc), -1);
-    for (size_t ci = 0; ci < info.st3.occ.size(); ++ci) {
-        info.cidx[static_cast<size_t>(info.st3.occ[ci])] = static_cast<int64_t>(ci);
-    }
 
     // 窗口里 c 沿 (dx,dy) 到 b 这一向是否还走得通:任一对区内 span 满足垂直可达即通。
     // 任一格在窗口里没有区内 span 就判不通,让这条边保持禁行。
     const auto passable = [&](int64_t c, int64_t b, int64_t dx, int64_t dy) {
-        const int64_t jc = info.cidx[static_cast<size_t>(c)];
-        const int64_t jb = info.cidx[static_cast<size_t>(b)];
+        const int64_t jc = info.st3.j(c);
+        const int64_t jb = info.st3.j(b);
         if (jc < 0 || jb < 0) {
             return false;
         }
         const SpanTable& st = info.st3;
-        for (int64_t ka = 0; ka < st.ccnt[static_cast<size_t>(jc)]; ++ka) {
-            const int64_t sa = st.cstart[static_cast<size_t>(jc)] + ka;
+        for (int64_t ka = 0; ka < st.ccnt(jc); ++ka) {
+            const int64_t sa = st.cstart(jc) + ka;
             if (info.vis3[static_cast<size_t>(sa)] == 0) {
                 continue;
             }
-            for (int64_t kb = 0; kb < st.ccnt[static_cast<size_t>(jb)]; ++kb) {
-                const int64_t sb = st.cstart[static_cast<size_t>(jb)] + kb;
+            for (int64_t kb = 0; kb < st.ccnt(jb); ++kb) {
+                const int64_t sb = st.cstart(jb) + kb;
                 if (info.vis3[static_cast<size_t>(sb)] == 0) {
                     continue;
                 }
@@ -490,7 +485,7 @@ std::optional<WindowInfo> buildWindow(
     // 一格里可见面的最高与最低之差。栅格化的立面被挤进一列, 这个跨度就够得上一堵墙,
     // 护岸那一列六个面从 270.92 到 276.83 即是。
     const auto stackSpan = [&](int64_t c) {
-        const int64_t j = info.cidx[static_cast<size_t>(c)];
+        const int64_t j = info.st3.j(c);
         if (j < 0) {
             return 0.0;
         }
@@ -498,8 +493,8 @@ std::optional<WindowInfo> buildWindow(
         double lo = 0.0;
         double hi = 0.0;
         bool have = false;
-        for (int64_t k = 0; k < st.ccnt[static_cast<size_t>(j)]; ++k) {
-            const int64_t s = st.cstart[static_cast<size_t>(j)] + k;
+        for (int64_t k = 0; k < st.ccnt(j); ++k) {
+            const int64_t s = st.cstart(j) + k;
             if (info.vis3[static_cast<size_t>(s)] == 0) {
                 continue;
             }
@@ -513,20 +508,20 @@ std::optional<WindowInfo> buildWindow(
 
     // c 与 b 两格之间落差最小的那一对面。任一格没有区内面时取无穷大。
     const auto minGap = [&](int64_t c, int64_t b) {
-        const int64_t jc = info.cidx[static_cast<size_t>(c)];
-        const int64_t jb = info.cidx[static_cast<size_t>(b)];
+        const int64_t jc = info.st3.j(c);
+        const int64_t jb = info.st3.j(b);
         if (jc < 0 || jb < 0) {
             return std::numeric_limits<double>::infinity();
         }
         const SpanTable& st = info.st3;
         double g = std::numeric_limits<double>::infinity();
-        for (int64_t ka = 0; ka < st.ccnt[static_cast<size_t>(jc)]; ++ka) {
-            const int64_t sa = st.cstart[static_cast<size_t>(jc)] + ka;
+        for (int64_t ka = 0; ka < st.ccnt(jc); ++ka) {
+            const int64_t sa = st.cstart(jc) + ka;
             if (info.vis3[static_cast<size_t>(sa)] == 0) {
                 continue;
             }
-            for (int64_t kb = 0; kb < st.ccnt[static_cast<size_t>(jb)]; ++kb) {
-                const int64_t sb = st.cstart[static_cast<size_t>(jb)] + kb;
+            for (int64_t kb = 0; kb < st.ccnt(jb); ++kb) {
+                const int64_t sb = st.cstart(jb) + kb;
                 if (info.vis3[static_cast<size_t>(sb)] == 0) {
                     continue;
                 }
@@ -583,11 +578,11 @@ std::optional<WindowInfo> buildWindow(
             info.sev.p1.push_back({ px + static_cast<double>(dy) * kCS, py + static_cast<double>(dx) * kCS });
         }
     }
-    const int64_t sj = info.cidx[static_cast<size_t>(cell0)];
+    const int64_t sj = info.st3.j(cell0);
     int64_t seed3 = -1;
     float best3 = 0.0F;
-    const int64_t sjb = info.st3.cstart[static_cast<size_t>(sj)];
-    for (int64_t k = 0, kn = info.st3.ccnt[static_cast<size_t>(sj)]; k < kn; ++k) {
+    const int64_t sjb = info.st3.cstart(sj);
+    for (int64_t k = 0, kn = info.st3.ccnt(sj); k < kn; ++k) {
         const int64_t sid = sjb + k;
         if (info.vis3[static_cast<size_t>(sid)] == 0) {
             continue;
@@ -902,7 +897,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         return { bc, std::sqrt(static_cast<double>(bd)) * kCS };
     };
     const SpanTable& st3 = info.st3;
-    const LayerOracle lyo(&st3, &info.cidx, nx, ny, x0, y0);
+    const LayerOracle lyo(&st3, nx, ny, x0, y0);
     const auto mk = [&](const Mask& m2, std::vector<uint8_t>& use, Mask& c3) {
         use.assign(st3.sp_h.size(), 0);
         c3 = Mask(nx, ny, 0);
@@ -919,12 +914,12 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     mk(walk, useW, cw3);
     const auto pick = [&](const CellPt& c, const std::vector<uint8_t>& use) {
         std::vector<int64_t> out;
-        const int64_t j = info.cidx[static_cast<size_t>(c.y * nx + c.x)];
+        const int64_t j = info.st3.j(c.y * nx + c.x);
         if (j < 0) {
             return out;
         }
-        const int64_t jb = st3.cstart[static_cast<size_t>(j)];
-        for (int64_t k = 0, kn = st3.ccnt[static_cast<size_t>(j)]; k < kn; ++k) {
+        const int64_t jb = st3.cstart(j);
+        for (int64_t k = 0, kn = st3.ccnt(j); k < kn; ++k) {
             const int64_t v = jb + k;
             if (use[static_cast<size_t>(v)] != 0) {
                 out.push_back(v);
@@ -1186,7 +1181,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             if (sd < 0 || (goal_deck.has_value() && gs.empty())) {
                 return std::nullopt;
             }
-            return SpanAstar(st3, use, info.cidx, m3, sd, gs, price, banned, bnp, faces, vis, vis != nullptr ? &corn : nullptr);
+            return SpanAstar(st3, use, m3, sd, gs, price, banned, bnp, faces, vis, vis != nullptr ? &corn : nullptr);
         };
         Topo t;
         t.on3 = w3;
@@ -1278,15 +1273,15 @@ std::optional<std::vector<WorldPoint>> routeWindow(
                         if (dx != 0 && dy != 0 && !(ok2.at(uy, vx) && ok2.at(vy, ux))) {
                             continue;
                         }
-                        if (info.cidx[static_cast<size_t>(cv)] < 0) {
+                        if (info.st3.j(cv) < 0) {
                             continue;
                         }
                         if (faces->has(backward ? cv : cu, backward ? cu : cv)) {
                             continue;
                         }
-                        const int64_t j = info.cidx[static_cast<size_t>(cv)];
-                        const int64_t jb = st3.cstart[static_cast<size_t>(j)];
-                        for (int64_t k = 0, kn = st3.ccnt[static_cast<size_t>(j)]; k < kn; ++k) {
+                        const int64_t j = info.st3.j(cv);
+                        const int64_t jb = st3.cstart(j);
+                        for (int64_t k = 0, kn = st3.ccnt(j); k < kn; ++k) {
                             const int64_t v = jb + k;
                             if (use[static_cast<size_t>(v)] == 0 || seen[static_cast<size_t>(v)] != 0) {
                                 continue;
@@ -1422,7 +1417,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         for (int64_t y = 0; y < ny; ++y) {
             for (int64_t x = 0; x < nx; ++x) {
                 const int64_t c = y * nx + x;
-                const int64_t jc = info.cidx[static_cast<size_t>(c)];
+                const int64_t jc = info.st3.j(c);
                 if (jc < 0) {
                     continue;
                 }
@@ -1436,20 +1431,20 @@ std::optional<std::vector<WorldPoint>> routeWindow(
                             continue;
                         }
                         const int64_t b = by * nx + bx;
-                        const int64_t jb = info.cidx[static_cast<size_t>(b)];
+                        const int64_t jb = info.st3.j(b);
                         if (jb < 0) {
                             continue;
                         }
                         const double up = kSlope * std::hypot(static_cast<double>(dx), static_cast<double>(dy)) * kCS;
                         bool any = false;
                         bool flat = false;
-                        for (int64_t ka = 0; ka < st3.ccnt[static_cast<size_t>(jc)] && !flat; ++ka) {
-                            const int64_t sa = st3.cstart[static_cast<size_t>(jc)] + ka;
+                        for (int64_t ka = 0; ka < st3.ccnt(jc) && !flat; ++ka) {
+                            const int64_t sa = st3.cstart(jc) + ka;
                             if (info.vis3[static_cast<size_t>(sa)] == 0) {
                                 continue;
                             }
-                            for (int64_t kb = 0; kb < st3.ccnt[static_cast<size_t>(jb)]; ++kb) {
-                                const int64_t sb = st3.cstart[static_cast<size_t>(jb)] + kb;
+                            for (int64_t kb = 0; kb < st3.ccnt(jb); ++kb) {
+                                const int64_t sb = st3.cstart(jb) + kb;
                                 if (info.vis3[static_cast<size_t>(sb)] == 0) {
                                     continue;
                                 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -2085,12 +2085,16 @@ RecastPlanResult RecastNavEngine::planLocked(
     const double t_win0 = nowMs();
     auto info = buildWindow(grid_, *gz, zc, start, ss->point, goal, h0, region, x0, y0, x1, y1, blocked_local, blocked_points, err);
     const double window_ms = nowMs() - t_win0;
+    // 区网格的读者到建窗为止, 往下只剩一个区号。它比一整套窗口图还大, 挂着不放就是白抬一份
+    // 峰值。下一条腿重建它: 峰值是用户量得到的东西, 常驻不是。
+    const uint16_t zone_id = zc.zone_id;
+    zones_.erase(zone_name);
     if (!info.has_value()) {
         res.error = err.empty() ? "路线失败" : err;
         return res;
     }
     RouteDiag dg;
-    auto line = routeWindow(*info, start, goal, dg, gdk, planner_, zc.zone_id);
+    auto line = routeWindow(*info, start, goal, dg, gdk, planner_, zone_id);
     // 失败的腿才最需要诊断: 断开时的缝、窗口范围、各阶段耗时全在这里, 两条出口都得带上。
     const auto dump = [&] {
         res.debug.timing = dg.timing;

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -407,15 +407,20 @@ std::optional<WindowInfo> buildWindow(
         sp_h.push_back(r.h);
         info.vis3.push_back(static_cast<uint8_t>(r.rid == region));
     }
+    // 记录表到此已经摊进上面这几张图, 后面再没人读它。建 span 表是建窗最耗内存的一步,
+    // 这份表是其中最大的一块, 不该一直占到那时。
+    pw.gw = GridWindow();
 
-    const BakedWalls walls = BakeWalls(zc, x0, y0, nx, ny);
-    const std::vector<uint8_t> keep = WallsAtLayer(walls.p0, walls.p1, walls.hh, lh, x0, y0);
     std::vector<WorldPoint> wP0;
     std::vector<WorldPoint> wP1;
-    for (size_t i = 0; i < keep.size(); ++i) {
-        if (keep[i] != 0) {
-            wP0.push_back(walls.p0[i]);
-            wP1.push_back(walls.p1[i]);
+    {
+        const BakedWalls walls = BakeWalls(zc, x0, y0, nx, ny);
+        const std::vector<uint8_t> keep = WallsAtLayer(walls.p0, walls.p1, walls.hh, lh, x0, y0);
+        for (size_t i = 0; i < keep.size(); ++i) {
+            if (keep[i] != 0) {
+                wP0.push_back(walls.p0[i]);
+                wP1.push_back(walls.p1[i]);
+            }
         }
     }
     info.whit = WallHits(wP0, wP1, x0, y0, nx, ny);
@@ -437,6 +442,7 @@ std::optional<WindowInfo> buildWindow(
             }
         }
     }
+    lh = Grid<float>();
 
     // 封堵点无自带高度;窗口层已按起点层高筛过,直接按平面距离盖格即可
     if (!blocked_points.empty()) {

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -31,12 +31,11 @@ struct WindowInfo
     double y0 = 0.0;
     int64_t nx = 0;
     int64_t ny = 0;
+    // 只留跨过 buildWindow 边界还有读者的表。层高图与挑剩的墙段都是建窗内部量, 留在结构里
+    // 就是让两张全窗口的图白白活过整个 routeWindow。
     Mask lay;
-    Grid<float> lh;
     Mask core;
     Grid<float> dist;
-    std::vector<WorldPoint> wP0;
-    std::vector<WorldPoint> wP1;
     Mask whit;
     StepBarrier sev;
     std::vector<WorldPoint> segA;
@@ -378,7 +377,7 @@ std::optional<WindowInfo> buildWindow(
     info.lay = Mask(nx, ny, 0);
     info.core = Mask(nx, ny, 0);
     info.dist = Grid<float>(nx, ny, 0.0F);
-    info.lh = Grid<float>(nx, ny, std::numeric_limits<float>::quiet_NaN());
+    Grid<float> lh(nx, ny, std::numeric_limits<float>::quiet_NaN());
     std::vector<uint8_t> stepbits(static_cast<size_t>(nx * ny), 0);
     std::vector<int32_t> sp_cell;
     std::vector<float> sp_h;
@@ -397,8 +396,8 @@ std::optional<WindowInfo> buildWindow(
             }
             info.dist.v[cell] = GridClearance(r.clr);
             stepbits[cell] |= r.steps;
-            if (!ghost && !fill && (std::isnan(info.lh.v[cell]) || r.h > info.lh.v[cell])) {
-                info.lh.v[cell] = r.h;
+            if (!ghost && !fill && (std::isnan(lh.v[cell]) || r.h > lh.v[cell])) {
+                lh.v[cell] = r.h;
             }
         }
         if (fill || (ghost && r.rid != region)) {
@@ -410,14 +409,16 @@ std::optional<WindowInfo> buildWindow(
     }
 
     const BakedWalls walls = BakeWalls(zc, x0, y0, nx, ny);
-    const std::vector<uint8_t> keep = WallsAtLayer(walls.p0, walls.p1, walls.hh, info.lh, x0, y0);
+    const std::vector<uint8_t> keep = WallsAtLayer(walls.p0, walls.p1, walls.hh, lh, x0, y0);
+    std::vector<WorldPoint> wP0;
+    std::vector<WorldPoint> wP1;
     for (size_t i = 0; i < keep.size(); ++i) {
         if (keep[i] != 0) {
-            info.wP0.push_back(walls.p0[i]);
-            info.wP1.push_back(walls.p1[i]);
+            wP0.push_back(walls.p0[i]);
+            wP1.push_back(walls.p1[i]);
         }
     }
-    info.whit = WallHits(info.wP0, info.wP1, x0, y0, nx, ny);
+    info.whit = WallHits(wP0, wP1, x0, y0, nx, ny);
 
     if (!blocked_local.empty()) {
         std::vector<std::array<int32_t, 3>> bt;
@@ -428,7 +429,7 @@ std::optional<WindowInfo> buildWindow(
         const RasterCells brc = Rasterize(zc.mesh.V, zc.mesh.H, bt, x0, y0, nx, ny);
         for (size_t ci = 0; ci < brc.cell.size(); ++ci) {
             const auto cell = static_cast<size_t>(brc.cell[ci]);
-            const float lf = info.lh.v[cell];
+            const float lf = lh.v[cell];
             // 层高带内才盖掉,免得误伤其他楼层的格
             if (!std::isnan(lf) && std::fabs(brc.h[ci] - lf) <= static_cast<float>(kClimb)) {
                 info.core.v[cell] = 0;
@@ -607,10 +608,13 @@ std::optional<WindowInfo> buildWindow(
     }
     info.reach3 = SpanReach(seed3, info.st3, info.vis3, nx, ny);
 
-    info.segA = info.wP0;
+    // 段表就此定型。挑剩的墙段与立面禁步段都整份进了 segA/segB, 源表留着只是同一批点的第二份。
+    info.segA = std::move(wP0);
     info.segA.insert(info.segA.end(), info.sev.p0.begin(), info.sev.p0.end());
-    info.segB = info.wP1;
+    info.segB = std::move(wP1);
     info.segB.insert(info.segB.end(), info.sev.p1.begin(), info.sev.p1.end());
+    info.sev.p0 = {};
+    info.sev.p1 = {};
     // 烘出来的净空是没封堵时的;盖掉格子会让通道变窄,代价场得按盖过的核心重算
     if (!blocked_local.empty() || !blocked_points.empty()) {
         info.dist = Clearance(info.core);
@@ -798,7 +802,7 @@ void LiftCorners(
 
 // goal_deck: 终点所在面的高度。不声明时终点集是该格全部 span,先够到哪张停哪张
 std::optional<std::vector<WorldPoint>> routeWindow(
-    const WindowInfo& info,
+    WindowInfo& info,
     const WorldPoint& s,
     const WorldPoint& g,
     RouteDiag& dg,
@@ -811,51 +815,59 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const int64_t ny = info.ny;
     const double x0 = info.x0;
     const double y0 = info.y0;
+    // 全窗口的图按最后一个读者就地释放: 早就没人读的表不该陪着活到最耗内存的那一刻。释放后再
+    // 取值是越界而不是错值, 逐腿比对因此能当场抓住漏算的读者 —— lambda 的调用点才算读者。
     Mask walk(nx, ny, 0);
     for (size_t i = 0; i < walk.v.size(); ++i) {
         walk.v[i] = static_cast<uint8_t>(info.core.v[i] != 0 && info.lay.v[i] != 0);
     }
+    info.lay = Mask();
     // 边界边只用来算余量, 不用来禁步: 补洞封缝那一步已经判定这些细缝可以跨,
     // 回头再拿同一批边禁掉跨缝的一步, 等于在每道接缝上凭空立一堵墙
     const EdgeBits& blocked_steps = info.sev.steps;
     // 掩膜距离场对跨越边界边无感, 取到边界的距离的下确界补上
-    Mask wfree(nx, ny, 0);
-    for (size_t i = 0; i < wfree.v.size(); ++i) {
-        wfree.v[i] = info.whit.v[i] != 0 ? 0 : 1;
-    }
-    // 共面重叠片各自留着自己的边界, 落到格上是间距约 1px 的栅格, 开阔广场因此与窄巷读出同样的
-    // 宽度, 按宽度定价的拓扑层于是分辨不出宽路。摘法只放不加: 四邻全可走、且这四步都没被禁的
-    // 格子才回自由集, 建筑外轮廓恒有一侧没有面, 一根真墙边都摘不掉。
-    for (int64_t y = 1; y + 1 < ny; ++y) {
-        for (int64_t x = 1; x + 1 < nx; ++x) {
-            const int64_t c = y * nx + x;
-            if (wfree.v[static_cast<size_t>(c)] != 0 || walk.v[static_cast<size_t>(c)] == 0) {
-                continue;
-            }
-            bool seam = true;
-            for (const int64_t d : { int64_t { 1 }, int64_t { -1 }, nx, -nx }) {
-                const int64_t b = c + d;
-                if (walk.v[static_cast<size_t>(b)] == 0 || blocked_steps.has(c, b) || blocked_steps.has(b, c)) {
-                    seam = false;
-                    break;
+    Grid<float> wdist;
+    {
+        Mask wfree(nx, ny, 0);
+        for (size_t i = 0; i < wfree.v.size(); ++i) {
+            wfree.v[i] = info.whit.v[i] != 0 ? 0 : 1;
+        }
+        info.whit = Mask();
+        // 共面重叠片各自留着自己的边界, 落到格上是间距约 1px 的栅格, 开阔广场因此与窄巷读出同样的
+        // 宽度, 按宽度定价的拓扑层于是分辨不出宽路。摘法只放不加: 四邻全可走、且这四步都没被禁的
+        // 格子才回自由集, 建筑外轮廓恒有一侧没有面, 一根真墙边都摘不掉。
+        for (int64_t y = 1; y + 1 < ny; ++y) {
+            for (int64_t x = 1; x + 1 < nx; ++x) {
+                const int64_t c = y * nx + x;
+                if (wfree.v[static_cast<size_t>(c)] != 0 || walk.v[static_cast<size_t>(c)] == 0) {
+                    continue;
+                }
+                bool seam = true;
+                for (const int64_t d : { int64_t { 1 }, int64_t { -1 }, nx, -nx }) {
+                    const int64_t b = c + d;
+                    if (walk.v[static_cast<size_t>(b)] == 0 || blocked_steps.has(c, b) || blocked_steps.has(b, c)) {
+                        seam = false;
+                        break;
+                    }
+                }
+                if (seam) {
+                    wfree.v[static_cast<size_t>(c)] = 1;
                 }
             }
-            if (seam) {
-                wfree.v[static_cast<size_t>(c)] = 1;
-            }
         }
+        wdist = Clearance(wfree);
     }
     // 取小就地写回接缝净空那张表: 另开一张同尺寸的只是让两张 36MB 的图在整个 routeWindow 里同时活着。
-    Grid<float> wdist = Clearance(wfree);
     for (size_t i = 0; i < wdist.v.size(); ++i) {
         wdist.v[i] = std::min(info.dist.v[i], wdist.v[i]);
     }
+    info.dist = Grid<float>();
     const Grid<float> dist = std::move(wdist);
     // VV(c): 障碍按期望净空 c 膨胀后仍自由的格走可见图那一侧, 膨胀后被吃掉的窄处只留中脊,
     // 对应论文里 V∩M(c) 的那段 Voronoi 弧。净空在这一层是掩膜: 开阔地没有贴墙这个选项, 窄缝
     // 里没有偏一侧这个选项, 中途钻的一小段窄缝也就无法被整条路长平均掉。
     const double cpref = kClrPref;
-    const Mask rdg = MedialAxis(dist, kClrLambda);
+    Mask rdg = MedialAxis(dist, kClrLambda);
     // 通道 = 障碍按 c 膨胀后仍自由的格, 并上中轴带。
     const auto chan = [&](double cc, const Mask& band) {
         Mask w(nx, ny, 0);
@@ -1408,6 +1420,8 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         dg.err = "不连通";
         return std::nullopt;
     }
+    // 走通了就再没人查这张逐 span 的可用表, 上面那两条出口都直接返回。
+    useW = std::vector<uint8_t>();
 
     // 突变抬升逐次计税: 跨越两侧找不到任何一对高差在坡度内的面时才算一次台阶, 连续缓坡不计。
     // 它不参与硬连通性, 只在同样走得通的两条线之间偏向不必迈的那条, 封不死唯一的楼梯。
@@ -1478,11 +1492,12 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     // 否则同一道立面在拓扑层变便宜, 花两格路就能买过去。
     const double taxw = tax * kClrWide / cpref;
     const double* bpw = tax > 0.0 ? &taxw : nullptr;
-    const Mask chan0 = chan(cpref, Mask(nx, ny, 0));
     // 接入链只算一次: 目标取实心通道 chan0, 它是自由集的子集, 接到它就等于接进了自由集。
     // 两端各自对着 chan0 算, 谁先算不影响结果。够不到 chan0 的那一端才对着自由集重算。
+    Mask chan0 = chan(cpref, Mask(nx, ny, 0));
     const std::optional<std::vector<int64_t>> ac_s = access(chan0, as_);
     const std::optional<std::vector<int64_t>> ac_g = access(chan0, ag_);
+    chan0 = Mask();
     const auto join = [&](Mask& lim) {
         const std::optional<std::vector<int64_t>> s = ac_s.has_value() ? ac_s : access(lim, as_);
         const std::optional<std::vector<int64_t>> g = ac_g.has_value() ? ac_g : access(lim, ag_);
@@ -1509,6 +1524,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const auto loops_core = toWorld(TraceContours(info.core));
 
     Mask limw = chan(cpref, rdg);
+    rdg = Mask();
     join(limw);
     std::optional<Topo> vv = solve(limw, multw, bn, bpw, false);
     if (!vv.has_value()) {
@@ -1538,16 +1554,18 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const double solid_c = cpref + kGeoMargin;
     // 走廊以中标的那条逐格路径为骨干张开, 半宽照它自己的净空取。按全局中轴取则会隔墙认到旁边
     // 那条窄缝上去: 宽处的半宽被压回地板, 该收紧的地方一点没收紧。
-    Mask bb(nx, ny, 0);
-    for (const CellPt& c : (vv.has_value() ? vv->q : base->q)) {
-        bb.at(c.y, c.x) = 1;
-    }
     Mask band;
-    const Grid<float> cw = CorridorWidth(dist, bb, &band);
     Mask solidc(nx, ny, 0);
-    for (size_t i = 0; i < solidc.v.size(); ++i) {
-        const double need = std::max(solid_c, kChordFrac * static_cast<double>(cw.v[i]));
-        solidc.v[i] = static_cast<uint8_t>(static_cast<double>(dist.v[i]) >= need);
+    {
+        Mask bb(nx, ny, 0);
+        for (const CellPt& c : (vv.has_value() ? vv->q : base->q)) {
+            bb.at(c.y, c.x) = 1;
+        }
+        const Grid<float> cw = CorridorWidth(dist, bb, &band);
+        for (size_t i = 0; i < solidc.v.size(); ++i) {
+            const double need = std::max(solid_c, kChordFrac * static_cast<double>(cw.v[i]));
+            solidc.v[i] = static_cast<uint8_t>(static_cast<double>(dist.v[i]) >= need);
+        }
     }
     const Blockers::OnMask onv { &solidc, x0, y0, kCS };
     // 搜索期的视线只靠 on 掩膜兜底, 不带轮廓挡线。
@@ -1561,6 +1579,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         for (size_t i = 0; i < limg.v.size(); ++i) {
             limg.v[i] = static_cast<uint8_t>(limg.v[i] != 0 && band.v[i] != 0);
         }
+        band = Mask();
         std::optional<Topo> tt = solve(limg, mult, bn, bp, false, &vis);
         if (!tt.has_value()) {
             // 走廊是偏好, 接通性不是。二维骨干必在走廊里, 层间接不通才会走到这里; 放开重解, 拿回

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -864,20 +864,12 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         return w;
     };
     // 中脊单价按净空亏欠比例上浮, 可见图一侧恒为一。这道价只在几条窄缝之间做取舍。
-    Grid<float> mult(nx, ny, 1.0F);
-    for (size_t i = 0; i < mult.v.size(); ++i) {
-        const double d = std::min(std::max(static_cast<double>(dist.v[i]), kCS), cpref);
-        mult.v[i] = static_cast<float>(cpref / d);
-    }
+    const PriceField mult { .dist = &dist, .lo = kCS, .hi = cpref };
     // 定通道那一层的单价同式, 但取值区间换成 [kClrNarrow, kClrWide]。封在 cpref 的话中轴上处处
     // 够宽的格单价一律为一, 平行分支里最短的那条必然中标 —— 而窄缝总比宽道短, 线于是钻缝。
     // 基准取在最宽处, 单价因此恒不低于一, 搜索拿欧氏距离当下界才成立; 基准落在窄处则它高估
     // 剩余代价, 反复重开已定好的节点。整体抬价保持逐格相对贵贱不变, 最优路径集合照旧。
-    Grid<float> multw(nx, ny, 1.0F);
-    for (size_t i = 0; i < multw.v.size(); ++i) {
-        const double d = std::min(std::max(static_cast<double>(dist.v[i]), kClrNarrow), kClrWide);
-        multw.v[i] = static_cast<float>(kClrWide / d);
-    }
+    const PriceField multw { .dist = &dist, .lo = kClrNarrow, .hi = kClrWide };
 
     const CellPt sc { static_cast<int64_t>((s.x - x0) / kCS), static_cast<int64_t>((s.y - y0) / kCS) };
     const CellPt gc { static_cast<int64_t>((g.x - x0) / kCS), static_cast<int64_t>((g.y - y0) / kCS) };
@@ -1151,7 +1143,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     // 目标面声明与 LayerOracle 全部原样。lim 只做减法, 无权放宽其中任何一条, 舒适选路因此造不出
     // unreachable。
     const auto solve = [&](const Mask& lim,
-                           const Grid<float>& price,
+                           const PriceField& price,
                            const EdgeBits* banned,
                            const double* bnp,
                            bool resnap,
@@ -1387,7 +1379,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     // 走得通的腿判成不可达。它同时是端点的回缩通道 —— 起终点天然贴墙时, 搜索沿这条按亏欠计价
     // 的线走几格就自然汇入 VV 图, 端点附近不需要任何放宽半径。
     const Mask all(nx, ny, 1);
-    const Grid<float> unit(nx, ny, 1.0F);
+    const PriceField unit {};
     const std::optional<Topo> base = solve(all, unit, nullptr, nullptr, true);
     if (!base.has_value()) {
         reportGap();

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -7,7 +7,11 @@
 #include <cmath>
 #include <limits>
 #include <optional>
-#include <set>
+#include <queue>
+#include <tuple>
+
+#include <cstdio>
+#include <cstdlib>
 
 namespace navmesh::recast
 {
@@ -41,251 +45,21 @@ struct WindowInfo
     SpanTable st3;
     std::vector<uint8_t> vis3;
     std::vector<int64_t> cidx;
+    std::vector<uint8_t> reach3;
 };
 
 struct RouteDiag
 {
-    RecastPlanResult::Debug::Timing timing;
     std::string err;
     std::vector<std::string> warn;
     std::vector<double> clearance;
     std::vector<double> height; // 逐点所在面的高度; 层预言机走不通时清空
     std::vector<size_t> waypoints;
     bool crossed_barrier = false;
+    bool hop_barrier = false; // 端点接线的那一跳跨了禁行边
     double snap_start = 0.0;
     double snap_goal = 0.0;
-    double x0 = 0.0;
-    double y0 = 0.0;
-    int64_t nx = 0;
-    int64_t ny = 0;
-    std::vector<WorldPoint> astar_cells;
-    std::vector<double> astar_heights;
-    std::vector<WorldPoint> rerouted_points;
-    std::vector<WorldPoint> string_pull_points;
-    std::vector<WorldPoint> assembled_points;
-    std::vector<WorldPoint> loop_fixed_points;
-    std::vector<WorldPoint> slim_points;
-    std::vector<WorldPoint> widened_points;
-    std::vector<WorldPoint> planned_points;
-    std::optional<WorldPoint> gap_start;
-    std::optional<WorldPoint> gap_goal;
-    std::optional<double> gap_distance;
 };
-
-double ElapsedMs(const std::chrono::steady_clock::time_point started_at)
-{
-    return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - started_at).count();
-}
-
-std::vector<uint8_t> topologyReach(
-    const SpanTable& st,
-    const std::vector<uint8_t>& ok,
-    const std::vector<int64_t>& cidx,
-    const Mask& ok2,
-    const std::vector<int64_t>& seeds,
-    const std::unordered_set<int64_t>* forbidden,
-    bool reverse)
-{
-    std::vector<uint8_t> visited(st.sp_h.size(), 0);
-    std::vector<int64_t> frontier;
-    frontier.reserve(seeds.size());
-    for (const int64_t seed : seeds) {
-        if (seed >= 0 && ok[static_cast<size_t>(seed)] != 0 && visited[static_cast<size_t>(seed)] == 0) {
-            visited[static_cast<size_t>(seed)] = 1;
-            frontier.push_back(seed);
-        }
-    }
-
-    struct Step
-    {
-        int64_t dx;
-        int64_t dy;
-        double weight;
-    };
-
-    constexpr double kDiagonalWeight = 1.4142135623730951;
-    constexpr Step kSteps[] = {
-        { -1, -1, kDiagonalWeight }, { 0, -1, 1.0 }, { 1, -1, kDiagonalWeight }, { -1, 0, 1.0 }, { 1, 0, 1.0 },
-        { -1, 1, kDiagonalWeight },  { 0, 1, 1.0 },  { 1, 1, kDiagonalWeight },
-    };
-    const int64_t nx = ok2.nx;
-    const int64_t ny = ok2.ny;
-    const int64_t cell_count = nx * ny;
-    for (size_t cursor = 0; cursor < frontier.size(); ++cursor) {
-        const int64_t current = frontier[cursor];
-        const int64_t current_cell = st.sp_cell[static_cast<size_t>(current)];
-        const int64_t x = current_cell % nx;
-        const int64_t y = current_cell / nx;
-        const float current_height = st.sp_h[static_cast<size_t>(current)];
-        for (const Step& step : kSteps) {
-            const int64_t next_x = x + step.dx;
-            const int64_t next_y = y + step.dy;
-            if (next_x < 0 || next_x >= nx || next_y < 0 || next_y >= ny) {
-                continue;
-            }
-            const int64_t next_cell = next_y * nx + next_x;
-            if (ok2.v[static_cast<size_t>(next_cell)] == 0) {
-                continue;
-            }
-            if (step.dx != 0 && step.dy != 0 && !(ok2.at(y, next_x) && ok2.at(next_y, x))) {
-                continue;
-            }
-            const int64_t column = cidx[static_cast<size_t>(next_cell)];
-            if (column < 0) {
-                continue;
-            }
-            const int64_t edge = reverse ? next_cell * cell_count + current_cell : current_cell * cell_count + next_cell;
-            if (forbidden != nullptr && forbidden->contains(edge)) {
-                continue;
-            }
-            for (int64_t slot = 0; slot < st.K; ++slot) {
-                const int64_t candidate = st.IK[static_cast<size_t>(column * st.K + slot)];
-                if (candidate < 0 || ok[static_cast<size_t>(candidate)] == 0 || visited[static_cast<size_t>(candidate)] != 0) {
-                    continue;
-                }
-                const float candidate_height = st.sp_h[static_cast<size_t>(candidate)];
-                const float dh = reverse ? current_height - candidate_height : candidate_height - current_height;
-                if (static_cast<double>(dh) > kUp * step.weight || dh < -static_cast<float>(kClimb)) {
-                    continue;
-                }
-                visited[static_cast<size_t>(candidate)] = 1;
-                frontier.push_back(candidate);
-            }
-        }
-    }
-    return visited;
-}
-
-struct ReachGap
-{
-    WorldPoint start;
-    WorldPoint goal;
-    double distance = 0.0;
-};
-
-std::optional<ReachGap> closestReachGap(
-    const SpanTable& st,
-    const std::vector<uint8_t>& start_reach,
-    const std::vector<uint8_t>& goal_reach,
-    int64_t nx,
-    int64_t ny,
-    double x0,
-    double y0)
-{
-    std::vector<uint8_t> start_cells(static_cast<size_t>(nx * ny), 0);
-    std::vector<uint8_t> goal_cells(static_cast<size_t>(nx * ny), 0);
-    for (size_t i = 0; i < st.sp_cell.size(); ++i) {
-        const size_t cell = static_cast<size_t>(st.sp_cell[i]);
-        start_cells[cell] |= start_reach[i];
-        goal_cells[cell] |= goal_reach[i];
-    }
-
-    struct TaggedCell
-    {
-        int64_t x;
-        int64_t y;
-        bool from_start;
-    };
-
-    const auto boundary = [&](const std::vector<uint8_t>& cells, int64_t x, int64_t y) {
-        constexpr int64_t kDx[] = { -1, 1, 0, 0 };
-        constexpr int64_t kDy[] = { 0, 0, -1, 1 };
-        for (size_t i = 0; i < std::size(kDx); ++i) {
-            const int64_t ax = x + kDx[i];
-            const int64_t ay = y + kDy[i];
-            if (ax < 0 || ax >= nx || ay < 0 || ay >= ny || cells[static_cast<size_t>(ay * nx + ax)] == 0) {
-                return true;
-            }
-        }
-        return false;
-    };
-
-    std::vector<TaggedCell> points;
-    std::optional<TaggedCell> first_start;
-    std::optional<TaggedCell> first_goal;
-    for (int64_t y = 0; y < ny; ++y) {
-        for (int64_t x = 0; x < nx; ++x) {
-            const size_t cell = static_cast<size_t>(y * nx + x);
-            if (start_cells[cell] != 0 && boundary(start_cells, x, y)) {
-                const TaggedCell point { .x = x, .y = y, .from_start = true };
-                points.push_back(point);
-                if (!first_start) {
-                    first_start = point;
-                }
-            }
-            if (goal_cells[cell] != 0 && boundary(goal_cells, x, y)) {
-                const TaggedCell point { .x = x, .y = y, .from_start = false };
-                points.push_back(point);
-                if (!first_goal) {
-                    first_goal = point;
-                }
-            }
-        }
-    }
-    if (!first_start || !first_goal) {
-        return std::nullopt;
-    }
-
-    std::sort(points.begin(), points.end(), [](const TaggedCell& lhs, const TaggedCell& rhs) {
-        return lhs.x < rhs.x || (lhs.x == rhs.x && (lhs.y < rhs.y || (lhs.y == rhs.y && lhs.from_start < rhs.from_start)));
-    });
-    const auto squaredDistance = [](const TaggedCell& lhs, const TaggedCell& rhs) {
-        const int64_t dx = lhs.x - rhs.x;
-        const int64_t dy = lhs.y - rhs.y;
-        return dx * dx + dy * dy;
-    };
-    int64_t best_squared = squaredDistance(*first_start, *first_goal);
-    TaggedCell best_start = *first_start;
-    TaggedCell best_goal = *first_goal;
-    std::set<std::pair<int64_t, size_t>> active_start;
-    std::set<std::pair<int64_t, size_t>> active_goal;
-    size_t left = 0;
-    for (size_t i = 0; i < points.size(); ++i) {
-        const TaggedCell& point = points[i];
-        while (left < i) {
-            const int64_t dx = point.x - points[left].x;
-            if (dx * dx <= best_squared) {
-                break;
-            }
-            auto& active = points[left].from_start ? active_start : active_goal;
-            active.erase({ points[left].y, left });
-            ++left;
-        }
-        const auto& opposite = point.from_start ? active_goal : active_start;
-        const int64_t radius = static_cast<int64_t>(std::floor(std::sqrt(static_cast<double>(best_squared))));
-        auto it = opposite.lower_bound({ point.y - radius, 0 });
-        const auto end = opposite.upper_bound({ point.y + radius, std::numeric_limits<size_t>::max() });
-        for (; it != end; ++it) {
-            const TaggedCell& candidate = points[it->second];
-            const int64_t distance = squaredDistance(point, candidate);
-            if (distance < best_squared) {
-                best_squared = distance;
-                if (point.from_start) {
-                    best_start = point;
-                    best_goal = candidate;
-                }
-                else {
-                    best_start = candidate;
-                    best_goal = point;
-                }
-            }
-        }
-        auto& active = point.from_start ? active_start : active_goal;
-        active.emplace(point.y, i);
-    }
-
-    const auto toWorld = [&](const TaggedCell& point) {
-        return WorldPoint {
-            .x = x0 + (static_cast<double>(point.x) + 0.5) * kCS,
-            .y = y0 + (static_cast<double>(point.y) + 0.5) * kCS,
-        };
-    };
-    return ReachGap {
-        .start = toWorld(best_start),
-        .goal = toWorld(best_goal),
-        .distance = std::sqrt(static_cast<double>(best_squared)) * kCS,
-    };
-}
 
 // 窗口里从预烘图解出来的记录。格号已换成窗口格号,窗外的与不属于本瓦自有矩形的
 // 都已剔除;一格只归一块瓦,所以同格的记录必然来自同一块瓦、按 (类号, 高) 排好。
@@ -419,6 +193,118 @@ double coreAnchorPx(const GridPack& gp, const GridZoneDir& gz, const WorldPoint&
     return best < 0 ? reach : std::sqrt(static_cast<double>(best)) * cs;
 }
 
+// 一个区的全部格范围, 单位是全局格号, 闭区间。瓦片互不重叠且铺满整区, 所以取并集即是区范围。
+struct ZoneBoundsPx
+{
+    int64_t x0 = 0;
+    int64_t y0 = 0;
+    int64_t x1 = -1;
+    int64_t y1 = -1;
+
+    bool empty() const { return x1 < x0 || y1 < y0; }
+};
+
+// 一块解开的格图连同它的原点与尺寸。原点落在全局格线上, 所以窗口格号与烘焙格号一一对上。
+struct GridPatch
+{
+    GridWindow gw;
+    double x0 = 0.0;
+    double y0 = 0.0;
+    int64_t nx = 0;
+    int64_t ny = 0;
+};
+
+// 定这条腿走哪一类。起点那一格定类; 终点声明了面时改由终点定, 免得起点二维吸附落在屋顶上
+// 把线拉到别层去。只读起点格与终点吸附半径内的格, 所以在覆盖了这两处的任何一块格图上定,
+// 结果都一样 —— 先在小块上定类再按类开图, 与直接在整区图上定类逐位相同。
+bool pickRegion(
+    const GridPatch& ps,
+    const GridPatch& pg,
+    const WorldPoint& s,
+    const WorldPoint& s_snap,
+    const WorldPoint& g,
+    double h0,
+    std::optional<double> goal_deck,
+    uint32_t& region,
+    int64_t& start_cell,
+    std::string& err)
+{
+    const auto cell_at = [](const GridPatch& p, int64_t cx, int64_t cy) {
+        return cx < 0 || cx >= p.nx || cy < 0 || cy >= p.ny ? -1 : cy * p.nx + cx;
+    };
+    int64_t gx = static_cast<int64_t>((s.x - ps.x0) / kCS);
+    int64_t gy = static_cast<int64_t>((s.y - ps.y0) / kCS);
+    int64_t cell0 = cell_at(ps, gx, gy);
+    int64_t start_rec = cell0 >= 0 ? pickStartRec(ps.gw, cell0, h0) : -1;
+    if (start_rec < 0) {
+        // 起点离网时其所在格无体素, 退用按楼层吸附过的起点定种子
+        gx = static_cast<int64_t>((s_snap.x - ps.x0) / kCS);
+        gy = static_cast<int64_t>((s_snap.y - ps.y0) / kCS);
+        cell0 = cell_at(ps, gx, gy);
+        start_rec = cell0 >= 0 ? pickStartRec(ps.gw, cell0, h0) : -1;
+    }
+    if (start_rec < 0) {
+        err = "起点格无体素 (gx=" + std::to_string(gx) + ",gy=" + std::to_string(gy) + ")";
+        return false;
+    }
+    region = ps.gw.rec[static_cast<size_t>(start_rec)].rid;
+    start_cell = cell0;
+    if (goal_deck.has_value()) {
+        const int64_t deck_rec = pickDeckRec(
+            pg.gw,
+            pg.nx,
+            pg.ny,
+            static_cast<int64_t>((g.x - pg.x0) / kCS),
+            static_cast<int64_t>((g.y - pg.y0) / kCS),
+            *goal_deck);
+        if (deck_rec < 0) {
+            err = "终点附近没有声明的面 (deck=" + std::to_string(*goal_deck) + ")";
+            return false;
+        }
+        region = pg.gw.rec[static_cast<size_t>(deck_rec)].rid;
+    }
+    return true;
+}
+
+// 一个类占的格范围。类是可走面的连通片, 类外的格进不了规划图, 所以按类开图与铺满整区等价。
+ZoneBoundsPx regionBounds(const GridPack& gp, const GridZoneDir& gz, uint32_t region)
+{
+    ZoneBoundsPx b;
+    b.x0 = std::numeric_limits<int64_t>::max();
+    b.y0 = std::numeric_limits<int64_t>::max();
+    b.x1 = std::numeric_limits<int64_t>::min();
+    b.y1 = std::numeric_limits<int64_t>::min();
+    GridTile tile;
+    std::vector<uint32_t> rids;
+    for (const GridTileRef& t : gz.tiles) {
+        if (t.records == 0) {
+            continue;
+        }
+        // 先看这块瓦的类号字典。一个类只落在少数几块瓦里, 其余的整块跳过, 不用解开。
+        if (!gp.tileRegions(t, rids) || std::find(rids.begin(), rids.end(), region) == rids.end()) {
+            continue;
+        }
+        if (!gp.decodeTile(t, tile)) {
+            continue;
+        }
+        for (const GridSpanRec& r : tile.rec) {
+            if (r.rid != region) {
+                continue;
+            }
+            const int64_t ix = r.cell % t.nx;
+            const int64_t iy = r.cell / t.nx;
+            if (ix < t.px0 || ix > t.px1 || iy < t.py0 || iy > t.py1) {
+                continue;
+            }
+            b.x0 = std::min<int64_t>(b.x0, t.gx0 + ix);
+            b.y0 = std::min<int64_t>(b.y0, t.gy0 + iy);
+            b.x1 = std::max<int64_t>(b.x1, t.gx0 + ix);
+            b.y1 = std::max<int64_t>(b.y1, t.gy0 + iy);
+        }
+    }
+    return b;
+}
+
 std::optional<WindowInfo> buildWindow(
     WallOracle& wo,
     const GridPack& gp,
@@ -428,7 +314,7 @@ std::optional<WindowInfo> buildWindow(
     const WorldPoint& s_snap,
     const WorldPoint& g,
     double h0,
-    std::optional<double> goal_deck,
+    uint32_t region,
     double x0,
     double y0,
     double x1,
@@ -442,39 +328,23 @@ std::optional<WindowInfo> buildWindow(
     // 窗口原点是对齐过的,所以它落在全局格线上,窗口格与烘焙格一一对上
     const int64_t wgx0 = std::llround(x0 / kCS);
     const int64_t wgy0 = std::llround(y0 / kCS);
-    GridWindow gw;
+    GridPatch pw;
+    pw.x0 = x0;
+    pw.y0 = y0;
+    pw.nx = nx;
+    pw.ny = ny;
+    GridWindow& gw = pw.gw;
     if (!loadGridWindow(gp, gz, wgx0, wgy0, nx, ny, gw)) {
         err = "预烘格图解不开";
         return std::nullopt;
     }
 
-    const auto cell_at = [&](int64_t cx, int64_t cy) {
-        return cx < 0 || cx >= nx || cy < 0 || cy >= ny ? -1 : cy * nx + cx;
-    };
-    int64_t gx = static_cast<int64_t>((s.x - x0) / kCS);
-    int64_t gy = static_cast<int64_t>((s.y - y0) / kCS);
-    int64_t cell0 = cell_at(gx, gy);
-    int64_t start_rec = cell0 >= 0 ? pickStartRec(gw, cell0, h0) : -1;
-    if (start_rec < 0) {
-        // 起点离网时其所在格无体素,退用按楼层吸附过的起点定种子
-        gx = static_cast<int64_t>((s_snap.x - x0) / kCS);
-        gy = static_cast<int64_t>((s_snap.y - y0) / kCS);
-        cell0 = cell_at(gx, gy);
-        start_rec = cell0 >= 0 ? pickStartRec(gw, cell0, h0) : -1;
-    }
-    if (start_rec < 0) {
-        err = "起点格无体素 (gx=" + std::to_string(gx) + ",gy=" + std::to_string(gy) + ")";
+    // 类由调用方定好传进来。这里只要起点格 —— 它是 span 可达域的种子, 与走哪一类无关,
+    // 所以定类的那一路参数传空。
+    uint32_t seed_region = 0;
+    int64_t cell0 = -1;
+    if (!pickRegion(pw, pw, s, s_snap, g, h0, std::nullopt, seed_region, cell0, err)) {
         return std::nullopt;
-    }
-    uint32_t region = gw.rec[static_cast<size_t>(start_rec)].rid;
-    if (goal_deck.has_value()) {
-        const int64_t deck_rec =
-            pickDeckRec(gw, nx, ny, static_cast<int64_t>((g.x - x0) / kCS), static_cast<int64_t>((g.y - y0) / kCS), *goal_deck);
-        if (deck_rec < 0) {
-            err = "终点附近没有声明的面 (deck=" + std::to_string(*goal_deck) + ")";
-            return std::nullopt;
-        }
-        region = gw.rec[static_cast<size_t>(deck_rec)].rid;
     }
 
     WindowInfo info;
@@ -565,9 +435,96 @@ std::optional<WindowInfo> buildWindow(
         }
     }
 
+    const int64_t nc = nx * ny;
+    info.h0 = h0;
+    info.sev.steps.resize(nx, ny);
+    info.st3 = PackSpans(std::move(sp_cell), std::move(sp_h), &info.vis3);
+    info.cidx.assign(static_cast<size_t>(nc), -1);
+    for (size_t ci = 0; ci < info.st3.occ.size(); ++ci) {
+        info.cidx[static_cast<size_t>(info.st3.occ[ci])] = static_cast<int64_t>(ci);
+    }
+
+    // 窗口里 c 沿 (dx,dy) 到 b 这一向是否还走得通:任一对区内 span 满足垂直可达即通。
+    // 任一格在窗口里没有区内 span 就判不通,让这条边保持禁行。
+    const auto passable = [&](int64_t c, int64_t b, int64_t dx, int64_t dy) {
+        const int64_t jc = info.cidx[static_cast<size_t>(c)];
+        const int64_t jb = info.cidx[static_cast<size_t>(b)];
+        if (jc < 0 || jb < 0) {
+            return false;
+        }
+        const SpanTable& st = info.st3;
+        for (int64_t ka = 0; ka < st.ccnt[static_cast<size_t>(jc)]; ++ka) {
+            const int64_t sa = st.cstart[static_cast<size_t>(jc)] + ka;
+            if (info.vis3[static_cast<size_t>(sa)] == 0) {
+                continue;
+            }
+            for (int64_t kb = 0; kb < st.ccnt[static_cast<size_t>(jb)]; ++kb) {
+                const int64_t sb = st.cstart[static_cast<size_t>(jb)] + kb;
+                if (info.vis3[static_cast<size_t>(sb)] == 0) {
+                    continue;
+                }
+                if (RiseOk(st, nx, ny, c, dx, dy, st.sp_h[static_cast<size_t>(sa)], st.sp_h[static_cast<size_t>(sb)])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+
+    // 一格里可见面的最高与最低之差。栅格化的立面被挤进一列, 这个跨度就够得上一堵墙,
+    // 护岸那一列六个面从 270.92 到 276.83 即是。
+    const auto stackSpan = [&](int64_t c) {
+        const int64_t j = info.cidx[static_cast<size_t>(c)];
+        if (j < 0) {
+            return 0.0;
+        }
+        const SpanTable& st = info.st3;
+        double lo = 0.0;
+        double hi = 0.0;
+        bool have = false;
+        for (int64_t k = 0; k < st.ccnt[static_cast<size_t>(j)]; ++k) {
+            const int64_t s = st.cstart[static_cast<size_t>(j)] + k;
+            if (info.vis3[static_cast<size_t>(s)] == 0) {
+                continue;
+            }
+            const double v = st.sp_h[static_cast<size_t>(s)];
+            lo = have ? std::min(lo, v) : v;
+            hi = have ? std::max(hi, v) : v;
+            have = true;
+        }
+        return hi - lo;
+    };
+
+    // c 与 b 两格之间落差最小的那一对面。任一格没有区内面时取无穷大。
+    const auto minGap = [&](int64_t c, int64_t b) {
+        const int64_t jc = info.cidx[static_cast<size_t>(c)];
+        const int64_t jb = info.cidx[static_cast<size_t>(b)];
+        if (jc < 0 || jb < 0) {
+            return std::numeric_limits<double>::infinity();
+        }
+        const SpanTable& st = info.st3;
+        double g = std::numeric_limits<double>::infinity();
+        for (int64_t ka = 0; ka < st.ccnt[static_cast<size_t>(jc)]; ++ka) {
+            const int64_t sa = st.cstart[static_cast<size_t>(jc)] + ka;
+            if (info.vis3[static_cast<size_t>(sa)] == 0) {
+                continue;
+            }
+            for (int64_t kb = 0; kb < st.ccnt[static_cast<size_t>(jb)]; ++kb) {
+                const int64_t sb = st.cstart[static_cast<size_t>(jb)] + kb;
+                if (info.vis3[static_cast<size_t>(sb)] == 0) {
+                    continue;
+                }
+                g = std::min(g, std::fabs(static_cast<double>(
+                    st.sp_h[static_cast<size_t>(sa)] - st.sp_h[static_cast<size_t>(sb)])));
+            }
+        }
+        return g;
+    };
+
     // 禁步面按烘出来的位还原。位序与方向表是写入方定的,方向倒序的那一位对应反向键;
     // 只有正交两向出线段,对角步不挡视线。封堵盖掉的格不再出面,与它被移出可走层一致。
-    const int64_t nc = nx * ny;
+    // 位是按老口径(可迈台阶高 = 体素边长)烘的,这里按 span 的真实高差逐向重判,只放行不新增:
+    // 路缘、地面微起伏这类连续地面不再被切成立面,真断层照旧禁行也照旧挡视线。
     for (int i = 0; i < 4; ++i) {
         const int64_t dx = kGridStepDx[i];
         const int64_t dy = kGridStepDy[i];
@@ -582,14 +539,27 @@ std::optional<WindowInfo> buildWindow(
                 continue;
             }
             const int64_t b = ay * nx + ax;
-            if ((bits & 0x01U) != 0) {
-                info.sev.steps.insert(c * nc + b);
+            const bool fwd = (bits & 0x01U) != 0 && !passable(c, b, dx, dy);
+            const bool bwd = (bits & 0x02U) != 0 && !passable(b, c, -dx, -dy);
+            if (fwd) {
+                info.sev.steps.set(c, b);
             }
-            if ((bits & 0x02U) != 0) {
-                info.sev.steps.insert(b * nc + c);
+            if (bwd) {
+                info.sev.steps.set(b, c);
             }
             if (dx != 0 && dy != 0) {
                 continue;
+            }
+            // 一格里叠着的面总跨度够得上一堵墙时, 这条边贴着被栅格化的立面, 直线一律不许穿。
+            // 其余地方沿用禁步口径: 有一层迈得过去就不挡视线, 最近的一对面落差够不上立面也
+            // 不挡。于是连续路面上的接缝不再把拉直切成锯齿, 立面照旧挡得住直线。
+            if (stackSpan(c) <= kClimb && stackSpan(b) <= kClimb) {
+                if (!fwd && !bwd) {
+                    continue;
+                }
+                if (minGap(c, b) < kWallH) {
+                    continue;
+                }
             }
             const double px = x0 + static_cast<double>(c % nx + dx) * kCS;
             const double py = y0 + static_cast<double>(c / nx + dy) * kCS;
@@ -597,19 +567,13 @@ std::optional<WindowInfo> buildWindow(
             info.sev.p1.push_back({ px + static_cast<double>(dy) * kCS, py + static_cast<double>(dx) * kCS });
         }
     }
-
-    info.h0 = h0;
-    info.st3 = PackSpans(std::move(sp_cell), std::move(sp_h), &info.vis3);
-    info.cidx.assign(static_cast<size_t>(nc), -1);
-    for (size_t ci = 0; ci < info.st3.occ.size(); ++ci) {
-        info.cidx[static_cast<size_t>(info.st3.occ[ci])] = static_cast<int64_t>(ci);
-    }
     const int64_t sj = info.cidx[static_cast<size_t>(cell0)];
     int64_t seed3 = -1;
     float best3 = 0.0F;
-    for (int64_t k = 0; k < info.st3.K; ++k) {
-        const int64_t sid = info.st3.IK[static_cast<size_t>(sj * info.st3.K + k)];
-        if (sid < 0 || info.vis3[static_cast<size_t>(sid)] == 0) {
+    const int64_t sjb = info.st3.cstart[static_cast<size_t>(sj)];
+    for (int64_t k = 0, kn = info.st3.ccnt[static_cast<size_t>(sj)]; k < kn; ++k) {
+        const int64_t sid = sjb + k;
+        if (info.vis3[static_cast<size_t>(sid)] == 0) {
             continue;
         }
         const float d = std::fabs(info.st3.sp_h[static_cast<size_t>(sid)] - static_cast<float>(h0));
@@ -622,6 +586,8 @@ std::optional<WindowInfo> buildWindow(
         err = "起点格没有与终点同类的面";
         return std::nullopt;
     }
+    info.reach3 = SpanReach(seed3, info.st3, info.vis3, nx, ny);
+
     info.segA = info.wP0;
     info.segA.insert(info.segA.end(), info.sev.p0.begin(), info.sev.p0.end());
     info.segB = info.wP1;
@@ -681,6 +647,136 @@ void PullWaypoints(
     dg.waypoints.push_back(anchor);
 }
 
+// 弦沿线的最小净空。取样与层走查同一套整数插值, 于是"弦经过哪些格"在两处判据里是同一个答案。
+double SegMinClr(const Grid<float>& d, double x0, double y0, const WorldPoint& a, const WorldPoint& b)
+{
+    const int64_t ax = static_cast<int64_t>((a.x - x0) / kCS);
+    const int64_t ay = static_cast<int64_t>((a.y - y0) / kCS);
+    const int64_t bx = static_cast<int64_t>((b.x - x0) / kCS);
+    const int64_t by = static_cast<int64_t>((b.y - y0) / kCS);
+    const int64_t n = std::max<int64_t>(std::max(std::abs(bx - ax), std::abs(by - ay)), 1);
+    double m = std::numeric_limits<double>::infinity();
+    for (int64_t k = 0; k <= n; ++k) {
+        const int64_t cx = ax + static_cast<int64_t>(std::nearbyint(static_cast<double>(bx - ax) * static_cast<double>(k) / static_cast<double>(n)));
+        const int64_t cy = ay + static_cast<int64_t>(std::nearbyint(static_cast<double>(by - ay) * static_cast<double>(k) / static_cast<double>(n)));
+        if (cx < 0 || cy < 0 || cx >= d.nx || cy >= d.ny) {
+            continue;
+        }
+        m = std::min(m, static_cast<double>(d.at(cy, cx)));
+    }
+    return m;
+}
+
+bool SegCross(const WorldPoint& p, const WorldPoint& q, const WorldPoint& r, const WorldPoint& s)
+{
+    const auto side = [](const WorldPoint& a, const WorldPoint& b, const WorldPoint& c) {
+        return (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+    };
+    return (side(r, s, p) > 0.0) != (side(r, s, q) > 0.0) && (side(p, q, r) > 0.0) != (side(p, q, s) > 0.0);
+}
+
+// 拐角抬升:把拐点朝净空更高的一侧挪不超过 lift, 两条新弦过与搜索同一道视线判据, 并要求
+// 两段的段内最小净空都不低于原值 —— 穿缝必然让段内极小值下探, 这一条接住了通道掩膜那层保护。
+// 净空严格变大才收, 落在净空极大线上的拐点因此一格不动: 那种贴墙是通道本身的宽度决定的。
+void LiftCorners(
+    std::vector<WorldPoint>& P,
+    const Grid<float>& d,
+    double x0,
+    double y0,
+    const Visibility& vis,
+    const LayerOracle& lyo,
+    float h0,
+    double lift)
+{
+    const int64_t rad = static_cast<int64_t>(std::lround(lift / kCS));
+    if (P.size() < 3 || rad <= 0) {
+        return;
+    }
+    const auto nearest = [](const std::vector<float>& hs, float ref) {
+        float best = hs.front();
+        for (const float v : hs) {
+            if (std::fabs(v - ref) < std::fabs(best - ref)) {
+                best = v;
+            }
+        }
+        return best;
+    };
+    float ha = h0;
+    for (size_t i = 1; i + 1 < P.size(); ++i) {
+        const auto hb = lyo.walk({ P[i - 1], P[i] }, ha);
+        if (!hb.has_value() || hb->empty()) {
+            return;
+        }
+        const float hv0 = nearest(*hb, ha);
+        const int64_t cx0 = static_cast<int64_t>((P[i].x - x0) / kCS);
+        const int64_t cy0 = static_cast<int64_t>((P[i].y - y0) / kCS);
+        if (cx0 < 0 || cy0 < 0 || cx0 >= d.nx || cy0 >= d.ny) {
+            ha = hv0;
+            continue;
+        }
+        const double here = static_cast<double>(d.at(cy0, cx0));
+        const double keep = std::min(
+            SegMinClr(d, x0, y0, P[i - 1], P[i]),
+            SegMinClr(d, x0, y0, P[i], P[i + 1]));
+        // 候选按净空降序, 同净空按线性格序破平 —— 顺序全序, 出线因此逐位可复现
+        std::vector<std::pair<double, int64_t>> cand;
+        for (int64_t dy = -rad; dy <= rad; ++dy) {
+            for (int64_t dx = -rad; dx <= rad; ++dx) {
+                if (dx * dx + dy * dy > rad * rad || (dx == 0 && dy == 0)) {
+                    continue;
+                }
+                const int64_t cx = cx0 + dx;
+                const int64_t cy = cy0 + dy;
+                if (cx < 0 || cy < 0 || cx >= d.nx || cy >= d.ny) {
+                    continue;
+                }
+                if (static_cast<double>(d.at(cy, cx)) > here) {
+                    cand.emplace_back(-static_cast<double>(d.at(cy, cx)), cy * d.nx + cx);
+                }
+            }
+        }
+        std::sort(cand.begin(), cand.end());
+        float hnext = hv0;
+        for (const auto& c : cand) {
+            const WorldPoint w {
+                x0 + (static_cast<double>(c.second % d.nx) + 0.5) * kCS,
+                y0 + (static_cast<double>(c.second / d.nx) + 0.5) * kCS
+            };
+            // 挪到与邻点重合就出零长段, 跟随层从零长段上取不到方向。阈值取半格: 严格小于
+            // 任意两个不同格心的间距, 于是拦得住重合又碰不到合法的一格位移。
+            if (std::hypot(w.x - P[i - 1].x, w.y - P[i - 1].y) < kCS * 0.5
+                || std::hypot(w.x - P[i + 1].x, w.y - P[i + 1].y) < kCS * 0.5) {
+                continue;
+            }
+            if (std::min(SegMinClr(d, x0, y0, P[i - 1], w), SegMinClr(d, x0, y0, w, P[i + 1])) < keep - 1e-9) {
+                continue;
+            }
+            // 隔一段的自交:中间那一小段比位移还短时, 挪一下就把它翻了过去。父链本身是树不自交,
+            // 只有这一类新交点需要挡, 挡在这里比事后去环便宜, 也不用再引一段几何工序。
+            if ((i >= 2 && SegCross(w, P[i + 1], P[i - 2], P[i - 1]))
+                || (i + 2 < P.size() && SegCross(P[i - 1], w, P[i + 1], P[i + 2]))) {
+                continue;
+            }
+            const auto h1 = lyo.walk({ P[i - 1], w }, ha);
+            if (!h1.has_value() || h1->empty()) {
+                continue;
+            }
+            const float hw = nearest(*h1, ha);
+            const auto h2 = lyo.walk({ w, P[i + 1] }, hw);
+            if (!h2.has_value() || h2->empty()) {
+                continue;
+            }
+            if (!vis.ok(P[i - 1], w, ha, hw) || !vis.ok(w, P[i + 1], hw, nearest(*h2, hw))) {
+                continue;
+            }
+            P[i] = w;
+            hnext = hw;
+            break;
+        }
+        ha = hnext;
+    }
+}
+
 // goal_deck: 终点所在面的高度。不声明时终点集是该格全部 span,先够到哪张停哪张
 std::optional<std::vector<WorldPoint>> routeWindow(
     const WindowInfo& info,
@@ -688,10 +784,8 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const WorldPoint& g,
     RouteDiag& dg,
     std::optional<double> goal_deck,
-    bool capture_gap,
     const BaseNavPlanner& pl,
-    uint16_t zid,
-    bool exact_slim)
+    uint16_t zid)
 {
     const int64_t nx = info.nx;
     const int64_t ny = info.ny;
@@ -703,38 +797,67 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     }
     // 边界边只用来算余量, 不用来禁步: 补洞封缝那一步已经判定这些细缝可以跨,
     // 回头再拿同一批边禁掉跨缝的一步, 等于在每道接缝上凭空立一堵墙
-    std::unordered_set<int64_t> blocked_steps(info.sev.steps.begin(), info.sev.steps.end());
+    const EdgeBits& blocked_steps = info.sev.steps;
     // 掩膜距离场对跨越边界边无感, 取到边界的距离的下确界补上
     Mask wfree(nx, ny, 0);
     for (size_t i = 0; i < wfree.v.size(); ++i) {
         wfree.v[i] = info.wcsr.start[i + 1] > info.wcsr.start[i] ? 0 : 1;
+    }
+    // 共面重叠片各自留着自己的边界, 落到格上是间距约 1px 的栅格, 开阔广场因此与窄巷读出同样的
+    // 宽度, 按宽度定价的拓扑层于是分辨不出宽路。摘法只放不加: 四邻全可走、且这四步都没被禁的
+    // 格子才回自由集, 建筑外轮廓恒有一侧没有面, 一根真墙边都摘不掉。
+    for (int64_t y = 1; y + 1 < ny; ++y) {
+        for (int64_t x = 1; x + 1 < nx; ++x) {
+            const int64_t c = y * nx + x;
+            if (wfree.v[static_cast<size_t>(c)] != 0 || walk.v[static_cast<size_t>(c)] == 0) {
+                continue;
+            }
+            bool seam = true;
+            for (const int64_t d : { int64_t { 1 }, int64_t { -1 }, nx, -nx }) {
+                const int64_t b = c + d;
+                if (walk.v[static_cast<size_t>(b)] == 0 || blocked_steps.has(c, b) || blocked_steps.has(b, c)) {
+                    seam = false;
+                    break;
+                }
+            }
+            if (seam) {
+                wfree.v[static_cast<size_t>(c)] = 1;
+            }
+        }
     }
     const Grid<float> wdist = Clearance(wfree);
     Grid<float> dist(nx, ny, 0.0F);
     for (size_t i = 0; i < dist.v.size(); ++i) {
         dist.v[i] = std::min(info.dist.v[i], wdist.v[i]);
     }
-    // 亏欠越多单价越高;脊线保底只进几何口径 prefg,禁入 mult
-    // 拓扑口径的余量目标随局部通道半宽下降, 窄通道的余量单价才不会把能走的路挤出选路
-    const Grid<float> pref = PrefField(dist, false);
-    const Grid<float> prefg = PrefField(dist, true);
-    Grid<float> mult(nx, ny, 0.0F);
+    // VV(c): 障碍按期望净空 c 膨胀后仍自由的格走可见图那一侧, 膨胀后被吃掉的窄处只留中脊,
+    // 对应论文里 V∩M(c) 的那段 Voronoi 弧。净空在这一层是掩膜: 开阔地没有贴墙这个选项, 窄缝
+    // 里没有偏一侧这个选项, 中途钻的一小段窄缝也就无法被整条路长平均掉。
+    const double cpref = kClrPref;
+    const Mask rdg = MedialAxis(dist, kClrLambda);
+    // 通道 = 障碍按 c 膨胀后仍自由的格, 并上中轴带。
+    const auto chan = [&](double cc, const Mask& band) {
+        Mask w(nx, ny, 0);
+        for (size_t i = 0; i < w.v.size(); ++i) {
+            w.v[i] = static_cast<uint8_t>(static_cast<double>(dist.v[i]) >= cc || band.v[i] != 0);
+        }
+        return w;
+    };
+    // 中脊单价按净空亏欠比例上浮, 可见图一侧恒为一。这道价只在几条窄缝之间做取舍。
+    Grid<float> mult(nx, ny, 1.0F);
     for (size_t i = 0; i < mult.v.size(); ++i) {
-        const float c = std::min(std::max((pref.v[i] - dist.v[i]) / pref.v[i], 0.0F), 1.0F);
-        mult.v[i] = 1.0F + static_cast<float>(kLam) * c;
+        const double d = std::min(std::max(static_cast<double>(dist.v[i]), kCS), cpref);
+        mult.v[i] = static_cast<float>(cpref / d);
     }
-    // 几何口径的余量目标: 通道半宽封顶 kGeoR, 供绿段重寻与拉直判定
-    // 通道目标之外再按固定余量目标 kR 追加平方亏欠, 使窄通道内部仍向中间收敛
-    const Grid<float> tgt = TargetField(dist);
-    Grid<float> multg(nx, ny, 0.0F);
-    Grid<float> cf(nx, ny, 0.0F);
-    for (size_t i = 0; i < multg.v.size(); ++i) {
-        const float c = std::min(std::max((tgt.v[i] - dist.v[i]) / tgt.v[i], 0.0F), 1.0F);
-        const float cdef = std::min(std::max((static_cast<float>(kR) - dist.v[i]) / static_cast<float>(kR), 0.0F), 1.0F);
-        multg.v[i] = 1.0F + static_cast<float>(kLam) * c + static_cast<float>(kLamR) * cdef * cdef;
-        cf.v[i] = std::min(dist.v[i], tgt.v[i]);
+    // 定通道那一层的单价同式, 但取值区间换成 [kClrNarrow, kClrWide]。封在 cpref 的话中轴上处处
+    // 够宽的格单价一律为一, 平行分支里最短的那条必然中标 —— 而窄缝总比宽道短, 线于是钻缝。
+    // 基准取在最宽处, 单价因此恒不低于一, 搜索拿欧氏距离当下界才成立; 基准落在窄处则它高估
+    // 剩余代价, 反复重开已定好的节点。整体抬价保持逐格相对贵贱不变, 最优路径集合照旧。
+    Grid<float> multw(nx, ny, 1.0F);
+    for (size_t i = 0; i < multw.v.size(); ++i) {
+        const double d = std::min(std::max(static_cast<double>(dist.v[i]), kClrNarrow), kClrWide);
+        multw.v[i] = static_cast<float>(kClrWide / d);
     }
-    const ClearanceFloor cfl(&cf, &multg, x0, y0, kCS);
 
     const CellPt sc { static_cast<int64_t>((s.x - x0) / kCS), static_cast<int64_t>((s.y - y0) / kCS) };
     const CellPt gc { static_cast<int64_t>((g.x - x0) / kCS), static_cast<int64_t>((g.y - y0) / kCS) };
@@ -768,27 +891,25 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         c3 = Mask(nx, ny, 0);
         for (size_t i = 0; i < use.size(); ++i) {
             const auto cell = static_cast<size_t>(st3.sp_cell[i]);
-            if (info.vis3[i] != 0 && m2.v[cell] != 0) {
+            if (info.reach3[i] != 0 && m2.v[cell] != 0) {
                 use[i] = 1;
                 c3.v[cell] = 1;
             }
         }
     };
     std::vector<uint8_t> useW;
-    std::vector<uint8_t> useC;
     Mask cw3;
-    Mask cc3;
     mk(walk, useW, cw3);
-    mk(info.core, useC, cc3);
     const auto pick = [&](const CellPt& c, const std::vector<uint8_t>& use) {
         std::vector<int64_t> out;
         const int64_t j = info.cidx[static_cast<size_t>(c.y * nx + c.x)];
         if (j < 0) {
             return out;
         }
-        for (int64_t k = 0; k < st3.K; ++k) {
-            const int64_t v = st3.IK[static_cast<size_t>(j * st3.K + k)];
-            if (v >= 0 && use[static_cast<size_t>(v)] != 0) {
+        const int64_t jb = st3.cstart[static_cast<size_t>(j)];
+        for (int64_t k = 0, kn = st3.ccnt[static_cast<size_t>(j)]; k < kn; ++k) {
+            const int64_t v = jb + k;
+            if (use[static_cast<size_t>(v)] != 0) {
                 out.push_back(v);
             }
         }
@@ -828,181 +949,481 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         return v >= 0 ? std::vector<int64_t> { v } : std::vector<int64_t> {};
     };
 
+    // 声明了终点面就按面吸附: 最近的可走格未必带着这张面, 吸上去 goalsOf 会交空集。同距再比
+    // 高度差, 让吸附结果跟 atDeck 选的那张 span 一致。
     const auto nearGoal = [&](const std::vector<uint8_t>& use, const Mask& cells) -> std::pair<std::optional<CellPt>, double> {
         if (!goal_deck.has_value()) {
             return near(cells, gc);
         }
         bool have = false;
-        int64_t best_distance = 0;
-        double best_height = 0.0;
-        CellPt best_cell;
+        int64_t bd = 0;
+        double bh = 0.0;
+        CellPt bc;
         for (size_t i = 0; i < use.size(); ++i) {
             if (use[i] == 0) {
                 continue;
             }
-            const double height_distance = std::fabs(static_cast<double>(st3.sp_h[i]) - *goal_deck);
-            if (height_distance > kDeckBand) {
+            const double dh = std::fabs(static_cast<double>(st3.sp_h[i]) - *goal_deck);
+            if (dh > kDeckBand) {
                 continue;
             }
             const int64_t cell = st3.sp_cell[i];
             const int64_t x = cell % nx;
             const int64_t y = cell / nx;
-            const int64_t distance = (x - gc.x) * (x - gc.x) + (y - gc.y) * (y - gc.y);
-            if (!have || distance < best_distance || (distance == best_distance && height_distance < best_height)) {
+            const int64_t d = (x - gc.x) * (x - gc.x) + (y - gc.y) * (y - gc.y);
+            if (!have || d < bd || (d == bd && dh < bh)) {
                 have = true;
-                best_distance = distance;
-                best_height = height_distance;
-                best_cell = { x, y };
+                bd = d;
+                bh = dh;
+                bc = { x, y };
             }
         }
         if (!have) {
             return { std::nullopt, 0.0 };
         }
-        return { best_cell, std::sqrt(static_cast<double>(best_distance)) * kCS };
+        return { bc, std::sqrt(static_cast<double>(bd)) * kCS };
     };
 
-    auto [as_, dsa] = near(cw3, sc);
-    auto [ag_, dga] = nearGoal(useW, cw3);
-    if (!as_.has_value()) {
+    const auto snap0 = near(cw3, sc);
+    const auto snap1 = nearGoal(useW, cw3);
+    if (!snap0.first.has_value()) {
         dg.err = "walk 掩膜为空";
         return std::nullopt;
     }
-    if (!ag_.has_value()) {
+    if (!snap1.first.has_value()) {
         dg.err = goal_deck.has_value() ? "目标附近没有未封堵的声明面" : "walk 掩膜为空";
         return std::nullopt;
     }
+    std::optional<CellPt> as_ = snap0.first;
+    std::optional<CellPt> ag_ = snap1.first;
+    double dsa = snap0.second;
+    double dga = snap1.second;
 
-    const std::unordered_set<int64_t>* faces = &info.sev.steps;
-    const std::unordered_set<int64_t>* soft = nullptr;
-    const double* soft_penalty = nullptr;
-    Mask on3 = cw3;
-    // 可走集已经限死在终点那张面所属的类里, 起点这侧只剩层内挑高度
-    const auto search = [&](const std::vector<uint8_t>& use,
-                            const Mask& c3,
-                            const std::vector<int64_t>& svs,
-                            const std::vector<int64_t>& gs) -> std::optional<std::vector<int64_t>> {
-        const int64_t sd = atSeedLayer(svs);
-        if (sd < 0) {
+    // VV(c) 的端点接入。作者点位常贴着墙放, 净空低于 c 又不在中脊上, 于是根本不在通道里。
+    // 论文里起终点是单独接进图的: 这里在可走面上求端点到通道的最短接入链, 只放开这一条。接入
+    // 是退化连接而不是路线, 取最短即最小开口; 同长再取瓶颈最高的一条, 最后按格序定全序。八角
+    // 距离取整数以免浮点累加出不确定的序。搜索遍历整片可走面, 口袋与量化平台都困不住它 ——
+    // 端点贴墙因此不再把整条腿的准入等级拖下去, 降档只留给中段真正的窄缝。
+    const auto access = [&](const Mask& lim, const std::optional<CellPt>& a) -> std::optional<std::vector<int64_t>> {
+        if (!a.has_value()) {
+            return std::vector<int64_t> {};
+        }
+        const size_t n = static_cast<size_t>(nx * ny);
+        const size_t s0 = static_cast<size_t>(a->y * nx + a->x);
+        if (lim.v[s0] != 0) {
+            return std::vector<int64_t> {};
+        }
+        std::vector<int32_t> cs(n, std::numeric_limits<int32_t>::max());
+        std::vector<float> bw(n, -1.0F);
+        std::vector<int64_t> pv(n, -1);
+        std::priority_queue<std::tuple<int32_t, float, int64_t>> pq;
+        cs[s0] = 0;
+        bw[s0] = dist.v[s0];
+        pq.emplace(0, bw[s0], -static_cast<int64_t>(s0));
+        int64_t hit = -1;
+        while (!pq.empty()) {
+            const int32_t cc = -std::get<0>(pq.top());
+            const float b = std::get<1>(pq.top());
+            const int64_t c = -std::get<2>(pq.top());
+            pq.pop();
+            if (cc != cs[static_cast<size_t>(c)] || b != bw[static_cast<size_t>(c)]) {
+                continue;
+            }
+            if (lim.v[static_cast<size_t>(c)] != 0) {
+                hit = c;
+                break;
+            }
+            const int64_t cx = c % nx;
+            const int64_t cy = c / nx;
+            for (int64_t dy = -1; dy <= 1; ++dy) {
+                for (int64_t dx = -1; dx <= 1; ++dx) {
+                    const int64_t bx = cx + dx;
+                    const int64_t by = cy + dy;
+                    if ((dx == 0 && dy == 0) || bx < 0 || by < 0 || bx >= nx || by >= ny) {
+                        continue;
+                    }
+                    const size_t k = static_cast<size_t>(by * nx + bx);
+                    if (cw3.v[k] == 0) {
+                        continue;
+                    }
+                    const int32_t kc = cc + (dx != 0 && dy != 0 ? 141 : 100);
+                    const float kb = std::min(b, dist.v[k]);
+                    if (kc < cs[k] || (kc == cs[k] && (kb > bw[k] || (kb == bw[k] && c < pv[k])))) {
+                        cs[k] = kc;
+                        bw[k] = kb;
+                        pv[k] = c;
+                        pq.emplace(-kc, kb, -static_cast<int64_t>(k));
+                    }
+                }
+            }
+        }
+        if (hit < 0) {
             return std::nullopt;
         }
-        return SpanAstar(st3, use, info.cidx, c3, sd, gs, mult, soft, soft_penalty, faces);
-    };
-    const auto findGap = [&](const std::vector<uint8_t>& use, const Mask& cells, const CellPt& start_cell, const CellPt& goal_cell) {
-        const int64_t start_span = atSeedLayer(pick(start_cell, use));
-        const std::vector<int64_t> goal_spans = goalsOf(pick(goal_cell, use));
-        if (start_span < 0 || goal_spans.empty()) {
-            return std::optional<ReachGap> {};
+        std::vector<int64_t> ch;
+        for (int64_t c = hit; c >= 0; c = pv[static_cast<size_t>(c)]) {
+            ch.push_back(c);
         }
-        const std::vector<uint8_t> start_reach = topologyReach(st3, use, info.cidx, cells, { start_span }, faces, false);
-        const std::vector<uint8_t> goal_reach = topologyReach(st3, use, info.cidx, cells, goal_spans, faces, true);
-        return closestReachGap(st3, start_reach, goal_reach, nx, ny, x0, y0);
+        return ch;
+    };
+    const auto openc = [&](Mask& lim, const std::vector<int64_t>& ch) {
+        for (const int64_t c : ch) {
+            lim.v[static_cast<size_t>(c)] = 1;
+        }
     };
 
-    const auto astar_started_at = std::chrono::steady_clock::now();
-    const std::vector<int64_t> walk_goals = goalsOf(pick(*ag_, useW));
-    std::optional<std::vector<int64_t>> qs = search(useW, cw3, pick(*as_, useW), walk_goals);
-    std::optional<ReachGap> failed_gap;
-    if (!qs.has_value()) {
-        const auto [ac_, dc_] = near(cc3, sc);
-        const auto [ag2, dg2] = nearGoal(useC, cc3);
-        if (ac_.has_value() && ag2.has_value()) {
-            const std::vector<int64_t> core_goals = goalsOf(pick(*ag2, useC));
-            qs = search(useC, cc3, pick(*ac_, useC), core_goals);
-            if (qs.has_value()) {
-                on3 = cc3;
-                as_ = ac_;
-                dsa = dc_;
-                ag_ = ag2;
-                dga = dg2;
-                dg.warn.push_back("walk 断开→退回 core");
+
+    const EdgeBits* faces = &info.sev.steps;
+
+    struct Topo
+    {
+        std::vector<CellPt> q;
+        std::optional<std::vector<int64_t>> qs;
+        // 搜索交出的父链。带视线判据那一路才有, 它就是几何要走的折线本身。
+        std::vector<int64_t> corn;
+        Mask on3;
+        std::vector<std::string> warn;
+    };
+
+    // 掩膜内两端是否八连通。span 图上的解投到格上必是掩膜内的一条八连通链, 因此这是必要条件:
+    // 判否时 solve 一定失败, 通道阶梯就不必为接不通的那些档建图。取 core∧lim, 它是 solve 两次
+    // 尝试里最宽松的集合。
+    std::vector<uint8_t> seen(static_cast<size_t>(nx * ny), 0);
+    std::vector<int64_t> stk;
+    const auto linked = [&](const Mask& lim) {
+        const int64_t sc = as_->y * nx + as_->x;
+        const int64_t gc = ag_->y * nx + ag_->x;
+        const auto in = [&](int64_t c) { return info.core.v[static_cast<size_t>(c)] != 0 && lim.v[static_cast<size_t>(c)] != 0; };
+        if (!in(sc) || !in(gc)) {
+            return false;
+        }
+        std::fill(seen.begin(), seen.end(), static_cast<uint8_t>(0));
+        stk.clear();
+        stk.push_back(sc);
+        seen[static_cast<size_t>(sc)] = 1;
+        while (!stk.empty()) {
+            const int64_t c = stk.back();
+            stk.pop_back();
+            if (c == gc) {
+                return true;
             }
-            else if (capture_gap) {
-                failed_gap = findGap(useC, cc3, *ac_, *ag2);
+            const int64_t cx = c % nx;
+            const int64_t cy = c / nx;
+            for (int64_t dy = -1; dy <= 1; ++dy) {
+                for (int64_t dx = -1; dx <= 1; ++dx) {
+                    const int64_t bx = cx + dx;
+                    const int64_t by = cy + dy;
+                    if (bx < 0 || by < 0 || bx >= nx || by >= ny) {
+                        continue;
+                    }
+                    const int64_t b = by * nx + bx;
+                    if (seen[static_cast<size_t>(b)] == 0 && in(b)) {
+                        seen[static_cast<size_t>(b)] = 1;
+                        stk.push_back(b);
+                    }
+                }
             }
         }
-    }
-    if (!qs.has_value() && !failed_gap.has_value() && capture_gap) {
-        failed_gap = findGap(useW, cw3, *as_, *ag_);
-    }
-    std::optional<std::vector<CellPt>> q;
-    dg.timing.astar_ms = ElapsedMs(astar_started_at);
-    if (qs.has_value()) {
-        std::vector<CellPt> cellq;
-        cellq.reserve(qs->size());
-        for (const int64_t v : *qs) {
-            const int64_t c = st3.sp_cell[static_cast<size_t>(v)];
-            cellq.push_back({ c % nx, c / nx });
+        return false;
+    };
+
+    // 一次拓扑求解。硬可达口径逐字不变: 掩膜按 walk→core 退, 层不通再退格级, RiseOk、立面禁步、
+    // 目标面声明与 LayerOracle 全部原样。lim 只做减法, 无权放宽其中任何一条, 舒适选路因此造不出
+    // unreachable。
+    const auto solve = [&](const Mask& lim,
+                           const Grid<float>& price,
+                           const EdgeBits* banned,
+                           const double* bnp,
+                           bool resnap,
+                           const Visibility* vis = nullptr) -> std::optional<Topo> {
+        // 接不通的掩膜不必建图。resnap 那一路会重挑吸附锚点, 判据里的两端就不再成立, 因此不查。
+        if (!resnap && !linked(lim)) {
+            return std::nullopt;
         }
-        q = std::move(cellq);
-    }
-    else {
+        Mask wl(nx, ny, 0);
+        Mask cr(nx, ny, 0);
+        for (size_t i = 0; i < wl.v.size(); ++i) {
+            wl.v[i] = static_cast<uint8_t>(walk.v[i] != 0 && lim.v[i] != 0);
+            cr.v[i] = static_cast<uint8_t>(info.core.v[i] != 0 && lim.v[i] != 0);
+        }
+        std::vector<uint8_t> uw;
+        std::vector<uint8_t> uc;
+        Mask w3;
+        Mask c3;
+        mk(wl, uw, w3);
+        mk(cr, uc, c3);
+        std::vector<int64_t> corn;
+        const auto run = [&](const std::vector<uint8_t>& use, const Mask& m3) -> std::optional<std::vector<int64_t>> {
+            corn.clear();
+            if (m3.at(as_->y, as_->x) == 0 || m3.at(ag_->y, ag_->x) == 0) {
+                return std::nullopt;
+            }
+            const std::vector<int64_t> gs = goalsOf(pick(*ag_, use));
+            const int64_t sd = atSeedLayer(pick(*as_, use));
+            if (as_->x == ag_->x && as_->y == ag_->y) {
+                if (!goal_deck.has_value()) {
+                    return sd >= 0 ? std::optional<std::vector<int64_t>> { { sd } } : std::nullopt;
+                }
+                return gs.empty() ? std::nullopt : std::optional<std::vector<int64_t>> { { gs.front() } };
+            }
+            if (sd < 0 || (goal_deck.has_value() && gs.empty())) {
+                return std::nullopt;
+            }
+            return SpanAstar(st3, use, info.cidx, m3, sd, gs, price, banned, bnp, faces, vis, vis != nullptr ? &corn : nullptr);
+        };
+        Topo t;
+        t.on3 = w3;
+        std::optional<std::vector<int64_t>> sq = run(uw, w3);
+        if (!sq.has_value()) {
+            sq = run(uc, c3);
+            if (sq.has_value()) {
+                t.on3 = c3;
+                t.warn.push_back("walk 断开→退回 core");
+            }
+        }
+        if (sq.has_value()) {
+            t.q.reserve(sq->size());
+            for (const int64_t v : *sq) {
+                const int64_t c = st3.sp_cell[static_cast<size_t>(v)];
+                t.q.push_back({ c % nx, c / nx });
+            }
+            t.qs = std::move(sq);
+            t.corn = std::move(corn);
+            return t;
+        }
         // 格级搜索连 span 都不看, 退到这一级等于把选层交回给楼层盲的那一级
         if (goal_deck.has_value()) {
-            char buf[32];
-            if (failed_gap.has_value()) {
-                dg.gap_start = failed_gap->start;
-                dg.gap_goal = failed_gap->goal;
-                dg.gap_distance = failed_gap->distance;
-                std::snprintf(buf, sizeof(buf), "%.1f", failed_gap->distance);
-                dg.err = "目标面与起点不连通 (最近断口 " + std::string(buf) + "px)";
-            }
-            else {
-                std::snprintf(buf, sizeof(buf), "%.2f", *goal_deck);
-                dg.err = "目标面不可达 (声明 " + std::string(buf) + ")";
-            }
             return std::nullopt;
         }
-        std::tie(as_, dsa) = near(walk, sc);
-        std::tie(ag_, dga) = near(walk, gc);
-        on3 = walk;
+        // 吸附锚点是硬可达的判定, 舒适选路无权改它: 够不着就报断开, 让基线并集那一轮接手
+        if (!resnap) {
+            return std::nullopt;
+        }
+        std::tie(as_, dsa) = near(wl, sc);
+        std::tie(ag_, dga) = near(wl, gc);
+        if (!as_.has_value() || !ag_.has_value()) {
+            return std::nullopt;
+        }
+        t.on3 = wl;
+        std::optional<std::vector<CellPt>> qc;
         if (as_->x == ag_->x && as_->y == ag_->y) {
-            q = std::vector<CellPt> { *as_ };
+            qc = std::vector<CellPt> { *as_ };
         }
         else {
-            q = CostAstar(walk, *as_, *ag_, mult, soft, soft_penalty, faces);
+            qc = CostAstar(wl, *as_, *ag_, price, banned, bnp, faces);
         }
-        if (!q.has_value()) {
-            on3 = info.core;
-            q = CostAstar(info.core, *as_, *ag_, mult, soft, soft_penalty, faces);
-            if (q.has_value()) {
-                dg.warn.push_back("walk 断开→退回 core");
+        if (!qc.has_value()) {
+            t.on3 = cr;
+            qc = CostAstar(cr, *as_, *ag_, price, banned, bnp, faces);
+            if (qc.has_value()) {
+                t.warn.push_back("walk 断开→退回 core");
             }
         }
-        if (!q.has_value()) {
-            if (failed_gap.has_value()) {
-                dg.gap_start = failed_gap->start;
-                dg.gap_goal = failed_gap->goal;
-                dg.gap_distance = failed_gap->distance;
-            }
-            dg.err = "不连通";
+        if (!qc.has_value()) {
             return std::nullopt;
         }
-        dg.warn.push_back("层不连通→退回格级");
-    }
-    dg.x0 = x0;
-    dg.y0 = y0;
-    dg.nx = nx;
-    dg.ny = ny;
-    dg.astar_cells.reserve(q->size());
-    dg.astar_heights.reserve(q->size());
-    for (size_t i = 0; i < q->size(); ++i) {
-        const CellPt& c = (*q)[i];
-        dg.astar_cells.push_back({ x0 + (static_cast<double>(c.x) + 0.5) * kCS, y0 + (static_cast<double>(c.y) + 0.5) * kCS });
-        if (qs.has_value()) {
-            dg.astar_heights.push_back(static_cast<double>(st3.sp_h[static_cast<size_t>((*qs)[i])]));
+        t.warn.push_back("层不连通→退回格级");
+        t.q = std::move(*qc);
+        return t;
+    };
+
+    // 硬约束基线: 原始硬图上的纯长度最短路。硬图可达它就一定存在, 于是舒适选路永远不会把一条
+    // 走得通的腿判成不可达。它同时是端点的回缩通道 —— 起终点天然贴墙时, 搜索沿这条按亏欠计价
+    // 的线走几格就自然汇入 VV 图, 端点附近不需要任何放宽半径。
+    const Mask all(nx, ny, 1);
+    const Grid<float> unit(nx, ny, 1.0F);
+    const std::optional<Topo> base = solve(all, unit, nullptr, nullptr, true);
+    if (!base.has_value()) {
+        if (goal_deck.has_value()) {
+            const std::vector<int64_t> gv = pick(*ag_, useW);
+            std::vector<float> hv;
+            hv.reserve(gv.size());
+            for (const int64_t v : gv) {
+                hv.push_back(st3.sp_h[static_cast<size_t>(v)]);
+            }
+            std::sort(hv.begin(), hv.end());
+            hv.erase(std::unique(hv.begin(), hv.end()), hv.end());
+            std::string list;
+            char buf[32];
+            for (const float h : hv) {
+                std::snprintf(buf, sizeof(buf), "%.2f", static_cast<double>(h));
+                list += (list.empty() ? "" : ", ") + std::string(buf);
+            }
+            std::snprintf(buf, sizeof(buf), "%.2f", *goal_deck);
+            dg.err =
+                "目标面不可达 (声明 " + std::string(buf) + ", 终点格里的面 " + (list.empty() ? std::string("无") : "[" + list + "]") + ")";
+            return std::nullopt;
         }
-        else {
-            dg.astar_heights.push_back(static_cast<double>(info.lh.at(c.y, c.x)));
+        dg.err = "不连通";
+        return std::nullopt;
+    }
+
+    // 突变抬升逐次计税: 跨越两侧找不到任何一对高差在坡度内的面时才算一次台阶, 连续缓坡不计。
+    // 它不参与硬连通性, 只在同样走得通的两条线之间偏向不必迈的那条, 封不死唯一的楼梯。
+    const double tax = kStepTax;
+    EdgeBits step_edges;
+    step_edges.resize(nx, ny);
+    if (tax > 0.0) {
+        for (int64_t y = 0; y < ny; ++y) {
+            for (int64_t x = 0; x < nx; ++x) {
+                const int64_t c = y * nx + x;
+                const int64_t jc = info.cidx[static_cast<size_t>(c)];
+                if (jc < 0) {
+                    continue;
+                }
+                for (int64_t i = 0; i < 4; ++i) {
+                    for (const int64_t sg : { int64_t { 1 }, int64_t { -1 } }) {
+                        const int64_t dx = sg * kGridStepDx[i];
+                        const int64_t dy = sg * kGridStepDy[i];
+                        const int64_t bx = x + dx;
+                        const int64_t by = y + dy;
+                        if (bx < 0 || by < 0 || bx >= nx || by >= ny) {
+                            continue;
+                        }
+                        const int64_t b = by * nx + bx;
+                        const int64_t jb = info.cidx[static_cast<size_t>(b)];
+                        if (jb < 0) {
+                            continue;
+                        }
+                        const double up = kSlope * std::hypot(static_cast<double>(dx), static_cast<double>(dy)) * kCS;
+                        bool any = false;
+                        bool flat = false;
+                        for (int64_t ka = 0; ka < st3.ccnt[static_cast<size_t>(jc)] && !flat; ++ka) {
+                            const int64_t sa = st3.cstart[static_cast<size_t>(jc)] + ka;
+                            if (info.vis3[static_cast<size_t>(sa)] == 0) {
+                                continue;
+                            }
+                            for (int64_t kb = 0; kb < st3.ccnt[static_cast<size_t>(jb)]; ++kb) {
+                                const int64_t sb = st3.cstart[static_cast<size_t>(jb)] + kb;
+                                if (info.vis3[static_cast<size_t>(sb)] == 0) {
+                                    continue;
+                                }
+                                const float ha = st3.sp_h[static_cast<size_t>(sa)];
+                                const float hb = st3.sp_h[static_cast<size_t>(sb)];
+                                if (!RiseOk(st3, nx, ny, c, dx, dy, ha, hb)) {
+                                    continue;
+                                }
+                                any = true;
+                                if (static_cast<double>(hb) - static_cast<double>(ha) <= up) {
+                                    flat = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (any && !flat) {
+                            step_edges.set(c, b);
+                        }
+                    }
+                }
+            }
         }
     }
+
+    // 自由集是膨胀后仍自由的实心区并上中脊: 宽处走净空 ≥c 的实心区, 窄段走中轴弧,
+    // 缝的准入因此由中轴自己定, 不必再拿一串阈值去试。
+    const EdgeBits* bn = tax > 0.0 ? &step_edges : nullptr;
+    const double* bp = tax > 0.0 ? &tax : nullptr;
+    // 立面这笔税以普通路面的一格为单位报价, 而定通道那层把普通路面抬了价, 汇率得跟着换,
+    // 否则同一道立面在拓扑层变便宜, 花两格路就能买过去。
+    const double taxw = tax * kClrWide / cpref;
+    const double* bpw = tax > 0.0 ? &taxw : nullptr;
+    const Mask chan0 = chan(cpref, Mask(nx, ny, 0));
+    // 接入链只算一次: 目标取实心通道 chan0, 它是自由集的子集, 接到它就等于接进了自由集。
+    // 两端各自对着 chan0 算, 谁先算不影响结果。够不到 chan0 的那一端才对着自由集重算。
+    const std::optional<std::vector<int64_t>> ac_s = access(chan0, as_);
+    const std::optional<std::vector<int64_t>> ac_g = access(chan0, ag_);
+    const auto join = [&](Mask& lim) {
+        const std::optional<std::vector<int64_t>> s = ac_s.has_value() ? ac_s : access(lim, as_);
+        const std::optional<std::vector<int64_t>> g = ac_g.has_value() ? ac_g : access(lim, ag_);
+        if (s.has_value()) {
+            openc(lim, *s);
+        }
+        if (g.has_value()) {
+            openc(lim, *g);
+        }
+    };
+    const auto toWorld = [&](const std::vector<std::vector<WorldPoint>>& loops) {
+        std::vector<std::vector<WorldPoint>> out;
+        out.reserve(loops.size());
+        for (const auto& L : loops) {
+            std::vector<WorldPoint> w;
+            w.reserve(L.size());
+            for (const auto& p : L) {
+                w.push_back({ x0 + p.x * kCS, y0 + p.y * kCS });
+            }
+            out.push_back(std::move(w));
+        }
+        return out;
+    };
+    const auto loops_core = toWorld(TraceContours(info.core));
+
+    Mask limw = chan(cpref, rdg);
+    join(limw);
+    std::optional<Topo> vv = solve(limw, multw, bn, bpw, false);
+    if (!vv.has_value()) {
+        limw = Mask(nx, ny, 1);
+        vv = solve(limw, multw, bn, bpw, false);
+        dg.warn.emplace_back("通道未接通, 退到全图亏欠计价");
+    }
+    // 通道定了才铺几何: 同一张中标掩膜上再解一次, 这次带视线判据, 出来的父链已经是紧绷折线。
+    // 弦只许落在 cpref 的实心区内 —— 中脊是净空极大线, 对它取直等于把线拽向墙, 那一段照旧逐格走;
+    // 实心区里单价恒为一, 弦的欧氏长度因此就是精确代价。拐角余量往上收窄这个自由集: 弦贴着障碍角
+    // 切过去时净空恰好等于这道阈值, 收一点拐角就离墙远一点, 且收后仍是单价恒一的子集, 计价不受影响。
+    const double solid_c = cpref + kGeoMargin;
+    // 走廊以中标的那条逐格路径为骨干张开, 半宽照它自己的净空取。按全局中轴取则会隔墙认到旁边
+    // 那条窄缝上去: 宽处的半宽被压回地板, 该收紧的地方一点没收紧。
+    Mask bb(nx, ny, 0);
+    for (const CellPt& c : (vv.has_value() ? vv->q : base->q)) {
+        bb.at(c.y, c.x) = 1;
+    }
+    Mask band;
+    const Grid<float> cw = CorridorWidth(dist, bb, &band);
+    Mask solidc(nx, ny, 0);
+    for (size_t i = 0; i < solidc.v.size(); ++i) {
+        const double need = std::max(solid_c, kChordFrac * static_cast<double>(cw.v[i]));
+        solidc.v[i] = static_cast<uint8_t>(static_cast<double>(dist.v[i]) >= need);
+    }
+    const Blockers::OnMask onv { &solidc, x0, y0, kCS };
+    const Blockers blk_vis({}, nullptr, nullptr, onv);
+    const Visibility vis(&blk_vis, &lyo, faces, bn, nx, ny, x0, y0);
+    if (vv.has_value()) {
+        // 几何这一次锁在走廊里。放开的话它按恒一的单价重解一遍, 又会挑回拓扑刚花钱绕开的那条
+        // 窄分支 —— 加权白做。走廊含整条骨干, 两端锚点也在上面, 接通性因此照旧成立。
+        Mask limg = limw;
+        for (size_t i = 0; i < limg.v.size(); ++i) {
+            limg.v[i] = static_cast<uint8_t>(limg.v[i] != 0 && band.v[i] != 0);
+        }
+        std::optional<Topo> tt = solve(limg, mult, bn, bp, false, &vis);
+        if (!tt.has_value()) {
+            // 走廊是偏好, 接通性不是。二维骨干必在走廊里, 层间接不通才会走到这里; 放开重解, 拿回
+            // 的仍是紧绷折线, 只是不再受宽度约束。
+            tt = solve(limw, mult, bn, bp, false, &vis);
+        }
+        if (tt.has_value()) {
+            vv = std::move(tt);
+        }
+    }
+    const Topo& win = vv.has_value() ? *vv : *base;
+    for (const std::string& w : win.warn) {
+        dg.warn.push_back(w);
+    }
+    Mask on3 = win.on3;
+    const std::optional<std::vector<CellPt>> q = win.q;
+    const std::optional<std::vector<int64_t>>& qs = win.qs;
     dg.snap_start = dsa;
     dg.snap_goal = dga;
-    const int64_t NC = nx * ny;
+    // 末段是从锚点直连终点的,不走阻挡检查。终点自己就踩在可走面上却没进可达集时,
+    // 这一跳等于穿墙;终点没有面才是作者点位的容差,那种照旧直连。
+    if (gc.x >= 0 && gc.y >= 0 && gc.x < nx && gc.y < ny) {
+        // 判据是硬可达集: on3 现在是舒适通道, 终点天然贴墙就不在里面, 拿它判等于把贴墙的
+        // 终点一律说成被禁行边隔开
+        dg.hop_barrier = walk.at(gc.y, gc.x) != 0 && base->on3.at(gc.y, gc.x) == 0;
+    }
     std::vector<size_t> bad;
     for (size_t k = 1; k < q->size(); ++k) {
         const int64_t ca = (*q)[k - 1].y * nx + (*q)[k - 1].x;
         const int64_t cb = (*q)[k].y * nx + (*q)[k].x;
-        if (blocked_steps.contains(ca * NC + cb)) {
+        if (blocked_steps.has(ca, cb)) {
             bad.push_back(k);
         }
     }
@@ -1019,239 +1440,65 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         }
         return out;
     };
-    const auto toWorld = [&](const std::vector<std::vector<WorldPoint>>& loops) {
-        std::vector<std::vector<WorldPoint>> out;
-        out.reserve(loops.size());
-        for (const auto& L : loops) {
-            std::vector<WorldPoint> w;
-            w.reserve(L.size());
-            for (const auto& p : L) {
-                w.push_back({ x0 + p.x * kCS, y0 + p.y * kCS });
-            }
-            out.push_back(std::move(w));
+    // 取直与计价共用一道挡线。两处判据分家的话, 搜索挑出来的居中拐点会被取直按另一套阈值切回墙边。
+    // 它与这条腿有没有放宽无关: 放宽只为接通拓扑, 几何跟着放宽等于把钻缝从拓扑挪到几何。合不成弦
+    // 的段退回逐格路径, 那条路径走的是中轴。再并上选定路径自身放宽一格, 端点接入链与格级回退路径
+    // 因此不会被自己的挡线判掉。
+    Mask tm = solidc;
+    join(tm);
+    for (size_t i = 0; i < tm.v.size(); ++i) {
+        tm.v[i] = static_cast<uint8_t>(tm.v[i] != 0 && on3.v[i] != 0);
+    }
+    for (const CellPt& c : *q) {
+        if (on3.at(c.y, c.x) == 0) {
+            continue;
         }
-        return out;
-    };
-
-    const auto loops_core = toWorld(TraceContours(info.core));
-    const Blockers::OnMask onm { &on3, x0, y0, kCS };
+        for (int64_t dy = -1; dy <= 1; ++dy) {
+            for (int64_t dx = -1; dx <= 1; ++dx) {
+                const int64_t bx = c.x + dx;
+                const int64_t by = c.y + dy;
+                if (bx >= 0 && by >= 0 && bx < nx && by < ny && on3.at(by, bx) != 0) {
+                    tm.at(by, bx) = 1;
+                }
+            }
+        }
+    }
+    const Blockers::OnMask onm { &tm, x0, y0, kCS };
     const Blockers blk_gray(loops_core, &info.segA, &info.segB, onm);
+    // 几何用的视线判据: 跨步禁行、立面、层判据与搜索那一个逐字相同, 只把自由区从计价用的实心区
+    // 换成这条路自己的管道。实心区那道限制是为让弦的欧氏长度等于代价, 只约束搜索; 终线取直不计价,
+    // 该由能不能走过去决定。管道只比路径宽一格, 拉直因此仍出不了这条通道。
+    const Visibility vis_geo(&blk_gray, &lyo, faces, bn, nx, ny, x0, y0);
 
-    std::vector<uint8_t> grn(q->size());
-    for (size_t i = 0; i < q->size(); ++i) {
-        grn[i] = static_cast<uint8_t>(dist.at((*q)[i].y, (*q)[i].x) >= prefg.at((*q)[i].y, (*q)[i].x) - 1e-9F);
-    }
-
-    struct Run
-    {
-        bool green;
-        int64_t i0;
-        int64_t i1;
-    };
-
-    std::vector<Run> runs;
-    for (size_t i = 0; i < q->size();) {
-        size_t j2 = i;
-        while (j2 + 1 < q->size() && grn[j2 + 1] == grn[i]) {
-            ++j2;
-        }
-        runs.push_back({ grn[i] != 0, static_cast<int64_t>(i), static_cast<int64_t>(j2) });
-        i = j2 + 1;
-    }
-    const auto merge = [](const std::vector<Run>& rs) {
-        std::vector<Run> out;
-        for (const auto& r : rs) {
-            if (!out.empty() && out.back().green == r.green) {
-                out.back().i1 = r.i1;
-            }
-            else {
-                out.push_back(r);
-            }
-        }
-        return out;
-    };
-    for (size_t k = 0; k < runs.size(); ++k) {
-        if (!runs[k].green && static_cast<double>(runs[k].i1 - runs[k].i0) * kCS < 2.0 && k > 0 && k < runs.size() - 1) {
-            runs[k].green = true;
+    // 全局取直: 挡线用同一张选定通道掩膜, 取直因此出不了通道。不再切绿灰段, 也不再把落脚处限在
+    // 原路径两侧 —— 那两件事把几何锁死在拓扑之后, 整段本可直走也留着折线。积分守卫一并撤掉:
+    // 通道是掩膜, 直不直走该由能不能看见对端决定, 不由两条线的积分代价谁便宜决定。
+    // 几何取搜索交出的父链: 拐点是搜索自己挑的, 弦是搜索自己验过视线的。逐格路径只留给拓扑
+    // 判据读。终线仍走一道最远可见 —— Theta* 只出近紧线 —— 判据用几何那一个, 中脊带里搜索
+    // 逐格走出来的点因此还能并成弦。
+    const bool by_corn = win.corn.size() >= 2;
+    const std::vector<int64_t>& gsrc = by_corn ? win.corn : (qs.has_value() ? *qs : win.corn);
+    std::vector<float> hs;
+    if (by_corn || qs.has_value()) {
+        hs.reserve(gsrc.size());
+        for (const int64_t v : gsrc) {
+            hs.push_back(st3.sp_h[static_cast<size_t>(v)]);
         }
     }
-    runs = merge(runs);
-    for (auto& r : runs) {
-        if (r.green && static_cast<double>(r.i1 - r.i0) * kCS < 1.5) {
-            r.green = false;
+    std::vector<CellPt> gq;
+    if (by_corn) {
+        gq.reserve(gsrc.size());
+        for (const int64_t v : gsrc) {
+            const int64_t c = st3.sp_cell[static_cast<size_t>(v)];
+            gq.push_back({ c % nx, c / nx });
         }
     }
-    const std::vector<Run> mg = merge(runs);
-
-    double rerouted_ms = 0.0;
-    double string_pull_ms = 0.0;
-    std::vector<WorldPoint> taut;
-    for (const auto& run : mg) {
-        const int64_t iend = std::min(run.i1 + 1, static_cast<int64_t>(q->size()) - 1);
-        const std::vector<CellPt> cells(q->begin() + run.i0, q->begin() + iend + 1);
-        std::vector<int64_t> sub;
-        std::vector<float> hs;
-        if (qs.has_value()) {
-            sub.assign(qs->begin() + run.i0, qs->begin() + iend + 1);
-            hs.reserve(sub.size());
-            for (const int64_t v : sub) {
-                hs.push_back(st3.sp_h[static_cast<size_t>(v)]);
-            }
-        }
-        std::vector<WorldPoint> pp = cen(cells);
-        if (cells.size() >= 2) {
-            std::optional<Blockers> blk_green;
-            if (run.green) {
-                const auto rerouted_started_at = std::chrono::steady_clock::now();
-                // 绿段:er = 腐蚀掩膜(脊线保底限路径走廊±kR),重寻守卫 l2≤l1×1.2+2px
-                Mask pm(nx, ny, 0);
-                for (const auto& c : cells) {
-                    pm.at(c.y, c.x) = 1;
-                }
-                Mask pmd = pm;
-                const int64_t kd = static_cast<int64_t>(std::ceil(kR / kCS));
-                const std::pair<int64_t, int64_t> axes[2] = { { 0, 1 }, { 1, 0 } };
-                for (const auto& [ddy, ddx] : axes) {
-                    Mask acc = pmd;
-                    for (int64_t sh = 1; sh <= kd; ++sh) {
-                        for (const int64_t sgn : { int64_t(1), int64_t(-1) }) {
-                            const int64_t dy = sgn * sh * ddy;
-                            const int64_t dx = sgn * sh * ddx;
-                            for (int64_t y = std::max<int64_t>(0, dy); y < ny + std::min<int64_t>(0, dy); ++y) {
-                                for (int64_t x = std::max<int64_t>(0, dx); x < nx + std::min<int64_t>(0, dx); ++x) {
-                                    if (pmd.at(y - dy, x - dx) != 0) {
-                                        acc.at(y, x) = 1;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    pmd = acc;
-                }
-                Mask er(nx, ny, 0);
-                for (int64_t y = 0; y < ny; ++y) {
-                    for (int64_t x = 0; x < nx; ++x) {
-                        er.at(y, x) = static_cast<uint8_t>(
-                            dist.at(y, x) >= pref.at(y, x) || (dist.at(y, x) >= prefg.at(y, x) && pmd.at(y, x) != 0) || pm.at(y, x) != 0);
-                    }
-                }
-                // 切角规则要求对角步两个正交伴格都在掩膜里, 原掩膜搜不出时才放行伴格;
-                // 挡线集恒用 er, 伴格进挡线集会把角内侧开口
-                Mask ers = er;
-                for (size_t k2 = 1; k2 < cells.size(); ++k2) {
-                    const CellPt& a3 = cells[k2 - 1];
-                    const CellPt& b3 = cells[k2];
-                    if (a3.x != b3.x && a3.y != b3.y) {
-                        ers.at(a3.y, b3.x) = 1;
-                        ers.at(b3.y, a3.x) = 1;
-                    }
-                }
-                // 重寻硬禁穿墙步,不可避穿墙处切开逐子段重寻,原步原样保留
-                std::vector<size_t> cuts;
-                for (const size_t k : bad) {
-                    if (k > static_cast<size_t>(run.i0) && k <= static_cast<size_t>(run.i0) + cells.size() - 1) {
-                        cuts.push_back(k - static_cast<size_t>(run.i0));
-                    }
-                }
-                cuts.push_back(cells.size());
-                const auto research = [&](const Mask& m3, std::vector<float>& oh) -> std::optional<std::vector<CellPt>> {
-                    std::vector<uint8_t> ue;
-                    Mask ce;
-                    if (qs.has_value()) {
-                        mk(m3, ue, ce);
-                    }
-                    std::vector<CellPt> o2;
-                    oh.clear();
-                    size_t a2 = 0;
-                    for (const size_t c2 : cuts) {
-                        const size_t b2 = c2 - 1;
-                        if (a2 == b2) {
-                            o2.push_back(cells[a2]);
-                            if (qs.has_value()) {
-                                oh.push_back(hs[a2]);
-                            }
-                        }
-                        else if (!qs.has_value()) {
-                            const auto r2 = CostAstar(m3, cells[a2], cells[b2], multg, &blocked_steps, nullptr);
-                            if (!r2.has_value()) {
-                                return std::nullopt;
-                            }
-                            o2.insert(o2.end(), r2->begin(), r2->end());
-                        }
-                        else {
-                            const auto r2 = SpanAstar(st3, ue, info.cidx, ce, sub[a2], { sub[b2] }, multg, &blocked_steps, nullptr);
-                            if (!r2.has_value()) {
-                                return std::nullopt;
-                            }
-                            for (const int64_t v : *r2) {
-                                const int64_t c = st3.sp_cell[static_cast<size_t>(v)];
-                                o2.push_back({ c % nx, c / nx });
-                                oh.push_back(st3.sp_h[static_cast<size_t>(v)]);
-                            }
-                        }
-                        a2 = c2;
-                    }
-                    return o2;
-                };
-                std::vector<float> h2;
-                auto q2 = research(er, h2);
-                if (!q2.has_value()) {
-                    q2 = research(ers, h2);
-                }
-                if (q2.has_value()) {
-                    double l1 = 0.0;
-                    double l2 = 0.0;
-                    for (size_t k = 1; k < cells.size(); ++k) {
-                        l1 +=
-                            std::hypot(static_cast<double>(cells[k].x - cells[k - 1].x), static_cast<double>(cells[k].y - cells[k - 1].y));
-                    }
-                    for (size_t k = 1; k < q2->size(); ++k) {
-                        l2 +=
-                            std::hypot(static_cast<double>((*q2)[k].x - (*q2)[k - 1].x), static_cast<double>((*q2)[k].y - (*q2)[k - 1].y));
-                    }
-                    if (l2 <= l1 * 1.2 + 2.0 / kCS) {
-                        pp = cen(*q2);
-                        for (const auto& p : pp) {
-                            if (dg.rerouted_points.empty()
-                                || std::hypot(p.x - dg.rerouted_points.back().x, p.y - dg.rerouted_points.back().y) > 1e-9) {
-                                dg.rerouted_points.push_back(p);
-                            }
-                        }
-                        if (qs.has_value()) {
-                            hs = h2;
-                        }
-                    }
-                }
-                auto loops_er = TraceContours(er);
-                std::vector<std::vector<WorldPoint>> lp;
-                lp.reserve(loops_er.size() + loops_core.size());
-                for (const auto& L : loops_er) {
-                    lp.push_back(SimplifyLoop(L, kMaxErr / kCS));
-                }
-                auto lw = toWorld(lp);
-                lw.insert(lw.end(), loops_core.begin(), loops_core.end());
-                blk_green.emplace(lw, &info.segA, &info.segB, onm);
-                rerouted_ms += ElapsedMs(rerouted_started_at);
-            }
-            const auto string_pull_started_at = std::chrono::steady_clock::now();
-            pp = StringPull(
-                pp,
-                blk_green.has_value() ? *blk_green : blk_gray,
-                &cfl,
-                hs.empty() ? nullptr : &lyo,
-                hs.empty() ? nullptr : &hs);
-            string_pull_ms += ElapsedMs(string_pull_started_at);
-        }
-        if (!taut.empty() && !pp.empty() && std::hypot(pp.front().x - taut.back().x, pp.front().y - taut.back().y) < 1e-9) {
-            pp.erase(pp.begin());
-        }
-        taut.insert(taut.end(), pp.begin(), pp.end());
+    std::vector<WorldPoint> taut = cen(by_corn ? gq : *q);
+    if (taut.size() >= 2) {
+        taut = StringPull(taut, blk_gray, hs.empty() ? nullptr : &lyo, hs.empty() ? nullptr : &hs,
+            by_corn ? &vis_geo : nullptr);
     }
-    dg.timing.rerouted_ms = rerouted_ms;
-    dg.string_pull_points = taut;
-    dg.timing.string_pull_ms = string_pull_ms;
 
-    const auto assembled_started_at = std::chrono::steady_clock::now();
     std::vector<WorldPoint> line;
     line.push_back(s);
     line.insert(line.end(), taut.begin(), taut.end());
@@ -1269,27 +1516,37 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             ded.push_back(stripped[i]);
         }
     }
-    dg.assembled_points = ded;
-    dg.timing.assembled_ms = ElapsedMs(assembled_started_at);
-    const auto loop_fixed_started_at = std::chrono::steady_clock::now();
-    std::vector<WorldPoint> out = DropLoops(ded);
-    dg.loop_fixed_points = out;
-    dg.timing.loop_fixed_ms = ElapsedMs(loop_fixed_started_at);
-    const LayerOracle* lyo_p = qs.has_value() ? &lyo : nullptr;
-    const float lyo_h = qs.has_value() ? st3.sp_h[static_cast<size_t>(qs->front())] : 0.0F;
-    const auto slim_started_at = std::chrono::steady_clock::now();
-    if (out.size() > 2) {
-        out = Slim(out, blk_gray, &cfl, lyo_p, lyo_h, true, exact_slim ? out.size() : 0);
+    const LayerOracle* lyo_p = (by_corn || qs.has_value()) ? &lyo : nullptr;
+    const float lyo_h = hs.empty() ? 0.0F : hs.front();
+    std::vector<WorldPoint> out;
+    if (by_corn && ded.size() >= 2) {
+        // 父链是树, 自身不自交, 去环无事可做; 落点已经是拐点, 抽稀与拐角外扩同理。剩下的只有
+        // 共线冗余点: a-b 与 b-c 都过视线且三点共线, a-c 必过, 删 b 是纯几何恒等。
+        out.push_back(ded.front());
+        for (size_t i = 1; i + 1 < ded.size(); ++i) {
+            const WorldPoint& a = out.back();
+            const WorldPoint& b = ded[i];
+            const WorldPoint& c = ded[i + 1];
+            const double cr = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+            if (std::fabs(cr) > 1e-9 * std::max(1.0, std::hypot(c.x - a.x, c.y - a.y))) {
+                out.push_back(b);
+            }
+        }
+        out.push_back(ded.back());
     }
-    dg.slim_points = out;
-    dg.timing.slim_ms = ElapsedMs(slim_started_at);
-    const auto widened_started_at = std::chrono::steady_clock::now();
-    if (out.size() > 2) {
-        out = WidenCorners(out, blk_gray, dist, info.x0, info.y0, kCS, &cfl, lyo_p, lyo_h);
+    else if (by_corn) {
+        out = ded;
     }
-    dg.widened_points = out;
-    dg.timing.widened_ms = ElapsedMs(widened_started_at);
-    const auto final_started_at = std::chrono::steady_clock::now();
+    else {
+        out = ded;
+    }
+    // 抬升放在取直之后: 放前面的话抬起来的拐点让两侧更容易连通, 取直一刀就把它跳过去了。
+    // 判据换成硬墙那一套 —— 通道掩膜只比路径宽一格, 拿它判等于禁止拐点离开原路径。
+    if (lyo_p != nullptr && out.size() >= 3) {
+        const Blockers blk_hard(loops_core, &info.segA, &info.segB, std::nullopt);
+        const Visibility vis_hard(&blk_hard, &lyo, faces, bn, nx, ny, x0, y0);
+        LiftCorners(out, dist, x0, y0, vis_hard, lyo, lyo_h, kLiftMax);
+    }
     dg.clearance.reserve(out.size());
     for (const auto& p : out) {
         const int64_t cx = std::min(std::max(static_cast<int64_t>(std::floor((p.x - info.x0) / kCS)), int64_t { 0 }), nx - 1);
@@ -1319,12 +1576,10 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         }
     }
     PullWaypoints(out, dg, pl, zid, blk_gray, lyo_p != nullptr);
-    dg.planned_points = out;
-    dg.timing.final_ms = ElapsedMs(final_started_at);
     return out;
 }
 
-} // namespace
+}
 
 RecastNavEngine::RecastNavEngine(const BaseNavPack& pack, const BaseNavPlanner& planner)
     : pack_(pack)
@@ -1345,7 +1600,7 @@ RecastNavEngine::ZoneEntry& RecastNavEngine::zoneEntry(const std::string& name)
     auto it = zones_.find(name);
     if (it == zones_.end()) {
         ZoneEntry e;
-        e.zc = std::make_unique<ZoneClean>(pack_, planner_, name);
+        e.zc = std::make_unique<ZoneClean>(pack_, planner_, name, walkable_flags_);
         if (e.zc->valid()) {
             e.wo = std::make_unique<WallOracle>(*e.zc);
         }
@@ -1376,6 +1631,70 @@ void RecastNavEngine::warm(const std::string& zone_name)
     zoneEntry(zone_name);
 }
 
+void RecastNavEngine::setWalkableFlags(uint32_t flags)
+{
+    const std::lock_guard<std::mutex> lk(mutex_);
+    if (flags == walkable_flags_) {
+        return;
+    }
+    walkable_flags_ = flags;
+    zones_.clear(); // 缓存的 ZoneClean 是按旧掩码建的,留着就是两套判据混用
+}
+
+std::vector<std::vector<uint32_t>> RecastNavEngine::regionsNear(const std::string& zone_name, const std::vector<WorldPoint>& points)
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::vector<uint32_t>> out(points.size());
+    const GridZoneDir* gz = grid_.valid() ? grid_.findZone(zone_name) : nullptr;
+    if (gz == nullptr || points.empty()) {
+        return out;
+    }
+    const double cs = grid_.cellSize();
+    const auto rad = static_cast<int64_t>(std::ceil(kSnapRadius / cs));
+    // 一批点常挤在同几张瓦上,而解瓦不带缓存,逐点各解一遍就是这道闸的全部开销。
+    std::unordered_map<const GridTileRef*, std::vector<size_t>> by_tile;
+    std::vector<int64_t> pcx(points.size());
+    std::vector<int64_t> pcy(points.size());
+    for (size_t i = 0; i < points.size(); ++i) {
+        pcx[i] = static_cast<int64_t>(std::floor(points[i].x / cs));
+        pcy[i] = static_cast<int64_t>(std::floor(points[i].y / cs));
+        for (const GridTileRef* t : GridTilesInRect(*gz, pcx[i] - rad, pcy[i] - rad, pcx[i] + rad, pcy[i] + rad)) {
+            if (t->records != 0) {
+                by_tile[t].push_back(i);
+            }
+        }
+    }
+    GridTile tile;
+    for (const auto& [t, idx] : by_tile) {
+        if (!grid_.decodeTile(*t, tile)) {
+            continue;
+        }
+        for (const GridSpanRec& r : tile.rec) {
+            // 无高度可传播的补格两个选类器都不会挑;别的一律算进来,宁可多算不可漏。
+            if ((r.flags & kGridFlagFill) != 0) {
+                continue;
+            }
+            const int64_t gx = t->gx0 + r.cell % t->nx;
+            const int64_t gy = t->gy0 + r.cell / t->nx;
+            for (const size_t i : idx) {
+                if (std::llabs(gx - pcx[i]) > rad || std::llabs(gy - pcy[i]) > rad) {
+                    continue;
+                }
+                const double dx = (static_cast<double>(gx) + 0.5) * cs - points[i].x;
+                const double dy = (static_cast<double>(gy) + 0.5) * cs - points[i].y;
+                if (dx * dx + dy * dy <= kSnapRadius * kSnapRadius) {
+                    out[i].push_back(r.rid);
+                }
+            }
+        }
+    }
+    for (std::vector<uint32_t>& v : out) {
+        std::sort(v.begin(), v.end());
+        v.erase(std::unique(v.begin(), v.end()), v.end());
+    }
+    return out;
+}
+
 RecastPlanResult RecastNavEngine::planLocked(
     const std::string& zone_name,
     const WorldPoint& start,
@@ -1386,7 +1705,7 @@ RecastPlanResult RecastNavEngine::planLocked(
     const std::vector<uint32_t>& blocked,
     const std::vector<WorldPoint>& blocked_points,
     const std::function<bool()>& should_stop,
-    bool exact_slim)
+    bool /*exact_slim*/)
 {
     RecastPlanResult res;
     if (!grid_.valid()) {
@@ -1435,115 +1754,111 @@ RecastPlanResult RecastNavEngine::planLocked(
     const double zga = coreAnchorPx(grid_, *gz, goal);
     if (zsa > kSnapRadius || zga > kSnapRadius) {
         char buf[128];
-        std::snprintf(buf, sizeof(buf), "端点接不上可走层 (起 %.1fpx / 终 %.1fpx, 疑似不连通)", zsa, zga);
+        std::snprintf(buf, sizeof(buf), "端点接不上可走层 (起 %.1fpx / 终 %.1fpx)", zsa, zga);
         res.error = buf;
         return res;
     }
 
-    // 扩窗只留两档。59 条生产腿里 ×100 与 ×200 零成功,只在必败腿上把时间烧掉。
-    constexpr int kWidenSteps = 2;
-    const double margins[kWidenSteps] = { kMargin, kMargin * 2 };
-    const int pass_count = (blocked.empty() && blocked_points.empty()) ? kWidenSteps : 1;
-    std::string last_err;
-    const auto storeDebug = [&](RouteDiag& dg) {
-        res.debug.x0 = dg.x0;
-        res.debug.y0 = dg.y0;
-        res.debug.nx = dg.nx;
-        res.debug.ny = dg.ny;
-        res.debug.cell_size = kCS;
-        res.debug.timing = dg.timing;
-        res.debug.astar_cells = std::move(dg.astar_cells);
-        res.debug.astar_heights = std::move(dg.astar_heights);
-        res.debug.rerouted_points = std::move(dg.rerouted_points);
-        res.debug.string_pull_points = std::move(dg.string_pull_points);
-        res.debug.assembled_points = std::move(dg.assembled_points);
-        res.debug.loop_fixed_points = std::move(dg.loop_fixed_points);
-        res.debug.slim_points = std::move(dg.slim_points);
-        res.debug.widened_points = std::move(dg.widened_points);
-        res.debug.planned_points = std::move(dg.planned_points);
-        res.debug.gap_start = dg.gap_start;
-        res.debug.gap_goal = dg.gap_goal;
-        res.debug.gap_distance = dg.gap_distance;
-        res.debug.warnings = dg.warn;
+    // 规划范围是这条腿走的那一类占的格。按端点包围盒开窗、失败再逐档扩大的老做法有两处死结:
+    // 绕行只要落在盒外就等不到更大的窗口, 连通的腿被判成不连通; 升档又把每次失败的代价乘上档数。
+    // 类是可走面的连通片, 类外的格进不了规划图, 所以按类开图与铺满整区拿到的是同一张图 ——
+    // 绕多远都在图里, 而不必为区里另外几千个类白铺内存。
+    const auto loadPatch = [&](const WorldPoint& a, const WorldPoint& b, double pad, GridPatch& p) {
+        const auto r = static_cast<int64_t>(std::ceil(pad / kCS));
+        const int64_t ax = static_cast<int64_t>(std::floor(a.x / kCS));
+        const int64_t ay = static_cast<int64_t>(std::floor(a.y / kCS));
+        const int64_t bx = static_cast<int64_t>(std::floor(b.x / kCS));
+        const int64_t by = static_cast<int64_t>(std::floor(b.y / kCS));
+        const int64_t gx0 = std::min(ax, bx) - r;
+        const int64_t gy0 = std::min(ay, by) - r;
+        p.nx = std::max(ax, bx) + r - gx0 + 1;
+        p.ny = std::max(ay, by) + r - gy0 + 1;
+        p.x0 = static_cast<double>(gx0) * kCS;
+        p.y0 = static_cast<double>(gy0) * kCS;
+        return loadGridWindow(grid_, *gz, gx0, gy0, p.nx, p.ny, p.gw);
     };
-    for (int pass = 0; pass < pass_count; ++pass) {
-        const bool last_margin = pass + 1 == kWidenSteps;
-        const bool capture_gap = pass + 1 == pass_count;
-        // 窗口边界对齐到全局网格。原点直接取 min-margin 时, 起点差 0.06px 就换一套体素相位,
-        // 同一段路两次规划得到的格子划分不同; 对齐后相位只由世界坐标决定, 与起终点无关。
-        const double x0 = std::floor((std::min(start.x, goal.x) - margins[pass]) / kCS) * kCS;
-        const double y0 = std::floor((std::min(start.y, goal.y) - margins[pass]) / kCS) * kCS;
-        const double x1 = std::ceil((std::max(start.x, goal.x) + margins[pass]) / kCS) * kCS;
-        const double y1 = std::ceil((std::max(start.y, goal.y) + margins[pass]) / kCS) * kCS;
-        const int64_t nx = static_cast<int64_t>(std::ceil((x1 - x0) / kCS));
-        const int64_t ny = static_cast<int64_t>(std::ceil((y1 - y0) / kCS));
-        if (nx * ny > kMaxCells) {
-            res.error = "窗口过大 (" + std::to_string(nx) + "×" + std::to_string(ny) + " 格)";
-            return res;
-        }
-        if (pass > 0 && should_stop && should_stop()) {
-            res.error = "规划已取消";
-            return res;
-        }
-        std::string err;
-        auto info = buildWindow(wo, grid_, *gz, zc, start, ss->point, goal, h0, gdk, x0, y0, x1, y1, blocked_local, blocked_points, err);
-        if (info.has_value()) {
-            RouteDiag dg;
-            auto line = routeWindow(*info, start, goal, dg, gdk, capture_gap, planner_, zc.zone_id, exact_slim);
-            if (line.has_value()) {
-                // 锚点远 = 走廊出窗,同触界扩窗,否则末段盲跳穿墙
-                if (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius) {
-                    if (last_margin) {
-                        char buf[128];
-                        std::snprintf(
-                            buf,
-                            sizeof(buf),
-                            "端点接不上可走层 (起 %.1fpx / 终 %.1fpx, 疑似不连通)",
-                            dg.snap_start,
-                            dg.snap_goal);
-                        res.error = buf;
-                        return res;
-                    }
-                    err = "端点锚点过远,扩窗重跑";
-                }
-                else {
-                    double mnx = line->front().x;
-                    double mxx = mnx;
-                    double mny = line->front().y;
-                    double mxy = mny;
-                    for (const auto& p : *line) {
-                        mnx = std::min(mnx, p.x);
-                        mxx = std::max(mxx, p.x);
-                        mny = std::min(mny, p.y);
-                        mxy = std::max(mxy, p.y);
-                    }
-                    const double pad = 2.0;
-                    if (last_margin || (mnx > x0 + pad && mxx < x1 - pad && mny > y0 + pad && mxy < y1 - pad)) {
-                        res.ok = true;
-                        res.points = *line;
-                        for (size_t i = 1; i < line->size(); ++i) {
-                            res.length += std::hypot((*line)[i].x - (*line)[i - 1].x, (*line)[i].y - (*line)[i - 1].y);
-                        }
-                        res.warnings = dg.warn;
-                        res.clearance = dg.clearance;
-                        res.snap_start = dg.snap_start;
-                        res.snap_goal = dg.snap_goal;
-                        res.waypoints = std::move(dg.waypoints);
-                        storeDebug(dg);
-                        return res;
-                    }
-                    err = "终线触界,扩窗重跑";
-                }
-            }
-            else {
-                err = dg.err.empty() ? "路线失败" : dg.err;
-                storeDebug(dg);
-            }
-        }
-        last_err = err;
+    // 定类只读起点那一格与终点吸附半径内的格, 两小块解开就够。
+    GridPatch ps;
+    GridPatch pg;
+    if (!loadPatch(start, ss->point, kCS, ps) || (gdk.has_value() && !loadPatch(goal, goal, kSnapRadius, pg))) {
+        res.error = "预烘格图解不开";
+        return res;
     }
-    res.error = last_err.empty() ? "路线失败" : last_err;
+    std::string err;
+    uint32_t region = 0;
+    int64_t seed_cell = -1;
+    if (!pickRegion(ps, pg, start, ss->point, goal, h0, gdk, region, seed_cell, err)) {
+        res.error = err;
+        return res;
+    }
+    ps = GridPatch {};
+    pg = GridPatch {};
+    const ZoneBoundsPx zb = regionBounds(grid_, *gz, region);
+    if (zb.empty()) {
+        res.error = "类内没有格图";
+        return res;
+    }
+    // 场都是局部算子, 依赖半径合起来不到这一圈。留出它, 类边缘那几格算出来的场
+    // 就与在整区图上算的逐位相同。
+    constexpr int64_t kFieldHalo = 32;
+    const int64_t nx = zb.x1 - zb.x0 + 1 + 2 * kFieldHalo;
+    const int64_t ny = zb.y1 - zb.y0 + 1 + 2 * kFieldHalo;
+    if (nx * ny > kMaxCells) {
+        res.error = "类过大 (" + std::to_string(nx) + "×" + std::to_string(ny) + " 格)";
+        return res;
+    }
+    if (should_stop && should_stop()) {
+        res.error = "规划已取消";
+        return res;
+    }
+    const double x0 = static_cast<double>(zb.x0 - kFieldHalo) * kCS;
+    const double y0 = static_cast<double>(zb.y0 - kFieldHalo) * kCS;
+    const double x1 = static_cast<double>(zb.x1 + 1 + kFieldHalo) * kCS;
+    const double y1 = static_cast<double>(zb.y1 + 1 + kFieldHalo) * kCS;
+
+    auto info = buildWindow(wo, grid_, *gz, zc, start, ss->point, goal, h0, region, x0, y0, x1, y1, blocked_local, blocked_points, err);
+    if (!info.has_value()) {
+        res.error = err.empty() ? "路线失败" : err;
+        return res;
+    }
+    RouteDiag dg;
+    auto line = routeWindow(*info, start, goal, dg, gdk, planner_, zc.zone_id);
+    if (!line.has_value()) {
+        res.error = dg.err.empty() ? "路线失败" : dg.err;
+        return res;
+    }
+    if (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius || dg.hop_barrier) {
+        // 两端都已过全区核心闸, 端点确实在可走面上, 差的是从起点出发的可达域够不着它。图铺满了
+        // 整区, 这就是最终结论。
+        char buf[160];
+        std::snprintf(
+            buf,
+            sizeof(buf),
+            "从起点走不到终点 (端点%s, 可达区距 起 %.1fpx / 终 %.1fpx)",
+            dg.hop_barrier ? "被禁行边隔开" : "在可走面上",
+            dg.snap_start,
+            dg.snap_goal);
+        res.error = buf;
+        return res;
+    }
+    res.ok = true;
+    res.points = *line;
+    for (size_t i = 1; i < line->size(); ++i) {
+        res.length += std::hypot((*line)[i].x - (*line)[i - 1].x, (*line)[i].y - (*line)[i - 1].y);
+    }
+    res.warnings = dg.warn;
+    res.clearance = dg.clearance;
+    res.snap_start = dg.snap_start;
+    res.snap_goal = dg.snap_goal;
+    res.waypoints = std::move(dg.waypoints);
+    res.debug.x0 = x0;
+    res.debug.y0 = y0;
+    res.debug.nx = nx;
+    res.debug.ny = ny;
+    res.debug.cell_size = kCS;
+    res.debug.planned_points = res.points;
+    res.debug.warnings = res.warnings;
     return res;
 }
 
-} // namespace navmesh::recast
+}

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -395,7 +395,7 @@ ZoneBoundsPx regionBounds(const GridPack& gp, const GridZoneDir& gz, uint32_t re
 std::optional<WindowInfo> buildWindow(
     const GridPack& gp,
     const GridZoneDir& gz,
-    const ZoneClean& zc,
+    ZoneClean& zc,
     const WorldPoint& s,
     const WorldPoint& s_snap,
     const WorldPoint& g,
@@ -515,6 +515,9 @@ std::optional<WindowInfo> buildWindow(
         }
     }
     lh = Grid<float>();
+    // 区网格的最后一个读者到此为止。往下是 span 表与各场, 建窗最吃内存的一段,
+    // 让它挂到那时就是白抬一份峰值。
+    zc.release();
 
     // 封堵点无自带高度;窗口层已按起点层高筛过,直接按平面距离盖格即可
     if (!blocked_points.empty()) {
@@ -1997,7 +2000,7 @@ RecastPlanResult RecastNavEngine::planLocked(
         res.error = ze.zc->error();
         return res;
     }
-    const ZoneClean& zc = *ze.zc;
+    ZoneClean& zc = *ze.zc;
     std::vector<int32_t> blocked_local;
     for (const uint32_t t : blocked) {
         const int64_t local = static_cast<int64_t>(t) - zc.lo;

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -37,7 +37,7 @@ struct WindowInfo
     Grid<float> dist;
     std::vector<WorldPoint> wP0;
     std::vector<WorldPoint> wP1;
-    WallCsr wcsr;
+    Mask whit;
     StepBarrier sev;
     std::vector<WorldPoint> segA;
     std::vector<WorldPoint> segB;
@@ -409,7 +409,7 @@ std::optional<WindowInfo> buildWindow(
             info.wP1.push_back(walls.p1[i]);
         }
     }
-    info.wcsr = BuildWallIndex(info.wP0, info.wP1, x0, y0, nx, ny);
+    info.whit = WallHits(info.wP0, info.wP1, x0, y0, nx, ny);
 
     if (!blocked_local.empty()) {
         std::vector<std::array<int32_t, 3>> bt;
@@ -813,7 +813,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     // 掩膜距离场对跨越边界边无感, 取到边界的距离的下确界补上
     Mask wfree(nx, ny, 0);
     for (size_t i = 0; i < wfree.v.size(); ++i) {
-        wfree.v[i] = info.wcsr.start[i + 1] > info.wcsr.start[i] ? 0 : 1;
+        wfree.v[i] = info.whit.v[i] != 0 ? 0 : 1;
     }
     // 共面重叠片各自留着自己的边界, 落到格上是间距约 1px 的栅格, 开阔广场因此与窄巷读出同样的
     // 宽度, 按宽度定价的拓扑层于是分辨不出宽路。摘法只放不加: 四邻全可走、且这四步都没被禁的

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -100,7 +100,6 @@ private:
     struct ZoneEntry
     {
         std::unique_ptr<ZoneClean> zc;
-        std::unique_ptr<WallOracle> wo;
     };
 
     ZoneEntry& zoneEntry(const std::string& name);

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -31,18 +31,18 @@ struct RecastPlanResult
     // 空 = 该腿没有层预言机,拉直交给调用方。
     std::vector<size_t> waypoints;
 
+    // 规划各阶段的中间产物。每个数组恰好对应一段算法的出口, 看哪一段把线拐坏了就开哪一层。
     struct Debug
     {
         struct Timing
         {
-            double astar_ms = 0.0;
-            double rerouted_ms = 0.0;
-            double string_pull_ms = 0.0;
-            double assembled_ms = 0.0;
-            double loop_fixed_ms = 0.0;
-            double slim_ms = 0.0;
-            double widened_ms = 0.0;
-            double final_ms = 0.0;
+            double window_ms = 0.0; // 建窗
+            double topology_ms = 0.0; // 硬约束基线 + 通道拓扑
+            double geometry_ms = 0.0; // 走廊内带视线重解
+            double pull_ms = 0.0; // 取直
+            double assemble_ms = 0.0; // 端点拼接、去重、共线去冗
+            double lift_ms = 0.0; // 拐角抬升
+            double total_ms = 0.0;
         } timing;
 
         double x0 = 0.0;
@@ -50,15 +50,12 @@ struct RecastPlanResult
         int64_t nx = 0;
         int64_t ny = 0;
         double cell_size = 0.0;
-        std::vector<WorldPoint> astar_cells;
-        std::vector<double> astar_heights;
-        std::vector<WorldPoint> rerouted_points;
-        std::vector<WorldPoint> string_pull_points;
-        std::vector<WorldPoint> assembled_points;
-        std::vector<WorldPoint> loop_fixed_points;
-        std::vector<WorldPoint> slim_points;
-        std::vector<WorldPoint> widened_points;
-        std::vector<WorldPoint> planned_points;
+        std::vector<WorldPoint> topology_cells; // 拓扑那一层的逐格路径
+        std::vector<double> topology_heights; // 与 topology_cells 同长的所在面高度
+        std::vector<WorldPoint> taut_points; // 几何搜索交出的父链折线, 取直之前
+        std::vector<WorldPoint> pulled_points; // 取直之后
+        std::vector<WorldPoint> assembled_points; // 拼上端点并去冗之后, 抬升之前
+        std::vector<WorldPoint> planned_points; // 终线
         std::optional<WorldPoint> gap_start;
         std::optional<WorldPoint> gap_goal;
         std::optional<double> gap_distance;
@@ -85,8 +82,7 @@ public:
         float goal_deck_y = kBaseNavFloorYNone,
         const std::vector<uint32_t>& blocked = {},
         const std::vector<WorldPoint>& blocked_points = {},
-        const std::function<bool()>& should_stop = {},
-        bool exact_slim = false);
+        const std::function<bool()>& should_stop = {});
 
     // 把该区的清洗网格与墙 oracle 提前建好,让首条路线不必冷吃这份开销。
     void warm(const std::string& zone_name);
@@ -117,8 +113,7 @@ private:
         float goal_deck_y,
         const std::vector<uint32_t>& blocked,
         const std::vector<WorldPoint>& blocked_points,
-        const std::function<bool()>& should_stop,
-        bool exact_slim);
+        const std::function<bool()>& should_stop);
 
     const BaseNavPack& pack_;
     const BaseNavPlanner& planner_;

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -91,6 +91,15 @@ public:
     // 把该区的清洗网格与墙 oracle 提前建好,让首条路线不必冷吃这份开销。
     void warm(const std::string& zone_name);
 
+    // 改可走面掩码(源 surface flags 的收取位)。运行端必须与烘格图时用的是同一个值,
+    // 否则格图铺出来的可走面与规划器认的可走面对不上。改值会丢掉已建好的区缓存。
+    void setWalkableFlags(uint32_t flags);
+
+    // 逐点给出附近的全区类号。一次规划只在单一类号内找路,所以两点的类号集合不相交
+    // 时这条腿必败,不必真去规划。半径取 kSnapRadius:选类只发生在点所在格或吸附后
+    // 那一格,都不出这个圈。空集表示无从判断(无格图、未知区、点周围无体素)。
+    std::vector<std::vector<uint32_t>> regionsNear(const std::string& zone_name, const std::vector<WorldPoint>& points);
+
 private:
     struct ZoneEntry
     {
@@ -117,6 +126,7 @@ private:
     std::unordered_map<std::string, ZoneEntry> zones_;
     GridPack grid_; // 包里的预烘格图,没有它就没法规划
     std::string grid_error_;
+    uint32_t walkable_flags_ = kWalkableFlagsDefault;
 };
 
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "BaseNavGeometry.h"
+#include "NavParallel.h"
 
 namespace navmesh::recast
 {
@@ -39,16 +40,20 @@ PolyMesh::PolyMesh(std::vector<WorldPoint> v, std::vector<std::array<int32_t, 3>
     , H(std::move(h))
     , T(std::move(t))
 {
-    for (auto& tri : T) {
-        const WorldPoint& a = V[tri[0]];
-        const double abx = V[tri[1]].x - a.x;
-        const double aby = V[tri[1]].y - a.y;
-        const double acx = V[tri[2]].x - a.x;
-        const double acy = V[tri[2]].y - a.y;
-        if (abx * acy - aby * acx < 0.0) {
-            std::swap(tri[1], tri[2]);
+    const int64_t nt = static_cast<int64_t>(T.size());
+    ParallelChunks(nt, NavWorkerCount(nt), [&](size_t, int64_t b, int64_t e) {
+        for (int64_t i = b; i < e; ++i) {
+            auto& tri = T[static_cast<size_t>(i)];
+            const WorldPoint& a = V[tri[0]];
+            const double abx = V[tri[1]].x - a.x;
+            const double aby = V[tri[1]].y - a.y;
+            const double acx = V[tri[2]].x - a.x;
+            const double acy = V[tri[2]].y - a.y;
+            if (abx * acy - aby * acx < 0.0) {
+                std::swap(tri[1], tri[2]);
+            }
         }
-    }
+    });
     buildNb();
     buildGrid();
 }
@@ -84,18 +89,20 @@ void PolyMesh::buildNb()
             slot[w] = static_cast<int32_t>(i * 3 + k);
         }
     }
-    for (int64_t i = 0; i < m; ++i) {
-        for (int64_t k = 0; k < 3; ++k) {
-            const int32_t a = T[static_cast<size_t>(i)][k];
-            const int32_t b = T[static_cast<size_t>(i)][(k + 1) % 3];
-            for (int32_t p = at[static_cast<size_t>(b)]; p < at[static_cast<size_t>(b) + 1]; ++p) {
-                if (dst[static_cast<size_t>(p)] == a) {
-                    NB[static_cast<size_t>(i)][k] = slot[static_cast<size_t>(p)] / 3;
-                    break;
+    ParallelChunks(m, NavWorkerCount(m), [&](size_t, int64_t lo_i, int64_t hi_i) {
+        for (int64_t i = lo_i; i < hi_i; ++i) {
+            for (int64_t k = 0; k < 3; ++k) {
+                const int32_t a = T[static_cast<size_t>(i)][k];
+                const int32_t b = T[static_cast<size_t>(i)][(k + 1) % 3];
+                for (int32_t p = at[static_cast<size_t>(b)]; p < at[static_cast<size_t>(b) + 1]; ++p) {
+                    if (dst[static_cast<size_t>(p)] == a) {
+                        NB[static_cast<size_t>(i)][k] = slot[static_cast<size_t>(p)] / 3;
+                        break;
+                    }
                 }
             }
         }
-    }
+    });
 }
 
 void PolyMesh::buildGrid()
@@ -351,15 +358,22 @@ ZoneClean::ZoneClean(
         ++n_dup;
     }
     std::vector<int64_t> kills;
-    for (int64_t slot = 0; slot < 3 * m; ++slot) {
-        const int32_t j = NB[static_cast<size_t>(slot / 3)][slot % 3];
-        if (j < 0) {
-            continue;
-        }
-        const auto& back = NB[static_cast<size_t>(j)];
-        if (back[0] != slot / 3 && back[1] != slot / 3 && back[2] != slot / 3) {
-            kills.push_back(slot);
-        }
+    {
+        const size_t nw = NavWorkerCount(3 * m);
+        std::vector<std::vector<int64_t>> bins(nw);
+        ParallelChunks(3 * m, nw, [&](size_t w, int64_t lo_s, int64_t hi_s) {
+            for (int64_t slot = lo_s; slot < hi_s; ++slot) {
+                const int32_t j = NB[static_cast<size_t>(slot / 3)][slot % 3];
+                if (j < 0) {
+                    continue;
+                }
+                const auto& back = NB[static_cast<size_t>(j)];
+                if (back[0] != slot / 3 && back[1] != slot / 3 && back[2] != slot / 3) {
+                    bins[w].push_back(slot);
+                }
+            }
+        });
+        ConcatBins(bins, kills);
     }
     for (const int64_t slot : kills) {
         NB[static_cast<size_t>(slot / 3)][slot % 3] = -1;
@@ -369,13 +383,20 @@ ZoneClean::ZoneClean(
     const auto& offs = planner.adjacencyOffsets();
     const auto& lnks = planner.adjacencyLinks();
     std::vector<std::pair<int32_t, int32_t>> lab;
-    for (int64_t src = lo; src < hi; ++src) {
-        for (uint32_t li = offs[static_cast<size_t>(src)]; li < offs[static_cast<size_t>(src) + 1]; ++li) {
-            const int64_t tgt = lnks[li];
-            if (tgt >= lo && tgt < hi && src < tgt) {
-                lab.emplace_back(static_cast<int32_t>(src - lo), static_cast<int32_t>(tgt - lo));
+    {
+        const size_t nw = NavWorkerCount(hi - lo);
+        std::vector<std::vector<std::pair<int32_t, int32_t>>> bins(nw);
+        ParallelChunks(hi - lo, nw, [&](size_t w, int64_t b, int64_t e) {
+            for (int64_t src = lo + b; src < lo + e; ++src) {
+                for (uint32_t li = offs[static_cast<size_t>(src)]; li < offs[static_cast<size_t>(src) + 1]; ++li) {
+                    const int64_t tgt = lnks[li];
+                    if (tgt >= lo && tgt < hi && src < tgt) {
+                        bins[w].emplace_back(static_cast<int32_t>(src - lo), static_cast<int32_t>(tgt - lo));
+                    }
+                }
             }
-        }
+        });
+        ConcatBins(bins, lab);
     }
     // 有背书的三角对按小号一端分桶。一个三角挂不了几条链接, 桶内直查比散列表快,
     // 而且查的是同一个集合, 结果与散列表一致。
@@ -393,27 +414,38 @@ ZoneClean::ZoneClean(
     }
     std::vector<int64_t> cand;
     int64_t n_mask_cut = 0;
-    for (int64_t slot = 0; slot < 3 * m; ++slot) {
-        const int64_t i = slot / 3;
-        const int32_t j = NB[static_cast<size_t>(i)][slot % 3];
-        if (j < 0) {
-            continue;
-        }
-        // 掩码外的三角一条缝都不接:它跟谁都断,自己落成孤立分量。割在并查集之前,
-        // 分量因此天然把水体、禁区与可走面分开。
-        if (walkable[static_cast<size_t>(i)] == 0 || walkable[static_cast<size_t>(j)] == 0) {
-            cand.push_back(slot);
-            ++n_mask_cut;
-            continue;
-        }
-        const auto a = static_cast<int32_t>(std::min<int64_t>(i, j));
-        const auto b = static_cast<int32_t>(std::max<int64_t>(i, j));
-        bool hit = false;
-        for (int32_t p = lat[static_cast<size_t>(a)]; p < lat[static_cast<size_t>(a) + 1] && !hit; ++p) {
-            hit = lhi[static_cast<size_t>(p)] == b;
-        }
-        if (!hit) {
-            cand.push_back(slot);
+    {
+        const size_t nw = NavWorkerCount(3 * m);
+        std::vector<std::vector<int64_t>> bins(nw);
+        std::vector<int64_t> masked(nw, 0);
+        ParallelChunks(3 * m, nw, [&](size_t w, int64_t lo_s, int64_t hi_s) {
+            for (int64_t slot = lo_s; slot < hi_s; ++slot) {
+                const int64_t i = slot / 3;
+                const int32_t j = NB[static_cast<size_t>(i)][slot % 3];
+                if (j < 0) {
+                    continue;
+                }
+                // 掩码外的三角一条缝都不接:它跟谁都断,自己落成孤立分量。割在并查集之前,
+                // 分量因此天然把水体、禁区与可走面分开。
+                if (walkable[static_cast<size_t>(i)] == 0 || walkable[static_cast<size_t>(j)] == 0) {
+                    bins[w].push_back(slot);
+                    ++masked[w];
+                    continue;
+                }
+                const auto a = static_cast<int32_t>(std::min<int64_t>(i, j));
+                const auto b = static_cast<int32_t>(std::max<int64_t>(i, j));
+                bool hit = false;
+                for (int32_t p = lat[static_cast<size_t>(a)]; p < lat[static_cast<size_t>(a) + 1] && !hit; ++p) {
+                    hit = lhi[static_cast<size_t>(p)] == b;
+                }
+                if (!hit) {
+                    bins[w].push_back(slot);
+                }
+            }
+        });
+        ConcatBins(bins, cand);
+        for (const int64_t c : masked) {
+            n_mask_cut += c;
         }
     }
     int64_t n_cut = 0;
@@ -477,17 +509,28 @@ ZoneClean::ZoneClean(
     // 同分量共焊边且非近连通 → srcadj 窄通道
     std::vector<int32_t> ia;
     std::vector<int32_t> ib;
-    for (const auto& [la, lb] : lab) {
-        // 掩码外的三角不接 hop。下面两个消费循环(跨分量门户、同分量 srcadj 窄通道)
-        // 都从 ia/ib 取料,滤在这里就是两处一起滤。
-        if (walkable[static_cast<size_t>(la)] == 0 || walkable[static_cast<size_t>(lb)] == 0) {
-            continue;
-        }
-        const auto& row = NB[static_cast<size_t>(la)];
-        if (row[0] != lb && row[1] != lb && row[2] != lb) {
-            ia.push_back(la);
-            ib.push_back(lb);
-        }
+    {
+        const auto nlab = static_cast<int64_t>(lab.size());
+        const size_t nw = NavWorkerCount(nlab);
+        std::vector<std::vector<int32_t>> bins_a(nw);
+        std::vector<std::vector<int32_t>> bins_b(nw);
+        ParallelChunks(nlab, nw, [&](size_t w, int64_t b, int64_t e) {
+            for (int64_t p = b; p < e; ++p) {
+                const auto& [la, lb] = lab[static_cast<size_t>(p)];
+                // 掩码外的三角不接 hop。下面两个消费循环(跨分量门户、同分量 srcadj 窄通道)
+                // 都从 ia/ib 取料,滤在这里就是两处一起滤。
+                if (walkable[static_cast<size_t>(la)] == 0 || walkable[static_cast<size_t>(lb)] == 0) {
+                    continue;
+                }
+                const auto& row = NB[static_cast<size_t>(la)];
+                if (row[0] != lb && row[1] != lb && row[2] != lb) {
+                    bins_a[w].push_back(la);
+                    bins_b[w].push_back(lb);
+                }
+            }
+        });
+        ConcatBins(bins_a, ia);
+        ConcatBins(bins_b, ib);
     }
     const auto nshared = [&](int32_t a, int32_t b) {
         int n = 0;

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -521,6 +521,14 @@ ZoneClean::ZoneClean(
              + std::to_string(ncomps);
 }
 
+void ZoneClean::release()
+{
+    mesh = PolyMesh();
+    comp = std::vector<int32_t>();
+    comp_island = std::vector<uint8_t>();
+    walkable = std::vector<uint8_t>();
+}
+
 std::optional<ZoneClean::SnapHit> ZoneClean::snap(const WorldPoint& p, double radius, std::optional<double> floor_y) const
 {
     const double r = std::max(0.0, radius);

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -4,7 +4,6 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <deque>
 #include <numeric>
 #include <utility>
 
@@ -552,35 +551,42 @@ ZoneClean::ZoneClean(
         cent[static_cast<size_t>(i)] = { (mesh.V[tri[0]].x + mesh.V[tri[1]].x + mesh.V[tri[2]].x) / 3.0,
                                          (mesh.V[tri[0]].y + mesh.V[tri[1]].y + mesh.V[tri[2]].y) / 3.0 };
     }
+    // 逐对局部泛洪都要一套访问标记, 每对新建散列集与双端队列的话分配与哈希就是这段的全部开销。
+    // 整段共用一组世代戳和一个当队列使的数组: 队列仍是先进先出、标记语义不变, 访问序逐位相同。
+    std::vector<uint32_t> vis(static_cast<size_t>(m), 0);
+    std::vector<int32_t> dq;
+    uint32_t vis_epoch = 0;
     for (size_t r = 0; r < ia.size(); ++r) {
         const int32_t ta = ia[r];
         const int32_t tb = ib[r];
         if (comp[static_cast<size_t>(ta)] != comp[static_cast<size_t>(tb)]) {
             continue;
         }
-        bool near = false;
-        for (int k1 = 0; k1 < 3 && !near; ++k1) {
+        bool adjacent = false;
+        for (int k1 = 0; k1 < 3 && !adjacent; ++k1) {
             const int32_t n1 = NB[static_cast<size_t>(ta)][k1];
             if (n1 < 0) {
                 continue;
             }
             const auto& row = NB[static_cast<size_t>(n1)];
-            near = row[0] == tb || row[1] == tb || row[2] == tb;
+            adjacent = row[0] == tb || row[1] == tb || row[2] == tb;
         }
-        if (near) {
+        if (adjacent) {
             continue;
         }
         const WorldPoint mx { (cent[static_cast<size_t>(ta)].x + cent[static_cast<size_t>(tb)].x) * 0.5,
                               (cent[static_cast<size_t>(ta)].y + cent[static_cast<size_t>(tb)].y) * 0.5 };
-        std::unordered_set<int32_t> seen { ta };
-        std::deque<int32_t> dq { ta };
+        ++vis_epoch;
+        vis[static_cast<size_t>(ta)] = vis_epoch;
+        dq.clear();
+        dq.push_back(ta);
+        size_t head = 0;
         bool hit = false;
-        while (!dq.empty() && !hit) {
-            const int32_t t2 = dq.front();
-            dq.pop_front();
+        while (head < dq.size() && !hit) {
+            const int32_t t2 = dq[head++];
             for (int k = 0; k < 3; ++k) {
                 const int32_t nb2 = NB[static_cast<size_t>(t2)][k];
-                if (nb2 < 0 || seen.contains(nb2)) {
+                if (nb2 < 0 || vis[static_cast<size_t>(nb2)] == vis_epoch) {
                     continue;
                 }
                 if (nb2 == tb) { // 目标判定先于出框判定
@@ -591,7 +597,7 @@ ZoneClean::ZoneClean(
                     || std::fabs(cent[static_cast<size_t>(nb2)].y - mx.y) > kSrcadjLocalR) {
                     continue;
                 }
-                seen.insert(nb2);
+                vis[static_cast<size_t>(nb2)] = vis_epoch;
                 dq.push_back(nb2);
             }
         }

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -166,11 +166,16 @@ void PolyMesh::buildGrid()
 
 std::vector<int32_t> PolyMesh::trisNear(const WorldPoint& p, double r) const
 {
+    return trisInBox(p.x - r, p.y - r, p.x + r, p.y + r);
+}
+
+std::vector<int32_t> PolyMesh::trisInBox(double x0, double y0, double x1, double y1) const
+{
     std::vector<int32_t> out;
-    const int64_t qx0 = std::max(gox, static_cast<int64_t>(std::floor((p.x - r) / kGridCell)));
-    const int64_t qx1 = std::min(gox + gnx - 1, static_cast<int64_t>(std::floor((p.x + r) / kGridCell)));
-    const int64_t qy0 = std::max(goy, static_cast<int64_t>(std::floor((p.y - r) / kGridCell)));
-    const int64_t qy1 = std::min(goy + gny - 1, static_cast<int64_t>(std::floor((p.y + r) / kGridCell)));
+    const int64_t qx0 = std::max(gox, static_cast<int64_t>(std::floor(x0 / kGridCell)));
+    const int64_t qx1 = std::min(gox + gnx - 1, static_cast<int64_t>(std::floor(x1 / kGridCell)));
+    const int64_t qy0 = std::max(goy, static_cast<int64_t>(std::floor(y0 / kGridCell)));
+    const int64_t qy1 = std::min(goy + gny - 1, static_cast<int64_t>(std::floor(y1 / kGridCell)));
     for (int64_t gx = qx0; gx <= qx1; ++gx) {
         for (int64_t gy = qy0; gy <= qy1; ++gy) {
             const auto c = static_cast<size_t>((gx - gox) * gny + (gy - goy));
@@ -733,48 +738,6 @@ std::optional<ZoneClean::SnapHit> ZoneClean::snap(const WorldPoint& p, double ra
         }
     }
     return std::nullopt;
-}
-
-// 收齐网格的边界边。这份数据只说哪里能走, 不带墙面/断崖之类的信息,
-// 再去分辨某条边是墙还是接缝等于凭空造数据, 所以这里只收边、不分类
-WallOracle::WallOracle(const ZoneClean& zc)
-{
-    const auto& mesh = zc.mesh;
-    for (size_t i = 0; i < mesh.T.size(); ++i) {
-        if (zc.walkable[i] == 0) {
-            // 掩码外的三角不出边。它与可走面之间那条缝已在 ZoneClean 里割断,
-            // 所以那条边会由可走面这一侧收成边界边 —— 水岸因此成墙,而不是消失。
-            continue;
-        }
-        for (int k = 0; k < 3; ++k) {
-            if (mesh.NB[i][k] >= 0) {
-                continue;
-            }
-            const int32_t a = mesh.T[i][k];
-            const int32_t b = mesh.T[i][(k + 1) % 3];
-            const WorldPoint p0 = mesh.V[a];
-            const WorldPoint p1 = mesh.V[b];
-            P0.push_back(p0);
-            P1.push_back(p1);
-            H0.push_back(mesh.H[a]);
-            H1.push_back(mesh.H[b]);
-            HH.push_back((mesh.H[a] + mesh.H[b]) / 2.0);
-            lo_.push_back({ std::min(p0.x, p1.x), std::min(p0.y, p1.y) });
-            hi_.push_back({ std::max(p0.x, p1.x), std::max(p0.y, p1.y) });
-        }
-    }
-}
-
-std::vector<int64_t> WallOracle::wallsInBbox(double x0, double y0, double x1, double y1) const
-{
-    std::vector<int64_t> idx;
-    for (int64_t i = 0; i < static_cast<int64_t>(P0.size()); ++i) {
-        if (hi_[static_cast<size_t>(i)].x >= x0 && lo_[static_cast<size_t>(i)].x <= x1 && hi_[static_cast<size_t>(i)].y >= y0
-            && lo_[static_cast<size_t>(i)].y <= y1) {
-            idx.push_back(i);
-        }
-    }
-    return idx;
 }
 
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -622,6 +622,9 @@ ZoneClean::ZoneClean(
         }
         ++n_srcadj;
     }
+    // 泛洪用完就还, 别让这两块一路压到墙判据建索引那一段的峰值上。swap 空容器才还得掉容量。
+    std::vector<uint32_t>().swap(vis);
+    std::vector<int32_t>().swap(dq);
 
     int64_t ncomps = 0;
     for (int64_t i = 0; i < m; ++i) {

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -62,29 +62,38 @@ void PolyMesh::buildNb()
     if (m == 0) {
         return;
     }
+    // 有向边按起点分桶: 每个顶点平均只挂六条边, 找反向边扫本桶即可。桶内按槽号递增填,
+    // 所以首个命中就是稳定序里的首槽, 与把三倍三角数的边整体排一遍再取首个逐位相同。
     const int64_t n = static_cast<int64_t>(V.size());
-    std::vector<std::pair<int64_t, int32_t>> se(static_cast<size_t>(3 * m));
-    for (int64_t i = 0; i < m; ++i) {
-        for (int64_t k = 0; k < 3; ++k) {
-            const int64_t a = T[static_cast<size_t>(i)][k];
-            const int64_t b = T[static_cast<size_t>(i)][(k + 1) % 3];
-            se[static_cast<size_t>(i * 3 + k)] = { a * n + b, static_cast<int32_t>(i * 3 + k) };
+    std::vector<int32_t> at(static_cast<size_t>(n) + 1, 0);
+    for (const auto& tri : T) {
+        for (const int32_t a : tri) {
+            ++at[static_cast<size_t>(a) + 1];
         }
     }
-    std::stable_sort(se.begin(), se.end(), [](const auto& l, const auto& r) { return l.first < r.first; });
-    std::vector<int64_t> skeys(se.size());
-    for (size_t s = 0; s < se.size(); ++s) {
-        skeys[s] = se[s].first;
+    for (int64_t i = 0; i < n; ++i) {
+        at[static_cast<size_t>(i) + 1] += at[static_cast<size_t>(i)];
+    }
+    std::vector<int32_t> wr = at;
+    std::vector<int32_t> dst(static_cast<size_t>(3 * m));
+    std::vector<int32_t> slot(static_cast<size_t>(3 * m));
+    for (int64_t i = 0; i < m; ++i) {
+        for (int64_t k = 0; k < 3; ++k) {
+            const int32_t a = T[static_cast<size_t>(i)][k];
+            const auto w = static_cast<size_t>(wr[static_cast<size_t>(a)]++);
+            dst[w] = T[static_cast<size_t>(i)][(k + 1) % 3];
+            slot[w] = static_cast<int32_t>(i * 3 + k);
+        }
     }
     for (int64_t i = 0; i < m; ++i) {
         for (int64_t k = 0; k < 3; ++k) {
-            const int64_t a = T[static_cast<size_t>(i)][k];
-            const int64_t b = T[static_cast<size_t>(i)][(k + 1) % 3];
-            const int64_t kr = b * n + a;
-            const size_t pos =
-                std::min(static_cast<size_t>(std::lower_bound(skeys.begin(), skeys.end(), kr) - skeys.begin()), skeys.size() - 1);
-            if (skeys[pos] == kr) {
-                NB[static_cast<size_t>(i)][k] = se[pos].second / 3;
+            const int32_t a = T[static_cast<size_t>(i)][k];
+            const int32_t b = T[static_cast<size_t>(i)][(k + 1) % 3];
+            for (int32_t p = at[static_cast<size_t>(b)]; p < at[static_cast<size_t>(b) + 1]; ++p) {
+                if (dst[static_cast<size_t>(p)] == a) {
+                    NB[static_cast<size_t>(i)][k] = slot[static_cast<size_t>(p)] / 3;
+                    break;
+                }
             }
         }
     }
@@ -92,42 +101,75 @@ void PolyMesh::buildNb()
 
 void PolyMesh::buildGrid()
 {
-    std::vector<std::pair<int64_t, int32_t>> kt;
-    for (size_t i = 0; i < T.size(); ++i) {
+    struct Box
+    {
+        int64_t x0, y0, x1, y1;
+    };
+    const auto box = [&](size_t i) {
         const WorldPoint& a = V[T[i][0]];
         const WorldPoint& b = V[T[i][1]];
         const WorldPoint& c = V[T[i][2]];
-        const int64_t g0x = static_cast<int64_t>(std::floor(std::min({ a.x, b.x, c.x }) / kGridCell));
-        const int64_t g0y = static_cast<int64_t>(std::floor(std::min({ a.y, b.y, c.y }) / kGridCell));
-        const int64_t g1x = static_cast<int64_t>(std::floor(std::max({ a.x, b.x, c.x }) / kGridCell));
-        const int64_t g1y = static_cast<int64_t>(std::floor(std::max({ a.y, b.y, c.y }) / kGridCell));
-        for (int64_t gy = g0y; gy <= g1y; ++gy) {
-            for (int64_t gx = g0x; gx <= g1x; ++gx) {
-                kt.emplace_back(gx * kGridStride + gy, static_cast<int32_t>(i));
+        return Box { static_cast<int64_t>(std::floor(std::min({ a.x, b.x, c.x }) / kGridCell)),
+                     static_cast<int64_t>(std::floor(std::min({ a.y, b.y, c.y }) / kGridCell)),
+                     static_cast<int64_t>(std::floor(std::max({ a.x, b.x, c.x }) / kGridCell)),
+                     static_cast<int64_t>(std::floor(std::max({ a.y, b.y, c.y }) / kGridCell)) };
+    };
+    goff.assign(1, 0);
+    gtris.clear();
+    gnx = 0;
+    gny = 0;
+    if (T.empty()) {
+        return;
+    }
+    gox = std::numeric_limits<int64_t>::max();
+    goy = std::numeric_limits<int64_t>::max();
+    int64_t hx = std::numeric_limits<int64_t>::min();
+    int64_t hy = std::numeric_limits<int64_t>::min();
+    for (size_t i = 0; i < T.size(); ++i) {
+        const Box b = box(i);
+        gox = std::min(gox, b.x0);
+        goy = std::min(goy, b.y0);
+        hx = std::max(hx, b.x1);
+        hy = std::max(hy, b.y1);
+    }
+    gnx = hx - gox + 1;
+    gny = hy - goy + 1;
+    goff.assign(static_cast<size_t>(gnx * gny) + 1, 0);
+    for (size_t i = 0; i < T.size(); ++i) {
+        const Box b = box(i);
+        for (int64_t gx = b.x0; gx <= b.x1; ++gx) {
+            for (int64_t gy = b.y0; gy <= b.y1; ++gy) {
+                ++goff[static_cast<size_t>((gx - gox) * gny + (gy - goy)) + 1];
             }
         }
     }
-    std::stable_sort(kt.begin(), kt.end(), [](const auto& l, const auto& r) { return l.first < r.first; });
-    gkeys.resize(kt.size());
-    gtris.resize(kt.size());
-    for (size_t s = 0; s < kt.size(); ++s) {
-        gkeys[s] = kt[s].first;
-        gtris[s] = kt[s].second;
+    for (size_t c = 0; c + 1 < goff.size(); ++c) {
+        goff[c + 1] += goff[c];
+    }
+    std::vector<int32_t> wr = goff;
+    gtris.resize(static_cast<size_t>(goff.back()));
+    for (size_t i = 0; i < T.size(); ++i) {
+        const Box b = box(i);
+        for (int64_t gx = b.x0; gx <= b.x1; ++gx) {
+            for (int64_t gy = b.y0; gy <= b.y1; ++gy) {
+                gtris[static_cast<size_t>(wr[static_cast<size_t>((gx - gox) * gny + (gy - goy))]++)] = static_cast<int32_t>(i);
+            }
+        }
     }
 }
 
 std::vector<int32_t> PolyMesh::trisNear(const WorldPoint& p, double r) const
 {
     std::vector<int32_t> out;
-    const int64_t gx0 = static_cast<int64_t>(std::floor((p.x - r) / kGridCell));
-    const int64_t gx1 = static_cast<int64_t>(std::floor((p.x + r) / kGridCell));
-    const int64_t gy0 = static_cast<int64_t>(std::floor((p.y - r) / kGridCell));
-    const int64_t gy1 = static_cast<int64_t>(std::floor((p.y + r) / kGridCell));
-    for (int64_t gx = gx0; gx <= gx1; ++gx) {
-        for (int64_t gy = gy0; gy <= gy1; ++gy) {
-            const auto [lo, hi] = std::equal_range(gkeys.begin(), gkeys.end(), gx * kGridStride + gy);
-            for (auto it = lo; it != hi; ++it) {
-                out.push_back(gtris[static_cast<size_t>(it - gkeys.begin())]);
+    const int64_t qx0 = std::max(gox, static_cast<int64_t>(std::floor((p.x - r) / kGridCell)));
+    const int64_t qx1 = std::min(gox + gnx - 1, static_cast<int64_t>(std::floor((p.x + r) / kGridCell)));
+    const int64_t qy0 = std::max(goy, static_cast<int64_t>(std::floor((p.y - r) / kGridCell)));
+    const int64_t qy1 = std::min(goy + gny - 1, static_cast<int64_t>(std::floor((p.y + r) / kGridCell)));
+    for (int64_t gx = qx0; gx <= qx1; ++gx) {
+        for (int64_t gy = qy0; gy <= qy1; ++gy) {
+            const auto c = static_cast<size_t>((gx - gox) * gny + (gy - goy));
+            for (int32_t s = goff[c]; s < goff[c + 1]; ++s) {
+                out.push_back(gtris[static_cast<size_t>(s)]);
             }
         }
     }
@@ -136,9 +178,11 @@ std::vector<int32_t> PolyMesh::trisNear(const WorldPoint& p, double r) const
     return out;
 }
 
-ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, const std::string& zone_name)
+ZoneClean::ZoneClean(
+    const BaseNavPack& pack, const BaseNavPlanner& planner, const std::string& zone_name, uint32_t walkable_flags_in)
 {
     name = zone_name;
+    walkable_flags = walkable_flags_in;
     const BaseNavZone* zone = pack.findZoneByName(zone_name);
     if (zone == nullptr || zone->triangle_count == 0) {
         error_ = zone_name + ": zone not found or empty";
@@ -149,8 +193,35 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
     hi = lo + zone->triangle_count;
     const auto& ptris = pack.triangles();
     const auto& pverts = pack.vertices();
+    // 坐标是不是导出侧精确焊过的,认 BGEO 段 —— 那是这一代包才有的几何段,带它的包
+    // 顶点身份已经定死,再按 0.05 网格 round 一遍并二次焊接只会挪动坐标。BSRF 只是
+    // 可选的取证段,拿它当几何判据的话,一个纯可走包(不带 BSRF)会被误判成老包。
+    const bool source_exact = pack.section("BGEO") != nullptr
+        || (!pack.surfaces().empty() && pack.surfaces().size() == ptris.size());
+    const bool has_source_surfaces = !pack.surfaces().empty() && pack.surfaces().size() == ptris.size();
 
-    // 区网格:顶点段连续,f32 坐标回吸 0.05 格点得精确 f64
+    // 源语义:BSRF 里那 32 位 flags 说了算,掩码没命中的三角不是可走面。就地打标,不压缩、
+    // 不重排 —— 下面六处消费点各自跳过它们(邻接、分量、hop、吸附、墙判据、体素化),
+    // 几何本身照旧留在包和网格里。没有 surface 表的包全部可走:纯可走包里「在包里」
+    // 本身就是可走的意思,旧包则行为与历史逐字节相同。
+    const int64_t m_all = hi - lo;
+    walkable.assign(static_cast<size_t>(m_all), 1);
+    int64_t n_masked = 0;
+    if (has_source_surfaces) {
+        const auto& psurf = pack.surfaces();
+        for (int64_t i = 0; i < m_all; ++i) {
+            if ((psurf[static_cast<size_t>(lo + i)].flags & walkable_flags) == 0U) {
+                walkable[static_cast<size_t>(i)] = 0;
+                ++n_masked;
+            }
+        }
+    }
+    if (n_masked == m_all) {
+        error_ = zone_name + ": walkable mask " + std::to_string(walkable_flags) + " left no walkable tris";
+        return;
+    }
+
+    // 带源 surface 表的新包保留导出坐标与顶点身份；旧包继续走历史焊接规则。
     uint32_t vmin = UINT32_MAX;
     uint32_t vmax = 0;
     for (int64_t i = lo; i < hi; ++i) {
@@ -164,43 +235,47 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
     std::vector<double> CH(static_cast<size_t>(nv));
     for (int64_t i = 0; i < nv; ++i) {
         const auto& vt = pverts[vmin + static_cast<size_t>(i)];
-        CV[static_cast<size_t>(i)] = { std::nearbyint(static_cast<double>(vt.u) * 20.0) / 20.0,
-                                       std::nearbyint(static_cast<double>(vt.v) * 20.0) / 20.0 };
+        CV[static_cast<size_t>(i)] = source_exact
+            ? WorldPoint { static_cast<double>(vt.u), static_cast<double>(vt.v) }
+            : WorldPoint { std::nearbyint(static_cast<double>(vt.u) * 20.0) / 20.0,
+                           std::nearbyint(static_cast<double>(vt.v) * 20.0) / 20.0 };
         CH[static_cast<size_t>(i)] = static_cast<double>(vt.height);
     }
 
-    std::vector<int64_t> kk(static_cast<size_t>(nv));
-    for (int64_t i = 0; i < nv; ++i) {
-        const int64_t kx = static_cast<int64_t>(std::nearbyint(CV[static_cast<size_t>(i)].x * 1e4));
-        const int64_t ky = static_cast<int64_t>(std::nearbyint(CV[static_cast<size_t>(i)].y * 1e4));
-        kk[static_cast<size_t>(i)] = kx * (int64_t(1) << 40) + ky;
-    }
-    std::vector<int32_t> order(static_cast<size_t>(nv));
-    std::iota(order.begin(), order.end(), 0);
-    std::stable_sort(order.begin(), order.end(), [&](int32_t a, int32_t b) { return kk[a] < kk[b]; });
     std::vector<int32_t> MAP(static_cast<size_t>(nv));
     std::iota(MAP.begin(), MAP.end(), 0);
     int64_t n_weld = 0;
-    for (size_t s0 = 0; s0 < order.size();) {
-        size_t e0 = s0 + 1;
-        while (e0 < order.size() && kk[order[e0]] == kk[order[s0]]) {
-            ++e0;
+    if (!source_exact) {
+        std::vector<int64_t> kk(static_cast<size_t>(nv));
+        for (int64_t i = 0; i < nv; ++i) {
+            const int64_t kx = static_cast<int64_t>(std::nearbyint(CV[static_cast<size_t>(i)].x * 1e4));
+            const int64_t ky = static_cast<int64_t>(std::nearbyint(CV[static_cast<size_t>(i)].y * 1e4));
+            kk[static_cast<size_t>(i)] = kx * (int64_t(1) << 40) + ky;
         }
-        if (e0 - s0 >= 2) {
-            std::vector<int32_t> ids(order.begin() + s0, order.begin() + e0);
-            std::stable_sort(ids.begin(), ids.end(), [&](int32_t a, int32_t b) { return CH[a] < CH[b]; });
-            int32_t rep = ids[0];
-            for (size_t t = 1; t < ids.size(); ++t) {
-                if (CH[ids[t]] - CH[ids[t - 1]] <= kWeldDh) {
-                    MAP[ids[t]] = rep;
-                    ++n_weld;
-                }
-                else {
-                    rep = ids[t];
+        std::vector<int32_t> order(static_cast<size_t>(nv));
+        std::iota(order.begin(), order.end(), 0);
+        std::stable_sort(order.begin(), order.end(), [&](int32_t a, int32_t b) { return kk[a] < kk[b]; });
+        for (size_t s0 = 0; s0 < order.size();) {
+            size_t e0 = s0 + 1;
+            while (e0 < order.size() && kk[order[e0]] == kk[order[s0]]) {
+                ++e0;
+            }
+            if (e0 - s0 >= 2) {
+                std::vector<int32_t> ids(order.begin() + s0, order.begin() + e0);
+                std::stable_sort(ids.begin(), ids.end(), [&](int32_t a, int32_t b) { return CH[a] < CH[b]; });
+                int32_t rep = ids[0];
+                for (size_t t = 1; t < ids.size(); ++t) {
+                    if (CH[ids[t]] - CH[ids[t - 1]] <= kWeldDh) {
+                        MAP[ids[t]] = rep;
+                        ++n_weld;
+                    }
+                    else {
+                        rep = ids[t];
+                    }
                 }
             }
+            s0 = e0;
         }
-        s0 = e0;
     }
     std::vector<std::array<int32_t, 3>> CT2(static_cast<size_t>(hi - lo));
     int64_t degen = 0;
@@ -224,19 +299,43 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
     const int64_t m = static_cast<int64_t>(T.size());
     const int64_t nvv = static_cast<int64_t>(mesh.V.size());
 
-    const auto slotKey = [&](int64_t slot) {
-        const int64_t i = slot / 3;
-        const int64_t k = slot % 3;
-        return static_cast<int64_t>(T[static_cast<size_t>(i)][k]) * nvv + T[static_cast<size_t>(i)][(k + 1) % 3];
-    };
-    std::unordered_map<int64_t, int32_t> kcnt;
-    kcnt.reserve(static_cast<size_t>(3 * m));
-    for (int64_t slot = 0; slot < 3 * m; ++slot) {
-        ++kcnt[slotKey(slot)];
+    // 同一条有向边出现两次以上的槽。按起点分桶后同一条边必落在同一桶里, 桶内平均六项,
+    // 就地数一遍即可, 不必给三倍三角数的边各算一次键再查散列。
+    std::vector<uint8_t> dup(static_cast<size_t>(3 * m), 0);
+    {
+        std::vector<int32_t> at(static_cast<size_t>(nvv) + 1, 0);
+        for (const auto& tri : T) {
+            for (const int32_t a : tri) {
+                ++at[static_cast<size_t>(a) + 1];
+            }
+        }
+        for (int64_t i = 0; i < nvv; ++i) {
+            at[static_cast<size_t>(i) + 1] += at[static_cast<size_t>(i)];
+        }
+        std::vector<int32_t> wr = at;
+        std::vector<int32_t> dst(static_cast<size_t>(3 * m));
+        std::vector<int32_t> slt(static_cast<size_t>(3 * m));
+        for (int64_t i = 0; i < m; ++i) {
+            for (int64_t k = 0; k < 3; ++k) {
+                const auto w = static_cast<size_t>(wr[static_cast<size_t>(T[static_cast<size_t>(i)][k])]++);
+                dst[w] = T[static_cast<size_t>(i)][(k + 1) % 3];
+                slt[w] = static_cast<int32_t>(i * 3 + k);
+            }
+        }
+        for (int64_t v = 0; v < nvv; ++v) {
+            for (int32_t p = at[static_cast<size_t>(v)]; p < at[static_cast<size_t>(v) + 1]; ++p) {
+                for (int32_t q = p + 1; q < at[static_cast<size_t>(v) + 1]; ++q) {
+                    if (dst[static_cast<size_t>(p)] == dst[static_cast<size_t>(q)]) {
+                        dup[static_cast<size_t>(slt[static_cast<size_t>(p)])] = 1;
+                        dup[static_cast<size_t>(slt[static_cast<size_t>(q)])] = 1;
+                    }
+                }
+            }
+        }
     }
     int64_t n_dup = 0;
     for (int64_t slot = 0; slot < 3 * m; ++slot) {
-        if (kcnt.find(slotKey(slot))->second < 2) {
+        if (dup[static_cast<size_t>(slot)] == 0) {
             continue;
         }
         const int64_t i = slot / 3;
@@ -271,25 +370,50 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
     const auto& offs = planner.adjacencyOffsets();
     const auto& lnks = planner.adjacencyLinks();
     std::vector<std::pair<int32_t, int32_t>> lab;
-    std::unordered_set<int64_t> lkey;
     for (int64_t src = lo; src < hi; ++src) {
         for (uint32_t li = offs[static_cast<size_t>(src)]; li < offs[static_cast<size_t>(src) + 1]; ++li) {
             const int64_t tgt = lnks[li];
             if (tgt >= lo && tgt < hi && src < tgt) {
                 lab.emplace_back(static_cast<int32_t>(src - lo), static_cast<int32_t>(tgt - lo));
-                lkey.insert((src - lo) * m + (tgt - lo));
             }
         }
     }
+    // 有背书的三角对按小号一端分桶。一个三角挂不了几条链接, 桶内直查比散列表快,
+    // 而且查的是同一个集合, 结果与散列表一致。
+    std::vector<int32_t> lat(static_cast<size_t>(m) + 1, 0);
+    for (const auto& e : lab) {
+        ++lat[static_cast<size_t>(e.first) + 1];
+    }
+    for (int64_t i = 0; i < m; ++i) {
+        lat[static_cast<size_t>(i) + 1] += lat[static_cast<size_t>(i)];
+    }
+    std::vector<int32_t> lwr = lat;
+    std::vector<int32_t> lhi(lab.size());
+    for (const auto& e : lab) {
+        lhi[static_cast<size_t>(lwr[static_cast<size_t>(e.first)]++)] = e.second;
+    }
     std::vector<int64_t> cand;
+    int64_t n_mask_cut = 0;
     for (int64_t slot = 0; slot < 3 * m; ++slot) {
         const int64_t i = slot / 3;
         const int32_t j = NB[static_cast<size_t>(i)][slot % 3];
         if (j < 0) {
             continue;
         }
-        const int64_t pk = std::min<int64_t>(i, j) * m + std::max<int64_t>(i, j);
-        if (!lkey.contains(pk)) {
+        // 掩码外的三角一条缝都不接:它跟谁都断,自己落成孤立分量。割在并查集之前,
+        // 分量因此天然把水体、禁区与可走面分开。
+        if (walkable[static_cast<size_t>(i)] == 0 || walkable[static_cast<size_t>(j)] == 0) {
+            cand.push_back(slot);
+            ++n_mask_cut;
+            continue;
+        }
+        const auto a = static_cast<int32_t>(std::min<int64_t>(i, j));
+        const auto b = static_cast<int32_t>(std::max<int64_t>(i, j));
+        bool hit = false;
+        for (int32_t p = lat[static_cast<size_t>(a)]; p < lat[static_cast<size_t>(a) + 1] && !hit; ++p) {
+            hit = lhi[static_cast<size_t>(p)] == b;
+        }
+        if (!hit) {
             cand.push_back(slot);
         }
     }
@@ -355,6 +479,11 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
     std::vector<int32_t> ia;
     std::vector<int32_t> ib;
     for (const auto& [la, lb] : lab) {
+        // 掩码外的三角不接 hop。下面两个消费循环(跨分量门户、同分量 srcadj 窄通道)
+        // 都从 ia/ib 取料,滤在这里就是两处一起滤。
+        if (walkable[static_cast<size_t>(la)] == 0 || walkable[static_cast<size_t>(lb)] == 0) {
+            continue;
+        }
         const auto& row = NB[static_cast<size_t>(la)];
         if (row[0] != lb && row[1] != lb && row[2] != lb) {
             ia.push_back(la);
@@ -494,9 +623,12 @@ ZoneClean::ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, con
             ++ncomps;
         }
     }
-    stats = "weld " + std::to_string(n_weld) + "v dup-sever " + std::to_string(n_dup) + ", link-mask cut " + std::to_string(n_cut)
-            + ", comps " + std::to_string(ncomps) + ", hops edge " + std::to_string(n_edge) + " touch " + std::to_string(n_touch)
-            + " bridge " + std::to_string(n_bridge) + " srcadj " + std::to_string(n_srcadj);
+    stats = source_exact ? "source-exact " : "weld " + std::to_string(n_weld) + "v ";
+    stats += "mask " + std::to_string(walkable_flags) + " masked " + std::to_string(n_masked) + " cut "
+             + std::to_string(n_mask_cut) + ", ";
+    stats += "dup-sever " + std::to_string(n_dup) + ", link-mask cut " + std::to_string(n_cut) + ", comps "
+             + std::to_string(ncomps) + ", hops edge " + std::to_string(n_edge) + " touch " + std::to_string(n_touch) + " bridge "
+             + std::to_string(n_bridge) + " srcadj " + std::to_string(n_srcadj);
 }
 
 std::optional<ZoneClean::SnapHit> ZoneClean::snap(const WorldPoint& p, double radius, std::optional<double> floor_y) const
@@ -509,16 +641,22 @@ std::optional<ZoneClean::SnapHit> ZoneClean::snap(const WorldPoint& p, double ra
         std::array<double, 4> bk {};
         SnapHit best;
         for (const int32_t t : mesh.trisNear(p, rr)) {
+            if (walkable[static_cast<size_t>(t)] == 0) {
+                continue; // 掩码外的面不接受吸附;这一关两轮半径都要过
+            }
             const auto& tri = mesh.T[static_cast<size_t>(t)];
             const auto [sp, dist] = closestOnTri(p, { mesh.V[tri[0]], mesh.V[tri[1]], mesh.V[tri[2]] });
             if (dist > rr) {
                 continue;
             }
             const double isl = comp_island[comp[static_cast<size_t>(t)]] != 0 ? 1.0 : 0.0;
-            // floor 盲键 (isl, dist, t) 全序;floor 感知键 (带外, isl, dist, delta)
+            // floor 盲键 (isl, dist, -高度, t) 全序;floor 感知键 (带外, isl, dist, delta)
+            // dist 打平只发生在同一 (u,v) 上摞着好几层地面(都含点 ⇒ 都是 0)。此时取最高那层:
+            // 底图像素是俯视图上的一点,那点看得见的就是最上面那层。拿三角号破平是任意的 ——
+            // 重烘一次三角序一换,起点就可能吸到水下/桥下那层,与终点分属两个分量,直接报不连通。
             std::array<double, 4> k;
             if (!floor_y.has_value()) {
-                k = { isl, dist, static_cast<double>(t), 0.0 };
+                k = { isl, dist, -triHeight(mesh, t), static_cast<double>(t) };
             }
             else {
                 const double delta = std::fabs(triHeight(mesh, t) - *floor_y);
@@ -543,6 +681,11 @@ WallOracle::WallOracle(const ZoneClean& zc)
 {
     const auto& mesh = zc.mesh;
     for (size_t i = 0; i < mesh.T.size(); ++i) {
+        if (zc.walkable[i] == 0) {
+            // 掩码外的三角不出边。它与可走面之间那条缝已在 ZoneClean 里割断,
+            // 所以那条边会由可走面这一侧收成边界边 —— 水岸因此成墙,而不是消失。
+            continue;
+        }
         for (int k = 0; k < 3; ++k) {
             if (mesh.NB[i][k] >= 0) {
                 continue;

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -544,7 +544,7 @@ ZoneClean::ZoneClean(
         }
         return n;
     };
-    const auto pushPortals = [&](int32_t ti, int32_t tj) {
+    const auto pushPortals = [&](int32_t ti, int32_t tj, std::vector<HopPt>& out) {
         int32_t sh[2] = { -1, -1 };
         int ns = 0;
         for (int ka = 0; ka < 3 && ns < 2; ++ka) {
@@ -557,8 +557,8 @@ ZoneClean::ZoneClean(
         const WorldPoint p1 = mesh.V[sh[1]];
         for (const double t : kPortalSamples) {
             const WorldPoint pt { p0.x + (p1.x - p0.x) * t, p0.y + (p1.y - p0.y) * t };
-            hops.push_back({ pt, pt, tj });
-            hops.push_back({ pt, pt, ti });
+            out.push_back({ pt, pt, tj });
+            out.push_back({ pt, pt, ti });
         }
     };
     int64_t n_edge = 0;
@@ -572,7 +572,7 @@ ZoneClean::ZoneClean(
             continue;
         }
         if (nshared(i, j) == 2) {
-            pushPortals(i, j);
+            pushPortals(i, j, hops);
             ++n_edge;
         }
         else {
@@ -595,79 +595,87 @@ ZoneClean::ZoneClean(
                                          (mesh.V[tri[0]].y + mesh.V[tri[1]].y + mesh.V[tri[2]].y) / 3.0 };
     }
     // 逐对局部泛洪都要一套访问标记, 每对新建散列集与双端队列的话分配与哈希就是这段的全部开销。
-    // 整段共用一组世代戳和一个当队列使的数组: 队列仍是先进先出、标记语义不变, 访问序逐位相同。
-    std::vector<uint32_t> vis(static_cast<size_t>(m), 0);
-    std::vector<int32_t> dq;
-    uint32_t vis_epoch = 0;
-    for (size_t r = 0; r < ia.size(); ++r) {
-        const int32_t ta = ia[r];
-        const int32_t tb = ib[r];
-        if (comp[static_cast<size_t>(ta)] != comp[static_cast<size_t>(tb)]) {
-            continue;
-        }
-        bool adjacent = false;
-        for (int k1 = 0; k1 < 3 && !adjacent; ++k1) {
-            const int32_t n1 = NB[static_cast<size_t>(ta)][k1];
-            if (n1 < 0) {
+    // 每块一组世代戳和一个当队列使的数组: 戳只在本块内比对, 队列仍是先进先出, 访问序逐位相同。
+    const auto n_pair = static_cast<int64_t>(ia.size());
+    const size_t nw_src = NavWorkerCount(n_pair);
+    std::vector<std::vector<HopPt>> bins_src(nw_src);
+    std::vector<int64_t> cnt_src(nw_src, 0);
+    ParallelChunks(n_pair, nw_src, [&](size_t w, int64_t pair_lo, int64_t pair_hi) {
+        std::vector<uint32_t> vis(static_cast<size_t>(m), 0);
+        std::vector<int32_t> dq;
+        uint32_t vis_epoch = 0;
+        for (int64_t r = pair_lo; r < pair_hi; ++r) {
+            const int32_t ta = ia[static_cast<size_t>(r)];
+            const int32_t tb = ib[static_cast<size_t>(r)];
+            if (comp[static_cast<size_t>(ta)] != comp[static_cast<size_t>(tb)]) {
                 continue;
             }
-            const auto& row = NB[static_cast<size_t>(n1)];
-            adjacent = row[0] == tb || row[1] == tb || row[2] == tb;
-        }
-        if (adjacent) {
-            continue;
-        }
-        const WorldPoint mx { (cent[static_cast<size_t>(ta)].x + cent[static_cast<size_t>(tb)].x) * 0.5,
-                              (cent[static_cast<size_t>(ta)].y + cent[static_cast<size_t>(tb)].y) * 0.5 };
-        ++vis_epoch;
-        vis[static_cast<size_t>(ta)] = vis_epoch;
-        dq.clear();
-        dq.push_back(ta);
-        size_t head = 0;
-        bool hit = false;
-        while (head < dq.size() && !hit) {
-            const int32_t t2 = dq[head++];
-            for (int k = 0; k < 3; ++k) {
-                const int32_t nb2 = NB[static_cast<size_t>(t2)][k];
-                if (nb2 < 0 || vis[static_cast<size_t>(nb2)] == vis_epoch) {
+            bool adjacent = false;
+            for (int k1 = 0; k1 < 3 && !adjacent; ++k1) {
+                const int32_t n1 = NB[static_cast<size_t>(ta)][k1];
+                if (n1 < 0) {
                     continue;
                 }
-                if (nb2 == tb) { // 目标判定先于出框判定
-                    hit = true;
-                    break;
+                const auto& row = NB[static_cast<size_t>(n1)];
+                adjacent = row[0] == tb || row[1] == tb || row[2] == tb;
+            }
+            if (adjacent) {
+                continue;
+            }
+            const WorldPoint mx { (cent[static_cast<size_t>(ta)].x + cent[static_cast<size_t>(tb)].x) * 0.5,
+                                  (cent[static_cast<size_t>(ta)].y + cent[static_cast<size_t>(tb)].y) * 0.5 };
+            ++vis_epoch;
+            vis[static_cast<size_t>(ta)] = vis_epoch;
+            dq.clear();
+            dq.push_back(ta);
+            size_t head = 0;
+            bool hit = false;
+            while (head < dq.size() && !hit) {
+                const int32_t t2 = dq[head++];
+                for (int k = 0; k < 3; ++k) {
+                    const int32_t nb2 = NB[static_cast<size_t>(t2)][k];
+                    if (nb2 < 0 || vis[static_cast<size_t>(nb2)] == vis_epoch) {
+                        continue;
+                    }
+                    if (nb2 == tb) { // 目标判定先于出框判定
+                        hit = true;
+                        break;
+                    }
+                    if (std::fabs(cent[static_cast<size_t>(nb2)].x - mx.x) > kSrcadjLocalR
+                        || std::fabs(cent[static_cast<size_t>(nb2)].y - mx.y) > kSrcadjLocalR) {
+                        continue;
+                    }
+                    vis[static_cast<size_t>(nb2)] = vis_epoch;
+                    dq.push_back(nb2);
                 }
-                if (std::fabs(cent[static_cast<size_t>(nb2)].x - mx.x) > kSrcadjLocalR
-                    || std::fabs(cent[static_cast<size_t>(nb2)].y - mx.y) > kSrcadjLocalR) {
+            }
+            if (hit) {
+                continue;
+            }
+            if (nshared(ta, tb) == 2) {
+                pushPortals(ta, tb, bins_src[w]);
+            }
+            else {
+                const auto br =
+                    planner.closestEdgeBridgePoints(static_cast<uint32_t>(lo + ta), static_cast<uint32_t>(lo + tb));
+                if (!br) {
                     continue;
                 }
-                vis[static_cast<size_t>(nb2)] = vis_epoch;
-                dq.push_back(nb2);
+                const WorldPoint ex = (*br)[0];
+                const WorldPoint en = (*br)[1];
+                if (std::hypot(ex.x - en.x, ex.y - en.y) > kSrcadjMaxGap) {
+                    continue;
+                }
+                bins_src[w].push_back({ ex, en, tb });
+                bins_src[w].push_back({ en, ex, ta });
             }
+            ++cnt_src[w];
         }
-        if (hit) {
-            continue;
-        }
-        if (nshared(ta, tb) == 2) {
-            pushPortals(ta, tb);
-        }
-        else {
-            const auto br = planner.closestEdgeBridgePoints(static_cast<uint32_t>(lo + ta), static_cast<uint32_t>(lo + tb));
-            if (!br) {
-                continue;
-            }
-            const WorldPoint ex = (*br)[0];
-            const WorldPoint en = (*br)[1];
-            if (std::hypot(ex.x - en.x, ex.y - en.y) > kSrcadjMaxGap) {
-                continue;
-            }
-            hops.push_back({ ex, en, tb });
-            hops.push_back({ en, ex, ta });
-        }
-        ++n_srcadj;
+    });
+    ConcatBins(bins_src, hops);
+    for (const int64_t c : cnt_src) {
+        n_srcadj += c;
     }
-    // 泛洪用完就还, 别让这两块一路压到墙判据建索引那一段的峰值上。swap 空容器才还得掉容量。
-    std::vector<uint32_t>().swap(vis);
-    std::vector<int32_t>().swap(dq);
 
     int64_t ncomps = 0;
     for (int64_t i = 0; i < m; ++i) {

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -16,8 +16,6 @@ namespace navmesh::recast
 namespace
 {
 
-constexpr double kPortalSamples[5] = { 0.5, 0.25, 0.75, 0.1, 0.9 }; // 共边 hop 的门户采样位
-
 double triHeight(const PolyMesh& mesh, int32_t t)
 {
     const auto& tri = mesh.T[static_cast<size_t>(t)];
@@ -510,178 +508,6 @@ ZoneClean::ZoneClean(
             (n_tot[static_cast<size_t>(c)] == 0 || n_isl[static_cast<size_t>(c)] * 2 > n_tot[static_cast<size_t>(c)]) ? 1 : 0;
     }
 
-    // link 层 hop:NB 已邻接跳过;跨分量共焊边 → 门户采样,否则 touch/bridge;
-    // 同分量共焊边且非近连通 → srcadj 窄通道
-    std::vector<int32_t> ia;
-    std::vector<int32_t> ib;
-    {
-        const auto nlab = static_cast<int64_t>(lab.size());
-        const size_t nw = NavWorkerCount(nlab);
-        std::vector<std::vector<int32_t>> bins_a(nw);
-        std::vector<std::vector<int32_t>> bins_b(nw);
-        ParallelChunks(nlab, nw, [&](size_t w, int64_t b, int64_t e) {
-            for (int64_t p = b; p < e; ++p) {
-                const auto& [la, lb] = lab[static_cast<size_t>(p)];
-                // 掩码外的三角不接 hop。下面两个消费循环(跨分量门户、同分量 srcadj 窄通道)
-                // 都从 ia/ib 取料,滤在这里就是两处一起滤。
-                if (walkable[static_cast<size_t>(la)] == 0 || walkable[static_cast<size_t>(lb)] == 0) {
-                    continue;
-                }
-                const auto& row = NB[static_cast<size_t>(la)];
-                if (row[0] != lb && row[1] != lb && row[2] != lb) {
-                    bins_a[w].push_back(la);
-                    bins_b[w].push_back(lb);
-                }
-            }
-        });
-        ConcatBins(bins_a, ia);
-        ConcatBins(bins_b, ib);
-    }
-    const auto nshared = [&](int32_t a, int32_t b) {
-        int n = 0;
-        for (int ka = 0; ka < 3; ++ka) {
-            for (int kb = 0; kb < 3; ++kb) {
-                if (T[static_cast<size_t>(a)][ka] == T[static_cast<size_t>(b)][kb]) {
-                    ++n;
-                    break;
-                }
-            }
-        }
-        return n;
-    };
-    const auto pushPortals = [&](int32_t ti, int32_t tj, std::vector<HopPt>& out) {
-        int32_t sh[2] = { -1, -1 };
-        int ns = 0;
-        for (int ka = 0; ka < 3 && ns < 2; ++ka) {
-            const int32_t v = T[static_cast<size_t>(ti)][ka];
-            if (v == T[static_cast<size_t>(tj)][0] || v == T[static_cast<size_t>(tj)][1] || v == T[static_cast<size_t>(tj)][2]) {
-                sh[ns++] = v;
-            }
-        }
-        const WorldPoint p0 = mesh.V[sh[0]];
-        const WorldPoint p1 = mesh.V[sh[1]];
-        for (const double t : kPortalSamples) {
-            const WorldPoint pt { p0.x + (p1.x - p0.x) * t, p0.y + (p1.y - p0.y) * t };
-            out.push_back({ pt, pt, tj });
-            out.push_back({ pt, pt, ti });
-        }
-    };
-    int64_t n_edge = 0;
-    int64_t n_touch = 0;
-    int64_t n_bridge = 0;
-    int64_t n_srcadj = 0;
-    for (size_t r = 0; r < ia.size(); ++r) {
-        const int32_t i = ia[r];
-        const int32_t j = ib[r];
-        if (comp[static_cast<size_t>(i)] == comp[static_cast<size_t>(j)]) {
-            continue;
-        }
-        if (nshared(i, j) == 2) {
-            pushPortals(i, j, hops);
-            ++n_edge;
-        }
-        else {
-            const auto br = planner.closestEdgeBridgePoints(static_cast<uint32_t>(lo + i), static_cast<uint32_t>(lo + j));
-            if (!br) {
-                continue;
-            }
-            const WorldPoint ex = (*br)[0];
-            const WorldPoint en = (*br)[1];
-            hops.push_back({ ex, en, j });
-            hops.push_back({ en, ex, i });
-            (std::hypot(ex.x - en.x, ex.y - en.y) > 1e-7 ? ++n_bridge : ++n_touch);
-        }
-    }
-
-    std::vector<WorldPoint> cent(static_cast<size_t>(m));
-    for (int64_t i = 0; i < m; ++i) {
-        const auto& tri = T[static_cast<size_t>(i)];
-        cent[static_cast<size_t>(i)] = { (mesh.V[tri[0]].x + mesh.V[tri[1]].x + mesh.V[tri[2]].x) / 3.0,
-                                         (mesh.V[tri[0]].y + mesh.V[tri[1]].y + mesh.V[tri[2]].y) / 3.0 };
-    }
-    // 逐对局部泛洪都要一套访问标记, 每对新建散列集与双端队列的话分配与哈希就是这段的全部开销。
-    // 每块一组世代戳和一个当队列使的数组: 戳只在本块内比对, 队列仍是先进先出, 访问序逐位相同。
-    const auto n_pair = static_cast<int64_t>(ia.size());
-    const size_t nw_src = NavWorkerCount(n_pair);
-    std::vector<std::vector<HopPt>> bins_src(nw_src);
-    std::vector<int64_t> cnt_src(nw_src, 0);
-    ParallelChunks(n_pair, nw_src, [&](size_t w, int64_t pair_lo, int64_t pair_hi) {
-        std::vector<uint32_t> vis(static_cast<size_t>(m), 0);
-        std::vector<int32_t> dq;
-        uint32_t vis_epoch = 0;
-        for (int64_t r = pair_lo; r < pair_hi; ++r) {
-            const int32_t ta = ia[static_cast<size_t>(r)];
-            const int32_t tb = ib[static_cast<size_t>(r)];
-            if (comp[static_cast<size_t>(ta)] != comp[static_cast<size_t>(tb)]) {
-                continue;
-            }
-            bool adjacent = false;
-            for (int k1 = 0; k1 < 3 && !adjacent; ++k1) {
-                const int32_t n1 = NB[static_cast<size_t>(ta)][k1];
-                if (n1 < 0) {
-                    continue;
-                }
-                const auto& row = NB[static_cast<size_t>(n1)];
-                adjacent = row[0] == tb || row[1] == tb || row[2] == tb;
-            }
-            if (adjacent) {
-                continue;
-            }
-            const WorldPoint mx { (cent[static_cast<size_t>(ta)].x + cent[static_cast<size_t>(tb)].x) * 0.5,
-                                  (cent[static_cast<size_t>(ta)].y + cent[static_cast<size_t>(tb)].y) * 0.5 };
-            ++vis_epoch;
-            vis[static_cast<size_t>(ta)] = vis_epoch;
-            dq.clear();
-            dq.push_back(ta);
-            size_t head = 0;
-            bool hit = false;
-            while (head < dq.size() && !hit) {
-                const int32_t t2 = dq[head++];
-                for (int k = 0; k < 3; ++k) {
-                    const int32_t nb2 = NB[static_cast<size_t>(t2)][k];
-                    if (nb2 < 0 || vis[static_cast<size_t>(nb2)] == vis_epoch) {
-                        continue;
-                    }
-                    if (nb2 == tb) { // 目标判定先于出框判定
-                        hit = true;
-                        break;
-                    }
-                    if (std::fabs(cent[static_cast<size_t>(nb2)].x - mx.x) > kSrcadjLocalR
-                        || std::fabs(cent[static_cast<size_t>(nb2)].y - mx.y) > kSrcadjLocalR) {
-                        continue;
-                    }
-                    vis[static_cast<size_t>(nb2)] = vis_epoch;
-                    dq.push_back(nb2);
-                }
-            }
-            if (hit) {
-                continue;
-            }
-            if (nshared(ta, tb) == 2) {
-                pushPortals(ta, tb, bins_src[w]);
-            }
-            else {
-                const auto br =
-                    planner.closestEdgeBridgePoints(static_cast<uint32_t>(lo + ta), static_cast<uint32_t>(lo + tb));
-                if (!br) {
-                    continue;
-                }
-                const WorldPoint ex = (*br)[0];
-                const WorldPoint en = (*br)[1];
-                if (std::hypot(ex.x - en.x, ex.y - en.y) > kSrcadjMaxGap) {
-                    continue;
-                }
-                bins_src[w].push_back({ ex, en, tb });
-                bins_src[w].push_back({ en, ex, ta });
-            }
-            ++cnt_src[w];
-        }
-    });
-    ConcatBins(bins_src, hops);
-    for (const int64_t c : cnt_src) {
-        n_srcadj += c;
-    }
-
     int64_t ncomps = 0;
     for (int64_t i = 0; i < m; ++i) {
         if (comp[static_cast<size_t>(i)] == i) {
@@ -692,8 +518,7 @@ ZoneClean::ZoneClean(
     stats += "mask " + std::to_string(walkable_flags) + " masked " + std::to_string(n_masked) + " cut "
              + std::to_string(n_mask_cut) + ", ";
     stats += "dup-sever " + std::to_string(n_dup) + ", link-mask cut " + std::to_string(n_cut) + ", comps "
-             + std::to_string(ncomps) + ", hops edge " + std::to_string(n_edge) + " touch " + std::to_string(n_touch) + " bridge "
-             + std::to_string(n_bridge) + " srcadj " + std::to_string(n_srcadj);
+             + std::to_string(ncomps);
 }
 
 std::optional<ZoneClean::SnapHit> ZoneClean::snap(const WorldPoint& p, double radius, std::optional<double> floor_y) const

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.h
@@ -74,6 +74,9 @@ public:
 
     std::optional<SnapHit> snap(const WorldPoint& p, double radius, std::optional<double> floor_y) const;
 
+    // 交还几何与逐三角的表。调用方保证之后不再读它们, 区号一类的标量照旧可用。
+    void release();
+
     std::string name;
     uint16_t zone_id = 0;
     int64_t lo = 0;

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.h
@@ -41,7 +41,8 @@ struct PolyMesh
     PolyMesh(std::vector<WorldPoint> v, std::vector<std::array<int32_t, 3>> t, std::vector<double> h);
 
     void buildNb();
-    std::vector<int32_t> trisNear(const WorldPoint& p, double r) const; // 升序去重
+    std::vector<int32_t> trisNear(const WorldPoint& p, double r) const;                // 升序去重
+    std::vector<int32_t> trisInBox(double x0, double y0, double x1, double y1) const;  // 升序去重
 
     // 三角按 24px 方格分桶。桶号在包围盒内连续, 所以只存一张偏移表, 查询按下标直接落桶。
     static constexpr double kGridCell = 24.0;
@@ -99,25 +100,6 @@ public:
 
 private:
     std::string error_;
-};
-
-// 网格的边界边索引: 可走面到此为止, 边的另一侧是什么一概不问
-class WallOracle
-{
-public:
-    explicit WallOracle(const ZoneClean& zc);
-
-    std::vector<int64_t> wallsInBbox(double x0, double y0, double x1, double y1) const;
-
-    std::vector<WorldPoint> P0;
-    std::vector<WorldPoint> P1;
-    std::vector<double> H0;
-    std::vector<double> H1;
-    std::vector<double> HH;
-
-private:
-    std::vector<WorldPoint> lo_;
-    std::vector<WorldPoint> hi_;
 };
 
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.h
@@ -16,8 +16,6 @@ namespace navmesh::recast
 
 inline constexpr double kWeldDh = 3.0;              // 顶点焊接同柱高差容差 px
 inline constexpr double kSnapFallbackRadius = 16.0; // 吸附兜底半径 px
-inline constexpr double kSrcadjMaxGap = 8.0;
-inline constexpr double kSrcadjLocalR = 12.0;
 
 // 源 surface 表(BSRF 段)那 32 位 flags 的收取掩码:第 n 位为 1 表示 area n 算可走面。
 // 导出端把 flags 写成 1<<area,所以这个掩码与一张 area 白名单等价。
@@ -57,13 +55,6 @@ private:
     void buildGrid();
 };
 
-struct HopPt
-{
-    WorldPoint exit_pt;
-    WorldPoint entry_pt;
-    int32_t to_tri = -1;
-};
-
 class ZoneClean
 {
 public:
@@ -95,7 +86,6 @@ public:
     // 绝不能压缩重排。
     std::vector<uint8_t> walkable;
     uint32_t walkable_flags = kWalkableFlagsDefault;
-    std::vector<HopPt> hops;
     std::string stats;
 
 private:

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.h
@@ -19,6 +19,17 @@ inline constexpr double kSnapFallbackRadius = 16.0; // 吸附兜底半径 px
 inline constexpr double kSrcadjMaxGap = 8.0;
 inline constexpr double kSrcadjLocalR = 12.0;
 
+// 源 surface 表(BSRF 段)那 32 位 flags 的收取掩码:第 n 位为 1 表示 area n 算可走面。
+// 导出端把 flags 写成 1<<area,所以这个掩码与一张 area 白名单等价。
+// 默认值取自游戏自己的 NavMeshProjectSettings.areas[32](Data/globalgamemanagers):
+// 判据是该 area 的 cost < 9999,即 {0 Walkable, 2 Jump, 3 Erosion, 4 Rock, 6 Trap,
+// 7 Tree, 10 Shallow Water, 11 Mid Water, 17 Walkable Override} = 0x00020CDD。
+// 排除的两类正是游戏自己标成 9999 的 12 Deep Water 与 18 Forbidden。
+// 它们照旧留在网格里 —— 几何与语义一个字节不丢,只是不参与邻接、分量、hop、吸附、
+// 墙判据与体素化,于是不再被当成普通地面走。
+// 包里没有 surface 表时全部可走,与历史行为逐字节相同。
+inline constexpr uint32_t kWalkableFlagsDefault = 0x00020CDDU;
+
 struct PolyMesh
 {
     std::vector<WorldPoint> V;
@@ -32,9 +43,13 @@ struct PolyMesh
     void buildNb();
     std::vector<int32_t> trisNear(const WorldPoint& p, double r) const; // 升序去重
 
+    // 三角按 24px 方格分桶。桶号在包围盒内连续, 所以只存一张偏移表, 查询按下标直接落桶。
     static constexpr double kGridCell = 24.0;
-    static constexpr int64_t kGridStride = int64_t(1) << 24;
-    std::vector<int64_t> gkeys;
+    int64_t gox = 0;
+    int64_t goy = 0;
+    int64_t gnx = 0;
+    int64_t gny = 0;
+    std::vector<int32_t> goff;
     std::vector<int32_t> gtris;
 
 private:
@@ -51,7 +66,8 @@ struct HopPt
 class ZoneClean
 {
 public:
-    ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, const std::string& zone_name);
+    ZoneClean(const BaseNavPack& pack, const BaseNavPlanner& planner, const std::string& zone_name,
+        uint32_t walkable_flags = kWalkableFlagsDefault);
 
     bool valid() const { return error_.empty(); }
 
@@ -73,6 +89,11 @@ public:
     PolyMesh mesh;
     std::vector<int32_t> comp;        // 三角 → 分量代表(区内最小三角号)
     std::vector<uint8_t> comp_island; // 按分量代表值索引
+    // 逐三角可走标记,与 mesh.T 同长同序。掩码外的三角照样占着自己那一行 ——
+    // RecastNavRoute 拿 (全局三角号 - lo) 直接索引 mesh,下标身份是硬约束,只能就地打标,
+    // 绝不能压缩重排。
+    std::vector<uint8_t> walkable;
+    uint32_t walkable_flags = kWalkableFlagsDefault;
     std::vector<HopPt> hops;
     std::string stats;
 

--- a/tools/MapNavigator/navtest_service.py
+++ b/tools/MapNavigator/navtest_service.py
@@ -82,7 +82,6 @@ class NavTestService:
         self._armed_path: list[Any] = []
         self._armed_kind = "route"
         self._armed_zip = False
-        self._armed_exact_slim = False
         self._tasker: Any = None
         self._resource: Any = None
         self._position_thread: threading.Thread | None = None
@@ -191,7 +190,6 @@ class NavTestService:
         *,
         exported: bool = False,
         zip_enabled: bool = False,
-        exact_slim: bool = False,
         assert_target: dict | None = None,
     ) -> None:
         """装载待跑的东西: 有断言框就装框, 否则装线。F3 跑的就是这一份。
@@ -218,7 +216,6 @@ class NavTestService:
             self._armed_path = nodes
             self._armed_kind = kind
             self._armed_zip = bool(zip_enabled and kind == "route")
-            self._armed_exact_slim = bool(exact_slim and kind == "route")
         self._on_armed(len(nodes), kind)
 
     def _export_assert(self, assert_target: dict) -> list[Any] | None:
@@ -248,7 +245,6 @@ class NavTestService:
                     points,
                     exported=bool(msg.get("exported")),
                     zip_enabled=bool(msg.get("zip")),
-                    exact_slim=bool(msg.get("exact_slim")),
                 )
             if kind == "run":
                 self.trigger_run()
@@ -372,7 +368,6 @@ class NavTestService:
             path = list(self._armed_path)
             kind = self._armed_kind
             zip_enabled = self._armed_zip
-            exact_slim = self._armed_exact_slim
         if not path:
             return
         if tasker.stopping or tasker.running:
@@ -394,8 +389,6 @@ class NavTestService:
             custom_action_param: dict[str, Any] = {"path": path}
             if zip_enabled:
                 custom_action_param["zip"] = True
-            if exact_slim:
-                custom_action_param["exact_slim"] = True
             override = {
                 node_name: {
                     "recognition": "DirectHit",

--- a/tools/MapNavigator/session_modes.py
+++ b/tools/MapNavigator/session_modes.py
@@ -75,7 +75,6 @@ def _build_navtest(runtime: Any, emit: Emit, log: Log, start: dict) -> Any:
         start.get("path") or [],
         exported=bool(start.get("exported")),
         zip_enabled=bool(start.get("zip")),
-        exact_slim=bool(start.get("exact_slim")),
         assert_target=start.get("assert_target"),
     )
     service.start(session_config_from_payload(start.get("config") or {}))

--- a/tools/MapNavigator/web/serve.py
+++ b/tools/MapNavigator/web/serve.py
@@ -1175,7 +1175,6 @@ async def _ws_session(websocket: WebSocket, mode: SessionMode) -> None:
             "path": path if isinstance(path, list) else [],
             # 白名单构造: 不显式搬过来的键在这里就没了, 提权子进程也拿不到。
             "exported": bool(first.get("exported")),
-            "exact_slim": bool(first.get("exact_slim")),
             "assert_target": assert_target if isinstance(assert_target, dict) else None,
         }
 

--- a/tools/MapNavigator/web/static/index.html
+++ b/tools/MapNavigator/web/static/index.html
@@ -192,35 +192,30 @@
             </summary>
             <div class="nav-debug-options-body">
               <label class="chk"
-                ><input id="three-chk-nav-debug-search" type="checkbox" /> A* 选择格点
-                <span class="nav-timing" data-nav-timing="astar">—</span></label
+                ><input id="three-chk-nav-debug-topology" type="checkbox" /> 拓扑逐格路径
+                <span class="nav-timing" data-nav-timing="topology">—</span></label
               >
               <label class="chk"
-                ><input id="three-chk-nav-debug-rerouted" type="checkbox" /> 绿色段二次重寻
-                <span class="nav-timing" data-nav-timing="rerouted">—</span></label
+                ><input id="three-chk-nav-debug-taut" type="checkbox" /> 几何紧绷折线
+                <span class="nav-timing" data-nav-timing="geometry">—</span></label
               >
               <label class="chk"
-                ><input id="three-chk-nav-debug-string-pull" type="checkbox" /> StringPull 连续拉直
-                <span class="nav-timing" data-nav-timing="string_pull">—</span></label
+                ><input id="three-chk-nav-debug-pulled" type="checkbox" /> 取直后折线
+                <span class="nav-timing" data-nav-timing="pull">—</span></label
               >
               <label class="chk"
-                ><input id="three-chk-nav-debug-assembled" type="checkbox" /> 端点拼接与去重
-                <span class="nav-timing" data-nav-timing="assembled">—</span></label
+                ><input id="three-chk-nav-debug-assembled" type="checkbox" /> 端点拼接与去冗
+                <span class="nav-timing" data-nav-timing="assemble">—</span></label
               >
               <label class="chk"
-                ><input id="three-chk-nav-debug-loop-fixed" type="checkbox" /> 交叉点处理
-                <span class="nav-timing" data-nav-timing="loop_fixed">—</span></label
+                ><input id="three-chk-nav-debug-planned" type="checkbox" /> 最终计划路径
+                <span class="nav-timing" data-nav-timing="lift">—</span></label
               >
-              <label class="chk"
-                ><input id="three-chk-nav-debug-slim" type="checkbox" /> Slim 抽稀
-                <span class="nav-timing" data-nav-timing="slim">—</span></label
-              >
-              <label class="chk"
-                ><input id="three-chk-nav-debug-widen-corners" type="checkbox" /> WidenCorners 拐角外移
-                <span class="nav-timing" data-nav-timing="widened">—</span></label
-              >
-              <label class="chk"><input id="three-chk-nav-debug-planned" type="checkbox" /> 最终计划路径</label>
               <label class="chk"><input id="three-chk-nav-debug-live-path" type="checkbox" /> 实时实际路径</label>
+              <div class="chk">
+                建窗 <span class="nav-timing" data-nav-timing="window">—</span> · 合计
+                <span class="nav-timing" data-nav-timing="total">—</span>
+              </div>
             </div>
           </details>
           <div class="sidebar-row">
@@ -356,9 +351,6 @@
             <label class="chk" title="按 MapNavigator 运行时语义规划当前区域片段；触屏控制器不会执行滑索">
               <input id="chk-edit-zipline" type="checkbox" /> 启用滑索规划（桌面端）
             </label>
-            <label class="chk" title="使用全候选动态规划优化路径，结果更精确但耗时较长">
-              <input id="chk-edit-exact-slim" type="checkbox" /> 精确优化路径（耗时较长）
-            </label>
           </div>
           <div id="edit-plan-start-label" class="sidebar-hint">规划起点：当前片段第一个路点</div>
           <div class="sidebar-hint">手动起点只用于规划预览，不会写入作者路径</div>
@@ -374,37 +366,32 @@
             </summary>
             <div class="nav-debug-options-body">
               <label class="chk"
-                ><input id="chk-nav-debug-search" type="checkbox" /> A* 选择格点
-                <span class="nav-timing" data-nav-timing="astar">—</span></label
+                ><input id="chk-nav-debug-topology" type="checkbox" /> 拓扑逐格路径
+                <span class="nav-timing" data-nav-timing="topology">—</span></label
               >
               <label class="chk"
-                ><input id="chk-nav-debug-rerouted" type="checkbox" /> 绿色段二次重寻
-                <span class="nav-timing" data-nav-timing="rerouted">—</span></label
+                ><input id="chk-nav-debug-taut" type="checkbox" /> 几何紧绷折线
+                <span class="nav-timing" data-nav-timing="geometry">—</span></label
               >
               <label class="chk"
-                ><input id="chk-nav-debug-string-pull" type="checkbox" /> StringPull 连续拉直
-                <span class="nav-timing" data-nav-timing="string_pull">—</span></label
+                ><input id="chk-nav-debug-pulled" type="checkbox" /> 取直后折线
+                <span class="nav-timing" data-nav-timing="pull">—</span></label
               >
               <label class="chk"
-                ><input id="chk-nav-debug-assembled" type="checkbox" /> 端点拼接与去重
-                <span class="nav-timing" data-nav-timing="assembled">—</span></label
+                ><input id="chk-nav-debug-assembled" type="checkbox" /> 端点拼接与去冗
+                <span class="nav-timing" data-nav-timing="assemble">—</span></label
               >
               <label class="chk"
-                ><input id="chk-nav-debug-loop-fixed" type="checkbox" /> 交叉点处理
-                <span class="nav-timing" data-nav-timing="loop_fixed">—</span></label
+                ><input id="chk-nav-debug-planned" type="checkbox" /> 最终计划路径
+                <span class="nav-timing" data-nav-timing="lift">—</span></label
               >
-              <label class="chk"
-                ><input id="chk-nav-debug-slim" type="checkbox" /> Slim 抽稀
-                <span class="nav-timing" data-nav-timing="slim">—</span></label
-              >
-              <label class="chk"
-                ><input id="chk-nav-debug-widen-corners" type="checkbox" /> WidenCorners 拐角外移
-                <span class="nav-timing" data-nav-timing="widened">—</span></label
-              >
-              <label class="chk"><input id="chk-nav-debug-planned" type="checkbox" /> 最终计划路径</label>
               <label class="chk" title="实机试跑时在地图上绘制游戏实际走过的轨迹"
                 ><input id="chk-nav-debug-live-path" type="checkbox" /> 实时实际路径</label
               >
+              <div class="chk">
+                建窗 <span class="nav-timing" data-nav-timing="window">—</span> · 合计
+                <span class="nav-timing" data-nav-timing="total">—</span>
+              </div>
             </div>
           </details>
         </div>

--- a/tools/MapNavigator/web/static/js/gl/overlay.js
+++ b/tools/MapNavigator/web/static/js/gl/overlay.js
@@ -1136,7 +1136,7 @@ export class Overlay {
    * planner, not a guessed heatmap of the priority queue.
    * @param {Camera} camera
    * @param {Array<Object>} diagnostics
-   * @param {{search?:boolean,rerouted?:boolean,stringPull?:boolean,assembled?:boolean,loopFixed?:boolean,slim?:boolean,widenCorners?:boolean}} options
+   * @param {{topology?:boolean,taut?:boolean,pulled?:boolean,assembled?:boolean}} options
    * @returns {void}
    */
   _drawAstarDiagnostics(camera, diagnostics, options) {
@@ -1165,40 +1165,28 @@ export class Overlay {
       ctx.restore();
     };
     for (const diag of diagnostics) {
-      if (options.search) {
-        drawDots(diag.astar_cells, "#38bdf8", 2.1, 0.9);
-        if (diag.astar_cells && diag.astar_cells.length > 1) {
+      if (options.topology) {
+        drawDots(diag.topology_cells, "#38bdf8", 2.1, 0.9);
+        if (diag.topology_cells && diag.topology_cells.length > 1) {
           ctx.save();
           ctx.strokeStyle = "#38bdf8";
           ctx.lineWidth = 1.1;
           ctx.setLineDash([2, 2]);
-          this._strokeSegments(camera, [diag.astar_cells]);
+          this._strokeSegments(camera, [diag.topology_cells]);
           ctx.restore();
         }
       }
-      if (options.rerouted) {
-        drawDots(diag.rerouted_points, "#22c55e", 2.8, 0.95);
-        drawLine(diag.rerouted_points, "#22c55e", 1.8);
+      if (options.taut) {
+        drawDots(diag.taut_points, "#22c55e", 2.8, 0.95);
+        drawLine(diag.taut_points, "#22c55e", 1.8);
       }
-      if (options.stringPull) {
-        drawDots(diag.string_pull_points, "#a78bfa", 2.8, 0.95);
-        drawLine(diag.string_pull_points, "#a78bfa", 2);
+      if (options.pulled) {
+        drawDots(diag.pulled_points, "#a78bfa", 2.8, 0.95);
+        drawLine(diag.pulled_points, "#a78bfa", 2);
       }
       if (options.assembled) {
         drawDots(diag.assembled_points, "#22d3ee", 3, 0.95);
         drawLine(diag.assembled_points, "#22d3ee", 1.8);
-      }
-      if (options.loopFixed) {
-        drawDots(diag.loop_fixed_points, "#60a5fa", 3, 0.95);
-        drawLine(diag.loop_fixed_points, "#60a5fa", 1.8);
-      }
-      if (options.slim) {
-        drawDots(diag.slim_points, "#f59e0b", 3.1, 0.95);
-        drawLine(diag.slim_points, "#f59e0b", 2);
-      }
-      if (options.widenCorners) {
-        drawDots(diag.widened_points, "#fb7185", 3.4, 0.95);
-        drawLine(diag.widened_points, "#fb7185", 2.2);
       }
     }
   }

--- a/tools/MapNavigator/web/static/js/main.js
+++ b/tools/MapNavigator/web/static/js/main.js
@@ -148,13 +148,10 @@ class MapNavigatorApp {
       return stored === null ? defaultValue : stored === "1";
     };
     this.navDebug = {
-      search: readDebugFlag("maaend.mapnavigator.debugSearch", false),
-      rerouted: readDebugFlag("maaend.mapnavigator.debugRerouted", false),
-      stringPull: readDebugFlag("maaend.mapnavigator.debugStringPull", false),
+      topology: readDebugFlag("maaend.mapnavigator.debugTopology", false),
+      taut: readDebugFlag("maaend.mapnavigator.debugTaut", false),
+      pulled: readDebugFlag("maaend.mapnavigator.debugPulled", false),
       assembled: readDebugFlag("maaend.mapnavigator.debugAssembled", false),
-      loopFixed: readDebugFlag("maaend.mapnavigator.debugLoopFixed", false),
-      slim: readDebugFlag("maaend.mapnavigator.debugSlim", false),
-      widenCorners: readDebugFlag("maaend.mapnavigator.debugWidenCorners", false),
       planned: readDebugFlag("maaend.mapnavigator.debugPlanned", true),
       live: readDebugFlag("maaend.mapnavigator.showLivePath", true),
     };
@@ -284,13 +281,10 @@ class MapNavigatorApp {
       threeRecolorRow: $("three-recolor-row"),
       btnThreeRecolor: $("btn-three-recolor"),
       threeNavDebugOptions: $("three-nav-debug-options"),
-      threeChkNavDebugSearch: $("three-chk-nav-debug-search"),
-      threeChkNavDebugRerouted: $("three-chk-nav-debug-rerouted"),
-      threeChkNavDebugStringPull: $("three-chk-nav-debug-string-pull"),
+      threeChkNavDebugTopology: $("three-chk-nav-debug-topology"),
+      threeChkNavDebugTaut: $("three-chk-nav-debug-taut"),
+      threeChkNavDebugPulled: $("three-chk-nav-debug-pulled"),
       threeChkNavDebugAssembled: $("three-chk-nav-debug-assembled"),
-      threeChkNavDebugLoopFixed: $("three-chk-nav-debug-loop-fixed"),
-      threeChkNavDebugSlim: $("three-chk-nav-debug-slim"),
-      threeChkNavDebugWidenCorners: $("three-chk-nav-debug-widen-corners"),
       threeChkNavDebugPlanned: $("three-chk-nav-debug-planned"),
       threeChkNavDebugLivePath: $("three-chk-nav-debug-live-path"),
       btnStart: $("btn-start"),
@@ -300,7 +294,6 @@ class MapNavigatorApp {
       btnEditPlanClear: $("btn-edit-plan-clear"),
       editPlanStartLabel: $("edit-plan-start-label"),
       chkEditZipline: $("chk-edit-zipline"),
-      chkEditExactSlim: $("chk-edit-exact-slim"),
       btnCopyAssert: $("btn-copy-assert"),
       assertCopyFormat: $("assert-copy-format"),
       btnImport: $("btn-import"),
@@ -354,13 +347,10 @@ class MapNavigatorApp {
       displayZoneCombo: $("display-zone-combo"),
       displayTierCombo: $("display-tier-combo"),
       navDebugOptions: $("nav-debug-options"),
-      chkNavDebugSearch: $("chk-nav-debug-search"),
-      chkNavDebugRerouted: $("chk-nav-debug-rerouted"),
-      chkNavDebugStringPull: $("chk-nav-debug-string-pull"),
+      chkNavDebugTopology: $("chk-nav-debug-topology"),
+      chkNavDebugTaut: $("chk-nav-debug-taut"),
+      chkNavDebugPulled: $("chk-nav-debug-pulled"),
       chkNavDebugAssembled: $("chk-nav-debug-assembled"),
-      chkNavDebugLoopFixed: $("chk-nav-debug-loop-fixed"),
-      chkNavDebugSlim: $("chk-nav-debug-slim"),
-      chkNavDebugWidenCorners: $("chk-nav-debug-widen-corners"),
       chkNavDebugPlanned: $("chk-nav-debug-planned"),
       chkNavDebugLivePath: $("chk-nav-debug-live-path"),
       loadProgress: $("load-progress"),
@@ -838,13 +828,10 @@ class MapNavigatorApp {
   /** Keep every diagnostic checkbox aligned with the persisted rendering state. */
   _syncNavDebugControls() {
     const controls = [
-      [this.els.chkNavDebugSearch, "search"],
-      [this.els.chkNavDebugRerouted, "rerouted"],
-      [this.els.chkNavDebugStringPull, "stringPull"],
+      [this.els.chkNavDebugTopology, "topology"],
+      [this.els.chkNavDebugTaut, "taut"],
+      [this.els.chkNavDebugPulled, "pulled"],
       [this.els.chkNavDebugAssembled, "assembled"],
-      [this.els.chkNavDebugLoopFixed, "loopFixed"],
-      [this.els.chkNavDebugSlim, "slim"],
-      [this.els.chkNavDebugWidenCorners, "widenCorners"],
       [this.els.chkNavDebugPlanned, "planned"],
       [this.els.chkNavDebugLivePath, "live"],
     ];
@@ -852,13 +839,10 @@ class MapNavigatorApp {
       entry.checked = Boolean(this.navDebug[key]);
     }
     const threeControls = [
-      [this.els.threeChkNavDebugSearch, "search"],
-      [this.els.threeChkNavDebugRerouted, "rerouted"],
-      [this.els.threeChkNavDebugStringPull, "stringPull"],
+      [this.els.threeChkNavDebugTopology, "topology"],
+      [this.els.threeChkNavDebugTaut, "taut"],
+      [this.els.threeChkNavDebugPulled, "pulled"],
       [this.els.threeChkNavDebugAssembled, "assembled"],
-      [this.els.threeChkNavDebugLoopFixed, "loopFixed"],
-      [this.els.threeChkNavDebugSlim, "slim"],
-      [this.els.threeChkNavDebugWidenCorners, "widenCorners"],
       [this.els.threeChkNavDebugPlanned, "planned"],
       [this.els.threeChkNavDebugLivePath, "live"],
     ];
@@ -912,11 +896,6 @@ class MapNavigatorApp {
       if (this.quickRouteTest?.goal) this._calculateQuickRouteTest();
       else if (this.editRoute) this._calculateEditPreview();
     });
-    e.chkEditExactSlim.addEventListener("change", () => {
-      if (this.navtest) this.navtest.routeChanged();
-      if (this.quickRouteTest?.goal) this._calculateQuickRouteTest();
-      else if (this.editRoute) this._calculateEditPreview();
-    });
     e.btnMapLayers.addEventListener("click", (event) => {
       event.stopPropagation();
       this._setMapLayerPanelOpen(e.mapLayerPanel.hidden);
@@ -947,13 +926,10 @@ class MapNavigatorApp {
     e.displayZoneCombo.addEventListener("change", () => this._onDisplayZoneChanged());
     e.displayTierCombo.addEventListener("change", () => this._onDisplayTierChanged());
     for (const [entry, key] of [
-      [e.chkNavDebugSearch, "search"],
-      [e.chkNavDebugRerouted, "rerouted"],
-      [e.chkNavDebugStringPull, "stringPull"],
+      [e.chkNavDebugTopology, "topology"],
+      [e.chkNavDebugTaut, "taut"],
+      [e.chkNavDebugPulled, "pulled"],
       [e.chkNavDebugAssembled, "assembled"],
-      [e.chkNavDebugLoopFixed, "loopFixed"],
-      [e.chkNavDebugSlim, "slim"],
-      [e.chkNavDebugWidenCorners, "widenCorners"],
       [e.chkNavDebugPlanned, "planned"],
     ]) {
       entry.addEventListener("change", () => {
@@ -974,13 +950,10 @@ class MapNavigatorApp {
       this._syncThreeOverlays();
     });
     for (const [entry, key] of [
-      [e.threeChkNavDebugSearch, "search"],
-      [e.threeChkNavDebugRerouted, "rerouted"],
-      [e.threeChkNavDebugStringPull, "stringPull"],
+      [e.threeChkNavDebugTopology, "topology"],
+      [e.threeChkNavDebugTaut, "taut"],
+      [e.threeChkNavDebugPulled, "pulled"],
       [e.threeChkNavDebugAssembled, "assembled"],
-      [e.threeChkNavDebugLoopFixed, "loopFixed"],
-      [e.threeChkNavDebugSlim, "slim"],
-      [e.threeChkNavDebugWidenCorners, "widenCorners"],
       [e.threeChkNavDebugPlanned, "planned"],
     ]) {
       entry.addEventListener("change", () => {
@@ -2506,13 +2479,10 @@ class MapNavigatorApp {
       });
     return (diagnostics || []).map((diag) => ({
       ...diag,
-      astar_cells: project(diag.astar_cells),
-      rerouted_points: project(diag.rerouted_points),
-      string_pull_points: project(diag.string_pull_points),
+      topology_cells: project(diag.topology_cells),
+      taut_points: project(diag.taut_points),
+      pulled_points: project(diag.pulled_points),
       assembled_points: project(diag.assembled_points),
-      loop_fixed_points: project(diag.loop_fixed_points),
-      slim_points: project(diag.slim_points),
-      widened_points: project(diag.widened_points),
       planned_points: project(diag.planned_points),
       start: project([diag.start])[0],
       goal: project([diag.goal])[0],
@@ -3956,10 +3926,7 @@ class MapNavigatorApp {
 
   /** Plan the temporary S/G pair through the runtime MapNavigateAction preview. */
   async _calculateQuickRouteTest() {
-    const built = buildQuickRouteTestRequest(this.quickRouteTest, {
-      zip: this.els.chkEditZipline.checked,
-      exact_slim: this.els.chkEditExactSlim.checked,
-    });
+    const built = buildQuickRouteTestRequest(this.quickRouteTest, {zip: this.els.chkEditZipline.checked});
     if (!built.ok) {
       setStatus(built.error, "#f59e0b");
       return;
@@ -4026,7 +3993,6 @@ class MapNavigatorApp {
       const exported = await exportPath(plan.targets);
       const customActionParam = {path: exported.nodes || []};
       if (this.els.chkEditZipline.checked) customActionParam.zip = true;
-      if (this.els.chkEditExactSlim.checked) customActionParam.exact_slim = true;
       const result = await postRoutePreview({
         position: plan.position,
         position_zone: plan.positionZone,
@@ -4905,8 +4871,7 @@ class MapNavigatorApp {
 
   /** Keep each copy button's label aligned with its selected output format. @returns {void} */
   _syncCopyButtonLabels() {
-    this.els.btnCopyPath.textContent =
-      this.els.chkEditZipline.checked || this.els.chkEditExactSlim.checked ? "复制完整参数" : "复制路径";
+    this.els.btnCopyPath.textContent = this.els.chkEditZipline.checked ? "复制完整参数" : "复制路径";
     this.els.btnCopyAssert.textContent =
       this.els.assertCopyFormat.value === COPY_FORMAT_COORDINATES ? "复制坐标" : "复制断言";
   }
@@ -4919,10 +4884,8 @@ class MapNavigatorApp {
     }
     try {
       const result = await exportPath(this.state.points);
-      if (this.els.chkEditZipline.checked || this.els.chkEditExactSlim.checked) {
-        const param = {path: result.nodes};
-        if (this.els.chkEditZipline.checked) param.zip = true;
-        if (this.els.chkEditExactSlim.checked) param.exact_slim = true;
+      if (this.els.chkEditZipline.checked) {
+        const param = {path: result.nodes, zip: true};
         await this._copyText(JSON.stringify(param, null, 4));
         setStatus("MapNavigator 完整参数已复制到剪贴板", "#10b981");
       } else {
@@ -4974,7 +4937,6 @@ class MapNavigatorApp {
       path: this.state.points,
       exported: false,
       zip: this.els.chkEditZipline.checked,
-      exact_slim: this.els.chkEditExactSlim.checked,
     };
   }
 

--- a/tools/MapNavigator/web/static/js/quick_route_test.js
+++ b/tools/MapNavigator/web/static/js/quick_route_test.js
@@ -53,10 +53,10 @@ export function advanceQuickRouteTest(current, endpoint) {
  * temporary NAVMESH target that never enters the editor's route state.
  *
  * @param {?{start:Object,goal:?Object}} state
- * @param {{zip?:boolean,exact_slim?:boolean}} [options]
+ * @param {{zip?:boolean}} [options]
  * @returns {{ok:true,request:Object}|{ok:false,error:string}}
  */
-export function buildQuickRouteTestRequest(state, {zip = false, exact_slim = false} = {}) {
+export function buildQuickRouteTestRequest(state, {zip = false} = {}) {
   const start = state?.start;
   const goal = state?.goal;
   if (!isValidEndpoint(start) || !isValidEndpoint(goal)) {
@@ -74,7 +74,6 @@ export function buildQuickRouteTestRequest(state, {zip = false, exact_slim = fal
 
   const customActionParam = {path: [target]};
   if (zip) customActionParam.zip = true;
-  if (exact_slim) customActionParam.exact_slim = true;
   return {
     ok: true,
     request: {

--- a/tools/MapNavigator/web/static/js/rpc.js
+++ b/tools/MapNavigator/web/static/js/rpc.js
@@ -520,7 +520,6 @@ export class NavTestSocket extends SessionSocket {
       path: (route && route.path) || [],
       exported: !!(route && route.exported),
       zip: !!(route && route.zip),
-      exact_slim: !!(route && route.exact_slim),
       assert_target: (route && route.assert_target) || null,
     };
   }

--- a/tools/MapNavigator/web/static/js/three_navmesh_view.js
+++ b/tools/MapNavigator/web/static/js/three_navmesh_view.js
@@ -461,13 +461,10 @@ export class ThreeNavmeshView {
     this.diagnosticMarkers = [];
     if (!this.mesh || !Array.isArray(diagnostics)) return;
     const stages = [
-      ["astar_cells", "search", 0x38bdf8, 0],
-      ["rerouted_points", "rerouted", 0x22c55e, DIAGNOSTIC_RADIUS],
-      ["string_pull_points", "stringPull", 0xf59e0b, DIAGNOSTIC_RADIUS],
+      ["topology_cells", "topology", 0x38bdf8, 0],
+      ["taut_points", "taut", 0x22c55e, DIAGNOSTIC_RADIUS],
+      ["pulled_points", "pulled", 0xf59e0b, DIAGNOSTIC_RADIUS],
       ["assembled_points", "assembled", 0xa78bfa, DIAGNOSTIC_RADIUS],
-      ["loop_fixed_points", "loopFixed", 0xfb7185, DIAGNOSTIC_RADIUS],
-      ["slim_points", "slim", 0x38bdf8, DIAGNOSTIC_RADIUS],
-      ["widened_points", "widenCorners", 0xf97316, DIAGNOSTIC_RADIUS],
     ];
     for (const [key, optionKey, color, width] of stages) {
       if (!options[optionKey]) continue;
@@ -489,7 +486,9 @@ export class ThreeNavmeshView {
           new THREE.PointsMaterial({
             color,
             size:
-              key === "astar_cells" ? Math.max(0.12, this.meshRadius * 0.001) : Math.max(0.2, this.meshRadius * 0.0015),
+              key === "topology_cells"
+                ? Math.max(0.12, this.meshRadius * 0.001)
+                : Math.max(0.2, this.meshRadius * 0.0015),
             sizeAttenuation: true,
             depthTest: false,
             transparent: true,

--- a/tools/MapNavigator/web/test_overlay.mjs
+++ b/tools/MapNavigator/web/test_overlay.mjs
@@ -211,10 +211,10 @@ test("draws selected-route diagnostics in edit mode", () => {
   overlay._drawAstarDiagnostics = (_camera, diagnostics, options) => calls.push({diagnostics, options});
   const diagnostics = [
     {
-      astar_cells: [[1, 2]],
+      topology_cells: [[1, 2]],
     },
   ];
-  const debugOptions = {search: true};
+  const debugOptions = {topology: true};
   overlay.render(
     {},
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增按可行走区域查询附近导航区域的能力。
  - 支持按可行走表面标记过滤导航区域。
  - 滑索路线会预先筛选可登乘及可落地点，减少无效路线尝试。

- **改进**
  - 导航诊断界面改为展示拓扑、紧绷、取直、组装及最终路线阶段，并提供对应耗时。
  - 优化导航网格构建与路线计算流程，提升复杂场景下的规划效率。

- **变更**
  - 移除“精确优化路径”选项及相关请求参数。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->