### PR TITLE
perf: 地图缩放逻辑精简

### DIFF
--- a/agent/cpp-algo/source/WorldMap/WorldMapFind.cpp
+++ b/agent/cpp-algo/source/WorldMap/WorldMapFind.cpp
@@ -89,11 +89,8 @@ constexpr int kMaxNudges = 6;
 constexpr double kNudgeRatio = 0.35;
 
 // 缩放档位是视口求解的未知量，进来先压到最小钉死。按钮坐标各端不同，
-// 所以复用 pipeline 那个节点而不在这儿抄一份
-constexpr const char* kZoomOutNode = "__ScenePrivateMapZoomOut";
-constexpr int kZoomOutMaxRounds = 10;
-constexpr int kZoomOutConfirmMisses = 3;
-constexpr int kZoomOutMissGapMillis = 400;
+// 交给 pipeline 的 SceneMapZoomOut 处理，cpp 只触发一次子任务
+constexpr const char* kZoomOutNode = "SceneMapZoomOut";
 
 bool ParseParam(const char* raw, FindParam* out)
 {
@@ -178,58 +175,11 @@ bool CaptureScreen(MaaController* controller, ScopedImageBuffer* buffer, cv::Mat
     return !out->empty();
 }
 
-enum class ZoomOutResult
-{
-    Pressed,       // 认到减号，按了一下
-    NotRecognized, // 没认到：可能已到底，也可能只是那一帧没画完
-    Undispatched,  // 子任务没发出去，再试也发不出去
-};
-
-// timeout 压成 0：否则入口认不中时框架会重扫满默认 20 秒。
-// 判不出来当作还能缩——误判成「已最小」会让视口求解必然失败，多按一次只是白按
-ZoomOutResult PressZoomOutOnce(MaaContext* context)
-{
-    const std::string overrides = json::value(json::object { { kZoomOutNode, json::object { { "timeout", 0 } } } }).dumps();
-
-    const MaaTaskId task_id = MaaContextRunTask(context, kZoomOutNode, overrides.c_str());
-    if (task_id == MaaInvalidId) {
-        LogWarn << "WorldMap: zoom-out subtask failed to dispatch" << VAR(kZoomOutNode);
-        return ZoomOutResult::Undispatched;
-    }
-
-    MaaTasker* tasker = MaaContextGetTasker(context);
-    ScopedStringBuffer entry;
-    constexpr MaaSize kNodeCap = 8;
-    MaaNodeId nodes[kNodeCap] {};
-    MaaSize node_count = kNodeCap;
-    MaaStatus status = MaaStatus_Invalid;
-    if (tasker == nullptr || !MaaTaskerGetTaskDetail(tasker, task_id, entry.Get(), nodes, &node_count, &status)) {
-        LogWarn << "WorldMap: zoom-out status unavailable, keeping on zooming" << VAR(task_id);
-        return ZoomOutResult::Pressed;
-    }
-    return status == MaaStatus_Failed ? ZoomOutResult::NotRecognized : ZoomOutResult::Pressed;
-}
-
-// 认到就接着按，一路按到底。认不到不等于已经到底（那一帧可能只是动画没画完），
-// 所以隔开确认几次才收手
 void ZoomMapOut(MaaContext* context)
 {
-    int misses = 0;
-    for (int round = 0; round < kZoomOutMaxRounds; ++round) {
-        const ZoomOutResult result = PressZoomOutOnce(context);
-        if (result == ZoomOutResult::Undispatched) {
-            return;
-        }
-        if (result == ZoomOutResult::Pressed) {
-            misses = 0;
-            continue;
-        }
-        if (++misses >= kZoomOutConfirmMisses) {
-            return;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(kZoomOutMissGapMillis));
+    if (MaaContextRunTask(context, kZoomOutNode, "{}") == MaaInvalidId) {
+        LogWarn << "WorldMap: zoom-out subtask failed to dispatch" << VAR(kZoomOutNode);
     }
-    LogWarn << "WorldMap: zoom-out never settled" << VAR(kZoomOutMaxRounds);
 }
 
 double RandomIn(double lo, double hi)

--- a/assets/resource/pipeline/Interface/Scene.json
+++ b/assets/resource/pipeline/Interface/Scene.json
@@ -234,7 +234,17 @@
     },
     "SceneMapZoomOut": {
         "desc": "在地图界面缩小地图（供 MapFind 等子任务调用）",
-        "recognition": "DirectHit",
+        "recognition": "TemplateMatch",
+        "roi": [
+            -350,
+            0,
+            350,
+            60
+        ],
+        "template": [
+            "SceneManager/MapMind.png"
+        ],
+        "method": 10001, // 默认5时，当弹出右侧面板，此图片依然能匹配上
         "pre_delay": 0,
         "action": "DoNothing",
         "post_delay": 0,

--- a/assets/resource/pipeline/Interface/Scene.json
+++ b/assets/resource/pipeline/Interface/Scene.json
@@ -232,6 +232,17 @@
             "__ScenePrivateNoticeRewardsUpgradeConfirm"
         ]
     },
