### PR TITLE
fix: 暂存区支持使用白色按钮领取

### DIFF
--- a/assets/resource/pipeline/DailyRewards/Emails.json
+++ b/assets/resource/pipeline/DailyRewards/Emails.json
@@ -200,7 +200,8 @@
         },
         "next": [
             "DailyEmailReceiveTSACannotClaim",
-            "DailyEmailReceiveTSA"
+            "DailyEmailReceiveTSAYellow",
+            "DailyEmailReceiveTSAWhite"
         ],
         "focus": {
             "Node.Recognition.Succeeded": "收取暂存区物资"
@@ -318,7 +319,8 @@
             }
         }
     },
-    "DailyEmailReceiveTSA": {
+    "DailyEmailReceiveTSAYellow": {
+        "desc": "暂存区全部领取（黄色按钮）",
         "recognition": {
             "type": "And",
             "param": {
@@ -344,6 +346,48 @@
             "type": "OCR",
             "param": {
                 "roi": "YellowConfirmButtonType1",
+                "roi_offset": [
+                    -106,
+                    -2,
+                    75,
+                    3
+                ],
+                "expected": [
+                    "全部领取",
+                    "全部領取",
+                    "(?i)Claim\\s*All",
+                    "一括受取"
+                ]
+            }
+        }
+    },
+    "DailyEmailReceiveTSAWhite": {
+        "desc": "暂存区全部领取（白色按钮）",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "WhiteConfirmButtonType1",
+                    "DailyEmailReceiveTSAWhiteText"
+                ],
+                "box_index": 1
+            }
+        },
+        "pre_wait_freezes": 200,
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "next": [
+            "DailyEmailConfirmTSA"
+        ]
+    },
+    "DailyEmailReceiveTSAWhiteText": {
+        "desc": "暂存区全部领取白色按钮文本",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": "WhiteConfirmButtonType1",
                 "roi_offset": [
                     -106,
                     -2,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 每日奖励邮件领取流程现支持识别黄色和白色领取按钮。
  - 系统会根据按钮颜色及领取文本完成识别，并自动执行点击操作。
  - 两种按钮均可进入领取确认步骤，提升不同界面样式下的领取兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->