### PR TITLE
feat(WorldMap): 添加武陵-雪松林传送点

### DIFF
--- a/assets/resource/pipeline/Interface/SceneWuling.json
+++ b/assets/resource/pipeline/Interface/SceneWuling.json
@@ -779,5 +779,89 @@
             "__ScenePrivateMapWulingNorthWulingExclusionZoneEnterWorldAnchorWithPick",
             "[JumpBack]SceneEnterMapWulingNorthWulingExclusionZone"
         ]
+    },
+    "SceneEnterWorldWulingSnowyForest0": {
+        "desc": "从任意界面进入武陵-雪松林-协议传送点1大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest0"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingSnowyForestEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingSnowyForest"
+        ]
+    },
+    "SceneEnterWorldWulingSnowyForest1": {
+        "desc": "从任意界面进入武陵-雪松林-协议传送点2大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest1"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingSnowyForestEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingSnowyForest"
+        ]
+    },
+    "SceneEnterWorldWulingSnowyForest2": {
+        "desc": "从任意界面进入武陵-雪松林-协议传送点3大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest2"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingSnowyForestEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingSnowyForest"
+        ]
+    },
+    "SceneEnterWorldWulingSnowyForest3": {
+        "desc": "从任意界面进入武陵-雪松林-协议传送点4大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest3"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingSnowyForestEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingSnowyForest"
+        ]
+    },
+    "SceneEnterWorldWulingSnowyForest4": {
+        "desc": "从任意界面进入武陵-雪松林-协议传送点5大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest4"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingSnowyForestEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingSnowyForest"
+        ]
+    },
+    "SceneEnterWorldWulingSnowyForest5": {
+        "desc": "从任意界面进入武陵-雪松林-协议传送点6大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest5"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingSnowyForestEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingSnowyForest"
+        ]
+    },
+    "SceneEnterWorldWulingSnowyForest6": {
+        "desc": "从任意界面进入武陵-雪松林-协议传送点7大世界",
+        "pre_delay": 0,
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest6"
+        },
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapWulingSnowyForestEnterWorldAnchorWithPick",
+            "[JumpBack]SceneEnterMapWulingSnowyForest"
+        ]
     }
 }

--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -2530,5 +2530,243 @@
                 "trace": true
             }
         }
+    },
+    "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest0": {
+        "desc": "在地图界面找锚点 (雪松林-协议传送点1)",
+        "recognition": "Custom",
+        "custom_recognition": "MapFind",
+        "custom_recognition_param": {
+            "zone": "Wuling",
+            "icon": "TeleportAnchor",
+            "at": [
+                1365.5,
+                987.7
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Click",
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "[JumpBack]__ScenePrivateMapMarkerPanelClose",
+            "__ScenePrivateMapTeleportConfirm",
+            "__ScenePrivateMapTeleportSuccess"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest1": {
+        "desc": "在地图界面找锚点 (雪松林-协议传送点2)",
+        "recognition": "Custom",
+        "custom_recognition": "MapFind",
+        "custom_recognition_param": {
+            "zone": "Wuling",
+            "icon": "TeleportAnchor",
+            "at": [
+                1413.0,
+                993.5
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Click",
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "[JumpBack]__ScenePrivateMapMarkerPanelClose",
+            "__ScenePrivateMapTeleportConfirm",
+            "__ScenePrivateMapTeleportSuccess"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest2": {
+        "desc": "在地图界面找锚点 (雪松林-协议传送点3)",
+        "recognition": "Custom",
+        "custom_recognition": "MapFind",
+        "custom_recognition_param": {
+            "zone": "Wuling",
+            "icon": "TeleportAnchor",
+            "at": [
+                1509.8,
+                990.6
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Click",
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "[JumpBack]__ScenePrivateMapMarkerPanelClose",
+            "__ScenePrivateMapTeleportConfirm",
+            "__ScenePrivateMapTeleportSuccess"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest3": {
+        "desc": "在地图界面找锚点 (雪松林-协议传送点4)",
+        "recognition": "Custom",
+        "custom_recognition": "MapFind",
+        "custom_recognition_param": {
+            "zone": "Wuling",
+            "icon": "TeleportAnchor",
+            "at": [
+                1593.1,
+                934.5
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Click",
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "[JumpBack]__ScenePrivateMapMarkerPanelClose",
+            "__ScenePrivateMapTeleportConfirm",
+            "__ScenePrivateMapTeleportSuccess"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest4": {
+        "desc": "在地图界面找锚点 (雪松林-协议传送点5)",
+        "recognition": "Custom",
+        "custom_recognition": "MapFind",
+        "custom_recognition_param": {
+            "zone": "Wuling",
+            "icon": "TeleportAnchor",
+            "at": [
+                1595.9,
+                1075.5
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Click",
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "[JumpBack]__ScenePrivateMapMarkerPanelClose",
+            "__ScenePrivateMapTeleportConfirm",
+            "__ScenePrivateMapTeleportSuccess"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest5": {
+        "desc": "在地图界面找锚点 (雪松林-协议传送点6)",
+        "recognition": "Custom",
+        "custom_recognition": "MapFind",
+        "custom_recognition_param": {
+            "zone": "Wuling",
+            "icon": "TeleportAnchor",
+            "at": [
+                1598.5,
+                993.8
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Click",
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "[JumpBack]__ScenePrivateMapMarkerPanelClose",
+            "__ScenePrivateMapTeleportConfirm",
+            "__ScenePrivateMapTeleportSuccess"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
+    },
+    "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest6": {
+        "desc": "在地图界面找锚点 (雪松林-协议传送点7)",
+        "recognition": "Custom",
+        "custom_recognition": "MapFind",
+        "custom_recognition_param": {
+            "zone": "Wuling",
+            "icon": "TeleportAnchor",
+            "at": [
+                1720.5,
+                995.0
+            ]
+        },
+        "pre_delay": 0,
+        "action": "Click",
+        "anchor": {
+            "__ScenePrivateMapTeleportPickAnchor": ""
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "[JumpBack]__ScenePrivateMapTeleportChoose",
+            "[JumpBack]__ScenePrivateMapMarkerPanelClose",
+            "__ScenePrivateMapTeleportConfirm",
+            "__ScenePrivateMapTeleportSuccess"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": {
+                "trace": true
+            },
+            "Node.Action.Failed": {
+                "trace": true
+            }
+        }
     }
 }

--- a/assets/resource/pipeline/SceneManager/SceneWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneWuling.json
@@ -959,5 +959,20 @@
         "next": [
             "__ScenePrivateMapAnyEnterMapWulingSnowyForestSuccess"
         ]
+    },
+    "__ScenePrivateMapWulingSnowyForestEnterWorldAnchorWithPick": {
+        "desc": "在武陵-雪松林地图界面，进入[锚点]大世界",
+        "recognition": "And",
+        "all_of": [
+            "InMapWulingSnowyForest"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "__ScenePrivateMapTeleportSuccess",
+            "[JumpBack]__ScenePrivateMapLayerSwitchToMain",
+            "[JumpBack]__ScenePrivateMapZoomOut",
+            "[JumpBack][Anchor]__ScenePrivateMapTeleportPickAnchor"
+        ]
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增武陵「雪松林」区域及 7 个协议传送点。
  - 支持通过对应传送锚点进入雪松林，并自动完成传送确认与地图切换。
  - 新增雪松林世界入口及锚点选择流程，传送成功或失败状态可被识别。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->