### PR TITLE
perf(Navmesh): 邻接表改槽位比特与 PackSpans 两级计数排序压低规划峰值内存

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -574,6 +574,14 @@ navmesh::BaseNavRouteResult PlanCorridorRoute(
         for (const std::string& warning : plan.warnings) {
             LogWarn << "RECAST plan warning." << VAR(request.zone_name) << VAR(warning);
         }
+        // 采信的窗口档与分段耗时: 实机上分辨"小窗一档过"与"升到整类"只有这一行。
+        std::string tier_notes;
+        for (const std::string& note : plan.debug.tier_notes) {
+            tier_notes += (tier_notes.empty() ? "" : " | ") + note;
+        }
+        LogInfo << "RECAST plan window." << VAR(request.zone_name) << VAR(plan.debug.tier) << VAR(plan.debug.nx) << VAR(plan.debug.ny)
+                << VAR(plan.debug.timing.window_ms) << VAR(plan.debug.timing.topology_ms) << VAR(plan.debug.timing.geometry_ms)
+                << VAR(plan.debug.timing.total_ms) << VAR(tier_notes);
     }
     result.status = navmesh::BaseNavRouteStatus::Success;
     result.path.zone_id = zone->zone_id;

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.cpp
@@ -20,10 +20,14 @@ BaseNavPack MakeBaseNavPack(
     std::vector<BaseNavLink> links,
     std::vector<BaseNavSurface> surfaces,
     std::vector<BaseNavOffMeshLink> off_mesh_links,
-    std::vector<BaseNavSection> sections)
+    std::vector<BaseNavSection> sections,
+    uint64_t build_hash,
+    uint64_t file_fnv)
 {
     BaseNavPack pack;
     pack.path_ = std::move(path);
+    pack.build_hash_ = build_hash;
+    pack.file_fnv_ = file_fnv;
     pack.zones_ = std::move(zones);
     pack.vertices_ = std::move(vertices);
     pack.triangles_ = std::move(triangles);

--- a/agent/cpp-algo/source/Navmesh/BaseNavPack.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPack.h
@@ -138,7 +138,9 @@ BaseNavPack MakeBaseNavPack(
     std::vector<BaseNavLink> links,
     std::vector<BaseNavSurface> surfaces,
     std::vector<BaseNavOffMeshLink> off_mesh_links,
-    std::vector<BaseNavSection> sections);
+    std::vector<BaseNavSection> sections,
+    uint64_t build_hash,
+    uint64_t file_fnv);
 
 }
 
@@ -177,6 +179,14 @@ public:
     // 建完后调这个把它还给系统 —— 单区 map02base 有 1050 万条,占 80MB。
     void releaseLinks();
 
+    // 包的身份:载入路径、头里的 build_hash、解压后整份字节的 FNV-1a。
+    // 旁包(预烘场)靠后两者认主包,按区裁剪载入也照样算整份文件。
+    const std::filesystem::path& path() const { return path_; }
+
+    uint64_t buildHash() const { return build_hash_; }
+
+    uint64_t fileFnv() const { return file_fnv_; }
+
 private:
     friend BaseNavPack detail::MakeBaseNavPack(
         std::filesystem::path path,
@@ -186,9 +196,13 @@ private:
         std::vector<BaseNavLink> links,
         std::vector<BaseNavSurface> surfaces,
         std::vector<BaseNavOffMeshLink> off_mesh_links,
-        std::vector<BaseNavSection> sections);
+        std::vector<BaseNavSection> sections,
+        uint64_t build_hash,
+        uint64_t file_fnv);
 
     std::filesystem::path path_;
+    uint64_t build_hash_ = 0;
+    uint64_t file_fnv_ = 0;
     std::vector<BaseNavZone> zones_;
     std::vector<BaseNavVertex> vertices_;
     std::vector<BaseNavTriangle> triangles_;

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -58,14 +58,6 @@ constexpr double kIndexBinSize = 4.0; // 空间分箱的格边长(px),与 Python
 // tier 细分后三角形极小,8px 每桶堆 ~200 个 → 每次 pointOnMesh 候选遍历是后处理热点;4px 每桶 ~12 个,查询 ~4x 快
 // (空间索引仅加速查询、不改判定结果)。建索引略增但 C++ 编译版快,可忽略。
 
-uint64_t PackBinKey(uint16_t zone_id, int32_t bin_x, int32_t bin_y)
-{
-    const uint64_t zone = static_cast<uint64_t>(zone_id);
-    const uint64_t packed_x = static_cast<uint64_t>(static_cast<uint32_t>(bin_x)) & 0xFFFFFFu;
-    const uint64_t packed_y = static_cast<uint64_t>(static_cast<uint32_t>(bin_y)) & 0xFFFFFFu;
-    return (zone << 48) | (packed_x << 24) | packed_y;
-}
-
 constexpr double kSegmentWalkSnapRadius = 1.0; // 点查询(pointOnMesh/groundHeightNearIndexed)取候选三角形的邻域半径(px)
 
 }
@@ -73,8 +65,7 @@ constexpr double kSegmentWalkSnapRadius = 1.0; // 点查询(pointOnMesh/groundHe
 BaseNavPlanner::BaseNavPlanner(const BaseNavPack& pack)
     : pack_(pack)
     , triangle_zones_(pack.triangles().size(), 0)
-    , adjacency_offsets_(pack.triangles().size() + 1, 0)
-    , triangle_heights_(pack.triangles().size(), 0.0)
+    , neighbor_link_bits_(pack.triangles().size(), 0)
 {
     for (const auto& zone : pack_.zones()) {
         const uint32_t end = zone.first_triangle + zone.triangle_count;
@@ -82,20 +73,17 @@ BaseNavPlanner::BaseNavPlanner(const BaseNavPack& pack)
             triangle_zones_[index] = zone.zone_id;
         }
     }
-    // 三段各写各的成员(连通分量与邻接表 / 空间桶 / 三角高度), 读的只有 pack_ 与刚填好的分区表,
-    // 谁都看不见另外两段的产物, 于是并起来跑与顺着跑逐位相同。
+    // 两段各写各的成员(连通分量与邻接表 / 空间桶), 读的只有 pack_ 与刚填好的分区表,
+    // 谁都看不见另一段的产物, 于是并起来跑与顺着跑逐位相同。
     if (NavWorkerCount(static_cast<int64_t>(pack_.triangles().size())) <= 1) {
         buildIndex();
         buildSpatialIndex();
-        computeTriangleHeights();
         return;
     }
-    // jthread: buildIndex 抛出时(分配失败是唯一的来路)这两个还在跑, 析构自己接回来。
+    // jthread: buildIndex 抛出时(分配失败是唯一的来路)另一个还在跑, 析构自己接回来。
     std::jthread bins([this] { buildSpatialIndex(); });
-    std::jthread heights([this] { computeTriangleHeights(); });
     buildIndex();
     bins.join();
-    heights.join();
 }
 
 void BaseNavPlanner::buildIndex()
@@ -126,25 +114,41 @@ void BaseNavPlanner::buildIndex()
             }
         });
 
-    size_t valid_link_count = 0;
+    // 过筛的链接按落点分两处: 目标是自带邻居的置槽位比特, 其余进桥接表; 置位与排序都不依赖遍历顺序。
+    const auto& triangles = pack_.triangles();
     for (size_t index = 0; index < links.size(); ++index) {
-        if (((passed[index >> 6] >> (index & 63)) & 1) != 0) {
-            ++adjacency_offsets_[links[index].source + 1];
-            ++valid_link_count;
+        if (((passed[index >> 6] >> (index & 63)) & 1) == 0) {
+            continue;
+        }
+        const BaseNavLink& link = links[index];
+        const auto& neighbors = triangles[link.source].neighbors;
+        bool slotted = false;
+        for (size_t slot = 0; slot < neighbors.size(); ++slot) {
+            if (neighbors[slot] >= 0 && static_cast<uint32_t>(neighbors[slot]) == link.target) {
+                neighbor_link_bits_[link.source] |= static_cast<uint8_t>(1U << slot);
+                slotted = true;
+            }
+        }
+        if (!slotted) {
+            bridge_links_.push_back((static_cast<uint64_t>(link.source) << 32U) | link.target);
         }
     }
-    for (size_t index = 1; index < adjacency_offsets_.size(); ++index) {
-        adjacency_offsets_[index] += adjacency_offsets_[index - 1];
-    }
+    std::sort(bridge_links_.begin(), bridge_links_.end());
+    bridge_links_.shrink_to_fit();
+}
 
