### PR TITLE
chore:修改基质刷取的选项

### DIFF
--- a/assets/tasks/AutoEssence/AutoEssence.json
+++ b/assets/tasks/AutoEssence/AutoEssence.json
@@ -495,9 +495,6 @@
                         }
                     },
                     "option": [
-                        "EssenceFilterAfterBattleSelectWeaponRarity",
-                        "EssenceFilterAfterBattleSelectEssence",
-                        "EssenceFilterAfterBattleSelectExtraRules",
                         "AutoUseSpMedication"
                     ]
                 },
@@ -525,9 +522,6 @@
                         }
                     },
                     "option": [
-                        "EssenceFilterAfterBattleSelectWeaponRarity",
-                        "EssenceFilterAfterBattleSelectEssence",
-                        "EssenceFilterAfterBattleSelectExtraRules",
                         "AutoUseSpMedication"
                     ]
                 }

--- a/assets/tasks/AutoEssence/Location/Slot1.json
+++ b/assets/tasks/AutoEssence/Location/Slot1.json
@@ -4,6 +4,8 @@
             "type": "checkbox",
             "label": "$option.AutoEssenceLocationSlot1.label",
             "description": "$option.AutoEssenceLocationSlot1.description",
+            "min_count": 3,
+            "max_count": 3,
             "default_case": [
                 "s1_2",
                 "s1_3",

--- a/tools/schema/interface.schema.json
+++ b/tools/schema/interface.schema.json
@@ -389,10 +389,23 @@
                         "default_case": {
                             "type": "array",
                             "title": "默认选中项",
-                            "description": "💡 v2.3.0 默认选中的选项名称数组，Client 使用该值作为多选框的初始选中值",
+                            "description": "💡 v2.3.0 默认选中的选项名称数组，Client 使用该值作为多选框的初始选中值。💡 v2.10.1 元素数量应满足 min_count / max_count（若已设置）",
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "min_count": {
+                            "type": "integer",
+                            "title": "最小选择数量",
+                            "description": "💡 v2.10.1 可选，默认 0。用户至少需要选中的 case 数量。为 0 时允许不选。不应大于 cases 长度；若同时设置 max_count，则不应大于 max_count",
+                            "minimum": 0,
+                            "default": 0
+                        },
+                        "max_count": {
+                            "type": "integer",
+                            "title": "最大选择数量",
+                            "description": "💡 v2.10.1 可选。用户最多可以选中的 case 数量。不设置表示不限制（最多可选中全部 case）。不应大于 cases 长度；若同时设置 min_count，则不应小于 min_count",
+                            "minimum": 0
                         }
                     },
                     "required": [

--- a/tools/schema/interface_import.schema.json
+++ b/tools/schema/interface_import.schema.json
@@ -352,10 +352,23 @@
                         "default_case": {
                             "type": "array",
                             "title": "默认选中项",
-                            "description": "💡 v2.3.0 默认选中的选项名称数组，Client 使用该值作为多选框的初始选中值",
+                            "description": "💡 v2.3.0 默认选中的选项名称数组，Client 使用该值作为多选框的初始选中值。💡 v2.10.1 元素数量应满足 min_count / max_count（若已设置）",
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "min_count": {
+                            "type": "integer",
+                            "title": "最小选择数量",
+                            "description": "💡 v2.10.1 可选，默认 0。用户至少需要选中的 case 数量。为 0 时允许不选。不应大于 cases 长度；若同时设置 max_count，则不应大于 max_count",
+                            "minimum": 0,
+                            "default": 0
+                        },
+                        "max_count": {
+                            "type": "integer",
+                            "title": "最大选择数量",
+                            "description": "💡 v2.10.1 可选。用户最多可以选中的 case 数量。不设置表示不限制（最多可选中全部 case）。不应大于 cases 长度；若同时设置 min_count，则不应小于 min_count",
+                            "minimum": 0
                         }
                     },
                     "required": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能调整**
  * 自动精华设置中，战后筛选配置项不再显示。
  * 自动精华位置选项现在固定选择 3 项。

* **改进**
  * 多选配置支持设置最少和最多可选项数量，并增加默认选择数量说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->