### PR TITLE
fix(account-switch): 加高复核节点 roi_offset 高度，修复邮箱识别失败

### DIFF
--- a/assets/resource/pipeline/AccountSwitch.json
+++ b/assets/resource/pipeline/AccountSwitch.json
@@ -282,9 +282,9 @@
                 "roi": "__AccountSwitchClickDropdown",
                 "roi_offset": [
                     -15,
-                    -15,
+                    -20,
                     60,
-                    30
+                    40
                 ],
                 "expected": [
                     // @i18n-skip
@@ -310,9 +310,9 @@
                 "roi": "__AccountSwitchClickDropdown",
                 "roi_offset": [
                     -15,
-                    -15,
+                    -20,
                     60,
-                    30
+                    40
                 ],
                 "expected": [
                     // @i18n-skip


### PR DESCRIPTION
## 问题
账号切换流程在关闭下拉后，由`__AccountSwitchCheckAccount`和`__AccountSwitchVerifySelected`OCR当前选中账号区域，这两个节点的`roi_offset`偏紧凑，2k分辨率下覆盖不全邮箱地址，存在识别失败的问题

## 改动
加高`__AccountSwitchCheckAccount`和`__AccountSwitchVerifySelected`对当前选中账号区域的`roi_offset`上下高度
调整后顶部上移5px、底部下移5px，同场景测试不再复现识别失败的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 调整账号检查与选中验证节点的 OCR 识别区域，扩大并向左移动范围，提升相关内容的识别覆盖率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->