### PR TITLE
fix(essencefilter): sync_zmdmap 数据源迁移至 assets.fz.wiki/output_maaend

### DIFF
--- a/tools/essence_filter/sync_zmdmap.py
+++ b/tools/essence_filter/sync_zmdmap.py
@@ -13,7 +13,9 @@ from urllib.request import Request, urlopen
 
 
 VERSION_API = "https://api.zmdmap.com/api/v1/endfield/version"
-DATA_BASE_URL = "https://assets.zmdmap.com/data/entity"
+# zmdmap 数据 CI 已把精简游戏数据发布到 assets.fz.wiki/output_maaend（旧地址
+# assets.zmdmap.com/data/entity 已停用），下载时需带 ?ver=<version>。
+DATA_BASE_URL = "https://assets.fz.wiki/output_maaend"
 LANGS = ("CN", "TC", "EN", "JP", "KR")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -25,7 +27,8 @@ TARGETS = {
 
 
 def _url(url: str) -> str:
-    return f"{url}?{urlencode({'source': 'MaaEnd', 't': time.time_ns() // 1_000_000})}"
+    sep = "&" if "?" in url else "?"
+    return f"{url}{sep}{urlencode({'source': 'MaaEnd', 't': time.time_ns() // 1_000_000})}"
 
 
 def _download_json(url: str) -> Any | None:
@@ -74,7 +77,8 @@ def _download_sources(version: str) -> dict[str, Any] | None:
     }
     result: dict[str, Any] = {}
     for filename, validator in validators.items():
-        url = f"{DATA_BASE_URL}/{quote(version, safe='')}/{filename}"
+        # output_maaend 使用查询参数 ?ver=<version> 指定数据版本（与 fetch-data.mjs 一致）。
+        url = f"{DATA_BASE_URL}/{filename}?ver={quote(version, safe='')}"
         data = _download_json(url)
         if not validator(data):
             print(f"[EssenceFilter] 跳过同步：{filename} 为空或结构无效")


### PR DESCRIPTION
zmdmap 数据 CI 已把精简游戏数据发布地址从 assets.zmdmap.com/data/entity 迁移到 assets.fz.wiki/output_maaend，下载接口改为 ?ver=<version> 查询参数。 旧地址已返回 404，导致 EssenceFilter 同步工具无法拉取最新数据。

- DATA_BASE_URL 更新为新发布地址
- 下载 URL 改用 ?ver=<version> 指定数据版本（与 fetch-data.mjs 一致）
- _url() 在 URL 已含查询参数时改用 & 分隔附加 source/t

数据文件（weapons_output/energy_point_gems/skill_pools/locations/matcher_config） 由 CI 的 Sync ZmdMap Data workflow 自动生成并单独开 PR，不在此提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 数据同步现已切换至新的数据源地址，避免继续使用已停用的来源。
  - 下载请求支持按版本获取数据，提升数据更新的准确性与可控性。
  - 优化请求参数处理，兼容已有查询参数，并继续附加必要的来源与时间信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->