### PR TITLE
fix: 补全菜单列表文字的多语言识别(#5515)

### DIFF
--- a/assets/resource/pipeline/Interface/InScene/Region.json
+++ b/assets/resource/pipeline/Interface/InScene/Region.json
@@ -380,7 +380,15 @@
         ],
         "expected": [
             "权限等阶",
-            "探索等级"
+            "權限等階",
+            "Authority Level",
+            "行動レベル",
+            "권한 등급",
+            "探索等级",
+            "探索等級",
+            "Exploration Level",
+            "探索レベル",
+            "탐색 레벨"
         ],
         "pre_delay": 0,
         "post_delay": 0,


### PR DESCRIPTION
# 问题
菜单列表增加“权限等阶”和“探索等级”文本，降低误识别时，未适配多语言，导致国际版本卡菜单页面

# 改动
增加“权限等阶”和“探索等级”多语言文本

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **本地化**
  * 新增繁体中文、英语、日语和韩语的“权限等阶”及“探索等级”文本匹配支持。
  * 保留简体中文的原有文本匹配。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->