+    "SceneMapZoomOut": {
+        "desc": "在地图界面缩小地图（供 MapFind 等子任务调用）",
+        "recognition": "DirectHit",
+        "pre_delay": 0,
+        "action": "DoNothing",
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapZoomOut",
+            "__ScenePrivateNextTrue"
+        ]
+    },
     "SceneWaitLoadingExit": {
         "desc": "判断当前场景在加载界面，什么都不做，用于等待加载界面消失",
         "recognition": {

--- a/docs/en_us/developers/components/world-map.md
+++ b/docs/en_us/developers/components/world-map.md
@@ -19,7 +19,7 @@ Find the given coordinate on the current map, and confirm the icon sitting there
 
 The node zooms the map all the way out first, then captures the screen itself, solves the viewport, and pans the map when needed, until the target is inside the usable area. **Once `icon` is given, no confirmation means no coordinate** — being able to compute a position does not mean anything is there. It would rather fail and let the caller retry or take another candidate than hand back a computed empty spot. Without an `icon` it just solves the coordinate and hands it back, making no such promise.
 
-The zoom level is the unknown the viewport solve has to sweep its scale band for, so pinning it down is the first thing the node does: it keeps running the Pipeline's `__ScenePrivateMapZoomOut`, pressing again for as long as the minus button is recognised. Once the minus button has greyed out — nothing left to zoom — that node no longer recognises and not a single touch goes out. But **failing to recognise it is not proof of having bottomed out**: that one frame may just be mid-animation, and believing the map is at its minimum when it is not makes the viewport solve fail every time. So it takes several spaced-out confirmations before it stops, and anything it cannot judge counts as "still zoomable". Writing `__ScenePrivateMapZoomOut` into the Pipeline is therefore optional: with it the zoom is already done, without it the node does it. The button sits at different coordinates on each client, so it follows the resource layers; the node itself carries no coordinates.
+The zoom level is the unknown the viewport solve has to sweep its scale band for, so pinning it down is the first thing the node does: it runs the Pipeline's `SceneMapZoomOut` once; when that subtask returns, the map should already be at minimum zoom. The button sits at different coordinates on each client, so it follows the resource layers; the node itself carries no coordinates. Writing `[JumpBack]__ScenePrivateMapZoomOut` into the Pipeline is therefore optional: with it the zoom is already done, without it `MapFind` still calls `SceneMapZoomOut`.
 
 ### Node parameters
 
@@ -143,7 +143,7 @@ Three entries exist today:
 
 Teleport nodes live in `assets/resource/pipeline/SceneManager/SceneTeleport<Zone>.json` and fill the `__ScenePrivateMapTeleportPickAnchor` slot; entry nodes live in `Interface/Scene<Zone>.json`, bind that slot and route through `__ScenePrivateMap<SubArea>EnterWorldAnchorWithPick`, which switches the map to its main layer, uses `all_of` to confirm that this really is that sub-area's map screen, and gives the zoom a head start on the way.
 
-The `__ScenePrivateMapZoomOut` in the entry node is a head start, not a requirement: `MapFind` zooms out on its own. Copy an existing entry when wiring up a new point; leaving it out costs nothing in recognition.
+The `[JumpBack]__ScenePrivateMapZoomOut` in the entry node is a head start, not a requirement: `MapFind` calls `SceneMapZoomOut` on its own. Copy an existing entry when wiring up a new point; leaving it out costs nothing in recognition.
 
 The sub-area check lives on `...EnterWorldAnchorWithPick`; the `MapFind` node no longer repeats it — the `recognition` slot went to `MapFind`, and solving the viewport is itself the stronger test of "are we on this map at all".
 

--- a/docs/zh_cn/developers/components/world-map.md
+++ b/docs/zh_cn/developers/components/world-map.md
@@ -19,7 +19,7 @@ WorldMap 属于识别层，只负责在已经打开的大地图上把坐标解�
 
 节点执行时会先把地图缩到最小，再自行截图、求解视口、必要时拖动地图，直到目标进入可用区域为止。**给了 `icon` 时，确认不到图标就不给坐标**——算得出位置不等于那里有东西，宁可返回失败让上层重试或走别的候选，也不交一个算出来的空位置。不给 `icon` 时只把坐标解出来交回，不作这层担保。
 
-缩放档位是视口求解要在尺度带里扫出来的那个未知量，所以节点进来第一件事就是把它钉死：反复跑 pipeline 的 `__ScenePrivateMapZoomOut`，认到减号就接着按，一路按到底。减号已经灰了（缩不动了）时那个节点认不中，一次触控都不会发出去。但**认不到不等于已经到底**——那一帧可能只是动画没画完，而「以为最小、其实没缩到」会让后面的视口求解必然失败，所以要隔开几帧连着确认几次才收手；判不出来的时候一律当作还能缩。因此 pipeline 里写不写 `__ScenePrivateMapZoomOut` 都行：写了是提前缩好，不写这里也会缩。按钮坐标各端不同，它跟着资源层走，节点自己不带坐标。
+缩放档位是视口求解要在尺度带里扫出来的那个未知量，所以节点进来第一件事就是把它钉死：调用一次 pipeline 的 `SceneMapZoomOut`，子任务返回时地图应已缩到最小。按钮坐标各端不同，它跟着资源层走，节点自己不带坐标。因此 pipeline 里写不写 `[JumpBack]__ScenePrivateMapZoomOut` 都行：写了是提前缩好，不写 `MapFind` 也会调 `SceneMapZoomOut`。
 
 ### 节点参数
 
@@ -143,7 +143,7 @@ WorldMap 属于识别层，只负责在已经打开的大地图上把坐标解�
 
 传送点节点写在 `assets/resource/pipeline/SceneManager/SceneTeleport<区域>.json`，填进 `__ScenePrivateMapTeleportPickAnchor` 槽位；入口节点写在 `Interface/Scene<区域>.json`，绑定该槽位并经由 `__ScenePrivateMap<子区域>EnterWorldAnchorWithPick` 进入——后者负责把地图切到主图层，并用 `all_of` 确认当前确实在该子区域的地图界面，顺带先往最小缩一把。
 
-入口里那条 `__ScenePrivateMapZoomOut` 是提前量、不是必需品：`MapFind` 自己会缩。新接的点照着现有入口抄一份就行，漏了也不会因此认不出来。
+入口里那条 `[JumpBack]__ScenePrivateMapZoomOut` 是提前量、不是必需品：`MapFind` 自己会调 `SceneMapZoomOut`。新接的点照着现有入口抄一份就行，漏了也不会因此认不出来。
 
 子区域的确认闸在 `...EnterWorldAnchorWithPick` 上，`MapFind` 节点自己不再重复一遍——`recognition` 槽位让给了 `MapFind`，而视口求解本身就是更强的「在不在这张图上」判据。
 


### PR DESCRIPTION
SceneMapZoomOut调用完毕后，地图一定是最小的，有问题修SceneMapZoomOut
之前的写法在地图最小时，会误报节点失败上传到遥测，导致误统计

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 地图查找流程改为调用一次地图缩小操作，减少重复识别与确认。
  - 地图缩小支持通过指定区域匹配地图缩小控件，提升识别适配性。
  - 地图传送点入口支持可选的预先缩放步骤，未执行时仍可自动完成缩放。

- **文档**
  - 更新中英文地图组件文档，说明新的地图缩放流程及可选前置步骤。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->