### PR TITLE
fix(MapNavigator): 上索后确认已上架再瞄准发射

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -346,6 +346,10 @@ constexpr int32_t kZiplineAbandonWalkFallbackCount = 3;
 // 判定圈收到这里, 让人真把那点距离走完(有备用站位就是走过去, 没有就是再走近点)。
 // 再往下收就到定位噪声底下了, 收不拢只会白等看门狗
 constexpr double kZiplineRestandBandWu = 1.0;
+// 顶在设备上走不动时换下一个站位的门限。这时到点判定过不去、提示也没出来, 再等下去先招来的是
+// 恢复阶梯 —— 它跳一下、挪一下设备, 把这一轮的站位拖走, 所以必须抢在它前面动手
+constexpr int32_t kZiplineMountSpotStallMs = 2000;
+static_assert(kZiplineMountSpotStallMs < kObstacleRecoveryMinTriggerMs);
 // 滑错索又滑回来之后, 同一跳最多再试这么多次, 用完就站在架子上等换路
 constexpr int32_t kZiplineHopRetryBudget = 2;
 // 下索键按完等定位稳定的基准时长: 两倍还不稳再按一次, 四倍还不稳当卡住

--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -310,8 +310,16 @@ constexpr int32_t kZiplineSettleFixes = 4;
 constexpr int32_t kZiplineDismountHoldMs = 80;
 // 索没通电、两端根本没挂索时起滑是空响, 人还站在架子上。滑一趟是大位移, 所以「过了确认时间
 // 还在原地」与「滑起来了但没到落点」分得开, 不必耗满整个滑行超时。两个值待实机核准
-constexpr int32_t kZiplineMountConfirmMs = 5000;
+constexpr int32_t kZiplineLaunchConfirmMs = 5000;
 constexpr double kZiplineMountMinMoveWu = 3.0;
+// 上索确认要求两个信号同时成立: 右上角按钮在架上收起, 底部操作引导出现「离开滑索架」。两侧各需连续
+// 若干帧一致, 架上一侧多要一帧。按键到按钮收起的延迟未经实测, settle 为其预留时间, 其间的地面读数
+// 不予采信。误判为已上架会使后续整条链建立在错误前提上, 故取偏保守的阈值。五个值待实机核准
+constexpr int32_t kZiplineMountSettleMs = 600;
+constexpr int32_t kZiplineMountWindowMs = 2000;
+constexpr int32_t kZiplineMountOnTowerFixes = 3;
+constexpr int32_t kZiplineMountOnGroundFixes = 2;
+constexpr int32_t kZiplineMountPressBudget = 2;
 // 同一个上索点最多让重规划试这么多次, 再要重规划就当这根架子够不着, 退索改走路。楔死看门狗
 // 6s 重规划一次、12s 掐掉整趟导航, 所以这里必须小到能在它掐之前让出路来。滑索省下的那点路
 // 远不值一次导航失败, 判错方向只损失一段捷径
@@ -381,6 +389,12 @@ constexpr const char* kZiplineMountRecognitionNode = "MapNavigatorZiplineMount";
 constexpr const char* kZiplineMountExitNode = "MapNavigatorZiplineMountEnd";
 constexpr const char* kZiplineMountScanNode = "MapNavigatorZiplineMountScan";
 constexpr const char* kZiplinePitchResetNode = "MapNavigatorZiplinePitchReset";
+// 上索判定的两个信号, 同样各配一个 Start 节点。地面判据的识别逻辑引自 Interface/InScene 的
+// 公开节点 InWorld, 在 pipeline 里包一层, 使未命中记在 MapNavigator 自己的节点名下
+constexpr const char* kZiplineOnGroundEntryNode = "MapNavigatorZiplineOnGroundStart";
+constexpr const char* kZiplineOnGroundNode = "MapNavigatorZiplineOnGround";
+constexpr const char* kZiplineOnTowerHintEntryNode = "MapNavigatorZiplineOnTowerHintStart";
+constexpr const char* kZiplineOnTowerHintNode = "MapNavigatorZiplineOnTowerHint";
 constexpr int32_t kPromptPostSleepMs = 80;
 
 // Resolution every pipeline ROI is authored against; the scanner rescales it to whatever the frame really is.

--- a/agent/cpp-algo/source/MapNavigator/navi_position.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_position.h
@@ -20,9 +20,9 @@ struct NaviPosition
     std::chrono::steady_clock::time_point timestamp;
 };
 
-// 上索认不出提示时的备用站位。面板给的是离身位最近的那台设备, 架子边上贴着供电桩时会被它抢走,
-// 这个点从供电桩那侧让开一点点, 让架子重新成为最近的那个。
-struct ZiplineRestand
+// 上索要走到的一个站位。坐标记录的是随朝向变化的角格锚点, 设备模型占着锚点四周哪一格未知,
+// 所以候选是各个可能的中心格; 末位那个从供电桩一侧让开, 让架子重新成为离身位最近的设备。
+struct ZiplineMountSpot
 {
     double x = 0.0;
     double y = 0.0;

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -287,14 +287,17 @@ struct ZiplineApproachState
 {
     size_t anchor_index = std::numeric_limits<size_t>::max();
     int32_t replans = 0;
-    // 到点按过一次没认出来。原地再按还是同一个答案, 所以改瞄备用站位并收紧判定圈, 让人挪一下再认
+    // 到点按过一次没认出来。原地再按还是同一个答案, 所以改瞄下一个站位并收紧判定圈, 让人挪一下再认
     bool press_missed = false;
+    // 正在试计划里的第几个站位。换架子才回到头, 同一根架子上只往后走, 走完就判这根上不去
+    size_t spot_index = 0;
 
     void Reset()
     {
         anchor_index = std::numeric_limits<size_t>::max();
         replans = 0;
         press_missed = false;
+        spot_index = 0;
     }
 };
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
+++ b/agent/cpp-algo/source/MapNavigator/navigation_runtime_state.h
@@ -289,8 +289,21 @@ struct ZiplineApproachState
     int32_t replans = 0;
     // 到点按过一次没认出来。原地再按还是同一个答案, 所以改瞄下一个站位并收紧判定圈, 让人挪一下再认
     bool press_missed = false;
-    // 正在试计划里的第几个站位。换架子才回到头, 同一根架子上只往后走, 走完就判这根上不去
+    // 正在试计划里的第几个站位, 连同这个进度算的是哪根架子
     size_t spot_index = 0;
+    ZiplineNodeRef spot_tower;
+
+    // 游标只对 spot_tower 那根架子有效: 同一根架子上只往后走, 换了架子从头试。一趟里后面那条链
+    // 要是接着用上一根的进度, 新架子头一次失败就会被判成上不去
+    size_t MountSpotCursor(const ZiplineNodeRef& mount)
+    {
+        if (!spot_tower.SameTower(mount)) {
+            spot_tower = mount;
+            spot_index = 0;
+            press_missed = false;
+        }
+        return spot_index;
+    }
 
     void Reset()
     {
@@ -298,6 +311,7 @@ struct ZiplineApproachState
         replans = 0;
         press_missed = false;
         spot_index = 0;
+        spot_tower = ZiplineNodeRef {};
     }
 };
 

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -821,6 +821,7 @@ bool NavigationStateMachine::GiveUpUnreachableZipline(const char* reason)
         approach.anchor_index = anchor->first;
         approach.replans = 0;
         approach.press_missed = false;
