### PR TITLE
fix(SeizeDeliveryJobs): 修复终点未匹配的时候无法继续扫描的问题

### DIFF
--- a/assets/resource/pipeline/LevelUpOperator.json
+++ b/assets/resource/pipeline/LevelUpOperator.json
@@ -451,10 +451,10 @@
                 ]
             }
         },
-        "post_wait_freezes": 100,
         "anchor": {
             "MouseMoveResetAnchor": "MouseMoveReset"
         },
+        "post_wait_freezes": 100,
         "next": [
             "[JumpBack][Anchor]MouseMoveResetAnchor",
             "LevelUpOperatorClearSwipeLeftHitCount"

--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsEndpointCandidates.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsEndpointCandidates.json
@@ -19,7 +19,8 @@
             "무릉성"
         ],
         "next": [
-            "SeizeDeliveryJobsEndpointCandidatesWulingCity"
+            "SeizeDeliveryJobsEndpointCandidatesWulingCity",
+            "SeizeDeliveryJobsEndpointNotMatched"
         ]
     },
     // 武陵城区域的送货终点候选：一次缩放 + 一次视口求解，判本区域全部已启用终点。
@@ -87,7 +88,8 @@
             "실험 구역"
         ],
         "next": [
-            "SeizeDeliveryJobsEndpointCandidatesTestArea"
+            "SeizeDeliveryJobsEndpointCandidatesTestArea",
+            "SeizeDeliveryJobsEndpointNotMatched"
         ]
     },
     // 试验园区区域的送货终点候选：一次缩放 + 一次视口求解，判本区域全部已启用终点。

--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsEndpointCandidates.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsEndpointCandidates.json
@@ -23,7 +23,7 @@
         ]
     },
     // 武陵城区域的送货终点候选：一次缩放 + 一次视口求解，判本区域全部已启用终点。
-    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则本节点识别失败。
+    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则继续扫描下一委托。
     // 候选开关 = 它 next 那个落点叶子的 enabled（task 选项逐个打开），关掉的候选直接跳过、连认都不认。
     // 守卫经门控只路由到对应区域节点，地图本就以终点为中心打开，故本区域候选基本在屏内、无需跨区域拖动。
     "SeizeDeliveryJobsEndpointCandidatesWulingCity": {
@@ -63,7 +63,10 @@
                     "next": "SeizeDeliveryJobsEndpointFilterTechProductionOffice"
                 }
             ]
-        }
+        },
+        "on_error": [
+            "SeizeDeliveryJobsEndpointNotMatched"
+        ]
     },
     // 试验园区区域门控：OCR 地图左上角「大区域 /子区域」里的子区域名，确认当前地图聚焦在本区域。
     // 门控在 candidates（MapFind 进来会 zoom out 钉死缩放）之前执行，此时地图还是游戏默认打开状态、左上角子区域名有效。
@@ -91,7 +94,7 @@
         ]
     },
     // 试验园区区域的送货终点候选：一次缩放 + 一次视口求解，判本区域全部已启用终点。
-    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则本节点识别失败。
+    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则继续扫描下一委托。
     // 候选开关 = 它 next 那个落点叶子的 enabled（task 选项逐个打开），关掉的候选直接跳过、连认都不认。
     // 守卫经门控只路由到对应区域节点，地图本就以终点为中心打开，故本区域候选基本在屏内、无需跨区域拖动。
     "SeizeDeliveryJobsEndpointCandidatesTestArea": {
@@ -124,6 +127,9 @@
                     "next": "SeizeDeliveryJobsEndpointFilterJingweiFieldArea"
                 }
             ]
-        }
+        },
+        "on_error": [
+            "SeizeDeliveryJobsEndpointNotMatched"
+        ]
     }
 }

--- a/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsEndpointCandidates.json
+++ b/assets/resource/pipeline/SeizeDeliveryJobs/SeizeDeliveryJobsEndpointCandidates.json
@@ -23,7 +23,7 @@
         ]
     },
     // 武陵城区域的送货终点候选：一次缩放 + 一次视口求解，判本区域全部已启用终点。
-    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则继续扫描下一委托。
+    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则本节点识别失败。
     // 候选开关 = 它 next 那个落点叶子的 enabled（task 选项逐个打开），关掉的候选直接跳过、连认都不认。
     // 守卫经门控只路由到对应区域节点，地图本就以终点为中心打开，故本区域候选基本在屏内、无需跨区域拖动。
     "SeizeDeliveryJobsEndpointCandidatesWulingCity": {
@@ -63,10 +63,7 @@
                     "next": "SeizeDeliveryJobsEndpointFilterTechProductionOffice"
                 }
             ]
-        },
-        "on_error": [
-            "SeizeDeliveryJobsEndpointNotMatched"
-        ]
+        }
     },
     // 试验园区区域门控：OCR 地图左上角「大区域 /子区域」里的子区域名，确认当前地图聚焦在本区域。
     // 门控在 candidates（MapFind 进来会 zoom out 钉死缩放）之前执行，此时地图还是游戏默认打开状态、左上角子区域名有效。
@@ -94,7 +91,7 @@
         ]
     },
     // 试验园区区域的送货终点候选：一次缩放 + 一次视口求解，判本区域全部已启用终点。
