### PR TITLE
feat(MapNavigator): 卡死恢复的 detour 一档改用运行期虚拟禁区重规划绕障

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
+++ b/agent/cpp-algo/source/MapNavigator/nav_run_controller.cpp
@@ -403,6 +403,7 @@ void NavRunController::invalidate()
 bool NavRunController::buildPlan(
     const NaviParam& param,
     const NavigationSession& session,
+    const NavigationRuntimeState& runtime,
     const NaviPosition& position,
     size_t anchor_index,
     const Waypoint& anchor,
@@ -459,7 +460,8 @@ bool NavRunController::buildPlan(
 
     const navmesh::WorldPoint start { .x = position.x, .y = position.y };
     const navmesh::WorldPoint goal { .x = anchor.x, .y = anchor.y };
-    auto route = PlanNavmeshRoute(param, position.zone_id, start, goal, anchor.target_deck_y);
+    auto route =
+        PlanNavmeshRoute(param, position.zone_id, start, goal, anchor.target_deck_y, std::nullopt, nullptr, &runtime.virtual_no_go);
     if (route && route->ok() && route->path.points.size() >= 2) {
         commit(std::move(route->path), false);
         return true;
@@ -592,7 +594,7 @@ NavRunTickResult NavRunController::tick(
         if (failed_build_anchor_ == anchor_index && ElapsedMs(failed_build_at_, now) < kNavRunPlanFailureCooldownMs) {
             return result;
         }
-        if (!buildPlan(param, *session, position, anchor_index, anchor, NavRunReplanReason::AnchorChanged, now)) {
+        if (!buildPlan(param, *session, *runtime, position, anchor_index, anchor, NavRunReplanReason::AnchorChanged, now)) {
             failed_build_anchor_ = anchor_index;
             failed_build_at_ = now;
             return result;
@@ -628,7 +630,7 @@ NavRunTickResult NavRunController::tick(
         if (budget_left && (hard_off || cooldown_ready)) {
             plan_.last_soft_replan_at = now;
             plan_.soft_replan_attempts += 1;
-            if (buildPlan(param, *session, position, anchor_index, anchor, reason, now)) {
+            if (buildPlan(param, *session, *runtime, position, anchor_index, anchor, reason, now)) {
                 auto reprojected = ProjectOntoCorridor(plan_.path, plan_.cursor, position);
                 if (!reprojected) {
                     invalidate();

--- a/agent/cpp-algo/source/MapNavigator/nav_run_controller.h
+++ b/agent/cpp-algo/source/MapNavigator/nav_run_controller.h
@@ -99,6 +99,7 @@ private:
     bool buildPlan(
         const NaviParam& param,
         const NavigationSession& session,
+        const NavigationRuntimeState& runtime,
         const NaviPosition& position,
         size_t anchor_index,
         const Waypoint& anchor,

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -155,8 +155,20 @@ constexpr int32_t kDynamicRecoveryTotalTimeoutMs = 30000;
 // abandons the precise route.
 constexpr int32_t kRecoveryJumpAttemptsBeforeDetour = 2;
 constexpr double kDynamicRecoveryResetDistance = 2.0;
-constexpr double kCloseGoalDetourSuppressSlack = 6.0;
-constexpr int32_t kRecoveryDetourAttemptsBeforeUnstick = 1;
+// Each detour attempt places one virtual no-go disc and re-plans around it; a further stall at the same
+// spot places a larger one. After this many attempts at one anchor the ladder moves on to the physical
+// unstick.
+constexpr int32_t kRecoveryDetourAttemptsBeforeUnstick = 3;
+// Virtual no-go disc placed ahead of a stall. The first radius is an estimate of the unseen obstacle's
+// size; a further stall against an existing disc adds one step, up to the cap. The standoff keeps the
+// agent's own cell outside the disc so the replan has a start point; the goal clearance keeps the anchor
+// outside it.
+constexpr double kVirtualNoGoRadius = 2.0;
+constexpr double kVirtualNoGoRadiusStep = 1.5;
+constexpr double kVirtualNoGoRadiusMax = 6.5;
+constexpr double kVirtualNoGoRadiusMin = 1.0;
+constexpr double kVirtualNoGoStandoff = 1.0;
+constexpr double kVirtualNoGoGoalClearance = 1.0;
 constexpr double kUnstickSampleStepM = 0.5;  // per-ray on/off scan resolution (world units)
 constexpr double kUnstickMaxRockCrossingM =
     2.0;                                     // tolerate this much off-mesh (the rock) before solid ground; longer = water => reject bearing

--- a/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_domain_types.h
@@ -97,6 +97,18 @@ struct ZiplineHopBan
     double to_y = 0.0;
 };
 
+// 运行期在卡死点前方生成的圆形禁区, 用于占位网格中未记录的障碍, 此后每次规划都绕开它。
+// 圆心按生成时所在定位区的坐标记录, 仅对同区规划生效。push_through 表示该禁区封闭了唯一通路,
+// 规划时不再计入, 只作为恢复流程判定此处需要物理脱困的依据。
+struct VirtualNoGoDisc
+{
+    std::string zone_id;
+    double x = 0.0;
+    double y = 0.0;
+    double radius = 0.0;
+    bool push_through = false;
+};
+
 struct Waypoint
 {
     double x;

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -374,6 +374,9 @@ struct NavigationRuntimeState
     // 跟着重规划清零, 重展开就会再选中刚失败的索。
     std::vector<ZiplineHopBan> zipline_hop_bans;
     int32_t zipline_abandon_count = 0;
+    // 置于顶层且不参与任何 Reset: 禁区按世界坐标记录障碍, 生命周期为整趟导航, 仅由 BeginNavigation 清空。
+    // 若随重规划一并清零, 下一次规划会再次穿过刚判定出障碍的位置。
+    std::vector<VirtualNoGoDisc> virtual_no_go;
     // Consecutive global re-acquires (the navigation_state_machine "recovered via global re-acquire" path) since
     // the last genuine waypoint advance. Top-level on purpose: the loss/escape/overlay Resets that fire all through
     // a wrong-tier thrash storm never clear it — only real forward progress does — so it is the one storm-proof
@@ -410,6 +413,7 @@ struct NavigationRuntimeState
         zipline_approach.Reset();
         zipline_recovery.Reset();
         zipline_hop_bans.clear();
+        virtual_no_go.clear();
         zipline_abandon_count = 0;
         progress_identity.Reset();
         global_reacquire_streak = 0;

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -666,8 +666,6 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
     const char* reason,
     size_t continue_index,
     const Waypoint& anchor,
-    bool use_detour,
-    double route_heading,
     bool emit_interior_corners)
 {
     if (!anchor.HasPosition()) {
@@ -677,26 +675,28 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
 
     const navmesh::WorldPoint start { .x = position_->x, .y = position_->y };
     const navmesh::WorldPoint goal { .x = anchor.x, .y = anchor.y };
-    navmesh::WorldPoint detour_vertex {};
-    const auto route = use_detour ? PlanNavmeshDetourRoute(param_, *position_, anchor, route_heading, &detour_vertex)
-                                  : PlanNavmeshRoute(param_, position_->zone_id, start, goal, anchor.target_deck_y);
+    const auto route = PlanNavmeshRoute(
+        param_,
+        position_->zone_id,
+        start,
+        goal,
+        anchor.target_deck_y,
+        std::nullopt,
+        nullptr,
+        &runtime_state_.virtual_no_go);
     if (!route) {
         return false;
     }
 
     std::vector<Waypoint> generated_prefix;
-    if (use_detour) {
-        generated_prefix.emplace_back(detour_vertex.x, detour_vertex.y, ActionType::RUN);
-        generated_prefix.back().strict_arrival = true;
-    }
-    else if (!AppendGeneratedNavmeshWaypoints(
-                 param_,
-                 position_->zone_id,
-                 *route,
-                 generated_prefix,
-                 /*include_goal=*/false,
-                 emit_interior_corners,
-                 /*strict_segment_breaks=*/false)) {
+    if (!AppendGeneratedNavmeshWaypoints(
+            param_,
+            position_->zone_id,
+            *route,
+            generated_prefix,
+            /*include_goal=*/false,
+            emit_interior_corners,
+            /*strict_segment_breaks=*/false)) {
         LogWarn << "Dynamic navmesh overlay skipped: generated path is unusable." << VAR(reason) << VAR(continue_index)
                 << VAR(route->path.points.size());
         return false;
@@ -717,12 +717,12 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToAnchor(
     }
     runtime_state_.dynamic_replan_requested = false;
     const size_t planned_points = route->path.points.size();
-    LogInfo << "Dynamic navmesh overlay selected." << VAR(reason) << VAR(use_detour) << VAR(continue_index) << VAR(generated_count)
-            << VAR(planned_points) << VAR(detour_vertex.x) << VAR(detour_vertex.y) << VAR(anchor.x) << VAR(anchor.y);
+    LogInfo << "Dynamic navmesh overlay selected." << VAR(reason) << VAR(continue_index) << VAR(generated_count) << VAR(planned_points)
+            << VAR(runtime_state_.virtual_no_go.size()) << VAR(anchor.x) << VAR(anchor.y);
     return true;
 }
 
-bool NavigationStateMachine::TryApplyDynamicOverlayToNextAnchor(const char* reason, bool use_detour, double route_heading)
+bool NavigationStateMachine::TryApplyDynamicOverlayToNextAnchor(const char* reason)
 {
     const std::optional<DynamicAnchor> anchor = ResolveCurrentAnchor(session_, *position_);
     if (!anchor) {
@@ -731,13 +731,86 @@ bool NavigationStateMachine::TryApplyDynamicOverlayToNextAnchor(const char* reas
                 << VAR(position_->zone_id);
         return false;
     }
-    return TryApplyDynamicOverlayToAnchor(
-        reason,
-        anchor->first,
-        anchor->second,
-        use_detour,
-        route_heading,
-        /*emit_interior_corners=*/false);
+    return TryApplyDynamicOverlayToAnchor(reason, anchor->first, anchor->second, /*emit_interior_corners=*/false);
+}
+
+bool NavigationStateMachine::TryVirtualNoGoReplan(
+    const char* reason,
+    size_t continue_index,
+    const Waypoint& anchor,
+    const NaviPosition& origin,
+    double stuck_heading)
+{
+    std::vector<VirtualNoGoDisc>& discs = runtime_state_.virtual_no_go;
+    // 朝向是罗盘角(0 朝上, 顺时针), 与 PlanUnstickTarget 同一口径
+    const double rad = NaviMath::NormalizeHeading(stuck_heading) * kPi / 180.0;
+    const double dir_x = std::sin(rad);
+    const double dir_y = -std::cos(rad);
+    // 圆心取在卡死点前方, 留出 standoff 以免把卡死点本身圈进禁区
+    const auto center_x = [&](double radius) {
+        return origin.x + dir_x * (radius + kVirtualNoGoStandoff);
+    };
+    const auto center_y = [&](double radius) {
+        return origin.y + dir_y * (radius + kVirtualNoGoStandoff);
+    };
+    // 物理脱困后当前位置已经离开卡死点。禁区若把当前位置一并圈入, 规划起点便落在禁区内,
+    // 因此逐次折半收缩, 直到当前位置落在禁区之外。
+    const auto fit_outside = [&](double radius) {
+        while (radius >= kVirtualNoGoRadiusMin && std::hypot(position_->x - center_x(radius), position_->y - center_y(radius)) < radius) {
+            radius *= 0.5;
+        }
+        return radius;
+    };
+
+    // 在既有禁区边缘再次卡死, 说明障碍大于该禁区, 新禁区在其半径上增加一档。旧禁区原样保留,
+    // 两者的并集仍然覆盖最初的卡死点。
+    double radius = kVirtualNoGoRadius;
+    bool grown = false;
+    for (const VirtualNoGoDisc& disc : discs) {
+        if (disc.zone_id != origin.zone_id || disc.push_through) {
+            continue;
+        }
+        if (std::hypot(center_x(kVirtualNoGoRadius) - disc.x, center_y(kVirtualNoGoRadius) - disc.y)
+            <= disc.radius + kVirtualNoGoRadiusStep) {
+            radius = std::max(radius, std::min(disc.radius + kVirtualNoGoRadiusStep, kVirtualNoGoRadiusMax));
+            grown = true;
+        }
+    }
+    // 锚点过近时禁区会覆盖锚点本身, 先按锚点净空压低半径, 压不到最小半径则放弃生成。
+    // 锚点正处前方时圆心到锚点最近, 按该最坏情形定上界: 距离 - standoff - 半径 ≥ 半径 + 净空。
+    const double anchor_distance = std::hypot(anchor.x - origin.x, anchor.y - origin.y);
+    const double radius_cap = (anchor_distance - kVirtualNoGoStandoff - kVirtualNoGoGoalClearance) * 0.5;
+    radius = fit_outside(std::min(radius, radius_cap));
+    if (radius < kVirtualNoGoRadiusMin) {
+        LogInfo << "Virtual no-go skipped: no room for a disc between here and the anchor." << VAR(reason) << VAR(anchor_distance)
+                << VAR(radius);
+        return false;
+    }
+
+    discs.push_back({ .zone_id = origin.zone_id, .x = center_x(radius), .y = center_y(radius), .radius = radius });
+    VirtualNoGoDisc* disc = &discs.back();
+    LogInfo << "Virtual no-go stamped." << VAR(reason) << VAR(grown) << VAR(disc->x) << VAR(disc->y) << VAR(disc->radius)
+            << VAR(stuck_heading) << VAR(discs.size());
+
+    if (TryApplyDynamicOverlayToAnchor(reason, continue_index, anchor)) {
+        return true;
+    }
+    // 规划失败: 禁区可能封住了整条窄路, 半径折半后再规划一次; 已是最小半径则不再重试
+    const double shrunk = fit_outside(disc->radius * 0.5);
+    if (shrunk >= kVirtualNoGoRadiusMin) {
+        disc->radius = shrunk;
+        disc->x = center_x(shrunk);
+        disc->y = center_y(shrunk);
+        LogInfo << "Virtual no-go shrunk after replan failure." << VAR(reason) << VAR(disc->radius);
+        if (TryApplyDynamicOverlayToAnchor(reason, continue_index, anchor)) {
+            return true;
+        }
+    }
+    // 收缩后仍规划失败: 此处是唯一通路。该禁区退出规划, 仅保留标记供恢复流程改走物理脱困。
+    disc->push_through = true;
+    LogWarn << "Virtual no-go blocks the only passage; marked push-through." << VAR(reason) << VAR(disc->x) << VAR(disc->y)
+            << VAR(disc->radius);
+    return false;
 }
 
 // 上索点是必到的语义点, 重规划总是把人瞄回它, 所以那根架子要是根本走不到(导入的坐标跟实际
@@ -836,12 +909,7 @@ bool NavigationStateMachine::HandleZiplineRecoveryReplan()
 
     const std::optional<DynamicAnchor> anchor =
         ResolveReachableNavmeshAnchor(param_, session_, *position_, session_->current_node_idx(), "zipline_recovery");
-    const bool rejoined = anchor
-                          && TryApplyDynamicOverlayToAnchor(
-                              "zipline_recovery",
-                              anchor->first,
-                              anchor->second,
-                              /*use_detour=*/false);
+    const bool rejoined = anchor && TryApplyDynamicOverlayToAnchor("zipline_recovery", anchor->first, anchor->second);
     // 链尾落点规划出的剩余展开路径从半路的架子上可能一个点都够不着; 那不代表导航失败, 只代表
     // 这份展开作废了 —— 回到作者的原始路线重新展开剩余部分, 刚判死的那跳已进封禁名单。
     if (!rejoined && !TryReplanRemainingAuthoredRoute("zipline_recovery_reexpand")) {
@@ -900,7 +968,8 @@ bool NavigationStateMachine::TryReplanRemainingAuthoredRoute(const char* reason)
     }
     replan_param.path.assign(authored.begin() + static_cast<std::ptrdiff_t>(slice_begin), authored.end());
     std::vector<Waypoint> replanned;
-    if (!ExpandNavmeshWaypoints(replan_param, *position_, should_stop_, replanned) || replanned.empty()) {
+    if (!ExpandNavmeshWaypoints(replan_param, *position_, should_stop_, replanned, nullptr, &runtime_state_.virtual_no_go)
+        || replanned.empty()) {
         LogWarn << "Authored route replan failed to expand the remaining route." << VAR(reason) << VAR(slice_begin)
                 << VAR(replan_param.path.size());
         return false;
@@ -919,7 +988,7 @@ bool NavigationStateMachine::TryReplanRemainingAuthoredRoute(const char* reason)
 
     const std::optional<DynamicAnchor> anchor = ResolveReachableNavmeshAnchor(param_, session_, *position_, 0, reason);
     if (anchor) {
-        TryApplyDynamicOverlayToAnchor(reason, anchor->first, anchor->second, /*use_detour=*/false);
+        TryApplyDynamicOverlayToAnchor(reason, anchor->first, anchor->second);
     }
     LogInfo << "Zipline recovery re-expanded the remaining authored route." << VAR(reason) << VAR(slice_begin)
             << VAR(session_->current_path().size()) << VAR(position_->x) << VAR(position_->y) << VAR(position_->zone_id);
@@ -931,7 +1000,7 @@ bool NavigationStateMachine::HandleDynamicReplanRequest(const char* reason)
     if (GiveUpUnreachableZipline(reason)) {
         return true;
     }
-    if (TryApplyDynamicOverlayToNextAnchor(reason, false)) {
+    if (TryApplyDynamicOverlayToNextAnchor(reason)) {
         return true;
     }
 
@@ -948,7 +1017,6 @@ bool NavigationStateMachine::HandleDynamicReplanRequest(const char* reason)
 
 bool NavigationStateMachine::PlanCrossTierEscapeCorridorFromHere(const char* reason)
 {
-    const double heading = NaviMath::NormalizeAngle(position_->angle);
     const std::vector<Waypoint>& path = session_->current_path();
     for (size_t index = session_->current_node_idx(); index < path.size(); ++index) {
         const Waypoint& candidate = session_->CurrentPathAt(index);
@@ -959,13 +1027,7 @@ bool NavigationStateMachine::PlanCrossTierEscapeCorridorFromHere(const char* rea
         if (!continue_index) {
             continue; // a generated overlay waypoint (no canonical index) is not a rejoin target
         }
-        if (TryApplyDynamicOverlayToAnchor(
-                reason,
-                *continue_index,
-                candidate,
-                /*use_detour=*/false,
-                heading,
-                /*emit_interior_corners=*/true)) {
+        if (TryApplyDynamicOverlayToAnchor(reason, *continue_index, candidate, /*emit_interior_corners=*/true)) {
             runtime_state_.cross_tier_escape.goal_x = candidate.x;
             runtime_state_.cross_tier_escape.goal_y = candidate.y;
             LogInfo << "Cross-tier escape corridor planned." << VAR(reason) << VAR(position_->zone_id) << VAR(position_->x)
@@ -1056,7 +1118,13 @@ bool NavigationStateMachine::ExecutePhysicalUnstick(double stuck_heading)
     LogInfo << "Physical unstick step executed." << VAR(distance) << VAR(moved) << VAR(dislodged) << VAR(unstick.count)
             << VAR(target_heading) << VAR(target->x) << VAR(target->y);
 
-    if (TryApplyDynamicOverlayToNextAnchor("recovery_unstick_replan", false)) {
+    // 位移之后先把刚顶住的障碍生成禁区再重新规划, 使新线自起点即绕开它; 生成或规划失败则退回普通重规划。
+    // 禁区以位移前的位置为原点: 障碍位于该位置的前方, 与位移后的当前位置的相对关系已不确定。
+    const std::optional<DynamicAnchor> anchor = ResolveCurrentAnchor(session_, *position_);
+    const bool replanned =
+        (anchor && TryVirtualNoGoReplan("recovery_unstick_replan", anchor->first, anchor->second, step_start, stuck_heading))
+        || TryApplyDynamicOverlayToNextAnchor("recovery_unstick_replan");
+    if (replanned) {
         session_->ResetProgress();
         SelectPhaseForCurrentWaypoint("recovery_unstick_replan");
         return true;
@@ -1488,11 +1556,6 @@ bool NavigationStateMachine::TickNavigate()
         runtime_state_.offroute.Reset();
     }
 
-    // Near a strict-arrival goal only the *detour* is unsafe (it routes away from the exact point);
-    // a jump is still a safe nudge, so recovery is allowed to enter here and the suppression is
-    // applied to the detour step alone, below.
-    const bool near_strict_goal =
-        waypoint.RequiresStrictArrival() && route.waypoint_distance <= arrival_distance + kCloseGoalDetourSuppressSlack;
     // "Too close to bother recovering" is measured on the same signal the stall clock runs on: while NavRun
     // steers, corridor remaining is the true distance left, and the serial waypoint is a breadcrumb that can sit
     // a pixel away with the whole leg still ahead. Reading the breadcrumb here closed the gate on an agent pinned
@@ -1634,21 +1697,26 @@ bool NavigationStateMachine::TickNavigate()
 
                 // The jump pulse above runs every recovery tick, so a fresh stall always tries to hop free
                 // first; the rest of the ladder only opens after the jump has failed
-                // kRecoveryJumpAttemptsBeforeDetour times for this anchor. Of the two escalations only the
-                // detour is unsafe next to a strict goal — it re-routes to a bypass vertex and gives up the
-                // exact point. The physical unstick just dislodges sideways and re-approaches the same anchor,
-                // so it stays available there; otherwise a stall inside the strict band has nothing left but
-                // the jump until the hard-progress timeout.
+                // kRecoveryJumpAttemptsBeforeDetour times for this anchor. The detour places a virtual no-go
+                // disc ahead and re-plans around it; the disc keeps the line off this spot for the rest of the
+                // navigation. Where a disc has already proven to block the only passage, the detour is skipped
+                // and the ladder goes straight to the physical unstick.
                 const bool escalated = escalation.jump_attempt_count >= kRecoveryJumpAttemptsBeforeDetour;
-                const bool detour_allowed = escalated && !near_strict_goal;
-                if (detour_allowed && escalation.detour_attempt_count < kRecoveryDetourAttemptsBeforeUnstick) {
+                const double stuck_heading = nav_run_result.has_corridor_heading ? nav_run_result.corridor_heading : route.route_heading;
+                const bool push_through_here =
+                    std::any_of(runtime_state_.virtual_no_go.begin(), runtime_state_.virtual_no_go.end(), [&](const VirtualNoGoDisc& disc) {
+                        return disc.push_through && disc.zone_id == position_->zone_id
+                               && std::hypot(disc.x - position_->x, disc.y - position_->y)
+                                      <= disc.radius + kVirtualNoGoStandoff + kVirtualNoGoRadiusStep;
+                    });
+                if (escalated && !push_through_here && escalation.detour_attempt_count < kRecoveryDetourAttemptsBeforeUnstick) {
                     ++escalation.detour_attempt_count;
-                    if (TryApplyDynamicOverlayToAnchor(
+                    if (TryVirtualNoGoReplan(
                             "recovery_navmesh_detour",
                             post_jump_anchor->first,
                             post_jump_anchor->second,
-                            true,
-                            route.route_heading)) {
+                            *position_,
+                            stuck_heading)) {
                         SelectPhaseForCurrentWaypoint("recovery_navmesh_detour");
                         return true;
                     }
@@ -1656,7 +1724,7 @@ bool NavigationStateMachine::TickNavigate()
                             << VAR(escalation.detour_attempt_count) << VAR(escalation.jump_attempt_count) << VAR(post_jump_anchor->first)
                             << VAR(route.progress_distance) << VAR(stalled_ms);
                 }
-                if (escalated && ExecutePhysicalUnstick(route.route_heading)) {
+                if (escalated && ExecutePhysicalUnstick(stuck_heading)) {
                     return true;
                 }
                 utils::SleepFor(kTargetTickMs);

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.h
@@ -63,10 +63,17 @@ private:
         const char* reason,
         size_t continue_index,
         const Waypoint& anchor,
-        bool use_detour,
-        double route_heading = 0.0,
         bool emit_interior_corners = false);
-    bool TryApplyDynamicOverlayToNextAnchor(const char* reason, bool use_detour, double route_heading = 0.0);
+    bool TryApplyDynamicOverlayToNextAnchor(const char* reason);
+    // 无观测绕障: 在 origin 前方生成一块虚拟禁区, 再从当前位置重新规划到锚点。禁区存续整趟导航,
+    // 此后每次规划都绕开它。带禁区规划失败则缩小半径重试一次; 仍失败说明此处是唯一通路,
+    // 该禁区标记为 push_through 并返回 false。
+    bool TryVirtualNoGoReplan(
+        const char* reason,
+        size_t continue_index,
+        const Waypoint& anchor,
+        const NaviPosition& origin,
+        double stuck_heading);
     // 走不到的上索点在这里让路: 判成够不着就丢掉这条链改走路, 返回 true 表示这一拍已经处理完。
     bool GiveUpUnreachableZipline(const char* reason);
     bool HandleZiplineRecoveryReplan();

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -63,6 +63,8 @@ struct NavmeshExpansionState
     std::string navmesh_zone;
     // 某一腿被虚拟禁区判掉。终态: 整条展开到此为止, 回放作者提示也只会再撞同一块禁区。
     bool no_go_rejected = false;
+    // 本趟导航已生成的虚拟禁区, 每条腿的规划都会带上。首次展开时尚未生成, 为空。
+    const std::vector<VirtualNoGoDisc>* no_go = nullptr;
 
     // 起点一挪，原来那张面的证据就不再成立：新起点属于哪层由生成它的那一段自己决定。
     // 两者绑在一起改，免得哪条支路只挪了点忘了清证据，把上一腿的层带进下一腿。
@@ -89,15 +91,6 @@ constexpr std::array<BaseNavZoneAlias, 6> kBaseNavZoneAliases { {
     { "indie_dg005", { "indie_dg005", "IndieDg005" } },
     { "indie_dg007", { "indie_dg007", "IndieDg007" } },
 } };
-
-constexpr std::array<double, 3> kDetourRadii { 3.0, 5.0, 7.0 };
-constexpr std::array<double, 8> kDetourHeadingOffsets { 30.0, -30.0, 50.0, -50.0, 70.0, -70.0, 90.0, -90.0 };
-constexpr double kDetourBlockedForwardDistance = 6.0;
-constexpr size_t kDetourBlockedTriangleCount = 4;
-// 点封堵对起/终点的净空(px),须大于 navmesh::recast::kBlockedPointRadius,否则把端点自己封死
-constexpr double kDetourBlockedPointStandoff = 2.0;
-constexpr double kDetourBacktrackPenalty = 8.0;
-constexpr double kDetourSnapPenalty = 3.0;
 
 // Blind-target fallback: navmesh omits water, so a target a human can reach is reported unreachable.
 // Route as close as the mesh allows, then walk the residual gap blind toward the exact target.
@@ -465,8 +458,7 @@ navmesh::BaseNavRouteRequest BuildRouteRequest(
     const std::string& navmesh_zone,
     const navmesh::WorldPoint& start,
     const navmesh::WorldPoint& goal,
-    const std::vector<uint32_t>& blocked_triangles = {},
-    const std::vector<navmesh::WorldPoint>& blocked_points = {},
+    const std::vector<VirtualNoGoDisc>* no_go = nullptr,
     float goal_floor_y = navmesh::kBaseNavFloorYNone,
     std::optional<double> goal_deck_y = std::nullopt,
     std::optional<double> start_floor_y = std::nullopt)
@@ -475,8 +467,14 @@ navmesh::BaseNavRouteRequest BuildRouteRequest(
     request.zone_name = navmesh_zone;
     request.start = start;
     request.goal = goal;
-    request.blocked_triangles = blocked_triangles;
-    request.blocked_points = blocked_points;
+    // 禁区按生成时所在的定位区记录, 只有同区规划把它当作墙; 已判定封闭唯一通路的禁区不再计入
+    if (no_go != nullptr) {
+        for (const VirtualNoGoDisc& disc : *no_go) {
+            if (!disc.push_through && disc.zone_id == locator_zone) {
+                request.no_go_discs.push_back({ .center = { .x = disc.x, .y = disc.y }, .radius = disc.radius });
+            }
+        }
+    }
     // 终点声明决定停在哪张面; 起点站在哪张面由搜索自己按起点高度定
     if (goal_deck_y) {
         request.goal_deck_y = static_cast<float>(*goal_deck_y);
@@ -560,8 +558,6 @@ navmesh::BaseNavRouteResult PlanCorridorRoute(
     }
     const float start_floor = request.start_floor_y > navmesh::kBaseNavFloorYValidMin ? request.start_floor_y : request.floor_y;
     const float goal_floor = request.goal_floor_y > navmesh::kBaseNavFloorYValidMin ? request.goal_floor_y : request.floor_y;
-    // 绕障候选探测(带封堵)会成批试错,失败与告警都不上日志,由绕障侧汇总
-    const bool detour_probe = !request.blocked_triangles.empty() || !request.blocked_points.empty();
     auto plan = navmesh.engine.plan(
         request.zone_name,
         request.start,
@@ -569,8 +565,7 @@ navmesh::BaseNavRouteResult PlanCorridorRoute(
         start_floor,
         goal_floor,
         request.goal_deck_y,
-        request.blocked_triangles,
-        request.blocked_points,
+        request.no_go_discs,
         should_stop);
     result.gap_start = plan.debug.gap_start;
     result.gap_goal = plan.debug.gap_goal;
@@ -580,24 +575,20 @@ navmesh::BaseNavRouteResult PlanCorridorRoute(
         if (plan.no_go) {
             result.status = navmesh::BaseNavRouteStatus::NoGo;
         }
-        if (!detour_probe) {
-            LogWarn << "RECAST plan failed." << VAR(request.zone_name) << VAR(result.error);
-        }
+        LogWarn << "RECAST plan failed." << VAR(request.zone_name) << VAR(request.no_go_discs.size()) << VAR(result.error);
         return result;
     }
-    if (!detour_probe) {
-        for (const std::string& warning : plan.warnings) {
-            LogWarn << "RECAST plan warning." << VAR(request.zone_name) << VAR(warning);
-        }
-        // 采信的窗口档与分段耗时: 实机上分辨"小窗一档过"与"升到整类"只有这一行。
-        std::string tier_notes;
-        for (const std::string& note : plan.debug.tier_notes) {
-            tier_notes += (tier_notes.empty() ? "" : " | ") + note;
-        }
-        LogInfo << "RECAST plan window." << VAR(request.zone_name) << VAR(plan.debug.tier) << VAR(plan.debug.nx) << VAR(plan.debug.ny)
-                << VAR(plan.debug.timing.window_ms) << VAR(plan.debug.timing.topology_ms) << VAR(plan.debug.timing.geometry_ms)
-                << VAR(plan.debug.timing.total_ms) << VAR(tier_notes);
+    for (const std::string& warning : plan.warnings) {
+        LogWarn << "RECAST plan warning." << VAR(request.zone_name) << VAR(warning);
     }
+    // 采信的窗口档与分段耗时: 实机上分辨"小窗一档过"与"升到整类"只有这一行。
+    std::string tier_notes;
+    for (const std::string& note : plan.debug.tier_notes) {
+        tier_notes += (tier_notes.empty() ? "" : " | ") + note;
+    }
+    LogInfo << "RECAST plan window." << VAR(request.zone_name) << VAR(plan.debug.tier) << VAR(plan.debug.nx) << VAR(plan.debug.ny)
+            << VAR(plan.debug.timing.window_ms) << VAR(plan.debug.timing.topology_ms) << VAR(plan.debug.timing.geometry_ms)
+            << VAR(plan.debug.timing.total_ms) << VAR(request.no_go_discs.size()) << VAR(tier_notes);
     result.status = navmesh::BaseNavRouteStatus::Success;
     result.path.zone_id = zone->zone_id;
     result.path.zone_name = request.zone_name;
@@ -636,8 +627,7 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRouteImpl(
     const std::string& locator_zone,
     const navmesh::WorldPoint& start,
     const navmesh::WorldPoint& goal,
-    const std::vector<uint32_t>& blocked_triangles,
-    const std::vector<navmesh::WorldPoint>& blocked_points = {},
+    const std::vector<VirtualNoGoDisc>* no_go,
     std::optional<double> goal_deck_y = std::nullopt,
     std::optional<double> start_floor_y = std::nullopt,
     NavmeshRouteDiagnostic* out_diagnostic = nullptr)
@@ -657,15 +647,13 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRouteImpl(
         return std::nullopt;
     }
 
-    const bool detour_probe = !blocked_triangles.empty() || !blocked_points.empty();
     auto request = BuildRouteRequest(
         navmesh->pack,
         locator_zone,
         navmesh_zone,
         start,
         goal,
-        blocked_triangles,
-        blocked_points,
+        no_go,
         navmesh::kBaseNavFloorYNone,
         goal_deck_y,
         start_floor_y);
@@ -674,17 +662,13 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRouteImpl(
     const int64_t plan_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - plan_started_at).count();
     if (!route_result.ok()) {
-        if (!detour_probe) {
-            LogWarn << "Failed to plan NAVMESH route." << VAR(navmesh_zone) << VAR(locator_zone) << VAR(start.x) << VAR(start.y)
-                    << VAR(goal.x) << VAR(goal.y) << VAR(navmesh::ToString(route_result.status)) << VAR(plan_ms);
-        }
+        LogWarn << "Failed to plan NAVMESH route." << VAR(navmesh_zone) << VAR(locator_zone) << VAR(start.x) << VAR(start.y) << VAR(goal.x)
+                << VAR(goal.y) << VAR(navmesh::ToString(route_result.status)) << VAR(plan_ms);
         return std::nullopt;
     }
 
-    if (!detour_probe) {
-        LogInfo << "NAVMESH route planned." << VAR(navmesh_zone) << VAR(locator_zone) << VAR(route_result.cost)
-                << VAR(route_result.path.points.size()) << VAR(plan_ms) << VAR(navmesh_load_ms);
-    }
+    LogInfo << "NAVMESH route planned." << VAR(navmesh_zone) << VAR(locator_zone) << VAR(route_result.cost)
+            << VAR(route_result.path.points.size()) << VAR(plan_ms) << VAR(navmesh_load_ms);
     return route_result;
 }
 
@@ -773,8 +757,7 @@ bool AppendBlindTargetFallback(
             state.navmesh_zone,
             start,
             entry->point,
-            {},
-            {},
+            state.no_go,
             goal_floor_y,
             std::nullopt,
             state.route_start_floor_y);
@@ -961,8 +944,7 @@ bool AppendNavmeshWaypoint(
         state.navmesh_zone,
         state.route_start,
         target.point,
-        {},
-        {},
+        state.no_go,
         target.floor_y,
         target.deck_y,
         state.route_start_floor_y);
@@ -1410,7 +1392,8 @@ bool ExpandNavmeshWaypoints(
     const NaviPosition& initial_pos,
     const std::function<bool()>& should_stop,
     std::vector<Waypoint>& out_path,
-    std::vector<NavmeshRouteDiagnostic>* out_diagnostics)
+    std::vector<NavmeshRouteDiagnostic>* out_diagnostics,
+    const std::vector<VirtualNoGoDisc>* no_go)
 {
     g_expansion_failure = {};
     if (out_diagnostics != nullptr) {
@@ -1436,6 +1419,7 @@ bool ExpandNavmeshWaypoints(
         }
         return false;
     }
+    state->no_go = no_go;
 
     const std::filesystem::path navmesh_path = ResolveNavmeshFile(param.navmesh_file);
     const auto expand_started_at = std::chrono::steady_clock::now();
@@ -1489,9 +1473,10 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(
     const navmesh::WorldPoint& goal,
     std::optional<double> goal_deck_y,
     std::optional<double> start_floor_y,
-    NavmeshRouteDiagnostic* out_diagnostic)
+    NavmeshRouteDiagnostic* out_diagnostic,
+    const std::vector<VirtualNoGoDisc>* no_go)
 {
-    return PlanNavmeshRouteImpl(param, locator_zone, start, goal, {}, {}, goal_deck_y, start_floor_y, out_diagnostic);
+    return PlanNavmeshRouteImpl(param, locator_zone, start, goal, no_go, goal_deck_y, start_floor_y, out_diagnostic);
 }
 
 float NavmeshFloorYForZone(const NaviParam& param, const std::string& locator_zone)
@@ -1618,136 +1603,6 @@ double NavmeshOffMeshFraction(
         return 0.0;
     }
     return static_cast<double>(off) / static_cast<double>(total);
-}
-
-std::optional<navmesh::BaseNavRouteResult> PlanNavmeshDetourRoute(
-    const NaviParam& param,
-    const NaviPosition& position,
-    const Waypoint& anchor,
-    double route_heading,
-    navmesh::WorldPoint* out_detour_vertex)
-{
-    if (!anchor.HasPosition()) {
-        return std::nullopt;
-    }
-
-    const navmesh::WorldPoint start { .x = position.x, .y = position.y };
-    const navmesh::WorldPoint goal { .x = anchor.x, .y = anchor.y };
-    const auto direct_route = PlanNavmeshRouteImpl(param, position.zone_id, start, goal, {});
-    if (!direct_route) {
-        return std::nullopt;
-    }
-
-    const std::string navmesh_zone = InferBaseNavZone(position.zone_id, param.map_name);
-    const auto navmesh = LoadCachedNavmesh(ResolveNavmeshFile(param.navmesh_file), navmesh_zone);
-    if (!navmesh) {
-        return std::nullopt;
-    }
-    const uint16_t zone_id = direct_route->path.zone_id;
-    const float floor_y = navmesh->pack.floorYForZoneName(position.zone_id);
-    const auto snapTriangle = [&](const navmesh::WorldPoint& point) -> std::optional<uint32_t> {
-        const auto hit = navmesh->planner.snap(zone_id, point, navmesh::recast::kSnapRadius, floor_y);
-        if (!hit) {
-            return std::nullopt;
-        }
-        return hit->triangle;
-    };
-
-    // 封堵正前方一小段直连走廊踩到的三角形,但绝不封起点/终点自己的三角形:短腿上固定预算会
-    // 摸到终点三角形,封了它绕障就永远到不了锚点。
-    const auto start_triangle = snapTriangle(start);
-    const auto goal_triangle = snapTriangle(goal);
-    std::vector<uint32_t> blocked;
-    std::vector<navmesh::WorldPoint> samples;
-    {
-        const auto& points = direct_route->path.points;
-        const double forward_limit = kDetourBlockedForwardDistance * 2.0;
-        double walked = 0.0;
-        double next = navmesh::recast::kCS;
-        for (size_t i = 1; i < points.size() && walked < forward_limit; ++i) {
-            const double seg = std::hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y);
-            while (next <= walked + seg + 1e-9 && next <= forward_limit + 1e-9) {
-                const double t = seg > 1e-12 ? (next - walked) / seg : 0.0;
-                const navmesh::WorldPoint sample { .x = points[i - 1].x + (points[i].x - points[i - 1].x) * t,
-                                                   .y = points[i - 1].y + (points[i].y - points[i - 1].y) * t };
-                next += navmesh::recast::kCS;
-                samples.push_back(sample);
-                const auto triangle = snapTriangle(sample);
-                if (!triangle || triangle == start_triangle || triangle == goal_triangle) {
-                    continue;
-                }
-                if (blocked.size() < kDetourBlockedTriangleCount && std::find(blocked.begin(), blocked.end(), *triangle) == blocked.end()) {
-                    blocked.push_back(*triangle);
-                }
-            }
-            walked += seg;
-        }
-    }
-
-    // 开阔地大三角形能盖住整段前程,起/终点排除后封堵集会成空集;此时退化为点封堵,
-    // 在起/终点净空之外沿直连采样点盖小半径,障碍粒度从三角形缩到格
-    std::vector<navmesh::WorldPoint> blocked_points;
-    if (blocked.empty()) {
-        for (const navmesh::WorldPoint& sample : samples) {
-            const double d_start = std::hypot(sample.x - start.x, sample.y - start.y);
-            const double d_goal = std::hypot(sample.x - goal.x, sample.y - goal.y);
-            if (d_start <= kDetourBlockedPointStandoff || d_goal <= kDetourBlockedPointStandoff) {
-                continue;
-            }
-            blocked_points.push_back(sample);
-        }
-    }
-
-    std::optional<navmesh::BaseNavRouteResult> best;
-    double best_score = std::numeric_limits<double>::infinity();
-    navmesh::WorldPoint best_detour;
-    navmesh::WorldPoint best_detour_vertex {};
-    const navmesh::WorldPoint forward_probe = OffsetPoint(position, route_heading, kDetourBlockedForwardDistance);
-    for (double radius : kDetourRadii) {
-        for (double heading_offset : kDetourHeadingOffsets) {
-            const navmesh::WorldPoint candidate = OffsetPoint(position, route_heading + heading_offset, radius);
-            if (std::hypot(candidate.x - forward_probe.x, candidate.y - forward_probe.y) <= radius * 0.35) {
-                continue;
-            }
-
-            // 候选先吸上网格:绕行点必须钉在网格上,吸附距离计入评分
-            const auto snapped = navmesh->planner.snap(zone_id, candidate, navmesh::recast::kSnapRadius, floor_y);
-            if (!snapped) {
-                continue;
-            }
-            const auto route_to_detour = PlanNavmeshRouteImpl(param, position.zone_id, start, snapped->point, blocked, blocked_points);
-            if (!route_to_detour) {
-                continue;
-            }
-            const auto route_to_goal = PlanNavmeshRouteImpl(param, position.zone_id, snapped->point, goal, blocked, blocked_points);
-            if (!route_to_goal) {
-                continue;
-            }
-
-            const double backtrack_penalty = std::max(0.0, std::abs(heading_offset) - 120.0) / 60.0 * kDetourBacktrackPenalty;
-            const double score = route_to_detour->cost + route_to_goal->cost + backtrack_penalty + snapped->distance * kDetourSnapPenalty;
-            if (score < best_score) {
-                best = *route_to_detour;
-                best->cost += route_to_goal->cost;
-                best_score = score;
-                best_detour = candidate;
-                best_detour_vertex = snapped->point;
-            }
-        }
-    }
-
-    if (!best) {
-        LogWarn << "NAVMESH detour failed to find a reachable bypass." << VAR(position.x) << VAR(position.y) << VAR(position.zone_id)
-                << VAR(anchor.x) << VAR(anchor.y) << VAR(blocked.size()) << VAR(blocked_points.size());
-        return std::nullopt;
-    }
-
-    if (out_detour_vertex != nullptr) {
-        *out_detour_vertex = best_detour_vertex;
-    }
-    LogInfo << "NAVMESH detour selected." << VAR(best_detour.x) << VAR(best_detour.y) << VAR(best_detour_vertex.x)
-            << VAR(best_detour_vertex.y) << VAR(best_score) << VAR(best->cost) << VAR(best->path.points.size());
-    return best;
 }
 
 std::optional<navmesh::WorldPoint>

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -58,16 +58,20 @@ void NormalizeLivePositionToBase(const NaviParam& param, NaviPosition& pos);
 void PreloadNavmeshWaypoints(const NaviParam& param);
 // `should_stop` is polled between waypoints and between fallback probes: expansion runs before the
 // state machine exists, so it is the only place a stop request can be honored during planning.
+// `no_go` carries the virtual no-go discs this navigation has stamped so far; every leg planned here
+// treats the discs of its zone as walls. Null on the initial expansion, when none exist yet.
 bool ExpandNavmeshWaypoints(
     const NaviParam& param,
     const NaviPosition& initial_pos,
     const std::function<bool()>& should_stop,
     std::vector<Waypoint>& out_path,
-    std::vector<NavmeshRouteDiagnostic>* out_diagnostics = nullptr);
+    std::vector<NavmeshRouteDiagnostic>* out_diagnostics = nullptr,
+    const std::vector<VirtualNoGoDisc>* no_go = nullptr);
 NavmeshExpansionFailure CurrentNavmeshExpansionFailure();
 // The goal deck pins which overlapping walkable surface the route must stop on; unset keeps the full span
 // set. `start_floor_y` overrides which floor the start snaps onto, for the rare caller that actually knows
 // the height it is standing at (a zipline dismount); unset keeps the zone's dominant floor, unchanged.
+// `no_go` is the navigation's virtual no-go discs; the ones stamped in `locator_zone` become walls.
 std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(
     const NaviParam& param,
     const std::string& locator_zone,
@@ -75,7 +79,8 @@ std::optional<navmesh::BaseNavRouteResult> PlanNavmeshRoute(
     const navmesh::WorldPoint& goal,
     std::optional<double> goal_deck_y = std::nullopt,
     std::optional<double> start_floor_y = std::nullopt,
-    NavmeshRouteDiagnostic* out_diagnostic = nullptr);
+    NavmeshRouteDiagnostic* out_diagnostic = nullptr,
+    const std::vector<VirtualNoGoDisc>* no_go = nullptr);
 
 // Which walkable surface `point` lands on: the planar distance to it, and its height on the same scale
 // as BaseNavRouteRequest::floor_y. Height matters as much as distance — a point directly above or below
@@ -135,12 +140,6 @@ double NavmeshOffMeshFraction(
     const std::string& locator_zone,
     const std::vector<navmesh::WorldPoint>& polyline,
     double step);
-std::optional<navmesh::BaseNavRouteResult> PlanNavmeshDetourRoute(
-    const NaviParam& param,
-    const NaviPosition& position,
-    const Waypoint& anchor,
-    double route_heading,
-    navmesh::WorldPoint* out_detour_vertex = nullptr);
 std::optional<navmesh::WorldPoint> PlanUnstickTarget(
     const NaviParam& param,
     const NaviPosition& position,

--- a/agent/cpp-algo/source/MapNavmesh/MapNavmeshQuery.cpp
+++ b/agent/cpp-algo/source/MapNavmesh/MapNavmeshQuery.cpp
@@ -340,7 +340,7 @@ json::object BuildRoute(QueryContext& context, const QueryParam& param)
     const navmesh::WorldPoint start { .x = param.start[0], .y = param.start[1] };
     const navmesh::WorldPoint goal { .x = param.goal[0], .y = param.goal[1] };
     const float floor_y = FloorOrNone(param.floor_y);
-    const auto plan = context.engine->plan(zone->name, start, goal, floor_y, floor_y, FloorOrNone(param.goal_deck_y), {}, {}, {});
+    const auto plan = context.engine->plan(zone->name, start, goal, floor_y, floor_y, FloorOrNone(param.goal_deck_y), {}, {});
 
     if (!plan.ok) {
         // 失败时带上两端的离网探针，调用方才能标出是哪个点掉在网格外。

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -20,16 +20,21 @@ struct BaseNavSnapResult
     double distance = 0.0;
 };
 
+// A disc placed at runtime where the agent stalled against an obstacle the mesh does not record.
+// Cleared from the walkable set like an authored no-go zone, yet never terminal: an endpoint inside it
+// still plans.
+struct BaseNavNoGoDisc
+{
+    WorldPoint center;
+    double radius = 0.0;
+};
+
 struct BaseNavRouteRequest
 {
     std::string zone_name;
     WorldPoint start;
     WorldPoint goal;
-    std::vector<uint32_t> blocked_triangles;
-    // World-coordinate blocked points (radius navmesh::recast::kBlockedPointRadius). Finer-grained than
-    // blocked_triangles for obstacles inside the start/goal triangle, where triangle blocking would seal
-    // an endpoint.
-    std::vector<WorldPoint> blocked_points;
+    std::vector<BaseNavNoGoDisc> no_go_discs;
     // Dominant-floor height of the floor being navigated (from the locator/tier zone). Lets snap resolve
     // onto the right floor of a multi-floor base. kBaseNavFloorYNone (default) keeps the floor-blind path.
     // Shared fallback for both endpoints; the per-endpoint overrides below take precedence when set.

--- a/agent/cpp-algo/source/Navmesh/RecastNavFieldsIO.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavFieldsIO.cpp
@@ -19,7 +19,7 @@ constexpr size_t kHeaderSize = 48;
 constexpr size_t kSectionEntrySize = 24;
 constexpr size_t kConstSize = 144;
 
-// 采样与包围盒口径写死在 StampWalls / WallHits / BakeWalls 里, 旁包按同样的值烘。
+// 采样与包围盒口径写死在 StampWalls / BakeWalls 里, 旁包按同样的值烘。
 constexpr double kWallSampleSub = 0.4;
 constexpr double kHitSampleSub = 0.2;
 constexpr double kWallBBoxPad = 4.0;

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.cpp
@@ -719,26 +719,6 @@ std::vector<uint8_t> WallsAtLayer(
     return keep;
 }
 
-Mask WallHits(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny)
-{
-    Mask hit(nx, ny, 0);
-    for (size_t i = 0; i < p0.size(); ++i) {
-        const double L = std::hypot(p1[i].x - p0[i].x, p1[i].y - p0[i].y);
-        const int64_t steps = sampleSteps(L, 0.2);
-        for (int64_t k = 0; k < steps; ++k) {
-            const double t = static_cast<double>(k) / static_cast<double>(steps - 1);
-            const double sx = p0[i].x + (p1[i].x - p0[i].x) * t;
-            const double sy = p0[i].y + (p1[i].y - p0[i].y) * t;
-            const int64_t gx = static_cast<int64_t>(std::floor((sx - ox) / kCS));
-            const int64_t gy = static_cast<int64_t>(std::floor((sy - oy) / kCS));
-            if (gx >= 0 && gx < nx && gy >= 0 && gy < ny) {
-                hit.at(gy, gx) = 1;
-            }
-        }
-    }
-    return hit;
-}
-
 std::vector<int64_t> Comps4(const Mask& mask)
 {
     const int64_t ny = mask.ny, nx = mask.nx, NC = nx * ny;

--- a/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavGrid.h
@@ -34,8 +34,7 @@ inline constexpr double kBkt = 4.0;             // 挡线索引桶边长 px
 inline constexpr double kBktPad = 1e-6;         // 入桶时给挡线包围盒的放量 px, 需盖过相交判据放给挡线两端的余量
 inline constexpr double kSnapRadius = 8.0;      // 起终点吸附半径 px
 inline constexpr double kDeckBand = 2.0;        // 声明面高度匹配容差 px, 需远小于相邻面间距
-inline constexpr double kBlockedPointRadius = 1.0; // 封堵点盖章半径 px
-inline constexpr int64_t kHoleMaxCells = 32;       // 封闭小洞填充上限(格 = 2px²)
+inline constexpr int64_t kHoleMaxCells = 32;    // 封闭小洞填充上限(格 = 2px²)
 // 整类窗口在类范围外留的圈(格)。场都是局部算子, 依赖半径合起来不到这一圈, 留出它,
 // 类边缘那几格算出来的场就与在整区图上算的逐位相同。旁包按同一个值烘。
 inline constexpr int64_t kFieldHalo = 32;
@@ -204,9 +203,6 @@ std::vector<uint8_t> WallsAtLayer(
     const Grid<float>& lh,
     double ox,
     double oy);
-
-// 逐格一位: 这一格里落过边界边的采样点。距离场对跨边界无感, 用它把边所在的格从自由集里扣掉。
-Mask WallHits(const std::vector<WorldPoint>& p0, const std::vector<WorldPoint>& p1, double ox, double oy, int64_t nx, int64_t ny);
 
 // (dy+1)*3+(dx+1) → 位号 |(位存在终点格 ? 8 : 0), -1 表示这个位移不是八邻。
 // 表由 kGridStepDx/Dy 现推, 于是与包里 stepbits 的位序同一份定义。

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.cpp
@@ -41,11 +41,9 @@ struct WindowInfo
     // 就是让两张全窗口的图白白活过整个 routeWindow。
     Mask lay;
     Mask core;
-    Grid<float> dist;    // 无封堵: 旁包烘好的封缝净空; 有封堵: 按盖过的核心重算
-    Mask whit;           // 只在有封堵时算, 无封堵的腿不需要它
-    Mask medial;         // 旁包烘好的中轴, 有封堵时不可信、留空
-    EdgeBits step_edges; // 旁包烘好的台阶税边, 与封堵无关
-    bool blocked = false;
+    Grid<float> dist;    // 旁包烘好的封缝净空, 禁区内清零
+    Mask medial;         // 旁包烘好的中轴
+    EdgeBits step_edges; // 旁包烘好的台阶税边
     StepBarrier sev;
     std::vector<WorldPoint> segA;
     std::vector<WorldPoint> segB;
@@ -531,8 +529,7 @@ std::optional<WindowInfo> buildWindow(
     double x1,
     double y1,
     const std::vector<NoGoPoly>* no_go,
-    const std::vector<int32_t>& blocked_local,
-    const std::vector<WorldPoint>& blocked_points,
+    const std::vector<BaseNavNoGoDisc>& no_go_discs,
     std::string& err)
 {
     const int64_t nx = static_cast<int64_t>(std::ceil((x1 - x0) / kCS));
@@ -541,17 +538,8 @@ std::optional<WindowInfo> buildWindow(
     const int64_t wgx0 = std::llround(x0 / kCS);
     const int64_t wgy0 = std::llround(y0 / kCS);
 
-    // 区网格只有取墙与盖封堵面两个读者, 两者都只认窗口矩形, 与格图无关。
+    // 区网格只有取墙一个读者, 它只认窗口矩形, 与格图无关。
     BakedWalls walls = BakeWalls(zc, x0, y0, nx, ny);
-    RasterCells brc;
-    if (!blocked_local.empty()) {
-        std::vector<std::array<int32_t, 3>> bt;
-        bt.reserve(blocked_local.size());
-        for (const int32_t t : blocked_local) {
-            bt.push_back(zc.mesh.T[static_cast<size_t>(t)]);
-        }
-        brc = Rasterize(zc.mesh.verts(), bt, x0, y0, nx, ny);
-    }
     GridPatch pw;
     pw.x0 = x0;
     pw.y0 = y0;
@@ -583,11 +571,7 @@ std::optional<WindowInfo> buildWindow(
     info.lay = Mask(nx, ny, 0);
     info.core = Mask(nx, ny, 0);
     info.dist = Grid<float>(nx, ny, 0.0F);
-    info.blocked = !blocked_local.empty() || !blocked_points.empty();
-    // 中轴是从封缝净空推出来的窗口量, 封堵会改净空, 所以只有无封堵的腿才采烘好的
-    if (!info.blocked) {
-        info.medial = Mask(nx, ny, 0);
-    }
+    info.medial = Mask(nx, ny, 0);
     info.step_edges.resize(nx, ny);
     Grid<float> lh(nx, ny, std::numeric_limits<float>::quiet_NaN());
     std::vector<uint8_t> stepbits(static_cast<size_t>(nx * ny), 0);
@@ -621,7 +605,7 @@ std::optional<WindowInfo> buildWindow(
             stepbits[cell] |= r.steps;
             stepbits2[cell] |= gw.steps2[ri];
             segbits[cell] |= static_cast<uint8_t>(gw.seg[ri] & ~kGwMedialBit);
-            if (!info.blocked && (gw.seg[ri] & kGwMedialBit) != 0) {
+            if ((gw.seg[ri] & kGwMedialBit) != 0) {
                 info.medial.v[cell] = 1;
             }
             // 台阶税边: 方向 i 正向在 bit 2i, 反向在 bit 2i+1。EdgeBits 的反向位记在对端格上,
@@ -676,21 +660,6 @@ std::optional<WindowInfo> buildWindow(
         }
     }
     walls = BakedWalls();
-    // 挡线格图只喂接缝净空那一步, 而无封堵时净空直接采旁包, 不必再算
-    if (info.blocked) {
-        info.whit = WallHits(wP0, wP1, x0, y0, nx, ny);
-    }
-
-    for (size_t ci = 0; ci < brc.cell.size(); ++ci) {
-        const auto cell = static_cast<size_t>(brc.cell[ci]);
-        const float lf = lh.v[cell];
-        // 层高带内才盖掉,免得误伤其他楼层的格
-        if (!std::isnan(lf) && std::fabs(brc.h[ci] - lf) <= static_cast<float>(kClimb)) {
-            info.core.v[cell] = 0;
-            info.lay.v[cell] = 0;
-        }
-    }
-    brc = RasterCells();
     // 虚拟禁区盖格并把净空清零: 净空是弦判据的开关, 留着的话拐角还能从禁区上空拉直过去。
     // 净空与中轴照旧采旁包烘好的值, 于是禁区不把这条腿推下预烘快路, 代价只有窗口内那几行格的写入。
     if (no_go != nullptr) {
@@ -698,23 +667,22 @@ std::optional<WindowInfo> buildWindow(
     }
     lh = Grid<float>();
 
-    // 封堵点无自带高度;窗口层已按起点层高筛过,直接按平面距离盖格即可
-    if (!blocked_points.empty()) {
-        const int64_t pr = static_cast<int64_t>(std::ceil(kBlockedPointRadius / kCS));
-        for (const WorldPoint& bp : blocked_points) {
-            const int64_t cgx = static_cast<int64_t>(std::floor((bp.x - x0) / kCS));
-            const int64_t cgy = static_cast<int64_t>(std::floor((bp.y - y0) / kCS));
-            for (int64_t by = std::max<int64_t>(cgy - pr, 0); by <= std::min<int64_t>(cgy + pr, ny - 1); ++by) {
-                for (int64_t bx = std::max<int64_t>(cgx - pr, 0); bx <= std::min<int64_t>(cgx + pr, nx - 1); ++bx) {
-                    const double px = x0 + (static_cast<double>(bx) + 0.5) * kCS;
-                    const double py = y0 + (static_cast<double>(by) + 0.5) * kCS;
-                    if (std::hypot(px - bp.x, py - bp.y) > kBlockedPointRadius) {
-                        continue;
-                    }
-                    const size_t cell = static_cast<size_t>(by * nx + bx);
-                    info.core.v[cell] = 0;
-                    info.lay.v[cell] = 0;
+    // 运行期禁区不带高度; 窗口层已按起点层高筛过, 按平面距离盖格即可
+    for (const BaseNavNoGoDisc& disc : no_go_discs) {
+        const int64_t pr = static_cast<int64_t>(std::ceil(disc.radius / kCS));
+        const int64_t cgx = static_cast<int64_t>(std::floor((disc.center.x - x0) / kCS));
+        const int64_t cgy = static_cast<int64_t>(std::floor((disc.center.y - y0) / kCS));
+        for (int64_t by = std::max<int64_t>(cgy - pr, 0); by <= std::min<int64_t>(cgy + pr, ny - 1); ++by) {
+            for (int64_t bx = std::max<int64_t>(cgx - pr, 0); bx <= std::min<int64_t>(cgx + pr, nx - 1); ++bx) {
+                const double px = x0 + (static_cast<double>(bx) + 0.5) * kCS;
+                const double py = y0 + (static_cast<double>(by) + 0.5) * kCS;
+                if (std::hypot(px - disc.center.x, py - disc.center.y) > disc.radius) {
+                    continue;
                 }
+                const size_t cell = static_cast<size_t>(by * nx + bx);
+                info.core.v[cell] = 0;
+                info.lay.v[cell] = 0;
+                info.dist.v[cell] = 0.0F;
             }
         }
     }
@@ -874,10 +842,6 @@ std::optional<WindowInfo> buildWindow(
     info.segB.insert(info.segB.end(), info.sev.p1.begin(), info.sev.p1.end());
     info.sev.p0 = {};
     info.sev.p1 = {};
-    // 烘出来的净空是没封堵时的;盖掉格子会让通道变窄,代价场得按盖过的核心重算
-    if (info.blocked) {
-        info.dist = Clearance(info.core);
-    }
     return info;
 }
 
@@ -1079,58 +1043,11 @@ std::optional<std::vector<WorldPoint>> routeWindow(
     info.lay = Mask();
     // 边界边只用来算余量, 不用来禁步: 补洞封缝那一步已经判定这些细缝可以跨,
     // 回头再拿同一批边禁掉跨缝的一步, 等于在每道接缝上凭空立一堵墙
-    const EdgeBits& blocked_steps = info.sev.steps;
-    // 无封堵的腿: 封缝净空与中轴都是旁包按整类窗口烘好的, 直接采。
-    // 有封堵的腿: 净空已按盖过的核心重算, 接缝补偿与中轴只能在这里现算。
-    Grid<float> dist;
-    Mask rdg;
-    if (!info.blocked) {
-        dist = std::move(info.dist);
-        info.dist = Grid<float>();
-        rdg = std::move(info.medial);
-        info.medial = Mask();
-    }
-    else {
-        // 掩膜距离场对跨越边界边无感, 取到边界的距离的下确界补上
-        Mask wfree(nx, ny, 0);
-        for (size_t i = 0; i < wfree.v.size(); ++i) {
-            wfree.v[i] = info.whit.v[i] != 0 ? 0 : 1;
-        }
-        info.whit = Mask();
-        // 共面重叠片各自留着自己的边界, 落到格上是间距约 1px 的栅格, 开阔广场因此与窄巷读出同样的
-        // 宽度, 按宽度定价的拓扑层于是分辨不出宽路。摘法只放不加: 四邻全可走、且这四步都没被禁的
-        // 格子才回自由集, 建筑外轮廓恒有一侧没有面, 一根真墙边都摘不掉。
-        for (int64_t y = 1; y + 1 < ny; ++y) {
-            for (int64_t x = 1; x + 1 < nx; ++x) {
-                const int64_t c = y * nx + x;
-                if (wfree.v[static_cast<size_t>(c)] != 0 || walk.v[static_cast<size_t>(c)] == 0) {
-                    continue;
-                }
-                bool seam = true;
-                for (const int64_t d : { int64_t { 1 }, int64_t { -1 }, nx, -nx }) {
-                    const int64_t b = c + d;
-                    if (walk.v[static_cast<size_t>(b)] == 0 || blocked_steps.has(c, b) || blocked_steps.has(b, c)) {
-                        seam = false;
-                        break;
-                    }
-                }
-                if (seam) {
-                    wfree.v[static_cast<size_t>(c)] = 1;
-                }
-            }
-        }
-        dist = Clearance(wfree);
-        wfree = Mask();
-        // 取小就地写回接缝净空那张表: 另开一张同尺寸的只是让两张 36MB 的图在整个 routeWindow 里同时活着。
-        for (size_t i = 0; i < dist.v.size(); ++i) {
-            dist.v[i] = std::min(info.dist.v[i], dist.v[i]);
-        }
-        info.dist = Grid<float>();
-        // VV(c): 障碍按期望净空 c 膨胀后仍自由的格走可见图那一侧, 膨胀后被吃掉的窄处只留中脊,
-        // 对应论文里 V∩M(c) 的那段 Voronoi 弧。净空在这一层是掩膜: 开阔地没有贴墙这个选项, 窄缝
-        // 里没有偏一侧这个选项, 中途钻的一小段窄缝也就无法被整条路长平均掉。
-        rdg = MedialAxis(dist, kClrLambda);
-    }
+    // 封缝净空与中轴都是旁包按整类窗口烘好的, 直接采。
+    Grid<float> dist = std::move(info.dist);
+    info.dist = Grid<float>();
+    Mask rdg = std::move(info.medial);
+    info.medial = Mask();
     const double cpref = kClrPref;
     // 通道 = 障碍按 c 膨胀后仍自由的格, 并上中轴带。
     const auto chan = [&](double cc, const Mask& band) {
@@ -2070,7 +1987,7 @@ std::optional<std::vector<WorldPoint>> routeWindow(
         const int64_t ca = (*q)[k - 1].y * nx + (*q)[k - 1].x;
         const int64_t cb = (*q)[k].y * nx + (*q)[k].x;
         // 跳边一步不计为跨越立面
-        if (blocked_steps.has(ca, cb) && !info.links_cell.has(ca, cb)) {
+        if (info.sev.steps.has(ca, cb) && !info.links_cell.has(ca, cb)) {
             bad.push_back(k);
         }
     }
@@ -2312,12 +2229,11 @@ RecastPlanResult RecastNavEngine::plan(
     float start_floor_y,
     float goal_floor_y,
     float goal_deck_y,
-    const std::vector<uint32_t>& blocked,
-    const std::vector<WorldPoint>& blocked_points,
+    const std::vector<BaseNavNoGoDisc>& no_go_discs,
     const std::function<bool()>& should_stop)
 {
     const std::lock_guard<std::mutex> lock(mutex_);
-    return planLocked(zone_name, start, goal, start_floor_y, goal_floor_y, goal_deck_y, blocked, blocked_points, should_stop);
+    return planLocked(zone_name, start, goal, start_floor_y, goal_floor_y, goal_deck_y, no_go_discs, should_stop);
 }
 
 void RecastNavEngine::warm(const std::string& zone_name)
@@ -2387,8 +2303,7 @@ RecastPlanResult RecastNavEngine::planLocked(
     float start_floor_y,
     float goal_floor_y,
     float goal_deck_y,
-    const std::vector<uint32_t>& blocked,
-    const std::vector<WorldPoint>& blocked_points,
+    const std::vector<BaseNavNoGoDisc>& no_go_discs,
     const std::function<bool()>& should_stop)
 {
     const double t_all0 = nowMs();
@@ -2414,13 +2329,6 @@ RecastPlanResult RecastNavEngine::planLocked(
     }
     const FieldsZone* fz = ze.fz.get();
     ZoneClean& zc = *ze.zc;
-    std::vector<int32_t> blocked_local;
-    for (const uint32_t t : blocked) {
-        const int64_t local = static_cast<int64_t>(t) - zc.lo;
-        if (local >= 0 && local < static_cast<int64_t>(zc.mesh.T.size())) {
-            blocked_local.push_back(static_cast<int32_t>(local));
-        }
-    }
     const std::optional<double> sfl =
         start_floor_y > kBaseNavFloorYValidMin ? std::optional<double>(static_cast<double>(start_floor_y)) : std::nullopt;
     const std::optional<double> gfl =
@@ -2652,26 +2560,8 @@ RecastPlanResult RecastNavEngine::planLocked(
         const int64_t margin = local ? kTrustMargin : 0;
 
         const double t_win0 = nowMs();
-        info = buildWindow(
-            grid_,
-            *gz,
-            fields_,
-            *fzd,
-            *fz,
-            zc,
-            seed_gx,
-            seed_gy,
-            seed_h,
-            h0,
-            region,
-            x0,
-            y0,
-            x1,
-            y1,
-            nogo,
-            blocked_local,
-            blocked_points,
-            err);
+        info =
+            buildWindow(grid_, *gz, fields_, *fzd, *fz, zc, seed_gx, seed_gy, seed_h, h0, region, x0, y0, x1, y1, nogo, no_go_discs, err);
         const double window_ms = nowMs() - t_win0;
         const uint16_t zone_id = zc.zone_id;
         if (!info.has_value()) {

--- a/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
+++ b/agent/cpp-algo/source/Navmesh/RecastNavRoute.h
@@ -91,8 +91,7 @@ public:
 
     // start/goal 各带楼层高度(<= kBaseNavFloorYValidMin ⇒ floor 盲吸附);
     // goal_deck_y = 终点所在重叠面的高度,选层用,与吸附用的 floor_y 是两件事;
-    // blocked = pack 全局三角形号封堵集,命中格从可走层盖掉;
-    // blocked_points = 世界坐标封堵点,kBlockedPointRadius 半径内的格盖掉;
+    // no_go_discs = 运行期虚拟禁区, 与作者禁区同口径盖格, 但端点落在里面照常规划;
     // should_stop = 外部取消,两档窗口之间查一次
     RecastPlanResult plan(
         const std::string& zone_name,
@@ -101,8 +100,7 @@ public:
         float start_floor_y = kBaseNavFloorYNone,
         float goal_floor_y = kBaseNavFloorYNone,
         float goal_deck_y = kBaseNavFloorYNone,
-        const std::vector<uint32_t>& blocked = {},
-        const std::vector<WorldPoint>& blocked_points = {},
+        const std::vector<BaseNavNoGoDisc>& no_go_discs = {},
         const std::function<bool()>& should_stop = {});
 
     // 把该区的清洗网格与预烘场提前建好,让首条路线不必冷吃这份开销。
@@ -134,8 +132,7 @@ private:
         float start_floor_y,
         float goal_floor_y,
         float goal_deck_y,
-        const std::vector<uint32_t>& blocked,
-        const std::vector<WorldPoint>& blocked_points,
+        const std::vector<BaseNavNoGoDisc>& no_go_discs,
         const std::function<bool()>& should_stop);
 
     const BaseNavPack& pack_;


### PR DESCRIPTION
<img width="1454" height="1458" alt="image" src="https://github.com/user-attachments/assets/8d8dded9-c307-438d-aa8a-b3faf3df1935" />
<img width="1454" height="1454" alt="image" src="https://github.com/user-attachments/assets/cd524674-d9d4-4a6b-a80d-5904d921c0df" />
<img width="1306" height="1300" alt="image" src="https://github.com/user-attachments/assets/6d752556-f4b2-4311-aac5-d74a7f3d5c8d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增虚拟禁行区机制：导航遇到无法通行区域时，可动态生成禁行圆盘并重新规划路线。
  - 禁行区将在当前导航过程中持续生效，帮助路线避开反复卡住的位置。
- **改进**
  - 增加多次重规划机会，减少过早触发物理脱困的情况。
  - 重规划失败时会自动调整禁行区范围，并在必要时继续执行脱困流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->