### PR TITLE
fix(IconRecognition): 修复非 ASCII 安装路径下物品识别失败的问题

### DIFF
--- a/agent/cpp-algo/source/IconRecognition/detail/TemplateCatalog.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/TemplateCatalog.cpp
@@ -7,6 +7,8 @@
 
 #include <meojson/json.hpp>
 
+#include <MaaUtils/ImageIo.h>
+
 #include "Common/JsoncFile.h"
 #include "CompositeIcon.h"
 #include "DisabledIcon.h"
@@ -27,17 +29,18 @@ constexpr int kRegionUnavailableMarkSourceHeight = 24;
 
 cv::Mat DecodeDisabledOverlay(const std::filesystem::path& path, const cv::Size& expected_size)
 {
+    // 同 DecodeBgra：安装路径可能含系统 ANSI 代码页无法表示的字符，禁止经 path.string() 读取或拼接。
     if (!std::filesystem::is_regular_file(path)) {
-        throw std::runtime_error("disabled overlay not found: " + path.string());
+        throw std::runtime_error("disabled overlay not found: " + MAA_NS::path_to_utf8_string(path));
     }
-    const cv::Mat overlay = cv::imread(path.string(), cv::IMREAD_UNCHANGED);
+    const cv::Mat overlay = MAA_NS::imread(path, cv::IMREAD_UNCHANGED);
     if (overlay.empty()) {
-        throw std::runtime_error("unable to decode disabled overlay: " + path.string());
+        throw std::runtime_error("unable to decode disabled overlay: " + MAA_NS::path_to_utf8_string(path));
     }
     if (overlay.type() != CV_8UC4 || overlay.size() != expected_size) {
         throw std::runtime_error(
             "disabled overlay must be a " + std::to_string(expected_size.width) + "x" + std::to_string(expected_size.height)
-            + " BGRA image: " + path.string());
+            + " BGRA image: " + MAA_NS::path_to_utf8_string(path));
     }
     return overlay;
 }

--- a/agent/cpp-algo/source/IconRecognition/detail/TemplateTypes.cpp
+++ b/agent/cpp-algo/source/IconRecognition/detail/TemplateTypes.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <stdexcept>
 
+#include <MaaUtils/ImageIo.h>
 #include <MaaUtils/NoWarningCV.hpp>
 
 #include "MaskPolicy.h"
@@ -74,17 +75,19 @@ cv::Mat AlphaMask(const cv::Mat& alpha, int threshold)
 
 cv::Mat DecodeBgra(const std::filesystem::path& path)
 {
-    const cv::Mat image = cv::imread(path.string(), cv::IMREAD_UNCHANGED);
+    // 必须经 MAA_NS::imread 读取：安装路径可能包含系统 ANSI 代码页无法表示的字符，
+    // path.string() 转换会抛出 system_error(1113)，导致物品识别整体不可用（issue #5687）。
+    const cv::Mat image = MAA_NS::imread(path, cv::IMREAD_UNCHANGED);
     if (image.empty()) {
-        throw std::runtime_error("unable to decode icon: " + path.string());
+        throw std::runtime_error("unable to decode icon: " + MAA_NS::path_to_utf8_string(path));
     }
     const int edge = image.cols;
     // 发布素材必须保持正方形二次幂尺寸，避免缩放时引入不可控的非等比基准。
     const bool is_power_of_two = edge > 0 && (edge & (edge - 1)) == 0;
     if (image.rows != edge || !is_power_of_two) {
         throw std::runtime_error(
-            "icon source must be a square power-of-two image: " + path.string() + " (" + std::to_string(image.cols) + "x"
-            + std::to_string(image.rows) + ")");
+            "icon source must be a square power-of-two image: " + MAA_NS::path_to_utf8_string(path) + " (" + std::to_string(image.cols)
+            + "x" + std::to_string(image.rows) + ")");
     }
     return image;
 }


### PR DESCRIPTION
- 模板图片读取改用宽字符安全的 MAA_NS::imread，避免 path.string() 在系统 ANSI 代码页无法表示安装路径字符时抛出 system_error(1113)，导致物品识别整体失败（issue #5687）
- 错误消息中的路径拼接改用 MAA_NS::path_to_utf8_string，避免构建异常消息时再次触发转换失败

Close #5687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进图像及覆盖层文件的路径处理，提升对包含非英文字符路径的读取支持。
  * 优化图像解码失败及尺寸校验的错误提示。
  * 保持图像格式、类型和尺寸校验规则不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->