### PR TITLE
fix(WorldMap): MapFind 认不到图标的收场日志降为 WARN

### DIFF
--- a/agent/cpp-algo/source/WorldMap/WorldMapFind.cpp
+++ b/agent/cpp-algo/source/WorldMap/WorldMapFind.cpp
@@ -666,9 +666,10 @@ MaaBool MAA_CALL MapFindRun(
         return true;
     }
 
-    // 认不出图标又没有角色标记佐证时就不给坐标：宁可让上层走失败分支，也不交一个算出来的空位置
-    LogError << "WorldMap: gave up without a confirmed icon" << VAR(param.zone) << VAR(targets.size()) << VAR(param.icon)
-             << VAR(param.max_attempts);
+    // 认不出图标又没有角色标记佐证时就不给坐标：宁可让上层走失败分支，也不交一个算出来的空位置。
+    // 认不到是上层预期的分支（候选筛选逐个试过来，全不中是常态），故为 WARN——ERR 会直接刷到用户界面
+    LogWarn << "WorldMap: gave up without a confirmed icon" << VAR(param.zone) << VAR(targets.size()) << VAR(param.icon)
+            << VAR(param.max_attempts);
     return false;
 }
 

--- a/assets/resource/pipeline/LevelUpOperator.json
+++ b/assets/resource/pipeline/LevelUpOperator.json
@@ -451,10 +451,10 @@
                 ]
             }
         },
-        "post_wait_freezes": 100,
         "anchor": {
             "MouseMoveResetAnchor": "MouseMoveReset"
         },
+        "post_wait_freezes": 100,
         "next": [
             "[JumpBack][Anchor]MouseMoveResetAnchor",
             "LevelUpOperatorClearSwipeLeftHitCount"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误修复**
  - 优化地图查找失败时的提示级别，预期内未找到候选目标的情况不再显示为错误。
  - 减少不必要的错误提示，避免干扰用户界面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->