### PR TITLE
fix: 送礼失败后无法继续其他任务

### DIFF
--- a/assets/resource/pipeline/SceneManager/SceneWorld.json
+++ b/assets/resource/pipeline/SceneManager/SceneWorld.json
@@ -44,12 +44,11 @@
         ],
         "template": "RealTimeTask/AutoSkipEsc.png",
         "threshold": 0.7,
-        "pre_delay": 0,
         "action": "Click",
-        "post_delay": 0,
+        "post_delay": 1000, // 在送礼界面会到其他地方，没有Confirm就交给上一层继续处理
         "next": [
             "__ScenePrivateWorldStorySkipConfirm",
-            "__ScenePrivateAnyEnterWorldSuccess"
+            "__ScenePrivateNextTrue"
         ]
     },
     "__ScenePrivateWorldStorySkipConfirm": {


### PR DESCRIPTION
## Summary
- #5548

## Test plan
- [ ] 送礼失败/卡住后确认可退出并继续其他任务

EOF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能调整**
  - 跳过世界剧情后增加 1 秒延迟。
  - 跳过成功后将进入新的后续流程节点。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->