### PR TITLE
fix(MapNavigator): 滑索规划剔除拦路与地形阻挡的索

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -873,13 +873,14 @@ bool NavigationStateMachine::HandleZiplineRecoveryReplan()
     const bool on_tower = runtime_state_.IsZiplineMounted();
     const navmesh::WorldPoint fix { .x = position_->x, .y = position_->y };
     const auto snap = NavmeshSnapAt(param_, position_->zone_id, fix, param_.navmesh_snap_radius);
-    const bool fresh_fix = !position_provider_->LastCaptureWasHeld();
     const bool on_mesh = on_tower || (snap && snap->distance <= param_.navmesh_snap_radius);
-    if (!fresh_fix || !on_mesh) {
+    // 滑行期间的跟踪结果不可用, 只接受新鲜定位。贴不回可走面的定位同样接受: 它表示落点不在路面
+    // 上(落到未登记的架子、崖边未铺面处), 坐标本身仍然有效, 重展开时规划会吸附回最近的可走面。
+    if (position_provider_->LastCaptureWasHeld()) {
         ++recovery.rejected_fixes;
         if (recovery.rejected_fixes == 1) {
-            LogWarn << "Zipline recovery rejected an untrusted position; forcing another global locate." << VAR(fresh_fix) << VAR(on_mesh)
-                    << VAR(position_->x) << VAR(position_->y) << VAR(position_->zone_id);
+            LogWarn << "Zipline recovery rejected a stale position; forcing another global locate." << VAR(on_mesh) << VAR(position_->x)
+                    << VAR(position_->y) << VAR(position_->zone_id);
         }
         recovery.stable_hits = 0;
         position_provider_->ResetTracking();
@@ -903,16 +904,17 @@ bool NavigationStateMachine::HandleZiplineRecoveryReplan()
     LogInfo << "Zipline recovery position stabilized." << VAR(elapsed_ms) << VAR(recovery.stable_hits) << VAR(recovery.rejected_fixes)
             << VAR(position_->x) << VAR(position_->y) << VAR(position_->zone_id);
 
-    // 站在架子上哪个点都走不到, 剩余展开路径直接作废, 只能重展开
-    bool rejoined = false;
-    if (!on_tower) {
+    // 剩余展开是按「从链尾落点出发」算的, 实际未抵达该点时它与当前位置无关: 可接入点可能在另
+    // 一侧, 沿途会撞上原本要用索越过的障碍。先回作者路线从当前位置重新展开, 判死的那一跳已记入
+    // 账本, 规划会绕开它另选链路。
+    bool rejoined = TryReplanRemainingAuthoredRoute("zipline_recovery_reexpand");
+    // 重展开失败才退回旧展开: 当前位置有可走面且不在架子上时, 它至少是一条经过规划的路径。
+    if (!rejoined && !on_tower && on_mesh) {
         const std::optional<DynamicAnchor> anchor =
             ResolveReachableNavmeshAnchor(param_, session_, *position_, session_->current_node_idx(), "zipline_recovery");
         rejoined = anchor && TryApplyDynamicOverlayToAnchor("zipline_recovery", anchor->first, anchor->second);
     }
-    // 链尾落点规划出的剩余展开路径从半路的架子上可能一个点都够不着; 那不代表导航失败, 只代表
-    // 这份展开作废了 —— 回到作者的原始路线重新展开剩余部分, 刚判死的那跳已经记在账本里。
-    if (!rejoined && !TryReplanRemainingAuthoredRoute("zipline_recovery_reexpand")) {
+    if (!rejoined) {
         if (on_tower) {
             semantic_nodes::LeaveZiplineTower(BuildSemanticContext(
                 action_wrapper_,

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -1568,6 +1568,35 @@ std::optional<NavmeshSnap> NavmeshSnapAt(
     return NavmeshSnap { .distance = entry->distance, .height = navmesh->planner.triangleHeight(entry->triangle) };
 }
 
+std::vector<std::optional<double>>
+    NavmeshLineRises(const NaviParam& param, const std::string& locator_zone, const std::vector<NavmeshAirLine>& lines)
+{
+    std::vector<std::optional<double>> rises(lines.size());
+    const std::string navmesh_zone = InferBaseNavZone(locator_zone, param.map_name);
+    if (navmesh_zone.empty()) {
+        return rises;
+    }
+    const auto navmesh = LoadCachedNavmesh(ResolveNavmeshFile(param.navmesh_file), navmesh_zone);
+    if (!navmesh) {
+        return rises;
+    }
+    for (size_t index = 0; index < lines.size(); ++index) {
+        const NavmeshAirLine& line = lines[index];
+        const auto from = navmesh->pack.projectToBase(navmesh_zone, line.a.x, line.a.y);
+        const auto to = navmesh->pack.projectToBase(navmesh_zone, line.b.x, line.b.y);
+        if (!from || !to || from->geometry_zone == nullptr || from->geometry_zone != to->geometry_zone) {
+            continue;
+        }
+        rises[index] = navmesh->planner.lineRise(
+            from->geometry_zone->zone_id,
+            { .x = from->x, .y = from->y },
+            line.a_height,
+            { .x = to->x, .y = to->y },
+            line.b_height);
+    }
+    return rises;
+}
+
 std::vector<std::vector<uint32_t>>
     NavmeshRegionsNear(const NaviParam& param, const std::string& locator_zone, const std::vector<navmesh::WorldPoint>& points)
 {

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.h
@@ -100,6 +100,22 @@ std::optional<NavmeshSnap> NavmeshSnapAt(
     const navmesh::WorldPoint& point,
     double radius,
     std::optional<double> floor_y = std::nullopt);
+
+// A straight line hanging in the air, each end carrying its own height (same frame as BaseNavRouteRequest::floor_y).
+struct NavmeshAirLine
+{
+    navmesh::WorldPoint a;
+    double a_height = 0.0;
+    navmesh::WorldPoint b;
+    double b_height = 0.0;
+};
+
+// How far terrain pushes up into each air line; see BaseNavPlanner::lineRise for the measure. An empty optional means
+// "no answer" (zone unresolved, or the two ends project into different geometry zones), never "rises by zero", so the
+// caller has to read it as a pass. One zone resolution is shared by the whole batch.
+std::vector<std::optional<double>>
+    NavmeshLineRises(const NaviParam& param, const std::string& locator_zone, const std::vector<NavmeshAirLine>& lines);
+
 // The bake-time connectivity classes each point sits in. A route is searched inside one class only, so
 // two points whose sets are disjoint cannot be connected by any plan — a cheap way to drop legs that are
 // bound to fail. An empty set means "no answer" (no baked grid, unknown zone, no voxel nearby), never

--- a/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
@@ -247,17 +247,20 @@ double PolylineLength(const navmesh::WorldPath& path)
 
 constexpr size_t kNoTower = std::numeric_limits<size_t>::max();
 
-// 索线中段横向近到这个距离还有另一根同型通电架子，就判这条直索不成立：滑行会终止在中间那根上。
-// 实测终止在中间架子的两条索，拦路架横向距离 11.23 / 10.14；实证滑到落点的索中段 30 内无架子。
-// 两组样本之间 13.2~15.3 存在空隙，取空隙下沿。
-constexpr double kRopeInterceptLateralWu = 12.0;
+// 索线中段横向近到这个距离还有另一根同型通电架子，这条直索就只算不确定边：滑行可能终止在中间
+// 那根上。三次实测终止在中间架子，拦路架横向 10.14 / 11.23 / 14.99；另有一次中段立着横向 4.55
+// 的架子，人却整条滑完了。横向距离分不开这四例，架子朝向又不在记录里，所以这条规则只降档不删边，
+// 取值取到盖住已知被拦的 14.99 为止。
+constexpr double kRopeInterceptLateralWu = 15.0;
 
-// 地形高出索线超过这个量就判这条索挂不成。实测可用区间 (1.06, 8.64)：被游戏判为路径受阻的一对
-// 顶起 8.64，同场景可通行的两对是 1.06 / 0.94。全局分布在此区间连续，取值属工程折中。
+// 地形高出索线超过这个量，这条索就只算不确定边。实证区间 (4.40, 8.64]：上界是被游戏判为路径受阻
+// 的那一对，顶起 8.64；下界是实测滑完的索里顶起最大的一根，顶起 4.40。去重后 433 条候选边的顶起量
+// 在取值附近连续，落在哪一侧是任意的，所以同样只降档；真挂不住时执行侧记一次账本再重规划。
 constexpr double kRopeTerrainRiseWu = 6.0;
 
-// 候选图分两档。certain 只收锚点原距离即在索长以内的边；其余边靠锚点格位的不确定半宽才够得上，
-// 是否真挂着索无法确定，单列一档，仅在确定边到不了目标时启用。
+// 候选图分两档。all 收下所有靠锚点格位不确定半宽够得上的边；certain 只收三件事同时成立的：锚点
+// 原距离即在索长以内、中段没有拦路架、地形没把索顶起。任一条不成立只降一档，边仍留在 all 里，
+// 所以没有哪条规则能把一根索从图里抹掉，阈值取错只改变偏好顺序。
 struct ZipLinkGraph
 {
     std::vector<std::vector<size_t>> all;
@@ -273,15 +276,21 @@ void DropEdge(std::vector<std::vector<size_t>>& links, size_t a, size_t b)
     drop(links[b], a);
 }
 
-// from→to 的索中段是否有另一根架子拦着。拦路架需离两端各超过一个拦截半径，更贴近端点的即端点
-// 自身，无需为此另设参数。nodes 已完成通电筛选，未通电的架子不承载索，也就不构成拦截。
-bool RopeIntercepted(const std::vector<zipline::ZiplineNode>& nodes, size_t from, size_t to)
+// from→to 的索中段拦着另一根架子时返回它的横向距离。拦路架需离两端各超过一个拦截半径，更贴近
+// 端点的即端点自身；到 from 的跨度也要在索长以内，从 from 够不到的架子接不住滑过来的人。
+// nodes 已完成通电筛选，不承载索的架子不构成拦截。
+std::optional<double> RopeIntercepted(
+    const std::vector<zipline::ZiplineNode>& nodes,
+    size_t from,
+    size_t to,
+    double span_limit,
+    const std::array<int, 2>& footprint)
 {
     const double dx = nodes[to].world_x - nodes[from].world_x;
     const double dz = nodes[to].world_z - nodes[from].world_z;
     const double span = std::hypot(dx, dz);
     if (span <= 2.0 * kRopeInterceptLateralWu) {
-        return false;
+        return std::nullopt;
     }
     for (size_t k = 0; k < nodes.size(); ++k) {
         if (k == from || k == to || nodes[k].template_id != nodes[from].template_id || nodes[k].level_id != nodes[from].level_id) {
@@ -295,19 +304,26 @@ bool RopeIntercepted(const std::vector<zipline::ZiplineNode>& nodes, size_t from
         }
         const double lateral_x = offset_x - dx * along / span;
         const double lateral_z = offset_z - dz * along / span;
-        if (std::hypot(lateral_x, lateral_z) <= kRopeInterceptLateralWu) {
-            return true;
+        const double lateral = std::hypot(lateral_x, lateral_z);
+        if (lateral > kRopeInterceptLateralWu) {
+            continue;
         }
+        const double limit_squared = span_limit * span_limit;
+        const double offset_y = nodes[k].world_y - nodes[from].world_y;
+        if (minimum_possible_world_span_squared(offset_x, offset_y, offset_z, footprint, footprint) > limit_squared) {
+            continue;
+        }
+        return lateral;
     }
-    return false;
+    return std::nullopt;
 }
 
 // 哪两根架子之间挂着索，记录本身没说，这里按几何推断：同一种架子、同一层、任一可能中心的
 // 世界距离不超过这种架子的索长上限，就当它们之间有一条候选索。索不分上下行，所以两个方向
 // 都算。位置含糊时优先保留候选；推错后执行侧会封掉失败边并重新规划，推漏则整条连续链都无法发现。
 //
-// 中段站着另一根架子的直索需要剔除：滑行终止在中间那根上，这条边的实际形态是经过它的两跳链。
-// 保留它会让求解器用一条不存在的索胜过真实的链。
+// 中段站着另一根架子的直索降到不确定档：滑行可能终止在中间那根上，这条边的实际形态是经过它的
+// 两跳链。实测里同样的几何有滑完整条的，所以只降不删，确定边够用时自然轮不到它。
 ZipLinkGraph BuildLinks(
     const std::vector<zipline::ZiplineNode>& nodes,
     const std::vector<double>& span_limit,
@@ -316,7 +332,9 @@ ZipLinkGraph BuildLinks(
     ZipLinkGraph graph;
     graph.all.resize(nodes.size());
     graph.certain.resize(nodes.size());
-    size_t intercepted = 0;
+    // 逐条记下拦路架的横向距离：kRopeInterceptLateralWu 的依据只有四条实测索，实机日志里攒起来的
+    // 这个分布才是后续调它的证据。
+    std::vector<double> demoted_lateral;
     for (size_t i = 0; i < nodes.size(); ++i) {
         if (span_limit[i] <= 0.0) {
             continue;
@@ -333,21 +351,21 @@ ZipLinkGraph BuildLinks(
             if (span_squared > span_limit[i] * span_limit[i]) {
                 continue;
             }
-            if (RopeIntercepted(nodes, i, j)) {
-                ++intercepted;
-                continue;
+            const std::optional<double> lateral = RopeIntercepted(nodes, i, j, span_limit[i], footprints[i]);
+            if (lateral) {
+                demoted_lateral.push_back(*lateral);
             }
             graph.all[i].push_back(j);
             graph.all[j].push_back(i);
             const double anchor_span_squared = anchor_delta_x * anchor_delta_x + delta_y * delta_y + anchor_delta_z * anchor_delta_z;
-            if (anchor_span_squared <= span_limit[i] * span_limit[i]) {
+            if (!lateral && anchor_span_squared <= span_limit[i] * span_limit[i]) {
                 graph.certain[i].push_back(j);
                 graph.certain[j].push_back(i);
             }
         }
     }
-    if (intercepted != 0) {
-        LogDebug << "ZiplineRoute: dropped the straight ropes intercepted by another tower." << VAR(intercepted);
+    if (!demoted_lateral.empty()) {
+        LogDebug << "ZiplineRoute: demoted the straight ropes intercepted by another tower." << VAR(demoted_lateral);
     }
     return graph;
 }
@@ -659,7 +677,7 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
         DropEdge(graph.certain, a, b);
     };
 
-    // 两根架子之间隔着地形时挂不住索。每条边只量一次，两个方向一并删除。
+    // 两根架子之间隔着地形时挂不住索，这条边降到不确定档。每条边只量一次，两个方向一并降档。
     {
         std::vector<std::pair<size_t, size_t>> pairs;
         std::vector<NavmeshAirLine> lines;
@@ -678,15 +696,24 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
             }
         }
         const std::vector<std::optional<double>> rises = NavmeshLineRises(param, locator_zone, lines);
-        size_t blocked = 0;
+        // 逐条记下降档的顶起量，连同没被这道降档的最大一条：kRopeTerrainRiseWu 的依据只有实测滑完的
+        // 那批索和一对被判受阻的，实机日志里攒到的这两行才是后续调这个值的证据。
+        std::vector<double> demoted_rises;
+        double kept_peak = 0.0;
         for (size_t index = 0; index < pairs.size(); ++index) {
-            if (rises[index] && *rises[index] > kRopeTerrainRiseWu) {
-                drop_from_graph(pairs[index].first, pairs[index].second);
-                ++blocked;
+            if (!rises[index]) {
+                continue;
+            }
+            if (*rises[index] > kRopeTerrainRiseWu) {
+                DropEdge(graph.certain, pairs[index].first, pairs[index].second);
+                demoted_rises.push_back(*rises[index]);
+            }
+            else {
+                kept_peak = std::max(kept_peak, *rises[index]);
             }
         }
-        if (blocked != 0) {
-            LogDebug << "ZiplineRoute: dropped the ropes blocked by terrain." << VAR(blocked) << VAR(pairs.size());
+        if (!demoted_rises.empty()) {
+            LogDebug << "ZiplineRoute: demoted the ropes blocked by terrain." << VAR(demoted_rises) << VAR(kept_peak) << VAR(pairs.size());
         }
     }
 
@@ -739,20 +766,26 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
             if (j == i || !can_land[j]) {
                 continue;
             }
-            // 确定边能到达就用确定边，即使它比不确定的直索多几跳、代价更高。多跳可达优于一条
-            // 可能不存在的索：推断错误要整段重新规划，代价高于多出的那几跳。
-            const bool certain = std::isfinite(certain_cost[j]);
-            const double chain = certain ? certain_cost[j] : chain_cost[j];
-            if (!std::isfinite(chain)) {
-                continue;
+            // 两档各记一个候选，不确定那档只在确实更便宜时才多记一条。哪档先用由下面的两趟
+            // 评估决定：确定边能到达就用确定边，即使它比不确定的直索多几跳、代价更高。多跳可达
+            // 优于一条可能不存在的索，推断错误要整段重新规划，代价高于多出的那几跳。
+            const auto offer = [&](double chain, bool certain) {
+                if (!std::isfinite(chain)) {
+                    return;
+                }
+                const double zip_cost = cost.mount_penalty - cost.transfer_penalty + chain;
+                const double lower_bound = lb_from_start[i] + zip_cost + lb_to_goal[j];
+                if (lower_bound >= gain_threshold) {
+                    return;
+                }
+                candidates.push_back(
+                    Candidate { .mount = i, .dismount = j, .zip_cost = zip_cost, .lower_bound = lower_bound, .certain = certain });
+            };
+            offer(certain_cost[j], true);
+            // 全图含确定图，所以松量链只在确实更便宜时才值得多记一条。
+            if (chain_cost[j] < certain_cost[j]) {
+                offer(chain_cost[j], false);
             }
-            const double zip_cost = cost.mount_penalty - cost.transfer_penalty + chain;
-            const double lower_bound = lb_from_start[i] + zip_cost + lb_to_goal[j];
-            if (lower_bound >= gain_threshold) {
-                continue;
-            }
-            candidates.push_back(
-                Candidate { .mount = i, .dismount = j, .zip_cost = zip_cost, .lower_bound = lower_bound, .certain = certain });
         }
     }
 
@@ -817,51 +850,64 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
     bool truncated = false;
     bool interrupted = false;
 
-    for (const auto& candidate : candidates) {
-        if (should_stop && should_stop()) {
-            interrupted = true;
-            break;
-        }
-        // 候选按下界升序，当前下界都追不上最好成绩时，后面的更追不上。
-        if (candidate.lower_bound >= best_cost) {
-            break;
-        }
+    // 分两趟评估：先只比确定边的候选，一条都走不通才比带不确定边的。代价比较会让便宜的不确定
+    // 直索赢过确定链，单靠排序换不来确定优先，得把两档隔开比。同一趟内候选仍按下界升序。
+    const auto evaluate = [&](bool want_certain) {
+        for (const auto& candidate : candidates) {
+            if (candidate.certain != want_certain) {
+                continue;
+            }
+            if (should_stop && should_stop()) {
+                interrupted = true;
+                break;
+            }
+            // 候选按下界升序，当前下界都追不上最好成绩时，后面的更追不上。
+            if (candidate.lower_bound >= best_cost) {
+                break;
+            }
 
-        const std::optional<PlannedLeg>* approach = approach_cache.get(candidate.mount);
-        if (!approach) {
-            truncated = true;
-            break;
-        }
-        if (!approach->has_value()) {
-            continue;
-        }
+            const std::optional<PlannedLeg>* approach = approach_cache.get(candidate.mount);
+            if (!approach) {
+                truncated = true;
+                break;
+            }
+            if (!approach->has_value()) {
+                continue;
+            }
 
-        // 上索段的真实长度到手，用它换掉欧氏下界再剪一次，省下终点段的规划。
-        if ((*approach)->length + candidate.zip_cost + lb_to_goal[candidate.dismount] >= best_cost) {
-            continue;
-        }
+            // 上索段的真实长度到手，用它换掉欧氏下界再剪一次，省下终点段的规划。
+            if ((*approach)->length + candidate.zip_cost + lb_to_goal[candidate.dismount] >= best_cost) {
+                continue;
+            }
 
-        const std::optional<PlannedLeg>* departure = departure_cache.get(candidate.dismount);
-        if (!departure) {
-            truncated = true;
-            break;
-        }
-        if (!departure->has_value()) {
-            continue;
-        }
+            const std::optional<PlannedLeg>* departure = departure_cache.get(candidate.dismount);
+            if (!departure) {
+                truncated = true;
+                break;
+            }
+            if (!departure->has_value()) {
+                continue;
+            }
 
-        const double total = (*approach)->length + candidate.zip_cost + (*departure)->length;
-        if (total >= best_cost) {
-            continue;
-        }
+            const double total = (*approach)->length + candidate.zip_cost + (*departure)->length;
+            if (total >= best_cost) {
+                continue;
+            }
 
-        best_cost = total;
-        best_candidate = candidate;
-        best = ZiplineRoute {
-            .approach = (*approach)->path,
-            .departure = (*departure)->path,
-            .cost = total,
-        };
+            best_cost = total;
+            best_candidate = candidate;
+            best = ZiplineRoute {
+                .approach = (*approach)->path,
+                .departure = (*departure)->path,
+                .cost = total,
+            };
+        }
+    };
+    evaluate(true);
+    // 第一趟把预算烧光也算一次失败，第二趟照样要跑：缓存里已经规划好的腿是白拿的，碰到第一个
+    // 没缓存的架子照旧记 truncated 退出，多跑这一趟不额外花预算。
+    if (!best && !interrupted) {
+        evaluate(false);
     }
 
     if (truncated) {

--- a/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
@@ -6,9 +6,11 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <system_error>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <MaaUtils/Logger.h>
@@ -245,15 +247,76 @@ double PolylineLength(const navmesh::WorldPath& path)
 
 constexpr size_t kNoTower = std::numeric_limits<size_t>::max();
 
+// 索线中段横向近到这个距离还有另一根同型通电架子，就判这条直索不成立：滑行会终止在中间那根上。
+// 实测终止在中间架子的两条索，拦路架横向距离 11.23 / 10.14；实证滑到落点的索中段 30 内无架子。
+// 两组样本之间 13.2~15.3 存在空隙，取空隙下沿。
+constexpr double kRopeInterceptLateralWu = 12.0;
+
+// 地形高出索线超过这个量就判这条索挂不成。实测可用区间 (1.06, 8.64)：被游戏判为路径受阻的一对
+// 顶起 8.64，同场景可通行的两对是 1.06 / 0.94。全局分布在此区间连续，取值属工程折中。
+constexpr double kRopeTerrainRiseWu = 6.0;
+
+// 候选图分两档。certain 只收锚点原距离即在索长以内的边；其余边靠锚点格位的不确定半宽才够得上，
+// 是否真挂着索无法确定，单列一档，仅在确定边到不了目标时启用。
+struct ZipLinkGraph
+{
+    std::vector<std::vector<size_t>> all;
+    std::vector<std::vector<size_t>> certain;
+};
+
+void DropEdge(std::vector<std::vector<size_t>>& links, size_t a, size_t b)
+{
+    const auto drop = [](std::vector<size_t>& outgoing, size_t target) {
+        outgoing.erase(std::remove(outgoing.begin(), outgoing.end(), target), outgoing.end());
+    };
+    drop(links[a], b);
+    drop(links[b], a);
+}
+
+// from→to 的索中段是否有另一根架子拦着。拦路架需离两端各超过一个拦截半径，更贴近端点的即端点
+// 自身，无需为此另设参数。nodes 已完成通电筛选，未通电的架子不承载索，也就不构成拦截。
+bool RopeIntercepted(const std::vector<zipline::ZiplineNode>& nodes, size_t from, size_t to)
+{
+    const double dx = nodes[to].world_x - nodes[from].world_x;
+    const double dz = nodes[to].world_z - nodes[from].world_z;
+    const double span = std::hypot(dx, dz);
+    if (span <= 2.0 * kRopeInterceptLateralWu) {
+        return false;
+    }
+    for (size_t k = 0; k < nodes.size(); ++k) {
+        if (k == from || k == to || nodes[k].template_id != nodes[from].template_id || nodes[k].level_id != nodes[from].level_id) {
+            continue;
+        }
+        const double offset_x = nodes[k].world_x - nodes[from].world_x;
+        const double offset_z = nodes[k].world_z - nodes[from].world_z;
+        const double along = (offset_x * dx + offset_z * dz) / span;
+        if (along <= kRopeInterceptLateralWu || along >= span - kRopeInterceptLateralWu) {
+            continue;
+        }
+        const double lateral_x = offset_x - dx * along / span;
+        const double lateral_z = offset_z - dz * along / span;
+        if (std::hypot(lateral_x, lateral_z) <= kRopeInterceptLateralWu) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // 哪两根架子之间挂着索，记录本身没说，这里按几何推断：同一种架子、同一层、任一可能中心的
 // 世界距离不超过这种架子的索长上限，就当它们之间有一条候选索。索不分上下行，所以两个方向
 // 都算。位置含糊时优先保留候选；推错后执行侧会封掉失败边并重新规划，推漏则整条连续链都无法发现。
-std::vector<std::vector<size_t>> BuildLinks(
+//
+// 中段站着另一根架子的直索需要剔除：滑行终止在中间那根上，这条边的实际形态是经过它的两跳链。
+// 保留它会让求解器用一条不存在的索胜过真实的链。
+ZipLinkGraph BuildLinks(
     const std::vector<zipline::ZiplineNode>& nodes,
     const std::vector<double>& span_limit,
     const std::vector<std::array<int, 2>>& footprints)
 {
-    std::vector<std::vector<size_t>> links(nodes.size());
+    ZipLinkGraph graph;
+    graph.all.resize(nodes.size());
+    graph.certain.resize(nodes.size());
+    size_t intercepted = 0;
     for (size_t i = 0; i < nodes.size(); ++i) {
         if (span_limit[i] <= 0.0) {
             continue;
@@ -262,20 +325,31 @@ std::vector<std::vector<size_t>> BuildLinks(
             if (nodes[i].template_id != nodes[j].template_id || nodes[i].level_id != nodes[j].level_id) {
                 continue;
             }
-            const double span_squared = minimum_possible_world_span_squared(
-                nodes[j].world_x - nodes[i].world_x,
-                nodes[j].world_y - nodes[i].world_y,
-                nodes[j].world_z - nodes[i].world_z,
-                footprints[i],
-                footprints[j]);
+            const double anchor_delta_x = nodes[j].world_x - nodes[i].world_x;
+            const double delta_y = nodes[j].world_y - nodes[i].world_y;
+            const double anchor_delta_z = nodes[j].world_z - nodes[i].world_z;
+            const double span_squared =
+                minimum_possible_world_span_squared(anchor_delta_x, delta_y, anchor_delta_z, footprints[i], footprints[j]);
             if (span_squared > span_limit[i] * span_limit[i]) {
                 continue;
             }
-            links[i].push_back(j);
-            links[j].push_back(i);
+            if (RopeIntercepted(nodes, i, j)) {
+                ++intercepted;
+                continue;
+            }
+            graph.all[i].push_back(j);
+            graph.all[j].push_back(i);
+            const double anchor_span_squared = anchor_delta_x * anchor_delta_x + delta_y * delta_y + anchor_delta_z * anchor_delta_z;
+            if (anchor_span_squared <= span_limit[i] * span_limit[i]) {
+                graph.certain[i].push_back(j);
+                graph.certain[j].push_back(i);
+            }
         }
     }
-    return links;
+    if (intercepted != 0) {
+        LogDebug << "ZiplineRoute: dropped the straight ropes intercepted by another tower." << VAR(intercepted);
+    }
+    return graph;
 }
 
 // 从 source 出发，沿索能到的每一根架子和到它最省的滑法。到不了的架子留 infinity。
@@ -573,10 +647,48 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
         // 上索到落地这一整段，已经含上索和沿途每一次换乘。
         double zip_cost = 0.0;
         double lower_bound = 0.0;
+        // 该链解自确定边子图。还原整条链与列举备选架子时须使用同一张图。
+        bool certain = false;
     };
 
     // 一条路线用几条索由代价决定，不设跳数上限：换乘要收钱，划不来的长链自己就被淘汰了。
-    std::vector<std::vector<size_t>> links = BuildLinks(nodes, span_limit, footprints);
+    ZipLinkGraph graph = BuildLinks(nodes, span_limit, footprints);
+
+    const auto drop_from_graph = [&graph](size_t a, size_t b) {
+        DropEdge(graph.all, a, b);
+        DropEdge(graph.certain, a, b);
+    };
+
+    // 两根架子之间隔着地形时挂不住索。每条边只量一次，两个方向一并删除。
+    {
+        std::vector<std::pair<size_t, size_t>> pairs;
+        std::vector<NavmeshAirLine> lines;
+        for (size_t i = 0; i < graph.all.size(); ++i) {
+            for (const size_t j : graph.all[i]) {
+                if (j <= i) {
+                    continue;
+                }
+                pairs.emplace_back(i, j);
+                lines.push_back(NavmeshAirLine {
+                    .a = ToWorld(nodes[i]),
+                    .a_height = nodes[i].height,
+                    .b = ToWorld(nodes[j]),
+                    .b_height = nodes[j].height,
+                });
+            }
+        }
+        const std::vector<std::optional<double>> rises = NavmeshLineRises(param, locator_zone, lines);
+        size_t blocked = 0;
+        for (size_t index = 0; index < pairs.size(); ++index) {
+            if (rises[index] && *rises[index] > kRopeTerrainRiseWu) {
+                drop_from_graph(pairs[index].first, pairs[index].second);
+                ++blocked;
+            }
+        }
+        if (blocked != 0) {
+            LogDebug << "ZiplineRoute: dropped the ropes blocked by terrain." << VAR(blocked) << VAR(pairs.size());
+        }
+    }
 
     // 执行侧账本里滑不动、滑错、落地丢了的跳直接从连通图里拿掉。索不分上下行, 一根滑不动的索
     // 反着大概率也滑不动, 两个方向一起封。
@@ -584,53 +696,63 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
         const auto near_tower = [&nodes](size_t tower, const ZiplineNodeRef& ref) {
             return std::hypot(nodes[tower].x - ref.x, nodes[tower].y - ref.y) <= kZiplineHopBanMatchWu;
         };
-        size_t banned_edges = 0;
-        for (size_t i = 0; i < links.size(); ++i) {
-            std::vector<size_t>& outgoing = links[i];
-            outgoing.erase(
-                std::remove_if(
-                    outgoing.begin(),
-                    outgoing.end(),
-                    [&](size_t j) {
-                        for (const ZiplineHopRecord& record : param.zipline_ledger) {
-                            if (!IsZiplineRopeFailure(record.outcome)) {
-                                continue;
-                            }
-                            const ZiplineNodeRef& from = record.plan.mount;
-                            const ZiplineNodeRef& to = record.plan.landing;
-                            if ((near_tower(i, from) && near_tower(j, to)) || (near_tower(i, to) && near_tower(j, from))) {
-                                ++banned_edges;
-                                return true;
-                            }
-                        }
-                        return false;
-                    }),
-                outgoing.end());
+        std::vector<std::pair<size_t, size_t>> banned;
+        for (size_t i = 0; i < graph.all.size(); ++i) {
+            for (const size_t j : graph.all[i]) {
+                if (j <= i) {
+                    continue;
+                }
+                for (const ZiplineHopRecord& record : param.zipline_ledger) {
+                    if (!IsZiplineRopeFailure(record.outcome)) {
+                        continue;
+                    }
+                    const ZiplineNodeRef& from = record.plan.mount;
+                    const ZiplineNodeRef& to = record.plan.landing;
+                    if ((near_tower(i, from) && near_tower(j, to)) || (near_tower(i, to) && near_tower(j, from))) {
+                        banned.emplace_back(i, j);
+                        break;
+                    }
+                }
+            }
+        }
+        for (const auto& edge : banned) {
+            drop_from_graph(edge.first, edge.second);
         }
         LogInfo << "ZiplineRoute: dropped the hops the runtime already gave up on." << VAR(param.zipline_ledger.size())
-                << VAR(banned_edges);
+                << VAR(banned.size());
     }
 
     std::vector<Candidate> candidates;
     std::vector<double> chain_cost;
     std::vector<size_t> chain_prev;
+    std::vector<double> certain_cost;
+    std::vector<size_t> certain_prev;
     for (size_t i = 0; i < nodes.size(); ++i) {
         // 这根架子连白送一整段滑行都够不着收益门槛，从它起头的所有链就都不必算了。
-        if (!can_board[i] || links[i].empty() || lb_from_start[i] + cost.mount_penalty >= gain_threshold) {
+        if (!can_board[i] || graph.all[i].empty() || lb_from_start[i] + cost.mount_penalty >= gain_threshold) {
             continue;
         }
 
-        SolveZipChains(nodes, links, cost, i, &chain_cost, &chain_prev);
+        SolveZipChains(nodes, graph.certain, cost, i, &certain_cost, &certain_prev);
+        SolveZipChains(nodes, graph.all, cost, i, &chain_cost, &chain_prev);
         for (size_t j = 0; j < nodes.size(); ++j) {
-            if (j == i || !can_land[j] || !std::isfinite(chain_cost[j])) {
+            if (j == i || !can_land[j]) {
                 continue;
             }
-            const double zip_cost = cost.mount_penalty - cost.transfer_penalty + chain_cost[j];
+            // 确定边能到达就用确定边，即使它比不确定的直索多几跳、代价更高。多跳可达优于一条
+            // 可能不存在的索：推断错误要整段重新规划，代价高于多出的那几跳。
+            const bool certain = std::isfinite(certain_cost[j]);
+            const double chain = certain ? certain_cost[j] : chain_cost[j];
+            if (!std::isfinite(chain)) {
+                continue;
+            }
+            const double zip_cost = cost.mount_penalty - cost.transfer_penalty + chain;
             const double lower_bound = lb_from_start[i] + zip_cost + lb_to_goal[j];
             if (lower_bound >= gain_threshold) {
                 continue;
             }
-            candidates.push_back(Candidate { .mount = i, .dismount = j, .zip_cost = zip_cost, .lower_bound = lower_bound });
+            candidates.push_back(
+                Candidate { .mount = i, .dismount = j, .zip_cost = zip_cost, .lower_bound = lower_bound, .certain = certain });
         }
     }
 
@@ -756,6 +878,7 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
     }
 
     // 中间经过哪几根架子到这时才还原：候选是成对枚举出来的，逐个存下整条链纯属浪费。
+    const std::vector<std::vector<size_t>>& links = best_candidate->certain ? graph.certain : graph.all;
     SolveZipChains(nodes, links, cost, best_candidate->mount, &chain_cost, &chain_prev);
     std::vector<size_t> chain;
     for (size_t at = best_candidate->dismount; at != kNoTower; at = chain_prev[at]) {

--- a/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.cpp
@@ -511,7 +511,7 @@ StageResult ZiplineRideMachine::TickLanded(const ZiplineObservation& obs, IZipli
 }
 
 // 决策表。到了就交回; 滑错了先滑回来再按预算重试; 没发出去换一档俯仰, 档用完先重新站一次上索点,
-// 再不行这根索就是滑不动; 定位对不上给一次冷启动的机会, 超时就丢
+// 再不行这根索就是滑不动, 人留在架子上等重规划; 定位对不上给一次冷启动的机会, 超时就丢
 StageResult ZiplineRideMachine::Classify(IZiplineObserver& observer, IZiplineActuator& actuator, Clock::time_point now)
 {
     EnterStage(ZiplineStage::Classified, now);
@@ -590,8 +590,13 @@ StageResult ZiplineRideMachine::Classify(IZiplineObserver& observer, IZiplineAct
             LogWarn << "zipline/no_launch/restand" << VAR(plan_.restand.has_value());
             return NeedsReposition { .restand = plan_.restand };
         }
+        // 人根本没滑出去, 还站在上索架上。先下来再重规划要白付一次上索, 而重规划本身就会看新路线
+        // 用不用得上脚下这根架子, 用不上时才下来
         CommitRecord(HopOutcome::NoLaunch, now);
-        return StartDismount(actuator, ReplanRequested { .still_on_tower = false }, now);
+        parked_on_ = plan_.mount;
+        pending_exit_ = ReplanRequested { .still_on_tower = true, .on_tower = plan_.mount };
+        EnterStage(ZiplineStage::Handoff, now);
+        return Handoff(now);
     }
     case LandingClass::Unknown: {
         if (!unknown_deadline_) {

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.cpp
@@ -22,6 +22,9 @@ constexpr double kBridgeMaxHeightDelta = 3.0;
 constexpr uint32_t kSmallBridgeComponentMaxTriangles = 512;
 constexpr double kSmallBridgeMaxGap = 4.0;
 constexpr double kRoutePullSampleStep = 0.5; // 拉直判据沿捷径采样的步长(像素),与 Python ROUTE_PULL_SAMPLE_STEP 对齐
+// lineRise 沿连线采样的步长(像素)。它同时是腐蚀尺度: 窄于此宽度的结构按孤立面片处理。
+// 不随体素边长下调, 步长越密越会把单格尖刺计入连续地形。
+constexpr double kLineRiseSampleStep = 1.0;
 
 struct DisjointSet
 {
@@ -591,6 +594,47 @@ bool BaseNavPlanner::isRouteSegmentDrivable(
         }
     }
     return true;
+}
+
+double BaseNavPlanner::lineRise(uint16_t zone_id, const WorldPoint& a, double a_height, const WorldPoint& b, double b_height) const
+{
+    if (pack_.findZone(zone_id) == nullptr) {
+        return 0.0;
+    }
+    const double length = std::hypot(b.x - a.x, b.y - a.y);
+    const int samples = std::max(1, static_cast<int>(length / kLineRiseSampleStep));
+
+    // 先整条采完再判: 腐蚀需要看采样点两侧, 边采边判取不到后一个。
+    // 每点取最低一层可走面(reference 留空): 可走面之上留有净空, 索线高于其中一层即可通过;
+    // 取最高会把头顶的楼板判成地形。
+    std::vector<std::optional<double>> ground(static_cast<size_t>(samples) + 1);
+    for (int index = 0; index <= samples; ++index) {
+        const double t = static_cast<double>(index) / samples;
+        const WorldPoint point { .x = a.x + (b.x - a.x) * t, .y = a.y + (b.y - a.y) * t };
+        uint32_t hit = kInvalidTriangle;
+        ground[static_cast<size_t>(index)] = groundHeightNearIndexed(zone_id, point, std::nullopt, hit);
+    }
+
+    double rise = 0.0;
+    for (int index = 0; index <= samples; ++index) {
+        // 相邻采样取小(形态学腐蚀): 仅顶起单个采样点的结构窄于采样间距, 属网格上的孤立面片;
+        // 相邻采不到面的同样按此处理, 一并剔除。
+        std::optional<double> covered;
+        for (int probe = std::max(index - 1, 0); probe <= std::min(index + 1, samples); ++probe) {
+            const std::optional<double>& height = ground[static_cast<size_t>(probe)];
+            if (!height) {
+                covered.reset();
+                break;
+            }
+            covered = covered ? std::min(*covered, *height) : *height;
+        }
+        if (!covered) {
+            continue;
+        }
+        const double t = static_cast<double>(index) / samples;
+        rise = std::max(rise, *covered - (a_height + (b_height - a_height) * t));
+    }
+    return rise;
 }
 
 bool BaseNavPlanner::isSmallIslandTriangle(uint32_t triangle_index) const

--- a/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
+++ b/agent/cpp-algo/source/Navmesh/BaseNavPlanner.h
@@ -100,6 +100,11 @@ public:
         double half_width = 0.0,
         std::optional<double> seed_height = std::nullopt) const;
 
+    // 这条空中连线被地形顶起多少(高度口径同 floor_y, 恒 >= 0)。沿 a→b 采样, 取可走面高出两端
+    // 连线(高度线性插值)的最大值。采不到可走面的采样点不计入: 网格只含可走面, 未铺面的陡壁孤石
+    // 无从判定, 一律按未阻挡处理。用于判定两根滑索架之间是否隔着地形。
+    double lineRise(uint16_t zone_id, const WorldPoint& a, double a_height, const WorldPoint& b, double b_height) const;
+
     // RecastNav 复用: pack 链接表里有没有 source→target 这条(且过了通行判据)。
     bool hasLink(uint32_t source, uint32_t target) const;
 


### PR DESCRIPTION
- close #5613 
<img width="1074" height="220" alt="image" src="https://github.com/user-attachments/assets/58d9ad84-c1a2-44f6-be96-812f5bf80deb" />
我继续用几把更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 优化滑索中断后的路线恢复：优先沿原路线继续规划，失败时再使用可达位置进行动态规划。
  * 提升对偏离可行走面的定位处理能力，重新规划时可自动贴回最近的可行走区域。
  * 改进滑索路线选择，优先使用确定畅通的连接，必要时才考虑存在地形或障碍风险的备选连接。
  * 增强地形抬升检测，减少因地形遮挡导致的滑索路线误判。
  * 无法发起滑索时，角色会保留在滑索架上并等待重新规划。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->