-    adjacency_links_.resize(valid_link_count);
-    std::vector<uint32_t> next_offsets = adjacency_offsets_;
-    for (size_t index = 0; index < links.size(); ++index) {
-        if (((passed[index >> 6] >> (index & 63)) & 1) != 0) {
-            const BaseNavLink& link = links[index];
-            adjacency_links_[next_offsets[link.source]++] = link.target;
+bool BaseNavPlanner::hasLink(uint32_t source, uint32_t target) const
+{
+    if (source >= neighbor_link_bits_.size()) {
+        return false;
+    }
+    const auto& neighbors = pack_.triangles()[source].neighbors;
+    for (size_t slot = 0; slot < neighbors.size(); ++slot) {
+        if (neighbors[slot] >= 0 && static_cast<uint32_t>(neighbors[slot]) == target) {
+            return ((neighbor_link_bits_[source] >> slot) & 1U) != 0;
         }
     }
+    return std::binary_search(bridge_links_.begin(), bridge_links_.end(), (static_cast<uint64_t>(source) << 32U) | target);
 }
 
 void BaseNavPlanner::buildNaturalComponents()
@@ -182,26 +186,118 @@ void BaseNavPlanner::buildNaturalComponents()
 void BaseNavPlanner::buildSpatialIndex()
 {
     const auto& triangles = pack_.triangles();
-    for (uint32_t triangle_index = 0; triangle_index < triangles.size(); ++triangle_index) {
-        const uint16_t zone_id = triangle_index < triangle_zones_.size() ? triangle_zones_[triangle_index] : 0;
-        if (zone_id == 0) {
-            continue; // 区外三角形不入索引(与 Python _build_index 一致)
-        }
+    // 三趟同一套遍历: 量各区格包围盒 → 数每格三角数 → 按三角升序回填。三角按区连续, 区槽缓存着查。
+    struct BinRect
+    {
+        int32_t x0, x1, y0, y1;
+    };
+    const auto bin_rect = [this](uint32_t triangle_index) -> BinRect {
         const auto points = trianglePoints(triangle_index);
         const double left = std::min({ points[0].x, points[1].x, points[2].x });
         const double right = std::max({ points[0].x, points[1].x, points[2].x });
         const double top = std::min({ points[0].y, points[1].y, points[2].y });
         const double bottom = std::max({ points[0].y, points[1].y, points[2].y });
-        const int32_t bin_x0 = static_cast<int32_t>(std::floor(left / kIndexBinSize));
-        const int32_t bin_x1 = static_cast<int32_t>(std::floor(right / kIndexBinSize));
-        const int32_t bin_y0 = static_cast<int32_t>(std::floor(top / kIndexBinSize));
-        const int32_t bin_y1 = static_cast<int32_t>(std::floor(bottom / kIndexBinSize));
-        for (int32_t bin_x = bin_x0; bin_x <= bin_x1; ++bin_x) {
-            for (int32_t bin_y = bin_y0; bin_y <= bin_y1; ++bin_y) {
-                spatial_bins_[PackBinKey(zone_id, bin_x, bin_y)].push_back(triangle_index);
-            }
+        return { static_cast<int32_t>(std::floor(left / kIndexBinSize)), static_cast<int32_t>(std::floor(right / kIndexBinSize)),
+                 static_cast<int32_t>(std::floor(top / kIndexBinSize)), static_cast<int32_t>(std::floor(bottom / kIndexBinSize)) };
+    };
+    // 区号 → 区槽。区外三角形(区号 0)不入索引, 与 Python _build_index 一致。
+    bin_grids_.clear();
+    std::vector<int32_t> zone_slot(size_t { 1 } << 16, -1);
+    for (const BaseNavZone& zone : pack_.zones()) {
+        if (zone.zone_id != 0 && zone.triangle_count != 0 && zone_slot[zone.zone_id] < 0) {
+            zone_slot[zone.zone_id] = static_cast<int32_t>(bin_grids_.size());
+            bin_grids_.push_back(BinGrid { .zone_id = zone.zone_id });
         }
     }
+    const size_t nslots = bin_grids_.size();
+    const int64_t n = static_cast<int64_t>(triangles.size());
+    const size_t workers = NavWorkerCount(n);
+    // 三趟按三角分块并行: 量各区格包围盒 → 每块数每格三角数 → 每块往自己那段区间回填。
+    // 块序即三角序, 块内也按三角序, 于是格内三角升序, 与线程数无关。
+    const auto for_each_tri = [&](auto&& fn) {
+        ParallelChunks(n, workers, [&](size_t w, int64_t begin, int64_t end) {
+            for (int64_t t = begin; t < end; ++t) {
+                const uint16_t zone_id = static_cast<size_t>(t) < triangle_zones_.size() ? triangle_zones_[static_cast<size_t>(t)] : 0;
+                const int32_t slot = zone_slot[zone_id];
+                if (slot < 0) {
+                    continue;
+                }
+                fn(w, static_cast<size_t>(slot), bin_rect(static_cast<uint32_t>(t)), static_cast<uint32_t>(t));
+            }
+        });
+    };
+    std::vector<std::vector<BinRect>> bounds(
+        workers, std::vector<BinRect>(nslots, { std::numeric_limits<int32_t>::max(), std::numeric_limits<int32_t>::min(),
+                                              std::numeric_limits<int32_t>::max(), std::numeric_limits<int32_t>::min() }));
+    for_each_tri([&bounds](size_t w, size_t slot, const BinRect& r, uint32_t) {
+        BinRect& b = bounds[w][slot];
+        b.x0 = std::min(b.x0, r.x0);
+        b.x1 = std::max(b.x1, r.x1);
+        b.y0 = std::min(b.y0, r.y0);
+        b.y1 = std::max(b.y1, r.y1);
+    });
+    for (size_t slot = 0; slot < nslots; ++slot) {
+        BinRect b = bounds[0][slot];
+        for (size_t w = 1; w < workers; ++w) {
+            b.x0 = std::min(b.x0, bounds[w][slot].x0);
+            b.x1 = std::max(b.x1, bounds[w][slot].x1);
+            b.y0 = std::min(b.y0, bounds[w][slot].y0);
+            b.y1 = std::max(b.y1, bounds[w][slot].y1);
+        }
+        BinGrid& grid = bin_grids_[slot];
+        if (b.x0 > b.x1) {
+            continue; // 该区没有入索引的三角
+        }
+        grid.bx0 = b.x0;
+        grid.by0 = b.y0;
+        grid.nx = b.x1 - b.x0 + 1;
+        grid.ny = b.y1 - b.y0 + 1;
+        grid.offsets.assign(static_cast<size_t>(grid.nx) * static_cast<size_t>(grid.ny) + 1, 0);
+    }
+    const auto cell = [](const BinGrid& grid, int32_t bin_x, int32_t bin_y) -> size_t {
+        return static_cast<size_t>(bin_x - grid.bx0) * static_cast<size_t>(grid.ny) + static_cast<size_t>(bin_y - grid.by0);
+    };
+    // counts[w][slot][c]: 第 w 块落进格 c 的三角数; 前缀后原地变成第 w 块在格 c 的写入游标。
+    std::vector<std::vector<std::vector<uint32_t>>> counts(workers, std::vector<std::vector<uint32_t>>(nslots));
+    for (size_t w = 0; w < workers; ++w) {
+        for (size_t slot = 0; slot < nslots; ++slot) {
+            counts[w][slot].assign(bin_grids_[slot].offsets.empty() ? 0 : bin_grids_[slot].offsets.size() - 1, 0);
+        }
+    }
+    for_each_tri([&](size_t w, size_t slot, const BinRect& r, uint32_t) {
+        const BinGrid& grid = bin_grids_[slot];
+        std::vector<uint32_t>& cnt = counts[w][slot];
+        for (int32_t bin_x = r.x0; bin_x <= r.x1; ++bin_x) {
+            for (int32_t bin_y = r.y0; bin_y <= r.y1; ++bin_y) {
+                ++cnt[cell(grid, bin_x, bin_y)];
+            }
+        }
+    });
+    for (size_t slot = 0; slot < nslots; ++slot) {
+        BinGrid& grid = bin_grids_[slot];
+        uint32_t running = 0;
+        for (size_t c = 0; c + 1 < grid.offsets.size(); ++c) {
+            grid.offsets[c] = running;
+            for (size_t w = 0; w < workers; ++w) {
+                const uint32_t here = counts[w][slot][c];
+                counts[w][slot][c] = running;
+                running += here;
+            }
+        }
+        if (!grid.offsets.empty()) {
+            grid.offsets.back() = running;
+        }
+        grid.triangles.assign(running, 0);
+    }
+    for_each_tri([&](size_t w, size_t slot, const BinRect& r, uint32_t triangle_index) {
+        BinGrid& grid = bin_grids_[slot];
+        std::vector<uint32_t>& next = counts[w][slot];
+        for (int32_t bin_x = r.x0; bin_x <= r.x1; ++bin_x) {
+            for (int32_t bin_y = r.y0; bin_y <= r.y1; ++bin_y) {
+                grid.triangles[next[cell(grid, bin_x, bin_y)]++] = triangle_index;
+            }
+        }
+    });
 }
 
 std::vector<uint32_t> BaseNavPlanner::candidateTriangles(uint16_t zone_id, const WorldPoint& point, double radius) const
@@ -212,13 +308,20 @@ std::vector<uint32_t> BaseNavPlanner::candidateTriangles(uint16_t zone_id, const
     const int32_t bin_x1 = static_cast<int32_t>(std::floor((point.x + query_radius) / kIndexBinSize));
     const int32_t bin_y0 = static_cast<int32_t>(std::floor((point.y - query_radius) / kIndexBinSize));
     const int32_t bin_y1 = static_cast<int32_t>(std::floor((point.y + query_radius) / kIndexBinSize));
-    for (int32_t bin_x = bin_x0; bin_x <= bin_x1; ++bin_x) {
-        for (int32_t bin_y = bin_y0; bin_y <= bin_y1; ++bin_y) {
-            const auto found = spatial_bins_.find(PackBinKey(zone_id, bin_x, bin_y));
-            if (found == spatial_bins_.end()) {
-                continue;
-            }
-            result.insert(result.end(), found->second.begin(), found->second.end());
+    const BinGrid* grid = nullptr;
+    for (const BinGrid& g : bin_grids_) {
+        if (g.zone_id == zone_id) {
+            grid = &g;
+            break;
+        }
+    }
+    if (grid == nullptr || grid->offsets.empty()) {
+        return result;
+    }
+    for (int32_t bin_x = std::max(bin_x0, grid->bx0); bin_x <= std::min(bin_x1, grid->bx0 + grid->nx - 1); ++bin_x) {
+        for (int32_t bin_y = std::max(bin_y0, grid->by0); bin_y <= std::min(bin_y1, grid->by0 + grid->ny - 1); ++bin_y) {
+            const size_t c = static_cast<size_t>(bin_x - grid->bx0) * static_cast<size_t>(grid->ny) + static_cast<size_t>(bin_y - grid->by0);
+            result.insert(result.end(), grid->triangles.begin() + grid->offsets[c], grid->triangles.begin() + grid->offsets[c + 1]);
         }
     }
     return result;
@@ -240,19 +343,6 @@ bool BaseNavPlanner::pointOnMesh(uint16_t zone_id, const WorldPoint& point) cons
     return false;
 }
 
-void BaseNavPlanner::computeTriangleHeights()
-{
-    const auto& triangles = pack_.triangles();
-    const auto& vertices = pack_.vertices();
-    for (size_t index = 0; index < triangles.size(); ++index) {
-        const auto& triangle = triangles[index];
-        triangle_heights_[index] =
-            (static_cast<double>(vertices[triangle.vertices[0]].height) + static_cast<double>(vertices[triangle.vertices[1]].height)
-             + static_cast<double>(vertices[triangle.vertices[2]].height))
-            / 3.0;
-    }
-}
-
 std::optional<double> BaseNavPlanner::groundHeightNearIndexed(
     uint16_t zone_id,
     const WorldPoint& point,
@@ -268,7 +358,7 @@ std::optional<double> BaseNavPlanner::groundHeightNearIndexed(
         if (!detail::PointInTriangle(point, trianglePoints(triangle_index))) {
             continue;
         }
-        const double height = triangle_heights_[triangle_index];
+        const double height = triangleHeight(triangle_index);
         if (!best) {
             best = height;
             out_triangle = triangle_index;
@@ -404,7 +494,7 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
                     continue;
                 }
             }
-            const double delta = std::abs(triangle_heights_[triangle_index] - static_cast<double>(floor_y));
+            const double delta = std::abs(triangleHeight(triangle_index) - static_cast<double>(floor_y));
             const std::tuple<int, int, double, double> key { delta <= static_cast<double>(kBaseNavFloorBand) ? 0 : 1,
                                                              is_small_island(triangle_index) ? 1 : 0,
                                                              distance,
@@ -448,7 +538,7 @@ std::optional<BaseNavSnapResult> BaseNavPlanner::snap(uint16_t zone_id, const Wo
         // 是任意的 —— 重烘一次三角顺序一换,起点就可能吸到桥下/水下那层,与终点分属两个分量,
         // A* 直接报不连通。非打平的候选不受影响,distance 仍排在高度前面。
         const std::tuple<int, double, double, uint32_t> key {
-            is_small_island(triangle_index) ? 1 : 0, distance, -triangle_heights_[triangle_index], triangle_index
+            is_small_island(triangle_index) ? 1 : 0, distance, -triangleHeight(triangle_index), triangle_index
         };
         if (!best_key || key < *best_key) {
             best_key = key;
@@ -508,9 +598,14 @@ std::array<WorldPoint, 3> BaseNavPlanner::trianglePoints(uint32_t triangle_index
     };
 }
 
+// 按需从三个顶点算, 不留 553 万条 double 的表(44 MB); 表达式与原来逐位相同。
 double BaseNavPlanner::triangleHeight(uint32_t triangle_index) const
 {
-    return triangle_heights_[triangle_index];
+    const auto& triangle = pack_.triangles()[triangle_index];
+    const auto& vertices = pack_.vertices();
+    return (static_cast<double>(vertices[triangle.vertices[0]].height) + static_cast<double>(vertices[triangle.vertices[1]].height)
+            + static_cast<double>(vertices[triangle.vertices[2]].height))
+        / 3.0;
 }
 
 uint32_t BaseNavPlanner::componentId(uint32_t triangle_index) const

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "BaseNavPack.h"
@@ -94,10 +93,8 @@ public:
         double half_width = 0.0,
         std::optional<double> seed_height = std::nullopt) const;
 
-    // RecastNav 复用
-    const std::vector<uint32_t>& adjacencyOffsets() const { return adjacency_offsets_; }
-
-    const std::vector<uint32_t>& adjacencyLinks() const { return adjacency_links_; }
+    // RecastNav 复用: pack 链接表里有没有 source→target 这条(且过了通行判据)。
+    bool hasLink(uint32_t source, uint32_t target) const;
 
     bool isSmallIslandTriangle(uint32_t triangle_index) const;
     std::optional<std::array<WorldPoint, 2>> closestEdgeBridgePoints(uint32_t lhs, uint32_t rhs) const;
@@ -112,19 +109,31 @@ public:
 private:
     const BaseNavPack& pack_;
     std::vector<uint16_t> triangle_zones_;
-    std::vector<uint32_t> adjacency_offsets_;
-    std::vector<uint32_t> adjacency_links_;
-    std::vector<double> triangle_heights_;
+    // 链接表 97% 都落在三角自带的三个邻居槽上, 按槽存一比特; 剩下的跨分量桥接单独排一张
+    // (source<<32|target) 小表。整包 1500 万条链接原先展成 CSR 要 83 MB, 这样不到 10 MB。
+    std::vector<uint8_t> neighbor_link_bits_;
+    std::vector<uint64_t> bridge_links_;
     std::vector<uint32_t> natural_component_ids_;
     std::vector<uint32_t> natural_component_sizes_;
     // 空间分箱索引:(zone_id, bin_x, bin_y) → 该格覆盖的三角形下标。使 snap/pointOnMesh 从全区线性
     // 扫描降为 O(邻近候选);剔除条件不变,结果与线性扫描完全一致。对齐 Python basenav_lib 的 bins。
-    std::unordered_map<uint64_t, std::vector<uint32_t>> spatial_bins_;
+    // 存法是每区一张按包围盒铺满的格偏移表(格内三角按下标升序), 格外即空格。整包不到 50 万格,
+    // 建表不用排序也不用哈希; 原来的哈希表光节点就要几十 MB。
+    struct BinGrid
+    {
+        uint16_t zone_id = 0;
+        int32_t bx0 = 0;
+        int32_t by0 = 0;
+        int32_t nx = 0;
+        int32_t ny = 0;
+        std::vector<uint32_t> offsets; // nx*ny+1, 行主序 (bin_x - bx0) * ny + (bin_y - by0)
+        std::vector<uint32_t> triangles;
+    };
+    std::vector<BinGrid> bin_grids_;
 
     void buildIndex();
     void buildNaturalComponents();
     void buildSpatialIndex();
-    void computeTriangleHeights();
     bool isNaturalNeighbor(uint32_t lhs, uint32_t rhs) const;
     bool isTraversableLink(uint32_t lhs, uint32_t rhs) const;
     // point 处的地面高度:取包含 point 的候选三角形中高度与 reference 最接近者(高度连续性,跨重叠缝

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -638,6 +638,8 @@ BaseNavLoadResult ReadGzipFile(const std::filesystem::path& path, std::vector<ui
     return {};
 }
 
+}
+
 BaseNavLoadResult ReadNavFileBytes(const std::filesystem::path& path, std::vector<uint8_t>* output)
 {
     if (HasGzipSuffix(path)) {
@@ -661,8 +663,6 @@ BaseNavLoadResult ReadNavFileBytes(const std::filesystem::path& path, std::vecto
     return {};
 }
 
-}
-
 BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string_view zone_name)
 {
     std::vector<uint8_t> file_bytes;
@@ -675,6 +675,8 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     if (file_size < kHeaderSize) {
         return Fail(BaseNavLoadStatus::InvalidSize, "nav file is smaller than header");
     }
+    // 整份解压字节的指纹,旁包靠它认主包;按区裁剪也算整份,两种载入口径得出同一个值
+    const uint64_t file_fnv = Fnv64Update(kFnvOffset, file_bytes.data(), file_bytes.size());
 
     if (std::memcmp(file_bytes.data(), "BNAV", 4) != 0) {
         return Fail(BaseNavLoadStatus::InvalidMagic, "invalid nav magic");
@@ -1146,7 +1148,9 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
         std::move(links),
         std::move(surfaces),
         std::move(off_mesh_links),
-        std::move(sections));
+        std::move(sections),
+        build_hash,
+        file_fnv);
     return result;
 }
 

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -121,14 +122,6 @@ BaseNavTriangle ReadTriangleRecord(const uint8_t*& cursor)
     // neighbors 自己重算。哈希仍按整条记录算, 所以按区加载时补重心的那段不能省。
     cursor += 12;
     return triangle;
-}
-
-BaseNavLink ReadLinkRecord(const uint8_t*& cursor)
-{
-    BaseNavLink link;
-    link.source = ReadU32(cursor);
-    link.target = ReadU32(cursor);
-    return link;
 }
 
 bool ParseOffMeshSection(const uint8_t* data, size_t size, std::vector<BaseNavOffMeshLink>* links)
@@ -488,30 +481,33 @@ bool DecodeLinkChunk(const uint8_t* data, size_t size, uint32_t count, uint8_t* 
     return source_cursor == source_end && target_cursor == target_end;
 }
 
-// 解第 [low, high] 块, 接在 out 尾上。块定长, 每块的输出长度只由自己的 span 定,
-// 所以先按总长开好再让各块写各自那段 —— 与一块块接着写逐字节相同, 于是能并起来解。
+// 第 [low, high] 块覆盖的记录数
+size_t ChunkSpanRecords(const GeoChunkTable& table, uint32_t low, uint32_t high)
+{
+    return static_cast<size_t>(table.first(high)) + table.span(high) - table.first(low);
+}
+
+// 解第 [low, high] 块到 dst(调用方按 ChunkSpanRecords 开好)。块定长, 每块的输出长度只由自己的
+// span 定, 各块写各自那段 —— 与一块块接着写逐字节相同, 于是能并起来解。
 bool DecodeChunkSpan(
     const GeoChunkTable& table,
     const uint8_t* base,
     uint32_t low,
     uint32_t high,
     size_t record_size,
-    std::vector<uint8_t>* out,
+    uint8_t* dst,
     const std::function<bool(const uint8_t*, size_t, uint32_t, uint32_t, uint8_t*)>& decode)
 {
     const uint32_t base_record = table.first(low);
-    const size_t records = static_cast<size_t>(table.first(high)) + table.span(high) - base_record;
-    const size_t at = out->size();
-    out->resize(at + records * record_size);
     const auto chunks = static_cast<int64_t>(high - low + 1);
     std::vector<uint8_t> ok(static_cast<size_t>(chunks), 1);
-    ParallelChunks(chunks, NavWorkerCount(static_cast<int64_t>(records)), [&](size_t, int64_t b, int64_t e) {
+    ParallelChunks(chunks, NavWorkerCount(static_cast<int64_t>(ChunkSpanRecords(table, low, high))), [&](size_t, int64_t b, int64_t e) {
         for (int64_t c = b; c < e; ++c) {
             const uint32_t i = low + static_cast<uint32_t>(c);
             uint32_t size = 0;
             const uint8_t* src = table.bytes(base, i, size);
-            uint8_t* dst = out->data() + at + (static_cast<size_t>(table.first(i)) - base_record) * record_size;
-            if (!decode(src, size, table.span(i), table.first(i), dst)) {
+            uint8_t* at = dst + (static_cast<size_t>(table.first(i)) - base_record) * record_size;
+            if (!decode(src, size, table.span(i), table.first(i), at)) {
                 ok[static_cast<size_t>(c)] = 0;
             }
         }
@@ -519,29 +515,35 @@ bool DecodeChunkSpan(
     return std::find(ok.begin(), ok.end(), 0) == ok.end();
 }
 
-// 解出覆盖 [from, to) 的整块,返回块首记录的全局下标。
-bool DecodeChunkRange(
-    const GeoChunkTable& table,
-    const uint8_t* base,
-    uint32_t from,
-    uint32_t to,
-    size_t record_size,
-    std::vector<uint8_t>* out,
-    uint32_t* out_first,
-    const std::function<bool(const uint8_t*, size_t, uint32_t, uint32_t, uint8_t*)>& decode)
+// 覆盖记录 [from, to) 的整块范围。from >= to 时是空范围, first 取 from。
+struct ChunkWindow
 {
+    uint32_t low = 0;
+    uint32_t high = 0;
+    uint32_t first = 0;
+    size_t records = 0;
+};
+
+std::optional<ChunkWindow> ChunkWindowFor(const GeoChunkTable& table, uint32_t from, uint32_t to)
+{
+    ChunkWindow window;
     if (from >= to) {
-        *out_first = from;
-        return true;
+        window.first = from;
+        return window;
     }
-    const uint32_t low = from / table.chunk;
-    const uint32_t high = (to - 1) / table.chunk;
-    if (high >= table.count()) {
-        return false;
+    window.low = from / table.chunk;
+    window.high = (to - 1) / table.chunk;
+    if (window.high >= table.count()) {
+        return std::nullopt;
     }
-    *out_first = table.first(low);
-    return DecodeChunkSpan(table, base, low, high, record_size, out, decode);
+    window.first = table.first(window.low);
+    window.records = ChunkSpanRecords(table, window.low, window.high);
+    return window;
 }
+
+// 三角逐批解码的一批记录数。整包 553 万条原始记录 200 MB, 一次全解出来会和结构体表叠成
+// 加载峰值; 一批装满这个数(至少工人数个块, 解码仍并行), 转完结构体就复用暂存。
+constexpr size_t kTriangleBatchRecords = 1U << 20U;
 
 BaseNavLoadResult Fail(BaseNavLoadStatus status, std::string message)
 {
@@ -562,14 +564,13 @@ uint32_t GeoLinkChunkFor(const GeoChunkTable& table, uint32_t source)
     return index;
 }
 
-size_t LowerBoundLinkSource(const uint8_t* link_bytes, uint32_t link_count, uint32_t source)
+size_t LowerBoundLinkSource(const std::vector<BaseNavLink>& links, uint32_t source)
 {
     size_t left = 0;
-    size_t right = link_count;
+    size_t right = links.size();
     while (left < right) {
         const size_t middle = left + (right - left) / 2;
-        const uint32_t middle_source = PeekU32(link_bytes + middle * kLinkSize);
-        if (middle_source < source) {
+        if (links[middle].source < source) {
             left = middle + 1;
         }
         else {
@@ -832,74 +833,162 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
     const uint32_t selected_triangle_end = selected_first_triangle + selected_triangle_count;
     const bool zone_scoped = selected_zone.has_value();
 
-    // v5:只解这次用得着的块。重心不在包里,所以先扫一遍三角拿到顶点下标范围,
-    // 解完顶点再把重心按 ((a+b)+c)/3.0f 补回记录里 —— 换成乘 1/3 不逐位相同。
-    std::vector<uint8_t> triangle_storage;
-    std::vector<uint8_t> vertex_storage;
-    std::vector<uint8_t> link_storage;
-    uint32_t triangle_base = 0;
-    uint32_t vertex_base = 0;
+    // 顶点与连接的记录字节和结构体逐字节同布局(小端), 直接解进结构体向量, 哈希也按向量算;
+    // 三角记录 36 字节(含分量号与重心)与 24 字节的结构体不同, 逐批解到暂存再转。
+    static_assert(std::endian::native == std::endian::little);
+    static_assert(sizeof(BaseNavVertex) == kVertexSize && sizeof(BaseNavLink) == kLinkSize);
+
+    std::vector<BaseNavVertex> vertices;
+    std::vector<BaseNavTriangle> triangles;
+    triangles.reserve(selected_triangle_count);
+    std::vector<BaseNavLink> link_table;
     uint32_t link_base = 0;
-    uint32_t link_table_count = link_count;
+    uint32_t first_vertex = zone_scoped ? vertex_count : 0;
+    uint32_t last_vertex = 0;
+
+    // 哈希定义在四块的规范字节上(三角含重心), 与它们怎么存无关。v5 的字节要先解码才有, 所以只在
+    // 整包加载时算, 且按解码顺序流式更新: 区表 → 顶点 → 三角逐批 → 连接; 按区加载的 gzip 流本来
+    // 就有 CRC 兜底。
+    const bool should_verify_hash = zone_name.empty() || (!sectioned && !HasGzipSuffix(path));
+    uint64_t hash = kFnvOffset;
+    if (should_verify_hash) {
+        hash = Fnv64Update(hash, zone_table, static_cast<size_t>(zone_table_size));
+    }
+
+    // 一段 36 字节记录 [first, first + count) 与选中区的交集转成结构体; 按区加载时邻居改成区内相对
+    // 下标, 并顺手记下顶点下标范围。
+    const auto convert_triangles = [&](const uint8_t* records, uint32_t first, size_t count) -> const char* {
+        const uint32_t begin = std::max(first, selected_first_triangle);
+        const uint32_t end = static_cast<uint32_t>(std::min<uint64_t>(static_cast<uint64_t>(first) + count, selected_triangle_end));
+        if (begin >= end) {
+            return nullptr;
+        }
+        const uint8_t* cursor = records + static_cast<size_t>(begin - first) * kTriangleSize;
+        for (uint32_t index = begin; index < end; ++index) {
+            BaseNavTriangle triangle = ReadTriangleRecord(cursor);
+            for (uint32_t value : triangle.vertices) {
+                if (value >= vertex_count) {
+                    return "triangle vertex index is outside vertex table";
+                }
+                if (zone_scoped) {
+                    first_vertex = std::min(first_vertex, value);
+                    last_vertex = std::max(last_vertex, value);
+                }
+            }
+            if (zone_scoped) {
+                for (int32_t& neighbor : triangle.neighbors) {
+                    if (neighbor < 0 || static_cast<uint32_t>(neighbor) < selected_first_triangle
+                        || static_cast<uint32_t>(neighbor) >= selected_triangle_end) {
+                        neighbor = -1;
+                        continue;
+                    }
+                    neighbor -= static_cast<int32_t>(selected_first_triangle);
+                }
+            }
+            triangles.push_back(triangle);
+        }
+        return nullptr;
+    };
+
     if (sectioned) {
-        if (!DecodeChunkRange(
-                geometry.triangles,
-                geometry.base,
-                selected_first_triangle,
-                selected_triangle_end,
-                kTriangleSize,
-                &triangle_storage,
-                &triangle_base,
-                [](const uint8_t* at, size_t size, uint32_t span, uint32_t first, uint8_t* dst) {
-                    return DecodeTriangleChunk(at, size, span, first, dst);
-                })) {
+        const auto decode_vertices = [&](uint32_t from, uint32_t to) -> const char* {
+            const auto window = ChunkWindowFor(geometry.vertices, from, to);
+            if (!window) {
+                return "nav vertex chunk is malformed";
+            }
+            vertices.resize(window->records);
+            if (window->records == 0) {
+                return nullptr;
+            }
+            if (!DecodeChunkSpan(
+                    geometry.vertices,
+                    geometry.base,
+                    window->low,
+                    window->high,
+                    kVertexSize,
+                    reinterpret_cast<uint8_t*>(vertices.data()),
+                    [](const uint8_t* at, size_t size, uint32_t span, uint32_t, uint8_t* dst) {
+                        return DecodeVertexChunk(at, size, span, dst);
+                    })) {
+                return "nav vertex chunk is malformed";
+            }
+            // 只留 [from, to): 块是整块解的, 两头多出来的不属于选中区
+            vertices.erase(vertices.begin() + static_cast<std::ptrdiff_t>(to - window->first), vertices.end());
+            vertices.erase(vertices.begin(), vertices.begin() + static_cast<std::ptrdiff_t>(from - window->first));
+            return nullptr;
+        };
+        // 整包时三角的重心要靠顶点补, 顶点先解; 按区时顶点范围要先扫三角才知道, 顶点后解。
+        if (!zone_scoped) {
+            if (const char* error = decode_vertices(0, vertex_count)) {
+                return Fail(BaseNavLoadStatus::InvalidSize, error);
+            }
+            if (should_verify_hash) {
+                hash = Fnv64Update(hash, reinterpret_cast<const uint8_t*>(vertices.data()), vertices.size() * kVertexSize);
+            }
+        }
+
+        const auto window = ChunkWindowFor(geometry.triangles, selected_first_triangle, selected_triangle_end);
+        if (!window) {
             return Fail(BaseNavLoadStatus::InvalidSize, "nav triangle chunk is malformed");
         }
-        uint32_t low = vertex_count;
-        uint32_t high = 0;
-        for (size_t at = 0; at + kTriangleSize <= triangle_storage.size(); at += kTriangleSize) {
-            for (int i = 0; i < 3; ++i) {
-                const uint32_t value = PeekU32(triangle_storage.data() + at + i * 4);
-                if (value >= vertex_count) {
-                    return Fail(BaseNavLoadStatus::InvalidSize, "triangle vertex index is outside vertex table");
+        std::vector<uint8_t> scratch;
+        const size_t workers = NavWorkerCount(static_cast<int64_t>(window->records));
+        for (uint32_t low = window->low; window->records != 0 && low <= window->high;) {
+            uint32_t high = low;
+            size_t records = geometry.triangles.span(low);
+            while (high < window->high
+                   && (records + geometry.triangles.span(high + 1) <= kTriangleBatchRecords || high + 1 - low < workers)) {
+                ++high;
+                records += geometry.triangles.span(high);
+            }
+            scratch.resize(records * kTriangleSize);
+            if (!DecodeChunkSpan(
+                    geometry.triangles,
+                    geometry.base,
+                    low,
+                    high,
+                    kTriangleSize,
+                    scratch.data(),
+                    [](const uint8_t* at, size_t size, uint32_t span, uint32_t first, uint8_t* dst) {
+                        return DecodeTriangleChunk(at, size, span, first, dst);
+                    })) {
+                return Fail(BaseNavLoadStatus::InvalidSize, "nav triangle chunk is malformed");
+            }
+            if (should_verify_hash) {
+                // 整包时选中区即全部, 这批每条都算数。重心按 ((a+b)+c)/3.0f 补回 —— 换成乘 1/3 不逐位相同。
+                for (size_t at = 0; at < scratch.size(); at += kTriangleSize) {
+                    uint8_t* const record = scratch.data() + at;
+                    float u[3] = {};
+                    float v[3] = {};
+                    for (int i = 0; i < 3; ++i) {
+                        const uint32_t value = PeekU32(record + i * 4);
+                        if (value >= vertex_count) {
+                            return Fail(BaseNavLoadStatus::InvalidSize, "triangle vertex index is outside vertex table");
+                        }
+                        u[i] = vertices[value].u;
+                        v[i] = vertices[value].v;
+                    }
+                    const float center_u = ((u[0] + u[1]) + u[2]) / 3.0F;
+                    const float center_v = ((v[0] + v[1]) + v[2]) / 3.0F;
+                    std::memcpy(record + 28, &center_u, sizeof(float));
+                    std::memcpy(record + 32, &center_v, sizeof(float));
                 }
-                low = std::min(low, value);
-                high = std::max(high, value);
+                hash = Fnv64Update(hash, scratch.data(), scratch.size());
             }
+            if (const char* error = convert_triangles(scratch.data(), geometry.triangles.first(low), records)) {
+                return Fail(BaseNavLoadStatus::InvalidSize, error);
+            }
+            low = high + 1;
         }
+        std::vector<uint8_t>().swap(scratch);
+
         // 三角为空的区(tier 只有一份仿射)不用解顶点。
-        uint32_t want_low = 0;
-        uint32_t want_high = vertex_count;
         if (zone_scoped) {
-            want_low = low <= high ? low : 0;
-            want_high = low <= high ? high + 1 : 0;
-        }
-        if (!DecodeChunkRange(
-                geometry.vertices,
-                geometry.base,
-                want_low,
-                want_high,
-                kVertexSize,
-                &vertex_storage,
-                &vertex_base,
-                [](const uint8_t* at, size_t size, uint32_t span, uint32_t, uint8_t* dst) {
-                    return DecodeVertexChunk(at, size, span, dst);
-                })) {
-            return Fail(BaseNavLoadStatus::InvalidSize, "nav vertex chunk is malformed");
-        }
-        for (size_t at = 0; at + kTriangleSize <= triangle_storage.size(); at += kTriangleSize) {
-            uint8_t* const record = triangle_storage.data() + at;
-            float u[3] = {};
-            float v[3] = {};
-            for (int i = 0; i < 3; ++i) {
-                const uint8_t* vertex = vertex_storage.data() + static_cast<size_t>(PeekU32(record + i * 4) - vertex_base) * kVertexSize;
-                std::memcpy(&u[i], vertex, sizeof(float));
-                std::memcpy(&v[i], vertex + 4, sizeof(float));
+            const uint32_t want_low = triangles.empty() ? 0 : first_vertex;
+            const uint32_t want_high = triangles.empty() ? 0 : last_vertex + 1;
+            if (const char* error = decode_vertices(want_low, want_high)) {
+                return Fail(BaseNavLoadStatus::InvalidSize, error);
             }
-            const float center_u = ((u[0] + u[1]) + u[2]) / 3.0F;
-            const float center_v = ((v[0] + v[1]) + v[2]) / 3.0F;
-            std::memcpy(record + 28, &center_u, sizeof(float));
-            std::memcpy(record + 32, &center_v, sizeof(float));
         }
 
         // 连接表可以一条都没有,那时一块都不解,下游按 0 条连接走。
@@ -908,13 +997,14 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
         const uint32_t high_chunk = zone_scoped ? GeoLinkChunkFor(geometry.links, selected_triangle_end) : link_chunks;
         if (low_chunk < link_chunks && low_chunk <= high_chunk) {
             const uint32_t last_chunk = std::min(high_chunk, link_chunks - 1);
+            link_table.resize(ChunkSpanRecords(geometry.links, low_chunk, last_chunk));
             if (!DecodeChunkSpan(
                     geometry.links,
                     geometry.base,
                     low_chunk,
                     last_chunk,
                     kLinkSize,
-                    &link_storage,
+                    reinterpret_cast<uint8_t*>(link_table.data()),
                     [](const uint8_t* at, size_t size, uint32_t span, uint32_t, uint8_t* dst) {
                         return DecodeLinkChunk(at, size, span, dst);
                     })) {
@@ -922,67 +1012,31 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
             }
         }
         link_base = geometry.links.first(low_chunk);
-        link_table_count = static_cast<uint32_t>(link_storage.size() / kLinkSize);
-        vertex_bytes = vertex_storage.data();
-        triangle_bytes = triangle_storage.data();
-        link_bytes = link_storage.data();
-    }
-
-    // 哈希仍定义在四块的规范字节上,与它们怎么存无关。v5 的字节要先解码才有,
-    // 所以只在整包加载时算;按区加载的 gzip 流本来就有 CRC 兜底。
-    const bool should_verify_hash = zone_name.empty() || (!sectioned && !HasGzipSuffix(path));
-    if (should_verify_hash) {
-        uint64_t hash = kFnvOffset;
-        hash = Fnv64Update(hash, zone_table, static_cast<size_t>(zone_table_size));
-        hash = Fnv64Update(hash, vertex_bytes, static_cast<size_t>(vertex_count) * kVertexSize);
-        hash = Fnv64Update(hash, triangle_bytes, static_cast<size_t>(triangle_count) * kTriangleSize);
-        hash = Fnv64Update(hash, link_bytes, static_cast<size_t>(link_count) * kLinkSize);
-        if (hash != build_hash) {
-            return Fail(BaseNavLoadStatus::HashMismatch, "nav build hash mismatch");
+        if (should_verify_hash) {
+            hash = Fnv64Update(hash, reinterpret_cast<const uint8_t*>(link_table.data()), link_table.size() * kLinkSize);
         }
     }
-
-    std::vector<BaseNavTriangle> triangles;
-    triangles.reserve(selected_triangle_count);
-    uint32_t first_vertex = zone_scoped ? vertex_count : 0;
-    uint32_t last_vertex = 0;
-    const uint8_t* triangle_cursor = triangle_bytes + static_cast<uint64_t>(selected_first_triangle - triangle_base) * kTriangleSize;
-    for (uint32_t index = 0; index < selected_triangle_count; ++index) {
-        BaseNavTriangle triangle = ReadTriangleRecord(triangle_cursor);
-        for (uint32_t value : triangle.vertices) {
-            if (value >= vertex_count) {
-                return Fail(BaseNavLoadStatus::InvalidSize, "triangle vertex index is outside vertex table");
-            }
-            if (zone_scoped) {
-                first_vertex = std::min(first_vertex, value);
-                last_vertex = std::max(last_vertex, value);
-            }
+    else {
+        if (should_verify_hash) {
+            hash = Fnv64Update(hash, vertex_bytes, static_cast<size_t>(vertex_count) * kVertexSize);
+            hash = Fnv64Update(hash, triangle_bytes, static_cast<size_t>(triangle_count) * kTriangleSize);
+            hash = Fnv64Update(hash, link_bytes, static_cast<size_t>(link_count) * kLinkSize);
         }
-        if (zone_scoped) {
-            for (int32_t& neighbor : triangle.neighbors) {
-                if (neighbor < 0 || static_cast<uint32_t>(neighbor) < selected_first_triangle
-                    || static_cast<uint32_t>(neighbor) >= selected_triangle_end) {
-                    neighbor = -1;
-                    continue;
-                }
-                neighbor -= static_cast<int32_t>(selected_first_triangle);
-            }
+        if (const char* error = convert_triangles(triangle_bytes, 0, triangle_count)) {
+            return Fail(BaseNavLoadStatus::InvalidSize, error);
         }
-        triangles.push_back(triangle);
+        const uint32_t selected_vertex_count = zone_scoped ? (triangles.empty() ? 0 : last_vertex - first_vertex + 1) : vertex_count;
+        vertices.resize(selected_vertex_count);
+        if (selected_vertex_count != 0) {
+            std::memcpy(vertices.data(), vertex_bytes + static_cast<size_t>(first_vertex) * kVertexSize, selected_vertex_count * kVertexSize);
+        }
+        link_table.resize(link_count);
+        std::memcpy(link_table.data(), link_bytes, static_cast<size_t>(link_count) * kLinkSize);
+    }
+    if (should_verify_hash && hash != build_hash) {
+        return Fail(BaseNavLoadStatus::HashMismatch, "nav build hash mismatch");
     }
 
-    const uint32_t selected_vertex_count = zone_scoped ? (triangles.empty() ? 0 : last_vertex - first_vertex + 1) : vertex_count;
-    std::vector<BaseNavVertex> vertices;
-    vertices.reserve(selected_vertex_count);
-    const uint64_t vertex_skip = selected_vertex_count == 0 ? 0 : static_cast<uint64_t>(first_vertex - vertex_base);
-    const uint8_t* vertex_cursor = vertex_bytes + vertex_skip * kVertexSize;
-    for (uint32_t index = 0; index < selected_vertex_count; ++index) {
-        BaseNavVertex vertex;
-        vertex.u = ReadF32(vertex_cursor);
-        vertex.v = ReadF32(vertex_cursor);
-        vertex.height = ReadF32(vertex_cursor);
-        vertices.push_back(vertex);
-    }
     if (zone_scoped) {
         for (BaseNavTriangle& triangle : triangles) {
             for (uint32_t& vertex_index : triangle.vertices) {
@@ -1010,27 +1064,44 @@ BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string
         zones = std::move(scoped_zones);
     }
 
-    std::vector<BaseNavLink> links;
-    const size_t first_link = zone_scoped ? LowerBoundLinkSource(link_bytes, link_table_count, selected_first_triangle) : 0;
-    const size_t last_link = zone_scoped ? LowerBoundLinkSource(link_bytes, link_table_count, selected_triangle_end) : link_table_count;
-    links.reserve(last_link - first_link);
-    const uint8_t* link_cursor = link_bytes + first_link * kLinkSize;
-    for (size_t index = first_link; index < last_link; ++index) {
-        BaseNavLink link = ReadLinkRecord(link_cursor);
+    const auto invalid_link = [&](size_t index) {
+        const BaseNavLink& link = link_table[index];
         if (link.source >= triangle_count || link.target >= triangle_count) {
             LogWarn << "Skipping invalid BaseNav link." << VAR(link_base + index) << VAR(link.source) << VAR(link.target)
                     << VAR(triangle_count);
-            continue;
+            return true;
         }
-        if (zone_scoped) {
+        return false;
+    };
+    std::vector<BaseNavLink> links;
+    if (zone_scoped) {
+        const size_t first_link = LowerBoundLinkSource(link_table, selected_first_triangle);
+        const size_t last_link = LowerBoundLinkSource(link_table, selected_triangle_end);
+        links.reserve(last_link - first_link);
+        for (size_t index = first_link; index < last_link; ++index) {
+            if (invalid_link(index)) {
+                continue;
+            }
+            BaseNavLink link = link_table[index];
             if (link.source < selected_first_triangle || link.source >= selected_triangle_end || link.target < selected_first_triangle
                 || link.target >= selected_triangle_end) {
                 continue;
             }
             link.source -= selected_first_triangle;
             link.target -= selected_first_triangle;
+            links.push_back(link);
         }
-        links.push_back(link);
+    }
+    else {
+        // 整包 1500 万条 116 MB, 原地剔除而不是再抄一份
+        size_t kept = 0;
+        for (size_t index = 0; index < link_table.size(); ++index) {
+            if (!invalid_link(index)) {
+                link_table[kept++] = link_table[index];
+            }
+        }
+        link_table.resize(kept);
+        links = std::move(link_table);
     }
 
     std::vector<BaseNavOffMeshLink> off_mesh_links;

--- a/agent/cpp-algo/source/Navmesh/BaseNavReader.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavReader.h
@@ -11,4 +11,7 @@ namespace navmesh
 
 BaseNavLoadResult LoadBaseNavPack(const std::filesystem::path& path, std::string_view zone_name = {});
 
+// 读整份文件字节,.gz 后缀的先解压。主包与旁包共用这一条读法。
+BaseNavLoadResult ReadNavFileBytes(const std::filesystem::path& path, std::vector<uint8_t>* output);
+
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavBake.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavBake.cpp
@@ -40,6 +40,8 @@ BakedWalls BakeWalls(const ZoneClean& zc, double x0, double y0, int64_t nx, int6
                 out.h0.push_back(mesh.h(a));
                 out.h1.push_back(mesh.h(b));
                 out.hh.push_back((mesh.h(a) + mesh.h(b)) / 2.0);
+                out.tri.push_back(t);
+                out.k.push_back(static_cast<uint8_t>(k));
             }
         }
     }

--- a/agent/cpp-algo/source/Navmesh/RecastNavBake.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavBake.cpp
@@ -26,20 +26,20 @@ BakedWalls BakeWalls(const ZoneClean& zc, double x0, double y0, int64_t nx, int6
             continue;
         }
         for (int k = 0; k < 3; ++k) {
-            if (mesh.NB[i][k] >= 0) {
-                continue;
+            if ((mesh.bnd[i] >> k & 1U) == 0U) {
+                continue; // 有邻居的边不是墙
             }
             const int32_t a = mesh.T[i][k];
             const int32_t b = mesh.T[i][(k + 1) % 3];
-            const WorldPoint p0 = mesh.V[a];
-            const WorldPoint p1 = mesh.V[b];
+            const WorldPoint p0 = mesh.v(a);
+            const WorldPoint p1 = mesh.v(b);
             if (std::max(p0.x, p1.x) >= bx0 && std::min(p0.x, p1.x) <= bx1 && std::max(p0.y, p1.y) >= by0
                 && std::min(p0.y, p1.y) <= by1) {
                 out.p0.push_back(p0);
                 out.p1.push_back(p1);
-                out.h0.push_back(mesh.H[a]);
-                out.h1.push_back(mesh.H[b]);
-                out.hh.push_back((mesh.H[a] + mesh.H[b]) / 2.0);
+                out.h0.push_back(mesh.h(a));
+                out.h1.push_back(mesh.h(b));
+                out.hh.push_back((mesh.h(a) + mesh.h(b)) / 2.0);
             }
         }
     }
@@ -54,7 +54,7 @@ BakedCells BakeCells(const ZoneClean& zc, double x0, double y0, int64_t nx, int6
     out.nx = nx;
     out.ny = ny;
     // 掩码随网格一起送进体素化 —— 烘焙期与运行期共用这一处判据,两边的可走面必然一致
-    out.rcs = Rasterize(zc.mesh.V, zc.mesh.H, zc.mesh.T, x0, y0, nx, ny, &zc.walkable);
+    out.rcs = Rasterize(zc.mesh.verts(), zc.mesh.T, x0, y0, nx, ny, &zc.walkable);
     AppendSeamBridge(out.rcs, nx, ny);
     out.st = BuildSpans(out.rcs.cell, out.rcs.h);
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavBake.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavBake.h
@@ -11,6 +11,7 @@ namespace navmesh::recast
 {
 
 // 一块矩形范围内的立面。取窗口外扩 4px 内的,与盖章口径一致。
+// tri/k 是这条边在区网格里的身份(区内三角号, 边内序), 旁包的留墙表按它索引。
 struct BakedWalls
 {
     std::vector<WorldPoint> p0;
@@ -18,6 +19,8 @@ struct BakedWalls
     std::vector<double> h0;
     std::vector<double> h1;
     std::vector<double> hh;
+    std::vector<int32_t> tri;
+    std::vector<uint8_t> k;
 };
 
 BakedWalls BakeWalls(const ZoneClean& zc, double x0, double y0, int64_t nx, int64_t ny);

--- a/agent/cpp-algo/source/Navmesh/RecastNavFieldsIO.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavFieldsIO.cpp
@@ -1,0 +1,541 @@
+#include "RecastNavFieldsIO.h"
+
+#include <algorithm>
+#include <cstring>
+#include <unordered_map>
+
+#include "BaseNavReader.h"
+#include "RecastNavGrid.h"
+#include "RecastNavZone.h"
+
+namespace navmesh::recast
+{
+
+namespace
+{
+
+constexpr size_t kHeaderSize = 48;
+constexpr size_t kSectionEntrySize = 24;
+constexpr size_t kConstSize = 144;
+
+// 采样与包围盒口径写死在 StampWalls / WallHits / BakeWalls 里, 旁包按同样的值烘。
+constexpr double kWallSampleSub = 0.4;
+constexpr double kHitSampleSub = 0.2;
+constexpr double kWallBBoxPad = 4.0;
+
+uint16_t peekU16(const uint8_t* p)
+{
+    uint16_t v = 0;
+    std::memcpy(&v, p, sizeof v);
+    return v;
+}
+
+uint32_t peekU32(const uint8_t* p)
+{
+    uint32_t v = 0;
+    std::memcpy(&v, p, sizeof v);
+    return v;
+}
+
+uint64_t peekU64(const uint8_t* p)
+{
+    uint64_t v = 0;
+    std::memcpy(&v, p, sizeof v);
+    return v;
+}
+
+// 运行期判据常数排成旁包 FCON 段的样子, 整段逐字节比对。
+std::vector<uint8_t> expectedConst()
+{
+    std::vector<uint8_t> out;
+    out.reserve(kConstSize);
+    const auto f64 = [&](double v) {
+        uint8_t b[8];
+        std::memcpy(b, &v, 8);
+        out.insert(out.end(), b, b + 8);
+    };
+    const auto i32 = [&](int32_t v) {
+        uint8_t b[4];
+        std::memcpy(b, &v, 4);
+        out.insert(out.end(), b, b + 4);
+    };
+    f64(kCS);
+    f64(kClimb);
+    f64(kSlope);
+    f64(kStepUp);
+    f64(kBumpUp);
+    f64(kWallH);
+    f64(kMcHBand);
+    f64(kMergeH);
+    f64(kEdtCap);
+    f64(kWallSampleSub);
+    f64(kHitSampleSub);
+    f64(kWallBBoxPad);
+    f64(kStepTax);
+    f64(kClrLambda);
+    f64(0.0);
+    i32(static_cast<int32_t>(kBumpCells));
+    i32(static_cast<int32_t>(kDipCells));
+    i32(static_cast<int32_t>(kFieldHalo));
+    i32(static_cast<int32_t>(kWalkableFlagsDefault));
+    i32(static_cast<int32_t>(kFieldsRulesVersion));
+    i32(0);
+    return out;
+}
+
+// 变长整数与带长度前缀的 zlib 流。越界即失败, 不越界读。
+struct Reader
+{
+    const uint8_t* p = nullptr;
+    const uint8_t* end = nullptr;
+
+    bool varint(uint64_t& out)
+    {
+        out = 0;
+        for (int shift = 0; shift < 64; shift += 7) {
+            if (p == end) {
+                return false;
+            }
+            const uint8_t c = *p++;
+            out |= static_cast<uint64_t>(c & 0x7FU) << shift;
+            if ((c & 0x80U) == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool u32(uint32_t& out)
+    {
+        uint64_t v = 0;
+        if (!varint(v) || v > 0xFFFFFFFFULL) {
+            return false;
+        }
+        out = static_cast<uint32_t>(v);
+        return true;
+    }
+
+    bool stream(std::vector<uint8_t>& out)
+    {
+        uint64_t len = 0;
+        if (!varint(len) || len > static_cast<uint64_t>(end - p)) {
+            return false;
+        }
+        const bool ok = InflateBytes(p, static_cast<size_t>(len), out);
+        p += len;
+        return ok;
+    }
+
+    bool done() const { return p == end; }
+};
+
+int64_t unzig(uint64_t u)
+{
+    return static_cast<int64_t>(u >> 1) ^ -static_cast<int64_t>(u & 1U);
+}
+
+}
+
+std::filesystem::path FieldsSidecarPath(const std::filesystem::path& main_pack)
+{
+    std::string name = main_pack.filename().string();
+    const auto endsWith = [&](const char* suffix) {
+        const size_t n = std::strlen(suffix);
+        return name.size() >= n && name.compare(name.size() - n, n, suffix) == 0;
+    };
+    if (endsWith(".nav.gz")) {
+        name.insert(name.size() - 7, ".fields");
+    }
+    else if (endsWith(".nav")) {
+        name.insert(name.size() - 4, ".fields");
+    }
+    else {
+        name += ".fields";
+    }
+    return main_pack.parent_path() / name;
+}
+
+std::vector<uint8_t> FieldsZone::reachFrom(uint32_t rid, uint32_t s0) const
+{
+    std::vector<uint8_t> seen;
+    if (rid >= regions.size() || s0 == 0 || s0 > regions[rid].n_scc) {
+        return seen;
+    }
+    const Region& r = regions[rid];
+    seen.assign(static_cast<size_t>(r.n_scc) + 1, 0);
+    std::vector<uint32_t> stack { s0 };
+    seen[s0] = 1;
+    while (!stack.empty()) {
+        const uint32_t s = stack.back();
+        stack.pop_back();
+        const uint32_t b = adj_start[r.adj_off + s];
+        const uint32_t e = adj_start[r.adj_off + s + 1];
+        for (uint32_t i = b; i < e; ++i) {
+            const uint32_t d = edge_dst[i];
+            if (seen[d] == 0) {
+                seen[d] = 1;
+                stack.push_back(d);
+            }
+        }
+    }
+    return seen;
+}
+
+bool FieldsZone::wallKeep(int32_t tri, int k, uint32_t rid, bool& known) const
+{
+    const auto key = static_cast<uint32_t>(tri) * 3U + static_cast<uint32_t>(k);
+    const auto it = std::lower_bound(wall_key.begin(), wall_key.end(), key);
+    known = it != wall_key.end() && *it == key;
+    if (!known) {
+        return false;
+    }
+    const auto w = static_cast<size_t>(it - wall_key.begin());
+    const auto b = wall_rid.begin() + wall_rid_start[w];
+    const auto e = wall_rid.begin() + wall_rid_start[w + 1];
+    return std::binary_search(b, e, rid);
+}
+
+bool FieldsPack::load(const std::filesystem::path& path, const BaseNavPack& main, const GridPack& grid, std::string& err)
+{
+    loaded_ = false;
+    zones_.clear();
+    bytes_.clear();
+    const BaseNavLoadResult read = ReadNavFileBytes(path, &bytes_);
+    if (read.status != BaseNavLoadStatus::Success) {
+        err = "旁包读不到 (" + path.string() + "): " + read.message;
+        return false;
+    }
+    const size_t size = bytes_.size();
+    const uint8_t* base = bytes_.data();
+    if (size < kHeaderSize || std::memcmp(base, "BNVF", 4) != 0) {
+        err = "旁包不是 BNVF";
+        return false;
+    }
+    const uint16_t version = peekU16(base + 4);
+    flags_ = peekU16(base + 6);
+    const uint64_t build_hash = peekU64(base + 8);
+    const uint64_t fnv = peekU64(base + 16);
+    const uint32_t rules = peekU32(base + 24);
+    const uint32_t section_count = peekU32(base + 28);
+    const uint64_t dir_off = peekU64(base + 32);
+    if (version != kFieldsFormatVersion) {
+        err = "旁包格式版本 " + std::to_string(version) + ", 需要 " + std::to_string(kFieldsFormatVersion);
+        return false;
+    }
+    if (build_hash != main.buildHash() || fnv != main.fileFnv()) {
+        err = "旁包不是配这份主包的 (build_hash/fnv 不符)";
+        return false;
+    }
+    if (rules != kFieldsRulesVersion) {
+        err = "旁包判据版本不符 (" + std::to_string(rules) + " ≠ " + std::to_string(kFieldsRulesVersion) + ")";
+        return false;
+    }
+    if (dir_off > size || static_cast<uint64_t>(section_count) * kSectionEntrySize > size - dir_off) {
+        err = "旁包段目录越界";
+        return false;
+    }
+    struct Sec
+    {
+        const uint8_t* p = nullptr;
+        size_t len = 0;
+    };
+    std::unordered_map<std::string, Sec> secs;
+    for (uint32_t i = 0; i < section_count; ++i) {
+        const uint8_t* e = base + dir_off + static_cast<size_t>(i) * kSectionEntrySize;
+        const std::string tag(reinterpret_cast<const char*>(e), 4);
+        const uint64_t off = peekU64(e + 8);
+        const uint64_t len = peekU64(e + 16);
+        if (off > size || len > size - off) {
+            err = "旁包段 " + tag + " 越界";
+            return false;
+        }
+        secs[tag] = Sec { base + off, static_cast<size_t>(len) };
+    }
+    for (const char* tag : { "FCON", "FZON", "FSPN", "FSCC", "FWAL" }) {
+        if (secs.find(tag) == secs.end()) {
+            err = std::string("旁包缺段 ") + tag;
+            return false;
+        }
+    }
+    const Sec con = secs["FCON"];
+    const std::vector<uint8_t> want = expectedConst();
+    if (con.len != kConstSize || std::memcmp(con.p, want.data(), kConstSize) != 0) {
+        err = "旁包的判据常数与运行期不符";
+        return false;
+    }
+    const Sec zon = secs["FZON"];
+    const Sec spn = secs["FSPN"];
+    const Sec scc = secs["FSCC"];
+    const Sec wal = secs["FWAL"];
+    if (zon.len < 4) {
+        err = "旁包区表残缺";
+        return false;
+    }
+    const uint32_t zone_count = peekU32(zon.p);
+    const uint8_t* p = zon.p + 4;
+    const uint8_t* zend = zon.p + zon.len;
+    for (uint32_t zi = 0; zi < zone_count; ++zi) {
+        if (zend - p < 4) {
+            err = "旁包区表残缺";
+            return false;
+        }
+        const uint32_t name_len = peekU32(p);
+        p += 4;
+        const size_t padded = (static_cast<size_t>(name_len) + 3) / 4 * 4;
+        if (static_cast<size_t>(zend - p) < padded + 8 + 48) {
+            err = "旁包区表残缺";
+            return false;
+        }
+        FieldsZoneDir z;
+        z.name.assign(reinterpret_cast<const char*>(p), name_len);
+        p += padded;
+        z.global_regions = peekU32(p);
+        const uint32_t tile_count = peekU32(p + 4);
+        const uint64_t spn_off = peekU64(p + 8), spn_len = peekU64(p + 16);
+        const uint64_t scc_off = peekU64(p + 24), scc_len = peekU64(p + 32);
+        const uint64_t wal_off = peekU64(p + 40), wal_len = peekU64(p + 48);
+        p += 56;
+        if (spn_off > spn.len || spn_len > spn.len - spn_off || scc_off > scc.len || scc_len > scc.len - scc_off
+            || wal_off > wal.len || wal_len > wal.len - wal_off) {
+            err = "旁包区 " + z.name + " 的段范围越界";
+            return false;
+        }
+        z.scc = scc.p + scc_off;
+        z.scc_len = static_cast<size_t>(scc_len);
+        z.wal = wal.p + wal_off;
+        z.wal_len = static_cast<size_t>(wal_len);
+        const uint8_t* zb = spn.p + spn_off;
+        if (static_cast<uint64_t>(tile_count) * 16 > spn_len) {
+            err = "旁包区 " + z.name + " 的瓦表越界";
+            return false;
+        }
+        z.tiles.resize(tile_count);
+        for (uint32_t t = 0; t < tile_count; ++t) {
+            const uint8_t* e = zb + static_cast<size_t>(t) * 16;
+            FieldsTileRef& r = z.tiles[t];
+            r.records = peekU32(e);
+            const uint64_t off = peekU64(e + 4);
+            const uint32_t len = peekU32(e + 12);
+            if (off > spn_len || len > spn_len - off) {
+                err = "旁包区 " + z.name + " 的瓦载荷越界";
+                return false;
+            }
+            r.data = zb + off;
+            r.len = len;
+        }
+        zones_.push_back(std::move(z));
+    }
+    // 对着格图目录核区: 主包按区裁剪载入时格图仍是整份, 所以按名字配, 格图里的区都得有。
+    for (const GridZoneDir& g : grid.zones()) {
+        const FieldsZoneDir* z = nullptr;
+        for (const FieldsZoneDir& c : zones_) {
+            if (c.name == g.name) {
+                z = &c;
+                break;
+            }
+        }
+        if (z == nullptr) {
+            err = "旁包没有区 " + g.name;
+            return false;
+        }
+        if (z->global_regions != g.global_regions || z->tiles.size() != g.tiles.size()) {
+            err = "旁包区 " + g.name + " 的类数或瓦数与格图不符";
+            return false;
+        }
+        for (size_t t = 0; t < g.tiles.size(); ++t) {
+            if (z->tiles[t].records != g.tiles[t].records) {
+                err = "旁包区 " + g.name + " 第 " + std::to_string(t) + " 瓦记录数与格图不符";
+                return false;
+            }
+        }
+    }
+    loaded_ = true;
+    return true;
+}
+
+const FieldsZoneDir* FieldsPack::findZone(const std::string& name) const
+{
+    for (const FieldsZoneDir& z : zones_) {
+        if (z.name == name) {
+            return &z;
+        }
+    }
+    return nullptr;
+}
+
+bool FieldsPack::decodeTile(const FieldsTileRef& t, FieldsTile& out) const
+{
+    out.scc.clear();
+    out.steps2x.clear();
+    out.seg.clear();
+    out.tax.clear();
+    out.clr2d.clear();
+    out.medial.clear();
+    if (t.records == 0) {
+        return true;
+    }
+    Reader rd { t.data, t.data + t.len };
+    uint64_t n = 0;
+    if (!rd.varint(n) || n != t.records) {
+        return false;
+    }
+    // 六条流依次: 分量号(zigzag 差分 varint)、禁步 XOR、段位、税边位、净空差(varint)、中轴位。
+    std::vector<uint8_t> s0;
+    std::vector<uint8_t> s4;
+    if (!rd.stream(s0) || !rd.stream(out.steps2x) || !rd.stream(out.seg) || !rd.stream(out.tax) || !rd.stream(s4)
+        || !rd.stream(out.medial) || !rd.done()) {
+        return false;
+    }
+    if (out.steps2x.size() != n || out.seg.size() != n || out.tax.size() != n || out.medial.size() != n) {
+        return false;
+    }
+    out.scc.resize(static_cast<size_t>(n));
+    Reader r0 { s0.data(), s0.data() + s0.size() };
+    int64_t prev = 0;
+    for (size_t i = 0; i < n; ++i) {
+        uint64_t u = 0;
+        if (!r0.varint(u)) {
+            return false;
+        }
+        prev += unzig(u);
+        if (prev < 0) {
+            return false;
+        }
+        out.scc[i] = static_cast<uint32_t>(prev);
+    }
+    out.clr2d.resize(static_cast<size_t>(n));
+    Reader r4 { s4.data(), s4.data() + s4.size() };
+    for (size_t i = 0; i < n; ++i) {
+        uint64_t u = 0;
+        if (!r4.varint(u) || u > 0xFFFFULL) {
+            return false;
+        }
+        out.clr2d[i] = static_cast<uint16_t>(u);
+    }
+    return r0.done() && r4.done();
+}
+
+bool FieldsPack::loadZone(const FieldsZoneDir& z, FieldsZone& out, std::string& err) const
+{
+    out = FieldsZone();
+    out.regions.assign(static_cast<size_t>(z.global_regions) + 1, FieldsZone::Region {});
+    // 分量图: 逐类读边表, 按源分量装成 CSR。边已按 (src, dst) 升序, 所以计数装填即成。
+    {
+        Reader rd { z.scc, z.scc + z.scc_len };
+        uint32_t rc = 0;
+        if (!rd.u32(rc)) {
+            err = "旁包区 " + z.name + " 的分量图残缺";
+            return false;
+        }
+        std::vector<uint8_t> st;
+        std::vector<uint32_t> src;
+        std::vector<uint32_t> dst;
+        for (uint32_t i = 0; i < rc; ++i) {
+            uint32_t rid = 0, n_scc = 0, n_edges = 0;
+            if (!rd.u32(rid) || !rd.u32(n_scc) || !rd.u32(n_edges) || rid > z.global_regions || n_scc == 0) {
+                err = "旁包区 " + z.name + " 的分量图残缺";
+                return false;
+            }
+            if ((flags_ & 1U) != 0) {
+                uint64_t skip = 0;
+                for (int b = 0; b < 4; ++b) {
+                    if (!rd.varint(skip)) {
+                        err = "旁包区 " + z.name + " 的分量图残缺";
+                        return false;
+                    }
+                }
+            }
+            if (!rd.stream(st)) {
+                err = "旁包区 " + z.name + " 的分量图解不开";
+                return false;
+            }
+            Reader es { st.data(), st.data() + st.size() };
+            src.assign(n_edges, 0);
+            dst.assign(n_edges, 0);
+            uint32_t prev = 0;
+            for (uint32_t e = 0; e < n_edges; ++e) {
+                uint32_t d = 0;
+                if (!es.u32(d) || !es.u32(dst[e])) {
+                    err = "旁包区 " + z.name + " 的分量图残缺";
+                    return false;
+                }
+                prev += d;
+                src[e] = prev;
+                if (src[e] == 0 || src[e] > n_scc || dst[e] == 0 || dst[e] > n_scc) {
+                    err = "旁包区 " + z.name + " 类 " + std::to_string(rid) + " 的边越界";
+                    return false;
+                }
+            }
+            if (!es.done()) {
+                err = "旁包区 " + z.name + " 的分量图残缺";
+                return false;
+            }
+            FieldsZone::Region& r = out.regions[rid];
+            r.n_scc = n_scc;
+            r.adj_off = static_cast<uint32_t>(out.adj_start.size());
+            const auto base_e = static_cast<uint32_t>(out.edge_dst.size());
+            out.adj_start.resize(out.adj_start.size() + n_scc + 2, base_e);
+            for (uint32_t e = 0; e < n_edges; ++e) {
+                out.adj_start[r.adj_off + src[e] + 1] += 1;
+            }
+            for (uint32_t s = 1; s <= n_scc + 1; ++s) {
+                out.adj_start[r.adj_off + s] += out.adj_start[r.adj_off + s - 1] - base_e;
+            }
+            out.edge_dst.insert(out.edge_dst.end(), dst.begin(), dst.end());
+        }
+        if (!rd.done()) {
+            err = "旁包区 " + z.name + " 的分量图有多余字节";
+            return false;
+        }
+    }
+    // 留墙表: 键升序差分, 逐墙的类表升序差分。
+    {
+        Reader rd { z.wal, z.wal + z.wal_len };
+        uint32_t nw = 0;
+        std::vector<uint8_t> a;
+        std::vector<uint8_t> b;
+        if (!rd.u32(nw) || !rd.stream(a) || !rd.stream(b) || !rd.done()) {
+            err = "旁包区 " + z.name + " 的留墙表残缺";
+            return false;
+        }
+        Reader ra { a.data(), a.data() + a.size() };
+        Reader rb { b.data(), b.data() + b.size() };
+        out.wall_key.resize(nw);
+        out.wall_rid_start.assign(static_cast<size_t>(nw) + 1, 0);
+        uint32_t prev = 0;
+        for (uint32_t i = 0; i < nw; ++i) {
+            uint32_t d = 0;
+            if (!ra.u32(d)) {
+                err = "旁包区 " + z.name + " 的留墙表残缺";
+                return false;
+            }
+            prev += d;
+            out.wall_key[i] = prev;
+        }
+        for (uint32_t i = 0; i < nw; ++i) {
+            uint32_t nr = 0;
+            if (!rb.u32(nr)) {
+                err = "旁包区 " + z.name + " 的留墙表残缺";
+                return false;
+            }
+            uint32_t rp = 0;
+            for (uint32_t k = 0; k < nr; ++k) {
+                uint32_t d = 0;
+                if (!rb.u32(d)) {
+                    err = "旁包区 " + z.name + " 的留墙表残缺";
+                    return false;
+                }
+                rp += d;
+                out.wall_rid.push_back(rp);
+            }
+            out.wall_rid_start[static_cast<size_t>(i) + 1] = static_cast<uint32_t>(out.wall_rid.size());
+        }
+        if (!ra.done() || !rb.done()) {
+            err = "旁包区 " + z.name + " 的留墙表有多余字节";
+            return false;
+        }
+    }
+    return true;
+}
+
+}

--- a/agent/cpp-algo/source/Navmesh/RecastNavFieldsIO.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavFieldsIO.cpp
@@ -449,6 +449,11 @@ bool FieldsPack::loadZone(const FieldsZoneDir& z, FieldsZone& out, std::string& 
                 err = "旁包区 " + z.name + " 的分量图解不开";
                 return false;
             }
+            // 每条边至少 2 字节 varint, 先按流长卡住 n_edges 再分配
+            if (st.size() < 2ULL * n_edges) {
+                err = "旁包区 " + z.name + " 的分量图残缺";
+                return false;
+            }
             Reader es { st.data(), st.data() + st.size() };
             src.assign(n_edges, 0);
             dst.assign(n_edges, 0);

--- a/agent/cpp-algo/source/Navmesh/RecastNavFieldsIO.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavFieldsIO.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "BaseNavPack.h"
+#include "RecastNavGridIO.h"
+
+namespace navmesh::recast
+{
+
+// 预烘场旁包 (BNVF v2)。主包每条 span 记录在这里各有六列: 类内强连通分量号、重判禁步位、
+// 立面段位、台阶税边位、封缝后净空、中轴位; 每类一张分量间的有向无环图; 每条边界边一张留它的类表。
+// 运行期靠它把"可达域 / 禁步重判 / 挑墙 / 台阶税 / 封缝净空 / 中轴"全省掉, 无封堵的腿只剩解瓦与 A*。
+inline constexpr uint32_t kFieldsRulesVersion = 2;
+inline constexpr uint16_t kFieldsFormatVersion = 2;
+
+// 主包路径 → 旁包路径: base.nav.gz → base.fields.nav.gz, 同一目录。
+std::filesystem::path FieldsSidecarPath(const std::filesystem::path& main_pack);
+
+struct FieldsTileRef
+{
+    uint32_t records = 0;
+    const uint8_t* data = nullptr; // 载荷首字节, 指进 FieldsPack 自有的字节
+    size_t len = 0;
+};
+
+struct FieldsZoneDir
+{
+    std::string name;
+    uint32_t global_regions = 0;
+    std::vector<FieldsTileRef> tiles; // 与 BGRD 同区的瓦表同序
+    const uint8_t* scc = nullptr;
+    size_t scc_len = 0;
+    const uint8_t* wal = nullptr;
+    size_t wal_len = 0;
+};
+
+// 一块瓦的六列, 与主包同一块瓦解出的记录逐条对位。
+struct FieldsTile
+{
+    std::vector<uint32_t> scc;     // 类内分量号 1..n_scc; 填充记录为 0
+    std::vector<uint8_t> steps2x;  // 重判禁步位 XOR 主包 steps 位
+    std::vector<uint8_t> seg;      // bit0 = c→b 出段, bit1 = b→c 出段; 只有正交两向有值
+    std::vector<uint8_t> tax;      // 台阶税边位: 方向 i 的正向在 bit 2i, 反向在 bit 2i+1
+    std::vector<uint16_t> clr2d;   // 主包 clr 减去封缝后净空 (≥ 0), 平方格数
+    std::vector<uint8_t> medial;   // bit0 = 该格在类内的中轴上
+};
+
+// 一个区的整类量。
+struct FieldsZone
+{
+    struct Region
+    {
+        uint32_t n_scc = 0;
+        uint32_t adj_off = 0; // adj_start 里这一类的起点, 长 n_scc + 2 (分量号 1 起)
+    };
+
+    std::vector<Region> regions; // 按类号索引
+    std::vector<uint32_t> adj_start;
+    std::vector<uint32_t> edge_dst;
+    std::vector<uint32_t> wall_key; // 升序: 区内三角号 * 3 + 边内序
+    std::vector<uint32_t> wall_rid_start;
+    std::vector<uint32_t> wall_rid;
+
+    // 从分量 s0 出发能到的分量集, 下标是分量号(0 位不用)。类号越界或 s0 越界给空表。
+    std::vector<uint8_t> reachFrom(uint32_t rid, uint32_t s0) const;
+
+    // 边 (tri, k) 在类 rid 的层上是否留下。不在表里的边是数据不一致, known 置 false。
+    bool wallKeep(int32_t tri, int k, uint32_t rid, bool& known) const;
+};
+
+class FieldsPack
+{
+public:
+    // 读旁包并对着主包与格图目录逐项核对: 身份、判据常数、区表、每瓦记录数。
+    // 任一项不符即失败, 不做降级 —— 判据不一致的场比没有场更糟。
+    bool load(const std::filesystem::path& path, const BaseNavPack& main, const GridPack& grid, std::string& err);
+
+    bool valid() const { return loaded_; }
+
+    const FieldsZoneDir* findZone(const std::string& name) const;
+
+    bool decodeTile(const FieldsTileRef& t, FieldsTile& out) const;
+
+    bool loadZone(const FieldsZoneDir& z, FieldsZone& out, std::string& err) const;
+
+private:
+    std::vector<uint8_t> bytes_;
+    bool loaded_ = false;
+    uint16_t flags_ = 0;
+    std::vector<FieldsZoneDir> zones_;
+};
+
+}

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -268,7 +268,7 @@ SpanTable BuildSpans(const std::vector<int64_t>& cell, const std::vector<float>&
     return PackSpans(std::move(st.sp_cell), std::move(st.sp_h));
 }
 
-SpanTable PackSpans(std::vector<int32_t> cell, std::vector<float> h, std::vector<uint8_t>* flags)
+SpanTable PackSpans(std::vector<int32_t> cell, std::vector<float> h, std::vector<uint8_t>* flags, std::vector<uint32_t>* aux)
 {
     SpanTable st;
     const int64_t n_span = static_cast<int64_t>(cell.size());
@@ -354,6 +354,13 @@ SpanTable PackSpans(std::vector<int32_t> cell, std::vector<float> h, std::vector
             fo[i] = (*flags)[static_cast<size_t>(ord[i])];
         }
         flags->swap(fo);
+    }
+    if (aux != nullptr) {
+        std::vector<uint32_t> ao(n);
+        for (size_t i = 0; i < n; ++i) {
+            ao[i] = (*aux)[static_cast<size_t>(ord[i])];
+        }
+        aux->swap(ao);
     }
     ord = std::vector<int32_t>();
     // 先数一遍占用格再一次分配。边数边 push 会按二的幂扩容, 逐格数组在满窗口上要白占近一倍。
@@ -684,8 +691,7 @@ std::vector<uint8_t> WallsAtLayer(
     const std::vector<double>& hh,
     const Grid<float>& lh,
     double ox,
-    double oy,
-    const OutsideLayerFn* outside)
+    double oy)
 {
     std::vector<uint8_t> keep(p0.size(), 0);
     for (size_t i = 0; i < p0.size(); ++i) {
@@ -697,11 +703,10 @@ std::vector<uint8_t> WallsAtLayer(
             const double sy = p0[i].y + (p1[i].y - p0[i].y) * t;
             const int64_t gx = static_cast<int64_t>(std::floor((sx - ox) / kCS));
             const int64_t gy = static_cast<int64_t>(std::floor((sy - oy) / kCS));
-            const bool in = gx >= 0 && gx < lh.nx && gy >= 0 && gy < lh.ny;
-            if (!in && outside == nullptr) {
+            if (gx < 0 || gx >= lh.nx || gy < 0 || gy >= lh.ny) {
                 continue;
             }
-            const float h = in ? lh.at(gy, gx) : (*outside)(i, gx, gy);
+            const float h = lh.at(gy, gx);
             if (!std::isnan(h) && std::abs(static_cast<double>(h) - hh[i]) <= kMcHBand) {
                 keep[i] = 1;
             }

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -136,8 +136,7 @@ bool RiseOk(const SpanTable& st, int64_t nx, int64_t ny, int64_t cid, int64_t dx
 }
 
 RasterCells Rasterize(
-    const std::vector<WorldPoint>& V,
-    const std::vector<double>& H,
+    const BaseNavVertex* V,
     const std::vector<std::array<int32_t, 3>>& T,
     double ox,
     double oy,
@@ -147,15 +146,17 @@ RasterCells Rasterize(
 {
     RasterCells out;
     const double hcs = kCS * 0.5;
+    const auto P = [V](int32_t i) { return WorldPoint { static_cast<double>(V[i].u), static_cast<double>(V[i].v) }; };
+    const auto H = [V](int32_t i) { return static_cast<double>(V[i].height); };
     std::vector<int64_t> kept;
     kept.reserve(T.size());
     for (int64_t ti = 0; ti < static_cast<int64_t>(T.size()); ++ti) {
         if (walkable != nullptr && (*walkable)[static_cast<size_t>(ti)] == 0) {
             continue; // 掩码外的三角不进体素:水面、禁区不再铺出可走格
         }
-        const WorldPoint& A = V[T[ti][0]];
-        const WorldPoint& B = V[T[ti][1]];
-        const WorldPoint& C = V[T[ti][2]];
+        const WorldPoint A = P(T[ti][0]);
+        const WorldPoint B = P(T[ti][1]);
+        const WorldPoint C = P(T[ti][2]);
         const double minx = std::min({ A.x, B.x, C.x });
         const double maxx = std::max({ A.x, B.x, C.x });
         const double miny = std::min({ A.y, B.y, C.y });
@@ -172,9 +173,9 @@ RasterCells Rasterize(
         ix1 = std::clamp<int64_t>(ix1, 0, nx - 1);
         iy0 = std::clamp<int64_t>(iy0, 0, ny - 1);
         iy1 = std::clamp<int64_t>(iy1, 0, ny - 1);
-        const double HA = H[T[ti][0]];
-        const double HB = H[T[ti][1]];
-        const double HC = H[T[ti][2]];
+        const double HA = H(T[ti][0]);
+        const double HB = H(T[ti][1]);
+        const double HC = H(T[ti][2]);
         for (int64_t gy = iy0; gy <= iy1; ++gy) {
             for (int64_t gx = ix0; gx <= ix1; ++gx) {
                 const double px = ox + (static_cast<double>(gx) + 0.5) * kCS;
@@ -215,9 +216,9 @@ RasterCells Rasterize(
         }
     }
     for (const int64_t ti : kept) {
-        const WorldPoint& A = V[T[ti][0]];
-        const WorldPoint& B = V[T[ti][1]];
-        const WorldPoint& C = V[T[ti][2]];
+        const WorldPoint A = P(T[ti][0]);
+        const WorldPoint B = P(T[ti][1]);
+        const WorldPoint C = P(T[ti][2]);
         const double cx = (A.x + B.x + C.x) / 3.0;
         const double cy = (A.y + B.y + C.y) / 3.0;
         if (!(cx >= ox && cx < ox + static_cast<double>(nx) * kCS && cy >= oy && cy < oy + static_cast<double>(ny) * kCS)) {
@@ -226,7 +227,7 @@ RasterCells Rasterize(
         const int64_t gx = std::clamp<int64_t>(static_cast<int64_t>((cx - ox) / kCS), 0, nx - 1);
         const int64_t gy = std::clamp<int64_t>(static_cast<int64_t>((cy - oy) / kCS), 0, ny - 1);
         out.cell.push_back(gy * nx + gx);
-        out.h.push_back(static_cast<float>((H[T[ti][0]] + H[T[ti][1]] + H[T[ti][2]]) / 3.0));
+        out.h.push_back(static_cast<float>((H(T[ti][0]) + H(T[ti][1]) + H(T[ti][2])) / 3.0));
         out.ins.push_back(0);
     }
     return out;
@@ -274,49 +275,87 @@ SpanTable PackSpans(std::vector<int32_t> cell, std::vector<float> h, std::vector
     if (n_span == 0) {
         return st;
     }
-    // 主键 cell 是格号, 计数排序按升序装桶且桶内保持原次序; 副键 h 在桶内插入排序, 严格大于
-    // 才挪位同样保序。两步都稳定 ⇒ 与按 (cell, h) 稳定排序同序, 而一格的 span 只有几条。
-    const int64_t nc = *std::max_element(cell.begin(), cell.end()) + 1;
-    std::vector<int32_t> ord(static_cast<size_t>(n_span));
-    std::vector<int32_t> cstart(static_cast<size_t>(nc + 1), 0);
+    // 主键 cell 是格号, 两级计数排序: 先按高 16 位分桶, 再逐桶按低 16 位装, 两级都保持原次序
+    // ⇒ 与按 cell 稳定排序同序; 副键 h 在同格内插入排序, 严格大于才挪位同样保序。
+    // 逐格的桶起点表在整区上要几千万格(几十 MB), 两级计数只要 65537 个计数和一个最大桶大小的临时表。
+    const size_t n = static_cast<size_t>(n_span);
+    const int32_t c_max = *std::max_element(cell.begin(), cell.end());
+    const size_t n_hi = (static_cast<size_t>(c_max) >> 16U) + 1;
+    std::vector<int32_t> ord(n);
+    std::vector<int32_t> hi_start(n_hi + 1, 0);
     for (const int32_t c : cell) {
-        ++cstart[static_cast<size_t>(c) + 1];
+        ++hi_start[(static_cast<size_t>(c) >> 16U) + 1];
     }
-    for (size_t k = 1; k < cstart.size(); ++k) {
-        cstart[k] += cstart[k - 1];
+    size_t bucket_max = 0;
+    for (size_t k = 1; k <= n_hi; ++k) {
+        bucket_max = std::max(bucket_max, static_cast<size_t>(hi_start[k]));
+        hi_start[k] += hi_start[k - 1];
     }
     {
-        std::vector<int32_t> fill(cstart.begin(), cstart.end() - 1);
-        for (int64_t i = 0; i < n_span; ++i) {
-            ord[static_cast<size_t>(fill[static_cast<size_t>(cell[static_cast<size_t>(i)])]++)] = static_cast<int32_t>(i);
+        std::vector<int32_t> cursor(hi_start.begin(), hi_start.end() - 1);
+        for (size_t i = 0; i < n; ++i) {
+            ord[static_cast<size_t>(cursor[static_cast<size_t>(cell[i]) >> 16U]++)] = static_cast<int32_t>(i);
         }
     }
-    for (int64_t c = 0; c < nc; ++c) {
-        const int64_t b = cstart[static_cast<size_t>(c)], e = cstart[static_cast<size_t>(c) + 1];
-        for (int64_t i = b + 1; i < e; ++i) {
-            const int32_t v = ord[static_cast<size_t>(i)];
+    {
+        std::vector<int32_t> lo_start(65537, 0);
+        std::vector<int32_t> tmp(bucket_max);
+        for (size_t k = 0; k < n_hi; ++k) {
+            const size_t b = static_cast<size_t>(hi_start[k]), e = static_cast<size_t>(hi_start[k + 1]);
+            if (e - b < 2) {
+                continue;
+            }
+            std::fill(lo_start.begin(), lo_start.end(), 0);
+            for (size_t i = b; i < e; ++i) {
+                ++lo_start[(static_cast<size_t>(cell[static_cast<size_t>(ord[i])]) & 0xFFFFU) + 1];
+            }
+            for (size_t d = 1; d < lo_start.size(); ++d) {
+                lo_start[d] += lo_start[d - 1];
+            }
+            for (size_t i = b; i < e; ++i) {
+                const int32_t v = ord[i];
+                tmp[static_cast<size_t>(lo_start[static_cast<size_t>(cell[static_cast<size_t>(v)]) & 0xFFFFU]++)] = v;
+            }
+            std::copy(tmp.begin(), tmp.begin() + static_cast<std::ptrdiff_t>(e - b), ord.begin() + static_cast<std::ptrdiff_t>(b));
+        }
+    }
+    // 逐列搬、搬完一列就放一列, 入参与出参不整份同时在。格号列先搬, 同格段就能顺序扫出来;
+    // 同格内按高插入排序只动 ord, 格号列不受影响。(按环原地搬是串行随机访存, 实测每段慢 0.4 s。)
+    st.sp_cell.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+        st.sp_cell[i] = cell[static_cast<size_t>(ord[i])];
+    }
+    cell = std::vector<int32_t>();
+    for (size_t b = 0; b < n;) {
+        size_t e = b + 1;
+        while (e < n && st.sp_cell[e] == st.sp_cell[b]) {
+            ++e;
+        }
+        for (size_t i = b + 1; i < e; ++i) {
+            const int32_t v = ord[i];
             const float hv = h[static_cast<size_t>(v)];
-            int64_t j = i;
-            while (j > b && h[static_cast<size_t>(ord[static_cast<size_t>(j - 1)])] > hv) {
-                ord[static_cast<size_t>(j)] = ord[static_cast<size_t>(j - 1)];
+            size_t j = i;
+            while (j > b && h[static_cast<size_t>(ord[j - 1])] > hv) {
+                ord[j] = ord[j - 1];
                 --j;
             }
-            ord[static_cast<size_t>(j)] = v;
+            ord[j] = v;
         }
+        b = e;
     }
-    st.sp_cell.resize(static_cast<size_t>(n_span));
-    st.sp_h.resize(static_cast<size_t>(n_span));
-    for (int64_t i = 0; i < n_span; ++i) {
-        st.sp_cell[i] = cell[ord[i]];
-        st.sp_h[i] = h[ord[i]];
+    st.sp_h.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+        st.sp_h[i] = h[static_cast<size_t>(ord[i])];
     }
+    h = std::vector<float>();
     if (flags != nullptr) {
-        std::vector<uint8_t> fo(static_cast<size_t>(n_span));
-        for (int64_t i = 0; i < n_span; ++i) {
-            fo[i] = (*flags)[ord[i]];
+        std::vector<uint8_t> fo(n);
+        for (size_t i = 0; i < n; ++i) {
+            fo[i] = (*flags)[static_cast<size_t>(ord[i])];
         }
         flags->swap(fo);
     }
+    ord = std::vector<int32_t>();
     // 先数一遍占用格再一次分配。边数边 push 会按二的幂扩容, 逐格数组在满窗口上要白占近一倍。
     int64_t n_occ = 0;
     for (int64_t i = 0; i < n_span; ++i) {
@@ -331,9 +370,16 @@ SpanTable PackSpans(std::vector<int32_t> cell, std::vector<float> h, std::vector
             st.cs[static_cast<size_t>(ci++)] = static_cast<int32_t>(i);
         }
     }
-    st.c2j.assign(static_cast<size_t>(st.sp_cell.back()) + 1, -1);
+    const size_t words = static_cast<size_t>(st.sp_cell.back() >> 6) + 1;
+    st.occ_bits.assign(words, 0);
+    st.occ_rank.assign(words, 0);
     for (int64_t ci = 0; ci < n_occ; ++ci) {
-        st.c2j[static_cast<size_t>(st.occ(ci))] = static_cast<int32_t>(ci);
+        const int64_t cid = st.occ(ci);
+        st.occ_bits[static_cast<size_t>(cid >> 6)] |= uint64_t { 1 } << (cid & 63);
+    }
+    for (size_t w = 0, acc = 0; w < words; ++w) {
+        st.occ_rank[w] = static_cast<int32_t>(acc);
+        acc += static_cast<size_t>(std::popcount(st.occ_bits[w]));
     }
     st.face.assign(static_cast<size_t>(n_occ), 0);
     for (int64_t ci = 0; ci < n_occ; ++ci) {
@@ -638,7 +684,8 @@ std::vector<uint8_t> WallsAtLayer(
     const std::vector<double>& hh,
     const Grid<float>& lh,
     double ox,
-    double oy)
+    double oy,
+    const OutsideLayerFn* outside)
 {
     std::vector<uint8_t> keep(p0.size(), 0);
     for (size_t i = 0; i < p0.size(); ++i) {
@@ -650,10 +697,11 @@ std::vector<uint8_t> WallsAtLayer(
             const double sy = p0[i].y + (p1[i].y - p0[i].y) * t;
             const int64_t gx = static_cast<int64_t>(std::floor((sx - ox) / kCS));
             const int64_t gy = static_cast<int64_t>(std::floor((sy - oy) / kCS));
-            if (gx < 0 || gx >= lh.nx || gy < 0 || gy >= lh.ny) {
+            const bool in = gx >= 0 && gx < lh.nx && gy >= 0 && gy < lh.ny;
+            if (!in && outside == nullptr) {
                 continue;
             }
-            const float h = lh.at(gy, gx);
+            const float h = in ? lh.at(gy, gx) : (*outside)(i, gx, gy);
             if (!std::isnan(h) && std::abs(static_cast<double>(h) - hh[i]) <= kMcHBand) {
                 keep[i] = 1;
             }
@@ -815,7 +863,8 @@ std::optional<std::vector<CellPt>> CostAstar(
     const PriceField& mult,
     const EdgeBits* banned,
     const double* bnp,
-    const EdgeBits* forbidden)
+    const EdgeBits* forbidden,
+    double* out_cost)
 {
     const int64_t ny = mask.ny, nx = mask.nx;
     if (!mask.at(s.y, s.x) || !mask.at(g.y, g.x)) {
@@ -870,6 +919,9 @@ std::optional<std::vector<CellPt>> CostAstar(
     }
     if (!std::isfinite(dist.at(g.y, g.x))) {
         return std::nullopt;
+    }
+    if (out_cost != nullptr) {
+        *out_cost = dist.at(g.y, g.x);
     }
     std::vector<CellPt> out { g };
     int64_t x = g.x, y = g.y;
@@ -939,7 +991,8 @@ std::optional<std::vector<int64_t>> SpanAstar(
     const double* bnp,
     const EdgeBits* forbidden,
     const Visibility* vis,
-    std::vector<int64_t>* corners)
+    std::vector<int64_t>* corners,
+    double* out_cost)
 {
     if (s < 0 || ok[static_cast<size_t>(s)] == 0 || gset.empty()) {
         return std::nullopt;
@@ -1112,6 +1165,9 @@ std::optional<std::vector<int64_t>> SpanAstar(
     }
     if (hit < 0) {
         return std::nullopt;
+    }
+    if (out_cost != nullptr) {
+        *out_cost = dist[static_cast<size_t>(hit)];
     }
     std::vector<int64_t> out { hit };
     while (out.back() != s) {

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -36,6 +36,9 @@ inline constexpr double kSnapRadius = 8.0;         // 起终点吸附半径 px
 inline constexpr double kDeckBand = 2.0;           // 声明面高度匹配容差 px, 需远小于相邻面间距
 inline constexpr double kBlockedPointRadius = 1.0; // 封堵点盖章半径 px
 inline constexpr int64_t kHoleMaxCells = 32;       // 封闭小洞填充上限(格 = 2px²)
+// 整类窗口在类范围外留的圈(格)。场都是局部算子, 依赖半径合起来不到这一圈, 留出它,
+// 类边缘那几格算出来的场就与在整区图上算的逐位相同。旁包按同一个值烘。
+inline constexpr int64_t kFieldHalo = 32;
 // 单区格数上限。规划铺满整区, 这道闸只用来挡烘出来就不正常的区, 正常区离它很远。
 inline constexpr int64_t kMaxCells = 400'000'000;
 
@@ -166,7 +169,9 @@ void AppendSeamBridge(RasterCells& rc, int64_t nx, int64_t ny);
 
 SpanTable BuildSpans(const std::vector<int64_t>& cell, const std::vector<float>& h);
 
-SpanTable PackSpans(std::vector<int32_t> cell, std::vector<float> h, std::vector<uint8_t>* flags = nullptr);
+// flags / aux 是与 cell 同长的随行列, 按同一置换重排后写回原处。
+SpanTable PackSpans(
+    std::vector<int32_t> cell, std::vector<float> h, std::vector<uint8_t>* flags = nullptr, std::vector<uint32_t>* aux = nullptr);
 
 std::vector<uint8_t> Flood(int64_t seed, const SpanTable& st, int64_t nx);
 
@@ -188,17 +193,15 @@ std::vector<uint8_t> StampWalls(
     int64_t ny,
     const SpanTable& st);
 
-// 落在 lh 外的采样交给 outside(墙号, 格x, 格y) 取层高, 不给就跳过。采样集只由端点定,
-// 所以窗内窗外两路的判据逐样本同口径。
-using OutsideLayerFn = std::function<float(size_t, int64_t, int64_t)>;
+// 逐墙一位: 沿墙采样, 任一样本落在层高图 lh 的带内即留下。落在 lh 外的采样跳过。
+// 运行期不再调它(留墙已烘进旁包), 留作烘焙口径的参考实现与旁包校验。
 std::vector<uint8_t> WallsAtLayer(
     const std::vector<WorldPoint>& p0,
     const std::vector<WorldPoint>& p1,
     const std::vector<double>& hh,
     const Grid<float>& lh,
     double ox,
-    double oy,
-    const OutsideLayerFn* outside = nullptr);
+    double oy);
 
 // 逐格一位: 这一格里落过边界边的采样点。距离场对跨边界无感, 用它把边所在的格从自由集里扣掉。
 Mask WallHits(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny);

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -2,11 +2,14 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <unordered_set>
 #include <vector>
 
+#include "BaseNavPack.h"
 #include "NavmeshTypes.h"
 #include "RecastNavGridIO.h"
 
@@ -116,9 +119,11 @@ struct SpanTable
     std::vector<int32_t> cs;
     // 逐占用格一位: 这一列是不是被栅格化的立面。判据只看该格自己的叠层, 建表时算一次。
     std::vector<uint8_t> face;
-    // 格号 → 占用格下标的直查表, 空格填 -1。邻格查询在 BFS 与垂直可达判据里是最内层的一步,
-    // 建表时摊掉一次, 就不必每次二分。长度只到最大占用格, 表外一律当空格。
-    std::vector<int32_t> c2j;
+    // 格号 → 占用格下标: 逐格一位的占用图加每 64 格的前缀占用数, 查一次是一位测试加一个
+    // popcount。邻格查询在 BFS 与垂直可达判据里是最内层的一步, 建表时摊掉一次, 就不必每次
+    // 二分; 比逐格 4 字节的直查表小 30 倍。长度只到最大占用格, 表外一律当空格。
+    std::vector<uint64_t> occ_bits;
+    std::vector<int32_t> occ_rank;
 
     int64_t nOcc() const { return cs.empty() ? 0 : static_cast<int64_t>(cs.size()) - 1; }
 
@@ -130,7 +135,16 @@ struct SpanTable
 
     int64_t j(int64_t cid) const
     {
-        return cid >= 0 && cid < static_cast<int64_t>(c2j.size()) ? c2j[static_cast<size_t>(cid)] : -1;
+        const auto w = static_cast<size_t>(cid >> 6);
+        if (cid < 0 || w >= occ_bits.size()) {
+            return -1;
+        }
+        const uint64_t bits = occ_bits[w];
+        const int b = static_cast<int>(cid & 63);
+        if (((bits >> b) & 1U) == 0) {
+            return -1;
+        }
+        return occ_rank[w] + std::popcount(bits & ((uint64_t { 1 } << b) - 1));
     }
 };
 
@@ -140,8 +154,7 @@ bool RiseOk(const SpanTable& st, int64_t nx, int64_t ny, int64_t cid, int64_t dx
 // walkable 非空时按三角下标逐个过滤:标 0 的不体素化。掩码须与 T 同长同序;
 // 调用方自己压缩过的子集三角表留 nullptr。
 RasterCells Rasterize(
-    const std::vector<WorldPoint>& V,
-    const std::vector<double>& H,
+    const BaseNavVertex* V,
     const std::vector<std::array<int32_t, 3>>& T,
     double ox,
     double oy,
@@ -175,13 +188,17 @@ std::vector<uint8_t> StampWalls(
     int64_t ny,
     const SpanTable& st);
 
+// 落在 lh 外的采样交给 outside(墙号, 格x, 格y) 取层高, 不给就跳过。采样集只由端点定,
+// 所以窗内窗外两路的判据逐样本同口径。
+using OutsideLayerFn = std::function<float(size_t, int64_t, int64_t)>;
 std::vector<uint8_t> WallsAtLayer(
     const std::vector<WorldPoint>& p0,
     const std::vector<WorldPoint>& p1,
     const std::vector<double>& hh,
     const Grid<float>& lh,
     double ox,
-    double oy);
+    double oy,
+    const OutsideLayerFn* outside = nullptr);
 
 // 逐格一位: 这一格里落过边界边的采样点。距离场对跨边界无感, 用它把边所在的格从自由集里扣掉。
 Mask WallHits(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny);
@@ -298,13 +315,15 @@ std::optional<std::vector<CellPt>> CostAstar(
     const PriceField& mult,
     const EdgeBits* banned,
     const double* bnp,
-    const EdgeBits* forbidden = nullptr);
+    const EdgeBits* forbidden = nullptr,
+    double* out_cost = nullptr);
 
 class Visibility;
 
 // vis 非空则按 Lazy Theta* 展开: 松弛先把父指针接到祖父, 弹出时才验一次视线, 验不过退回格步。
 // 于是路径由父链上的直线段构成, 紧绷这件事在搜索里完成, 不再靠事后拉直。
 // 返回值恒为逐格路径, 拓扑判据按格读。corners 非空则另交出父链本身, 那才是几何要走的折线。
+// out_cost 非空则交出终点的累计代价; 单价恒 ≥1, 它就是路径格长的上界, 小窗验收拿它判搜索有没有碰边。
 std::optional<std::vector<int64_t>> SpanAstar(
     const SpanTable& st,
     const std::vector<uint8_t>& ok,
@@ -316,7 +335,8 @@ std::optional<std::vector<int64_t>> SpanAstar(
     const double* bnp,
     const EdgeBits* forbidden = nullptr,
     const Visibility* vis = nullptr,
-    std::vector<int64_t>* corners = nullptr);
+    std::vector<int64_t>* corners = nullptr,
+    double* out_cost = nullptr);
 
 Mask MedialAxis(const Grid<float>& dist, double lam);
 

--- a/agent/cpp-algo/source/Navmesh/RecastNavGridIO.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGridIO.cpp
@@ -628,4 +628,9 @@ std::vector<const GridTileRef*> GridTilesInRect(const GridZoneDir& zone, int64_t
     return hit;
 }
 
+bool InflateBytes(const uint8_t* data, size_t len, std::vector<uint8_t>& out)
+{
+    return Inflate(data, len, out);
+}
+
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavGridIO.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGridIO.h
@@ -125,4 +125,7 @@ private:
 // 自有矩形与全局格矩形 [gx0,gx1]×[gy0,gy1] 相交的瓦。
 std::vector<const GridTileRef*> GridTilesInRect(const GridZoneDir& zone, int64_t gx0, int64_t gy0, int64_t gx1, int64_t gy1);
 
+// 解一段 zlib 流到 out(覆盖)。瓦载荷与旁包的各条流都是这种不带原长的流。
+bool InflateBytes(const uint8_t* data, size_t len, std::vector<uint8_t>& out);
+
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <bit>
 #include <chrono>
 #include <cmath>
 #include <limits>
@@ -24,8 +25,11 @@ namespace
 double triHeightOf(const PolyMesh& mesh, int32_t t)
 {
     const auto& tri = mesh.T[static_cast<size_t>(t)];
-    return (mesh.H[tri[0]] + mesh.H[tri[1]] + mesh.H[tri[2]]) / 3.0;
+    return (mesh.h(tri[0]) + mesh.h(tri[1]) + mesh.h(tri[2])) / 3.0;
 }
+
+// 净空截断的格数(含取整余量), 与 Clearance 的扫描半径同式。小窗档的可信余量要盖过它。
+constexpr int64_t kEdtCells = static_cast<int64_t>(kEdtCap / kCS) + 1;
 
 struct WindowInfo
 {
@@ -46,6 +50,9 @@ struct WindowInfo
     SpanTable st3;
     std::vector<uint8_t> vis3;
     std::vector<uint8_t> reach3;
+    // 可达域种子所在格的全局格号, 整类可达域按同一颗种子洪水
+    int64_t seed_gx = 0;
+    int64_t seed_gy = 0;
 };
 
 struct RouteDiag
@@ -59,6 +66,17 @@ struct RouteDiag
     bool hop_barrier = false; // 端点接线的那一跳跨了禁行边
     double snap_start = 0.0;
     double snap_goal = 0.0;
+
+    // 小窗档的验收。margin > 0 时窗口只是端点附近的一块, 凡是结果可能被窗口边切过的判据
+    // (搜索碰边、吸附受可达域限制、任何退档分支) 都置 escalate 立即返回, 由调用方换大窗重算。
+    // margin = 0 是整类窗口, 所有验收关掉, 逐字走原路。
+    int64_t margin = 0;
+    // 可达域已按整类洪水映射, 与整类窗口逐位相同; 只与可达域有关的验收(口袋、吸附受限)关掉
+    bool exact_reach = false;
+    // 封顶档: 没有更大的小窗可升, 只与窗口大小有关的验收(碰边类)关掉, 结果照采
+    bool final = false;
+    bool escalate = false;
+    std::string escalate_why;
 
     // 诊断埋点。只读各阶段的出口, 不参与任何判据, 摘掉它们路线逐点不变。
     RecastPlanResult::Debug::Timing timing;
@@ -392,6 +410,227 @@ ZoneBoundsPx regionBounds(const GridPack& gp, const GridZoneDir& gz, uint32_t re
     return b;
 }
 
+// 起点格里离 h0 最近的本类面, 它是 span 可达域的种子。
+int64_t seedSpan(const SpanTable& st, const std::vector<uint8_t>& vis, int64_t cell, double h0)
+{
+    const int64_t sj = st.j(cell);
+    if (sj < 0) {
+        return -1;
+    }
+    int64_t seed = -1;
+    float best = 0.0F;
+    const int64_t b = st.cstart(sj);
+    for (int64_t k = 0, kn = st.ccnt(sj); k < kn; ++k) {
+        const int64_t sid = b + k;
+        if (vis[static_cast<size_t>(sid)] == 0) {
+            continue;
+        }
+        const float d = std::fabs(st.sp_h[static_cast<size_t>(sid)] - static_cast<float>(h0));
+        if (seed < 0 || d < best) {
+            seed = sid;
+            best = d;
+        }
+    }
+    return seed;
+}
+
+// 整类可达域: 只加载整类格图、建 span 表、从起点面洪水, 不算任何场。小窗按格与层序把它映射进
+// 自己的 reach3, 可达域便与整类窗口逐位相同, 绕窗外接上的口袋因此不再是差异。窗口矩形、记录
+// 筛选与种子规则都必须与 buildWindow 的整类档一字不差。
+struct RegionReach
+{
+    int64_t gx0 = 0;
+    int64_t gy0 = 0;
+    int64_t nx = 0;
+    int64_t ny = 0;
+    // 洪水完只留映射要查的: 逐格一位的占用图加每 64 格的前缀数(顶替逐格 4 字节的直查表),
+    // CSR 起点、逐 span 的高与可达位。整区的 span 表本体不留, 它比这几列大三倍多。
+    std::vector<uint64_t> occ_bits;
+    std::vector<int32_t> occ_rank;
+    std::vector<int32_t> cs;
+    std::vector<float> sp_h;
+    std::vector<uint8_t> reach;
+
+    int64_t j(int64_t cid) const
+    {
+        const auto w = static_cast<size_t>(cid >> 6);
+        if (cid < 0 || w >= occ_bits.size()) {
+            return -1;
+        }
+        const uint64_t bits = occ_bits[w];
+        const int b = static_cast<int>(cid & 63);
+        if (((bits >> b) & 1U) == 0) {
+            return -1;
+        }
+        return occ_rank[w] + std::popcount(bits & ((uint64_t { 1 } << b) - 1));
+    }
+
+    int64_t cstart(int64_t ci) const { return cs[static_cast<size_t>(ci)]; }
+
+    int64_t ccnt(int64_t ci) const { return cs[static_cast<size_t>(ci) + 1] - cs[static_cast<size_t>(ci)]; }
+};
+
+// 整类的 span 三列直接从瓦解出来, 不经 GridWindow 的记录与链表; 填充记录和别类的幽灵记录当场
+// 丢掉, 与 buildWindow 整类档的筛法一字不差。分块与压紧同 loadGridWindow, 次序与线程数无关。
+bool loadRegionSpans(
+    const GridPack& gp,
+    const GridZoneDir& gz,
+    uint32_t region,
+    int64_t wgx0,
+    int64_t wgy0,
+    int64_t nx,
+    int64_t ny,
+    std::vector<int32_t>& sp_cell,
+    std::vector<float>& sp_h,
+    std::vector<uint8_t>& vis)
+{
+    const std::vector<const GridTileRef*> tiles = GridTilesInRect(gz, wgx0, wgy0, wgx0 + nx - 1, wgy0 + ny - 1);
+    const auto nt = static_cast<int64_t>(tiles.size());
+    const size_t nw = NavWorkerCountForBlocks(nt);
+    size_t cap = 0;
+    for (const GridTileRef* t : tiles) {
+        cap += t->records;
+    }
+    sp_cell.assign(cap, 0);
+    sp_h.assign(cap, 0.0F);
+    vis.assign(cap, 0);
+    std::vector<size_t> beg(nw, 0);
+    std::vector<size_t> cnt(nw, 0);
+    std::atomic<bool> ok { true };
+    ParallelChunks(nt, nw, [&](size_t w, int64_t lo, int64_t hi) {
+        size_t at = 0;
+        for (int64_t i = 0; i < lo; ++i) {
+            at += tiles[static_cast<size_t>(i)]->records;
+        }
+        beg[w] = at;
+        GridTile tile;
+        for (int64_t i = lo; i < hi; ++i) {
+            const GridTileRef* t = tiles[static_cast<size_t>(i)];
+            if (t->records == 0) {
+                continue;
+            }
+            if (!gp.decodeTile(*t, tile)) {
+                ok.store(false);
+                return;
+            }
+            for (const GridSpanRec& r : tile.rec) {
+                const int64_t ix = r.cell % t->nx;
+                const int64_t iy = r.cell / t->nx;
+                if (ix < t->px0 || ix > t->px1 || iy < t->py0 || iy > t->py1) {
+                    continue;
+                }
+                const int64_t wx = t->gx0 + ix - wgx0;
+                const int64_t wy = t->gy0 + iy - wgy0;
+                if (wx < 0 || wx >= nx || wy < 0 || wy >= ny) {
+                    continue;
+                }
+                const bool ghost = (r.flags & kGridFlagGhost) != 0;
+                const bool fill = (r.flags & kGridFlagFill) != 0;
+                if (fill || (ghost && r.rid != region)) {
+                    continue;
+                }
+                sp_cell[at] = static_cast<int32_t>(wy * nx + wx);
+                sp_h[at] = r.h;
+                vis[at] = static_cast<uint8_t>(r.rid == region);
+                ++at;
+            }
+        }
+        cnt[w] = at - beg[w];
+    });
+    if (!ok.load()) {
+        sp_cell.clear();
+        sp_h.clear();
+        vis.clear();
+        return false;
+    }
+    size_t kept = cnt[0];
+    for (size_t w = 1; w < nw; ++w) {
+        if (cnt[w] != 0 && beg[w] != kept) {
+            const auto b = static_cast<int64_t>(beg[w]);
+            const auto e = static_cast<int64_t>(beg[w] + cnt[w]);
+            const auto k = static_cast<int64_t>(kept);
+            std::move(sp_cell.begin() + b, sp_cell.begin() + e, sp_cell.begin() + k);
+            std::move(sp_h.begin() + b, sp_h.begin() + e, sp_h.begin() + k);
+            std::move(vis.begin() + b, vis.begin() + e, vis.begin() + k);
+        }
+        kept += cnt[w];
+    }
+    sp_cell.resize(kept);
+    sp_h.resize(kept);
+    vis.resize(kept);
+    return true;
+}
+
+std::optional<RegionReach> buildRegionReach(
+    const GridPack& gp,
+    const GridZoneDir& gz,
+    uint32_t region,
+    int64_t gx0,
+    int64_t gy0,
+    int64_t nx,
+    int64_t ny,
+    int64_t seed_gx,
+    int64_t seed_gy,
+    double h0,
+    std::string& err)
+{
+    RegionReach rr;
+    rr.gx0 = gx0;
+    rr.gy0 = gy0;
+    rr.nx = nx;
+    rr.ny = ny;
+    std::vector<int32_t> sp_cell;
+    std::vector<float> sp_h;
+    std::vector<uint8_t> vis3;
+    if (!loadRegionSpans(gp, gz, region, gx0, gy0, nx, ny, sp_cell, sp_h, vis3)) {
+        err = "预烘格图解不开";
+        return std::nullopt;
+    }
+    SpanTable st = PackSpans(std::move(sp_cell), std::move(sp_h), &vis3);
+    const int64_t sx = seed_gx - gx0;
+    const int64_t sy = seed_gy - gy0;
+    const int64_t seed = sx >= 0 && sy >= 0 && sx < nx && sy < ny ? seedSpan(st, vis3, sy * nx + sx, h0) : -1;
+    if (seed < 0) {
+        err = "起点格没有与终点同类的面";
+        return std::nullopt;
+    }
+    rr.reach = SpanReach(seed, st, vis3, nx, ny);
+    vis3 = std::vector<uint8_t>();
+    rr.occ_bits = std::move(st.occ_bits);
+    rr.occ_rank = std::move(st.occ_rank);
+    rr.cs = std::move(st.cs);
+    rr.sp_h = std::move(st.sp_h);
+    return rr;
+}
+
+// 把整类可达域按 (全局格, 槽位) 映射进窗口的 reach3。两边同一格的 span 由同一批记录按同一规则排,
+// 层序一一对应; 不在整类表里的只会是别类的 span, 本来就不可达。
+bool mapRegionReach(WindowInfo& info, const RegionReach& rr, std::string& err)
+{
+    const int64_t nx = info.nx;
+    const int64_t wgx0 = std::llround(info.x0 / kCS);
+    const int64_t wgy0 = std::llround(info.y0 / kCS);
+    info.reach3.assign(info.vis3.size(), 0);
+    for (int64_t ci = 0, cn = info.st3.nOcc(); ci < cn; ++ci) {
+        const int64_t c = info.st3.occ(ci);
+        const int64_t gx = wgx0 + c % nx - rr.gx0;
+        const int64_t gy = wgy0 + c / nx - rr.gy0;
+        const int64_t rj = gx >= 0 && gy >= 0 && gx < rr.nx && gy < rr.ny ? rr.j(gy * rr.nx + gx) : -1;
+        const int64_t b = info.st3.cstart(ci), n = info.st3.ccnt(ci);
+        for (int64_t k = 0; k < n; ++k) {
+            if (info.vis3[static_cast<size_t>(b + k)] == 0) {
+                continue;
+            }
+            if (rj < 0 || rr.ccnt(rj) != n || rr.sp_h[static_cast<size_t>(rr.cstart(rj) + k)] != info.st3.sp_h[static_cast<size_t>(b + k)]) {
+                err = "整类可达域与窗口 span 表对不上";
+                return false;
+            }
+            info.reach3[static_cast<size_t>(b + k)] = rr.reach[static_cast<size_t>(rr.cstart(rj) + k)];
+        }
+    }
+    return true;
+}
+
 std::optional<WindowInfo> buildWindow(
     const GridPack& gp,
     const GridZoneDir& gz,
@@ -407,6 +646,8 @@ std::optional<WindowInfo> buildWindow(
     double y1,
     const std::vector<int32_t>& blocked_local,
     const std::vector<WorldPoint>& blocked_points,
+    int64_t margin,
+    const RegionReach* rr,
     std::string& err)
 {
     const int64_t nx = static_cast<int64_t>(std::ceil((x1 - x0) / kCS));
@@ -415,8 +656,8 @@ std::optional<WindowInfo> buildWindow(
     const int64_t wgx0 = std::llround(x0 / kCS);
     const int64_t wgy0 = std::llround(y0 / kCS);
 
-    // 区网格只有取墙与盖封堵面两个读者, 两者都只认窗口矩形, 与格图无关。放在开图之前算,
-    // 它就能在建窗最吃内存的那一段开始前整个交还, 不必一直挂到用完。
+    // 区网格只有取墙与盖封堵面两个读者, 两者都只认窗口矩形, 与格图无关。它在小窗档之间本就
+    // 常驻(最大的区约 70 MB), 整类档也留着, 只多抬那一刻的峰值, 省下下一条腿 1.5 s 的重建。
     BakedWalls walls = BakeWalls(zc, x0, y0, nx, ny);
     RasterCells brc;
     if (!blocked_local.empty()) {
@@ -425,10 +666,8 @@ std::optional<WindowInfo> buildWindow(
         for (const int32_t t : blocked_local) {
             bt.push_back(zc.mesh.T[static_cast<size_t>(t)]);
         }
-        brc = Rasterize(zc.mesh.V, zc.mesh.H, bt, x0, y0, nx, ny);
+        brc = Rasterize(zc.mesh.verts(), bt, x0, y0, nx, ny);
     }
-    zc.release();
-
     GridPatch pw;
     pw.x0 = x0;
     pw.y0 = y0;
@@ -501,11 +740,105 @@ std::optional<WindowInfo> buildWindow(
     std::vector<WorldPoint> wP0;
     std::vector<WorldPoint> wP1;
     {
-        const std::vector<uint8_t> keep = WallsAtLayer(walls.p0, walls.p1, walls.hh, lh, x0, y0);
+        // 挑墙按整条墙判, 窗外的采样看不见。小窗档里一条伸出窗外又被丢掉的墙, 整类窗口可能
+        // 留下它; 它离可信区不到净空半径就会改写可信区里的净空。lh 是全局量(本类非幽灵非填充
+        // 记录的最高 h), 所以这种墙的窗外采样直接查预烘格图, 逐瓦解、逐瓦缓存 lh, 判据与整类
+        // 窗口逐样本同口径; 只有解瓦超预算才升档。
+        const double wx1 = x0 + static_cast<double>(nx) * kCS;
+        const double wy1 = y0 + static_cast<double>(ny) * kCS;
+        const double shrink = static_cast<double>(margin - kEdtCells - 1) * kCS;
+        const auto inWindow = [&](const WorldPoint& p) { return p.x >= x0 && p.x < wx1 && p.y >= y0 && p.y < wy1; };
+        const auto hitsTrusted = [&](const WorldPoint& a, const WorldPoint& b) {
+            // Liang–Barsky 线段裁剪: 与内缩矩形有交即命中。
+            const double rx0 = x0 + shrink, ry0 = y0 + shrink, rx1 = wx1 - shrink, ry1 = wy1 - shrink;
+            double t0 = 0.0, t1 = 1.0;
+            const double dx = b.x - a.x, dy = b.y - a.y;
+            const double p[4] = { -dx, dx, -dy, dy };
+            const double q[4] = { a.x - rx0, rx1 - a.x, a.y - ry0, ry1 - a.y };
+            for (int k = 0; k < 4; ++k) {
+                if (p[k] == 0.0) {
+                    if (q[k] < 0.0) {
+                        return false;
+                    }
+                    continue;
+                }
+                const double t = q[k] / p[k];
+                if (p[k] < 0.0) {
+                    t0 = std::max(t0, t);
+                }
+                else {
+                    t1 = std::min(t1, t);
+                }
+            }
+            return t0 <= t1;
+        };
+        std::vector<uint8_t> cross(walls.p0.size(), 0);
+        if (margin > 0) {
+            for (size_t i = 0; i < cross.size(); ++i) {
+                cross[i] = static_cast<uint8_t>(
+                    !(inWindow(walls.p0[i]) && inWindow(walls.p1[i])) && hitsTrusted(walls.p0[i], walls.p1[i]));
+            }
+        }
+        constexpr size_t kOutsideTileBudget = 64;
+        bool over_budget = false;
+        std::vector<std::pair<const GridTileRef*, Grid<float>>> tiles;
+        GridTile tile;
+        const auto tileLayer = [&](const GridTileRef* t) -> const Grid<float>* {
+            for (const auto& [ref, g] : tiles) {
+                if (ref == t) {
+                    return &g;
+                }
+            }
+            if (tiles.size() >= kOutsideTileBudget || !gp.decodeTile(*t, tile)) {
+                over_budget = true;
+                return nullptr;
+            }
+            Grid<float> g(t->nx, t->ny, std::numeric_limits<float>::quiet_NaN());
+            for (const GridSpanRec& r : tile.rec) {
+                const int64_t ix = r.cell % t->nx;
+                const int64_t iy = r.cell / t->nx;
+                if (ix < t->px0 || ix > t->px1 || iy < t->py0 || iy > t->py1 || r.rid != region
+                    || (r.flags & (kGridFlagGhost | kGridFlagFill)) != 0) {
+                    continue;
+                }
+                float& v = g.v[static_cast<size_t>(r.cell)];
+                if (std::isnan(v) || r.h > v) {
+                    v = r.h;
+                }
+            }
+            tiles.emplace_back(t, std::move(g));
+            return &tiles.back().second;
+        };
+        const OutsideLayerFn outside = [&](size_t i, int64_t gx, int64_t gy) -> float {
+            constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+            if (cross[i] == 0 || over_budget) {
+                return nan;
+            }
+            const int64_t cx = wgx0 + gx;
+            const int64_t cy = wgy0 + gy;
+            // 瓦的自有矩形互不重叠, 一格至多落在一块瓦里; 先看已解的
+            for (const auto& [t, g] : tiles) {
+                if (cx >= t->gx0 + t->px0 && cx <= t->gx0 + t->px1 && cy >= t->gy0 + t->py0 && cy <= t->gy0 + t->py1) {
+                    return g.at(cy - t->gy0, cx - t->gx0);
+                }
+            }
+            const std::vector<const GridTileRef*> hit = GridTilesInRect(gz, cx, cy, cx, cy);
+            if (hit.empty() || hit.front()->records == 0) {
+                return nan;
+            }
+            const GridTileRef* t = hit.front();
+            const Grid<float>* g = tileLayer(t);
+            return g == nullptr ? nan : g->at(cy - t->gy0, cx - t->gx0);
+        };
+        const std::vector<uint8_t> keep = WallsAtLayer(walls.p0, walls.p1, walls.hh, lh, x0, y0, margin > 0 ? &outside : nullptr);
         for (size_t i = 0; i < keep.size(); ++i) {
             if (keep[i] != 0) {
                 wP0.push_back(walls.p0[i]);
                 wP1.push_back(walls.p1[i]);
+            }
+            else if (over_budget && cross[i] != 0) {
+                err = "escalate: 跨窗墙的层判据不完整";
+                return std::nullopt;
             }
         }
     }
@@ -673,26 +1006,19 @@ std::optional<WindowInfo> buildWindow(
             info.sev.p1.push_back({ px + static_cast<double>(dy) * kCS, py + static_cast<double>(dx) * kCS });
         }
     }
-    const int64_t sj = info.st3.j(cell0);
-    int64_t seed3 = -1;
-    float best3 = 0.0F;
-    const int64_t sjb = info.st3.cstart(sj);
-    for (int64_t k = 0, kn = info.st3.ccnt(sj); k < kn; ++k) {
-        const int64_t sid = sjb + k;
-        if (info.vis3[static_cast<size_t>(sid)] == 0) {
-            continue;
-        }
-        const float d = std::fabs(info.st3.sp_h[static_cast<size_t>(sid)] - static_cast<float>(h0));
-        if (seed3 < 0 || d < best3) {
-            seed3 = sid;
-            best3 = d;
-        }
-    }
+    const int64_t seed3 = seedSpan(info.st3, info.vis3, cell0, h0);
     if (seed3 < 0) {
         err = "起点格没有与终点同类的面";
         return std::nullopt;
     }
-    info.reach3 = SpanReach(seed3, info.st3, info.vis3, nx, ny);
+    info.seed_gx = wgx0 + cell0 % nx;
+    info.seed_gy = wgy0 + cell0 / nx;
+    if (rr == nullptr) {
+        info.reach3 = SpanReach(seed3, info.st3, info.vis3, nx, ny);
+    }
+    else if (!mapRegionReach(info, *rr, err)) {
+        return std::nullopt;
+    }
 
     // 段表就此定型。挑剩的墙段与立面禁步段都整份进了 segA/segB, 源表留着只是同一批点的第二份。
     info.segA = std::move(wP0);
@@ -973,6 +1299,62 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const CellPt sc { static_cast<int64_t>((s.x - x0) / kCS), static_cast<int64_t>((s.y - y0) / kCS) };
     const CellPt gc { static_cast<int64_t>((g.x - x0) / kCS), static_cast<int64_t>((g.y - y0) / kCS) };
 
+    // 小窗验收的尺子: 端点离窗边最近的格数减去可信余量。单价恒 ≥1, 所以累计代价是走过格数的
+    // 上界; 代价小于这把尺子的搜索碰不到可信区外的格, 弹出序列与整类窗口里的逐步相同。
+    // 带启发式的搜索更紧: 弹出的格满足 g+h ≤ 终代价, 而 g ≥ 到起点格数、h = 到终点欧氏格数,
+    // 于是只在两端为焦点、和为终代价的椭圆里; limit2 取可信区外的格两距之和的下界。
+    const bool tentative = dg.margin > 0;
+    const bool bounded = tentative && !dg.final; // 只与窗口大小有关的验收
+    // 不通类的验收: 封顶档且可达域已补齐时没有更大的窗可换, 按整类窗口的规则就地退档或报断
+    const bool strict = tentative && !(dg.final && dg.exact_reach);
+    const int64_t edge_s = std::min({ sc.x, sc.y, nx - 1 - sc.x, ny - 1 - sc.y });
+    const int64_t edge_g = std::min({ gc.x, gc.y, nx - 1 - gc.x, ny - 1 - gc.y });
+    const int64_t edge = std::min(edge_s, edge_g);
+    const double limit = static_cast<double>(edge - dg.margin);
+    // 两距之和是凸函数且最小值在可信区里, 区外任一点连向最小点的线段穿过可信区边界, 凸性
+    // 使穿越点不比它大; 所以下界就是边界四条边上的最小值, 每条边上三分求。可信区外的格落在
+    // x ≤ margin-1 或 x ≥ nx-margin 那圈上, 矩形按这两条取; 再让一格给取整。
+    const auto ellipseFloor = [&]() {
+        const auto sum2 = [&](double x, double y) {
+            return std::hypot(x - static_cast<double>(sc.x), y - static_cast<double>(sc.y))
+                   + std::hypot(x - static_cast<double>(gc.x), y - static_cast<double>(gc.y));
+        };
+        const auto onSeg = [&](double ax, double ay, double bx, double by) {
+            double lo = 0.0;
+            double hi = 1.0;
+            for (int i = 0; i < 100; ++i) {
+                const double m1 = lo + (hi - lo) / 3.0;
+                const double m2 = hi - (hi - lo) / 3.0;
+                if (sum2(ax + (bx - ax) * m1, ay + (by - ay) * m1) < sum2(ax + (bx - ax) * m2, ay + (by - ay) * m2)) {
+                    hi = m2;
+                }
+                else {
+                    lo = m1;
+                }
+            }
+            return sum2(ax + (bx - ax) * lo, ay + (by - ay) * lo);
+        };
+        const double rx0 = static_cast<double>(dg.margin - 1);
+        const double ry0 = static_cast<double>(dg.margin - 1);
+        const double rx1 = static_cast<double>(nx - dg.margin);
+        const double ry1 = static_cast<double>(ny - dg.margin);
+        return std::min({ onSeg(rx0, ry0, rx1, ry0), onSeg(rx1, ry0, rx1, ry1), onSeg(rx1, ry1, rx0, ry1), onSeg(rx0, ry1, rx0, ry0) })
+               - 1.0;
+    };
+    const double limit2 = tentative ? ellipseFloor() : 0.0;
+    const auto esc = [&](const char* why) {
+        if (!dg.escalate) {
+            dg.escalate = true;
+            dg.escalate_why = why;
+        }
+    };
+    if (tentative && limit <= 0.0) {
+        esc("端点离窗边不足");
+        return std::nullopt;
+    }
+    double cost_far = 0.0; // 各次搜索交出的最大代价(格), 口袋检查的半径由它定
+    double access_far = 0.0;
+
     const auto nearestCell = [&](const Mask& mask, const CellPt& p) -> std::pair<std::optional<CellPt>, double> {
         bool have = false;
         int64_t bd = 0;
@@ -1011,6 +1393,21 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     std::vector<uint8_t> useW;
     Mask cw3;
     mk(walk, useW, cw3);
+    // 不限可达域的同款。可达域是从起点泛洪的, 小窗里绕到窗外才够得着的面在这里不可达;
+    // 吸附与口袋检查都要拿它对照, 差一张面就说明答案被窗口切过。
+    std::vector<uint8_t> useA;
+    Mask cwA;
+    if (tentative) {
+        useA.assign(st3.sp_h.size(), 0);
+        cwA = Mask(nx, ny, 0);
+        for (size_t i = 0; i < useA.size(); ++i) {
+            const auto cell = static_cast<size_t>(st3.sp_cell[i]);
+            if (info.vis3[i] != 0 && walk.v[cell] != 0) {
+                useA[i] = 1;
+                cwA.v[cell] = 1;
+            }
+        }
+    }
     const auto pick = [&](const CellPt& c, const std::vector<uint8_t>& use) {
         std::vector<int64_t> out;
         const int64_t j = info.st3.j(c.y * nx + c.x);
@@ -1109,6 +1506,26 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     std::optional<CellPt> ag_ = snap1.first;
     double dsa = snap0.second;
     double dga = snap1.second;
+    if (tentative) {
+        if (bounded && (dsa / kCS >= limit || dga / kCS >= limit)) {
+            esc("吸附距离碰边");
+            return std::nullopt;
+        }
+        if (!dg.exact_reach) {
+            const auto a0 = nearestCell(cwA, sc);
+            const auto a1 = nearGoal(useA, cwA);
+            if (!a0.first.has_value() || a0.first->x != as_->x || a0.first->y != as_->y || !a1.first.has_value()
+                || a1.first->x != ag_->x || a1.first->y != ag_->y) {
+                esc("吸附受可达域限制");
+                return std::nullopt;
+            }
+            if (atSeedLayer(pick(*as_, useW)) != atSeedLayer(pick(*as_, useA))
+                || goalsOf(pick(*ag_, useW)).size() != goalsOf(pick(*ag_, useA)).size()) {
+                esc("端点格的面受可达域限制");
+                return std::nullopt;
+            }
+        }
+    }
 
     // VV(c) 的端点接入。作者点位常贴着墙放, 净空低于 c 又不在中脊上, 于是根本不在通道里。
     // 论文里起终点是单独接进图的: 这里在可走面上求端点到通道的最短接入链, 只放开这一条。接入
@@ -1170,6 +1587,15 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             }
         }
         if (hit < 0) {
+            if (strict) {
+                esc("接入链接不通");
+            }
+            return std::nullopt;
+        }
+        const double chain_len = static_cast<double>(cs[static_cast<size_t>(hit)]) / 100.0;
+        access_far = std::max(access_far, chain_len);
+        if (bounded && chain_len >= limit) {
+            esc("接入链碰边");
             return std::nullopt;
         }
         std::vector<int64_t> ch;
@@ -1250,6 +1676,9 @@ std::optional<std::vector<WorldPoint>> routeWindow(
                            const Visibility* vis = nullptr) -> std::optional<Topo> {
         // 接不通的掩膜不必建图。resnap 那一路会重挑吸附锚点, 判据里的两端就不再成立, 因此不查。
         if (!resnap && !linked(lim)) {
+            if (strict) {
+                esc("掩膜内两端不连通");
+            }
             return std::nullopt;
         }
         Mask wl(nx, ny, 0);
@@ -1265,8 +1694,10 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         mk(wl, uw, w3);
         mk(cr, uc, c3);
         std::vector<int64_t> corn;
+        double cost = 0.0;
         const auto run = [&](const std::vector<uint8_t>& use, const Mask& m3) -> std::optional<std::vector<int64_t>> {
             corn.clear();
+            cost = 0.0;
             if (m3.at(as_->y, as_->x) == 0 || m3.at(ag_->y, ag_->x) == 0) {
                 return std::nullopt;
             }
@@ -1281,12 +1712,17 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             if (sd < 0 || (goal_deck.has_value() && gs.empty())) {
                 return std::nullopt;
             }
-            return SpanAstar(st3, use, m3, sd, gs, price, banned, bnp, faces, vis, vis != nullptr ? &corn : nullptr);
+            return SpanAstar(st3, use, m3, sd, gs, price, banned, bnp, faces, vis, vis != nullptr ? &corn : nullptr, &cost);
         };
         Topo t;
         t.on3 = w3;
         std::optional<std::vector<int64_t>> sq = run(uw, w3);
         if (!sq.has_value()) {
+            // 小窗里的任何退档都可能是被窗口切出来的假失败, 不采信。
+            if (strict) {
+                esc("walk 断开");
+                return std::nullopt;
+            }
             sq = run(uc, c3);
             if (sq.has_value()) {
                 t.on3 = c3;
@@ -1294,6 +1730,12 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             }
         }
         if (sq.has_value()) {
+            cost_far = std::max(cost_far, cost);
+            // 搜索从吸附锚点出发, 焦点却取端点格, 两段吸附偏移并入代价
+            if (bounded && cost + (dsa + dga) / kCS >= limit2) {
+                esc("搜索碰边");
+                return std::nullopt;
+            }
             t.q.reserve(sq->size());
             for (const int64_t v : *sq) {
                 const int64_t c = st3.sp_cell[static_cast<size_t>(v)];
@@ -1309,6 +1751,10 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         }
         // 吸附锚点是硬可达的判定, 舒适选路无权改它: 够不着就报断开, 让基线并集那一轮接手
         if (!resnap) {
+            return std::nullopt;
+        }
+        if (strict) {
+            esc("层不连通");
             return std::nullopt;
         }
         std::tie(as_, dsa) = nearestCell(wl, sc);
@@ -1481,6 +1927,10 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const Mask all(nx, ny, 1);
     const PriceField unit {};
     const std::optional<Topo> base = solve(all, unit, nullptr, nullptr, true);
+    if (strict && !base.has_value()) {
+        esc("基线不通");
+        return std::nullopt;
+    }
     if (!base.has_value()) {
         reportGap();
         dg.timing.topology_ms = nowMs() - t_topo0;
@@ -1585,6 +2035,9 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     const std::optional<std::vector<int64_t>> ac_s = access(chan0, as_);
     const std::optional<std::vector<int64_t>> ac_g = access(chan0, ag_);
     chan0 = Mask();
+    if (dg.escalate) {
+        return std::nullopt;
+    }
     const auto join = [&](Mask& lim) {
         const std::optional<std::vector<int64_t>> s = ac_s.has_value() ? ac_s : access(lim, as_);
         const std::optional<std::vector<int64_t>> g = ac_g.has_value() ? ac_g : access(lim, ag_);
@@ -1613,7 +2066,14 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     Mask limw = chan(cpref, rdg);
     rdg = Mask();
     join(limw);
+    if (dg.escalate) {
+        return std::nullopt;
+    }
     std::optional<Topo> vv = solve(limw, multw, bn, bpw, false);
+    if (strict && !vv.has_value()) {
+        esc("通道未接通");
+        return std::nullopt;
+    }
     if (!vv.has_value()) {
         limw = Mask(nx, ny, 1);
         vv = solve(limw, multw, bn, bpw, false);
@@ -1653,6 +2113,18 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             const double need = std::max(solid_c, kChordFrac * static_cast<double>(cw.v[i]));
             solidc.v[i] = static_cast<uint8_t>(static_cast<double>(dist.v[i]) >= need);
         }
+        // 走廊读的是净空场, 它只在可信区里与整类窗口相同。
+        if (bounded) {
+            const int64_t m = dg.margin;
+            for (int64_t y = 0; y < ny; ++y) {
+                for (int64_t x = 0; x < nx; ++x) {
+                    if (band.at(y, x) != 0 && (x < m || y < m || x >= nx - m || y >= ny - m)) {
+                        esc("走廊碰边");
+                        return std::nullopt;
+                    }
+                }
+            }
+        }
     }
     const Blockers::OnMask onv { &solidc, x0, y0, kCS };
     // 搜索期的视线只靠 on 掩膜兜底, 不带轮廓挡线。
@@ -1668,6 +2140,10 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         }
         band = Mask();
         std::optional<Topo> tt = solve(limg, mult, bn, bp, false, &vis);
+        if (strict && !tt.has_value()) {
+            esc("走廊内几何不通");
+            return std::nullopt;
+        }
         if (!tt.has_value()) {
             // 走廊是偏好, 接通性不是。二维骨干必在走廊里, 层间接不通才会走到这里; 放开重解, 拿回
             // 的仍是紧绷折线, 只是不再受宽度约束。
@@ -1675,6 +2151,34 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         }
         if (tt.has_value()) {
             vv = std::move(tt);
+        }
+    }
+    // 口袋: 可信区里有面却不在窗内可达域里的可走格。整类窗口里它可能绕窗外接上, 于是可达掩膜
+    // 不同; 只有搜索与取直够得着的那个椭圆里的口袋才影响答案, 椭圆之外的差异谁也读不到。
+    // 搜索弹出的格都在两端为焦点的椭圆里, 取直的弦落在路径点的凸包里, 椭圆是凸的所以也盖住;
+    // 接入链两头各算一次, 再放一圈给弦的栅格化与挡线的膨胀。
+    if (tentative && !dg.exact_reach) {
+        const double sum = cost_far + (dsa + dga) / kCS + 2.0 * access_far + 8.0;
+        if (bounded && sum >= limit2) {
+            esc("搜索椭圆碰边");
+            return std::nullopt;
+        }
+        const auto r = static_cast<int64_t>(std::ceil(sum / 2.0));
+        const auto far2 = [&](int64_t x, int64_t y) {
+            return std::hypot(static_cast<double>(x - sc.x), static_cast<double>(y - sc.y))
+                   + std::hypot(static_cast<double>(x - gc.x), static_cast<double>(y - gc.y));
+        };
+        const int64_t ex0 = std::max<int64_t>(std::min(sc.x, gc.x) - r, 0);
+        const int64_t ex1 = std::min<int64_t>(std::max(sc.x, gc.x) + r, nx - 1);
+        const int64_t ey0 = std::max<int64_t>(std::min(sc.y, gc.y) - r, 0);
+        const int64_t ey1 = std::min<int64_t>(std::max(sc.y, gc.y) + r, ny - 1);
+        for (int64_t y = ey0; y <= ey1; ++y) {
+            for (int64_t x = ex0; x <= ex1; ++x) {
+                if (cwA.at(y, x) != 0 && cw3.at(y, x) == 0 && far2(x, y) <= sum) {
+                    esc("可达域内有口袋");
+                    return std::nullopt;
+                }
+            }
         }
     }
     dg.timing.geometry_ms = nowMs() - t_geo0;
@@ -1693,6 +2197,10 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         // 判据是硬可达集: on3 现在是舒适通道, 终点天然贴墙就不在里面, 拿它判等于把贴墙的
         // 终点一律说成被禁行边隔开
         dg.hop_barrier = walk.at(gc.y, gc.x) != 0 && base->on3.at(gc.y, gc.x) == 0;
+    }
+    if (tentative && !dg.exact_reach && (dg.hop_barrier || std::max(dsa, dga) > kSnapRadius)) {
+        esc("端点在可达域外");
+        return std::nullopt;
     }
     std::vector<size_t> bad;
     for (size_t k = 1; k < q->size(); ++k) {
@@ -1884,12 +2392,28 @@ RecastNavEngine::RecastNavEngine(const BaseNavPack& pack, const BaseNavPlanner& 
 
 RecastNavEngine::ZoneEntry& RecastNavEngine::zoneEntry(const std::string& name)
 {
+    // 返回的引用在下一次 zoneEntry/warm 之后失效(会淘汰), 调用方不得跨调用持有。
     auto it = zones_.find(name);
     if (it == zones_.end()) {
+        // 先腾位再建: 建的过程本身还要一份临时内存, 别让新旧两个大区叠在一起。
+        // 包里没有的区只会得到一条错误串, 不占位; 淘汰时也先淘汰这种空条目。
+        const BaseNavZone* zone = pack_.findZoneByName(name);
+        const bool real = zone != nullptr && zone->triangle_count > 0;
+        auto rank = [](const ZoneEntry& e) { return e.zc->valid() ? e.used_at : 0; };
+        while (real && zones_.size() >= kZoneCacheMax) {
+            auto victim = zones_.begin();
+            for (auto z = zones_.begin(); z != zones_.end(); ++z) {
+                if (rank(z->second) < rank(victim->second)) {
+                    victim = z;
+                }
+            }
+            zones_.erase(victim);
+        }
         ZoneEntry e;
         e.zc = std::make_unique<ZoneClean>(pack_, planner_, name, walkable_flags_);
         it = zones_.emplace(name, std::move(e)).first;
     }
+    it->second.used_at = ++zone_clock_;
     return it->second;
 }
 
@@ -2075,95 +2599,286 @@ RecastPlanResult RecastNavEngine::planLocked(
     }
     ps = GridPatch {};
     pg = GridPatch {};
+
+    // 窗口分档。整类窗口是精确答案, 但它的代价与腿长无关; 先按搜索椭圆开小窗, 小窗只在证明了
+    // 答案与整类逐位相同时才采信: 场是局部算子, 可信余量盖过它们的依赖半径; 搜索单价恒 ≥1,
+    // 弹出的格都在两端为焦点、和为终代价的椭圆里, 椭圆没碰可信区边就碰不到窗外; 吸附与可达域
+    // 另与不限可达域的版本对照。任一条不成立就把允许的代价翻倍, 椭圆随之长大。
+    // 面积到上限那一档是最后一档: 与窗口大小有关的验收不再做, 结果照采; 可达域相关的差异用
+    // 整类洪水补齐; 只有"窗内不通而整类可达"才退到整类窗口。最坏耗时与内存由上限定住。
+    constexpr int64_t kTrustMargin = 64; // 可信余量(格), 须盖过净空截断 kEdtCells 与中轴邻域
+    constexpr int64_t kLocalMaxCells = 3'000'000;
+    constexpr double kRatio0 = 2.0; // 首档允许的 代价/直线 比; 语料里过半的腿一档就过
+    constexpr double kRatioStep = 2.0;
+    constexpr double kCostSlack = 200.0; // 短腿的固定余裕(格): 吸附偏移、接入链、栅格化
+    static_assert(kTrustMargin > kEdtCells + 8);
+    const auto cellOf = [](double v) { return static_cast<int64_t>(std::floor(v / kCS)); };
+    const int64_t bx0 = std::min({ cellOf(start.x), cellOf(ss->point.x), cellOf(goal.x) });
+    const int64_t bx1 = std::max({ cellOf(start.x), cellOf(ss->point.x), cellOf(goal.x) });
+    const int64_t by0 = std::min({ cellOf(start.y), cellOf(ss->point.y), cellOf(goal.y) });
+    const int64_t by1 = std::max({ cellOf(start.y), cellOf(ss->point.y), cellOf(goal.y) });
+    // 整类窗口矩形。场都是局部算子, 依赖半径合起来不到 kFieldHalo 这一圈; 留出它, 类边缘
+    // 那几格算出来的场就与在整区图上算的逐位相同。整类可达域也按这个矩形洪水。
     const ZoneBoundsPx zb = regionBounds(grid_, *gz, region);
     if (zb.empty()) {
         res.error = "类内没有格图";
         return res;
     }
-    // 场都是局部算子, 依赖半径合起来不到这一圈。留出它, 类边缘那几格算出来的场
-    // 就与在整区图上算的逐位相同。
     constexpr int64_t kFieldHalo = 32;
-    const int64_t nx = zb.x1 - zb.x0 + 1 + 2 * kFieldHalo;
-    const int64_t ny = zb.y1 - zb.y0 + 1 + 2 * kFieldHalo;
-    if (nx * ny > kMaxCells) {
-        res.error = "类过大 (" + std::to_string(nx) + "×" + std::to_string(ny) + " 格)";
-        return res;
-    }
-    if (should_stop && should_stop()) {
-        res.error = "规划已取消";
-        return res;
-    }
-    const double x0 = static_cast<double>(zb.x0 - kFieldHalo) * kCS;
-    const double y0 = static_cast<double>(zb.y0 - kFieldHalo) * kCS;
-    const double x1 = static_cast<double>(zb.x1 + 1 + kFieldHalo) * kCS;
-    const double y1 = static_cast<double>(zb.y1 + 1 + kFieldHalo) * kCS;
-
-    const double t_win0 = nowMs();
-    auto info = buildWindow(grid_, *gz, zc, start, ss->point, goal, h0, region, x0, y0, x1, y1, blocked_local, blocked_points, err);
-    const double window_ms = nowMs() - t_win0;
-    // 区网格的读者到建窗为止, 往下只剩一个区号。它比一整套窗口图还大, 挂着不放就是白抬一份
-    // 峰值。下一条腿重建它: 峰值是用户量得到的东西, 常驻不是。
-    const uint16_t zone_id = zc.zone_id;
-    zones_.erase(zone_name);
-    if (!info.has_value()) {
-        res.error = err.empty() ? "路线失败" : err;
-        return res;
-    }
-    RouteDiag dg;
-    auto line = routeWindow(*info, start, goal, dg, gdk, planner_, zone_id);
-    // 失败的腿才最需要诊断: 断开时的缝、窗口范围、各阶段耗时全在这里, 两条出口都得带上。
-    const auto dump = [&] {
-        res.debug.timing = dg.timing;
-        res.debug.timing.window_ms = window_ms;
-        res.debug.timing.total_ms = nowMs() - t_all0;
-        res.debug.x0 = x0;
-        res.debug.y0 = y0;
-        res.debug.nx = nx;
-        res.debug.ny = ny;
-        res.debug.cell_size = kCS;
-        res.debug.topology_cells = std::move(dg.topology_cells);
-        res.debug.topology_heights = std::move(dg.topology_heights);
-        res.debug.taut_points = std::move(dg.taut_points);
-        res.debug.pulled_points = std::move(dg.pulled_points);
-        res.debug.assembled_points = std::move(dg.assembled_points);
-        res.debug.gap_start = dg.gap_start;
-        res.debug.gap_goal = dg.gap_goal;
-        res.debug.gap_distance = dg.gap_distance;
-        res.debug.warnings = dg.warn;
+    const int64_t rgx0 = zb.x0 - kFieldHalo;
+    const int64_t rgy0 = zb.y0 - kFieldHalo;
+    const int64_t rnx = zb.x1 - zb.x0 + 1 + 2 * kFieldHalo;
+    const int64_t rny = zb.y1 - zb.y0 + 1 + 2 * kFieldHalo;
+    // 搜索椭圆的外接矩形: 焦点取起终点, 半长轴 C/2, 半短轴 sqrt(C²-L²)/2, 按腿的方向投影到两轴;
+    // 再并上端点包围盒, 外加可信余量。直腿的椭圆是细长条, 窗口跟着细, 不再按腿长开正方形。
+    const double fsx = start.x / kCS;
+    const double fsy = start.y / kCS;
+    const double fgx = goal.x / kCS;
+    const double fgy = goal.y / kCS;
+    const double leg = std::hypot(fgx - fsx, fgy - fsy);
+    const double ang = std::atan2(fgy - fsy, fgx - fsx);
+    struct Rect
+    {
+        int64_t x0 = 0, y0 = 0, nx = 0, ny = 0;
+        int64_t cells() const { return nx * ny; }
     };
-    if (!line.has_value()) {
-        res.error = dg.err.empty() ? "路线失败" : dg.err;
+    const auto rectFor = [&](double cost) {
+        const double a = cost / 2.0;
+        const double b = std::sqrt(std::max(cost * cost - leg * leg, 0.0)) / 2.0;
+        const double c = std::cos(ang);
+        const double s = std::sin(ang);
+        const double ex = std::sqrt(a * a * c * c + b * b * s * s);
+        const double ey = std::sqrt(a * a * s * s + b * b * c * c);
+        const double cx = (fsx + fgx) / 2.0;
+        const double cy = (fsy + fgy) / 2.0;
+        constexpr int64_t halo = kTrustMargin + 8;
+        const int64_t x0 = std::min(bx0, static_cast<int64_t>(std::floor(cx - ex))) - halo;
+        const int64_t x1 = std::max(bx1, static_cast<int64_t>(std::ceil(cx + ex))) + halo;
+        const int64_t y0 = std::min(by0, static_cast<int64_t>(std::floor(cy - ey))) - halo;
+        const int64_t y1 = std::max(by1, static_cast<int64_t>(std::ceil(cy + ey))) + halo;
+        return Rect { x0, y0, x1 - x0 + 1, y1 - y0 + 1 };
+    };
+    enum class Kind
+    {
+        Tentative, // 小窗, 全套验收
+        Capped, // 封顶档: 面积到上限, 窗口大小相关的验收关掉
+        Full // 整类窗口, 不做验收
+    };
+    const Rect region_rect { rgx0, rgy0, rnx, rny };
+    const auto tierRect = [&](int tier) -> std::pair<Rect, Kind> {
+        const double cost = leg * kRatio0 * std::pow(kRatioStep, tier) + kCostSlack;
+        Rect r = rectFor(cost);
+        const bool covers = r.x0 <= rgx0 && r.y0 <= rgy0 && r.x0 + r.nx >= rgx0 + rnx && r.y0 + r.ny >= rgy0 + rny;
+        // 小类: 椭圆盖住整类, 或差不到两成, 直接走整类那一档, 精确且不比小窗贵
+        if (region_rect.cells() <= kLocalMaxCells && (covers || r.cells() * 5 >= region_rect.cells() * 4)) {
+            return { region_rect, Kind::Full };
+        }
+        if (r.cells() <= kLocalMaxCells) {
+            return { r, Kind::Tentative };
+        }
+        // 超上限: 在 [直线, cost] 里二分出面积刚好不超的椭圆; 连直线的外接矩形都超就只能用它
+        double lo = leg;
+        double hi = cost;
+        if (rectFor(lo).cells() > kLocalMaxCells) {
+            return { rectFor(lo), Kind::Capped };
+        }
+        for (int i = 0; i < 40; ++i) {
+            const double mid = (lo + hi) / 2.0;
+            (rectFor(mid).cells() <= kLocalMaxCells ? lo : hi) = mid;
+        }
+        return { rectFor(lo), Kind::Capped };
+    };
+    // 小窗的可达域被窗口切过时, 有两条路: 扩窗一档, 或按整类洪水一次换成逐位相同的可达域后
+    // 同一档重跑。整类洪水只建 span 表不算场, 每格约为窗口档的 1/5; 按估出的代价选便宜的那条。
+    // 与窗口本身有关的升档(搜索碰边、walk 断开)只能扩窗。
+    std::optional<RegionReach> rr;
+    const auto reachBound = [](const std::string& why) {
+        return why == "可达域内有口袋" || why == "搜索椭圆碰边" || why == "吸附受可达域限制"
+               || why == "端点格的面受可达域限制" || why == "端点在可达域外";
+    };
+    constexpr int64_t kReachCostDiv = 5;
+    // 换可达域重跑的是同一个窗口: 建窗的产物只有 reach3 与可达域有关, 留着不重建。routeWindow 会
+    // 就地释放三张全窗口的表, 试探档先留副本, 重跑前放回去。
+    std::optional<WindowInfo> info;
+    Mask keep_lay;
+    Mask keep_whit;
+    Grid<float> keep_dist;
+    bool reuse = false;
+    int level = 0; // 椭圆档位; 换可达域重跑同一窗口时不升
+    bool last_resort = false;
+    Rect cur;
+    Kind kind = Kind::Tentative;
+    for (int tier = 0;; ++tier) {
+        if (!reuse) {
+            if (last_resort) {
+                cur = region_rect;
+                kind = Kind::Full;
+            }
+            else {
+                std::tie(cur, kind) = tierRect(level);
+            }
+        }
+        const bool local = kind != Kind::Full;
+        const bool capped = kind == Kind::Capped;
+        if (!local && region_rect.cells() > kMaxCells) {
+            res.error = "类过大 (" + std::to_string(rnx) + "×" + std::to_string(rny) + " 格)";
+            return res;
+        }
+        const int64_t gx0 = cur.x0;
+        const int64_t gy0 = cur.y0;
+        const int64_t nx = cur.nx;
+        const int64_t ny = cur.ny;
+        if (should_stop && should_stop()) {
+            res.error = "规划已取消";
+            return res;
+        }
+        const double x0 = static_cast<double>(gx0) * kCS;
+        const double y0 = static_cast<double>(gy0) * kCS;
+        const double x1 = static_cast<double>(gx0 + nx) * kCS;
+        const double y1 = static_cast<double>(gy0 + ny) * kCS;
+        const int64_t margin = local ? kTrustMargin : 0;
+
+        const double t_win0 = nowMs();
+        if (reuse) {
+            reuse = false;
+            info->lay = std::move(keep_lay);
+            info->whit = std::move(keep_whit);
+            info->dist = std::move(keep_dist);
+            if (!mapRegionReach(*info, *rr, err)) {
+                info.reset();
+            }
+        }
+        else {
+            info = buildWindow(grid_, *gz, zc, start, ss->point, goal, h0, region, x0, y0, x1, y1, blocked_local,
+                blocked_points, margin, local && rr.has_value() ? &*rr : nullptr, err);
+        }
+        const double window_ms = nowMs() - t_win0;
+        const uint16_t zone_id = zc.zone_id;
+        if (!info.has_value()) {
+            if (local && !capped) {
+                res.debug.tier_notes.push_back(err);
+                ++level;
+                continue;
+            }
+            if (local) {
+                res.debug.tier_notes.push_back(err + "→整类窗口");
+                last_resort = true;
+                continue;
+            }
+            res.error = err.empty() ? "路线失败" : err;
+            return res;
+        }
+        const int64_t seed_gx = info->seed_gx;
+        const int64_t seed_gy = info->seed_gy;
+        const bool tentative = local && !rr.has_value();
+        if (tentative) {
+            keep_lay = info->lay;
+            keep_whit = info->whit;
+            keep_dist = info->dist;
+        }
+        RouteDiag dg;
+        dg.margin = margin;
+        dg.final = capped;
+        dg.exact_reach = local && rr.has_value();
+        auto line = routeWindow(*info, start, goal, dg, gdk, planner_, zone_id);
+        // 封顶档补齐可达域之后就是最终答案, 与整类窗口同一套出口
+        if (local && !(capped && dg.exact_reach)) {
+            std::string why;
+            if (dg.escalate) {
+                why = dg.escalate_why;
+            }
+            else if (!line.has_value()) {
+                why = dg.err.empty() ? "路线失败" : dg.err;
+            }
+            else if (!dg.exact_reach && (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius || dg.hop_barrier)) {
+                why = "端点在可达域外";
+            }
+            if (!why.empty()) {
+                // 整类洪水按格约为一档的 1/5, 重跑省掉建窗只剩约 2/3; 与扩一档整档比, 走便宜的。
+                // 封顶档没有更大的小窗: 可达域没补过就先补, 补过还不通才退整类。
+                const int64_t next_cells = tierRect(level + 1).first.cells();
+                const bool reach_cheaper = capped || rnx * rny / kReachCostDiv + nx * ny * 2 / 3 < next_cells;
+                if (tentative && (reachBound(why) || capped) && reach_cheaper) {
+                    rr = buildRegionReach(grid_, *gz, region, rgx0, rgy0, rnx, rny, seed_gx, seed_gy, h0, err);
+                    if (rr.has_value()) {
+                        res.debug.tier_notes.push_back(why + "→整类可达域");
+                        reuse = true;
+                        continue;
+                    }
+                }
+                info.reset();
+                keep_lay = Mask();
+                keep_whit = Mask();
+                keep_dist = Grid<float>();
+                if (capped) {
+                    res.debug.tier_notes.push_back(why + "→整类窗口");
+                    last_resort = true;
+                }
+                else {
+                    res.debug.tier_notes.push_back(why);
+                    ++level;
+                }
+                continue;
+            }
+        }
+        keep_lay = Mask();
+        keep_whit = Mask();
+        keep_dist = Grid<float>();
+        // 失败的腿才最需要诊断: 断开时的缝、窗口范围、各阶段耗时全在这里, 两条出口都得带上。
+        const auto dump = [&] {
+            res.debug.timing = dg.timing;
+            res.debug.timing.window_ms = window_ms;
+            res.debug.timing.total_ms = nowMs() - t_all0;
+            res.debug.x0 = x0;
+            res.debug.y0 = y0;
+            res.debug.nx = nx;
+            res.debug.ny = ny;
+            res.debug.cell_size = kCS;
+            res.debug.tier = tier;
+            res.debug.topology_cells = std::move(dg.topology_cells);
+            res.debug.topology_heights = std::move(dg.topology_heights);
+            res.debug.taut_points = std::move(dg.taut_points);
+            res.debug.pulled_points = std::move(dg.pulled_points);
+            res.debug.assembled_points = std::move(dg.assembled_points);
+            res.debug.gap_start = dg.gap_start;
+            res.debug.gap_goal = dg.gap_goal;
+            res.debug.gap_distance = dg.gap_distance;
+            res.debug.warnings = dg.warn;
+        };
+        if (!line.has_value()) {
+            res.error = dg.err.empty() ? "路线失败" : dg.err;
+            dump();
+            return res;
+        }
+        if (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius || dg.hop_barrier) {
+            // 两端都已过全区核心闸, 端点确实在可走面上, 差的是从起点出发的可达域够不着它。图铺满了
+            // 整区, 这就是最终结论。
+            char buf[160];
+            std::snprintf(
+                buf,
+                sizeof(buf),
+                "从起点走不到终点 (端点%s, 可达区距 起 %.1fpx / 终 %.1fpx)",
+                dg.hop_barrier ? "被禁行边隔开" : "在可走面上",
+                dg.snap_start,
+                dg.snap_goal);
+            res.error = buf;
+            dump();
+            return res;
+        }
+        res.ok = true;
+        res.points = *line;
+        for (size_t i = 1; i < line->size(); ++i) {
+            res.length += std::hypot((*line)[i].x - (*line)[i - 1].x, (*line)[i].y - (*line)[i - 1].y);
+        }
+        res.warnings = dg.warn;
+        res.clearance = dg.clearance;
+        res.snap_start = dg.snap_start;
+        res.snap_goal = dg.snap_goal;
+        res.waypoints = std::move(dg.waypoints);
         dump();
+        res.debug.planned_points = res.points;
         return res;
     }
-    if (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius || dg.hop_barrier) {
-        // 两端都已过全区核心闸, 端点确实在可走面上, 差的是从起点出发的可达域够不着它。图铺满了
-        // 整区, 这就是最终结论。
-        char buf[160];
-        std::snprintf(
-            buf,
-            sizeof(buf),
-            "从起点走不到终点 (端点%s, 可达区距 起 %.1fpx / 终 %.1fpx)",
-            dg.hop_barrier ? "被禁行边隔开" : "在可走面上",
-            dg.snap_start,
-            dg.snap_goal);
-        res.error = buf;
-        dump();
-        return res;
-    }
-    res.ok = true;
-    res.points = *line;
-    for (size_t i = 1; i < line->size(); ++i) {
-        res.length += std::hypot((*line)[i].x - (*line)[i - 1].x, (*line)[i].y - (*line)[i - 1].y);
-    }
-    res.warnings = dg.warn;
-    res.clearance = dg.clearance;
-    res.snap_start = dg.snap_start;
-    res.snap_goal = dg.snap_goal;
-    res.waypoints = std::move(dg.waypoints);
-    dump();
-    res.debug.planned_points = res.points;
-    return res;
 }
 
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -2321,6 +2321,7 @@ RecastPlanResult RecastNavEngine::planLocked(
     int level = 0; // 椭圆档位
     bool last_resort = false;
     Rect cur;
+    Rect prev { 0, 0, 0, 0 };
     Kind kind = Kind::Tentative;
     for (int tier = 0;; ++tier) {
         if (last_resort) {
@@ -2329,7 +2330,20 @@ RecastPlanResult RecastNavEngine::planLocked(
         }
         else {
             std::tie(cur, kind) = tierRect(level);
+            // 极短腿的椭圆一档长不出一格, 腿长为 0 时永远不长: 同一窗口不重跑, 跳到变大的那一档, 跳不动就整类
+            constexpr int kMaxLevel = 64;
+            while (kind == Kind::Tentative && tier > 0 && cur.x0 == prev.x0 && cur.y0 == prev.y0 && cur.nx == prev.nx
+                   && cur.ny == prev.ny) {
+                if (++level > kMaxLevel) {
+                    cur = region_rect;
+                    kind = Kind::Full;
+                    last_resort = true;
+                    break;
+                }
+                std::tie(cur, kind) = tierRect(level);
+            }
         }
+        prev = cur;
         const bool local = kind != Kind::Full;
         const bool capped = kind == Kind::Capped;
         if (!local && region_rect.cells() > kMaxCells) {
@@ -2388,6 +2402,13 @@ RecastPlanResult RecastNavEngine::planLocked(
                 ++level;
                 continue;
             }
+        }
+        // 封顶档关掉了碰边验收, 窗内走不通分不清是真不通还是绕路出了窗: 整类窗口买得起就退整类再下结论
+        if (local && capped && !line.has_value() && region_rect.cells() <= kMaxCells) {
+            info.reset();
+            res.debug.tier_notes.push_back((dg.err.empty() ? std::string("路线失败") : dg.err) + "→整类窗口");
+            last_resort = true;
+            continue;
         }
         // 失败的腿才最需要诊断: 断开时的缝、窗口范围、各阶段耗时全在这里, 两条出口都得带上。
         const auto dump = [&] {

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -41,8 +41,11 @@ struct WindowInfo
     // 就是让两张全窗口的图白白活过整个 routeWindow。
     Mask lay;
     Mask core;
-    Grid<float> dist;
-    Mask whit;
+    Grid<float> dist; // 无封堵: 旁包烘好的封缝净空; 有封堵: 按盖过的核心重算
+    Mask whit; // 只在有封堵时算, 无封堵的腿不需要它
+    Mask medial; // 旁包烘好的中轴, 有封堵时不可信、留空
+    EdgeBits step_edges; // 旁包烘好的台阶税边, 与封堵无关
+    bool blocked = false;
     StepBarrier sev;
     std::vector<WorldPoint> segA;
     std::vector<WorldPoint> segB;
@@ -50,9 +53,6 @@ struct WindowInfo
     SpanTable st3;
     std::vector<uint8_t> vis3;
     std::vector<uint8_t> reach3;
-    // 可达域种子所在格的全局格号, 整类可达域按同一颗种子洪水
-    int64_t seed_gx = 0;
-    int64_t seed_gy = 0;
 };
 
 struct RouteDiag
@@ -71,8 +71,6 @@ struct RouteDiag
     // (搜索碰边、吸附受可达域限制、任何退档分支) 都置 escalate 立即返回, 由调用方换大窗重算。
     // margin = 0 是整类窗口, 所有验收关掉, 逐字走原路。
     int64_t margin = 0;
-    // 可达域已按整类洪水映射, 与整类窗口逐位相同; 只与可达域有关的验收(口袋、吸附受限)关掉
-    bool exact_reach = false;
     // 封顶档: 没有更大的小窗可升, 只与窗口大小有关的验收(碰边类)关掉, 结果照采
     bool final = false;
     bool escalate = false;
@@ -103,14 +101,32 @@ struct GridWindow
     std::vector<GridSpanRec> rec;
     std::vector<int32_t> head; // 逐格: 记录链表头,无记录为 -1
     std::vector<int32_t> next; // 逐记录: 同格的下一条
+    // 旁包的列, 与 rec 逐条对位; 不带旁包解的窗口留空。建窗那一刻记录表是内存峰, 所以能并
+    // 就并: 封缝净空直接写回 rec.clr (窗口里没人再读原值), 中轴位放在 seg 的 bit7。
+    std::vector<uint32_t> scc;
+    std::vector<uint8_t> steps2;
+    std::vector<uint8_t> seg; // bit0/1 = 立面段, bit7 = 中轴
+    std::vector<uint8_t> tax;
 };
+constexpr uint8_t kGwMedialBit = 0x80U;
 
-bool loadGridWindow(const GridPack& gp, const GridZoneDir& gz, int64_t wgx0, int64_t wgy0, int64_t nx, int64_t ny, GridWindow& out)
+// fp/fz 给了就连旁包的六列一起解; 定类那两小块不需要它们, 传空。
+bool loadGridWindow(
+    const GridPack& gp,
+    const GridZoneDir& gz,
+    const FieldsPack* fp,
+    const FieldsZoneDir* fz,
+    int64_t wgx0,
+    int64_t wgy0,
+    int64_t nx,
+    int64_t ny,
+    GridWindow& out)
 {
     const std::vector<const GridTileRef*> tiles = GridTilesInRect(gz, wgx0, wgy0, wgx0 + nx - 1, wgy0 + ny - 1);
     // 先按瓦目录里的记录数开够。窗外与非自有矩形的记录会被滤掉, 所以这是个上界。
     // 解瓦是纯读: 每块领一段瓦, 按同一个上界给它划一段互不相交的写区直写, 收工按块序压紧。
     // 写区起点与压紧次序都只由瓦下标定, 于是 rec 的次序与线程数无关, 表也始终只有一份。
+    const bool with_fields = fp != nullptr && fz != nullptr;
     const auto nt = static_cast<int64_t>(tiles.size());
     const size_t nw = NavWorkerCountForBlocks(nt);
     size_t cap = 0;
@@ -118,6 +134,12 @@ bool loadGridWindow(const GridPack& gp, const GridZoneDir& gz, int64_t wgx0, int
         cap += t->records;
     }
     out.rec.assign(cap, GridSpanRec {});
+    if (with_fields) {
+        out.scc.assign(cap, 0);
+        out.steps2.assign(cap, 0);
+        out.seg.assign(cap, 0);
+        out.tax.assign(cap, 0);
+    }
     std::vector<size_t> beg(nw, 0);
     std::vector<size_t> cnt(nw, 0);
     std::atomic<bool> ok { true };
@@ -128,6 +150,7 @@ bool loadGridWindow(const GridPack& gp, const GridZoneDir& gz, int64_t wgx0, int
         }
         beg[w] = at;
         GridTile tile;
+        FieldsTile ft;
         for (int64_t i = lo; i < hi; ++i) {
             const GridTileRef* t = tiles[static_cast<size_t>(i)];
             if (t->records == 0) {
@@ -137,7 +160,16 @@ bool loadGridWindow(const GridPack& gp, const GridZoneDir& gz, int64_t wgx0, int
                 ok.store(false);
                 return;
             }
-            for (GridSpanRec& r : tile.rec) {
+            if (with_fields) {
+                // 旁包的瓦表与格图同区同序, 记录按解出的次序逐条对位
+                const auto ti = static_cast<size_t>(t - gz.tiles.data());
+                if (ti >= fz->tiles.size() || !fp->decodeTile(fz->tiles[ti], ft) || ft.scc.size() != tile.rec.size()) {
+                    ok.store(false);
+                    return;
+                }
+            }
+            for (size_t k = 0; k < tile.rec.size(); ++k) {
+                GridSpanRec& r = tile.rec[k];
                 const int64_t ix = r.cell % t->nx;
                 const int64_t iy = r.cell / t->nx;
                 if (ix < t->px0 || ix > t->px1 || iy < t->py0 || iy > t->py1) {
@@ -149,6 +181,18 @@ bool loadGridWindow(const GridPack& gp, const GridZoneDir& gz, int64_t wgx0, int
                     continue;
                 }
                 r.cell = static_cast<int32_t>(wy * nx + wx);
+                if (with_fields) {
+                    // 封缝只会让净空变小, 差值超过主包净空就是旁包烘错了, 不猜
+                    if (ft.clr2d[k] > r.clr) {
+                        ok.store(false);
+                        return;
+                    }
+                    out.scc[at] = ft.scc[k];
+                    out.steps2[at] = static_cast<uint8_t>(ft.steps2x[k] ^ r.steps);
+                    out.seg[at] = static_cast<uint8_t>(ft.seg[k] | ((ft.medial[k] & 0x01U) != 0 ? kGwMedialBit : 0U));
+                    out.tax[at] = ft.tax[k];
+                    r.clr = static_cast<uint16_t>(r.clr - ft.clr2d[k]);
+                }
                 out.rec[at++] = r;
             }
         }
@@ -161,14 +205,26 @@ bool loadGridWindow(const GridPack& gp, const GridZoneDir& gz, int64_t wgx0, int
     size_t kept = cnt[0];
     for (size_t w = 1; w < nw; ++w) {
         if (cnt[w] != 0 && beg[w] != kept) {
-            std::move(
-                out.rec.begin() + static_cast<int64_t>(beg[w]),
-                out.rec.begin() + static_cast<int64_t>(beg[w] + cnt[w]),
-                out.rec.begin() + static_cast<int64_t>(kept));
+            const auto b = static_cast<int64_t>(beg[w]);
+            const auto e = static_cast<int64_t>(beg[w] + cnt[w]);
+            const auto k = static_cast<int64_t>(kept);
+            std::move(out.rec.begin() + b, out.rec.begin() + e, out.rec.begin() + k);
+            if (with_fields) {
+                std::move(out.scc.begin() + b, out.scc.begin() + e, out.scc.begin() + k);
+                std::move(out.steps2.begin() + b, out.steps2.begin() + e, out.steps2.begin() + k);
+                std::move(out.seg.begin() + b, out.seg.begin() + e, out.seg.begin() + k);
+                std::move(out.tax.begin() + b, out.tax.begin() + e, out.tax.begin() + k);
+            }
         }
         kept += cnt[w];
     }
     out.rec.resize(kept);
+    if (with_fields) {
+        out.scc.resize(kept);
+        out.steps2.resize(kept);
+        out.seg.resize(kept);
+        out.tax.resize(kept);
+    }
     out.head.assign(static_cast<size_t>(nx * ny), -1);
     out.next.assign(out.rec.size(), -1);
     for (size_t i = out.rec.size(); i-- > 0;) {
@@ -266,17 +322,6 @@ double coreAnchorPx(const GridPack& gp, const GridZoneDir& gz, const WorldPoint&
     }
     return best < 0 ? reach : std::sqrt(static_cast<double>(best)) * cs;
 }
-
-// 一个区的全部格范围, 单位是全局格号, 闭区间。瓦片互不重叠且铺满整区, 所以取并集即是区范围。
-struct ZoneBoundsPx
-{
-    int64_t x0 = 0;
-    int64_t y0 = 0;
-    int64_t x1 = -1;
-    int64_t y1 = -1;
-
-    bool empty() const { return x1 < x0 || y1 < y0; }
-};
 
 // 一块解开的格图连同它的原点与尺寸。原点落在全局格线上, 所以窗口格号与烘焙格号一一对上。
 struct GridPatch
@@ -434,206 +479,14 @@ int64_t seedSpan(const SpanTable& st, const std::vector<uint8_t>& vis, int64_t c
     return seed;
 }
 
-// 整类可达域: 只加载整类格图、建 span 表、从起点面洪水, 不算任何场。小窗按格与层序把它映射进
-// 自己的 reach3, 可达域便与整类窗口逐位相同, 绕窗外接上的口袋因此不再是差异。窗口矩形、记录
-// 筛选与种子规则都必须与 buildWindow 的整类档一字不差。
-struct RegionReach
-{
-    int64_t gx0 = 0;
-    int64_t gy0 = 0;
-    int64_t nx = 0;
-    int64_t ny = 0;
-    // 洪水完只留映射要查的: 逐格一位的占用图加每 64 格的前缀数(顶替逐格 4 字节的直查表),
-    // CSR 起点、逐 span 的高与可达位。整区的 span 表本体不留, 它比这几列大三倍多。
-    std::vector<uint64_t> occ_bits;
-    std::vector<int32_t> occ_rank;
-    std::vector<int32_t> cs;
-    std::vector<float> sp_h;
-    std::vector<uint8_t> reach;
-
-    int64_t j(int64_t cid) const
-    {
-        const auto w = static_cast<size_t>(cid >> 6);
-        if (cid < 0 || w >= occ_bits.size()) {
-            return -1;
-        }
-        const uint64_t bits = occ_bits[w];
-        const int b = static_cast<int>(cid & 63);
-        if (((bits >> b) & 1U) == 0) {
-            return -1;
-        }
-        return occ_rank[w] + std::popcount(bits & ((uint64_t { 1 } << b) - 1));
-    }
-
-    int64_t cstart(int64_t ci) const { return cs[static_cast<size_t>(ci)]; }
-
-    int64_t ccnt(int64_t ci) const { return cs[static_cast<size_t>(ci) + 1] - cs[static_cast<size_t>(ci)]; }
-};
-
-// 整类的 span 三列直接从瓦解出来, 不经 GridWindow 的记录与链表; 填充记录和别类的幽灵记录当场
-// 丢掉, 与 buildWindow 整类档的筛法一字不差。分块与压紧同 loadGridWindow, 次序与线程数无关。
-bool loadRegionSpans(
-    const GridPack& gp,
-    const GridZoneDir& gz,
-    uint32_t region,
-    int64_t wgx0,
-    int64_t wgy0,
-    int64_t nx,
-    int64_t ny,
-    std::vector<int32_t>& sp_cell,
-    std::vector<float>& sp_h,
-    std::vector<uint8_t>& vis)
-{
-    const std::vector<const GridTileRef*> tiles = GridTilesInRect(gz, wgx0, wgy0, wgx0 + nx - 1, wgy0 + ny - 1);
-    const auto nt = static_cast<int64_t>(tiles.size());
-    const size_t nw = NavWorkerCountForBlocks(nt);
-    size_t cap = 0;
-    for (const GridTileRef* t : tiles) {
-        cap += t->records;
-    }
-    sp_cell.assign(cap, 0);
-    sp_h.assign(cap, 0.0F);
-    vis.assign(cap, 0);
-    std::vector<size_t> beg(nw, 0);
-    std::vector<size_t> cnt(nw, 0);
-    std::atomic<bool> ok { true };
-    ParallelChunks(nt, nw, [&](size_t w, int64_t lo, int64_t hi) {
-        size_t at = 0;
-        for (int64_t i = 0; i < lo; ++i) {
-            at += tiles[static_cast<size_t>(i)]->records;
-        }
-        beg[w] = at;
-        GridTile tile;
-        for (int64_t i = lo; i < hi; ++i) {
-            const GridTileRef* t = tiles[static_cast<size_t>(i)];
-            if (t->records == 0) {
-                continue;
-            }
-            if (!gp.decodeTile(*t, tile)) {
-                ok.store(false);
-                return;
-            }
-            for (const GridSpanRec& r : tile.rec) {
-                const int64_t ix = r.cell % t->nx;
-                const int64_t iy = r.cell / t->nx;
-                if (ix < t->px0 || ix > t->px1 || iy < t->py0 || iy > t->py1) {
-                    continue;
-                }
-                const int64_t wx = t->gx0 + ix - wgx0;
-                const int64_t wy = t->gy0 + iy - wgy0;
-                if (wx < 0 || wx >= nx || wy < 0 || wy >= ny) {
-                    continue;
-                }
-                const bool ghost = (r.flags & kGridFlagGhost) != 0;
-                const bool fill = (r.flags & kGridFlagFill) != 0;
-                if (fill || (ghost && r.rid != region)) {
-                    continue;
-                }
-                sp_cell[at] = static_cast<int32_t>(wy * nx + wx);
-                sp_h[at] = r.h;
-                vis[at] = static_cast<uint8_t>(r.rid == region);
-                ++at;
-            }
-        }
-        cnt[w] = at - beg[w];
-    });
-    if (!ok.load()) {
-        sp_cell.clear();
-        sp_h.clear();
-        vis.clear();
-        return false;
-    }
-    size_t kept = cnt[0];
-    for (size_t w = 1; w < nw; ++w) {
-        if (cnt[w] != 0 && beg[w] != kept) {
-            const auto b = static_cast<int64_t>(beg[w]);
-            const auto e = static_cast<int64_t>(beg[w] + cnt[w]);
-            const auto k = static_cast<int64_t>(kept);
-            std::move(sp_cell.begin() + b, sp_cell.begin() + e, sp_cell.begin() + k);
-            std::move(sp_h.begin() + b, sp_h.begin() + e, sp_h.begin() + k);
-            std::move(vis.begin() + b, vis.begin() + e, vis.begin() + k);
-        }
-        kept += cnt[w];
-    }
-    sp_cell.resize(kept);
-    sp_h.resize(kept);
-    vis.resize(kept);
-    return true;
-}
-
-std::optional<RegionReach> buildRegionReach(
-    const GridPack& gp,
-    const GridZoneDir& gz,
-    uint32_t region,
-    int64_t gx0,
-    int64_t gy0,
-    int64_t nx,
-    int64_t ny,
-    int64_t seed_gx,
-    int64_t seed_gy,
-    double h0,
-    std::string& err)
-{
-    RegionReach rr;
-    rr.gx0 = gx0;
-    rr.gy0 = gy0;
-    rr.nx = nx;
-    rr.ny = ny;
-    std::vector<int32_t> sp_cell;
-    std::vector<float> sp_h;
-    std::vector<uint8_t> vis3;
-    if (!loadRegionSpans(gp, gz, region, gx0, gy0, nx, ny, sp_cell, sp_h, vis3)) {
-        err = "预烘格图解不开";
-        return std::nullopt;
-    }
-    SpanTable st = PackSpans(std::move(sp_cell), std::move(sp_h), &vis3);
-    const int64_t sx = seed_gx - gx0;
-    const int64_t sy = seed_gy - gy0;
-    const int64_t seed = sx >= 0 && sy >= 0 && sx < nx && sy < ny ? seedSpan(st, vis3, sy * nx + sx, h0) : -1;
-    if (seed < 0) {
-        err = "起点格没有与终点同类的面";
-        return std::nullopt;
-    }
-    rr.reach = SpanReach(seed, st, vis3, nx, ny);
-    vis3 = std::vector<uint8_t>();
-    rr.occ_bits = std::move(st.occ_bits);
-    rr.occ_rank = std::move(st.occ_rank);
-    rr.cs = std::move(st.cs);
-    rr.sp_h = std::move(st.sp_h);
-    return rr;
-}
-
-// 把整类可达域按 (全局格, 槽位) 映射进窗口的 reach3。两边同一格的 span 由同一批记录按同一规则排,
-// 层序一一对应; 不在整类表里的只会是别类的 span, 本来就不可达。
-bool mapRegionReach(WindowInfo& info, const RegionReach& rr, std::string& err)
-{
-    const int64_t nx = info.nx;
-    const int64_t wgx0 = std::llround(info.x0 / kCS);
-    const int64_t wgy0 = std::llround(info.y0 / kCS);
-    info.reach3.assign(info.vis3.size(), 0);
-    for (int64_t ci = 0, cn = info.st3.nOcc(); ci < cn; ++ci) {
-        const int64_t c = info.st3.occ(ci);
-        const int64_t gx = wgx0 + c % nx - rr.gx0;
-        const int64_t gy = wgy0 + c / nx - rr.gy0;
-        const int64_t rj = gx >= 0 && gy >= 0 && gx < rr.nx && gy < rr.ny ? rr.j(gy * rr.nx + gx) : -1;
-        const int64_t b = info.st3.cstart(ci), n = info.st3.ccnt(ci);
-        for (int64_t k = 0; k < n; ++k) {
-            if (info.vis3[static_cast<size_t>(b + k)] == 0) {
-                continue;
-            }
-            if (rj < 0 || rr.ccnt(rj) != n || rr.sp_h[static_cast<size_t>(rr.cstart(rj) + k)] != info.st3.sp_h[static_cast<size_t>(b + k)]) {
-                err = "整类可达域与窗口 span 表对不上";
-                return false;
-            }
-            info.reach3[static_cast<size_t>(b + k)] = rr.reach[static_cast<size_t>(rr.cstart(rj) + k)];
-        }
-    }
-    return true;
-}
-
+// 建窗。可达域、禁步重判、挑墙三样都是整类量, 全从旁包读: 小窗与整类窗口在这三样上逐位相同,
+// 窗口大小只影响场(净空、通道)与搜索范围, 那是小窗验收管的事。
 std::optional<WindowInfo> buildWindow(
     const GridPack& gp,
     const GridZoneDir& gz,
+    const FieldsPack& fp,
+    const FieldsZoneDir& fzd,
+    const FieldsZone& fz,
     ZoneClean& zc,
     const WorldPoint& s,
     const WorldPoint& s_snap,
@@ -646,8 +499,6 @@ std::optional<WindowInfo> buildWindow(
     double y1,
     const std::vector<int32_t>& blocked_local,
     const std::vector<WorldPoint>& blocked_points,
-    int64_t margin,
-    const RegionReach* rr,
     std::string& err)
 {
     const int64_t nx = static_cast<int64_t>(std::ceil((x1 - x0) / kCS));
@@ -656,8 +507,7 @@ std::optional<WindowInfo> buildWindow(
     const int64_t wgx0 = std::llround(x0 / kCS);
     const int64_t wgy0 = std::llround(y0 / kCS);
 
-    // 区网格只有取墙与盖封堵面两个读者, 两者都只认窗口矩形, 与格图无关。它在小窗档之间本就
-    // 常驻(最大的区约 70 MB), 整类档也留着, 只多抬那一刻的峰值, 省下下一条腿 1.5 s 的重建。
+    // 区网格只有取墙与盖封堵面两个读者, 两者都只认窗口矩形, 与格图无关。
     BakedWalls walls = BakeWalls(zc, x0, y0, nx, ny);
     RasterCells brc;
     if (!blocked_local.empty()) {
@@ -674,8 +524,8 @@ std::optional<WindowInfo> buildWindow(
     pw.nx = nx;
     pw.ny = ny;
     GridWindow& gw = pw.gw;
-    if (!loadGridWindow(gp, gz, wgx0, wgy0, nx, ny, gw)) {
-        err = "预烘格图解不开";
+    if (!loadGridWindow(gp, gz, &fp, &fzd, wgx0, wgy0, nx, ny, gw)) {
+        err = "预烘格图或旁包解不开";
         return std::nullopt;
     }
 
@@ -698,17 +548,28 @@ std::optional<WindowInfo> buildWindow(
     info.lay = Mask(nx, ny, 0);
     info.core = Mask(nx, ny, 0);
     info.dist = Grid<float>(nx, ny, 0.0F);
+    info.blocked = !blocked_local.empty() || !blocked_points.empty();
+    // 中轴是从封缝净空推出来的窗口量, 封堵会改净空, 所以只有无封堵的腿才采烘好的
+    if (!info.blocked) {
+        info.medial = Mask(nx, ny, 0);
+    }
+    info.step_edges.resize(nx, ny);
     Grid<float> lh(nx, ny, std::numeric_limits<float>::quiet_NaN());
     std::vector<uint8_t> stepbits(static_cast<size_t>(nx * ny), 0);
+    std::vector<uint8_t> stepbits2(static_cast<size_t>(nx * ny), 0);
+    std::vector<uint8_t> segbits(static_cast<size_t>(nx * ny), 0);
     // 记录数就是 span 表的上界。让它自己长的话, 扩容那一刻新旧两份缓冲同时活着,
     // 而这一刻正是建窗内存最高的时候。
     std::vector<int32_t> sp_cell;
     std::vector<float> sp_h;
+    std::vector<uint32_t> sp_scc;
     sp_cell.reserve(gw.rec.size());
     sp_h.reserve(gw.rec.size());
+    sp_scc.reserve(gw.rec.size());
     info.vis3.reserve(gw.rec.size());
     // 表里留着别的类的 span:层判据要看整列,少一层就会从楼板底下穿过去
-    for (const GridSpanRec& r : gw.rec) {
+    for (size_t ri = 0; ri < gw.rec.size(); ++ri) {
+        const GridSpanRec& r = gw.rec[ri];
         const bool ghost = (r.flags & kGridFlagGhost) != 0;
         const bool fill = (r.flags & kGridFlagFill) != 0;
         const auto cell = static_cast<size_t>(r.cell);
@@ -720,8 +581,33 @@ std::optional<WindowInfo> buildWindow(
             if (core) {
                 info.core.v[cell] = 1;
             }
+            // r.clr 已在解瓦时换成封缝净空; 按记录序后写覆盖, 与老路 min(烘净空, 接缝净空) 的取值次序一致
             info.dist.v[cell] = GridClearance(r.clr);
             stepbits[cell] |= r.steps;
+            stepbits2[cell] |= gw.steps2[ri];
+            segbits[cell] |= static_cast<uint8_t>(gw.seg[ri] & ~kGwMedialBit);
+            if (!info.blocked && (gw.seg[ri] & kGwMedialBit) != 0) {
+                info.medial.v[cell] = 1;
+            }
+            // 台阶税边: 方向 i 正向在 bit 2i, 反向在 bit 2i+1。EdgeBits 的反向位记在对端格上,
+            // 所以不能整字节搬, 逐位 set; 窗边格的记录可能带出窗的边, 越界的丢
+            if (const uint8_t tb = gw.tax[ri]; tb != 0) {
+                const int64_t cx = static_cast<int64_t>(cell) % nx;
+                const int64_t cy = static_cast<int64_t>(cell) / nx;
+                for (int i = 0; i < 4; ++i) {
+                    for (const int64_t sg : { int64_t { 1 }, int64_t { -1 } }) {
+                        if (((tb >> (2 * i + (sg < 0 ? 1 : 0))) & 0x01U) == 0) {
+                            continue;
+                        }
+                        const int64_t bx = cx + sg * kGridStepDx[i];
+                        const int64_t by = cy + sg * kGridStepDy[i];
+                        if (bx < 0 || by < 0 || bx >= nx || by >= ny) {
+                            continue;
+                        }
+                        info.step_edges.set(static_cast<int64_t>(cell), by * nx + bx);
+                    }
+                }
+            }
             if (!ghost && !fill && (std::isnan(lh.v[cell]) || r.h > lh.v[cell])) {
                 lh.v[cell] = r.h;
             }
@@ -731,119 +617,34 @@ std::optional<WindowInfo> buildWindow(
         }
         sp_cell.push_back(static_cast<int32_t>(r.cell));
         sp_h.push_back(r.h);
+        sp_scc.push_back(gw.scc[ri]);
         info.vis3.push_back(static_cast<uint8_t>(r.rid == region));
     }
     // 记录表到此已经摊进上面这几张图, 后面再没人读它。建 span 表是建窗最耗内存的一步,
     // 这份表是其中最大的一块, 不该一直占到那时。
     pw.gw = GridWindow();
 
+    // 挑墙: 这条边在本类的层上留不留, 是按整区采样烘好的整类量, 直接查表。表里没有的边
+    // 说明旁包与区网格对不上, 不猜。
     std::vector<WorldPoint> wP0;
     std::vector<WorldPoint> wP1;
-    {
-        // 挑墙按整条墙判, 窗外的采样看不见。小窗档里一条伸出窗外又被丢掉的墙, 整类窗口可能
-        // 留下它; 它离可信区不到净空半径就会改写可信区里的净空。lh 是全局量(本类非幽灵非填充
-        // 记录的最高 h), 所以这种墙的窗外采样直接查预烘格图, 逐瓦解、逐瓦缓存 lh, 判据与整类
-        // 窗口逐样本同口径; 只有解瓦超预算才升档。
-        const double wx1 = x0 + static_cast<double>(nx) * kCS;
-        const double wy1 = y0 + static_cast<double>(ny) * kCS;
-        const double shrink = static_cast<double>(margin - kEdtCells - 1) * kCS;
-        const auto inWindow = [&](const WorldPoint& p) { return p.x >= x0 && p.x < wx1 && p.y >= y0 && p.y < wy1; };
-        const auto hitsTrusted = [&](const WorldPoint& a, const WorldPoint& b) {
-            // Liang–Barsky 线段裁剪: 与内缩矩形有交即命中。
-            const double rx0 = x0 + shrink, ry0 = y0 + shrink, rx1 = wx1 - shrink, ry1 = wy1 - shrink;
-            double t0 = 0.0, t1 = 1.0;
-            const double dx = b.x - a.x, dy = b.y - a.y;
-            const double p[4] = { -dx, dx, -dy, dy };
-            const double q[4] = { a.x - rx0, rx1 - a.x, a.y - ry0, ry1 - a.y };
-            for (int k = 0; k < 4; ++k) {
-                if (p[k] == 0.0) {
-                    if (q[k] < 0.0) {
-                        return false;
-                    }
-                    continue;
-                }
-                const double t = q[k] / p[k];
-                if (p[k] < 0.0) {
-                    t0 = std::max(t0, t);
-                }
-                else {
-                    t1 = std::min(t1, t);
-                }
-            }
-            return t0 <= t1;
-        };
-        std::vector<uint8_t> cross(walls.p0.size(), 0);
-        if (margin > 0) {
-            for (size_t i = 0; i < cross.size(); ++i) {
-                cross[i] = static_cast<uint8_t>(
-                    !(inWindow(walls.p0[i]) && inWindow(walls.p1[i])) && hitsTrusted(walls.p0[i], walls.p1[i]));
-            }
+    for (size_t i = 0; i < walls.p0.size(); ++i) {
+        bool known = false;
+        const bool keep = fz.wallKeep(walls.tri[i], walls.k[i], region, known);
+        if (!known) {
+            err = "旁包留墙表没有这条边 (tri " + std::to_string(walls.tri[i]) + ")";
+            return std::nullopt;
         }
-        constexpr size_t kOutsideTileBudget = 64;
-        bool over_budget = false;
-        std::vector<std::pair<const GridTileRef*, Grid<float>>> tiles;
-        GridTile tile;
-        const auto tileLayer = [&](const GridTileRef* t) -> const Grid<float>* {
-            for (const auto& [ref, g] : tiles) {
-                if (ref == t) {
-                    return &g;
-                }
-            }
-            if (tiles.size() >= kOutsideTileBudget || !gp.decodeTile(*t, tile)) {
-                over_budget = true;
-                return nullptr;
-            }
-            Grid<float> g(t->nx, t->ny, std::numeric_limits<float>::quiet_NaN());
-            for (const GridSpanRec& r : tile.rec) {
-                const int64_t ix = r.cell % t->nx;
-                const int64_t iy = r.cell / t->nx;
-                if (ix < t->px0 || ix > t->px1 || iy < t->py0 || iy > t->py1 || r.rid != region
-                    || (r.flags & (kGridFlagGhost | kGridFlagFill)) != 0) {
-                    continue;
-                }
-                float& v = g.v[static_cast<size_t>(r.cell)];
-                if (std::isnan(v) || r.h > v) {
-                    v = r.h;
-                }
-            }
-            tiles.emplace_back(t, std::move(g));
-            return &tiles.back().second;
-        };
-        const OutsideLayerFn outside = [&](size_t i, int64_t gx, int64_t gy) -> float {
-            constexpr float nan = std::numeric_limits<float>::quiet_NaN();
-            if (cross[i] == 0 || over_budget) {
-                return nan;
-            }
-            const int64_t cx = wgx0 + gx;
-            const int64_t cy = wgy0 + gy;
-            // 瓦的自有矩形互不重叠, 一格至多落在一块瓦里; 先看已解的
-            for (const auto& [t, g] : tiles) {
-                if (cx >= t->gx0 + t->px0 && cx <= t->gx0 + t->px1 && cy >= t->gy0 + t->py0 && cy <= t->gy0 + t->py1) {
-                    return g.at(cy - t->gy0, cx - t->gx0);
-                }
-            }
-            const std::vector<const GridTileRef*> hit = GridTilesInRect(gz, cx, cy, cx, cy);
-            if (hit.empty() || hit.front()->records == 0) {
-                return nan;
-            }
-            const GridTileRef* t = hit.front();
-            const Grid<float>* g = tileLayer(t);
-            return g == nullptr ? nan : g->at(cy - t->gy0, cx - t->gx0);
-        };
-        const std::vector<uint8_t> keep = WallsAtLayer(walls.p0, walls.p1, walls.hh, lh, x0, y0, margin > 0 ? &outside : nullptr);
-        for (size_t i = 0; i < keep.size(); ++i) {
-            if (keep[i] != 0) {
-                wP0.push_back(walls.p0[i]);
-                wP1.push_back(walls.p1[i]);
-            }
-            else if (over_budget && cross[i] != 0) {
-                err = "escalate: 跨窗墙的层判据不完整";
-                return std::nullopt;
-            }
+        if (keep) {
+            wP0.push_back(walls.p0[i]);
+            wP1.push_back(walls.p1[i]);
         }
     }
     walls = BakedWalls();
-    info.whit = WallHits(wP0, wP1, x0, y0, nx, ny);
+    // 挡线格图只喂接缝净空那一步, 而无封堵时净空直接采旁包, 不必再算
+    if (info.blocked) {
+        info.whit = WallHits(wP0, wP1, x0, y0, nx, ny);
+    }
 
     for (size_t ci = 0; ci < brc.cell.size(); ++ci) {
         const auto cell = static_cast<size_t>(brc.cell[ci]);
@@ -881,89 +682,12 @@ std::optional<WindowInfo> buildWindow(
     const int64_t nc = nx * ny;
     info.h0 = h0;
     info.sev.steps.resize(nx, ny);
-    info.st3 = PackSpans(std::move(sp_cell), std::move(sp_h), &info.vis3);
-
-    // 窗口里 c 沿 (dx,dy) 到 b 这一向是否还走得通:任一对区内 span 满足垂直可达即通。
-    // 任一格在窗口里没有区内 span 就判不通,让这条边保持禁行。
-    const auto passable = [&](int64_t c, int64_t b, int64_t dx, int64_t dy) {
-        const int64_t jc = info.st3.j(c);
-        const int64_t jb = info.st3.j(b);
-        if (jc < 0 || jb < 0) {
-            return false;
-        }
-        const SpanTable& st = info.st3;
-        for (int64_t ka = 0; ka < st.ccnt(jc); ++ka) {
-            const int64_t sa = st.cstart(jc) + ka;
-            if (info.vis3[static_cast<size_t>(sa)] == 0) {
-                continue;
-            }
-            for (int64_t kb = 0; kb < st.ccnt(jb); ++kb) {
-                const int64_t sb = st.cstart(jb) + kb;
-                if (info.vis3[static_cast<size_t>(sb)] == 0) {
-                    continue;
-                }
-                if (RiseOk(st, nx, ny, c, dx, dy, st.sp_h[static_cast<size_t>(sa)], st.sp_h[static_cast<size_t>(sb)])) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    };
-
-    // 一格里可见面的最高与最低之差。栅格化的立面被挤进一列, 这个跨度就够得上一堵墙,
-    // 护岸那一列六个面从 270.92 到 276.83 即是。
-    const auto stackSpan = [&](int64_t c) {
-        const int64_t j = info.st3.j(c);
-        if (j < 0) {
-            return 0.0;
-        }
-        const SpanTable& st = info.st3;
-        double lo = 0.0;
-        double hi = 0.0;
-        bool have = false;
-        for (int64_t k = 0; k < st.ccnt(j); ++k) {
-            const int64_t s = st.cstart(j) + k;
-            if (info.vis3[static_cast<size_t>(s)] == 0) {
-                continue;
-            }
-            const double v = st.sp_h[static_cast<size_t>(s)];
-            lo = have ? std::min(lo, v) : v;
-            hi = have ? std::max(hi, v) : v;
-            have = true;
-        }
-        return hi - lo;
-    };
-
-    // c 与 b 两格之间落差最小的那一对面。任一格没有区内面时取无穷大。
-    const auto minGap = [&](int64_t c, int64_t b) {
-        const int64_t jc = info.st3.j(c);
-        const int64_t jb = info.st3.j(b);
-        if (jc < 0 || jb < 0) {
-            return std::numeric_limits<double>::infinity();
-        }
-        const SpanTable& st = info.st3;
-        double g = std::numeric_limits<double>::infinity();
-        for (int64_t ka = 0; ka < st.ccnt(jc); ++ka) {
-            const int64_t sa = st.cstart(jc) + ka;
-            if (info.vis3[static_cast<size_t>(sa)] == 0) {
-                continue;
-            }
-            for (int64_t kb = 0; kb < st.ccnt(jb); ++kb) {
-                const int64_t sb = st.cstart(jb) + kb;
-                if (info.vis3[static_cast<size_t>(sb)] == 0) {
-                    continue;
-                }
-                g = std::min(g, std::fabs(static_cast<double>(
-                    st.sp_h[static_cast<size_t>(sa)] - st.sp_h[static_cast<size_t>(sb)])));
-            }
-        }
-        return g;
-    };
+    info.st3 = PackSpans(std::move(sp_cell), std::move(sp_h), &info.vis3, &sp_scc);
 
     // 禁步面按烘出来的位还原。位序与方向表是写入方定的,方向倒序的那一位对应反向键;
     // 只有正交两向出线段,对角步不挡视线。封堵盖掉的格不再出面,与它被移出可走层一致。
-    // 位是按老口径(可迈台阶高 = 体素边长)烘的,这里按 span 的真实高差逐向重判,只放行不新增:
-    // 路缘、地面微起伏这类连续地面不再被切成立面,真断层照旧禁行也照旧挡视线。
+    // 主包的位是按老口径烘的门, 旁包的重判位与立面段位是整区口径算好的答案: 门开着才读,
+    // 读到什么就是什么, 这里不再看 span。
     for (int i = 0; i < 4; ++i) {
         const int64_t dx = kGridStepDx[i];
         const int64_t dy = kGridStepDy[i];
@@ -978,27 +702,15 @@ std::optional<WindowInfo> buildWindow(
                 continue;
             }
             const int64_t b = ay * nx + ax;
-            const bool fwd = (bits & 0x01U) != 0 && !passable(c, b, dx, dy);
-            const bool bwd = (bits & 0x02U) != 0 && !passable(b, c, -dx, -dy);
-            if (fwd) {
+            const uint8_t bits2 = static_cast<uint8_t>(stepbits2[static_cast<size_t>(c)] >> (2 * i)) & 0x03U;
+            if ((bits2 & 0x01U) != 0) {
                 info.sev.steps.set(c, b);
             }
-            if (bwd) {
+            if ((bits2 & 0x02U) != 0) {
                 info.sev.steps.set(b, c);
             }
-            if (dx != 0 && dy != 0) {
+            if (i >= 2 || ((segbits[static_cast<size_t>(c)] >> i) & 0x01U) == 0) {
                 continue;
-            }
-            // 一格里叠着的面总跨度够得上一堵墙时, 这条边贴着被栅格化的立面, 直线一律不许穿。
-            // 其余地方沿用禁步口径: 有一层迈得过去就不挡视线, 最近的一对面落差够不上立面也
-            // 不挡。于是连续路面上的接缝不再把拉直切成锯齿, 立面照旧挡得住直线。
-            if (stackSpan(c) <= kClimb && stackSpan(b) <= kClimb) {
-                if (!fwd && !bwd) {
-                    continue;
-                }
-                if (minGap(c, b) < kWallH) {
-                    continue;
-                }
             }
             const double px = x0 + static_cast<double>(c % nx + dx) * kCS;
             const double py = y0 + static_cast<double>(c / nx + dy) * kCS;
@@ -1006,18 +718,33 @@ std::optional<WindowInfo> buildWindow(
             info.sev.p1.push_back({ px + static_cast<double>(dy) * kCS, py + static_cast<double>(dx) * kCS });
         }
     }
+    stepbits = std::vector<uint8_t>();
+    stepbits2 = std::vector<uint8_t>();
+    segbits = std::vector<uint8_t>();
     const int64_t seed3 = seedSpan(info.st3, info.vis3, cell0, h0);
     if (seed3 < 0) {
         err = "起点格没有与终点同类的面";
         return std::nullopt;
     }
-    info.seed_gx = wgx0 + cell0 % nx;
-    info.seed_gy = wgy0 + cell0 / nx;
-    if (rr == nullptr) {
-        info.reach3 = SpanReach(seed3, info.st3, info.vis3, nx, ny);
-    }
-    else if (!mapRegionReach(info, *rr, err)) {
-        return std::nullopt;
+    // 可达域: 起点面所在分量在类的分量图上能到的分量集, 与整类洪水逐位相同, 窗口切不到它。
+    {
+        const std::vector<uint8_t> hit = fz.reachFrom(region, sp_scc[static_cast<size_t>(seed3)]);
+        if (hit.empty()) {
+            err = "旁包分量图里没有起点面所在的分量";
+            return std::nullopt;
+        }
+        info.reach3.assign(info.vis3.size(), 0);
+        for (size_t sid = 0; sid < info.vis3.size(); ++sid) {
+            if (info.vis3[sid] == 0) {
+                continue;
+            }
+            const uint32_t comp = sp_scc[sid];
+            if (comp == 0 || comp >= hit.size()) {
+                err = "旁包分量号越界";
+                return std::nullopt;
+            }
+            info.reach3[sid] = hit[comp];
+        }
     }
 
     // 段表就此定型。挑剩的墙段与立面禁步段都整份进了 segA/segB, 源表留着只是同一批点的第二份。
@@ -1028,7 +755,7 @@ std::optional<WindowInfo> buildWindow(
     info.sev.p0 = {};
     info.sev.p1 = {};
     // 烘出来的净空是没封堵时的;盖掉格子会让通道变窄,代价场得按盖过的核心重算
-    if (!blocked_local.empty() || !blocked_points.empty()) {
+    if (info.blocked) {
         info.dist = Clearance(info.core);
     }
     return info;
@@ -1237,9 +964,18 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     // 边界边只用来算余量, 不用来禁步: 补洞封缝那一步已经判定这些细缝可以跨,
     // 回头再拿同一批边禁掉跨缝的一步, 等于在每道接缝上凭空立一堵墙
     const EdgeBits& blocked_steps = info.sev.steps;
-    // 掩膜距离场对跨越边界边无感, 取到边界的距离的下确界补上
-    Grid<float> wdist;
-    {
+    // 无封堵的腿: 封缝净空与中轴都是旁包按整类窗口烘好的, 直接采。
+    // 有封堵的腿: 净空已按盖过的核心重算, 接缝补偿与中轴只能在这里现算。
+    Grid<float> dist;
+    Mask rdg;
+    if (!info.blocked) {
+        dist = std::move(info.dist);
+        info.dist = Grid<float>();
+        rdg = std::move(info.medial);
+        info.medial = Mask();
+    }
+    else {
+        // 掩膜距离场对跨越边界边无感, 取到边界的距离的下确界补上
         Mask wfree(nx, ny, 0);
         for (size_t i = 0; i < wfree.v.size(); ++i) {
             wfree.v[i] = info.whit.v[i] != 0 ? 0 : 1;
@@ -1267,19 +1003,19 @@ std::optional<std::vector<WorldPoint>> routeWindow(
                 }
             }
         }
-        wdist = Clearance(wfree);
+        dist = Clearance(wfree);
+        wfree = Mask();
+        // 取小就地写回接缝净空那张表: 另开一张同尺寸的只是让两张 36MB 的图在整个 routeWindow 里同时活着。
+        for (size_t i = 0; i < dist.v.size(); ++i) {
+            dist.v[i] = std::min(info.dist.v[i], dist.v[i]);
+        }
+        info.dist = Grid<float>();
+        // VV(c): 障碍按期望净空 c 膨胀后仍自由的格走可见图那一侧, 膨胀后被吃掉的窄处只留中脊,
+        // 对应论文里 V∩M(c) 的那段 Voronoi 弧。净空在这一层是掩膜: 开阔地没有贴墙这个选项, 窄缝
+        // 里没有偏一侧这个选项, 中途钻的一小段窄缝也就无法被整条路长平均掉。
+        rdg = MedialAxis(dist, kClrLambda);
     }
-    // 取小就地写回接缝净空那张表: 另开一张同尺寸的只是让两张 36MB 的图在整个 routeWindow 里同时活着。
-    for (size_t i = 0; i < wdist.v.size(); ++i) {
-        wdist.v[i] = std::min(info.dist.v[i], wdist.v[i]);
-    }
-    info.dist = Grid<float>();
-    const Grid<float> dist = std::move(wdist);
-    // VV(c): 障碍按期望净空 c 膨胀后仍自由的格走可见图那一侧, 膨胀后被吃掉的窄处只留中脊,
-    // 对应论文里 V∩M(c) 的那段 Voronoi 弧。净空在这一层是掩膜: 开阔地没有贴墙这个选项, 窄缝
-    // 里没有偏一侧这个选项, 中途钻的一小段窄缝也就无法被整条路长平均掉。
     const double cpref = kClrPref;
-    Mask rdg = MedialAxis(dist, kClrLambda);
     // 通道 = 障碍按 c 膨胀后仍自由的格, 并上中轴带。
     const auto chan = [&](double cc, const Mask& band) {
         Mask w(nx, ny, 0);
@@ -1304,9 +1040,10 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     // 带启发式的搜索更紧: 弹出的格满足 g+h ≤ 终代价, 而 g ≥ 到起点格数、h = 到终点欧氏格数,
     // 于是只在两端为焦点、和为终代价的椭圆里; limit2 取可信区外的格两距之和的下界。
     const bool tentative = dg.margin > 0;
-    const bool bounded = tentative && !dg.final; // 只与窗口大小有关的验收
-    // 不通类的验收: 封顶档且可达域已补齐时没有更大的窗可换, 按整类窗口的规则就地退档或报断
-    const bool strict = tentative && !(dg.final && dg.exact_reach);
+    // 只与窗口大小有关的验收。可达域来自旁包, 小窗就已是整类口径, 所以只有碰边类要升档;
+    // 封顶档没有更大的窗可换, 不通类按整类窗口的规则就地退档或报断。
+    const bool bounded = tentative && !dg.final;
+    const bool strict = bounded;
     const int64_t edge_s = std::min({ sc.x, sc.y, nx - 1 - sc.x, ny - 1 - sc.y });
     const int64_t edge_g = std::min({ gc.x, gc.y, nx - 1 - gc.x, ny - 1 - gc.y });
     const int64_t edge = std::min(edge_s, edge_g);
@@ -1352,8 +1089,6 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         esc("端点离窗边不足");
         return std::nullopt;
     }
-    double cost_far = 0.0; // 各次搜索交出的最大代价(格), 口袋检查的半径由它定
-    double access_far = 0.0;
 
     const auto nearestCell = [&](const Mask& mask, const CellPt& p) -> std::pair<std::optional<CellPt>, double> {
         bool have = false;
@@ -1393,21 +1128,6 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     std::vector<uint8_t> useW;
     Mask cw3;
     mk(walk, useW, cw3);
-    // 不限可达域的同款。可达域是从起点泛洪的, 小窗里绕到窗外才够得着的面在这里不可达;
-    // 吸附与口袋检查都要拿它对照, 差一张面就说明答案被窗口切过。
-    std::vector<uint8_t> useA;
-    Mask cwA;
-    if (tentative) {
-        useA.assign(st3.sp_h.size(), 0);
-        cwA = Mask(nx, ny, 0);
-        for (size_t i = 0; i < useA.size(); ++i) {
-            const auto cell = static_cast<size_t>(st3.sp_cell[i]);
-            if (info.vis3[i] != 0 && walk.v[cell] != 0) {
-                useA[i] = 1;
-                cwA.v[cell] = 1;
-            }
-        }
-    }
     const auto pick = [&](const CellPt& c, const std::vector<uint8_t>& use) {
         std::vector<int64_t> out;
         const int64_t j = info.st3.j(c.y * nx + c.x);
@@ -1506,25 +1226,9 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     std::optional<CellPt> ag_ = snap1.first;
     double dsa = snap0.second;
     double dga = snap1.second;
-    if (tentative) {
-        if (bounded && (dsa / kCS >= limit || dga / kCS >= limit)) {
-            esc("吸附距离碰边");
-            return std::nullopt;
-        }
-        if (!dg.exact_reach) {
-            const auto a0 = nearestCell(cwA, sc);
-            const auto a1 = nearGoal(useA, cwA);
-            if (!a0.first.has_value() || a0.first->x != as_->x || a0.first->y != as_->y || !a1.first.has_value()
-                || a1.first->x != ag_->x || a1.first->y != ag_->y) {
-                esc("吸附受可达域限制");
-                return std::nullopt;
-            }
-            if (atSeedLayer(pick(*as_, useW)) != atSeedLayer(pick(*as_, useA))
-                || goalsOf(pick(*ag_, useW)).size() != goalsOf(pick(*ag_, useA)).size()) {
-                esc("端点格的面受可达域限制");
-                return std::nullopt;
-            }
-        }
+    if (bounded && (dsa / kCS >= limit || dga / kCS >= limit)) {
+        esc("吸附距离碰边");
+        return std::nullopt;
     }
 
     // VV(c) 的端点接入。作者点位常贴着墙放, 净空低于 c 又不在中脊上, 于是根本不在通道里。
@@ -1593,7 +1297,6 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             return std::nullopt;
         }
         const double chain_len = static_cast<double>(cs[static_cast<size_t>(hit)]) / 100.0;
-        access_far = std::max(access_far, chain_len);
         if (bounded && chain_len >= limit) {
             esc("接入链碰边");
             return std::nullopt;
@@ -1730,7 +1433,6 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             }
         }
         if (sq.has_value()) {
-            cost_far = std::max(cost_far, cost);
             // 搜索从吸附锚点出发, 焦点却取端点格, 两段吸附偏移并入代价
             if (bounded && cost + (dsa + dga) / kCS >= limit2) {
                 esc("搜索碰边");
@@ -1960,70 +1662,13 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     // 走通了就再没人查这张逐 span 的可用表, 上面那两条出口都直接返回。
     useW = std::vector<uint8_t>();
 
-    // 突变抬升逐次计税: 跨越两侧找不到任何一对高差在坡度内的面时才算一次台阶, 连续缓坡不计。
-    // 它不参与硬连通性, 只在同样走得通的两条线之间偏向不必迈的那条, 封不死唯一的楼梯。
+    // 台阶税边: 跨越两侧找不到任何一对高差在坡度内的面才算一次台阶, 连续缓坡不计。它是整类量,
+    // 旁包烘好了直接用。不参与硬连通性, 只在同样走得通的两条线之间偏向不必迈的那条。
     const double tax = kStepTax;
-    EdgeBits step_edges;
-    step_edges.resize(nx, ny);
-    if (tax > 0.0) {
-        for (int64_t y = 0; y < ny; ++y) {
-            for (int64_t x = 0; x < nx; ++x) {
-                const int64_t c = y * nx + x;
-                const int64_t jc = info.st3.j(c);
-                if (jc < 0) {
-                    continue;
-                }
-                for (int64_t i = 0; i < 4; ++i) {
-                    for (const int64_t sg : { int64_t { 1 }, int64_t { -1 } }) {
-                        const int64_t dx = sg * kGridStepDx[i];
-                        const int64_t dy = sg * kGridStepDy[i];
-                        const int64_t bx = x + dx;
-                        const int64_t by = y + dy;
-                        if (bx < 0 || by < 0 || bx >= nx || by >= ny) {
-                            continue;
-                        }
-                        const int64_t b = by * nx + bx;
-                        const int64_t jb = info.st3.j(b);
-                        if (jb < 0) {
-                            continue;
-                        }
-                        const double up = kSlope * std::hypot(static_cast<double>(dx), static_cast<double>(dy)) * kCS;
-                        bool any = false;
-                        bool flat = false;
-                        for (int64_t ka = 0; ka < st3.ccnt(jc) && !flat; ++ka) {
-                            const int64_t sa = st3.cstart(jc) + ka;
-                            if (info.vis3[static_cast<size_t>(sa)] == 0) {
-                                continue;
-                            }
-                            for (int64_t kb = 0; kb < st3.ccnt(jb); ++kb) {
-                                const int64_t sb = st3.cstart(jb) + kb;
-                                if (info.vis3[static_cast<size_t>(sb)] == 0) {
-                                    continue;
-                                }
-                                const float ha = st3.sp_h[static_cast<size_t>(sa)];
-                                const float hb = st3.sp_h[static_cast<size_t>(sb)];
-                                if (!RiseOk(st3, nx, ny, c, dx, dy, ha, hb)) {
-                                    continue;
-                                }
-                                any = true;
-                                if (static_cast<double>(hb) - static_cast<double>(ha) <= up) {
-                                    flat = true;
-                                    break;
-                                }
-                            }
-                        }
-                        if (any && !flat) {
-                            step_edges.set(c, b);
-                        }
-                    }
-                }
-            }
-        }
-    }
 
     // 自由集是膨胀后仍自由的实心区并上中脊: 宽处走净空 ≥c 的实心区, 窄段走中轴弧,
     // 缝的准入因此由中轴自己定, 不必再拿一串阈值去试。
-    const EdgeBits* bn = tax > 0.0 ? &step_edges : nullptr;
+    const EdgeBits* bn = tax > 0.0 ? &info.step_edges : nullptr;
     const double* bp = tax > 0.0 ? &tax : nullptr;
     // 立面这笔税以普通路面的一格为单位报价, 而定通道那层把普通路面抬了价, 汇率得跟着换,
     // 否则同一道立面在拓扑层变便宜, 花两格路就能买过去。
@@ -2153,34 +1798,6 @@ std::optional<std::vector<WorldPoint>> routeWindow(
             vv = std::move(tt);
         }
     }
-    // 口袋: 可信区里有面却不在窗内可达域里的可走格。整类窗口里它可能绕窗外接上, 于是可达掩膜
-    // 不同; 只有搜索与取直够得着的那个椭圆里的口袋才影响答案, 椭圆之外的差异谁也读不到。
-    // 搜索弹出的格都在两端为焦点的椭圆里, 取直的弦落在路径点的凸包里, 椭圆是凸的所以也盖住;
-    // 接入链两头各算一次, 再放一圈给弦的栅格化与挡线的膨胀。
-    if (tentative && !dg.exact_reach) {
-        const double sum = cost_far + (dsa + dga) / kCS + 2.0 * access_far + 8.0;
-        if (bounded && sum >= limit2) {
-            esc("搜索椭圆碰边");
-            return std::nullopt;
-        }
-        const auto r = static_cast<int64_t>(std::ceil(sum / 2.0));
-        const auto far2 = [&](int64_t x, int64_t y) {
-            return std::hypot(static_cast<double>(x - sc.x), static_cast<double>(y - sc.y))
-                   + std::hypot(static_cast<double>(x - gc.x), static_cast<double>(y - gc.y));
-        };
-        const int64_t ex0 = std::max<int64_t>(std::min(sc.x, gc.x) - r, 0);
-        const int64_t ex1 = std::min<int64_t>(std::max(sc.x, gc.x) + r, nx - 1);
-        const int64_t ey0 = std::max<int64_t>(std::min(sc.y, gc.y) - r, 0);
-        const int64_t ey1 = std::min<int64_t>(std::max(sc.y, gc.y) + r, ny - 1);
-        for (int64_t y = ey0; y <= ey1; ++y) {
-            for (int64_t x = ex0; x <= ex1; ++x) {
-                if (cwA.at(y, x) != 0 && cw3.at(y, x) == 0 && far2(x, y) <= sum) {
-                    esc("可达域内有口袋");
-                    return std::nullopt;
-                }
-            }
-        }
-    }
     dg.timing.geometry_ms = nowMs() - t_geo0;
     const Topo& win = vv.has_value() ? *vv : *base;
     for (const std::string& w : win.warn) {
@@ -2197,10 +1814,6 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         // 判据是硬可达集: on3 现在是舒适通道, 终点天然贴墙就不在里面, 拿它判等于把贴墙的
         // 终点一律说成被禁行边隔开
         dg.hop_barrier = walk.at(gc.y, gc.x) != 0 && base->on3.at(gc.y, gc.x) == 0;
-    }
-    if (tentative && !dg.exact_reach && (dg.hop_barrier || std::max(dsa, dga) > kSnapRadius)) {
-        esc("端点在可达域外");
-        return std::nullopt;
     }
     std::vector<size_t> bad;
     for (size_t k = 1; k < q->size(); ++k) {
@@ -2387,6 +2000,11 @@ RecastNavEngine::RecastNavEngine(const BaseNavPack& pack, const BaseNavPlanner& 
     }
     if (!grid_.parse(sec->bytes.data(), sec->bytes.size(), grid_error_)) {
         grid_ = GridPack();
+        return;
+    }
+    // 旁包与主包同目录同名配对; 缺了或对不上就整个引擎不可用, 不退回运行期重建。
+    if (!fields_.load(FieldsSidecarPath(pack_.path()), pack_, grid_, grid_error_)) {
+        grid_ = GridPack();
     }
 }
 
@@ -2410,7 +2028,16 @@ RecastNavEngine::ZoneEntry& RecastNavEngine::zoneEntry(const std::string& name)
             zones_.erase(victim);
         }
         ZoneEntry e;
-        e.zc = std::make_unique<ZoneClean>(pack_, planner_, name, walkable_flags_);
+        e.zc = std::make_unique<ZoneClean>(pack_, planner_, name);
+        if (const FieldsZoneDir* fzd = fields_.findZone(name); fzd != nullptr) {
+            e.fz = std::make_unique<FieldsZone>();
+            if (!fields_.loadZone(*fzd, *e.fz, e.fields_error)) {
+                e.fz.reset();
+            }
+        }
+        else {
+            e.fields_error = "旁包里没有这个区";
+        }
         it = zones_.emplace(name, std::move(e)).first;
     }
     it->second.used_at = ++zone_clock_;
@@ -2436,16 +2063,6 @@ void RecastNavEngine::warm(const std::string& zone_name)
 {
     const std::lock_guard<std::mutex> lock(mutex_);
     zoneEntry(zone_name);
-}
-
-void RecastNavEngine::setWalkableFlags(uint32_t flags)
-{
-    const std::lock_guard<std::mutex> lk(mutex_);
-    if (flags == walkable_flags_) {
-        return;
-    }
-    walkable_flags_ = flags;
-    zones_.clear(); // 缓存的 ZoneClean 是按旧掩码建的,留着就是两套判据混用
 }
 
 std::vector<std::vector<uint32_t>> RecastNavEngine::regionsNear(const std::string& zone_name, const std::vector<WorldPoint>& points)
@@ -2529,6 +2146,12 @@ RecastPlanResult RecastNavEngine::planLocked(
         res.error = ze.zc->error();
         return res;
     }
+    const FieldsZoneDir* fzd = fields_.findZone(zone_name);
+    if (fzd == nullptr || ze.fz == nullptr) {
+        res.error = "旁包读不出这个区 (" + zone_name + "): " + ze.fields_error;
+        return res;
+    }
+    const FieldsZone* fz = ze.fz.get();
     ZoneClean& zc = *ze.zc;
     std::vector<int32_t> blocked_local;
     for (const uint32_t t : blocked) {
@@ -2581,7 +2204,7 @@ RecastPlanResult RecastNavEngine::planLocked(
         p.ny = std::max(ay, by) + r - gy0 + 1;
         p.x0 = static_cast<double>(gx0) * kCS;
         p.y0 = static_cast<double>(gy0) * kCS;
-        return loadGridWindow(grid_, *gz, gx0, gy0, p.nx, p.ny, p.gw);
+        return loadGridWindow(grid_, *gz, nullptr, nullptr, gx0, gy0, p.nx, p.ny, p.gw);
     };
     // 定类只读起点那一格与终点吸附半径内的格, 两小块解开就够。
     GridPatch ps;
@@ -2618,13 +2241,17 @@ RecastPlanResult RecastNavEngine::planLocked(
     const int64_t by0 = std::min({ cellOf(start.y), cellOf(ss->point.y), cellOf(goal.y) });
     const int64_t by1 = std::max({ cellOf(start.y), cellOf(ss->point.y), cellOf(goal.y) });
     // 整类窗口矩形。场都是局部算子, 依赖半径合起来不到 kFieldHalo 这一圈; 留出它, 类边缘
-    // 那几格算出来的场就与在整区图上算的逐位相同。整类可达域也按这个矩形洪水。
-    const ZoneBoundsPx zb = regionBounds(grid_, *gz, region);
+    // 那几格算出来的场就与在整区图上算的逐位相同。旁包的整类量也是按这个矩形烘的。
+    // 类范围是整类量, 每区每类只扫一次瓦, 之后的腿直接查。
+    auto zbit = ze.bounds.find(region);
+    if (zbit == ze.bounds.end()) {
+        zbit = ze.bounds.emplace(region, regionBounds(grid_, *gz, region)).first;
+    }
+    const ZoneBoundsPx zb = zbit->second;
     if (zb.empty()) {
         res.error = "类内没有格图";
         return res;
     }
-    constexpr int64_t kFieldHalo = 32;
     const int64_t rgx0 = zb.x0 - kFieldHalo;
     const int64_t rgy0 = zb.y0 - kFieldHalo;
     const int64_t rnx = zb.x1 - zb.x0 + 1 + 2 * kFieldHalo;
@@ -2688,35 +2315,20 @@ RecastPlanResult RecastNavEngine::planLocked(
         }
         return { rectFor(lo), Kind::Capped };
     };
-    // 小窗的可达域被窗口切过时, 有两条路: 扩窗一档, 或按整类洪水一次换成逐位相同的可达域后
-    // 同一档重跑。整类洪水只建 span 表不算场, 每格约为窗口档的 1/5; 按估出的代价选便宜的那条。
-    // 与窗口本身有关的升档(搜索碰边、walk 断开)只能扩窗。
-    std::optional<RegionReach> rr;
-    const auto reachBound = [](const std::string& why) {
-        return why == "可达域内有口袋" || why == "搜索椭圆碰边" || why == "吸附受可达域限制"
-               || why == "端点格的面受可达域限制" || why == "端点在可达域外";
-    };
-    constexpr int64_t kReachCostDiv = 5;
-    // 换可达域重跑的是同一个窗口: 建窗的产物只有 reach3 与可达域有关, 留着不重建。routeWindow 会
-    // 就地释放三张全窗口的表, 试探档先留副本, 重跑前放回去。
+    // 可达域、禁步、留墙都从旁包读, 小窗与整类窗口在这三样上逐位相同; 小窗只剩与窗口大小
+    // 有关的验收(搜索碰边、场的可信余量), 不过就扩一档, 封顶档的答案照采, 只有窗内不通才退整类。
     std::optional<WindowInfo> info;
-    Mask keep_lay;
-    Mask keep_whit;
-    Grid<float> keep_dist;
-    bool reuse = false;
-    int level = 0; // 椭圆档位; 换可达域重跑同一窗口时不升
+    int level = 0; // 椭圆档位
     bool last_resort = false;
     Rect cur;
     Kind kind = Kind::Tentative;
     for (int tier = 0;; ++tier) {
-        if (!reuse) {
-            if (last_resort) {
-                cur = region_rect;
-                kind = Kind::Full;
-            }
-            else {
-                std::tie(cur, kind) = tierRect(level);
-            }
+        if (last_resort) {
+            cur = region_rect;
+            kind = Kind::Full;
+        }
+        else {
+            std::tie(cur, kind) = tierRect(level);
         }
         const bool local = kind != Kind::Full;
         const bool capped = kind == Kind::Capped;
@@ -2739,19 +2351,8 @@ RecastPlanResult RecastNavEngine::planLocked(
         const int64_t margin = local ? kTrustMargin : 0;
 
         const double t_win0 = nowMs();
-        if (reuse) {
-            reuse = false;
-            info->lay = std::move(keep_lay);
-            info->whit = std::move(keep_whit);
-            info->dist = std::move(keep_dist);
-            if (!mapRegionReach(*info, *rr, err)) {
-                info.reset();
-            }
-        }
-        else {
-            info = buildWindow(grid_, *gz, zc, start, ss->point, goal, h0, region, x0, y0, x1, y1, blocked_local,
-                blocked_points, margin, local && rr.has_value() ? &*rr : nullptr, err);
-        }
+        info = buildWindow(grid_, *gz, fields_, *fzd, *fz, zc, start, ss->point, goal, h0, region, x0, y0, x1, y1,
+            blocked_local, blocked_points, err);
         const double window_ms = nowMs() - t_win0;
         const uint16_t zone_id = zc.zone_id;
         if (!info.has_value()) {
@@ -2768,21 +2369,12 @@ RecastPlanResult RecastNavEngine::planLocked(
             res.error = err.empty() ? "路线失败" : err;
             return res;
         }
-        const int64_t seed_gx = info->seed_gx;
-        const int64_t seed_gy = info->seed_gy;
-        const bool tentative = local && !rr.has_value();
-        if (tentative) {
-            keep_lay = info->lay;
-            keep_whit = info->whit;
-            keep_dist = info->dist;
-        }
         RouteDiag dg;
         dg.margin = margin;
         dg.final = capped;
-        dg.exact_reach = local && rr.has_value();
         auto line = routeWindow(*info, start, goal, dg, gdk, planner_, zone_id);
-        // 封顶档补齐可达域之后就是最终答案, 与整类窗口同一套出口
-        if (local && !(capped && dg.exact_reach)) {
+        // 封顶档就是最终答案, 与整类窗口同一套出口
+        if (local && !capped) {
             std::string why;
             if (dg.escalate) {
                 why = dg.escalate_why;
@@ -2790,40 +2382,13 @@ RecastPlanResult RecastNavEngine::planLocked(
             else if (!line.has_value()) {
                 why = dg.err.empty() ? "路线失败" : dg.err;
             }
-            else if (!dg.exact_reach && (std::max(dg.snap_start, dg.snap_goal) > kSnapRadius || dg.hop_barrier)) {
-                why = "端点在可达域外";
-            }
             if (!why.empty()) {
-                // 整类洪水按格约为一档的 1/5, 重跑省掉建窗只剩约 2/3; 与扩一档整档比, 走便宜的。
-                // 封顶档没有更大的小窗: 可达域没补过就先补, 补过还不通才退整类。
-                const int64_t next_cells = tierRect(level + 1).first.cells();
-                const bool reach_cheaper = capped || rnx * rny / kReachCostDiv + nx * ny * 2 / 3 < next_cells;
-                if (tentative && (reachBound(why) || capped) && reach_cheaper) {
-                    rr = buildRegionReach(grid_, *gz, region, rgx0, rgy0, rnx, rny, seed_gx, seed_gy, h0, err);
-                    if (rr.has_value()) {
-                        res.debug.tier_notes.push_back(why + "→整类可达域");
-                        reuse = true;
-                        continue;
-                    }
-                }
                 info.reset();
-                keep_lay = Mask();
-                keep_whit = Mask();
-                keep_dist = Grid<float>();
-                if (capped) {
-                    res.debug.tier_notes.push_back(why + "→整类窗口");
-                    last_resort = true;
-                }
-                else {
-                    res.debug.tier_notes.push_back(why);
-                    ++level;
-                }
+                res.debug.tier_notes.push_back(why);
+                ++level;
                 continue;
             }
         }
-        keep_lay = Mask();
-        keep_whit = Mask();
-        keep_dist = Grid<float>();
         // 失败的腿才最需要诊断: 断开时的缝、窗口范围、各阶段耗时全在这里, 两条出口都得带上。
         const auto dump = [&] {
             res.debug.timing = dg.timing;

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -11,6 +11,7 @@
 
 #include "BaseNavPack.h"
 #include "BaseNavPlanner.h"
+#include "RecastNavFieldsIO.h"
 #include "RecastNavGridIO.h"
 #include "RecastNavZone.h"
 
@@ -66,9 +67,22 @@ struct RecastPlanResult
     } debug;
 };
 
+// 一个类占的格范围, 单位是全局格号, 闭区间。
+struct ZoneBoundsPx
+{
+    int64_t x0 = 0;
+    int64_t y0 = 0;
+    int64_t x1 = -1;
+    int64_t y1 = -1;
+
+    bool empty() const { return x1 < x0 || y1 < y0; }
+};
+
 class RecastNavEngine
 {
 public:
+    // 预烘场旁包从主包同目录按名找 (base.nav.gz → base.fields.nav.gz), 读不到或对不上主包
+    // 就没法规划 —— 运行期不再重建那些场。
     RecastNavEngine(const BaseNavPack& pack, const BaseNavPlanner& planner);
 
     // start/goal 各带楼层高度(<= kBaseNavFloorYValidMin ⇒ floor 盲吸附);
@@ -87,12 +101,8 @@ public:
         const std::vector<WorldPoint>& blocked_points = {},
         const std::function<bool()>& should_stop = {});
 
-    // 把该区的清洗网格与墙 oracle 提前建好,让首条路线不必冷吃这份开销。
+    // 把该区的清洗网格与预烘场提前建好,让首条路线不必冷吃这份开销。
     void warm(const std::string& zone_name);
-
-    // 改可走面掩码(源 surface flags 的收取位)。运行端必须与烘格图时用的是同一个值,
-    // 否则格图铺出来的可走面与规划器认的可走面对不上。改值会丢掉已建好的区缓存。
-    void setWalkableFlags(uint32_t flags);
 
     // 逐点给出附近的全区类号。一次规划只在单一类号内找路,所以两点的类号集合不相交
     // 时这条腿必败,不必真去规划。半径取 kSnapRadius:选类只发生在点所在格或吸附后
@@ -103,7 +113,10 @@ private:
     struct ZoneEntry
     {
         std::unique_ptr<ZoneClean> zc;
+        std::unique_ptr<FieldsZone> fz; // 该区的分量图与留墙表, 与 zc 同进同出
+        std::string fields_error; // fz 为空时的原因
         uint64_t used_at = 0; // zoneEntry 的调用序号, 淘汰最久没用的
+        std::unordered_map<uint32_t, ZoneBoundsPx> bounds; // 每类的格范围, 整类量, 算一次
     };
     // 每个 ZoneClean 常驻几十到两百 MB, 只留最近用过的两个(通常是一层 base 加一层 tier)
     static constexpr size_t kZoneCacheMax = 2;
@@ -126,8 +139,8 @@ private:
     std::unordered_map<std::string, ZoneEntry> zones_;
     uint64_t zone_clock_ = 0;
     GridPack grid_; // 包里的预烘格图,没有它就没法规划
+    FieldsPack fields_; // 旁包里的预烘场, 同样缺不得
     std::string grid_error_;
-    uint32_t walkable_flags_ = kWalkableFlagsDefault;
 };
 
 }

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -50,6 +50,9 @@ struct RecastPlanResult
         int64_t nx = 0;
         int64_t ny = 0;
         double cell_size = 0.0;
+        // 采信的是第几档窗口 (0 = 端点包围盒外扩的最小一档), 以及前面各档被否掉的原因。
+        int tier = 0;
+        std::vector<std::string> tier_notes;
         std::vector<WorldPoint> topology_cells; // 拓扑那一层的逐格路径
         std::vector<double> topology_heights; // 与 topology_cells 同长的所在面高度
         std::vector<WorldPoint> taut_points; // 几何搜索交出的父链折线, 取直之前
@@ -100,7 +103,10 @@ private:
     struct ZoneEntry
     {
         std::unique_ptr<ZoneClean> zc;
+        uint64_t used_at = 0; // zoneEntry 的调用序号, 淘汰最久没用的
     };
+    // 每个 ZoneClean 常驻几十到两百 MB, 只留最近用过的两个(通常是一层 base 加一层 tier)
+    static constexpr size_t kZoneCacheMax = 2;
 
     ZoneEntry& zoneEntry(const std::string& name);
     RecastPlanResult planLocked(
@@ -118,6 +124,7 @@ private:
     const BaseNavPlanner& planner_;
     std::mutex mutex_;
     std::unordered_map<std::string, ZoneEntry> zones_;
+    uint64_t zone_clock_ = 0;
     GridPack grid_; // 包里的预烘格图,没有它就没法规划
     std::string grid_error_;
     uint32_t walkable_flags_ = kWalkableFlagsDefault;

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.cpp
@@ -19,7 +19,7 @@ namespace
 double triHeight(const PolyMesh& mesh, int32_t t)
 {
     const auto& tri = mesh.T[static_cast<size_t>(t)];
-    return (mesh.H[tri[0]] + mesh.H[tri[1]] + mesh.H[tri[2]]) / 3.0;
+    return (mesh.h(tri[0]) + mesh.h(tri[1]) + mesh.h(tri[2])) / 3.0;
 }
 
 std::pair<WorldPoint, double> closestOnTri(const WorldPoint& p, const std::array<WorldPoint, 3>& tri)
@@ -33,40 +33,64 @@ std::pair<WorldPoint, double> closestOnTri(const WorldPoint& p, const std::array
 
 }
 
-PolyMesh::PolyMesh(std::vector<WorldPoint> v, std::vector<std::array<int32_t, 3>> t, std::vector<double> h)
-    : V(std::move(v))
-    , H(std::move(h))
+PolyMesh::PolyMesh(const BaseNavVertex* vb_in, int64_t nv_in, std::vector<std::array<int32_t, 3>> t, std::vector<uint8_t>* dup)
+    : vb(vb_in)
+    , nv(nv_in)
     , T(std::move(t))
 {
     const int64_t nt = static_cast<int64_t>(T.size());
     ParallelChunks(nt, NavWorkerCount(nt), [&](size_t, int64_t b, int64_t e) {
         for (int64_t i = b; i < e; ++i) {
             auto& tri = T[static_cast<size_t>(i)];
-            const WorldPoint& a = V[tri[0]];
-            const double abx = V[tri[1]].x - a.x;
-            const double aby = V[tri[1]].y - a.y;
-            const double acx = V[tri[2]].x - a.x;
-            const double acy = V[tri[2]].y - a.y;
+            const WorldPoint a = v(tri[0]);
+            const WorldPoint bb = v(tri[1]);
+            const WorldPoint c = v(tri[2]);
+            const double abx = bb.x - a.x;
+            const double aby = bb.y - a.y;
+            const double acx = c.x - a.x;
+            const double acy = c.y - a.y;
             if (abx * acy - aby * acx < 0.0) {
                 std::swap(tri[1], tri[2]);
             }
         }
     });
-    buildNb();
+    buildNb(dup);
     buildGrid();
 }
 
+PolyMesh::PolyMesh(std::vector<BaseNavVertex> own, std::vector<std::array<int32_t, 3>> t, std::vector<uint8_t>* dup)
+    : PolyMesh(own.data(), static_cast<int64_t>(own.size()), std::move(t), dup)
+{
+    vown = std::move(own); // 堆块随 move 原样搬走, verts() 之后改走 vown
+}
+
+void PolyMesh::foldNb()
+{
+    bnd.assign(T.size(), 0);
+    for (size_t i = 0; i < NB.size(); ++i) {
+        for (int k = 0; k < 3; ++k) {
+            if (NB[i][k] < 0) {
+                bnd[i] |= static_cast<uint8_t>(1U << k);
+            }
+        }
+    }
+    std::vector<std::array<int32_t, 3>>().swap(NB);
+}
+
 // 重 key 取稳定序首槽
-void PolyMesh::buildNb()
+void PolyMesh::buildNb(std::vector<uint8_t>* dup)
 {
     const int64_t m = static_cast<int64_t>(T.size());
     NB.assign(T.size(), { -1, -1, -1 });
+    if (dup != nullptr) {
+        dup->assign(static_cast<size_t>(3 * m), 0);
+    }
     if (m == 0) {
         return;
     }
     // 有向边按起点分桶: 每个顶点平均只挂六条边, 找反向边扫本桶即可。桶内按槽号递增填,
     // 所以首个命中就是稳定序里的首槽, 与把三倍三角数的边整体排一遍再取首个逐位相同。
-    const int64_t n = static_cast<int64_t>(V.size());
+    const int64_t n = nv;
     std::vector<int32_t> at(static_cast<size_t>(n) + 1, 0);
     for (const auto& tri : T) {
         for (const int32_t a : tri) {
@@ -76,25 +100,37 @@ void PolyMesh::buildNb()
     for (int64_t i = 0; i < n; ++i) {
         at[static_cast<size_t>(i) + 1] += at[static_cast<size_t>(i)];
     }
-    std::vector<int32_t> wr = at;
-    std::vector<int32_t> dst(static_cast<size_t>(3 * m));
+    // 桶里只存槽号, 边的终点从 T 现算: 少一张三倍三角数的 int32 表(最大区 47 MB)。
     std::vector<int32_t> slot(static_cast<size_t>(3 * m));
-    for (int64_t i = 0; i < m; ++i) {
-        for (int64_t k = 0; k < 3; ++k) {
-            const int32_t a = T[static_cast<size_t>(i)][k];
-            const auto w = static_cast<size_t>(wr[static_cast<size_t>(a)]++);
-            dst[w] = T[static_cast<size_t>(i)][(k + 1) % 3];
-            slot[w] = static_cast<int32_t>(i * 3 + k);
+    {
+        std::vector<int32_t> wr = at;
+        for (int64_t i = 0; i < m; ++i) {
+            for (int64_t k = 0; k < 3; ++k) {
+                const int32_t a = T[static_cast<size_t>(i)][k];
+                slot[static_cast<size_t>(wr[static_cast<size_t>(a)]++)] = static_cast<int32_t>(i * 3 + k);
+            }
         }
     }
+    const auto dst = [&](int32_t s) { return T[static_cast<size_t>(s / 3)][(s % 3 + 1) % 3]; };
     ParallelChunks(m, NavWorkerCount(m), [&](size_t, int64_t lo_i, int64_t hi_i) {
         for (int64_t i = lo_i; i < hi_i; ++i) {
             for (int64_t k = 0; k < 3; ++k) {
                 const int32_t a = T[static_cast<size_t>(i)][k];
                 const int32_t b = T[static_cast<size_t>(i)][(k + 1) % 3];
                 for (int32_t p = at[static_cast<size_t>(b)]; p < at[static_cast<size_t>(b) + 1]; ++p) {
-                    if (dst[static_cast<size_t>(p)] == a) {
+                    if (dst(slot[static_cast<size_t>(p)]) == a) {
                         NB[static_cast<size_t>(i)][k] = slot[static_cast<size_t>(p)] / 3;
+                        break;
+                    }
+                }
+                if (dup == nullptr) {
+                    continue;
+                }
+                // 本槽的有向边 a→b 在 a 桶里还有别的槽也是 a→b, 即重边。每个线程只写自己的槽。
+                const auto self = static_cast<int32_t>(i * 3 + k);
+                for (int32_t p = at[static_cast<size_t>(a)]; p < at[static_cast<size_t>(a) + 1]; ++p) {
+                    if (slot[static_cast<size_t>(p)] != self && dst(slot[static_cast<size_t>(p)]) == b) {
+                        (*dup)[static_cast<size_t>(self)] = 1;
                         break;
                     }
                 }
@@ -110,9 +146,9 @@ void PolyMesh::buildGrid()
         int64_t x0, y0, x1, y1;
     };
     const auto box = [&](size_t i) {
-        const WorldPoint& a = V[T[i][0]];
-        const WorldPoint& b = V[T[i][1]];
-        const WorldPoint& c = V[T[i][2]];
+        const WorldPoint a = v(T[i][0]);
+        const WorldPoint b = v(T[i][1]);
+        const WorldPoint c = v(T[i][2]);
         return Box { static_cast<int64_t>(std::floor(std::min({ a.x, b.x, c.x }) / kGridCell)),
                      static_cast<int64_t>(std::floor(std::min({ a.y, b.y, c.y }) / kGridCell)),
                      static_cast<int64_t>(std::floor(std::max({ a.x, b.x, c.x }) / kGridCell)),
@@ -240,30 +276,32 @@ ZoneClean::ZoneClean(
         }
     }
     const int64_t nv = static_cast<int64_t>(vmax) - vmin + 1;
-    std::vector<WorldPoint> CV(static_cast<size_t>(nv));
-    std::vector<double> CH(static_cast<size_t>(nv));
-    for (int64_t i = 0; i < nv; ++i) {
-        const auto& vt = pverts[vmin + static_cast<size_t>(i)];
-        CV[static_cast<size_t>(i)] = source_exact
-            ? WorldPoint { static_cast<double>(vt.u), static_cast<double>(vt.v) }
-            : WorldPoint { std::nearbyint(static_cast<double>(vt.u) * 20.0) / 20.0,
-                           std::nearbyint(static_cast<double>(vt.v) * 20.0) / 20.0 };
-        CH[static_cast<size_t>(i)] = static_cast<double>(vt.height);
-    }
-
-    std::vector<int32_t> MAP(static_cast<size_t>(nv));
-    std::iota(MAP.begin(), MAP.end(), 0);
+    // 源精确包: 顶点就是包里那段 float, 三角只换成区内局部顶点号, 不复制、不焊接。
+    // 旧包: 取整到 0.05 后按 (x,y) 同柱、高差 ≤ kWeldDh 焊接; 取整值以 float 存, 与历史
+    // 的 double 差在 1e-6 px 量级, 远小于取整步长本身。
+    std::vector<BaseNavVertex> CV;
+    std::vector<int32_t> MAP;
     int64_t n_weld = 0;
     if (!source_exact) {
+        CV.resize(static_cast<size_t>(nv));
+        for (int64_t i = 0; i < nv; ++i) {
+            const auto& vt = pverts[vmin + static_cast<size_t>(i)];
+            CV[static_cast<size_t>(i)].u = static_cast<float>(std::nearbyint(static_cast<double>(vt.u) * 20.0) / 20.0);
+            CV[static_cast<size_t>(i)].v = static_cast<float>(std::nearbyint(static_cast<double>(vt.v) * 20.0) / 20.0);
+            CV[static_cast<size_t>(i)].height = vt.height;
+        }
+        MAP.resize(static_cast<size_t>(nv));
+        std::iota(MAP.begin(), MAP.end(), 0);
         std::vector<int64_t> kk(static_cast<size_t>(nv));
         for (int64_t i = 0; i < nv; ++i) {
-            const int64_t kx = static_cast<int64_t>(std::nearbyint(CV[static_cast<size_t>(i)].x * 1e4));
-            const int64_t ky = static_cast<int64_t>(std::nearbyint(CV[static_cast<size_t>(i)].y * 1e4));
+            const int64_t kx = static_cast<int64_t>(std::nearbyint(static_cast<double>(CV[static_cast<size_t>(i)].u) * 1e4));
+            const int64_t ky = static_cast<int64_t>(std::nearbyint(static_cast<double>(CV[static_cast<size_t>(i)].v) * 1e4));
             kk[static_cast<size_t>(i)] = kx * (int64_t(1) << 40) + ky;
         }
         std::vector<int32_t> order(static_cast<size_t>(nv));
         std::iota(order.begin(), order.end(), 0);
         std::stable_sort(order.begin(), order.end(), [&](int32_t a, int32_t b) { return kk[a] < kk[b]; });
+        const auto CH = [&](int32_t i) { return static_cast<double>(CV[static_cast<size_t>(i)].height); };
         for (size_t s0 = 0; s0 < order.size();) {
             size_t e0 = s0 + 1;
             while (e0 < order.size() && kk[order[e0]] == kk[order[s0]]) {
@@ -271,10 +309,10 @@ ZoneClean::ZoneClean(
             }
             if (e0 - s0 >= 2) {
                 std::vector<int32_t> ids(order.begin() + s0, order.begin() + e0);
-                std::stable_sort(ids.begin(), ids.end(), [&](int32_t a, int32_t b) { return CH[a] < CH[b]; });
+                std::stable_sort(ids.begin(), ids.end(), [&](int32_t a, int32_t b) { return CH(a) < CH(b); });
                 int32_t rep = ids[0];
                 for (size_t t = 1; t < ids.size(); ++t) {
-                    if (CH[ids[t]] - CH[ids[t - 1]] <= kWeldDh) {
+                    if (CH(ids[t]) - CH(ids[t - 1]) <= kWeldDh) {
                         MAP[ids[t]] = rep;
                         ++n_weld;
                     }
@@ -291,7 +329,8 @@ ZoneClean::ZoneClean(
     for (int64_t i = 0; i < hi - lo; ++i) {
         auto& row = CT2[static_cast<size_t>(i)];
         for (int k = 0; k < 3; ++k) {
-            row[k] = MAP[ptris[static_cast<size_t>(lo + i)].vertices[k] - vmin];
+            const auto local = static_cast<int32_t>(ptris[static_cast<size_t>(lo + i)].vertices[k] - vmin);
+            row[k] = MAP.empty() ? local : MAP[static_cast<size_t>(local)];
         }
         if (row[0] == row[1] || row[1] == row[2] || row[2] == row[0]) {
             ++degen;
@@ -301,47 +340,15 @@ ZoneClean::ZoneClean(
         error_ = zone_name + ": weld produced " + std::to_string(degen) + " degenerate tris";
         return;
     }
+    std::vector<int32_t>().swap(MAP);
 
-    mesh = PolyMesh(std::move(CV), std::move(CT2), std::move(CH));
+    // 同一条有向边出现两次以上的槽, 与邻接一趟分桶顺带标出
+    std::vector<uint8_t> dup;
+    mesh = source_exact ? PolyMesh(pverts.data() + vmin, nv, std::move(CT2), &dup)
+                        : PolyMesh(std::move(CV), std::move(CT2), &dup);
     const auto& T = mesh.T;
     auto& NB = mesh.NB;
     const int64_t m = static_cast<int64_t>(T.size());
-    const int64_t nvv = static_cast<int64_t>(mesh.V.size());
-
-    // 同一条有向边出现两次以上的槽。按起点分桶后同一条边必落在同一桶里, 桶内平均六项,
-    // 就地数一遍即可, 不必给三倍三角数的边各算一次键再查散列。
-    std::vector<uint8_t> dup(static_cast<size_t>(3 * m), 0);
-    {
-        std::vector<int32_t> at(static_cast<size_t>(nvv) + 1, 0);
-        for (const auto& tri : T) {
-            for (const int32_t a : tri) {
-                ++at[static_cast<size_t>(a) + 1];
-            }
-        }
-        for (int64_t i = 0; i < nvv; ++i) {
-            at[static_cast<size_t>(i) + 1] += at[static_cast<size_t>(i)];
-        }
-        std::vector<int32_t> wr = at;
-        std::vector<int32_t> dst(static_cast<size_t>(3 * m));
-        std::vector<int32_t> slt(static_cast<size_t>(3 * m));
-        for (int64_t i = 0; i < m; ++i) {
-            for (int64_t k = 0; k < 3; ++k) {
-                const auto w = static_cast<size_t>(wr[static_cast<size_t>(T[static_cast<size_t>(i)][k])]++);
-                dst[w] = T[static_cast<size_t>(i)][(k + 1) % 3];
-                slt[w] = static_cast<int32_t>(i * 3 + k);
-            }
-        }
-        for (int64_t v = 0; v < nvv; ++v) {
-            for (int32_t p = at[static_cast<size_t>(v)]; p < at[static_cast<size_t>(v) + 1]; ++p) {
-                for (int32_t q = p + 1; q < at[static_cast<size_t>(v) + 1]; ++q) {
-                    if (dst[static_cast<size_t>(p)] == dst[static_cast<size_t>(q)]) {
-                        dup[static_cast<size_t>(slt[static_cast<size_t>(p)])] = 1;
-                        dup[static_cast<size_t>(slt[static_cast<size_t>(q)])] = 1;
-                    }
-                }
-            }
-        }
-    }
     int64_t n_dup = 0;
     for (int64_t slot = 0; slot < 3 * m; ++slot) {
         if (dup[static_cast<size_t>(slot)] == 0) {
@@ -382,39 +389,11 @@ ZoneClean::ZoneClean(
         NB[static_cast<size_t>(slot / 3)][slot % 3] = -1;
     }
 
-    // NB 掩码:焊接邻接必须在 pack link 表有背书,无背书的缝一律割掉
-    const auto& offs = planner.adjacencyOffsets();
-    const auto& lnks = planner.adjacencyLinks();
-    std::vector<std::pair<int32_t, int32_t>> lab;
-    {
-        const size_t nw = NavWorkerCount(hi - lo);
-        std::vector<std::vector<std::pair<int32_t, int32_t>>> bins(nw);
-        ParallelChunks(hi - lo, nw, [&](size_t w, int64_t b, int64_t e) {
-            for (int64_t src = lo + b; src < lo + e; ++src) {
-                for (uint32_t li = offs[static_cast<size_t>(src)]; li < offs[static_cast<size_t>(src) + 1]; ++li) {
-                    const int64_t tgt = lnks[li];
-                    if (tgt >= lo && tgt < hi && src < tgt) {
-                        bins[w].emplace_back(static_cast<int32_t>(src - lo), static_cast<int32_t>(tgt - lo));
-                    }
-                }
-            }
-        });
-        ConcatBins(bins, lab);
-    }
-    // 有背书的三角对按小号一端分桶。一个三角挂不了几条链接, 桶内直查比散列表快,
-    // 而且查的是同一个集合, 结果与散列表一致。
-    std::vector<int32_t> lat(static_cast<size_t>(m) + 1, 0);
-    for (const auto& e : lab) {
-        ++lat[static_cast<size_t>(e.first) + 1];
-    }
-    for (int64_t i = 0; i < m; ++i) {
-        lat[static_cast<size_t>(i) + 1] += lat[static_cast<size_t>(i)];
-    }
-    std::vector<int32_t> lwr = lat;
-    std::vector<int32_t> lhi(lab.size());
-    for (const auto& e : lab) {
-        lhi[static_cast<size_t>(lwr[static_cast<size_t>(e.first)]++)] = e.second;
-    }
+    // NB 掩码:焊接邻接必须在 pack link 表有背书,无背书的缝一律割掉。
+    // 背书直接问规划器: 小号一端有没有指向大号那端的链接, 不必把整区链接再抄成一份分桶表。
+    const auto endorsed = [&](int32_t a, int32_t b) {
+        return planner.hasLink(static_cast<uint32_t>(lo + a), static_cast<uint32_t>(lo + b));
+    };
     std::vector<int64_t> cand;
     int64_t n_mask_cut = 0;
     {
@@ -437,11 +416,7 @@ ZoneClean::ZoneClean(
                 }
                 const auto a = static_cast<int32_t>(std::min<int64_t>(i, j));
                 const auto b = static_cast<int32_t>(std::max<int64_t>(i, j));
-                bool hit = false;
-                for (int32_t p = lat[static_cast<size_t>(a)]; p < lat[static_cast<size_t>(a) + 1] && !hit; ++p) {
-                    hit = lhi[static_cast<size_t>(p)] == b;
-                }
-                if (!hit) {
+                if (!endorsed(a, b)) {
                     bins[w].push_back(slot);
                 }
             }
@@ -488,29 +463,30 @@ ZoneClean::ZoneClean(
             }
         }
     }
-    comp.resize(static_cast<size_t>(m));
+    // 邻接到此用完, 压成边界位。分量号(par)只用来算孤岛位, 算完随作用域释放。
+    mesh.foldNb();
     for (int64_t i = 0; i < m; ++i) {
-        comp[static_cast<size_t>(i)] = find(static_cast<int32_t>(i));
+        par[static_cast<size_t>(i)] = find(static_cast<int32_t>(i));
     }
 
     // 岛 = 天然分量(pack n 字段)不超过阈值的三角占多数的 comp
-    std::vector<int64_t> n_tot(static_cast<size_t>(m), 0);
-    std::vector<int64_t> n_isl(static_cast<size_t>(m), 0);
+    std::vector<int32_t> n_tot(static_cast<size_t>(m), 0);
+    std::vector<int32_t> n_isl(static_cast<size_t>(m), 0);
     for (int64_t i = 0; i < m; ++i) {
-        ++n_tot[comp[static_cast<size_t>(i)]];
+        ++n_tot[par[static_cast<size_t>(i)]];
         if (planner.isSmallIslandTriangle(static_cast<uint32_t>(lo + i))) {
-            ++n_isl[comp[static_cast<size_t>(i)]];
+            ++n_isl[par[static_cast<size_t>(i)]];
         }
     }
-    comp_island.resize(static_cast<size_t>(m));
-    for (int64_t c = 0; c < m; ++c) {
-        comp_island[static_cast<size_t>(c)] =
-            (n_tot[static_cast<size_t>(c)] == 0 || n_isl[static_cast<size_t>(c)] * 2 > n_tot[static_cast<size_t>(c)]) ? 1 : 0;
+    island.resize(static_cast<size_t>(m));
+    for (int64_t i = 0; i < m; ++i) {
+        const auto c = static_cast<size_t>(par[static_cast<size_t>(i)]);
+        island[static_cast<size_t>(i)] = (n_tot[c] == 0 || n_isl[c] * 2 > n_tot[c]) ? 1 : 0;
     }
 
     int64_t ncomps = 0;
     for (int64_t i = 0; i < m; ++i) {
-        if (comp[static_cast<size_t>(i)] == i) {
+        if (par[static_cast<size_t>(i)] == i) {
             ++ncomps;
         }
     }
@@ -524,8 +500,7 @@ ZoneClean::ZoneClean(
 void ZoneClean::release()
 {
     mesh = PolyMesh();
-    comp = std::vector<int32_t>();
-    comp_island = std::vector<uint8_t>();
+    island = std::vector<uint8_t>();
     walkable = std::vector<uint8_t>();
 }
 
@@ -543,11 +518,11 @@ std::optional<ZoneClean::SnapHit> ZoneClean::snap(const WorldPoint& p, double ra
                 continue; // 掩码外的面不接受吸附;这一关两轮半径都要过
             }
             const auto& tri = mesh.T[static_cast<size_t>(t)];
-            const auto [sp, dist] = closestOnTri(p, { mesh.V[tri[0]], mesh.V[tri[1]], mesh.V[tri[2]] });
+            const auto [sp, dist] = closestOnTri(p, { mesh.v(tri[0]), mesh.v(tri[1]), mesh.v(tri[2]) });
             if (dist > rr) {
                 continue;
             }
-            const double isl = comp_island[comp[static_cast<size_t>(t)]] != 0 ? 1.0 : 0.0;
+            const double isl = island[static_cast<size_t>(t)] != 0 ? 1.0 : 0.0;
             // floor 盲键 (isl, dist, -高度, t) 全序;floor 感知键 (带外, isl, dist, delta)
             // dist 打平只发生在同一 (u,v) 上摞着好几层地面(都含点 ⇒ 都是 0)。此时取最高那层:
             // 底图像素是俯视图上的一点,那点看得见的就是最上面那层。拿三角号破平是任意的 ——

--- a/agent/cpp-algo/source/Navmesh/RecastNavZone.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavZone.h
@@ -30,15 +30,35 @@ inline constexpr uint32_t kWalkableFlagsDefault = 0x00020CDDU;
 
 struct PolyMesh
 {
-    std::vector<WorldPoint> V;
-    std::vector<double> H;
+    // 顶点不复制: 源精确包直接指向包里的 float 数组(vb), 旧包要先取整焊接才自留一份(vown)。
+    // 最大的区有 247 万顶点, 按 double 抄一遍要 59 MB, 而下游算的本来就是这些 float 值。
+    const BaseNavVertex* vb = nullptr;
+    std::vector<BaseNavVertex> vown;
+    int64_t nv = 0;
     std::vector<std::array<int32_t, 3>> T;
+    // 邻接只在 ZoneClean 构造期存在, 分量算完就压成 bnd(第 k 位 = 第 k 条边无邻居)并释放:
+    // 运行期唯一的读者 BakeWalls 只问"这条边是不是边界", 12 字节/三角换 1 字节。
     std::vector<std::array<int32_t, 3>> NB;
+    std::vector<uint8_t> bnd;
 
     PolyMesh() = default;
-    PolyMesh(std::vector<WorldPoint> v, std::vector<std::array<int32_t, 3>> t, std::vector<double> h);
+    // dup 非空时顺便标出"同一条有向边出现两次以上"的槽(3*三角数, 按 i*3+k 索引):
+    // 它和邻接用同一套按起点分桶的边表, 单独再建一遍要多占三倍三角数的两张 int32 表。
+    PolyMesh(const BaseNavVertex* vb, int64_t nv, std::vector<std::array<int32_t, 3>> t, std::vector<uint8_t>* dup = nullptr);
+    PolyMesh(std::vector<BaseNavVertex> own, std::vector<std::array<int32_t, 3>> t, std::vector<uint8_t>* dup = nullptr);
 
-    void buildNb();
+    const BaseNavVertex* verts() const { return vown.empty() ? vb : vown.data(); }
+
+    WorldPoint v(int32_t i) const
+    {
+        const BaseNavVertex& p = verts()[i];
+        return { static_cast<double>(p.u), static_cast<double>(p.v) };
+    }
+
+    double h(int32_t i) const { return static_cast<double>(verts()[i].height); }
+
+    void buildNb(std::vector<uint8_t>* dup);
+    void foldNb(); // NB → bnd, 然后释放 NB
     std::vector<int32_t> trisNear(const WorldPoint& p, double r) const;                // 升序去重
     std::vector<int32_t> trisInBox(double x0, double y0, double x1, double y1) const;  // 升序去重
 
@@ -82,8 +102,7 @@ public:
     int64_t lo = 0;
     int64_t hi = 0;
     PolyMesh mesh;
-    std::vector<int32_t> comp;        // 三角 → 分量代表(区内最小三角号)
-    std::vector<uint8_t> comp_island; // 按分量代表值索引
+    std::vector<uint8_t> island; // 逐三角: 所在分量以小岛三角为主。分量号本身没人读, 不留
     // 逐三角可走标记,与 mesh.T 同长同序。掩码外的三角照样占着自己那一行 ——
     // RecastNavRoute 拿 (全局三角号 - lo) 直接索引 mesh,下标身份是硬约束,只能就地打标,
     // 绝不能压缩重排。

--- a/tools/MapNavigator/README.md
+++ b/tools/MapNavigator/README.md
@@ -213,10 +213,11 @@ BaseNav 用于直接从 GLB 三角面生成寻路数据。它不是展示图，�
 
 ```text
 assets/resource/model/map/navmesh/base.nav.gz
+assets/resource/model/map/navmesh/base.fields.nav.gz   # 与主包配对的预烘场旁包
 assets/resource/model/map/navmesh/base.nav      # optional local fallback
 ```
 
-寻路要求包内带预烘格图段（`BGRD`，见 BaseNav 版本 4）；没有这一段的包仍可显示网格与底图，但点不出线路。
+寻路要求包内带预烘格图段（`BGRD`，见 BaseNav 版本 4）；没有这一段的包仍可显示网格与底图，但点不出线路。运行时还会从主包同目录读取同名的 `*.fields.nav.gz` 旁包（magic `BNVF`），里面是按类烘好的可达域分量图、禁步重判位、留墙表、台阶税边、封缝净空与中轴（BNVF v2）；旁包缺失、或其记录的主包哈希与当前主包不符时，规划直接报错而不会退回运行期重建，换主包必须连旁包一起换。
 
 可选 zone：
 

--- a/tools/MapNavigator/README.md
+++ b/tools/MapNavigator/README.md
@@ -217,7 +217,7 @@ assets/resource/model/map/navmesh/base.fields.nav.gz   # 与主包配对的预�
 assets/resource/model/map/navmesh/base.nav      # optional local fallback
 ```
 
-寻路要求包内带预烘格图段（`BGRD`，见 BaseNav 版本 4）；没有这一段的包仍可显示网格与底图，但点不出线路。运行时还会从主包同目录读取同名的 `*.fields.nav.gz` 旁包（magic `BNVF`），里面是按类烘好的可达域分量图、禁步重判位、留墙表、台阶税边、封缝净空与中轴（BNVF v2）；旁包缺失、或其记录的主包哈希与当前主包不符时，规划直接报错而不会退回运行期重建，换主包必须连旁包一起换。
+当前 BaseNav 格式版本为 5（v4 起带段目录，v5 起几何分段存放）；寻路要求包内带预烘格图段 `BGRD`，没有这一段的包仍可显示网格与底图，但点不出线路。运行时还会从主包同目录读取同名的 `*.fields.nav.gz` 旁包（magic `BNVF`），里面是按类烘好的可达域分量图、禁步重判位、留墙表、台阶税边、封缝净空与中轴（BNVF v2）；旁包缺失、或其记录的主包哈希与当前主包不符时，规划直接报错而不会退回运行期重建，换主包必须连旁包一起换。
 
 可选 zone：
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持加载与主导航包配套的预烘字段旁包，提供净空、连通性、台阶及边界等数据。
  - 路径规划支持搜索范围逐级扩展、升级原因记录及整区域回退。
  - 导航包提供路径、构建标识和文件校验信息。
  - 路径结果支持累计代价和更丰富的调试信息。

- **改进**
  - 优化导航网格索引与路径搜索，降低运行时计算开销。

- **错误处理**
  - 旁包缺失、版本或校验不匹配时明确报错。

- **文档**
  - 更新导航文件格式、旁包配对规则及回退行为说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->