### PR TITLE
feat(EssenceFilter): 支持导出基质库存

### DIFF
--- a/agent/go-service/essencefilter/README.md
+++ b/agent/go-service/essencefilter/README.md
@@ -33,6 +33,7 @@ Go 只通过 `ctx.OverrideNext` 选择 Pipeline 分支：
 | `options.go` | 从合并后的节点 `attach` 读取运行选项 |
 | `ui.go` | MXU 展示、匹配摘要和预刻写输出 |
 | `plan_export.go` | 可选的 `EssencePlan.html` 导出 |
+| `inventory.go` | 无暇库存分组计数和 `EssenceInventory.json` 导出 |
 | `matchapi/` | 可复用的纯匹配 API：`OCRInput -> MatchResult` |
 | `register.go` | 注册本包 CustomAction / CustomRecognition |
 
@@ -45,7 +46,17 @@ Go 只通过 `ctx.OverrideNext` 选择 Pipeline 分支：
 5. Pipeline 识别按钮、点击并确认状态。
 6. `EssenceFilterFinishAction` 输出统计并把 `currentRun` 置空。
 
-Agent 回调按当前框架模型串行执行，因此 `currentRun` 不加锁。新的任务必须先经过 Init，Finish 后状态不再复用。
+Agent 回调按当前框架模型串行执行，因此 `currentRun` 不加锁。新的任务先经过 Init，正常 Finish 清理状态；失败或中断时由任务结束事件按 TaskID 清理。战后仅在同一任务内保留累计统计。
+
+## 输出基质库存
+
+任务顶层的「输出基质库存」默认关闭。开启时 UI 仅显示游戏语言和库存输出开关，原筛选选项放在关闭分支下，关闭后重新显示。盘点使用固定预设：只读取未标记弃置的无暇基质（包括已锁定的基质），匹配全部四至六星武器，不执行锁定、弃置、扩展规则和预刻写推荐。弃置项在缩略图阶段排除，不点击、不调用 OCR、不计入库存。网格参数只覆盖品质与跳过标志，保留控制器对应的 ROI 和滑动配置。
+
+输出为工作目录下的 `EssenceInventory.json`，结构见 [库存 Schema](../../../tools/schema/essence_inventory.schema.json)。每个词条组合一组，武器共享该组的 `essences` 等级与数量分布；数量不乘以武器数。等级依次为基础属性、附加属性、技能属性。无匹配结果输出 `[]`。
+
+`Engine.MatchInventoryOCR` 区分已识别但不匹配的基质与识别失败。网格遍历、品质过滤与跨页去重交给 C++ 和框架；Go 每收到一份完整识别结果就汇总一次，不回查网格状态或校验扫描编号。
+
+库存模式通过 Pipeline 预设把 OCR fallback、点击失败及入口失败改为 `StopTask`，不跳格继续。合法但不适配的基质照常略过；OCR 文本无法解析或等级非法则由 Go 返回动作失败。只有正常到达 Finish 才写入 `EssenceInventory.json`，并在临时文件写完、关闭后替换旧文件；失败或中断保留旧导出。普通筛选仍使用原有 fallback。
 
 ## 匹配数据
 

