### PR TITLE
fix: 自动使用理智药剂任务完成后会关闭使用理智界面

### DIFF
--- a/assets/resource/pipeline/AutoUseSpMedication/Main.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/Main.json
@@ -23,6 +23,7 @@
         },
         "next": [
             "[JumpBack]AutoUseSpMedicationLoop",
+            "[JumpBack]AutoUseSpMedicationCloseUsePage",
             "EmptyNode"
         ]
     },
@@ -47,7 +48,10 @@
                 ]
             }
         },
-        "action": "StopTask",
+        "next": [
+            "[JumpBack]AutoUseSpMedicationCloseUsePage",
+            "StopNode"
+        ],
         "focus": {
             "Node.Recognition.Succeeded": "$task.AutoUseSpMedication.focus.no_booster_available"
         }

--- a/assets/resource/pipeline/AutoUseSpMedication/UseEmergencySanityBooster.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/UseEmergencySanityBooster.json
@@ -38,7 +38,7 @@
         ]
     },
     "AutoUseSpMedicationCheckSanityEnough": {
-        "desc": "检查理智大于用户输入,停止",
+        "desc": "检查理智大于用户输入,关闭使用页后停止",
         "recognition": {
             "type": "Custom",
             "param": {
@@ -50,11 +50,12 @@
             }
         },
         "pre_delay": 0,
-        "action": {
-            "type": "StopTask"
-        },
         "post_delay": 0,
         "rate_limit": 0,
+        "next": [
+            "[JumpBack]AutoUseSpMedicationCloseUsePage",
+            "StopNode"
+        ],
         "focus": {
             "Node.Recognition.Succeeded": "$task.AutoUseSpMedication.focus.check_sanity_sufficient"
         }
@@ -211,5 +212,24 @@
         "focus": {
             "Node.Action.Succeeded": "$task.AutoUseSpMedication.focus.quick_use_unavailable"
         }
+    },
+    "AutoUseSpMedicationCloseUsePage": {
+        "desc": "关闭吃理智药界面",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "CloseButtonType1"
+                ],
+                "box_index": 0
+            }
+        },
+        "pre_delay": 0,
+        "action": {
+            "type": "Click"
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": []
     }
 }

--- a/assets/resource/pipeline/AutoUseSpMedication/UseEmergencySanityBooster.json
+++ b/assets/resource/pipeline/AutoUseSpMedication/UseEmergencySanityBooster.json
@@ -230,6 +230,24 @@
         },
         "post_delay": 0,
         "rate_limit": 0,
-        "next": []
+        "next": [
+            "AutoUseSpMedicationUsePageClosed",
+            "AutoUseSpMedicationCloseUsePage"
+        ]
+    },
+    "AutoUseSpMedicationUsePageClosed": {
+        "desc": "确认吃理智药界面已关闭",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "CloseButtonType1"
+                ]
+            }
+        },
+        "inverse": true,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **优化**
  - 优化应急理智药使用流程：无可用药剂或理智充足时，系统会先关闭药剂使用页面，再结束任务。
  - 增加关闭后的页面状态确认；若页面未成功关闭，系统会重试关闭操作，减少流程中断和页面残留。
  - 在珍贵物品页面识别流程中增加关闭使用页面后的回跳处理，提升任务执行的连续性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->