### PR TITLE
fix: 装备制造弹窗卡死

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -1906,6 +1906,33 @@
             }
         },
         "next": [
+            "__ScenePrivateAnyEnterMenuGearAssemblyUnlock",
+            "__ScenePrivateAnyEnterMenuGearAssemblySuccess"
+        ]
+    },
+    "__ScenePrivateAnyEnterMenuGearAssemblyUnlock": {
+        "desc": "有新的装备模版解锁",
+        "recognition": "And",
+        "all_of": [
+            {
+                "recognition": "OCR",
+                "roi": [
+                    400,
+                    250,
+                    550,
+                    150
+                ],
+                "expected": [
+                    "已解锁获得",
+                    "已解鎖獲得"
+                ]
+            },
+            "YellowConfirmButtonType1"
+        ],
+        "box_index": 1,
+        "pre_wait_freezes": 100,
+        "action": "Click",
+        "next": [
             "__ScenePrivateAnyEnterMenuGearAssemblySuccess"
         ]
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增对“装备模板已解锁”提示弹窗的处理：进入装备加工菜单后可自动确认提示，并继续进入加工成功状态。
  * 未出现提示弹窗时，仍可直接进入加工成功状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->