### PR TITLE
fix(MapNavigator): 缩短协议核心移动后的等待时间

### DIFF
--- a/assets/resource/pipeline/MapNavigator/ObstacleDevice.json
+++ b/assets/resource/pipeline/MapNavigator/ObstacleDevice.json
@@ -312,7 +312,7 @@
         "action": {
             "type": "Click"
         },
-        "post_delay": 1500,
+        "post_delay": 1350,
         "next": [
             "__MapNavigatorObstacleDevice_CancelMove"
         ]


### PR DESCRIPTION
## 问题

协议核心阻挡寻路时，`__MapNavigatorObstacleDevice_MoveAICCore` 点击“移动”后会等待 1500 ms，再由 `__MapNavigatorObstacleDevice_CancelMove` 发送 Esc。

在 #5698 的复现场景中，协议核心移动状态会在 Esc 前结束，导致 Esc 被解释为打开主菜单；小地图随后不可见，MapNavigator 最终因 `localization_lost_timeout` 失败。

## 修改

- 将协议核心移动后的 `post_delay` 从 1500 ms 调整为 1350 ms，使 Esc 更早发送。

## 验证

- 用户在 Issue 的同一复现场景中使用本地合并资源连续测试 10 次，结果 10/10 通过，未再误开主菜单。
- `pnpm check`
- `pnpm test`：1279/1279
- Prettier：目标文件无需额外格式化
- `git diff --check`

Fixes #5698