+        approach.spot_index = 0;
     }
     if (++approach.replans <= kZiplineApproachReplanBudget) {
         return false;
@@ -1434,6 +1435,18 @@ bool NavigationStateMachine::TickNavigate()
                 stalled_ms);
         }
         if (prompt_result.consumed) {
+            return true;
+        }
+    }
+
+    // 顶在设备上走不动时也要换站位: 这时到点判定过不去、提示也没出来, 等下去先招来的是恢复阶梯,
+    // 它跳一下、挪一下设备, 把这一轮的站位拖走。提示在就先按(上面那段), 所以这里排在它后面。
+    // 只管站位跟前这一小片: 进场路上被地形卡住时换站位解决不了, 还会把硬时钟一直按回零, 让阶梯饿死
+    if (waypoint.action == ActionType::ZIPLINE && !runtime_state_.IsZiplineMounted() && waypoint.zipline_hop
+        && runtime_state_.zipline_approach.spot_index + 1 < waypoint.zipline_hop->mount_spots.size()
+        && route.waypoint_distance <= kZiplineWalkEnterBandWu && session_->HardStalledMs(now) >= kZiplineMountSpotStallMs) {
+        const semantic_nodes::Result advanced = semantic_nodes::AdvanceMountSpot(semantic_ctx, waypoint, "zipline_mount_spot_stalled");
+        if (advanced.consumed) {
             return true;
         }
     }

--- a/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navigation_state_machine.cpp
@@ -1442,12 +1442,14 @@ bool NavigationStateMachine::TickNavigate()
     // 顶在设备上走不动时也要换站位: 这时到点判定过不去、提示也没出来, 等下去先招来的是恢复阶梯,
     // 它跳一下、挪一下设备, 把这一轮的站位拖走。提示在就先按(上面那段), 所以这里排在它后面。
     // 只管站位跟前这一小片: 进场路上被地形卡住时换站位解决不了, 还会把硬时钟一直按回零, 让阶梯饿死
