### PR TITLE
CI(essencefilter): 使用上游 Last-Modified 记录数据更新时间

### DIFF
--- a/.github/workflows/sync-zmdmap.yml
+++ b/.github/workflows/sync-zmdmap.yml
@@ -101,23 +101,20 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install dependencies
+        run: python3 -m pip install json5
+
       - name: Sync EssenceFilter source data
         id: sync
-        run: |
-          python3 -u tools/essence_filter/sync_zmdmap.py
-          if git diff --quiet -- \
-            assets/data/EssenceFilter/energy_point_gems.json \
-            assets/data/EssenceFilter/weapons_output.json; then
-            echo "updated=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "updated=true" >> "$GITHUB_OUTPUT"
-          fi
+        run: python3 -u tools/essence_filter/sync_zmdmap.py
 
       - name: Generate EssenceFilter data
         if: steps.sync.outputs.updated == 'true'
+        env:
+          DATA_VERSION: ${{ steps.sync.outputs.data_version }}
         run: |
           python3 -u tools/essence_filter/extract_skill_pools.py
-          python3 -u tools/essence_filter/build_locations.py --time
+          python3 -u tools/essence_filter/build_locations.py --data-version "$DATA_VERSION"
 
       - name: Create Pull Request
         if: steps.sync.outputs.updated == 'true'

--- a/tools/essence_filter/README.md
+++ b/tools/essence_filter/README.md
@@ -5,6 +5,12 @@
 从 zmdmap 当前版本下载 `energy_point_gems.json` 与 `weapons.json`，校验两份数据后分别写入
 `assets/data/EssenceFilter/energy_point_gems.json` 与 `weapons_output.json`。任一请求失败、返回非 JSON、空数据或结构无效时，整次同步不修改本地文件。
 
+两份文件下载成功后，取本次下载响应中较新的 `Last-Modified`，格式为 `YYYY-MM-DD HH:MM:SS UTC`。
+脚本向 `GITHUB_OUTPUT` 输出 `updated`（源数据或日期是否变化）和 `data_version`；CI 在 `skill_pools.json`、
+`locations.json` 都生成成功后，才将该时间写入 `matcher_config.json`，随后创建包含五份数据文件的同步 PR。
+任一文件的该响应头缺失或无效时保留原日期，不使用本机时间补值。源数据内容未变化时也会同步该时间。
+请求 URL 中的 `t` 仍使用本机时间，仅用于绕过缓存。
+
 ```bash
 uv run tools/essence_filter/sync_zmdmap.py
 ```
@@ -38,11 +44,13 @@ uv run tools/essence_filter/extract_skill_pools.py
 - 从每个武器的 `skills.CN` 按位置归入 slot：`[0]` → slot1，`[1]` → slot2（若长度为 3）或 slot3（若长度为 2），`[2]` → slot3。
 - 技能名取「基名」：按 `·`、`・`、`:`、`：`、`[` 分割，取第一段（如 `力量提升·小` → `力量提升`，`Strength Boost [S]` → `Strength Boost`）。
 - 五语从同武器的 skills.CN/TC/EN/JP/KR 同位置提取基名。
-- 每 slot 用 set 去重后按排序赋 id 1..n。
+- 每 slot 去重后保留已有 `(slot, cn)` 的 id；新增词条从该 slot 的最大 id 加一分配，最后按 id 排序。
 
 ## build_locations.py
 
 从 `energy_point_gems.json` 解析地点词条并映射到 `skill_pools.json`，生成 `locations.json`。
+通过 `--data-version` 接收本轮同步得到的时间，在生成成功后更新数据日期；未提供时保留原日期。
+`--time` 参数已移除，不再使用本机当天日期。
 
 ### 用法
 
@@ -58,6 +66,7 @@ uv run tools/essence_filter/build_locations.py
 | `--skill-pools` | `assets/data/EssenceFilter/skill_pools.json` | 当前技能池 |
 | `--output` / `-o` | `assets/data/EssenceFilter/locations.json` | 输出 locations |
 | `--debug` | 关闭 | 打印未匹配项以便排查 |
+| `--data-version` | 不更新 | 本轮同步得到的 Last-Modified，格式为 `YYYY-MM-DD HH:MM:SS UTC` |
 
 ### 解析规则
 

