### PR TITLE
fix(存放背包): 存放小于等于四个可用道具后再次点击排序

### DIFF
--- a/assets/resource/pipeline/StashBackpack.json
+++ b/assets/resource/pipeline/StashBackpack.json
@@ -80,6 +80,24 @@
     "StashBackpackUsableItemsLimited": {
         "desc": "少量可用物品存放",
         "enabled": false,
+        "pre_delay": 0,
+        "action": "Custom",
+        "custom_action": "SubTask",
+        "custom_action_param": {
+            "sub": [
+                "StashBackpackSort"
+            ]
+        },
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "StashBackpackUsableItemsStoreFull",
+            "[JumpBack]StashBackpackUsableItemsLimitedDrag",
+            "StashBackpackSort"
+        ]
+    },
+    "StashBackpackSort": {
+        "desc": "点击排序",
         "recognition": "TemplateMatch",
         "roi": [
             1023,
@@ -96,8 +114,6 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
-            "StashBackpackUsableItemsStoreFull",
-            "[JumpBack]StashBackpackUsableItemsLimitedDrag",
             "EmptyNode"
         ]
     },


### PR DESCRIPTION
不想每次执行完发现背包里总有个空格

这个功能本来就强制要点一次排序，所以没有做成选项

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 整理背包时会自动识别并点击排序按钮。
  * 排序完成后再继续后续的物品处理流程。
* **改进**
  * 优化背包整理流程，使物品处理顺序更加合理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->