### PR TITLE
fix(icon-recognition): 修复空网格阴影导致的定位偏移

### DIFF
--- a/agent/cpp-algo/source/IconRecognition/detail/GridDetector.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/GridDetector.cpp
@@ -1506,14 +1506,13 @@ struct TransferEmptyGridFit
 std::optional<TransferEmptyGridFit> FitTransferEmptyGrid(
     const TransferGridHint& hint,
     const std::vector<int>& x_seed_starts,
-    const std::vector<int>& baseline_y_starts,
     double pitch,
     const TransferGridProfile& profile,
     const cv::Mat& cell_score,
     const std::vector<float>& signed_x,
     const std::vector<float>& signed_y)
 {
-    if (x_seed_starts.empty() || baseline_y_starts.empty() || hint.y_starts.empty() || cell_score.empty() || pitch <= 0.0) {
+    if (x_seed_starts.empty() || hint.y_starts.empty() || cell_score.empty() || pitch <= 0.0) {
         return std::nullopt;
     }
     std::optional<TransferEmptyGridFit> best;
@@ -1589,27 +1588,9 @@ std::optional<TransferEmptyGridFit> FitTransferEmptyGrid(
             best = std::move(candidate);
         }
     }
-    std::vector<double> baseline_supports;
-    baseline_supports.reserve(x_seed_starts.size() * baseline_y_starts.size());
-    double baseline_total = 0.0;
-    for (int y : baseline_y_starts) {
-        for (int x : x_seed_starts) {
-            const double support = structure_support(x, y);
-            baseline_supports.push_back(support);
-            baseline_total += support;
-        }
-    }
-    const TransferEmptyGridFit baseline {
-        .x_starts = x_seed_starts,
-        .y_starts = baseline_y_starts,
-        .pitch = pitch,
-        .median_support = Median(baseline_supports),
-        .mean_support = baseline_total / baseline_supports.size(),
-    };
-    const bool equivalent_lattice = best && best->x_starts.size() == baseline.x_starts.size()
-                                    && best->y_starts.size() == baseline.y_starts.size() && !is_better(*best, baseline)
-                                    && !is_better(baseline, *best);
-    if (!best || best->median_support <= kEpsilon || (!is_better(*best, baseline) && !equivalent_lattice)) {
+    // 阴影内沿可能比真实格框有更强的结构响应；不能在双边缘校正前用旧相位分数淘汰候选。
+    // 校正后的候选仍须逐格通过低纹理判空，才可接管最终网格。
+    if (!best || best->median_support <= kEpsilon) {
         return std::nullopt;
     }
 
@@ -1864,16 +1845,9 @@ GridLayout BuildTransferLayout(
             maximum_columns,
             true,
             true);
-        const auto empty_grid = empty_x_fit ? FitTransferEmptyGrid(
-                                    hint,
-                                    empty_x_fit->starts,
-                                    *structural_y,
-                                    empty_x_fit->pitch,
-                                    profile,
-                                    cell_score,
-                                    signed_x,
-                                    signed_y)
-                                            : std::nullopt;
+        const auto empty_grid =
+            empty_x_fit ? FitTransferEmptyGrid(hint, empty_x_fit->starts, empty_x_fit->pitch, profile, cell_score, signed_x, signed_y)
+                        : std::nullopt;
         empty_grid_selected =
             empty_grid
             && IsTransferEmptyGridCandidate(image, roi, empty_grid->x_starts, empty_grid->y_starts, profile.cell_size, texture_context);

--- a/agent/cpp-algo/source/IconRecognition/test/test_small_algorithms.cpp
+++ b/agent/cpp-algo/source/IconRecognition/test/test_small_algorithms.cpp
@@ -1336,6 +1336,54 @@ void TestTransferEmptyGridDiagnosticsSkipUnexecutedRarity()
     Check(diagnostics.rejected_reasons.empty(), "skipped rarity scans must not report rejected rarity evidence");
 }
 
+void TestTransferEmptyGridRefinesInsetShadowsBeforeRejectingCandidate()
+{
+    constexpr int kCellSize = 64;
+    constexpr int kPitch = 69;
+    constexpr int kColumns = 5;
+    constexpr int kRows = 4;
+    const cv::Point origin(771, 203);
+    cv::Mat image(720, 1280, CV_8UC3, cv::Scalar(90, 90, 90));
+    // 半透明面板会透出平滑变化的背景；均匀背景无法复现旧候选抢先胜出的排序。
+    for (int y = 0; y < image.rows; ++y) {
+        for (int x = 0; x < image.cols; ++x) {
+            const auto value = cv::saturate_cast<unsigned char>(90.0 + 20.0 * std::sin(x / 71.0) * std::cos(y / 53.0));
+            image.at<cv::Vec3b>(y, x) = cv::Vec3b(value, value, value);
+        }
+    }
+    // 空槽的内阴影向内部衰减；顶部被面板裁去 6px，但其余行仍能确定共同边框相位。
+    for (int row = 0; row < kRows; ++row) {
+        for (int column = 0; column < kColumns; ++column) {
+            const cv::Rect cell(origin.x + column * kPitch, origin.y + row * kPitch, kCellSize, kCellSize);
+            for (int y = 0; y < kCellSize; ++y) {
+                for (int x = 0; x < kCellSize; ++x) {
+                    const int distance = std::min({ x, y, kCellSize - 1 - x, kCellSize - 1 - y });
+                    const auto value = cv::saturate_cast<unsigned char>(
+                        image.at<cv::Vec3b>(cell.y + y, cell.x + x)[0] * 0.85 - 20.0 * std::exp(-distance / 1.5));
+                    image.at<cv::Vec3b>(cell.y + y, cell.x + x) = cv::Vec3b(value, value, value);
+                }
+            }
+        }
+    }
+    const auto grid = iconrecognition::detail::DetectGrid(image, iconrecognition::GridType::Transfer, cv::Rect(739, 202, 398, 291), 1.0);
+    Check(grid.grids.size() == 1 && grid.grids.front().selection_diagnostics, "inset-shadow grid must retain diagnostics");
+    const auto& layout = grid.grids.front();
+    Check(layout.columns == kColumns && layout.rows == kRows, "inset-shadow grid must preserve all twenty empty cells");
+    Check(
+        layout.selection_diagnostics->fallback_reason == "empty-grid-structure",
+        "inset shadows must reach boundary refinement before candidate rejection");
+    for (const auto& cell : layout.cells) {
+        Check(
+            std::abs(cell.cell_box.x - (origin.x + cell.column * kPitch)) <= 1
+                && std::abs(cell.cell_box.y - (origin.y + cell.row * kPitch)) <= 1,
+            "inset-shadow grid must follow measured borders");
+        const auto texture = iconrecognition::detail::ForegroundTextureScore(image, cell.cell_box, iconrecognition::GridType::Transfer);
+        Check(
+            texture && *texture < iconrecognition::detail::kDefaultLowTextureThreshold,
+            "inset shadows must stay outside content sampling");
+    }
+}
+
 void TestPortStoragerWideRoiUsesStablePanelPartitions()
 {
     const auto win32 = iconrecognition::detail::PartitionPortStoragerRegions(cv::Size(880, 350));
@@ -2221,6 +2269,7 @@ int main()
         TestTransferEmptyGridFitsOneCompleteLattice();
         TestTransferEmptyGridSkipsCroppedTopRowAndKeepsWeakColumn();
         TestTransferEmptyGridDiagnosticsSkipUnexecutedRarity();
+        TestTransferEmptyGridRefinesInsetShadowsBeforeRejectingCandidate();
         TestPortStoragerWideRoiUsesStablePanelPartitions();
         TestCreditTradeGridUsesDimCardStructures();
         TestCreditTradeGridUsesSixColumnsWhenRoiCannotContainSeven();


### PR DESCRIPTION
- 移除双边缘校正前以旧网格结构分数淘汰空网格候选的判断，保留结构证据与逐格低纹理校验
- 新增平滑背景、衰减内阴影和顶部裁切场景的回归测试，校验网格数量、边框定位及内容采样

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改进空传输面板的网格识别，即使存在内阴影或顶部裁剪，也能更准确地精化边界并识别网格。
  - 优化候选网格判断，减少因基线比较导致的误拒绝。
  - 保留“空网格结构”诊断信息，并避免将内阴影误判为内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->