--- a/tools/essence_filter/build_locations.py
+++ b/tools/essence_filter/build_locations.py
@@ -14,7 +14,6 @@ import argparse
 import json
 import sys
 import unicodedata
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -68,20 +67,17 @@ def _slot2_chinese_stem(chinese: str) -> str:
     return _norm_key(s)
 
 
-def _update_data_version(config_path: Path) -> None:
-    """将 matcher_config 的 data_version 更新为当天日期（d/m/yyyy）。"""
+def _update_data_version(config_path: Path, data_version: str) -> None:
+    """在生成成功后写入本轮源数据的 Last-Modified 时间。"""
     if not config_path.exists():
         return
     with config_path.open("r", encoding="utf-8-sig") as f:
         data = json5.load(f)
     if not isinstance(data, dict):
         return
-
-    now = datetime.now()
-    new_version = f"{now.day}/{now.month}/{now.year}"
-    if data.get("data_version") == new_version:
+    if data.get("data_version") == data_version:
         return  # 无变化不重写，避免用 json.dump 抹掉手写注释
-    data["data_version"] = new_version
+    data["data_version"] = data_version
     with config_path.open("w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=4)
         f.write("\n")
@@ -99,9 +95,8 @@ def main() -> int:
     parser.add_argument("-o", "--output", type=Path, default=root / DEFAULT_OUTPUT)
     parser.add_argument("--debug", action="store_true", help="打印映射与未匹配的键")
     parser.add_argument(
-        "--time",
-        action="store_true",
-        help="写入 matcher_config.json 的 data_version 为当天日期",
+        "--data-version",
+        help="本轮同步得到的 Last-Modified（UTC）；未提供或为空时保留原数据日期",
     )
     args = parser.parse_args()
 
@@ -197,8 +192,8 @@ def main() -> int:
     with args.output.open("w", encoding="utf-8") as f:
         json.dump(out_locations, f, ensure_ascii=False, indent=4)
 
-    if args.time:
-        _update_data_version(root / DEFAULT_MATCHER_CONFIG)
+    if args.data_version:
+        _update_data_version(root / DEFAULT_MATCHER_CONFIG, args.data_version)
 
     print(f"Wrote {len(out_locations)} locations to {args.output}")
     return 0

--- a/tools/essence_filter/sync_zmdmap.py
+++ b/tools/essence_filter/sync_zmdmap.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
+
+import json5
 
 
 VERSION_API = "https://api.zmdmap.com/api/v1/endfield/version"
@@ -31,18 +36,18 @@ def _url(url: str) -> str:
     return f"{url}{sep}{urlencode({'source': 'MaaEnd', 't': time.time_ns() // 1_000_000})}"
 
 
-def _download_json(url: str) -> Any | None:
+def _download_json(url: str) -> tuple[Any, str]:
     try:
         request = Request(_url(url), headers={"User-Agent": "MaaEnd/EssenceFilter"})
         with urlopen(request, timeout=60) as response:
-            return json.loads(response.read())
+            return json.loads(response.read()), response.headers.get("Last-Modified", "")
     except (OSError, ValueError) as error:
         print(f"[EssenceFilter] 跳过无效数据 {url}: {error}")
-        return None
+        return None, ""
 
 
 def _latest_version() -> str | None:
-    payload = _download_json(VERSION_API)
+    payload, _ = _download_json(VERSION_API)
     try:
         version = payload["data"]["list"][0]["version"]
     except (KeyError, IndexError, TypeError):
@@ -70,21 +75,31 @@ def _valid_weapons(data: Any) -> bool:
     )
 
 
-def _download_sources(version: str) -> dict[str, Any] | None:
+def _download_sources(version: str) -> tuple[dict[str, Any], datetime | None] | None:
     validators = {
         "energy_point_gems.json": _valid_energy_points,
         "weapons.json": _valid_weapons,
     }
     result: dict[str, Any] = {}
+    last_modified: list[str] = []
     for filename, validator in validators.items():
         # output_maaend 使用查询参数 ?ver=<version> 指定数据版本（与 fetch-data.mjs 一致）。
         url = f"{DATA_BASE_URL}/{filename}?ver={quote(version, safe='')}"
-        data = _download_json(url)
+        data, modified = _download_json(url)
         if not validator(data):
             print(f"[EssenceFilter] 跳过同步：{filename} 为空或结构无效")
             return None
         result[filename] = data