--- a/agent/go-service/essencefilter/actions.go
+++ b/agent/go-service/essencefilter/actions.go
@@ -29,12 +29,13 @@ func (a *EssenceFilterInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg
 	log.Info().Str("component", "EssenceFilter").Msg("init start")
 
 	// EssenceFilterAfterBattleInit：每次战利品流程都会进入；仅首次做下方完整初始化，之后每次只做 afterBattleInitResetPerLoot。
-	if arg != nil && arg.CurrentTaskName == "EssenceFilterAfterBattleInit" {
-		if st := currentRun; st != nil && st.MatchEngine != nil {
+	if arg.CurrentTaskName == "EssenceFilterAfterBattleInit" {
+		if st := currentRun; st != nil && st.TaskID == arg.TaskID {
 			afterBattleInitResetPerLoot(st)
 			return true
 		}
 	}
+	currentRun = nil
 
 	engine, opts, err := loadMatchEngine(ctx, arg.CurrentTaskName)
 	if err != nil {
@@ -42,6 +43,7 @@ func (a *EssenceFilterInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg
 		reportFocusByKey(ctx, "focus.error.load_engine_failed", err.Error())
 		return false
 	}
+	*opts = inventoryPreset(*opts)
 	inputLocale := engine.Locale()
 
 	log.Info().Str("component", "EssenceFilter").Str("input_language", inputLocale).Msg("match engine ready")
@@ -79,7 +81,7 @@ func (a *EssenceFilterInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg
 		essenceMode = EssenceModePureOnly
 	}
 
-	st := &RunState{}
+	st := &RunState{TaskID: arg.TaskID}
 	st.PipelineOpts = *opts
 	st.MatchEngine = engine
 	st.EssenceMode = essenceMode
@@ -88,6 +90,13 @@ func (a *EssenceFilterInitAction) Run(ctx *maa.Context, arg *maa.CustomActionArg
 	st.TargetSkillCombinations = engine.BuildTargets(matchOpts)
 	st.MatchedCombinationSummary = make(map[string]*matchapi.SkillCombinationSummary)
 	currentRun = st
+	if opts.ExportInventory {
+		st.Inventory = &inventoryState{groups: make(map[[3]int]*inventoryCounts)}
+		if err := ctx.OverridePipeline(inventoryGridOverride()); err != nil {
+			return inventoryFailed(err)
+		}
+		reportSimpleByKey(ctx, "inventory.started")
+	}
 	reportInitSelection(ctx, weaponRarity, essenceTypes)
 
 	names := make([]string, 0, len(st.TargetSkillCombinations))
@@ -210,6 +219,14 @@ func (a *EssenceFilterSkillDecisionAction) Run(ctx *maa.Context, arg *maa.Custom
 		reportFocusByKey(ctx, "focus.error.no_match_engine")
 		return false
 	}
+	if st.Inventory != nil {
+		match, err := st.MatchEngine.MatchInventoryOCR(ocr)
+		if err != nil {
+			return inventoryFailed(err)
+		}
+		st.Inventory.record(match)
+		return true
+	}
 	return runUnifiedSkillDecision(ctx, arg, st, st.MatchEngine, ocr, decisionNextNodes{
 		Lock:    "EssenceFilterLockItem",
 		Discard: "EssenceFilterDiscardItem",
@@ -225,7 +242,14 @@ type EssenceFilterFinishAction struct{}
 func (a *EssenceFilterFinishAction) Run(ctx *maa.Context, arg *maa.CustomActionArg) bool {
 	log.Info().Str("component", "EssenceFilter").Msg("finish")
 	st := currentRun
-	if st != nil {
+	if st == nil {
+		return true
+	}
+	if st.Inventory != nil {
+		if !finishInventory(ctx, st) {
+			return false
+		}
+	} else {
 		log.Info().Str("component", "EssenceFilter").Int("matched_total", st.MatchedCount).Msg("locked items")
 		reportColoredByKey(ctx, "#11cf00", "focus.finish.summary", st.MatchedCount)
 		reportFinishExtRuleStats(ctx, st)

--- a/agent/go-service/essencefilter/inventory.go
+++ b/agent/go-service/essencefilter/inventory.go
@@ -1,0 +1,115 @@
+package essencefilter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/essencefilter/matchapi"
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+	"github.com/rs/zerolog/log"
+)
+
+const inventoryExportPath = "EssenceInventory.json"
+
+type inventoryEssence struct {
+	Levels [3]int `json:"levels"`
+	Count  int    `json:"count"`
+}
+
+type inventoryGroup struct {
+	WeaponIDs []string           `json:"weapon_ids"`
+	Essences  []inventoryEssence `json:"essences"`
+}
+
+type inventoryCounts struct {
+	weaponIDs []string
+	levels    map[[3]int]int
+}
+
+type inventoryState struct {
+	groups map[[3]int]*inventoryCounts
+}
+
+// record aggregates one essence selected by the grid scanner.
+func (s *inventoryState) record(match *matchapi.InventoryMatch) {
+	if match == nil {
+		return
+	}
+	group := s.groups[match.SkillIDs]
+	if group == nil {
+		group = &inventoryCounts{levels: make(map[[3]int]int)}
+		for _, weapon := range match.Weapons {
+			group.weaponIDs = append(group.weaponIDs, weapon.InternalID)
+		}
+		slices.Sort(group.weaponIDs)
+		s.groups[match.SkillIDs] = group
+	}
+	group.levels[match.Levels]++
+}
+
+func (s *inventoryState) exportGroups() ([]inventoryGroup, int) {
+	groups := make([]inventoryGroup, 0, len(s.groups))
+	total := 0
+	for _, counts := range s.groups {
+		group := inventoryGroup{WeaponIDs: counts.weaponIDs}
+		for levels, count := range counts.levels {
+			group.Essences = append(group.Essences, inventoryEssence{Levels: levels, Count: count})
+			total += count
+		}
+		slices.SortFunc(group.Essences, func(a, b inventoryEssence) int {
+			return slices.Compare(a.Levels[:], b.Levels[:])
+		})
+		groups = append(groups, group)
+	}
+	slices.SortFunc(groups, func(a, b inventoryGroup) int {
+		return slices.Compare(a.WeaponIDs, b.WeaponIDs)
+	})
+	return groups, total
+}
+
+func inventoryFailed(err error) bool {
+	log.Error().Err(err).Str("component", "EssenceInventory").Msg("inventory not exported")
+	return false
+}
+
+func finishInventory(ctx *maa.Context, st *RunState) bool {
+	groups, total := st.Inventory.exportGroups()
+	path, err := filepath.Abs(inventoryExportPath)
+	if err == nil {
+		err = writeInventoryFile(path, groups)
+	}
+	if err != nil {
+		return inventoryFailed(err)
+	}
+	log.Info().Str("component", "EssenceInventory").Str("path", path).
+		Int("groups", len(groups)).Int("count", total).Msg("inventory exported")
+	reportSimpleByKey(ctx, "inventory.saved", path, len(groups), total)
+	return true
+}
+
+func writeInventoryFile(path string, groups []inventoryGroup) error {
+	data, err := json.MarshalIndent(groups, "", "    ")
+	if err != nil {
+		return err
+	}
+	// Follow the existing snapshot writers: replace only after the temporary
+	// file has been written, synced and closed. Never delete the previous export.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".EssenceInventory-*.tmp")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+	if _, err = tmp.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	if err = tmp.Sync(); err != nil {
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}

--- a/agent/go-service/essencefilter/matchapi/README.md
+++ b/agent/go-service/essencefilter/matchapi/README.md
@@ -24,6 +24,8 @@ matchapi 只返回结构化匹配结果；面向用户的文案由上层 `essenc
 
 ## 最简单用法：只调用匹配
 
+库存盘点使用 `engine.MatchInventoryOCR(ocr)`：固定匹配全部四至六星武器，返回 `InventoryMatch` 中的组合 ID、按基础属性／附加属性／技能属性排列的等级，以及全部适配武器。已识别但不匹配的组合返回 `(nil, nil)`；无法解析的词条或非法等级返回错误。此入口不返回锁定或弃置指令。
+
 ```go
 engine, err := matchapi.NewDefaultEngine()
 if err != nil {

--- a/agent/go-service/essencefilter/matchapi/engine.go
+++ b/agent/go-service/essencefilter/matchapi/engine.go
@@ -2,6 +2,7 @@ package matchapi
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -251,6 +252,46 @@ func (e *Engine) MatchOCR(ocr OCRInput, opts EssenceFilterOptions) (*MatchResult
 		ShouldLock:    false,
 		ShouldDiscard: opts.DiscardUnmatched,
 	}, nil
+}
+
+// MatchInventoryOCR matches against all supported four- to six-star weapons.
+// A resolved but incompatible essence returns (nil, nil); unresolved skills or
+// invalid levels return an error. No filtering or lock/discard rules are applied.
+func (e *Engine) MatchInventoryOCR(ocr OCRInput) (*InventoryMatch, error) {
+	e.ensureSlotIndices()
+	var result InventoryMatch
+	var used [3]bool
+	for i, text := range ocr.Skills {
+		slot, ok := e.assignSlotForOCRText(text)
+		if !ok {
+			return nil, fmt.Errorf("cannot resolve skill at position %d: %q", i+1, text)
+		}
+		id, _ := e.matchSkillIDEnhanced(slot, text)
+		maxLevel := 6
+		if slot == 3 {
+			maxLevel = 3
+		}
+		if ocr.Levels[i] < 1 || ocr.Levels[i] > maxLevel {
+			return nil, fmt.Errorf("invalid level %d for skill pool %d", ocr.Levels[i], slot)
+		}
+		used[slot-1] = true
+		result.SkillIDs[slot-1] = id
+		result.Levels[slot-1] = ocr.Levels[i]
+	}
+	// Multiple skills from the same pool are valid inventory, but cannot match
+	// a weapon's three distinct pools. Validate every skill before skipping them.
+	if used != [3]bool{true, true, true} {
+		return nil, nil
+	}
+	targets := e.BuildTargets(EssenceFilterOptions{
+		Rarity4Weapon: true, Rarity5Weapon: true, Rarity6Weapon: true,
+	})
+	match, ok := matchSkillIDs(result.SkillIDs, targets)
+	if !ok {
+		return nil, nil
+	}
+	result.Weapons = match.Weapons
+	return &result, nil
 }
 
 // reorderByPoolAssignmentIfPossible reorders OCR skills/levels into slot1/2/3 order

--- a/agent/go-service/essencefilter/matchapi/matcher.go
+++ b/agent/go-service/essencefilter/matchapi/matcher.go
@@ -143,7 +143,10 @@ func (e *Engine) matchEssenceSkills(ocrSkills [3]string, targets []SkillCombinat
 		}
 		ocrIDs[i] = id
 	}
+	return matchSkillIDs(ocrIDs, targets)
+}
 
+func matchSkillIDs(ocrIDs [3]int, targets []SkillCombination) (*SkillCombinationMatch, bool) {
 	var matchedWeapons []WeaponData
 	var skillIDs []int
 	var skillsChinese []string

--- a/agent/go-service/essencefilter/matchapi/types.go
+++ b/agent/go-service/essencefilter/matchapi/types.go
@@ -90,6 +90,13 @@ type OCRInput struct {
 	Levels [3]int    // slot1..slot3 levels
 }
 
+// InventoryMatch describes an exact weapon match with levels in semantic slot order.
+type InventoryMatch struct {
+	SkillIDs [3]int
+	Levels   [3]int
+	Weapons  []WeaponData
+}
+
 type MatchKind int
 
 const (

--- a/agent/go-service/essencefilter/matchapi/util.go
+++ b/agent/go-service/essencefilter/matchapi/util.go
@@ -54,11 +54,11 @@ func normalizeForMatchEN(text string) string {
 func normalizeForMatchJP(text string) string {
 	var b strings.Builder
 	for _, r := range text {
-		if unicode.Is(unicode.Han, r) ||
+		if unicode.Is(unicode.Han, r) || unicode.Is(unicode.Latin, r) || // HP / UP are part of Japanese skill names.
 			(r >= 0x3040 && r <= 0x309F) || // Hiragana
 			(r >= 0x30A0 && r <= 0x30FF) || // Katakana
 			(r >= 0xFF66 && r <= 0xFF9F) { // Halfwidth Katakana
-			b.WriteRune(r)
+			b.WriteRune(unicode.ToUpper(r))
 		}
 	}
 	return b.String()

--- a/agent/go-service/essencefilter/options.go
+++ b/agent/go-service/essencefilter/options.go
@@ -12,6 +12,33 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+func inventoryPreset(opts EssenceFilterOptions) EssenceFilterOptions {
+	if !opts.ExportInventory {
+		return opts
+	}
+	return EssenceFilterOptions{
+		ExportInventory: true,
+		InputLanguage:   opts.InputLanguage,
+		FlawlessEssence: true,
+		Rarity4Weapon:   true,
+		Rarity5Weapon:   true,
+		Rarity6Weapon:   true,
+	}
+}
+
+func inventoryGridOverride() map[string]any {
+	return map[string]any{
+		"EssenceGridAdvance": map[string]any{
+			"attach": map[string]any{
+				"flawless_essence":   true,
+				"pure_essence":       false,
+				"skip_thumb_lock":    false,
+				"skip_thumb_discard": true,
+			},
+		},
+	}
+}
+
 // matchOptsFromPipeline maps pipeline attach options to the match engine subset.
 func matchOptsFromPipeline(opts *EssenceFilterOptions) matchapi.EssenceFilterOptions {
 	if opts == nil {

--- a/agent/go-service/essencefilter/register.go
+++ b/agent/go-service/essencefilter/register.go
@@ -3,6 +3,7 @@ package essencefilter
 import maa "github.com/MaaXYZ/maa-framework-go/v4"
 
 func Register() {
+	maa.AgentServerAddTaskerSink(&runStateResetSink{})
 	maa.AgentServerRegisterCustomAction("EssenceFilterInitAction", &EssenceFilterInitAction{})
 	maa.AgentServerRegisterCustomAction("EssenceFilterCheckItemAction", &EssenceFilterCheckItemAction{})
 	maa.AgentServerRegisterCustomAction("EssenceFilterCheckItemLevelAction", &EssenceFilterCheckItemLevelAction{})

--- a/agent/go-service/essencefilter/state.go
+++ b/agent/go-service/essencefilter/state.go
@@ -1,12 +1,19 @@
 package essencefilter
 
-import "github.com/MaaXYZ/MaaEnd/agent/go-service/essencefilter/matchapi"
+import (
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/essencefilter/matchapi"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/i18n"
+	"github.com/MaaXYZ/MaaEnd/agent/go-service/pkg/maafocus"
+	maa "github.com/MaaXYZ/maa-framework-go/v4"
+)
 
 var currentRun *RunState
 
 // RunState holds all runtime state for a single EssenceFilter run.
 // Init allocates it; Finish clears it. Agent callbacks execute serially.
 type RunState struct {
+	TaskID    int64
+	Inventory *inventoryState
 	// Stats
 	MatchedCount            int
 	ExtFuturePromisingCount int
@@ -31,4 +38,23 @@ type RunState struct {
 
 	// PipelineOpts is a copy of EssenceFilterInit attach JSON; filled in Init for the run (avoids re-parsing).
 	PipelineOpts EssenceFilterOptions
+}
+
+// runStateResetSink clears state even when a task is stopped before Finish.
+type runStateResetSink struct{}
+
+var _ maa.TaskerEventSink = &runStateResetSink{}
+
+func (*runStateResetSink) OnTaskerTask(_ *maa.Tasker, event maa.EventStatus, detail maa.TaskerTaskDetail) {
+	if event != maa.EventStatusSucceeded && event != maa.EventStatusFailed {
+		return
+	}
+	st := currentRun
+	if st == nil || st.TaskID != int64(detail.TaskID) {
+		return
+	}
+	currentRun = nil
+	if st.Inventory != nil {
+		maafocus.PrintLargeContent(i18n.T("essencefilter.inventory.failed"))
+	}
 }

--- a/agent/go-service/essencefilter/types.go
+++ b/agent/go-service/essencefilter/types.go
@@ -23,6 +23,8 @@ type EssenceFilterOptions struct {
 	DiscardUnmatched bool `json:"discard_unmatched"`
 	// 筛选结束后推荐预刻写方案（枚举最优方案并输出到日志）；开启时会同时写入工作目录 ./EssencePlan.html（每次覆盖）
 	ExportCalculatorScript bool `json:"export_calculator_script"`
+	// ExportInventory selects the read-only flawless inventory preset.
+	ExportInventory bool `json:"export_inventory"`
 	// InputLanguage is game/OCR language for skill matching: CN|TC|EN|JP|KR (default CN).
 	InputLanguage string `json:"input_language"`
 }

--- a/assets/locales/go-service/en_us.json
+++ b/assets/locales/go-service/en_us.json
@@ -1,4 +1,7 @@
 {
+    "essencefilter.inventory.started": "Scanning flawless essences, including locked ones. Discarded essences are skipped without OCR. All supported 4- to 6-star weapons are matched; marks are not changed.",
+    "essencefilter.inventory.saved": "Essence inventory exported to %s: %d groups, %d essences.",
+    "essencefilter.inventory.failed": "Essence inventory was not updated. Any existing file is unchanged. See the logs for the failure reason.",
     "visitfriends.friend_missing": "Friend is missing: %s",
     "visitfriends.clue_exchange": "Clue Exchange",
     "visitfriends.control_nexus_assist": "Control Nexus Assist",

--- a/assets/locales/go-service/ja_jp.json
+++ b/assets/locales/go-service/ja_jp.json
@@ -1,4 +1,7 @@
 {
+    "essencefilter.inventory.started": "ロック済みも含む無瑕基質をスキャンします。破棄マーク付きの基質は OCR を行わずスキップします。対応するすべての星4～6武器と照合し、マークは変更しません。",
+    "essencefilter.inventory.saved": "基質の所持数を %s に出力しました：%d グループ、基質 %d 個。",
+    "essencefilter.inventory.failed": "基質の所持数は更新されませんでした。既存のファイルは変更されていません。失敗の原因はログをご確認ください。",
     "visitfriends.friend_missing": "フレンドに %s がありません",
     "visitfriends.clue_exchange": "手がかり交換",
     "visitfriends.control_nexus_assist": "制御中枢支援",

--- a/assets/locales/go-service/ko_kr.json
+++ b/assets/locales/go-service/ko_kr.json
@@ -1,4 +1,7 @@
 {
+    "essencefilter.inventory.started": "잠금 상태와 관계없이 무결 기질을 스캔합니다. 폐기 표시된 기질은 OCR 없이 건너뜁니다. 지원되는 모든 4~6성 무기와 매칭하며 표시는 변경하지 않습니다.",
+    "essencefilter.inventory.saved": "기질 보유 현황을 %s에 내보냈습니다: %d개 그룹, 기질 %d개.",
+    "essencefilter.inventory.failed": "기질 보유 현황이 업데이트되지 않았습니다. 기존 파일은 변경되지 않았습니다. 실패 원인은 로그를 확인해 주세요.",
     "visitfriends.friend_missing": "해당 친구에게 %s가 없습니다",
     "visitfriends.clue_exchange": "단서 교환",
     "visitfriends.control_nexus_assist": "컨트롤 넥서스 지원",

--- a/assets/locales/go-service/zh_cn.json
+++ b/assets/locales/go-service/zh_cn.json
@@ -1,4 +1,7 @@
 {
+    "essencefilter.inventory.started": "开始盘点无暇基质：已锁定的照常扫描，已标记弃置的直接跳过；匹配全部四至六星武器，不修改标记。",
+    "essencefilter.inventory.saved": "基质库存已导出至 %s，共 %d 组、%d 份基质。",
+    "essencefilter.inventory.failed": "本次基质库存未更新，已有文件保持不变。请查看日志了解失败原因。",
     "visitfriends.friend_missing": "该好友缺少 %s",
     "visitfriends.clue_exchange": "线索交换",
     "visitfriends.control_nexus_assist": "总控中枢助力",

--- a/assets/locales/go-service/zh_tw.json
+++ b/assets/locales/go-service/zh_tw.json
@@ -1,4 +1,7 @@
 {
+    "essencefilter.inventory.started": "開始盤點無暇基質：已鎖定的照常掃描，已標記棄置的直接跳過；匹配全部四至六星武器，不修改標記。",
+    "essencefilter.inventory.saved": "基質庫存已匯出至 %s，共 %d 組、%d 份基質。",
+    "essencefilter.inventory.failed": "本次基質庫存未更新，既有檔案保持不變。請查看日誌了解失敗原因。",
     "visitfriends.friend_missing": "該好友缺少 %s",
     "visitfriends.clue_exchange": "線索交換",
     "visitfriends.control_nexus_assist": "總控中樞助力",

--- a/assets/locales/interface/en_us.json
+++ b/assets/locales/interface/en_us.json
@@ -1,4 +1,6 @@
 {
+    "option.ExportInventory.label": "Export essence inventory",
+    "option.ExportInventory.description": "Scan flawless essences that are not marked as discarded, including locked ones, and export EssenceInventory.json. Discarded essences are skipped without OCR. Match all supported 4- to 6-star weapons without changing any marks. Other filter options are hidden while enabled; the game language remains available. Turn this off to show the original filter options again.",
     "global.region.ValleyIV": "Valley IV",
     "global.region.TheHub": "The Hub",
     "global.region.Wuling": "Wuling",

--- a/assets/locales/interface/ja_jp.json
+++ b/assets/locales/interface/ja_jp.json
@@ -1,4 +1,6 @@
 {
+    "option.ExportInventory.label": "基質の所持数を出力",
+    "option.ExportInventory.description": "破棄マークのない無瑕基質を、ロック済みも含めてスキャンし、EssenceInventory.json に出力します。破棄マーク付きの基質は OCR を行わずスキップします。対応するすべての星4～6武器と照合し、マークは変更しません。有効時はゲーム言語以外の絞り込み設定を非表示にします。無効にすると元の絞り込み設定が再表示されます。",
     "global.region.ValleyIV": "第4谷地 (Valley IV)",
     "global.region.TheHub": "ハブ地区",
     "global.region.Wuling": "武陵 (Wuling)",

--- a/assets/locales/interface/ko_kr.json
+++ b/assets/locales/interface/ko_kr.json
@@ -1,4 +1,6 @@
 {
+    "option.ExportInventory.label": "기질 보유 현황 내보내기",
+    "option.ExportInventory.description": "폐기 표시가 없는 무결 기질을 잠금 상태와 관계없이 스캔하여 EssenceInventory.json으로 내보냅니다. 폐기 표시된 기질은 OCR 없이 건너뜁니다. 지원되는 모든 4~6성 무기와 매칭하며 표시는 변경하지 않습니다. 활성화하면 게임 언어를 제외한 다른 필터 옵션이 숨겨집니다. 비활성화하면 기존 필터 옵션이 다시 표시됩니다.",
     "global.region.ValleyIV": "제4 계곡 (Valley IV)",
     "global.region.TheHub": "허브 구역",
     "global.region.Wuling": "무릉 (Wuling)",

--- a/assets/locales/interface/zh_cn.json
+++ b/assets/locales/interface/zh_cn.json
@@ -1,4 +1,6 @@
 {
+    "option.ExportInventory.label": "输出基质库存",
+    "option.ExportInventory.description": "开启后盘点未标记弃置的无暇基质，包括已锁定的基质，并输出 EssenceInventory.json。弃置项直接跳过，不调用 OCR。匹配全部四至六星武器，不修改标记；开启时隐藏其他筛选选项，仅保留游戏语言；关闭后重新显示原筛选选项。",
     "global.region.ValleyIV": "四号谷地",
     "global.region.TheHub": "枢纽区",
     "global.region.Wuling": "武陵",

--- a/assets/locales/interface/zh_tw.json
+++ b/assets/locales/interface/zh_tw.json
@@ -1,4 +1,6 @@
 {
+    "option.ExportInventory.label": "輸出基質庫存",
+    "option.ExportInventory.description": "開啟後盤點未標記棄置的無暇基質，包括已鎖定的基質，並輸出 EssenceInventory.json。棄置項直接跳過，不呼叫 OCR。匹配全部四至六星武器，不修改標記；開啟時隱藏其他篩選選項，僅保留遊戲語言；關閉後重新顯示原篩選選項。",
     "global.region.ValleyIV": "四號谷地",
     "global.region.TheHub": "樞紐區",
     "global.region.Wuling": "武陵",

--- a/assets/tasks/EssenceFilter.json
+++ b/assets/tasks/EssenceFilter.json
@@ -7,11 +7,7 @@
             "description": "$task.EssenceFilter.description",
             "option": [
                 "SelectInputLanguage",
-                "SelectWeaponRarity",
-                "SelectEssence",
-                "SelectExtraRules",
-                "SkipThumbLock",
-                "SkipThumbDiscard"
+                "ExportInventory"
             ],
             "controller": [
                 "ADB",
@@ -29,6 +25,55 @@
         }
     ],
     "option": {
+        "ExportInventory": {
+            "type": "switch",
+            "label": "$option.ExportInventory.label",
+            "description": "$option.ExportInventory.description",
+            "default_case": "No",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "EssenceFilterInit": {
+                            "attach": {
+                                "export_inventory": true
+                            }
+                        },
+                        "EssenceFilterCheckItemOCRFallback": {
+                            "action": "StopTask"
+                        },
+                        "EssenceGridClickPending": {
+                            "on_error": [
+                                "EssenceFilterCheckItemOCRFallback"
+                            ]
+                        },
+                        "EssenceFilterMainFailed": {
+                            "action": "StopTask"
+                        },
+                        "EssenceFilterNavigateToInventory": {
+                            "action": "StopTask"
+                        }
+                    }
+                },
+                {
+                    "name": "No",
+                    "option": [
+                        "SelectWeaponRarity",
+                        "SelectEssence",
+                        "SelectExtraRules",
+                        "SkipThumbLock",
+                        "SkipThumbDiscard"
+                    ],
+                    "pipeline_override": {
+                        "EssenceFilterInit": {
+                            "attach": {
+                                "export_inventory": false
+                            }
+                        }
+                    }
+                }
+            ]
+        },
         "SelectInputLanguage": {
             "type": "select",
             "label": "$option.SelectInputLanguage.label",

--- a/tools/schema/essence_inventory.schema.json
+++ b/tools/schema/essence_inventory.schema.json
@@ -1,0 +1,99 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "MaaEnd 无暇基质库存导出",
+    "description": "扫描未标记弃置的无暇基质，包含已锁定的基质；仅导出能精确匹配当前支持武器的组合。每个词条组合一组，组内按三个等级合并计数。空数组表示完整扫描后没有符合条件的基质。",
+    "$comment": "框架与网格扫描器负责遍历和去重，Pipeline 在识别或操作失败时终止盘点。导出按词条组合及等级聚合，武器列表完整且升序；JSON Schema 校验结构和取值。仅正常扫描结束时更新文件。",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+            "weapon_ids",
+            "essences"
+        ],
+        "properties": {
+            "weapon_ids": {
+                "description": "该词条组合精确匹配的全部武器 ID，去重并按 ID 升序排列。表示适配关系，不表示已装备。",
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                    "type": "string",
+                    "pattern": "^wpn_[a-z0-9_]+$"
+                }
+            },
+            "essences": {
+                "description": "本组基质的等级与数量分布。不同等级分别记录，相同等级合并；weapon_ids 中所有武器共享这份库存。",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "levels",
+                        "count"
+                    ],
+                    "properties": {
+                        "levels": {
+                            "description": "依次为基础属性、附加属性、技能属性的等级，必须与词条类别对齐。",
+                            "type": "array",
+                            "minItems": 3,
+                            "items": false,
+                            "prefixItems": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 6
+                                },
+                                {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 6
+                                },
+                                {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 3
+                                }
+                            ]
+                        },
+                        "count": {
+                            "description": "本组中三个等级完全相同、未标记弃置的基质持有份数，包含已锁定的基质；不能乘以武器数。",
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "examples": [
+        [],
+        [
+            {
+                "weapon_ids": [
+                    "wpn_sword_0012",
+                    "wpn_sword_0016"
+                ],
+                "essences": [
+                    {
+                        "levels": [
+                            3,
+                            2,
+                            1
+                        ],
+                        "count": 2
+                    },
+                    {
+                        "levels": [
+                            6,
+                            6,
+                            3
+                        ],
+                        "count": 1
+                    }
+                ]
+            }
+        ]
+    ]
+}


### PR DESCRIPTION
在“基质筛选锁定”中新增默认关闭的“输出基质库存”。开启后，UI 仅保留游戏语言和输出开关，以只读方式扫描未标记弃置的无暇基质（包含已锁定项），匹配全部四至六星武器；关闭后使用原筛选选项和流程。

结果写入工作目录的 `EssenceInventory.json`：每种词条组合一个 group，适配武器共享该组的等级与数量分布。`levels` 依次为基础属性、附加属性、技能属性。附带 JSON Schema 和五语言说明。

```json
[
  {
    "weapon_ids": ["wpn_sword_0012", "wpn_sword_0016"],
    "essences": [
      { "levels": [3, 2, 1], "count": 2 },
      { "levels": [6, 6, 3], "count": 1 }
    ]
  }
]
```

盘点模式由 Pipeline 在 OCR、点击或入口失败时停止，正常完成后才通过临时文件替换旧导出。复用现有网格遍历、去重和词条匹配；同时修复日文 `HP` / `UP` 被归一化过滤的问题。

验证：

- `pnpm check`
- `uv run build-and-install`（Go Agent 调试构建及安装目录资源同步）
- 尚未进行真实游戏实测。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“导出基质库存”选项，可盘点未标记弃置的无暇基质，并匹配四至六星武器。
  * 库存结果按技能组合与等级统计，并导出为 `EssenceInventory.json`。
  * 新增扫描进度、保存成功及失败提示。
  * 库存模式支持失败处理与普通筛选流程回退。

* **文档**
  * 补充库存导出、匹配规则及输出格式说明。

* **本地化**
  * 新增英语、日语、韩语、简体中文和繁体中文界面及运行提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->