### PR TITLE
fix(icon-recognition): 修复空格边缘纹理误识别

### DIFF
--- a/agent/cpp-algo/source/IconRecognition/IconRecognizer.cpp
+++ b/agent/cpp-algo/source/IconRecognition/IconRecognizer.cpp
@@ -750,7 +750,12 @@ public:
                 std::optional<double> transfer_foreground_texture;
                 if (request.grid_type == GridType::Transfer) {
                     const auto texture_started = performance ? PerformanceClock::now() : PerformanceClock::time_point {};
-                    transfer_foreground_texture = detail::ForegroundTextureScore(image, cell.cell_box, request.grid_type, cell.texture_roi);
+                    transfer_foreground_texture = detail::ForegroundTextureScore(
+                        image,
+                        cell.cell_box,
+                        request.grid_type,
+                        cell.texture_roi,
+                        detail::TextureBoundaryMode::SourceContext);
                     if (performance) {
                         performance->foreground_texture_ms += ElapsedMilliseconds(texture_started);
                     }

--- a/agent/cpp-algo/source/IconRecognition/detail/ForegroundTexture.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/ForegroundTexture.cpp
@@ -18,9 +18,25 @@ constexpr int kContentInsetTop = 6;
 constexpr int kContentInsetRight = 6;
 // 纹理检测区域排除 cell 底部色带的像素数；调大可避开 rarity 色带，但可能裁掉图标下沿。
 constexpr int kContentInsetBottom = 8;
+// 拉普拉斯核需要目标区域外 1px 邻域；缺少上下文时 OpenCV 的镜像补边会把平滑渐变制造成伪边缘。
+constexpr int kLaplacianContext = 1;
+
+cv::Rect texture_measurement_region(const cv::Rect& region, TextureBoundaryMode boundary_mode)
+{
+    if (boundary_mode != TextureBoundaryMode::SourceContext || region.width <= kLaplacianContext * 2
+        || region.height <= kLaplacianContext * 2) {
+        return region;
+    }
+    // 上下文必须取自既定内容区，不能跨回 cell 边框；因此先留出一圈再执行带邻域的拉普拉斯。
+    return cv::Rect(
+        region.x + kLaplacianContext,
+        region.y + kLaplacianContext,
+        region.width - kLaplacianContext * 2,
+        region.height - kLaplacianContext * 2);
+}
 } // namespace
 
-double LaplacianVariance(const cv::Mat& image, const cv::Rect& region)
+double LaplacianVariance(const cv::Mat& image, const cv::Rect& region, TextureBoundaryMode boundary_mode)
 {
     if (image.empty()) {
         return 0.0;
@@ -29,21 +45,31 @@ double LaplacianVariance(const cv::Mat& image, const cv::Rect& region)
     if (clipped.width < 3 || clipped.height < 3) {
         return 0.0;
     }
+    const cv::Rect image_bounds(0, 0, image.cols, image.rows);
+    const cv::Rect context = boundary_mode == TextureBoundaryMode::SourceContext
+                                 ? cv::Rect(
+                                       clipped.x - kLaplacianContext,
+                                       clipped.y - kLaplacianContext,
+                                       clipped.width + kLaplacianContext * 2,
+                                       clipped.height + kLaplacianContext * 2)
+                                       & image_bounds
+                                 : clipped;
     cv::Mat gray;
     if (image.channels() == 4) {
-        cv::cvtColor(image(clipped), gray, cv::COLOR_BGRA2GRAY);
+        cv::cvtColor(image(context), gray, cv::COLOR_BGRA2GRAY);
     }
     else if (image.channels() == 3) {
-        cv::cvtColor(image(clipped), gray, cv::COLOR_BGR2GRAY);
+        cv::cvtColor(image(context), gray, cv::COLOR_BGR2GRAY);
     }
     else {
-        gray = image(clipped);
+        gray = image(context);
     }
     cv::Mat laplacian;
     gray.convertTo(gray, CV_32F);
     cv::Laplacian(gray, laplacian, CV_32F);
+    const cv::Rect measured(clipped.x - context.x, clipped.y - context.y, clipped.width, clipped.height);
     cv::Scalar mean, stddev;
-    cv::meanStdDev(laplacian, mean, stddev);
+    cv::meanStdDev(laplacian(measured), mean, stddev);
     return stddev[0] * stddev[0];
 }
 
@@ -59,7 +85,12 @@ bool IsLowTexture(
 }
 
 std::optional<double>
-    ForegroundTextureScore(const cv::Mat& image, const cv::Rect& region, GridType grid_type, const std::optional<cv::Rect>& texture_roi)
+    ForegroundTextureScore(
+        const cv::Mat& image,
+        const cv::Rect& region,
+        GridType grid_type,
+        const std::optional<cv::Rect>& texture_roi,
+        TextureBoundaryMode boundary_mode)
 {
     if (grid_type != GridType::Transfer && grid_type != GridType::PortStorager) {
         return std::nullopt;
@@ -76,9 +107,9 @@ std::optional<double>
             || visible.area() < content.area() * kTransferMinimumTextureCoverage) {
             return std::nullopt;
         }
-        return LaplacianVariance(image, visible);
+        return LaplacianVariance(image, texture_measurement_region(visible, boundary_mode), boundary_mode);
     }
-    return LaplacianVariance(image, content);
+    return LaplacianVariance(image, texture_measurement_region(content, boundary_mode), boundary_mode);
 }
 
 } // namespace iconrecognition::detail

