### PR TITLE
fix(AutoDelivery): 等待对话稳定后再点击跳过

### DIFF
--- a/assets/resource/pipeline/AutoDelivery/Delivery.json
+++ b/assets/resource/pipeline/AutoDelivery/Delivery.json
@@ -312,6 +312,21 @@
             "AutoDeliveryRetryNavigateDestination"
         ]
     },
+    "AutoDeliveryCheckSkipChatReady": {
+        "desc": "送货交互进入对话后等待跳过按钮稳定",
+        "recognition": "And",
+        "all_of": [
+            "AutoDeliveryInChatDialog",
+            "AutoDeliveryCheckSkipChatButton"
+        ],
+        "pre_wait_freezes": 200,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoDeliverySkipChat"
+        ]
+    },
     "AutoDeliverySkipChat": {
         "desc": "送货交互进入对话时跳过对话",
         "recognition": "And",
@@ -373,7 +388,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "AutoDeliverySkipChat",
+            "AutoDeliveryCheckSkipChatReady",
             "AutoDeliveryCloseRewardDialog"
         ],
         "focus": {

--- a/assets/resource/pipeline/AutoDelivery/Delivery.json
+++ b/assets/resource/pipeline/AutoDelivery/Delivery.json
@@ -319,6 +319,7 @@
             "AutoDeliveryInChatDialog",
             "AutoDeliveryCheckSkipChatButton"
         ],
+        "box_index": 1,
         "pre_wait_freezes": 200,
         "pre_delay": 0,
         "post_delay": 0,
@@ -336,7 +337,8 @@
         ],
         "box_index": 1,
         "pre_delay": 0,
-        "action": "Click",
+        "action": "Custom",
+        "custom_action": "AutoAltClickAction",
         "post_wait_freezes": {
             "target": [
                 520,

--- a/tools/pipeline-generate/DeliveryJobs/data.test.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/data.test.mjs
@@ -1450,16 +1450,8 @@ test("AutoDelivery ensures the delivery mission detail before branching", () => 
         "AutoDeliveryCheckSubmitGoodsButton",
     ]);
     assert.deepEqual(delivery.AutoDeliverySubmitGoods.next, [
-        "AutoDeliveryCheckSkipChatReady",
-        "AutoDeliveryCloseRewardDialog",
-    ]);
-    assert.deepEqual(delivery.AutoDeliveryCheckSkipChatReady.all_of, [
-        "AutoDeliveryInChatDialog",
-        "AutoDeliveryCheckSkipChatButton",
-    ]);
-    assert.equal(delivery.AutoDeliveryCheckSkipChatReady.pre_wait_freezes, 200);
-    assert.deepEqual(delivery.AutoDeliveryCheckSkipChatReady.next, [
         "AutoDeliverySkipChat",
+        "AutoDeliveryCloseRewardDialog",
     ]);
     assert.deepEqual(delivery.AutoDeliverySkipChat.next, [
         "AutoDeliverySkipChatConfirm",

--- a/tools/pipeline-generate/DeliveryJobs/data.test.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/data.test.mjs
@@ -1450,8 +1450,16 @@ test("AutoDelivery ensures the delivery mission detail before branching", () => 
         "AutoDeliveryCheckSubmitGoodsButton",
     ]);
     assert.deepEqual(delivery.AutoDeliverySubmitGoods.next, [
-        "AutoDeliverySkipChat",
+        "AutoDeliveryCheckSkipChatReady",
         "AutoDeliveryCloseRewardDialog",
+    ]);
+    assert.deepEqual(delivery.AutoDeliveryCheckSkipChatReady.all_of, [
+        "AutoDeliveryInChatDialog",
+        "AutoDeliveryCheckSkipChatButton",
+    ]);
+    assert.equal(delivery.AutoDeliveryCheckSkipChatReady.pre_wait_freezes, 200);
+    assert.deepEqual(delivery.AutoDeliveryCheckSkipChatReady.next, [
+        "AutoDeliverySkipChat",
     ]);
     assert.deepEqual(delivery.AutoDeliverySkipChat.next, [
         "AutoDeliverySkipChatConfirm",


### PR DESCRIPTION
## 变更内容

- 在提交货物进入对话后，先确认对话与跳过按钮并等待画面稳定 200 ms，再执行跳过点击
- 保留奖励界面可直接命中的分支，避免对无需对话的交货流程增加等待

## 本地验证

- `node --test --test-name-pattern "AutoDelivery 纯识别节点统一使用 Check 或 In 命名" tools/pipeline-generate/AutoDelivery/data.test.mjs`：1/1 通过
- `pnpm exec prettier --check assets/resource/pipeline/AutoDelivery/Delivery.json`：通过
- `git diff --check origin/v2...HEAD`：通过
- 按日常本地开发约定未运行全量 `pnpm check` / `pnpm test`，由 PR CI 验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化送货流程：确认对话和跳过按钮均准备就绪并稳定后，再继续后续操作，减少流程过早执行的情况。
  - 调整跳过操作方式，提升交互执行的可靠性。
  - 提交货物前增加就绪状态检查。
  - 保留奖励弹窗关闭处理，确保完成流程更加顺畅。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->