### PR TITLE
feat(MapNavigator): 滑索落地定位以规划落点为先验参与比分

### DIFF
--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -2013,6 +2013,33 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
     if (!prefetchedCandidatesConsumed) {
         globalResult = tryGlobalSearchWithFallback(minimap, targetZoneId, constraint, featureCache, &bestRawGlobal);
     }
+    // 调用方给了先验位置时，在每个先验附近再搜一小窗，跟 YOLO 格窗比原始峰分，高者胜出。
+    // YOLO 报到相邻格时正确位置根本不在它的窗里，窗内最优再高也是错的，分数门看不出来。
+    // 只在 YOLO 验过区域的帧上搜：区域都没认出来的帧上，小窗撞出的峰没有对照。
+    if (constraint.yolo_validated) {
+        for (const SearchHint& hint : options.search_hints) {
+            const int radius = static_cast<int>(std::lround(hint.radius));
+            if (hint.zone_id != targetZoneId || radius <= 0) {
+                continue;
+            }
+            SearchConstraint hintConstraint;
+            hintConstraint.mode = GlobalSearchMode::RoiFine;
+            hintConstraint.yolo_validated = true;
+            hintConstraint.roi = cv::Rect(
+                static_cast<int>(std::lround(hint.x)) - radius,
+                static_cast<int>(std::lround(hint.y)) - radius,
+                radius * 2 + 1,
+                radius * 2 + 1);
+            MapPosition hintRaw {};
+            auto hintResult = tryGlobalSearchWithFallback(minimap, targetZoneId, hintConstraint, featureCache, &hintRaw);
+            LogInfo << "Global Search: hint window." << VAR(hint.x) << VAR(hint.y) << VAR(hint.radius) << VAR(hintRaw.x) << VAR(hintRaw.y)
+                    << VAR(hintRaw.score) << VAR(bestRawGlobal.x) << VAR(bestRawGlobal.y) << VAR(bestRawGlobal.score);
+            if (hintRaw.score > bestRawGlobal.score) {
+                bestRawGlobal = hintRaw;
+                globalResult = hintResult;
+            }
+        }
+    }
     if (!globalResult) {
         if (bestRawGlobal.score > kSeamFallbackMinPeakScore) {
             bestRawGlobal.isHeld = true;

--- a/agent/cpp-algo/source/MapLocator/MapLocator.cpp
+++ b/agent/cpp-algo/source/MapLocator/MapLocator.cpp
@@ -2034,7 +2034,8 @@ LocateResult MapLocator::Impl::locate(const cv::Mat& minimap, const LocateOption
             auto hintResult = tryGlobalSearchWithFallback(minimap, targetZoneId, hintConstraint, featureCache, &hintRaw);
             LogInfo << "Global Search: hint window." << VAR(hint.x) << VAR(hint.y) << VAR(hint.radius) << VAR(hintRaw.x) << VAR(hintRaw.y)
                     << VAR(hintRaw.score) << VAR(bestRawGlobal.x) << VAR(bestRawGlobal.y) << VAR(bestRawGlobal.score);
-            if (hintRaw.score > bestRawGlobal.score) {
+            // 双策略回退的裸峰分与主策略不同量纲, 没过校验的提示窗不能顶掉已校验的结果
+            if (hintRaw.score > bestRawGlobal.score && (hintResult.has_value() || !globalResult.has_value())) {
                 bestRawGlobal = hintRaw;
                 globalResult = hintResult;
             }

--- a/agent/cpp-algo/source/MapLocator/MapTypes.h
+++ b/agent/cpp-algo/source/MapLocator/MapTypes.h
@@ -3,6 +3,7 @@
 #include <meojson/json.hpp>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include <MaaUtils/NoWarningCV.hpp>
 
@@ -28,6 +29,18 @@ struct MapLocatorConfig
     int yoloThreads = 1;
 };
 
+// 调用方对「人大概在哪」的先验，例如滑索落点、传送落点。只在全局搜索时多开一个以它为中心的
+// 小窗参与比分，位置仍由匹配分数决定；坐标是 zone_id 那张图自己的像素。
+struct SearchHint
+{
+    std::string zone_id;
+    double x = 0.0;
+    double y = 0.0;
+    double radius = 0.0;
+
+    MEO_JSONIZATION(zone_id, x, y, radius)
+};
+
 struct LocateOptions
 {
     double loc_threshold = 0.55;      // 最低分数线
@@ -35,13 +48,15 @@ struct LocateOptions
     bool force_global_search = false; // 是否强制放弃当前追踪，进行全局全图搜
     int max_lost_frames = 3;          // 允许丢失追踪的帧数
     std::string expected_zone_id;     // 非空时仅接受该区域的定位结果
+    std::vector<SearchHint> search_hints;
 
     MEO_JSONIZATION(
         MEO_OPT loc_threshold,
         MEO_OPT yolo_threshold,
         MEO_OPT force_global_search,
         MEO_OPT max_lost_frames,
-        MEO_OPT expected_zone_id)
+        MEO_OPT expected_zone_id,
+        MEO_OPT search_hints)
 };
 
 // --- 返回结果枚举与封装 ---

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -260,6 +260,10 @@ constexpr double kRelocationResumeMinDistance = 3.0;
 // 一跳分三步: 站上架子(仅链首)、把镜头对准落点、按左键起滑。滑行途中人悬在半空, 位置一路在动,
 // 所以判完成只认「进了落点圈」这一条, 任何「动了就算走完」的判据都会在起滑瞬间成立
 constexpr double kZiplineLandingBandWu = 6.0;
+// 落地那一帧是冷启动, 把落点(和同一架子上其它索的落点)交给定位器当搜索先验, 每个点开这么大
+// 半径的小窗跟 YOLO 格窗比分。要装得下落点散布(band), 又小到错先验只能撞出弱峰；模板半宽由
+// 定位器自己补边, 这里不用算进去
+constexpr double kZiplineLandingHintRadiusWu = 24.0;
 constexpr int32_t kZiplineRideRetryIntervalMs = 150;
 constexpr int32_t kZiplineRideTimeoutMs = 30000;
 // 落点圈内还要连着读到这么多个非 held 定位才收工, 避免滑行途中恰好飞过落点上方就提前落地
@@ -289,11 +293,6 @@ constexpr int32_t kZiplineLaunchAttempts = 3;
 // 滑行中位置每拍都在变, 连着这么多拍几乎不动就说明这趟已经结束了
 constexpr double kZiplineSettleMoveWu = 1.5;
 constexpr int32_t kZiplineSettleFixes = 4;
-// 全局搜索偶尔会在同一区域错锁到远处的相似纹理。低分本身不能判错，滑到相邻索也可能真离开
-// 目标线段；只有「低于断言定位的常用及格线」且「距上索点远超当前索跨度」才拒绝这一帧。
-constexpr double kZiplineOutlierFixConfidence = 0.70;
-constexpr double kZiplineOutlierSpanFactorSquared = 9.0;
-constexpr double kZiplineOutlierDistanceSlackWu = 12.0;
 // 下索是一次右键。站在架子上时移动指令会被架子的选点状态吃掉, 所以走路之前必须先下来
 constexpr int32_t kZiplineDismountHoldMs = 80;
 // 索没通电、两端根本没挂索时起滑是空响, 人还站在架子上。滑一趟是大位移, 所以「过了确认时间

--- a/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
@@ -58,6 +58,12 @@ enum class ActionType
     MEOJSON_ENUM_RANGE(RUN, ZIPLINE)
 };
 
+struct ZiplinePoint
+{
+    double x = 0.0;
+    double y = 0.0;
+};
+
 // 滑索的另一端。执行时先把镜头转向这里再交互上索，滑行结束后角色就落在这个点上。
 struct ZiplineTarget
 {
@@ -67,6 +73,9 @@ struct ZiplineTarget
     // 索的仰角，正数是往上滑。落差大的一跳镜头不抬到这个角度就起不了滑。规划时按两端的世界
     // 坐标算好，运行时不再碰单位——x/y 是缩放过的平面单位，跟 height 不同尺。
     double elevation_deg = 0.0;
+    // 上索那根架子上其它索通向的架子。两根索靠得近时游戏可能挂错一根，落地定位把这些点
+    // 也当搜索先验，滑错了也能立刻认出落在哪。
+    std::vector<ZiplinePoint> alternates;
 };
 
 // 上索认不出提示时的备用站位。面板给的是离身位最近的那台设备, 架子边上贴着供电桩时会被它抢走,

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -83,9 +83,6 @@ struct SemanticState
     int zipline_settle_hits = 0;
     // 滑反了正在原路滑回上索点。回去了就退索走路, 不会再滑第二趟
     bool zipline_returning = false;
-    // 停稳判定要下"滑岔了"结论前, 是否已经扔掉跟踪状态强制重定位复核过一次。冷启动后的
-    // 低分错锁能连着几帧纹丝不动骗过稳定判据, 弃索这么贵的决定不能建立在它上面
-    bool zipline_settle_relocated = false;
     // 这一次上索是行进预筛叫停的, 人可能还差几步。此时认不出提示只说明预筛看错了, 不该丢链
     bool zipline_prompt_probe = false;
     // 人是不是站在架子上。链首上索时置位, 链尾下索或中途退索时清掉。站着时不能直接走路,
@@ -112,7 +109,6 @@ struct SemanticState
         zipline_last_pos = {};
         zipline_settle_hits = 0;
         zipline_returning = false;
-        zipline_settle_relocated = false;
         zipline_prompt_probe = false;
         zipline_mounted = false;
         held_zone_candidate.clear();

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -904,6 +904,11 @@ bool TryAppendZiplineLeg(
             .height = to.height,
             .elevation_deg = std::atan2(rise, std::hypot(span_x, span_z)) * 180.0 / kPi,
         };
+        if (hop < route->hop_alternates.size()) {
+            for (const zipline::ZiplineNode& other : route->hop_alternates[hop]) {
+                out_path.back().zipline_target->alternates.push_back(ZiplinePoint { .x = other.x, .y = other.y });
+            }
+        }
     }
 
     const size_t departure_index = out_path.size();

