### PR TITLE
fix(AutoStockpile): 修复购买数量误识别

### DIFF
--- a/assets/resource/pipeline/AutoStockpile/Purchase.json
+++ b/assets/resource/pipeline/AutoStockpile/Purchase.json
@@ -85,22 +85,22 @@
                     "SliderQuantity": {
                         "Box": [
                             360,
-                            480,
+                            484,
                             100,
-                            45
+                            38
                         ],
                         "Filter": {
                             "lower": [
-                                20,
-                                150,
-                                150
+                                75,
+                                75,
+                                75
                             ],
                             "upper": [
-                                35,
+                                255,
                                 255,
                                 255
                             ],
-                            "method": 40
+                            "method": 4
                         }
                     },
                     "ClampTargetToSliderMax": true


### PR DESCRIPTION
- 购买数量OCR由选取黄色改为过滤黄色
- 缩减roi高度
- case: 将1识别为7

close #5578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 调整自动采购数量滑块的检测区域，使识别范围更加精准。
  - 优化数量识别的颜色过滤参数，提升滑块数量检测的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->