### PR TITLE
fix(AutoEssence): 修复雪松林基质刷取错误选择锚点

### DIFF
--- a/assets/resource/pipeline/AutoEssence/RegionNodes/WLSnowyForest.json
+++ b/assets/resource/pipeline/AutoEssence/RegionNodes/WLSnowyForest.json
@@ -36,8 +36,8 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [
-            // 距离淤积点最近的锚点：寒雾松林（锚点编号按 X 从左到右递增）
-            "SceneEnterWorldWulingSnowyForest1"
+            // 距离淤积点最近的锚点：雪祀木屋
+            "SceneEnterWorldWulingSnowyForest2"
         ]
     },
     "__GotoTriggerPointNearAnchor_WLSnowyForest": {
@@ -49,10 +49,10 @@
                 "custom_recognition_param": {
                     "zone_id": "Wuling_Base",
                     "target": [
-                        1408.68,
-                        986.93,
-                        15.66,
-                        16.44
+                        1505.45,
+                        982.74,
+                        15.43,
+                        16.63
                     ]
                 }
             }


### PR DESCRIPTION
# Summary
- 将选择的锚点从“寒雾松林”修改为“雪祀木屋左侧”
- 同步修改传送后断言区

FIx #5560



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化雪地森林区域中雪祀木屋的传送场景。
  - 更新最近锚点的位置识别数据，提升传送定位的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->