--- a/agent/cpp-algo/source/MapNavigator/position_provider.cpp
+++ b/agent/cpp-algo/source/MapNavigator/position_provider.cpp
@@ -64,7 +64,11 @@ void PositionProvider::SetFrameObserver(std::function<void(const cv::Mat&)> obse
     frame_observer_ = std::move(observer);
 }
 
-bool PositionProvider::Capture(NaviPosition* out_pos, bool force_global_search, const std::string& expected_zone_id)
+bool PositionProvider::Capture(
+    NaviPosition* out_pos,
+    bool force_global_search,
+    const std::string& expected_zone_id,
+    const std::vector<maplocator::SearchHint>& search_hints)
 {
     if (out_pos == nullptr) {
         return false;
@@ -96,6 +100,7 @@ bool PositionProvider::Capture(NaviPosition* out_pos, bool force_global_search, 
     maplocator::LocateOptions options;
     options.force_global_search = force_global_search;
     options.expected_zone_id = expected_zone_id;
+    options.search_hints = search_hints;
 
     const auto locate_result = locator_->locate(minimap, options);
     const auto locate_done_at = std::chrono::steady_clock::now();

--- a/agent/cpp-algo/source/MapNavigator/position_provider.h
+++ b/agent/cpp-algo/source/MapNavigator/position_provider.h
@@ -17,7 +17,12 @@ class PositionProvider
 public:
     PositionProvider(MaaController* controller, std::shared_ptr<maplocator::MapLocator> locator);
 
-    bool Capture(NaviPosition* out_pos, bool force_global_search, const std::string& expected_zone_id);
+    // search_hints: 调用方知道人大概在哪时（滑索落点等）交给定位器多搜几个小窗，见 SearchHint。
+    bool Capture(
+        NaviPosition* out_pos,
+        bool force_global_search,
+        const std::string& expected_zone_id,
+        const std::vector<maplocator::SearchHint>& search_hints = {});
     bool WaitForFix(
         NaviPosition* out_pos,
         const std::string& expected_zone_id,

--- a/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
@@ -139,7 +139,25 @@ void ClearRideState(const Context& ctx)
     ctx.runtime_state->semantic.zipline_last_pos = {};
     ctx.runtime_state->semantic.zipline_settle_hits = 0;
     ctx.runtime_state->semantic.zipline_returning = false;
-    ctx.runtime_state->semantic.zipline_settle_relocated = false;
+}
+
+// 落地那一帧是冷启动。把这跳的落点、同一架子上其它索的落点、以及上索点本身都交给定位器当
+// 搜索先验：挂对了落在第一个, 挂错了落在其中一个, 空响没滑走就还在上索点。位置由匹配分决定。
+std::vector<maplocator::SearchHint> RideSearchHints(const NaviPosition& mount, const ZiplineTarget& landing)
+{
+    std::vector<maplocator::SearchHint> hints;
+    if (!mount.valid || mount.zone_id.empty()) {
+        return hints;
+    }
+    const auto add = [&hints, &mount](double x, double y) {
+        hints.push_back(maplocator::SearchHint { .zone_id = mount.zone_id, .x = x, .y = y, .radius = kZiplineLandingHintRadiusWu });
+    };
+    add(landing.x, landing.y);
+    for (const ZiplinePoint& other : landing.alternates) {
+        add(other.x, other.y);
+    }
+    add(mount.x, mount.y);
+    return hints;
 }
 
 // 一跳里第几次按左键该把镜头抬到多少度。俯仰读不回来, dy 的正负也没实机核过, 所以第二次直接
@@ -158,34 +176,6 @@ double PitchTargetForAttempt(double elevation_deg, int attempt)
     }
     return 0.0;
 }
-
-constexpr double SquaredDistance(double from_x, double from_y, double to_x, double to_y)
-{
-    const double dx = to_x - from_x;
-    const double dy = to_y - from_y;
-    return dx * dx + dy * dy;
-}
-
-// 不能只按距离拒绝：确实滑到同一架子上的另一根索时也会偏离预期落点，后面还要靠现有逻辑
-// 判断是否原路滑回。低分与异常位移同时成立才说明更像全局搜索错锁，而不是真实滑行结果。
-constexpr bool
-    IsPlausibleZiplineFix(double mount_x, double mount_y, double landing_x, double landing_y, double fix_x, double fix_y, double fix_score)
-{
-    if (fix_score >= kZiplineOutlierFixConfidence) {
-        return true;
-    }
-    const double span_squared = SquaredDistance(mount_x, mount_y, landing_x, landing_y);
-    const double moved_squared = SquaredDistance(mount_x, mount_y, fix_x, fix_y);
-    const double max_distance_squared =
-        kZiplineOutlierSpanFactorSquared * span_squared + kZiplineOutlierDistanceSlackWu * kZiplineOutlierDistanceSlackWu;
-    return moved_squared <= max_distance_squared;
-}
-
-// 2026-08-25 实机回归样本：低分的真实落点仍应接受，远处 (950, 542) 错锁必须拒绝。
-static_assert(IsPlausibleZiplineFix(906.04, 268.94, 925.3125, 291.796875, 927.0, 293.17, 0.68));
-static_assert(!IsPlausibleZiplineFix(906.04, 268.94, 925.3125, 291.796875, 950.2, 542.51, 0.680377));
-// 高置信度的远端结果仍交给既有错索/回索分支处理，避免几何门控吞掉真实的误滑。
-static_assert(IsPlausibleZiplineFix(906.04, 268.94, 925.3125, 291.796875, 950.2, 542.51, 0.90));
 
 std::string BuildPitchResetOverride(int units)
 {
@@ -446,7 +436,8 @@ Result StartZiplineHop(
     ctx.runtime_state->semantic.zipline_landing = landing;
     ctx.runtime_state->semantic.zipline_landing_hits = 0;
     ctx.runtime_state->semantic.zipline_settle_hits = 0;
-    ctx.runtime_state->semantic.zipline_settle_relocated = false;
+    // 滑行中小地图整个隐藏, 跟踪必然断; 落地帧离上索点一整跨, 若上索点的旧位置还留在跟踪器里,
+    // 分数不到直通线的真落点会被当远跳拒掉, 白等几帧。起滑就清掉, 落地直接走冷启动
     ctx.position_provider->ResetTracking();
 
     // 起滑那一刻人还在上索点, 这条链就算已经是路线的尾巴也不能在这里收工:
@@ -472,37 +463,14 @@ Result TickZiplineRide(const Context& ctx)
     const int64_t waited_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(now - ctx.runtime_state->semantic.zipline_ride_started).count();
 
-    if (!ctx.position_provider->Capture(ctx.position, false, {}) || ctx.position_provider->LastCaptureWasHeld()) {
+    const NaviPosition& mount = ctx.runtime_state->semantic.zipline_mount_pos;
+    const ZiplineTarget& landing = ctx.runtime_state->semantic.zipline_landing;
+    if (!ctx.position_provider->Capture(ctx.position, false, {}, RideSearchHints(mount, landing))
+        || ctx.position_provider->LastCaptureWasHeld()) {
         ctx.runtime_state->semantic.zipline_landing_hits = 0;
         ctx.runtime_state->semantic.zipline_settle_hits = 0;
         if (waited_ms > kZiplineRideTimeoutMs) {
             return AbandonZipline(ctx, "zipline_ride_timeout", "no usable locator fix for the whole ride");
-        }
-        result.stay_in_current_tick = true;
-        utils::SleepFor(kZiplineRideRetryIntervalMs);
-        return result;
-    }
-
-    const NaviPosition& mount = ctx.runtime_state->semantic.zipline_mount_pos;
-    const ZiplineTarget& landing = ctx.runtime_state->semantic.zipline_landing;
-    if (mount.valid
-        && !IsPlausibleZiplineFix(mount.x, mount.y, landing.x, landing.y, ctx.position->x, ctx.position->y, ctx.position->score)) {
-        ctx.runtime_state->semantic.zipline_landing_hits = 0;
-        ctx.runtime_state->semantic.zipline_last_pos = {};
-        ctx.runtime_state->semantic.zipline_settle_hits = 0;
-        ctx.runtime_state->semantic.zipline_settle_relocated = false;
-        ctx.position_provider->ResetTracking();
-
-        const double expected_span = std::hypot(landing.x - mount.x, landing.y - mount.y);
-        const double distance_to_mount = std::hypot(ctx.position->x - mount.x, ctx.position->y - mount.y);
-        const double max_distance = std::sqrt(
-            kZiplineOutlierSpanFactorSquared * expected_span * expected_span
-            + kZiplineOutlierDistanceSlackWu * kZiplineOutlierDistanceSlackWu);
-        LogWarn << "Action: ZIPLINE rejected an implausible locator fix; forcing a fresh global locate." << VAR(ctx.position->x)
-                << VAR(ctx.position->y) << VAR(ctx.position->score) << VAR(distance_to_mount) << VAR(expected_span) << VAR(max_distance)
-                << VAR(waited_ms);
-        if (waited_ms > kZiplineRideTimeoutMs) {
-            return AbandonZipline(ctx, "zipline_ride_timeout", "locator fixes stayed outside the plausible ride envelope");
         }
         result.stay_in_current_tick = true;
         utils::SleepFor(kZiplineRideRetryIntervalMs);
@@ -546,19 +514,6 @@ Result TickZiplineRide(const Context& ctx)
         // 滑走了, 人却停在既不是落点也不是架子的地方, 这趟就是滑岔了。离落点更近说明方向没错,
         // 就地退索走路; 离上索点更近说明滑反了, 索是双向的, 原路滑回去再走
         if (ctx.runtime_state->semantic.zipline_settle_hits >= kZiplineSettleFixes && moved >= kZiplineMountMinMoveWu) {
-            // 冷启动后的第一批低分错锁能连着几帧纹丝不动, 骗过上面的稳定判据(实测把滑到落点的
-            // 链整条判死过)。弃索是贵决定: 先扔掉跟踪状态强制一次全新全局定位, 用干净的锁定
-            // 重新数满稳定帧, 结论没变才作数; 新锁定落在落点圈里就顺着成功路径走。
-            if (!ctx.runtime_state->semantic.zipline_settle_relocated) {
-                ctx.runtime_state->semantic.zipline_settle_relocated = true;
-                ctx.runtime_state->semantic.zipline_settle_hits = 0;
-                ctx.position_provider->ResetTracking();
-                LogInfo << "Action: ZIPLINE settle verdict deferred for a fresh global locate." << VAR(distance_to_landing) << VAR(moved)
-                        << VAR(waited_ms);
-                result.stay_in_current_tick = true;
-                utils::SleepFor(kZiplineRideRetryIntervalMs);
-                return result;
-            }
             const double distance_to_mount = std::hypot(ctx.position->x - mount.x, ctx.position->y - mount.y);
             LogWarn << "Action: ZIPLINE stopped away from the landing point." << VAR(distance_to_landing) << VAR(distance_to_mount)
                     << VAR(waited_ms) << VAR(ctx.runtime_state->semantic.zipline_returning);
@@ -567,13 +522,15 @@ Result TickZiplineRide(const Context& ctx)
             }
             // 滑回去也是一根索, 仰角反过来只是个种子: 真正滑的是哪根索没人知道, 对不上就靠
             // 起滑那三档重试换角度
-            const ZiplineTarget back { .x = mount.x, .y = mount.y, .elevation_deg = -landing.elevation_deg };
+            ZiplineTarget back { .x = mount.x, .y = mount.y, .elevation_deg = -landing.elevation_deg };
+            // 滑回去的落地先验: 原上索点、原落点、原架子上的其它落点, 这趟不管挂到哪根都罩得住
+            back.alternates.push_back(ZiplinePoint { .x = landing.x, .y = landing.y });
+            back.alternates.insert(back.alternates.end(), landing.alternates.begin(), landing.alternates.end());
             ctx.runtime_state->semantic.zipline_returning = true;
             ctx.runtime_state->semantic.zipline_mount_pos = *ctx.position;
             ctx.runtime_state->semantic.zipline_landing = back;
             ctx.runtime_state->semantic.zipline_landing_hits = 0;
             ctx.runtime_state->semantic.zipline_settle_hits = 0;
-            ctx.runtime_state->semantic.zipline_settle_relocated = false;
             ctx.runtime_state->semantic.zipline_launch_attempts = 0;
             if (!AimAtLanding(ctx, back, 0, false)) {
                 return AbandonZipline(ctx, "zipline_aim_failed", "could not aim back at the mount tower");

--- a/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
@@ -743,10 +743,23 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
 
     // 中间经过哪几根架子到这时才还原：候选是成对枚举出来的，逐个存下整条链纯属浪费。
     SolveZipChains(nodes, links, cost, best_candidate->mount, &chain_cost, &chain_prev);
+    std::vector<size_t> chain;
     for (size_t at = best_candidate->dismount; at != kNoTower; at = chain_prev[at]) {
-        best->towers.push_back(nodes[at]);
+        chain.push_back(at);
     }
-    std::reverse(best->towers.begin(), best->towers.end());
+    std::reverse(chain.begin(), chain.end());
+    for (size_t hop = 0; hop < chain.size(); ++hop) {
+        best->towers.push_back(nodes[chain[hop]]);
+        if (hop + 1 < chain.size()) {
+            std::vector<zipline::ZiplineNode> alternates;
+            for (const size_t other : links[chain[hop]]) {
+                if (other != chain[hop + 1]) {
+                    alternates.push_back(nodes[other]);
+                }
+            }
+            best->hop_alternates.push_back(std::move(alternates));
+        }
+    }
     if (capture_diagnostics) {
         const std::optional<PlannedLeg>* approach = approach_cache.get(best_candidate->mount);
         const std::optional<PlannedLeg>* departure = departure_cache.get(best_candidate->dismount);

--- a/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.h
+++ b/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.h
@@ -35,6 +35,9 @@ struct ZiplineRoute
     // 依次经过的架子，至少两根。中间那些既是上一跳的落点也是下一跳的上索点，
     // 人落下来就站在下一根上，所以跳与跳之间不需要走路。
     std::vector<zipline::ZiplineNode> towers;
+    // 与 towers 逐跳对应(最后一根没有)：这根架子上除了下一跳以外还挂着索通向哪些架子。
+    // 执行侧拿它当落地定位的备选先验，挂错索也认得出落在哪。
+    std::vector<std::vector<zipline::ZiplineNode>> hop_alternates;
     // 折算成等效走路距离的总代价，与 baseline_length 可直接比大小。
     double cost = 0.0;
     // 上索点旁边贴着供电结构时给的备用站位，执行侧认不出上索提示才改瞄它。


### PR DESCRIPTION
- fix #5519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增定位搜索提示，可在指定区域及位置附近进行精细定位。
  * 滑索路线支持记录多个备选落点，并用于落地、滑行及异常回滑时的辅助定位。
* **改进**
  * 优化滑索路线规划与落点识别，提升复杂场景下的定位稳定性和判断准确度。
  * 定位接口支持传入可选的搜索提示信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->