### PR TITLE
chore: 重命名雪松林传送 pipeline 描述

### DIFF
--- a/assets/resource/pipeline/Interface/SceneWuling.json
+++ b/assets/resource/pipeline/Interface/SceneWuling.json
@@ -781,7 +781,7 @@
         ]
     },
     "SceneEnterWorldWulingSnowyForest0": {
-        "desc": "从任意界面进入武陵-雪松林-协议传送点1大世界",
+        "desc": "从任意界面进入武陵-雪松林-落雪山道大世界",
         "pre_delay": 0,
         "anchor": {
             "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest0"
@@ -793,7 +793,7 @@
         ]
     },
     "SceneEnterWorldWulingSnowyForest1": {
-        "desc": "从任意界面进入武陵-雪松林-协议传送点2大世界",
+        "desc": "从任意界面进入武陵-雪松林-寒雾松林大世界",
         "pre_delay": 0,
         "anchor": {
             "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest1"
@@ -805,7 +805,7 @@
         ]
     },
     "SceneEnterWorldWulingSnowyForest2": {
-        "desc": "从任意界面进入武陵-雪松林-协议传送点3大世界",
+        "desc": "从任意界面进入武陵-雪松林-雪祀木屋左侧大世界",
         "pre_delay": 0,
         "anchor": {
             "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest2"
@@ -817,7 +817,7 @@
         ]
     },
     "SceneEnterWorldWulingSnowyForest3": {
-        "desc": "从任意界面进入武陵-雪松林-协议传送点4大世界",
+        "desc": "从任意界面进入武陵-雪松林-仪式祭坛大世界",
         "pre_delay": 0,
         "anchor": {
             "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest3"
@@ -829,7 +829,7 @@
         ]
     },
     "SceneEnterWorldWulingSnowyForest4": {
-        "desc": "从任意界面进入武陵-雪松林-协议传送点5大世界",
+        "desc": "从任意界面进入武陵-雪松林-雾凇山谷左上角大世界",
         "pre_delay": 0,
         "anchor": {
             "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest4"
@@ -841,7 +841,7 @@
         ]
     },
     "SceneEnterWorldWulingSnowyForest5": {
-        "desc": "从任意界面进入武陵-雪松林-协议传送点6大世界",
+        "desc": "从任意界面进入武陵-雪松林-雪祀木屋右侧大世界",
         "pre_delay": 0,
         "anchor": {
             "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest5"
@@ -853,7 +853,7 @@
         ]
     },
     "SceneEnterWorldWulingSnowyForest6": {
-        "desc": "从任意界面进入武陵-雪松林-协议传送点7大世界",
+        "desc": "从任意界面进入武陵-雪松林-雾凇山谷右上角大世界",
         "pre_delay": 0,
         "anchor": {
             "__ScenePrivateMapTeleportPickAnchor": "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest6"

--- a/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
+++ b/assets/resource/pipeline/SceneManager/SceneTeleportWuling.json
@@ -2532,7 +2532,7 @@
         }
     },
     "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest0": {
-        "desc": "在地图界面找锚点 (雪松林-协议传送点1)",
+        "desc": "在地图界面找锚点 (雪松林-落雪山道)",
         "recognition": "Custom",
         "custom_recognition": "MapFind",
         "custom_recognition_param": {
@@ -2566,7 +2566,7 @@
         }
     },
     "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest1": {
-        "desc": "在地图界面找锚点 (雪松林-协议传送点2)",
+        "desc": "在地图界面找锚点 (雪松林-寒雾松林)",
         "recognition": "Custom",
         "custom_recognition": "MapFind",
         "custom_recognition_param": {
@@ -2600,7 +2600,7 @@
         }
     },
     "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest2": {
-        "desc": "在地图界面找锚点 (雪松林-协议传送点3)",
+        "desc": "在地图界面找锚点 (雪松林-雪祀木屋左侧)",
         "recognition": "Custom",
         "custom_recognition": "MapFind",
         "custom_recognition_param": {
@@ -2634,7 +2634,7 @@
         }
     },
     "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest3": {
-        "desc": "在地图界面找锚点 (雪松林-协议传送点4)",
+        "desc": "在地图界面找锚点 (雪松林-仪式祭坛)",
         "recognition": "Custom",
         "custom_recognition": "MapFind",
         "custom_recognition_param": {
@@ -2668,7 +2668,7 @@
         }
     },
     "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest4": {
-        "desc": "在地图界面找锚点 (雪松林-协议传送点5)",
+        "desc": "在地图界面找锚点 (雪松林-雾凇山谷左上角)",
         "recognition": "Custom",
         "custom_recognition": "MapFind",
         "custom_recognition_param": {
@@ -2702,7 +2702,7 @@
         }
     },
     "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest5": {
-        "desc": "在地图界面找锚点 (雪松林-协议传送点6)",
+        "desc": "在地图界面找锚点 (雪松林-雪祀木屋右侧)",
         "recognition": "Custom",
         "custom_recognition": "MapFind",
         "custom_recognition_param": {
@@ -2736,7 +2736,7 @@
         }
     },
     "__ScenePrivateMapWulingSnowyForestEnterWorldWulingSnowyForest6": {
-        "desc": "在地图界面找锚点 (雪松林-协议传送点7)",
+        "desc": "在地图界面找锚点 (雪松林-雾凇山谷右上角)",
         "recognition": "Custom",
         "custom_recognition": "MapFind",
         "custom_recognition_param": {


### PR DESCRIPTION
## 变更内容

- 重命名雪松林 7 个传送点的 Pipeline 描述
- 将“协议传送点1至7”改为对应的实际地点名称
- 同步修改公共接口与内部传送节点描述

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 更新雪杉林 7 个传送锚点的名称，以显示更具体的地点名称。
  * 传送锚点位置、交互方式、延迟及后续流程保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->