### PR TITLE
fix: 协议空间庄方宜大招结束位移导致无法领取奖励

### DIFF
--- a/assets/resource/pipeline/ProtocolSpace/InSpace.json
+++ b/assets/resource/pipeline/ProtocolSpace/InSpace.json
@@ -580,9 +580,56 @@
         ],
         "box_index": 1,
         "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "AutoAltClickAction",
+        "action": "ClickKey",
+        "key": 70, // F 交互
+        "post_delay": 2000, // 等一下看有没有弹出界面，如果没有的话继续找，避免例如庄方宜在此时大招结束位移
+        "next": [
+            "ProtocolSpaceReward",
+            "ProtocolSpaceTouchExitRetry"
+        ],
+        "focus": {
+            "Node.Action.Succeeded": "$task.ProtocolSpace.focus.open_reward"
+        }
+    },
+    "ProtocolSpaceTouchExitRetry": {
+        "desc": "触碰后仍在协议空间，重新找退出点",
+        "recognition": "And",
+        "all_of": [
+            "InProtocolSpace"
+        ],
+        "pre_delay": 0,
         "post_delay": 0,
+        "next": [
+            "ProtocolSpaceTouchExitTouchRetry",
+            "[JumpBack]ProtocolSpaceTouchExitMoveToTarget",
+            "[JumpBack]ProtocolSpaceTouchExitNotFound"
+        ]
+    },
+    "ProtocolSpaceTouchExitTouchRetry": {
+        "desc": "重试触碰退出点",
+        "recognition": "And",
+        "all_of": [
+            "InProtocolSpace",
+            {
+                "recognition": "OCR",
+                "roi": [
+                    755,
+                    330,
+                    297,
+                    312
+                ],
+                "expected": [
+                    "领取",
+                    "領取",
+                    "[Cc]laim",
+                    "受取",
+                    "획득하기"
+                ]
+            }
+        ],
+        "box_index": 1,
+        "action": "ClickKey",
+        "key": 70, // F 交互
         "next": [
             "ProtocolSpaceReward"
         ],

--- a/assets/tasks/setting/Keymap.json
+++ b/assets/tasks/setting/Keymap.json
@@ -58,6 +58,12 @@
                 },
                 "AutoPickInteractive": {
                     "key": "{KeymapInteract.primary}"
+                },
+                "ProtocolSpaceTouchExitTouch": {
+                    "key": "{KeymapInteract.primary}"
+                },
+                "ProtocolSpaceTouchExitTouchRetry": {
+                    "key": "{KeymapInteract.primary}"
                 }
             }
         },


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **交互优化**
  - 协议空间退出操作改为按下 F 键，交互完成后的等待时间延长，提升操作稳定性。

- **流程改进**
  - 退出后若仍处于协议空间，将自动重新识别退出点并尝试交互。
  - 重试成功后进入奖励界面；失败时会继续寻找退出点。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->