### PR TITLE
fix(EssenceFilter): 点击基质格子时向中心收束点击区域

### DIFF
--- a/assets/resource/pipeline/EssenceFilter/EssenceGridScan.json
+++ b/assets/resource/pipeline/EssenceFilter/EssenceGridScan.json
@@ -59,7 +59,16 @@
         },
         "pre_delay": 0,
         "action": {
-            "type": "Click"
+            // target_offset 为 [dx, dy, dw, dh]：96x96 格子向中心收束为 48x48，避免落点偏散
+            "type": "Click",
+            "param": {
+                "target_offset": [
+                    24,
+                    24,
+                    -48,
+                    -48
+                ]
+            }
         },
         "post_wait_freezes": {
             "time": 50,


### PR DESCRIPTION
- EssenceGridClickPending 增加 target_offset [24, 24, -48, -48]
- 96x96 格子点击框四边各向中心收 24px，落点集中在中心区域，避免偏散

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **问题修复**
  - 优化 EssenceGrid 的点击判定区域：将原 96×96 网格的有效点击范围调整为居中的 48×48 区域，并相应设置点击偏移。
  - 点击类型及后续处理流程保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->