-    if (waypoint.action == ActionType::ZIPLINE && !runtime_state_.IsZiplineMounted() && waypoint.zipline_hop
-        && runtime_state_.zipline_approach.spot_index + 1 < waypoint.zipline_hop->mount_spots.size()
-        && route.waypoint_distance <= kZiplineWalkEnterBandWu && session_->HardStalledMs(now) >= kZiplineMountSpotStallMs) {
-        const semantic_nodes::Result advanced = semantic_nodes::AdvanceMountSpot(semantic_ctx, waypoint, "zipline_mount_spot_stalled");
-        if (advanced.consumed) {
-            return true;
+    if (waypoint.action == ActionType::ZIPLINE && !runtime_state_.IsZiplineMounted() && waypoint.zipline_hop) {
+        const size_t cursor = runtime_state_.zipline_approach.MountSpotCursor(waypoint.zipline_hop->mount);
+        if (cursor + 1 < waypoint.zipline_hop->mount_spots.size() && route.waypoint_distance <= kZiplineWalkEnterBandWu
+            && session_->HardStalledMs(now) >= kZiplineMountSpotStallMs) {
+            const semantic_nodes::Result advanced = semantic_nodes::AdvanceMountSpot(semantic_ctx, waypoint, "zipline_mount_spot_stalled");
+            if (advanced.consumed) {
+                return true;
+            }
         }
     }
 

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -869,6 +869,8 @@ bool TryAppendZiplineLeg(
     // 上索点自己补, 不让通用追加代劳: 起点已经站在索下时它一个点都不会产出, 而这个点必须存在
     AppendGeneratedNavmeshWaypoints(route->approach, out_path, false, false, &navmesh.planner, route->approach.zone_id);
     const navmesh::WorldPoint mount = route->approach.points.back();
+    // 头一跳瞄第一个站位, 而不是架子坐标本身: 那是个角格锚点, 走到它跟前常常碰不到设备模型
+    const navmesh::WorldPoint mount_spot = route->mount_spots.empty() ? mount : route->mount_spots.front();
     auto ToNodeRef = [](const zipline::ZiplineNode& node) -> ZiplineNodeRef {
         ZiplineNodeRef ref;
         ref.level_id = node.level_id;
@@ -889,8 +891,8 @@ bool TryAppendZiplineLeg(
         const ZiplineNodeRef from_ref = ToNodeRef(from);
         const ZiplineNodeRef to_ref = ToNodeRef(to);
 
-        // 头一跳的上索点取走路那一段的末点, 让两段严丝合缝地接上
-        out_path.emplace_back(hop == 0 ? mount.x : from.x, hop == 0 ? mount.y : from.y, ActionType::ZIPLINE);
+        // 头一跳的上索点接在走路那一段后面, 让两段严丝合缝地接上
+        out_path.emplace_back(hop == 0 ? mount_spot.x : from.x, hop == 0 ? mount_spot.y : from.y, ActionType::ZIPLINE);
         out_path.back().strict_arrival = true;
         out_path.back().target_deck_y = from.height;
         // 仰角只能用世界坐标算: 平面 x/y 是按地图比例缩放过的, 跟高度不同尺, 混着算出来的角
@@ -904,9 +906,11 @@ bool TryAppendZiplineLeg(
         hop_plan.mount = from_ref;
         hop_plan.landing = to_ref;
         hop_plan.planned_elevation_deg = elevation_deg;
-        // 备用站位只挂在链首: 后面那些跳是从索上落下来的, 不再按上索提示
-        if (hop == 0 && route->mount_restand) {
-            hop_plan.restand = ZiplineRestand { .x = route->mount_restand->x, .y = route->mount_restand->y };
+        // 站位表只挂在链首: 后面那些跳是从索上落下来的, 不再按上索提示
+        if (hop == 0) {
+            for (const navmesh::WorldPoint& spot : route->mount_spots) {
+                hop_plan.mount_spots.push_back(ZiplineMountSpot { .x = spot.x, .y = spot.y });
+            }
         }
         if (hop < route->hop_alternates.size()) {
             for (const zipline::ZiplineNode& other : route->hop_alternates[hop]) {
@@ -940,7 +944,8 @@ bool TryAppendZiplineLeg(
     const bool walking_baseline_available = walking != nullptr;
     LogInfo << "Expanded NAVMESH waypoint via zipline." << VAR(state.navmesh_zone) << VAR(state.current_zone)
             << VAR(walking_baseline_available) << VAR(route->cost) << VAR(insert_index) << VAR(out_path.size() - insert_index)
-            << VAR(route->towers.size()) << VAR(mount.x) << VAR(mount.y) << VAR(route->towers.back().x) << VAR(route->towers.back().y);
+            << VAR(route->towers.size()) << VAR(mount_spot.x) << VAR(mount_spot.y) << VAR(route->mount_spots.size())
+            << VAR(route->towers.back().x) << VAR(route->towers.back().y);
     return true;
 }
 

--- a/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
+++ b/agent/cpp-algo/source/MapNavigator/navmesh_path_expander.cpp
@@ -871,19 +871,6 @@ bool TryAppendZiplineLeg(
     const navmesh::WorldPoint mount = route->approach.points.back();
     // 头一跳瞄第一个站位, 而不是架子坐标本身: 那是个角格锚点, 走到它跟前常常碰不到设备模型
     const navmesh::WorldPoint mount_spot = route->mount_spots.empty() ? mount : route->mount_spots.front();
-    auto ToNodeRef = [](const zipline::ZiplineNode& node) -> ZiplineNodeRef {
-        ZiplineNodeRef ref;
-        ref.level_id = node.level_id;
-        ref.world_x = node.world_x;
-        ref.world_y = node.world_y;
-        ref.world_z = node.world_z;
-        ref.has_world = true;
-        ref.x = node.x;
-        ref.y = node.y;
-        ref.height = node.height;
-        return ref;
-    };
-
     // 一跳一个航点。中途落在下一根架子上, 人就站在下一跳的上索点上, 所以跳与跳之间不插走路点
     for (size_t hop = 0; hop + 1 < route->towers.size(); ++hop) {
         const zipline::ZiplineNode& from = route->towers[hop];

--- a/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
@@ -304,26 +304,42 @@ Result FinishHop(const Context& ctx, const HopCompleted& done)
     return result;
 }
 
-// 上索点站得不对, 人已经下来了。面板给的是离身位最近的那台设备, 原地重按拿到的还是同一个答案:
-// 有备用站位就改瞄它(从供电桩那侧让开一点, 顺带也更近了), 没有就只把判定圈收紧, 让人把差的那点走完
-Result Reposition(const Context& ctx, const NeedsReposition& need)
+} // namespace
+
+// 这个站位上没出提示。面板给的是离身位最近的那台设备, 原地重按拿到的还是同一个答案, 所以改瞄
+// 计划里的下一个站位, 走过去的这一路提示预筛照样开着, 先冒出来就先按下去。站位全试过还不出提示
+// 就把这根架子记成上不去, 退索走路
+Result AdvanceMountSpot(const Context& ctx, const Waypoint& waypoint, const char* reason)
 {
-    Result result;
-    result.consumed = true;
-    result.stay_in_current_tick = true;
-    ctx.runtime_state->zipline_approach.press_missed = true;
-    const bool restood = need.restand && ctx.session->RetargetCurrentWaypoint(need.restand->x, need.restand->y, "zipline_mount_restand");
-    LogWarn << "Action: ZIPLINE never left this stand; re-mounting after a short walk." << VAR(restood) << VAR(kZiplineRestandBandWu);
+    ZiplineApproachState& approach = ctx.runtime_state->zipline_approach;
+    const size_t spot_count = waypoint.zipline_hop ? waypoint.zipline_hop->mount_spots.size() : 0;
+    if (approach.spot_index + 1 >= spot_count) {
+        if (waypoint.zipline_hop) {
+            ctx.runtime_state->zipline_ride.MarkMountUnreachable(*waypoint.zipline_hop);
+        }
+        return AbandonZipline(ctx, "zipline_prompt_missing", "no mount prompt from any stand point at this tower");
+    }
+
+    ++approach.spot_index;
+    approach.press_missed = true;
+    const ZiplineMountSpot& spot = waypoint.zipline_hop->mount_spots[approach.spot_index];
+    const bool retargeted = ctx.session->RetargetCurrentWaypoint(spot.x, spot.y, reason);
+    // 顶在设备上走不动也算这个站位试过了。硬时钟不归零, 下一拍就会把剩下的站位一口气烧光
+    ctx.session->ResetHardProgress();
+    LogWarn << "Action: ZIPLINE no mount prompt here; walking to the next stand point." << VAR(reason) << VAR(retargeted)
+            << VAR(approach.spot_index) << VAR(spot_count) << VAR(spot.x) << VAR(spot.y);
     ctx.runtime_state->route.Reset();
     ctx.runtime_state->route.startup_anchor_pos = *ctx.position;
     ctx.runtime_state->route.startup_anchor_initialized = true;
     ctx.runtime_state->route.startup_motion_confirmed = true;
     ctx.position_provider->ResetTracking();
-    SelectPhaseForCurrentWaypoint(ctx, "zipline_mount_restand");
+    SelectPhaseForCurrentWaypoint(ctx, reason);
+
+    Result result;
+    result.consumed = true;
+    result.stay_in_current_tick = true;
     return result;
 }
-
-} // namespace
 
 bool CurrentHopStartsUnderfoot(const Context& ctx)
 {
@@ -384,13 +400,10 @@ Result StartZiplineHop(const Context& ctx, const Waypoint& waypoint, double actu
                 LogInfo << "Zipline mount pre-filter did not hold up; keeping the approach." << VAR(actual_distance);
                 return result;
             }
-            // 认不出只有两种走法: 人还差一点点没走到跟前, 或者架子边上那根供电桩把面板占着。两种都
-            // 得靠挪身位解决, 所以记一笔交回导航, 预筛一路开着, 提示先冒出来就先按下去
-            if (!ctx.runtime_state->zipline_approach.press_missed) {
-                LogInfo << "No mount prompt at the tower; walking a bit around it for another look." << VAR(actual_distance);
-                return Reposition(ctx, NeedsReposition { .restand = waypoint.zipline_hop->restand });
-            }
-            return AbandonZipline(ctx, "zipline_prompt_missing", "no mount prompt at the tower");
+            // 认不出都得靠挪身位解决: 人差一点点没走到跟前、站位猜的方向上没有设备模型、或者架子
+            // 边上那根供电桩把面板占着。交回导航换下一个站位, 预筛一路开着, 提示先冒出来就先按下去
+            LogInfo << "No mount prompt at this stand point; moving on to the next one." << VAR(actual_distance);
+            return AdvanceMountSpot(ctx, waypoint, "zipline_mount_no_prompt");
         }
         // 此处只负责发出上索按键, 是否已上架由阶段机的 Mounting 段判定; 判定落定前不瞄准也不发射
         ctx.runtime_state->zipline_approach.press_missed = false;
@@ -433,8 +446,8 @@ Result TickZiplineRide(const Context& ctx)
             replan->still_on_tower ? "waiting on the tower for a new route" : "this hop is dead, re-routing from the ground",
             replan->still_on_tower);
     }
-    if (const auto* need = std::get_if<NeedsReposition>(&outcome)) {
-        return Reposition(ctx, *need);
+    if (std::get_if<NeedsReposition>(&outcome) != nullptr) {
+        return AdvanceMountSpot(ctx, ctx.session->CurrentWaypoint(), "zipline_mount_unmounted");
     }
     result.stay_in_current_tick = true;
     utils::SleepFor(kZiplineRideRetryIntervalMs);

--- a/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
@@ -313,14 +313,15 @@ Result AdvanceMountSpot(const Context& ctx, const Waypoint& waypoint, const char
 {
     ZiplineApproachState& approach = ctx.runtime_state->zipline_approach;
     const size_t spot_count = waypoint.zipline_hop ? waypoint.zipline_hop->mount_spots.size() : 0;
-    if (approach.spot_index + 1 >= spot_count) {
+    const size_t cursor = waypoint.zipline_hop ? approach.MountSpotCursor(waypoint.zipline_hop->mount) : 0;
+    if (cursor + 1 >= spot_count) {
         if (waypoint.zipline_hop) {
             ctx.runtime_state->zipline_ride.MarkMountUnreachable(*waypoint.zipline_hop);
         }
         return AbandonZipline(ctx, "zipline_prompt_missing", "no mount prompt from any stand point at this tower");
     }
 
-    ++approach.spot_index;
+    approach.spot_index = cursor + 1;
     approach.press_missed = true;
     const ZiplineMountSpot& spot = waypoint.zipline_hop->mount_spots[approach.spot_index];
     const bool retargeted = ctx.session->RetargetCurrentWaypoint(spot.x, spot.y, reason);

--- a/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_action.cpp
@@ -130,6 +130,20 @@ public:
         return obs;
     }
 
+    // 两个信号按代价从低到高求值: 右上角按钮在架上收起, 故地面判据命中即判定角色在地面; 未命中时
+    // 再读底部操作引导, 命中「离开滑索架」的片段才判定已上架
+    MountVerdict CheckMounted() override
+    {
+        if (ctx_.maa_context == nullptr) {
+            return MountVerdict::Unclear;
+        }
+        if (RunNodeAndReportHit(ctx_.maa_context, kZiplineOnGroundEntryNode, kZiplineOnGroundNode, "{}")) {
+            return MountVerdict::OnGround;
+        }
+        const bool hint = RunNodeAndReportHit(ctx_.maa_context, kZiplineOnTowerHintEntryNode, kZiplineOnTowerHintNode, "{}");
+        return hint ? MountVerdict::OnTower : MountVerdict::Unclear;
+    }
+
     void ResetTracking() override { ctx_.position_provider->ResetTracking(); }
 
 private:
@@ -181,6 +195,8 @@ public:
         const int units = static_cast<int>(std::lround(-delta_deg * ctx_.action_wrapper->DefaultPitchUnitsPerDegree()));
         return units == 0 || ctx_.action_wrapper->SendViewDeltaSync(0, units);
     }
+
+    bool PressMount() override { return PressMountPrompt(ctx_.maa_context); }
 
     // 起滑就是对着瞄好的方向按一下左键
     void FireLaunch() override
@@ -376,8 +392,7 @@ Result StartZiplineHop(const Context& ctx, const Waypoint& waypoint, double actu
             }
             return AbandonZipline(ctx, "zipline_prompt_missing", "no mount prompt at the tower");
         }
-        // 交互键已经发出去了, 从这里起就当人已经站在架子上: 认错方向的代价是走不动路, 反过来白按
-        // 一次右键什么也不会发生。真没站上去由阶段机认出来(怎么发射都不动), 下来重新站一次
+        // 此处只负责发出上索按键, 是否已上架由阶段机的 Mounting 段判定; 判定落定前不瞄准也不发射
         ctx.runtime_state->zipline_approach.press_missed = false;
     }
 

--- a/agent/cpp-algo/source/MapNavigator/zipline_action.h
+++ b/agent/cpp-algo/source/MapNavigator/zipline_action.h
@@ -15,6 +15,10 @@ Result StartZiplineHop(const Context& ctx, const Waypoint& waypoint, double actu
 // 滑行中的每一拍。阶段机自己判落点、滑错回程、重试；这里只把它的出口事件接回导航。
 Result TickZiplineRide(const Context& ctx);
 
+// 这个站位上没出上索提示：改瞄计划里的下一个站位走过去再认一次。站位全试过还不出提示就记一笔
+// 「这根架子上不去」并退索走路，让后续重规划不再挑它当上索点。
+Result AdvanceMountSpot(const Context& ctx, const Waypoint& waypoint, const char* reason);
+
 // 滑索走不成时的退路：还站在架子上就先下来，再丢掉这条链剩下的每一跳。状态机随后等待稳定
 // 定位，从剩余路线中第一个实际可达的点重新接入；接不回去就明确失败，不沿用从预期落点生成的旧路线。
 Result AbandonZipline(const Context& ctx, const char* reason, const char* detail);

--- a/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
@@ -507,6 +507,20 @@ private:
 
 } // namespace
 
+ZiplineNodeRef ToNodeRef(const zipline::ZiplineNode& node)
+{
+    ZiplineNodeRef ref;
+    ref.level_id = node.level_id;
+    ref.world_x = node.world_x;
+    ref.world_y = node.world_y;
+    ref.world_z = node.world_z;
+    ref.has_world = true;
+    ref.x = node.x;
+    ref.y = node.y;
+    ref.height = node.height;
+    return ref;
+}
+
 void ResetZiplineOutcome()
 {
     g_zipline_used = false;
@@ -705,16 +719,7 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
             continue;
         }
         for (size_t i = 0; i < nodes.size(); ++i) {
-            ZiplineNodeRef probe;
-            probe.level_id = nodes[i].level_id;
-            probe.world_x = nodes[i].world_x;
-            probe.world_y = nodes[i].world_y;
-            probe.world_z = nodes[i].world_z;
-            probe.has_world = true;
-            probe.x = nodes[i].x;
-            probe.y = nodes[i].y;
-            probe.height = nodes[i].height;
-            if (can_board[i] && probe.SameTower(record.plan.mount)) {
+            if (can_board[i] && ToNodeRef(nodes[i]).SameTower(record.plan.mount)) {
                 can_board[i] = false;
                 ++unboardable;
             }

--- a/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.cpp
@@ -219,6 +219,64 @@ std::optional<navmesh::WorldPoint> MountStandPoint(
     return stand;
 }
 
+// 上索依次走到哪。坐标记的是随朝向变化的角格锚点, 设备模型占着锚点四周哪一格未知; 互动要人面朝
+// 设备且身位与模型有交集, 走到锚点上两条都不一定成立, 所以把各个可能的中心格排成候选逐个试。
+// 取中心格而不取更深处: 行进中的提示预筛按到航点的距离开窗, 目标越往模型里推, 身位被挡住那一刻
+// 离航点越远, 越容易落在窗外。顺着进场方向的那个排前面, 少一次掉头。
+std::vector<navmesh::WorldPoint> MountSpots(
+    const NaviParam& param,
+    const std::string& locator_zone,
+    const zipline::ZiplineFrame& frame,
+    const zipline::ZiplineNode& tower,
+    const std::array<int, 2>& footprint,
+    const navmesh::WorldPoint& approach_from,
+    const std::vector<navmesh::WorldPoint>& supplies)
+{
+    const navmesh::WorldPoint anchor = ToWorld(tower);
+    const double half_x = grid_half_span(footprint[0]);
+    const double half_z = grid_half_span(footprint[1]);
+    // 进场方向取最后一段走路; 起点已经站在架子跟前时这两个分量都是零, 排序退化成固定顺序
+    const double toward_x = anchor.x - approach_from.x;
+    const double toward_y = anchor.y - approach_from.y;
+    const std::array<double, 2> signs { 1.0, -1.0 };
+    const size_t x_count = half_x > 0.0 ? signs.size() : 1;
+    const size_t z_count = half_z > 0.0 ? signs.size() : 1;
+    std::vector<std::pair<double, navmesh::WorldPoint>> ranked;
+    for (size_t xi = 0; xi < x_count; ++xi) {
+        for (size_t zi = 0; zi < z_count; ++zi) {
+            // 偏移量在原始世界坐标里按格算, 再走投影拿到像素: 地图比例不进这里
+            const zipline::ZiplineMark shifted {
+                .template_id = tower.template_id,
+                .level_id = tower.level_id,
+                .x = tower.world_x + signs[xi] * half_x,
+                .y = tower.world_y,
+                .z = tower.world_z + signs[zi] * half_z,
+            };
+            const navmesh::WorldPoint spot = ToWorld(frame.project(shifted));
+            const auto snap = NavmeshSnapAt(param, locator_zone, spot, kMountStandSnapRadiusPx, tower.height);
+            if (!snap || snap->distance > kMountStandSnapTolPx || std::abs(snap->height - tower.height) > navmesh::kBaseNavFloorBand) {
+                continue;
+            }
+            ranked.emplace_back((spot.x - anchor.x) * toward_x + (spot.y - anchor.y) * toward_y, spot);
+        }
+    }
+    std::stable_sort(ranked.begin(), ranked.end(), [](const auto& lhs, const auto& rhs) { return lhs.first > rhs.first; });
+    std::vector<navmesh::WorldPoint> spots;
+    for (const auto& entry : ranked) {
+        spots.push_back(entry.second);
+    }
+    if (spots.empty()) {
+        // 只占一格时锚点就是中心; 几个中心格全贴不住同一层的面时也只剩它
+        spots.push_back(anchor);
+    }
+    if (const std::optional<navmesh::WorldPoint> stand = MountStandPoint(param, locator_zone, tower, supplies)) {
+        spots.push_back(*stand);
+    }
+    LogDebug << "ZiplineRoute: stand points to try at the mount tower" << VAR(spots.size()) << VAR(anchor.x) << VAR(anchor.y) << VAR(half_x)
+             << VAR(half_z);
+    return spots;
+}
+
 // 森空岛只给随朝向变化的角格锚点，双方中心在每条水平轴上都可能朝彼此靠近各自的
 // 占地半宽。高度坐标不受朝向影响，原样计入三维距离。返回平方值供配对内层循环直接比较。
 constexpr double minimum_possible_world_span_squared(
@@ -639,6 +697,32 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
     if (cut_off != 0) {
         LogDebug << "ZiplineRoute: these ziplines share no walkable ground with either end" << VAR(cut_off) << VAR(nodes.size());
     }
+    // 执行侧每个站位都走到过、一次上索提示都没出来的架子, 这一趟不再当上索点。当落点照旧:
+    // 人是从索上落到架子上的, 上不去跟够不着是两件事
+    size_t unboardable = 0;
+    for (const ZiplineHopRecord& record : param.zipline_ledger) {
+        if (record.outcome != HopOutcome::Unboardable) {
+            continue;
+        }
+        for (size_t i = 0; i < nodes.size(); ++i) {
+            ZiplineNodeRef probe;
+            probe.level_id = nodes[i].level_id;
+            probe.world_x = nodes[i].world_x;
+            probe.world_y = nodes[i].world_y;
+            probe.world_z = nodes[i].world_z;
+            probe.has_world = true;
+            probe.x = nodes[i].x;
+            probe.y = nodes[i].y;
+            probe.height = nodes[i].height;
+            if (can_board[i] && probe.SameTower(record.plan.mount)) {
+                can_board[i] = false;
+                ++unboardable;
+            }
+        }
+    }
+    if (unboardable != 0) {
+        LogInfo << "ZiplineRoute: left out the towers the runtime never managed to board." << VAR(unboardable) << VAR(nodes.size());
+    }
     // 一头都接不上时后面配对必然是空的。链中间的架子仍然全留着，那些是从索上落下去的。
     if (std::none_of(can_board.begin(), can_board.end(), [](bool v) { return v; })
         || std::none_of(can_land.begin(), can_land.end(), [](bool v) { return v; })) {
@@ -954,7 +1038,16 @@ std::optional<ZiplineRoute> PlanZiplineRoute(
         }
     }
     // 只有链首那一根要按提示上索, 中途都是从索上落到下一根架子上的
-    best->mount_restand = MountStandPoint(param, locator_zone, best->towers.front(), supply_points);
+    const navmesh::WorldPoint& approach_from =
+        best->approach.points.size() >= 2 ? best->approach.points[best->approach.points.size() - 2] : start;
+    best->mount_spots = MountSpots(
+        param,
+        locator_zone,
+        *frame,
+        best->towers.front(),
+        data->frames.footprint(best->towers.front().template_id),
+        approach_from,
+        supply_points);
 
     LogInfo << "ZiplineRoute: picked" << VAR(walking_baseline_available) << VAR(baseline_length) << VAR(best->cost)
             << VAR(best->towers.size()) << VAR(best->towers.front().x) << VAR(best->towers.front().y) << VAR(best->towers.back().x)

--- a/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.h
+++ b/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.h
@@ -41,9 +41,10 @@ struct ZiplineRoute
     std::vector<std::vector<zipline::ZiplineNode>> hop_alternates;
     // 折算成等效走路距离的总代价，与 baseline_length 可直接比大小。
     double cost = 0.0;
-    // 上索点旁边贴着供电结构时给的备用站位，执行侧认不出上索提示才改瞄它。
-    // 接近段仍然走到架子本身：让开量再小也是往外推，把它当常规落脚点会把人推出够得着的那圈。
-    std::optional<navmesh::WorldPoint> mount_restand;
+    // 链首上索要依次试的站位，执行侧按顺序走，认不出提示就换下一个。
+    // 坐标记的是随朝向变化的角格锚点，设备模型占着锚点四周哪一格未知，所以前几个是各个可能的
+    // 中心格；贴着供电结构时末位再补一个让开它的点。为空表示只能按架子坐标本身走。
+    std::vector<navmesh::WorldPoint> mount_spots;
     // 仅 WebUI 预览请求收集；只含最终选中方案的接近段和离索段。
     std::vector<NavmeshRouteDiagnostic> diagnostics;
 };

--- a/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.h
+++ b/agent/cpp-algo/source/MapNavigator/zipline_leg_planner.h
@@ -8,6 +8,7 @@
 #include "../Navmesh/BaseNavPlanner.h"
 #include "../Zipline/ZiplineFrames.h"
 #include "navmesh_diagnostics.h"
+#include "zipline_types.h"
 
 namespace mapnavigator
 {
@@ -48,6 +49,10 @@ struct ZiplineRoute
     // 仅 WebUI 预览请求收集；只含最终选中方案的接近段和离索段。
     std::vector<NavmeshRouteDiagnostic> diagnostics;
 };
+
+// 把标定里的一根架子转成执行侧认身份用的引用。身份判定靠世界坐标，漏掉任何一个分量都会让
+// SameTower 悄悄退化成按像素认架子，所以两侧共用这一份映射。
+ZiplineNodeRef ToNodeRef(const zipline::ZiplineNode& node);
 
 // 在本区找一条滑索路线：纯走路可达时只返回显著更省的方案；纯走路不可达时返回能把
 // 起终两侧可走面接起来的最低成本连续链。没有可用方案、该区没标定过、或请求没开滑索时返回 nullopt。

--- a/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.cpp
@@ -389,10 +389,23 @@ StageResult ZiplineRideMachine::Remount(IZiplineActuator& actuator, const char* 
         EnterStage(ZiplineStage::Mounting, now);
         return {};
     }
-    LogWarn << "zipline/mount/unmounted" << VAR(reason) << VAR(elapsed_ms) << VAR(mount_presses_) << VAR(plan_.restand.has_value());
+    LogWarn << "zipline/mount/unmounted" << VAR(reason) << VAR(elapsed_ms) << VAR(mount_presses_) << VAR(plan_.mount_spots.size());
     CommitRecord(HopOutcome::NotMounted, now);
     EnterStage(ZiplineStage::Idle, now);
-    return NeedsReposition { .restand = plan_.restand };
+    return NeedsReposition {};
+}
+
+// 这根架子的站位全试过了, 一次提示都没出来。记一笔让重规划别再拿它当上索点; 当落点不受影响
+void ZiplineRideMachine::MarkMountUnreachable(const ZiplineHopPlan& plan)
+{
+    const Clock::time_point now = Clock::now();
+    ZiplineHopRecord record;
+    record.plan = plan;
+    record.outcome = HopOutcome::Unboardable;
+    record.began_at = now;
+    record.ended_at = now;
+    ledger_.push_back(record);
+    LogWarn << "zipline/mount/unboardable" << VAR(plan.mount.x) << VAR(plan.mount.y) << VAR(plan.mount_spots.size()) << VAR(ledger_.size());
 }
 
 StageResult ZiplineRideMachine::TickOnTower(IZiplineActuator& actuator, Clock::time_point now)

--- a/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.cpp
@@ -62,6 +62,8 @@ const char* StageName(ZiplineStage stage)
     switch (stage) {
     case ZiplineStage::Idle:
         return "idle";
+    case ZiplineStage::Mounting:
+        return "mounting";
     case ZiplineStage::OnTower:
         return "on_tower";
     case ZiplineStage::Aiming:
@@ -128,6 +130,8 @@ LandingClass ClassifyLanding(
 void ZiplineRideMachine::Begin(const ZiplineHopPlan& plan)
 {
     const auto now = Clock::now();
+    // 链中续跳与滑回原架时角色已在架上, 直接进入瞄准; 其余情况调用方刚发出上索按键, 需先确认已上架
+    const bool standing = OnTower();
     // 上索点重新站过一次再回来的是同一跳, 记录接着写; 换了跳就把上一跳按下索了结
     const bool resume = hop_open_ && plan_.mount.SameTower(plan.mount) && plan_.landing.SameTower(plan.landing);
     if (!resume) {
@@ -152,8 +156,8 @@ void ZiplineRideMachine::Begin(const ZiplineHopPlan& plan)
     unknown_deadline_.reset();
     pending_exit_ = {};
     LogInfo << "zipline/begin" << VAR(resume) << VAR(plan_.mount.x) << VAR(plan_.mount.y) << VAR(plan_.landing.x) << VAR(plan_.landing.y)
-            << VAR(plan_.planned_elevation_deg) << VAR(plan_.siblings.size()) << VAR(plan_.chain_continues);
-    EnterStage(ZiplineStage::OnTower, now);
+            << VAR(plan_.planned_elevation_deg) << VAR(plan_.siblings.size()) << VAR(plan_.chain_continues) << VAR(standing);
+    EnterStage(standing ? ZiplineStage::OnTower : ZiplineStage::Mounting, now);
 }
 
 StageResult ZiplineRideMachine::Tick(IZiplineObserver& observer, IZiplineActuator& actuator)
@@ -174,6 +178,8 @@ StageResult ZiplineRideMachine::Tick(IZiplineObserver& observer, IZiplineActuato
 
     const ZiplineObservation obs = observer.Observe(KnownNodes());
     switch (stage_) {
+    case ZiplineStage::Mounting:
+        return TickMounting(obs, observer, actuator);
     case ZiplineStage::Aiming:
     case ZiplineStage::ReturnAiming:
         return TickAiming(obs, actuator);
@@ -202,6 +208,7 @@ void ZiplineRideMachine::Dismount(IZiplineActuator& actuator)
     Reset();
 }
 
+// Mounting 不计入在架上: 该阶段正在判定是否已上架, 计入会退回到按键即认定
 bool ZiplineRideMachine::OnTower() const
 {
     return parked_on_.has_value() || stage_ == ZiplineStage::OnTower || stage_ == ZiplineStage::Aiming || stage_ == ZiplineStage::Fired
@@ -233,7 +240,9 @@ void ZiplineRideMachine::Reset()
     pitch_tier_ = 0;
     returning_ = false;
     hop_retry_count_ = 0;
-    mount_retry_used_ = false;
+    mount_presses_ = 0;
+    on_tower_hits_ = 0;
+    on_ground_hits_ = 0;
     discovered_towers_.clear();
     parked_on_.reset();
     launch_fix_.reset();
@@ -317,6 +326,73 @@ double ZiplineRideMachine::AimBiasDeg() const
         return 0.0;
     }
     return delta > 0.0 ? -kZiplineAimToleranceDeg / 2.0 : kZiplineAimToleranceDeg / 2.0;
+}
+
+// 上索按键发出后, 先确认已上架再放开俯仰与左键。两个判定各需连续若干帧一致才落定。位移只作否决用:
+// 角色被架子锁住时无法移动, 故能移动即判定在地面, 零位移本身是二义的
+StageResult ZiplineRideMachine::TickMounting(const ZiplineObservation& obs, IZiplineObserver& observer, IZiplineActuator& actuator)
+{
+    const auto now = obs.at;
+    const int64_t elapsed_ms = StageElapsedMs(now);
+    const bool walking = obs.fix && last_fix_ && DistanceWu(*obs.fix, *last_fix_) >= kZiplineMountMinMoveWu;
+    if (obs.fix) {
+        last_fix_ = obs.fix;
+    }
+    const MountVerdict verdict = walking ? MountVerdict::OnGround : observer.CheckMounted();
+    // settle 之内的地面读数不予采信: 按钮尚未收起时, 角色可能正在上架过程中。故这段时间内的读数
+    // 一律不计入连续帧数, 重按所依据的若干帧全部取自窗口之后
+    const bool settled = elapsed_ms >= kZiplineMountSettleMs;
+    on_tower_hits_ = verdict == MountVerdict::OnTower ? on_tower_hits_ + 1 : 0;
+    on_ground_hits_ = verdict == MountVerdict::OnGround && settled ? on_ground_hits_ + 1 : 0;
+
+    if (on_tower_hits_ >= kZiplineMountOnTowerFixes) {
+        LogInfo << "zipline/mount/confirmed" << VAR(elapsed_ms) << VAR(mount_presses_);
+        EnterStage(ZiplineStage::OnTower, now);
+        return {};
+    }
+    // 余速未停时不重按: 带着惯性发出的交互正是这一跳落空的成因, 此时重按同样不会生效
+    if (walking) {
+        return {};
+    }
+    if (on_ground_hits_ >= kZiplineMountOnGroundFixes) {
+        return Remount(actuator, "zipline/mount/on_ground", now);
+    }
+    // 两个信号都未命中在窗口内只当过渡态, 等窗口耗满再判定
+    if (elapsed_ms <= kZiplineMountWindowMs) {
+        return {};
+    }
+    // 窗口耗满时架上一侧的连续读数仍在累计: 等它满足或中断, 避免在上架完成的瞬间重按上索键
+    if (verdict == MountVerdict::OnTower) {
+        return {};
+    }
+    // 窗口耗满、两个信号都未命中且无位移: 按「已被架子锁住而提示漏读」处理, 先发下索键回到可判定的地面态
+    // 再重规划, 避免在位置未定的状态下继续瞄准和发射
+    if (verdict == MountVerdict::Unclear) {
+        LogWarn << "zipline/mount/unreadable" << VAR(elapsed_ms) << VAR(mount_presses_);
+        CommitRecord(HopOutcome::NotMounted, now);
+        return StartDismount(actuator, ReplanRequested { .still_on_tower = false }, now);
+    }
+    return Remount(actuator, "zipline/mount/window_expired", now);
+}
+
+// 判定未上架后的第一级处置是重按上索键。两道防护避免对已上架的角色重按: 地面态须由 InWorld 命中,
+// 以及识别不到架子的交互提示时不发按键。预算用尽仍未上架才交回导航, 由其调整站位后重来
+StageResult ZiplineRideMachine::Remount(IZiplineActuator& actuator, const char* reason, Clock::time_point now)
+{
+    // elapsed_ms 是这次按键到判定未上架的实际耗时, settle 与窗口两个时限按它核准
+    const int64_t elapsed_ms = StageElapsedMs(now);
+    if (mount_presses_ < kZiplineMountPressBudget && actuator.PressMount()) {
+        ++mount_presses_;
+        on_tower_hits_ = 0;
+        on_ground_hits_ = 0;
+        LogWarn << "zipline/mount/repress" << VAR(reason) << VAR(elapsed_ms) << VAR(mount_presses_);
+        EnterStage(ZiplineStage::Mounting, now);
+        return {};
+    }
+    LogWarn << "zipline/mount/unmounted" << VAR(reason) << VAR(elapsed_ms) << VAR(mount_presses_) << VAR(plan_.restand.has_value());
+    CommitRecord(HopOutcome::NotMounted, now);
+    EnterStage(ZiplineStage::Idle, now);
+    return NeedsReposition { .restand = plan_.restand };
 }
 
 StageResult ZiplineRideMachine::TickOnTower(IZiplineActuator& actuator, Clock::time_point now)
@@ -448,7 +524,7 @@ StageResult ZiplineRideMachine::TickFired(const ZiplineObservation& obs, IZiplin
             EnterStage(ZiplineStage::Landed, now);
             return {};
         }
-        if (elapsed_ms > kZiplineMountConfirmMs) {
+        if (elapsed_ms > kZiplineLaunchConfirmMs) {
             last_fix_ = obs.fix;
             LogWarn << "zipline/fired/no_launch" << VAR(moved) << VAR(elapsed_ms) << VAR(pitch_tier_);
             return Classify(observer, actuator, now);
@@ -581,14 +657,6 @@ StageResult ZiplineRideMachine::Classify(IZiplineObserver& observer, IZiplineAct
         if (returning_) {
             CommitRecord(HopOutcome::WrongRope, now);
             return StartDismount(actuator, ChainAbandoned { "zipline/return/no_launch" }, now);
-        }
-        if (!mount_retry_used_) {
-            mount_retry_used_ = true;
-            pitch_tier_ = 0;
-            actuator.Dismount();
-            EnterStage(ZiplineStage::Idle, now);
-            LogWarn << "zipline/no_launch/restand" << VAR(plan_.restand.has_value());
-            return NeedsReposition { .restand = plan_.restand };
         }
         // 人根本没滑出去, 还站在上索架上。先下来再重规划要白付一次上索, 而重规划本身就会看新路线
         // 用不用得上脚下这根架子, 用不上时才下来

--- a/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.cpp
@@ -350,9 +350,16 @@ StageResult ZiplineRideMachine::TickMounting(const ZiplineObservation& obs, IZip
         EnterStage(ZiplineStage::OnTower, now);
         return {};
     }
-    // 余速未停时不重按: 带着惯性发出的交互正是这一跳落空的成因, 此时重按同样不会生效
+    // 余速未停时不重按: 带着惯性发出的交互正是这一跳落空的成因, 此时重按同样不会生效。一路都在动
+    // 说明人没被架子锁住, 窗口耗满就交回导航换站位 —— 这个相位外头没有看门狗, 等不到别人来收场
     if (walking) {
-        return {};
+        if (elapsed_ms <= kZiplineMountWindowMs) {
+            return {};
+        }
+        LogWarn << "zipline/mount/still_moving" << VAR(elapsed_ms) << VAR(mount_presses_);
+        CommitRecord(HopOutcome::NotMounted, now);
+        EnterStage(ZiplineStage::Idle, now);
+        return NeedsReposition {};
     }
     if (on_ground_hits_ >= kZiplineMountOnGroundFixes) {
         return Remount(actuator, "zipline/mount/on_ground", now);

--- a/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.h
@@ -58,6 +58,8 @@ public:
     StageResult Tick(IZiplineObserver& observer, IZiplineActuator& actuator);
     // 外部要人立刻下来(丢链、换路)。跳还开着就按 Dismounted 记账
     void Dismount(IZiplineActuator& actuator);
+    // 上索点的每个站位都走到过却一次提示都没出来, 由导航侧判定后记账
+    void MarkMountUnreachable(const ZiplineHopPlan& plan);
 
     bool OnTower() const;
     std::optional<ZiplineNodeRef> TowerUnderfoot() const;

--- a/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.h
+++ b/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.h
@@ -16,6 +16,8 @@ class IZiplineObserver
 public:
     virtual ~IZiplineObserver() = default;
     virtual ZiplineObservation Observe(const std::vector<ZiplineNodeRef>& hint_nodes) = 0;
+    // 判定角色在架上还是在地面。仅在上索确认期间调用: 一次调用要跑识别, 开销高于一帧定位
+    virtual MountVerdict CheckMounted() = 0;
     virtual void ResetTracking() = 0;
 };
 
@@ -28,6 +30,8 @@ public:
     // 只发一个后端批次, 返回实际发出的度数; 发不出去返回空
     virtual std::optional<double> TurnYaw(double delta_deg) = 0;
     virtual bool TurnPitch(double delta_deg) = 0;
+    // 重按上索键。识别不到架子的交互提示时不发按键, 返回值为是否识别到
+    virtual bool PressMount() = 0;
     virtual void FireLaunch() = 0;
     virtual void Dismount() = 0;
     virtual void Wait(int32_t ms) = 0;
@@ -43,8 +47,8 @@ LandingClass ClassifyLanding(
     bool riding_entered,
     ZiplineNodeRef* reached);
 
-// 一跳滑索从站上架子到交还导航的阶段机。上索键、下索键按出去就当成了, 之后只看定位:
-// 起滑后连着定位不到就是滑出去了, 定位回来并停稳就是落地了, 落在哪由分类决定。
+// 一跳滑索从上索按键到交还导航的阶段机。按键后先确认已上架, 再放开俯仰与左键; 此后只依据定位:
+// 起滑后连续定位失败即判定在滑行, 定位恢复并停稳即判定落地, 落点归属由分类决定。
 // 每跳的发射与结果记进账本, 规划器据此排掉滑不动/滑错的索
 class ZiplineRideMachine
 {
@@ -75,6 +79,8 @@ private:
     std::vector<ZiplineNodeRef> KnownNodes() const;
     double AimBiasDeg() const;
 
+    StageResult TickMounting(const ZiplineObservation& obs, IZiplineObserver& observer, IZiplineActuator& actuator);
+    StageResult Remount(IZiplineActuator& actuator, const char* reason, Clock::time_point now);
     StageResult TickOnTower(IZiplineActuator& actuator, Clock::time_point now);
     StageResult TickAiming(const ZiplineObservation& obs, IZiplineActuator& actuator);
     StageResult TickFired(const ZiplineObservation& obs, IZiplineObserver& observer, IZiplineActuator& actuator);
@@ -101,7 +107,10 @@ private:
     int pitch_tier_ = 0;
     bool returning_ = false;
     int hop_retry_count_ = 0;
-    bool mount_retry_used_ = false;
+    // 上索确认: 本次站位已发出的上索按键次数, 两个判定各自的连续成立帧数
+    int mount_presses_ = 0;
+    int on_tower_hits_ = 0;
+    int on_ground_hits_ = 0;
     std::vector<ZiplineNodeRef> discovered_towers_;
     // 交回导航后人还站着的架子
     std::optional<ZiplineNodeRef> parked_on_;

--- a/agent/cpp-algo/source/MapNavigator/zipline_types.h
+++ b/agent/cpp-algo/source/MapNavigator/zipline_types.h
@@ -45,8 +45,8 @@ struct ZiplineHopPlan
     std::vector<ZiplineNodeRef> siblings;
     // 索的仰角, 正数往上滑。按两端世界坐标算好, 运行时不再碰单位
     double planned_elevation_deg = 0.0;
-    // 上索认不出提示时的备用站位。架子旁边没有供电结构就不写
-    std::optional<ZiplineRestand> restand;
+    // 上索依次要试的站位, 第一个就是航点本身的落脚点。只有链首那一跳用得上
+    std::vector<ZiplineMountSpot> mount_spots;
     // 落点就是下一跳的上索架: 落地不下索, 直接接着瞄
     bool chain_continues = false;
 };
@@ -75,11 +75,12 @@ struct ZiplineLaunch
 enum class HopOutcome
 {
     Completed,
-    WrongRope,  // 滑错过, 滑回后重试仍没到
-    NoLaunch,   // 在架上逐档俯仰都发射过, 索未起滑: 索被挡或未通电
-    NotMounted, // 上索按键发出后未上架: 这根索尚未试过, 架子本身也不判死
-    Lost,       // 落地定位一直对不上
-    Dismounted, // 主动下索交给恢复
+    WrongRope,   // 滑错过, 滑回后重试仍没到
+    NoLaunch,    // 在架上逐档俯仰都发射过, 索未起滑: 索被挡或未通电
+    NotMounted,  // 上索按键发出后未上架: 这根索尚未试过, 架子本身也不判死
+    Unboardable, // 每个站位都走到过, 一次提示都没出来: 这根架子上不去, 别再拿它当上索点
+    Lost,        // 落地定位一直对不上
+    Dismounted,  // 主动下索交给恢复
 };
 
 struct ZiplineHopRecord
@@ -146,10 +147,9 @@ struct ReplanRequested
     std::optional<ZiplineNodeRef> on_tower;
 };
 
-// 上索点站得不对, 人已经下来了。有备用站位就改瞄它, 没有就只收紧判定圈, 让人挪一下再上一次
+// 上索点站得不对, 人已经下来了。改瞄计划里的下一个站位再上一次
 struct NeedsReposition
 {
-    std::optional<ZiplineRestand> restand;
 };
 
 using StageResult = std::variant<std::monostate, HopCompleted, ChainAbandoned, ReplanRequested, NeedsReposition>;

--- a/agent/cpp-algo/source/MapNavigator/zipline_types.h
+++ b/agent/cpp-algo/source/MapNavigator/zipline_types.h
@@ -76,7 +76,8 @@ enum class HopOutcome
 {
     Completed,
     WrongRope,  // 滑错过, 滑回后重试仍没到
-    NoLaunch,   // 每档俯仰都没发出去: 索被挡、没上去, 观测上同形, 不再分
+    NoLaunch,   // 在架上逐档俯仰都发射过, 索未起滑: 索被挡或未通电
+    NotMounted, // 上索按键发出后未上架: 这根索尚未试过, 架子本身也不判死
     Lost,       // 落地定位一直对不上
     Dismounted, // 主动下索交给恢复
 };
@@ -95,10 +96,11 @@ struct ZiplineHopRecord
 // 一趟导航里每一跳的记录。规划器据此排掉滑不动/滑错的索, 主状态机据此决定要不要整段退回走路
 using HopLedger = std::vector<ZiplineHopRecord>;
 
-// 上索键、下索键按出去就当成了, 没有二次确认的阶段
+// 上索按键后须先经 Mounting 才判定在架上; 下索按键发出即判定已下架, 只等定位稳定
 enum class ZiplineStage
 {
     Idle,
+    Mounting,     // 上索按键已发出, 正在判定是否已上架
     OnTower,      // 站在架子上, 准备这一次发射
     Aiming,       // 闭环转 yaw, 开环俯仰, 然后左键
     Fired,        // 已左键, 等定位断掉(滑出去了)或位置离开起点
@@ -109,6 +111,14 @@ enum class ZiplineStage
     Dismounting,  // 已发下索键, 等定位稳定
     Handoff,      // 把出口事件交回导航
     Failed,
+};
+
+// 角色在架上还是在地面。两个信号都未命中即 Unclear: 窗口耗满之前它只表示继续等下一帧
+enum class MountVerdict
+{
+    OnTower,
+    OnGround,
+    Unclear,
 };
 
 // 一帧观测。fix 只在定位到且不是 held 时有值, 朝向就是 fix 的角度

--- a/agent/cpp-algo/source/MapNavmesh/MapNavmeshQuery.cpp
+++ b/agent/cpp-algo/source/MapNavmesh/MapNavmeshQuery.cpp
@@ -650,8 +650,12 @@ json::object BuildRoutePreview(const QueryParam& query)
             { "elevation_deg", hop.planned_elevation_deg },
             { "authored_group_begin", waypoint.authored_group_begin },
         };
-        if (hop.restand) {
-            segment.emplace("mount_restand", json::array { hop.restand->x, hop.restand->y });
+        if (!hop.mount_spots.empty()) {
+            json::array spots;
+            for (const mapnavigator::ZiplineMountSpot& spot : hop.mount_spots) {
+                spots.emplace_back(json::array { spot.x, spot.y });
+            }
+            segment.emplace("mount_spots", std::move(spots));
         }
         zipline_segments.emplace_back(std::move(segment));
         AppendDistinct(all_points, landing);

--- a/assets/resource/pipeline/MapNavigator/Zipline.json
+++ b/assets/resource/pipeline/MapNavigator/Zipline.json
@@ -113,6 +113,65 @@
         "pre_delay": 0,
         "post_delay": 0
     },
+    // 上索确认的第一个信号：右上角那两个大世界按钮在架上收起，所以认得出就是人还在地面。
+    // 识别逻辑引自 Interface/InScene 的公开节点 InWorld，此处包一层，使未命中记在 MapNavigator
+    // 自己的节点名下，不计入那个二十余处业务共用的节点。
+    "MapNavigatorZiplineOnGroundStart": {
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "MapNavigatorZiplineOnGround",
+            "MapNavigatorZiplineMountEnd"
+        ]
+    },
+    "MapNavigatorZiplineOnGround": {
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "InWorld"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0
+    },
+    // 上索确认的第二个信号：在架上时底部操作引导出现「离开滑索架」。认不出才是想要的结果，
+    // 故与上面同样挂直通出口兜底，让这一趟照常成功返回。
+    "MapNavigatorZiplineOnTowerHintStart": {
+        "pre_delay": 0,
+        "post_delay": 0,
+        "next": [
+            "MapNavigatorZiplineOnTowerHint",
+            "MapNavigatorZiplineMountEnd"
+        ]
+    },
+    // OCR 会把相邻提示连成一串、也会掉字，故 expected 按片段书写，覆盖这五个字中任意缺一字的
+    // 读法。roi 左边界避开左下角的 ping / UID，坐标基于 1280x720 基准帧。
+    "MapNavigatorZiplineOnTowerHint": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    200,
+                    668,
+                    900,
+                    44
+                ],
+                "expected": [
+                    // "离开滑索架"
+                    // @i18n-skip
+                    "滑索",
+                    "索架",
+                    "滑架",
+                    "开滑"
+                ]
+            }
+        },
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
     "MapNavigatorZiplinePitchReset": {
         "desc": "首次上索后通过相对鼠标移动将镜头拉到俯仰上限，以天空方向作为固定基准；dy 由 MapNavigator 按分辨率覆盖",
         "recognition": "DirectHit",

--- a/tools/MapNavigator/web/static/js/main.js
+++ b/tools/MapNavigator/web/static/js/main.js
@@ -1467,7 +1467,7 @@ class MapNavigatorApp {
           ...segment,
           from: project(segment.from),
           to: project(segment.to),
-          mount_restand: Array.isArray(segment.mount_restand) ? project(segment.mount_restand) : null,
+          mount_spots: Array.isArray(segment.mount_spots) ? segment.mount_spots.filter(Array.isArray).map(project) : [],
         })),
       failure: failure
         ? {


### PR DESCRIPTION
- fix #5229
- fix #5277 
- fix #5614
- fix #5470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能优化**
  - 优化滑索上架流程：按键后确认角色已上架或仍在地面。
  - 支持按顺序尝试多个候选上架站位，并在卡住时自动切换。
  - 增加上架失败后的重试、稳定性判断与超时恢复。
  - 区分未上架、已上架但未发射及无法上架等结果。
  - 记录无法上架的滑索并避开，交由后续路线重新规划。
  - 路线预览现支持展示多个候选上架位置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->