### PR TITLE
fix(MapNavigator): 按实机日志核准起滑确认时间与上索确认窗口

### DIFF
--- a/agent/cpp-algo/source/MapNavigator/navi_config.h
+++ b/agent/cpp-algo/source/MapNavigator/navi_config.h
@@ -308,15 +308,15 @@ constexpr double kZiplineSettleMoveWu = 1.5;
 constexpr int32_t kZiplineSettleFixes = 4;
 // 下索是一次右键。站在架子上时移动指令会被架子的选点状态吃掉, 所以走路之前必须先下来
 constexpr int32_t kZiplineDismountHoldMs = 80;
-// 索没通电、两端根本没挂索时起滑是空响, 人还站在架子上。滑一趟是大位移, 所以「过了确认时间
-// 还在原地」与「滑起来了但没到落点」分得开, 不必耗满整个滑行超时。两个值待实机核准
-constexpr int32_t kZiplineLaunchConfirmMs = 5000;
+// 索没通电、两端根本没挂索时起滑是空响, 人还站在架子上。真滑起来小地图随即读不回坐标, 空响时坐标
+// 一直有效且位移为零, 两种结局分得开, 确认时间只要盖住失定位到判出滑行那几拍
+constexpr int32_t kZiplineLaunchConfirmMs = 1500;
 constexpr double kZiplineMountMinMoveWu = 3.0;
 // 上索确认要求两个信号同时成立: 右上角按钮在架上收起, 底部操作引导出现「离开滑索架」。两侧各需连续
-// 若干帧一致, 架上一侧多要一帧。按键到按钮收起的延迟未经实测, settle 为其预留时间, 其间的地面读数
-// 不予采信。误判为已上架会使后续整条链建立在错误前提上, 故取偏保守的阈值。五个值待实机核准
+// 若干帧一致, 架上一侧多要一帧。按键到按钮收起的延迟里地面读数不予采信, settle 为其预留时间。窗口
+// 要盖住引导文字出现的滞后再加上攒够连续帧的那几拍, 余量不足会把已经上架的人按下索键弄下来
 constexpr int32_t kZiplineMountSettleMs = 600;
-constexpr int32_t kZiplineMountWindowMs = 2000;
+constexpr int32_t kZiplineMountWindowMs = 4000;
 constexpr int32_t kZiplineMountOnTowerFixes = 3;
 constexpr int32_t kZiplineMountOnGroundFixes = 2;
 constexpr int32_t kZiplineMountPressBudget = 2;

--- a/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.cpp
+++ b/agent/cpp-algo/source/MapNavigator/zipline_ride_machine.cpp
@@ -15,8 +15,8 @@ namespace mapnavigator
 namespace
 {
 
-// 一跳里第几次按左键该把镜头抬到多少度。俯仰读不回来, dy 的正负也没实机核过, 所以第二次直接
-// 反着来, 第三次干脆不动俯仰——三次里必有一次踩在对的那一侧
+// 一跳里第几次按左键该把镜头抬到多少度。俯仰读不回来, 下降索按规划仰角朝下瞄已经能发出去, 上升索
+// 的正仰角还没核过, 所以第二次反着来, 第三次干脆不动俯仰——三次里必有一次踩在对的那一侧
 double PitchTargetForAttempt(double elevation_deg, int attempt)
 {
     if (std::abs(elevation_deg) < kZiplinePitchDeadbandDeg) {

--- a/assets/resource/pipeline/LevelUpOperator.json
+++ b/assets/resource/pipeline/LevelUpOperator.json
@@ -451,10 +451,10 @@
                 ]
             }
         },
-        "post_wait_freezes": 100,
         "anchor": {
             "MouseMoveResetAnchor": "MouseMoveReset"
         },
+        "post_wait_freezes": 100,
         "next": [
             "[JumpBack][Anchor]MouseMoveResetAnchor",
             "LevelUpOperatorClearSwipeLeftHitCount"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 调整滑索发射确认时长，由 5 秒缩短至 1.5 秒，提升操作响应速度。
  - 延长滑索挂载判定窗口，由 2 秒增加至 4 秒，为玩家提供更充裕的挂载时间。
  - 优化滑索俯仰尝试策略说明，明确不同尝试阶段的瞄准与调整方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->