### PR TITLE
fix: 切换贵重品库失败

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneMenu.json
+++ b/assets/resource/pipeline/SceneManager/SceneMenu.json
@@ -1176,6 +1176,7 @@
                 "template": "SceneManager/ProgressionTabNotChoose.png"
             }
         },
+        "pre_wait_freezes": 100,
         "action": {
             "type": "Click"
         },


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **体验优化**
  - 切换培养素材标签页前增加短暂等待时间，使标签页切换过程更加稳定、顺畅。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->