--- a/agent/cpp-algo/source/IconRecognition/detail/ForegroundTexture.h
+++ b/agent/cpp-algo/source/IconRecognition/detail/ForegroundTexture.h
@@ -10,13 +10,23 @@ namespace iconrecognition::detail
 // 沿用低纹理判定的灰度拉普拉斯方差阈值；调高会排除更多空格，也增加低纹理物品被误排的风险。
 constexpr double kDefaultLowTextureThreshold = 10.0;
 
-double LaplacianVariance(const cv::Mat& image, const cv::Rect& region);
+enum class TextureBoundaryMode
+{
+    IsolatedRegion,
+    SourceContext,
+};
+
+double LaplacianVariance(
+    const cv::Mat& image,
+    const cv::Rect& region,
+    TextureBoundaryMode boundary_mode = TextureBoundaryMode::IsolatedRegion);
 // texture_roi 仅约束 Transfer；先内缩完整格框再求交，证据不足时不提供判空分数。
 std::optional<double> ForegroundTextureScore(
     const cv::Mat& image,
     const cv::Rect& region,
     GridType grid_type,
-    const std::optional<cv::Rect>& texture_roi = std::nullopt);
+    const std::optional<cv::Rect>& texture_roi = std::nullopt,
+    TextureBoundaryMode boundary_mode = TextureBoundaryMode::IsolatedRegion);
 // threshold 为拉普拉斯方差下限；调高会拒绝更多低纹理 cell，调低可保留暗淡物品但增加空格误检。
 bool IsLowTexture(
     const cv::Mat& image,

--- a/agent/cpp-algo/source/IconRecognition/test/test_small_algorithms.cpp
+++ b/agent/cpp-algo/source/IconRecognition/test/test_small_algorithms.cpp
@@ -362,6 +362,28 @@ void TestForegroundTextureUsesContentInsets()
         "texture inside the content inset must be retained");
 }
 
+void TestLaplacianVarianceUsesSourceContext()
+{
+    cv::Mat image(80, 80, CV_8UC3, cv::Scalar(140, 140, 140));
+    const cv::Rect region(12, 12, 56, 56);
+    // 目标区域顶边存在平滑亮度过渡；脱离原图单独求导时，镜像补点会把它放大成整行强边缘。
+    image.row(region.y - 1).setTo(cv::Scalar(110, 110, 110));
+    image.row(region.y).setTo(cv::Scalar(120, 120, 120));
+    image.row(region.y + 1).setTo(cv::Scalar(132, 132, 132));
+
+    const cv::Mat isolated = image(region).clone();
+    const double isolated_score = iconrecognition::detail::LaplacianVariance(
+        isolated,
+        cv::Rect(0, 0, isolated.cols, isolated.rows),
+        iconrecognition::detail::TextureBoundaryMode::IsolatedRegion);
+    const double contextual_score = iconrecognition::detail::LaplacianVariance(
+        image,
+        region,
+        iconrecognition::detail::TextureBoundaryMode::SourceContext);
+    Check(isolated_score > 10.0, "isolated crop must reproduce the Laplacian boundary artifact");
+    Check(contextual_score < 10.0, "source context must keep a smooth empty region below the texture threshold");
+}
+
 void TestForegroundTextureUsesNativeLargerCell()
 {
     cv::Mat image = cv::Mat::zeros(80, 80, CV_8UC3);
@@ -2234,6 +2256,7 @@ int main()
         TestMaskDiagnosticsDescribeComposedPolicies();
         TestValuablesPortraitDetectionDoesNotDependOnTemplateMask();
         TestForegroundTextureUsesContentInsets();
+        TestLaplacianVarianceUsesSourceContext();
         TestForegroundTextureUsesNativeLargerCell();
         TestForegroundTextureInsetsStayGridSpecific();
         TestTransferPanelIntersections();


### PR DESCRIPTION
- 拉普拉斯纹理计算读取原图邻域，避免裁剪边界产生伪边缘
- 仅在 Transfer 正式逐格判空启用新模式并补充回归测试

优化空网格识别，降低错误率

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化网格区域的前景纹理识别，结合源图像上下文进行纹理评分，减少区域边界造成的误判。
  * 保留对独立区域进行纹理分析的支持。

* **测试**
  * 新增边界纹理场景验证，确保纹理评分结果更加准确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->