-    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则继续扫描下一委托。
+    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则本节点识别失败。
     // 候选开关 = 它 next 那个落点叶子的 enabled（task 选项逐个打开），关掉的候选直接跳过、连认都不认。
     // 守卫经门控只路由到对应区域节点，地图本就以终点为中心打开，故本区域候选基本在屏内、无需跨区域拖动。
     "SeizeDeliveryJobsEndpointCandidatesTestArea": {
@@ -127,9 +124,6 @@
                     "next": "SeizeDeliveryJobsEndpointFilterJingweiFieldArea"
                 }
             ]
-        },
-        "on_error": [
-            "SeizeDeliveryJobsEndpointNotMatched"
-        ]
+        }
     }
 }

--- a/tools/pipeline-generate/SeizeDeliveryJobs/endpoint-candidates-template.jsonc
+++ b/tools/pipeline-generate/SeizeDeliveryJobs/endpoint-candidates-template.jsonc
@@ -15,7 +15,8 @@
         ],
         "expected": "${Expected}",
         "next": [
-            "SeizeDeliveryJobsEndpointCandidates${AreaId}"
+            "SeizeDeliveryJobsEndpointCandidates${AreaId}",
+            "SeizeDeliveryJobsEndpointNotMatched"
         ]
     },
     // ${AreaName}区域的送货终点候选：一次缩放 + 一次视口求解，判本区域全部已启用终点。

--- a/tools/pipeline-generate/SeizeDeliveryJobs/endpoint-candidates-template.jsonc
+++ b/tools/pipeline-generate/SeizeDeliveryJobs/endpoint-candidates-template.jsonc
@@ -19,7 +19,7 @@
         ]
     },
     // ${AreaName}区域的送货终点候选：一次缩放 + 一次视口求解，判本区域全部已启用终点。
-    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则本节点识别失败。
+    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则继续扫描下一委托。
     // 候选开关 = 它 next 那个落点叶子的 enabled（task 选项逐个打开），关掉的候选直接跳过、连认都不认。
     // 守卫经门控只路由到对应区域节点，地图本就以终点为中心打开，故本区域候选基本在屏内、无需跨区域拖动。
     "SeizeDeliveryJobsEndpointCandidates${AreaId}": {
@@ -30,6 +30,9 @@
             "zone": "${Zone}",
             "icon": "${Icon}",
             "candidates": "${Candidates}"
-        }
+        },
+        "on_error": [
+            "SeizeDeliveryJobsEndpointNotMatched"
+        ]
     }
 }

--- a/tools/pipeline-generate/SeizeDeliveryJobs/endpoint-candidates-template.jsonc
+++ b/tools/pipeline-generate/SeizeDeliveryJobs/endpoint-candidates-template.jsonc
@@ -19,7 +19,7 @@
         ]
     },
     // ${AreaName}区域的送货终点候选：一次缩放 + 一次视口求解，判本区域全部已启用终点。
-    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则继续扫描下一委托。
+    // 命中的候选把自己的 next 交回框架（顶掉本节点 next），前往对应落点叶子；全部未中则本节点识别失败。
     // 候选开关 = 它 next 那个落点叶子的 enabled（task 选项逐个打开），关掉的候选直接跳过、连认都不认。
     // 守卫经门控只路由到对应区域节点，地图本就以终点为中心打开，故本区域候选基本在屏内、无需跨区域拖动。
     "SeizeDeliveryJobsEndpointCandidates${AreaId}": {
@@ -30,9 +30,6 @@
             "zone": "${Zone}",
             "icon": "${Icon}",
             "candidates": "${Candidates}"
-        },
-        "on_error": [
-            "SeizeDeliveryJobsEndpointNotMatched"
-        ]
+        }
     }
 }


### PR DESCRIPTION
## 改动

- 为各区域的送货终点候选节点补充 `on_error`。
- 当所有已启用目的地均未命中时，转入现有的 `SeizeDeliveryJobsEndpointNotMatched` 流程，关闭地图并继续扫描下一委托。
- 修改生成器模板并重新生成 `SeizeDeliveryJobsEndpointCandidates.json`，保证两个区域的生成产物一致。

## 原因

#5551 将终点筛选改为“区域门控 -> MapFind candidates”后，`SeizeDeliveryJobsEndpointNotMatched` 仍留在外层分发器。区域 OCR 一旦命中，内层 candidates 识别失败会直接向上冒泡，外层不会再回到其 `next` 列表尝试 `EndpointNotMatched`，最终导致整项送货任务失败。

本次修改只把该失败结果接回已经存在的“未匹配 -> 关闭地图 -> 下一单”流程，不改变候选识别及命中后的接单行为。

## #5653 中仍存在的另一个问题（本 PR 不处理）

#5653 的日志还显示：实际目的地为已启用的经纬田区，送货点位于预期坐标附近，但 `DeliveryPoint.png` 的匹配分数仅为 `0.542096`，低于当前 `0.55` 阈值。

这个图标识别问题需要单独验证模板或显示状态。本 PR 不修改 `DeliveryPoint` 模板，也不调整阈值，避免把流程回退修复与识别参数修复混在一起。

因此本 PR 仅修复 #5653 中“目的地均未命中后任务直接中止”的问题。

## 验证

- `pnpm generate:SeizeDeliveryJobs`
- `pnpm format:check`
- `pnpm check`
- `pnpm test`
- 确认生成后的武陵城、试验园区两个 candidates 节点都包含指向 `SeizeDeliveryJobsEndpointNotMatched` 的 `on_error`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug 修复

* 当所有候选项均未匹配时，系统将判定当前节点识别失败，不再继续扫描下一个委托。
* 优化未匹配场景的处理流程，使其正确进入“未匹配”后续处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->