### PR TITLE
fix(AutoDelivery): 跳过对话前先移动鼠标再点击跳过键

### DIFF
--- a/assets/resource/pipeline/AutoDelivery/Delivery.json
+++ b/assets/resource/pipeline/AutoDelivery/Delivery.json
@@ -347,14 +347,29 @@
         "post_delay": 0,
         "rate_limit": 0,
         "next": [
+            "AutoDeliveryCheckSkipChatAfterMoveAway"
+        ]
+    },
+    "AutoDeliveryCheckSkipChatAfterMoveAway": {
+        "desc": "鼠标移到左上角脱离悬停态后，重新识别对话和跳过按钮，确认按钮仍可见并产出最新识别框",
+        "recognition": "And",
+        "all_of": [
+            "AutoDeliveryInChatDialog",
+            "AutoDeliveryCheckSkipChatButton"
+        ],
+        "box_index": 1,
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
             "AutoDeliverySkipChatMoveToButton"
         ]
     },
     "AutoDeliverySkipChatMoveToButton": {
-        "desc": "移回入口节点中 AutoDeliveryCheckSkipChatButton 返回的识别框",
+        "desc": "按移开后重新识别到的跳过按钮位置，将鼠标移回跳过按钮",
         "pre_delay": 0,
         "action": "TouchMove",
-        "target": "AutoDeliverySkipChat",
+        "target": "AutoDeliveryCheckSkipChatAfterMoveAway",
         "post_delay": 0,
         "rate_limit": 0,
         "next": [

--- a/assets/resource/pipeline/AutoDelivery/Delivery.json
+++ b/assets/resource/pipeline/AutoDelivery/Delivery.json
@@ -351,7 +351,7 @@
         ]
     },
     "AutoDeliveryCheckSkipChatAfterMoveAway": {
-        "desc": "鼠标移到左上角脱离悬停态后，重新识别对话和跳过按钮，确认按钮仍可见并产出最新识别框",
+        "desc": "鼠标移到左上角后，重新识别对话和跳过按钮，确认按钮仍可见并产出最新识别框",
         "recognition": "And",
         "all_of": [
             "AutoDeliveryInChatDialog",

--- a/assets/resource/pipeline/AutoDelivery/Delivery.json
+++ b/assets/resource/pipeline/AutoDelivery/Delivery.json
@@ -329,7 +329,7 @@
         ]
     },
     "AutoDeliverySkipChat": {
-        "desc": "送货交互进入对话时跳过对话",
+        "desc": "送货交互进入对话时，先将鼠标移到左上角",
         "recognition": "And",
         "all_of": [
             "AutoDeliveryInChatDialog",
@@ -337,8 +337,40 @@
         ],
         "box_index": 1,
         "pre_delay": 0,
-        "action": "Custom",
-        "custom_action": "AutoAltClickAction",
+        "action": "TouchMove",
+        "target": [
+            0,
+            0,
+            1,
+            1
+        ],
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoDeliverySkipChatMoveToButton"
+        ]
+    },
+    "AutoDeliverySkipChatMoveToButton": {
+        "desc": "移回入口节点中 AutoDeliveryCheckSkipChatButton 返回的识别框",
+        "pre_delay": 0,
+        "action": "TouchMove",
+        "target": "AutoDeliverySkipChat",
+        "post_delay": 0,
+        "rate_limit": 0,
+        "next": [
+            "AutoDeliverySkipChatClick"
+        ]
+    },
+    "AutoDeliverySkipChatClick": {
+        "desc": "鼠标移回跳过按钮后，重新确认对话和按钮仍然可见再点击",
+        "recognition": "And",
+        "all_of": [
+            "AutoDeliveryInChatDialog",
+            "AutoDeliveryCheckSkipChatButton"
+        ],
+        "box_index": 1,
+        "pre_delay": 0,
+        "action": "Click",
         "post_wait_freezes": {
             "target": [
                 520,

--- a/tools/pipeline-generate/DeliveryJobs/data.test.mjs
+++ b/tools/pipeline-generate/DeliveryJobs/data.test.mjs
@@ -1450,10 +1450,39 @@ test("AutoDelivery ensures the delivery mission detail before branching", () => 
         "AutoDeliveryCheckSubmitGoodsButton",
     ]);
     assert.deepEqual(delivery.AutoDeliverySubmitGoods.next, [
-        "AutoDeliverySkipChat",
+        "AutoDeliveryCheckSkipChatReady",
         "AutoDeliveryCloseRewardDialog",
     ]);
+    assert.deepEqual(delivery.AutoDeliveryCheckSkipChatReady.next, [
+        "AutoDeliverySkipChat",
+    ]);
+    assert.equal(delivery.AutoDeliverySkipChat.action, "TouchMove");
+    assert.deepEqual(delivery.AutoDeliverySkipChat.target, [
+        0,
+        0,
+        1,
+        1,
+    ]);
     assert.deepEqual(delivery.AutoDeliverySkipChat.next, [
+        "AutoDeliveryCheckSkipChatAfterMoveAway",
+    ]);
+    assert.deepEqual(delivery.AutoDeliveryCheckSkipChatAfterMoveAway.all_of, [
+        "AutoDeliveryInChatDialog",
+        "AutoDeliveryCheckSkipChatButton",
+    ]);
+    assert.deepEqual(delivery.AutoDeliveryCheckSkipChatAfterMoveAway.next, [
+        "AutoDeliverySkipChatMoveToButton",
+    ]);
+    assert.equal(delivery.AutoDeliverySkipChatMoveToButton.action, "TouchMove");
+    assert.equal(
+        delivery.AutoDeliverySkipChatMoveToButton.target,
+        "AutoDeliveryCheckSkipChatAfterMoveAway",
+    );
+    assert.deepEqual(delivery.AutoDeliverySkipChatMoveToButton.next, [
+        "AutoDeliverySkipChatClick",
+    ]);
+    assert.equal(delivery.AutoDeliverySkipChatClick.action, "Click");
+    assert.deepEqual(delivery.AutoDeliverySkipChatClick.next, [
         "AutoDeliverySkipChatConfirm",
         "AutoDeliveryCloseRewardDialog",
     ]);


### PR DESCRIPTION
回退 #5417 内的 AltClick 改动
识别到对话与跳过按钮后先 TouchMove 到左上角，再移回跳过按钮识别框，重新确认两者仍可见后用 Click 点击。

fix #5444 
fix #5473
fix #5514
fix #5518
ref #5463 #5467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化自动送货时跳过对话的操作流程。
  - 移开鼠标后重新确认对话框和跳过按钮，再移动至按钮并点击，提升操作稳定性。
  - 完成跳过操作后继续确认并关闭奖励对话框。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->