### PR TITLE
fix: 地区建设更新弹窗卡死

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -658,7 +658,7 @@
         ]
     },
     "__ScenePrivateMenuRegionalDevelopmentUnlockClose": {
-        "desc": "关闭地区建设解锁弹窗",
+        "desc": "关闭版本更新地区建设解锁弹窗",
         "recognition": "And",
         "all_of": [
             "CheckRegionalDevelopmentText",
@@ -678,7 +678,16 @@
                     "해제"
                 ]
             },
-            "CloseButtonType1"
+            {
+                "recognition": "TemplateMatch",
+                "roi": [
+                    950,
+                    150,
+                    270,
+                    180
+                ],
+                "template": "Common/Button/CloseButtonType4.png"
+            }
         ],
         "box_index": 2,
         "pre_wait_freezes": {

--- a/assets/resource/pipeline/SceneManager/SceneRegionalDevelopment.json
+++ b/assets/resource/pipeline/SceneManager/SceneRegionalDevelopment.json
@@ -242,6 +242,7 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "[JumpBack]__ScenePrivateMenuRegionalDevelopmentUnlockClose",
             "[Anchor]__ScenePrivateAnyEnterMenuRegionalDevelopmentRegionAnchorSuccess"
         ]
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 地区建设解锁弹窗的描述新增版本更新限定。
  * 优化弹窗关闭识别，确保匹配指定区域内的关闭控件。
  * 优化地区切换确认流程，确认后先完成解锁弹窗关闭，再进入目标地区。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->