-    return result
+        last_modified.append(modified)
+    try:
+        modified_at = max(
+            parsedate_to_datetime(value).astimezone(timezone.utc)
+            for value in last_modified
+        )
+    except ValueError:
+        print("[EssenceFilter] Last-Modified 缺失或无效，保留原数据日期")
+        modified_at = None
+    return result, modified_at
 
 
 def _write_json(path: Path, data: Any) -> None:
@@ -106,9 +121,13 @@ def main() -> int:
         return 1 if args.check_version else 0
 
     print(f"[EssenceFilter] 检查 zmdmap {version}")
-    sources = _download_sources(version)
-    if sources is None:
+    downloaded = _download_sources(version)
+    if downloaded is None:
         return 1 if args.check_version else 0
+    sources, modified_at = downloaded
+    data_version = modified_at.strftime("%Y-%m-%d %H:%M:%S UTC") if modified_at else ""
+    if data_version:
+        print(f"[EssenceFilter] 上游 Last-Modified: {data_version}")
     if args.check_version:
         print(f"[EssenceFilter] zmdmap {version} 数据有效")
         return 0
@@ -118,13 +137,24 @@ def main() -> int:
         for filename, path in TARGETS.items()
         if json.loads(path.read_text(encoding="utf-8")) != sources[filename]
     ]
-    if not changed:
-        print("[EssenceFilter] 本地数据已是最新")
-        return 0
+    version_changed = False
+    if data_version:
+        config = json5.loads(
+            (DATA_DIR / "matcher_config.json").read_text(encoding="utf-8-sig")
+        )
+        version_changed = config.get("data_version") != data_version
 
     for filename in changed:
         _write_json(TARGETS[filename], sources[filename])
         print(f"[EssenceFilter] 已更新 {TARGETS[filename].relative_to(REPO_ROOT)}")
+
+    # 时间随本轮源数据传给生成步骤，全部生成成功后才写入 matcher_config。
+    if github_output := os.environ.get("GITHUB_OUTPUT"):
+        with Path(github_output).open("a", encoding="utf-8") as output:
+            output.write(f"updated={str(bool(changed) or version_changed).lower()}\n")
+            output.write(f"data_version={data_version}\n")
+    if not changed and not version_changed:
+        print("[EssenceFilter] 本地数据已是最新")
     return 0
 
 


### PR DESCRIPTION
基质筛选原先将生成当天日期写入 `data_version`，同步延迟时无法反映上游文件的更新时间。改为从两份源数据的下载响应读取 `Last-Modified`，取较新的时间并统一为 `YYYY-MM-DD HH:MM:SS UTC`。

同步步骤通过 Actions outputs 传递时间；仍在 `skill_pools.json` 和 `locations.json` 全部生成成功后才写入 `matcher_config.json`。仅时间变化也会触发同步，缺失或无效的时间头保留原日期。保留配置的 JSONC 兼容和原有词条 ID、地点生成规则，并为 CI 补齐 `json5` 依赖。

验证：

- 在临时目录使用 Docker / Linux / Python 3.12.14 复现基质同步与生成步骤，12 项检查通过。
- 真实下载 zmdmap 1.5.3，两份响应头均为 `Fri, 04 Sep 2026 14:13:31 GMT`，最终配置写入 `2026-09-04 14:13:31 UTC`；读取 79 把武器、84 条淤积点源数据，生成 12 个地点。
- 同一份真实输入分别运行原生成器与修改后的生成器，四份业务数据产物一致。覆盖相同快照重跑、仅时间变化及时区转换、JSONC/BOM、缺失或无效时间头、无效/空 JSON、网络失败、地点映射失败和产物写入失败。
- `pnpm check`、工作流 Prettier 检查、Markdown 检查及 `git diff --check` 通过。

本地验证覆盖数据步骤；GitHub App 授权与机器人创建数据 PR 的步骤未在本地执行。此 PR 仅修改同步脚本、生成器参数、工作流和文档，数据更新由同步工作流另行提交。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 数据同步流程现可根据远端数据的最后更新时间判断版本变化，避免仅依赖文件差异。
  - 生成的数据会记录源数据版本；源数据未变化时仍可同步更新版本日期。
  - 技能池新增词条将按现有编号顺序分配并排序，提升数据一致性。

- **文档**
  - 补充数据版本处理、同步状态及地点数据生成规则说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->