### PR TITLE
fix(go-service): 售卖产品执行 BetterSliding 时 Go Agent 因 zmq::error_t 崩溃

### DIFF
--- a/agent/go-service/asyncpreempt.go
+++ b/agent/go-service/asyncpreempt.go
@@ -1,0 +1,28 @@
+package main
+
+import "strings"
+
+// asyncPreemptOffEnv 返回把 GODEBUG=asyncpreemptoff=1 合并进 env 后的新环境变量列表。
+// changed 为 false 表示 env 里已经关闭了异步抢占，调用方无需再做任何事。
+func asyncPreemptOffEnv(env []string) (result []string, changed bool) {
+	for i, kv := range env {
+		name, value, ok := strings.Cut(kv, "=")
+		if !ok || name != "GODEBUG" {
+			continue
+		}
+		for _, setting := range strings.Split(value, ",") {
+			if setting == "asyncpreemptoff=1" {
+				return env, false
+			}
+		}
+		result = append([]string{}, env...)
+		if value == "" {
+			result[i] = "GODEBUG=asyncpreemptoff=1"
+		} else {
+			result[i] = "GODEBUG=" + value + ",asyncpreemptoff=1"
+		}
+		return result, true
+	}
+	result = append(append([]string{}, env...), "GODEBUG=asyncpreemptoff=1")
+	return result, true
+}

--- a/agent/go-service/asyncpreempt_other.go
+++ b/agent/go-service/asyncpreempt_other.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/rs/zerolog/log"
+)
+
+// disableAsyncPreempt 关闭 Go 运行时基于 SIGURG 的异步抢占。
+// MAA 原生库通过 zmq 与本进程做阻塞式 IPC；抢占信号打断阻塞系统调用后，
+// zmq 会以未捕获的 C++ 异常终止整个进程（SIGABRT），而不是让当前调用失败并走正常错误处理。
+// GODEBUG 只在运行时启动时读一次，main 里 os.Setenv 已经来不及生效，
+// 因此这里用同一份可执行文件重新 exec 自己，让新进程从头读取带该开关的环境变量。
+func disableAsyncPreempt() {
+	env, changed := asyncPreemptOffEnv(os.Environ())
+	if !changed {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if err := syscall.Exec(exe, os.Args, env); err != nil {
+		log.Warn().
+			Err(err).
+			Msg("Failed to re-exec go-service with asyncpreemptoff")
+	}
+}

--- a/agent/go-service/asyncpreempt_test.go
+++ b/agent/go-service/asyncpreempt_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAsyncPreemptOffEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         []string
+		wantEnv     []string
+		wantChanged bool
+	}{
+		{
+			name:        "no GODEBUG entry appends one",
+			env:         []string{"PATH=/usr/bin"},
+			wantEnv:     []string{"PATH=/usr/bin", "GODEBUG=asyncpreemptoff=1"},
+			wantChanged: true,
+		},
+		{
+			name:        "empty GODEBUG is set directly",
+			env:         []string{"GODEBUG="},
+			wantEnv:     []string{"GODEBUG=asyncpreemptoff=1"},
+			wantChanged: true,
+		},
+		{
+			name:        "existing settings are preserved and appended",
+			env:         []string{"GODEBUG=http2client=0"},
+			wantEnv:     []string{"GODEBUG=http2client=0,asyncpreemptoff=1"},
+			wantChanged: true,
+		},
+		{
+			name:        "already disabled is left untouched",
+			env:         []string{"PATH=/usr/bin", "GODEBUG=asyncpreemptoff=1"},
+			wantEnv:     []string{"PATH=/usr/bin", "GODEBUG=asyncpreemptoff=1"},
+			wantChanged: false,
+		},
+		{
+			name:        "already disabled alongside other settings is left untouched",
+			env:         []string{"GODEBUG=http2client=0,asyncpreemptoff=1"},
+			wantEnv:     []string{"GODEBUG=http2client=0,asyncpreemptoff=1"},
+			wantChanged: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotEnv, gotChanged := asyncPreemptOffEnv(test.env)
+			if gotChanged != test.wantChanged || !reflect.DeepEqual(gotEnv, test.wantEnv) {
+				t.Fatalf(
+					"asyncPreemptOffEnv(%v) = (%v, %t), want (%v, %t)",
+					test.env,
+					gotEnv,
+					gotChanged,
+					test.wantEnv,
+					test.wantChanged,
+				)
+			}
+		})
+	}
+}

--- a/agent/go-service/asyncpreempt_windows.go
+++ b/agent/go-service/asyncpreempt_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main
+
+// disableAsyncPreempt 在 Windows 下是空操作：Windows 的 goroutine 抢占不依赖信号，
+// 不会打断阻塞系统调用，因此不存在 zmq 收到 EINTR 而崩溃的场景。
+func disableAsyncPreempt() {}

--- a/agent/go-service/main.go
+++ b/agent/go-service/main.go
@@ -15,6 +15,8 @@ import (
 const usage = "Usage: go-service <identifier> | go-service --pretask <taskname> [args...]"
 
 func main() {
+	disableAsyncPreempt()
+
 	if _, ok := os.LookupEnv("GOTRACEBACK"); !ok {
 		debug.SetTraceback("crash")
 	}


### PR DESCRIPTION
This is a small, targeted change to agent/go-service/asyncpreempt.go, agent/go-service/asyncpreempt_other.go, agent/go-service/asyncpreempt_test.go, agent/go-service/asyncpreempt_windows.go and a few others that resolves the reported issue without touching anything unrelated.

Fixes #5047.

The checks evaluated by the fork CI gate passed. This excludes skipped checks and checks filtered out for fork-only conditions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改善服务启动时的运行稳定性，减少底层通信调用因异步抢占中断而导致进程异常终止的情况。
  - 在非 Windows 平台启动时自动应用相关运行时设置；Windows 平台保持现有行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->